### PR TITLE
Fix Z-Index Issue for Link Options in Block Editor

### DIFF
--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -7,6 +7,7 @@
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
+	z-index: 20;
 
 	&.is-resizable {
 		max-height: 100%;


### PR DESCRIPTION
Fixes [#63795](https://github.com/WordPress/gutenberg/issues/63795)

## What?
This PR adds a z-index to the .editor-visual-editor class to prevent link options from being hidden when editing text at the bottom of the page.

## Why?
Currently, when editing text at the bottom of the page in the new block editor, the link options can be hidden behind other elements (such as SEO options). This issue occurs because the .editor-visual-editor class lacks a z-index property. Adding a z-index resolves this problem and improves the user experience when working with links in the editor.

## How?
The fix involves adding a `z-index: 20` to the .editor-visual-editor class in the appropriate CSS file. This ensures that the editor's content, including link options, appears above other page elements.

## Testing Instructions
1. Go to "Add New Post"
2. Add a long block of text that extends beyond the initial viewport
3. Scroll to the bottom of the text
4. Try to add or edit a link in the text at the bottom of the page
5. Verify that the link options are visible and not hidden behind other page elements

## Screenshots or screencast <!-- if applicable -->
<img width="1055" alt="Screenshot 2024-07-23 at 11 06 55 AM" src="https://github.com/user-attachments/assets/320cbd0a-1795-4ad6-946f-c9bb83280370">
