### PR TITLE
Block editor settings: add missing global styles links dependencies

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -353,6 +353,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		setIsInserterOpened,
 		sectionRootClientId,
 		globalStylesData,
+		globalStylesLinksData,
 	] );
 }
 


### PR DESCRIPTION
## What?

Follow up to:

- https://github.com/WordPress/gutenberg/pull/60100

Adds the `globalStylesLinksData` dependency to the useMemo dependency list.

Thanks to @youknowriad for catching it.

## Why?
The `globalStylesLinksData` dependency was missing from the useMemo dependency list.

## How?

Add the `globalStylesLinksData` dependency to the useMemo dependency list.

## Testing Instructions

Smoke test that background images with relative paths in theme.json appear as they should in the editor.

Here's some test JSON that can be used with TT4:


```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
				"backgroundImage": {
					"url": "file:./assets/images/art-gallery.webp"
				},
				"backgroundAttachment": "fixed"
		}
	}
}
```

In the Site Editor, check that:

1. The background image appears correctly in the canvas.
2. The image preview appears in the Global Styles controls, in both the round icon and also the focal point picker preview.

<img width="675" alt="Screenshot 2024-07-23 at 7 39 36 AM" src="https://github.com/user-attachments/assets/4dc4bec6-a606-41bc-8aaf-aa65652123de">


