### PR TITLE
DropdownMenuV2: Make disabled cursor style consistent

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `DropdownMenuV2`: invert animation direction. ([#63443](https://github.com/WordPress/gutenberg/pull/63443)).
 -   `Tabs`: Vertical Tabs should be 40px min height. ([#63446](https://github.com/WordPress/gutenberg/pull/63446)).
 -   `ColorPicker`: Use `minimal` variant for `SelectControl` ([#63676](https://github.com/WordPress/gutenberg/pull/63676)).
+-   `DropdownMenuV2`: Make disabled cursor style consistent ([#63816](https://github.com/WordPress/gutenberg/pull/63816)).
 
 ### Documentation
 

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -161,12 +161,13 @@ const baseItem = css`
 	 */
 	scroll-margin: ${ CONTENT_WRAPPER_PADDING };
 
+	cursor: pointer;
 	user-select: none;
 	outline: none;
 
 	&[aria-disabled='true'] {
 		color: ${ COLORS.ui.textDisabled };
-		cursor: not-allowed;
+		cursor: default;
 	}
 
 	/* Hover */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In DropdownMenuV2 items, show `cursor: pointer` when interactive and `cursor: default` when disabled.

## Why?

To make consistent with other components (#63756).

## Testing Instructions

See Storybook story for DropdownMenuV2.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/bd2a7b4b-d234-4a10-b27f-921190024b2a

