### PR TITLE
[Type] Enhancement : post higher priority in link search results

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -268,6 +268,7 @@ export function sortResults( results: SearchResult[], search: string ) {
 
 	const scores = {};
 	for ( const result of results ) {
+		let score = 0;
 		if ( result.title ) {
 			const titleTokens = tokenize( result.title );
 			const matchingTokens = titleTokens.filter( ( titleToken ) =>
@@ -275,10 +276,17 @@ export function sortResults( results: SearchResult[], search: string ) {
 					titleToken.includes( searchToken )
 				)
 			);
-			scores[ result.id ] = matchingTokens.length / titleTokens.length;
-		} else {
-			scores[ result.id ] = 0;
+			score = matchingTokens.length / titleTokens.length;
 		}
+
+		// Prioritize pages and posts.
+		if (
+			result.kind === 'post-type' &&
+			( result.type === 'post' || result.type === 'page' )
+		) {
+			score += 1;
+		}
+		scores[ result.id ] = score;
 	}
 
 	return results.sort( ( a, b ) => scores[ b.id ] - scores[ a.id ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR updates the `sortResults` function in the link suggestions feature to prioritize pages and posts above attachments in search results.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Attachments were being surfaced higher in search results than posts matching the search requirements. This change ensures that pages and posts are prioritized in the search results, which is more likely to be the desired outcome for users.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The `sortResults` function has been updated to add a score increment for results that are of `kind` `post-type` and `type` `post` or `page`. This adjustment ensures that these types of results are prioritized above others, such as attachments.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Use the link control to search for content.
3. Observe that pages and posts are prioritized in the search results over attachments.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open a post or page using keyboard navigation.
2. Use the link control to search for content using keyboard navigation.
3. Ensure that pages and posts are prioritized in the search results over attachments.

### Issue
- https://github.com/WordPress/gutenberg/issues/63683

## Screenshots or screencast
<!-- if applicable -->
N/A