### PR TITLE
Make hover block outlines not present in Distraction Free

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -58,9 +58,9 @@ function Root( { className, ...settings } ) {
 			getTemporarilyEditingAsBlocks,
 			isTyping,
 		} = unlock( select( blockEditorStore ) );
-		const { outlineMode, focusMode } = getSettings();
+		const { outlineMode, focusMode, isDistractionFree } = getSettings();
 		return {
-			isOutlineMode: outlineMode && ! isTyping(),
+			isOutlineMode: outlineMode && ! isTyping() && ! isDistractionFree,
 			isFocusMode: focusMode,
 			editorMode: __unstableGetEditorMode(),
 			temporarilyEditingAsBlocks: getTemporarilyEditingAsBlocks(),

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -60,7 +60,7 @@ function Root( { className, ...settings } ) {
 		} = unlock( select( blockEditorStore ) );
 		const { outlineMode, focusMode, isDistractionFree } = getSettings();
 		return {
-			isOutlineMode: outlineMode && ! isTyping() && ! isDistractionFree,
+			isOutlineMode: outlineMode && ! isDistractionFree && ! isTyping(),
 			isFocusMode: focusMode,
 			editorMode: __unstableGetEditorMode(),
 			temporarilyEditingAsBlocks: getTemporarilyEditingAsBlocks(),

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -58,9 +58,9 @@ function Root( { className, ...settings } ) {
 			getTemporarilyEditingAsBlocks,
 			isTyping,
 		} = unlock( select( blockEditorStore ) );
-		const { outlineMode, focusMode, isDistractionFree } = getSettings();
+		const { outlineMode, focusMode } = getSettings();
 		return {
-			isOutlineMode: outlineMode && ! isDistractionFree && ! isTyping(),
+			isOutlineMode: outlineMode && ! isTyping(),
 			isFocusMode: focusMode,
 			editorMode: __unstableGetEditorMode(),
 			temporarilyEditingAsBlocks: getTemporarilyEditingAsBlocks(),

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -311,7 +311,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			__experimentalUndo: undo,
 			// Check whether we want all site editor frames to have outlines
 			// including the navigation / pattern / parts editors.
-			outlineMode: postType === 'wp_template',
+			outlineMode: ! isDistractionFree && postType === 'wp_template',
 			// Check these two properties: they were not present in the site editor.
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #63766 by ensuring that the Post Editor and Site Editor hover block outlines conditionally render the same: where distraction free means no block outlines on hover. 

## Why?
The Post Editor already does not render block outlines on hover in Distraction Free (as they're not available on the post editor generally). The Site Editor should perform the same. 

## How?
If isDistractionFree, outlineMode is set to false — resulting in no hover outlines when distraction free mode is enabled (regardless of editor). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a page in the Site Editor.
2. Insert patterns. 
3. Turn on Distraction Free from the editor options vertical ellipsis in the editor header. 
4. See no block outlines on hover, only on select. 

## Screenshots or screencast <!-- if applicable -->

### Before 

https://github.com/user-attachments/assets/2716f12d-99b4-4daf-a70e-b79ed1e1b9b9


### After 

https://github.com/user-attachments/assets/58a21e43-9e19-43c5-b909-a583f4ec6f23

