### PR TITLE
Fix selected row styles in table layout

### DIFF
--- a/packages/dataviews/src/layouts/table/style.scss
+++ b/packages/dataviews/src/layouts/table/style.scss
@@ -92,7 +92,7 @@
 			}
 		}
 
-		&.is-ed {
+		&.is-selected {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-700;
 


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/63694.

Fixes a regression where table rows were no longer showing theme-color accents on selection.

### Before
<img width="527" alt="Screenshot 2024-07-22 at 16 10 43" src="https://github.com/user-attachments/assets/38441ecc-4236-4b96-a76d-007371b1a517">


### After
<img width="761" alt="Screenshot 2024-07-22 at 16 10 20" src="https://github.com/user-attachments/assets/0d2e492e-c083-4847-94ff-55a40cefbea0">
