### PR TITLE
Fix unlabeled Spacer block controls

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -174,6 +174,8 @@ function FlexControls( {
 						} );
 					} }
 					value={ flexSize }
+					label={ flexResetLabel }
+					hideLabelFromVision
 				/>
 			) }
 		</VStack>

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -267,6 +267,7 @@ export default function SpacingInputControl( {
 						className="spacing-sizes-control__custom-value-range"
 						__nextHasNoMarginBottom
 						label={ ariaLabel }
+						hideLabelFromVision
 					/>
 				</>
 			) }

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -266,6 +266,7 @@ export default function SpacingInputControl( {
 						onChange={ handleCustomValueSliderChange }
 						className="spacing-sizes-control__custom-value-range"
 						__nextHasNoMarginBottom
+						label={ ariaLabel }
 					/>
 				</>
 			) }

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -61,13 +61,13 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 					isResetValueOnUnitChange
 					min={ MIN_SPACER_SIZE }
 					onChange={ handleOnChange }
-					style={ { maxWidth: 80 } }
+					style={ { maxWidth: '50%' } }
 					value={ computedValue }
 					units={ units }
 					label={ label }
+					__next40pxDefaultSize
 				/>
 			) }
-
 			{ spacingSizes?.length > 0 && (
 				<View className="tools-panel-item-spacing">
 					<SpacingSizesControl

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -10,7 +10,6 @@ import {
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
-	BaseControl,
 	PanelBody,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
@@ -57,17 +56,16 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	return (
 		<>
 			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
-				<BaseControl label={ label } id={ inputId }>
-					<UnitControl
-						id={ inputId }
-						isResetValueOnUnitChange
-						min={ MIN_SPACER_SIZE }
-						onChange={ handleOnChange }
-						style={ { maxWidth: 80 } }
-						value={ computedValue }
-						units={ units }
-					/>
-				</BaseControl>
+				<UnitControl
+					id={ inputId }
+					isResetValueOnUnitChange
+					min={ MIN_SPACER_SIZE }
+					onChange={ handleOnChange }
+					style={ { maxWidth: 80 } }
+					value={ computedValue }
+					units={ units }
+					label={ label }
+				/>
 			) }
 
 			{ spacingSizes?.length > 0 && (

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -55,7 +55,7 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 	return (
 		<>
-			{ ( spacingSizes || spacingSizes?.length === 0 ) && (
+			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
 				<UnitControl
 					id={ inputId }
 					isResetValueOnUnitChange

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -14,7 +14,6 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
-	__experimentalGrid as Grid,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { View } from '@wordpress/primitives';
@@ -56,19 +55,17 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 
 	return (
 		<>
-			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
-				<Grid gap="2" templateColumns="1fr 1fr 24px">
-					<UnitControl
-						id={ inputId }
-						isResetValueOnUnitChange
-						min={ MIN_SPACER_SIZE }
-						onChange={ handleOnChange }
-						value={ computedValue }
-						units={ units }
-						label={ label }
-						__next40pxDefaultSize
-					/>
-				</Grid>
+			{ ( spacingSizes || spacingSizes?.length === 0 ) && (
+				<UnitControl
+					id={ inputId }
+					isResetValueOnUnitChange
+					min={ MIN_SPACER_SIZE }
+					onChange={ handleOnChange }
+					value={ computedValue }
+					units={ units }
+					label={ label }
+					__next40pxDefaultSize
+				/>
 			) }
 			{ spacingSizes?.length > 0 && (
 				<View className="tools-panel-item-spacing">

--- a/packages/block-library/src/spacer/controls.js
+++ b/packages/block-library/src/spacer/controls.js
@@ -14,6 +14,7 @@ import {
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+	__experimentalGrid as Grid,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { View } from '@wordpress/primitives';
@@ -56,17 +57,18 @@ function DimensionInput( { label, onChange, isResizing, value = '' } ) {
 	return (
 		<>
 			{ ( ! spacingSizes || spacingSizes?.length === 0 ) && (
-				<UnitControl
-					id={ inputId }
-					isResetValueOnUnitChange
-					min={ MIN_SPACER_SIZE }
-					onChange={ handleOnChange }
-					style={ { maxWidth: '50%' } }
-					value={ computedValue }
-					units={ units }
-					label={ label }
-					__next40pxDefaultSize
-				/>
+				<Grid gap="2" templateColumns="1fr 1fr 24px">
+					<UnitControl
+						id={ inputId }
+						isResetValueOnUnitChange
+						min={ MIN_SPACER_SIZE }
+						onChange={ handleOnChange }
+						value={ computedValue }
+						units={ units }
+						label={ label }
+						__next40pxDefaultSize
+					/>
+				</Grid>
 			) }
 			{ spacingSizes?.length > 0 && (
 				<View className="tools-panel-item-spacing">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/63800

## What?
<!-- In a few words, what is the PR actually doing? -->
Two Spacer block controls are unlabeled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All form controls must be labeled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds missing `label` prop to the `UnitControl` in `FlexControls`.
- Adds missing `label` prop to `RangeControl` in `SpacingInputControl`.
- Removes unnecessary `BaseControl` wrapping `UnitControl` in the Spacer block inspector controls.

Queation regarding the last point: I noticed other cases where a `BaseControl` wraps another control. I'm not sure to understand why. Any clue? Anything I may be missing?

Cc @WordPress/gutenberg-components 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the testing instructions from the issue https://github.com/WordPress/gutenberg/issues/63800
- Observe the two controls are now properly labeled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
