### PR TITLE
Avoid stripping attributes via group block migration when no layout is specified

### DIFF
--- a/packages/block-library/src/group/deprecated.js
+++ b/packages/block-library/src/group/deprecated.js
@@ -109,15 +109,11 @@ const deprecated = [
 			);
 		},
 		isEligible: ( { layout } ) =>
-			! layout ||
-			layout.inherit ||
-			( layout.contentSize && layout.type !== 'constrained' ),
+			layout?.inherit ||
+			( layout?.contentSize && layout?.type !== 'constrained' ),
 		migrate: ( attributes ) => {
 			const { layout = null } = attributes;
-			if ( ! layout ) {
-				return attributes;
-			}
-			if ( layout.inherit || layout.contentSize ) {
+			if ( layout?.inherit || layout?.contentSize ) {
 				return {
 					...attributes,
 					layout: {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #63820

## What?
Fixes a group block deprecation/migration that's a little too far reaching, and is causing attribute values to be stripped from perfectly valid blocks.

## Why?
When a deprecation is run, it uses the list of attributes in the deprecation to filter out extraneous attribute values on the incoming parsed block.

In this case, the group block has a deprecation and migration that can match valid group blocks because the `isEligible ` function on the deprecation forces the deprecation to run whenever `layout` is not defined. According to the group block's definition and layout support, it's perfectly valid not to set `layout`, a default value will be assumed.

The problem is that the group block has some newer attributes (`allowedBlocks` and `templateLock`) not included in the deprecation that are being stripped by the deprecation because of the way `isEligible` matches so easily.

## How?
I noticed that when `isEligible` matches because of the `! layout` clause, it then triggers this early return in the migration:

```
migrate: ( attributes ) => {
	const { layout = null } = attributes;
	if ( ! layout ) {
		return attributes;
	}
```

It returns the unmodified attributes (and without `templateLock` and `allowedBlocks` because of the way deprecations work). I couldn't see much point to this code, so this PR fixes the issue by deleting it.

It does leave me wondering if there is a purpose to the code being removed that I'm not seeing. It might be that in the original PR it seemed harmless so it flew under the radar during code review and these future problems were quite hard to anticipate.

## Testing Instructions
1. Create a new post
2. Switch to code editor and paste the below snippet
```html
<!-- wp:group {"templateLock":"contentOnly","style":{"border":{"radius":"8px","width":"1px"},"spacing":{"blockGap":"0","padding":{"top":"var:preset|spacing|20","bottom":"var:preset|spacing|20","left":"var:preset|spacing|20","right":"var:preset|spacing|20"}}},"backgroundColor":"white","borderColor":"contrast-3"} -->
<div class="wp-block-group has-border-color has-contrast-3-border-color has-white-background-color has-background" style="border-width:1px;border-radius:8px;padding-top:var(--wp--preset--spacing--20);padding-right:var(--wp--preset--spacing--20);padding-bottom:var(--wp--preset--spacing--20);padding-left:var(--wp--preset--spacing--20)"><!-- wp:heading {"style":{"typography":{"fontStyle":"normal","fontWeight":"500","fontSize":"1.5rem"}},"fontFamily":"body"} -->
<h2 class="wp-block-heading has-body-font-family" style="font-size:1.5rem;font-style:normal;font-weight:500">Card heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"fontSize":"small"} -->
<p class="has-small-font-size">Card description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
3. Switch back to visual editor

Expected: the block is in `contentOnly` mode due to the attribute in the snippet

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-07-23 at 2 40 27 PM](https://github.com/user-attachments/assets/66231f56-1c22-40e3-9601-6696f789911a)
