### PR TITLE
Update: Simplify and do not pass renderingMode on editor SidebarContent.

### DIFF
--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -51,7 +51,6 @@ const SIDEBAR_ACTIVE_BY_DEFAULT = Platform.select( {
 const SidebarContent = ( {
 	tabName,
 	keyboardShortcut,
-	renderingMode,
 	onActionPerformed,
 	extraPanels,
 } ) => {
@@ -112,7 +111,7 @@ const SidebarContent = ( {
 				<Tabs.TabPanel tabId={ sidebars.document } focusable={ false }>
 					<PostSummary onActionPerformed={ onActionPerformed } />
 					<PluginDocumentSettingPanel.Slot />
-					<TemplateContentPanel renderingMode={ renderingMode } />
+					<TemplateContentPanel />
 					<TemplatePartContentPanel />
 					<PostTransformPanel />
 					<PostTaxonomiesPanel />
@@ -129,7 +128,7 @@ const SidebarContent = ( {
 
 const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 	useAutoSwitchEditorSidebars();
-	const { tabName, keyboardShortcut, showSummary, renderingMode } = useSelect(
+	const { tabName, keyboardShortcut, showSummary } = useSelect(
 		( select ) => {
 			const shortcut = select(
 				keyboardShortcutsStore
@@ -158,7 +157,6 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 					TEMPLATE_PART_POST_TYPE,
 					NAVIGATION_POST_TYPE,
 				].includes( select( editorStore ).getCurrentPostType() ),
-				renderingMode: select( editorStore ).getRenderingMode(),
 			};
 		},
 		[]
@@ -185,7 +183,6 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 				tabName={ tabName }
 				keyboardShortcut={ keyboardShortcut }
 				showSummary={ showSummary }
-				renderingMode={ renderingMode }
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
 			/>

--- a/packages/editor/src/components/template-content-panel/index.js
+++ b/packages/editor/src/components/template-content-panel/index.js
@@ -27,9 +27,9 @@ const PAGE_CONTENT_BLOCKS = [
 
 const TEMPLATE_PART_BLOCK = 'core/template-part';
 
-export default function TemplateContentPanel( { renderingMode } ) {
+export default function TemplateContentPanel() {
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
-	const { clientIds, postType } = useSelect( ( select ) => {
+	const { clientIds, postType, renderingMode } = useSelect( ( select ) => {
 		const { getBlocksByName } = select( blockEditorStore );
 		const { getCurrentPostType } = select( editorStore );
 		const _postType = getCurrentPostType();
@@ -40,6 +40,7 @@ export default function TemplateContentPanel( { renderingMode } ) {
 					? TEMPLATE_PART_BLOCK
 					: PAGE_CONTENT_BLOCKS
 			),
+			renderingMode: select( editorStore ).getRenderingMode(),
 		};
 	}, [] );
 


### PR DESCRIPTION
Applies a suggestion by @youknowriad at https://github.com/WordPress/gutenberg/pull/62033#pullrequestreview-2158641939. Removes the querying and passing of renderingMode on SidebarContent to TemplateContentPanel.
TemplateContentPanel now retrieves the renderingMode from the store instead of receiving it as a prop.


## Testing Instructions
I opened a template and verified the template content panel still works as expected.
