### PR TITLE
Inserter: Allow searching for variations via the `block.id` instead of the `block.name`

### DIFF
--- a/packages/block-editor/src/components/inserter/search-items.js
+++ b/packages/block-editor/src/components/inserter/search-items.js
@@ -5,7 +5,9 @@ import removeAccents from 'remove-accents';
 import { noCase } from 'change-case';
 
 // Default search helpers.
-const defaultGetName = ( item ) => item.name || '';
+// For the block name, prioritize returning the id,
+// which is similar to the name, but includes the variation.
+const defaultGetName = ( item ) => item.id || item.name || '';
 const defaultGetTitle = ( item ) => item.title;
 const defaultGetDescription = ( item ) => item.description || '';
 const defaultGetKeywords = ( item ) => item.keywords || [];


### PR DESCRIPTION
## What?
Fixes #63802
Fixes #61982

## Why?
The block search feature has used the `block.name` (e.g. `core/paragraph`) for a while as part of the search criteria. It seems this was never updated when variations where introduced so as mentioned in #63802 and #61982 search doesn't work as well for variations as it does for regular blocks.

## How?
In the inserter block types there's a `block.id` which is very similar to the name, but includes the variation name (e.g. `core/group/group-grid`). The fix is to use the `block.id` as a preference over the `block.name` in the search criteria. For non-variations, the `id` is the same as `name`, so it won't change anything.

Even if what was described in the linked issues was never intended as a feature, this will provide a better chance of matching block variations in the search, while also providing an easy way to solve those issues.

## Testing Instructions
1. Switch to Japanese site language
2. Type `/gri` in an empty paragraph and check the 'Grid' block is returned in the search results.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-07-23 at 1 10 25 PM](https://github.com/user-attachments/assets/2ae39c99-b260-4329-9641-ad046a95c8a1)
