### PR TITLE
Tag Cloud: Prevent duplicate spacing in editor

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -44,6 +44,7 @@
 @import "./social-links/editor.scss";
 @import "./spacer/editor.scss";
 @import "./table/editor.scss";
+@import "./tag-cloud/editor.scss";
 @import "./template-part/editor.scss";
 @import "./text-columns/editor.scss";
 @import "./video/editor.scss";

--- a/packages/block-library/src/tag-cloud/editor.scss
+++ b/packages/block-library/src/tag-cloud/editor.scss
@@ -1,0 +1,9 @@
+// The following styles are to prevent duplicate spacing for the tag cloud
+// block in the editor given it uses server side rendering. The specificity
+// must be higher than `0-1-0` to override global styles. Targeting the
+// inner use of the .wp-block-tag-cloud class should minimize impact on
+// other 3rd party styles targeting the block.
+.wp-block-tag-cloud .wp-block-tag-cloud {
+	margin: 0;
+	padding: 0;
+}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63716

## What?

Avoids the duplicate application of default padding and margin styles on the Tag Cloud block in the editor due to its use of server-side rendering.

## Why?

Without these changes, default margin and padding are applied twice creating a visual difference between the editor and frontend.

## How?

- Reset padding and margin on the inner element with `.wp-block-tag-cloud` class

#### Alternate Approach

Initially, it was suggested to reset the spacing styles on the outer wrapping element in the editor. The catch here is that there is default padding for different alignments and the CSS classes for those alignments are only applied to the outer wrapper. 

If the spacing style resets occur on the outer wrapper, these defaults need to be plumbed through to the inner `p.wp-block-tag-cloud` element. The current approach in this PR minimises any additional CSS to reset spacing.

## Testing Instructions

1. Make sure you have some posts with tags assigned to them
2. Activate TT4 and add some global spacing styles for the Tag Cloud block via Global Styles or theme.json
3. Add a Tag Cloud block in the editor
4. Inspect the inner `p.wp-block-tag-cloud` element and ensure that padding and margin styles are reset
5. Compare the visual layout of the block in the editor and the frontend, there should be no duplicate spacing in the editor
6. Clear global styles and theme.json customizations
7. Select the Tag Cloud block and toggle on different alignments
8. Ensure the outer wrapper still gets the default padding values and none are applied to the inner element


## Screenshots or screencast <!-- if applicable -->

| Before | After | Frontend |
|---|---|---|
| <img width="1111" alt="Screenshot 2024-07-23 at 1 06 36 PM" src="https://github.com/user-attachments/assets/33efb501-19a0-43cd-8367-242c24ddf60c"> | <img width="1112" alt="Screenshot 2024-07-23 at 2 13 55 PM" src="https://github.com/user-attachments/assets/d1168165-45cb-440f-92ed-1c34ae48e825"> | <img width="1098" alt="Screenshot 2024-07-23 at 2 14 18 PM" src="https://github.com/user-attachments/assets/a8e88b3d-8dc5-4972-913f-a7fafe89b2b8"> |

