### PR TITLE
Fix: New block editor z-index issue. Link options are hidden at the bottom of the page 

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -21,6 +21,7 @@ $z-layers: (
 	".interface-complementary-area .components-panel__header": 1, // higher sticky element
 
 	".components-modal__header": 10,
+	".edit-post-layout.has-metaboxes .edit-post-visual-editor": 1, // The popovers contained in visual editor go in front of the metabox container.
 	".edit-post-meta-boxes-area.is-loading::before": 1,
 	".edit-post-meta-boxes-area .spinner": 5,
 	".components-popover__close": 5,

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -8,6 +8,10 @@
 	clear: both;
 }
 
+.edit-post-layout.has-metaboxes .edit-post-visual-editor {
+	z-index: 99;
+}
+
 // Adjust the position of the notices
 .components-editor-notices__snackbar {
 	position: fixed;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -9,7 +9,7 @@
 }
 
 .edit-post-layout.has-metaboxes .edit-post-visual-editor {
-	z-index: 99;
+	z-index: z-index(".edit-post-layout.has-metaboxes .edit-post-visual-editor");
 }
 
 // Adjust the position of the notices

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -5,7 +5,6 @@
 	background-color: $gray-300;
 	// Make this a stacking context to contain the z-index of children elements.
 	isolation: isolate;
-	z-index: 5;
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -5,6 +5,7 @@
 	background-color: $gray-300;
 	// Make this a stacking context to contain the z-index of children elements.
 	isolation: isolate;
+	z-index: 5;
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
PR is intended to fix this issue: https://github.com/WordPress/gutenberg/issues/63795

## Why?
When you are editing text in the new block editor if your text is on the bottom of the page and you are trying to add/edit a link, the options are hidden if you have some options for example seo options

## How?
Added `z-index: 5` to `.editor-visual-editor` as per the suggestion  

## Testing Instructions
Works as expected, the results are now no more blocked by the box below the text

## Screenshots or screencast <!-- if applicable -->
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/b480b321-fdbe-49a3-b4d6-631880e25f6a">
