### PR TITLE
Fix user patterns disabling sync filter

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -22,7 +22,8 @@ import {
 	INSERTER_PATTERN_TYPES,
 } from './utils';
 
-const getShouldDisableSyncFilter = ( sourceFilter ) => sourceFilter !== 'all';
+const getShouldDisableSyncFilter = ( sourceFilter ) =>
+	sourceFilter !== 'all' && sourceFilter !== 'user';
 const getShouldDisableNonUserSources = ( category ) => {
 	return category.name === myPatternsCategory.name;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fix part of https://github.com/WordPress/gutenberg/issues/61826.

The sync filter for user patterns is not enabled in the inserter.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This seems like an accidental mistake introduced in https://github.com/WordPress/gutenberg/pull/57570.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add back the condition for user patterns.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open the editor.
2. Open the global inserter and navigate to "Patterns", then "My patterns".
3. Click "Filter patterns" on the top right corner.
4. Expect the sync status filter "type" to be enabled.

## Screenshots or screencast <!-- if applicable -->

**Before**
![image](https://github.com/user-attachments/assets/0e4a3b1c-1a1b-4f8d-9aca-6de272a593e1)

**After**
![image](https://github.com/user-attachments/assets/8eb155b3-7276-4b01-8160-17daccc7ebc3)

