### PR TITLE
Update: Simplify some permission checks.

### DIFF
--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -33,24 +33,18 @@ export function mergeBaseAndUserConfigs( base, user ) {
 function useGlobalStylesUserConfig() {
 	const { globalStylesId, isReady, settings, styles, _links } = useSelect(
 		( select ) => {
-			const {
-				getEditedEntityRecord,
-				hasFinishedResolution,
-				getUser,
-				getCurrentUser,
-			} = select( coreStore );
+			const { getEditedEntityRecord, hasFinishedResolution, canUser } =
+				select( coreStore );
 			const _globalStylesId =
 				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
 
-			// Doing canUser( 'read', 'global_styles' ) returns false even for users with the capability.
-			// See: https://github.com/WordPress/gutenberg/issues/63438
-			// So we need to check the user capabilities directly.
-			const userId = getCurrentUser()?.id;
-			const canEditThemeOptions =
-				userId && getUser( userId )?.capabilities?.edit_theme_options;
-
 			const record =
-				_globalStylesId && canEditThemeOptions
+				_globalStylesId &&
+				canUser( 'read', {
+					kind: 'root',
+					name: 'globalStyles',
+					id: _globalStylesId,
+				} )
 					? getEditedEntityRecord(
 							'root',
 							'globalStyles',
@@ -139,21 +133,11 @@ function useGlobalStylesUserConfig() {
 
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
-		const {
-			getCurrentUser,
-			getUser,
-			__experimentalGetCurrentThemeBaseGlobalStyles,
-		} = select( coreStore );
-
-		// Doing canUser( 'read', 'global_styles' ) returns false even for users with the capability.
-		// See: https://github.com/WordPress/gutenberg/issues/63438
-		// So we need to check the user capabilities directly.
-		const userId = getCurrentUser()?.id;
-		const canEditThemeOptions =
-			userId && getUser( userId )?.capabilities?.edit_theme_options;
+		const { __experimentalGetCurrentThemeBaseGlobalStyles, canUser } =
+			select( coreStore );
 
 		return (
-			canEditThemeOptions &&
+			canUser( 'read', { kind: 'root', name: 'theme' } ) &&
 			__experimentalGetCurrentThemeBaseGlobalStyles()
 		);
 	}, [] );


### PR DESCRIPTION
Simplifies some permission checks by using canUser instead of checking capabilities directly which is not as reliable (e.g: may not take into account some backend filters).

Props to @Mamaduka for the research that led to this PR.

## Testing Instructions
I checked the editor still works as expected.
With an author role, I checked in the developer tools that there are no 403 HTTP errors while opening the editor.