### PR TITLE
DataForm: Add a simple story for the DataForm component

### DIFF
--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataForm from '../index';
+
+const meta = {
+	title: 'DataViews/DataForm',
+	component: DataForm,
+};
+export default meta;
+
+const fields = [
+	{
+		id: 'title',
+		label: 'Title',
+		type: 'text' as const,
+	},
+];
+
+export const Default = () => {
+	const [ post, setPost ] = useState( {
+		title: 'Hello, World!',
+	} );
+
+	const form = {
+		visibleFields: [ 'title' ],
+	};
+
+	return (
+		<DataForm
+			data={ post }
+			fields={ fields }
+			form={ form }
+			onChange={ setPost }
+		/>
+	);
+};

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -12,7 +12,7 @@ import {
 /**
  * Internal dependencies
  */
-import { LAYOUT_TABLE } from '../constants';
+import { LAYOUT_TABLE } from '../../../constants';
 
 export const data = [
 	{

--- a/packages/dataviews/src/components/dataviews/stories/index.story.js
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.js
@@ -6,10 +6,10 @@ import { useState, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { DataViews } from '../index';
+import DataViews from '../index';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
-import { LAYOUT_GRID, LAYOUT_TABLE } from '../constants';
-import { filterSortAndPaginate } from '../filter-and-sort-data-view';
+import { LAYOUT_GRID, LAYOUT_TABLE } from '../../../constants';
+import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
 
 const meta = {
 	title: 'DataViews/DataViews',

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { filterSortAndPaginate } from '../filter-and-sort-data-view';
-import { data, fields } from '../stories/fixtures';
+import { data, fields } from '../components/dataviews/stories/fixtures';
 
 describe( 'filters', () => {
 	it( 'should return empty if the data is empty', () => {


### PR DESCRIPTION
Related #59745 

## What?

This adds a simple Storybook story for the `DataForm` component that we're iterating on. The story doesn't do much at the moment aside rendering an input to edit a "post title".

## Testing Instructions

You can run `npm run storybook:dev` locally and see the new DataForm story.