### PR TITLE
Quick Edit: Support bulk selection

### DIFF
--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -49,7 +49,7 @@ function DataFormTextControl< Item >( {
 		<TextControl
 			label={ header }
 			placeholder={ placeholder }
-			value={ value }
+			value={ value ?? '' }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 		/>

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -142,7 +142,7 @@ export default function PostList( { postType } ) {
 	const history = useHistory();
 	const location = useLocation();
 	const { postId, quickEdit = false } = location.params;
-	const [ selection, setSelection ] = useState( [ postId ] );
+	const [ selection, setSelection ] = useState( postId.split( ',' ) );
 	const onChangeSelection = useCallback(
 		( items ) => {
 			setSelection( items );
@@ -150,7 +150,7 @@ export default function PostList( { postType } ) {
 			if ( ( params.isCustom ?? 'false' ) === 'false' ) {
 				history.push( {
 					...params,
-					postId: items.length === 1 ? items[ 0 ] : undefined,
+					postId: items.join( ',' ),
 				} );
 			}
 		},

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -142,7 +142,7 @@ export default function PostList( { postType } ) {
 	const history = useHistory();
 	const location = useLocation();
 	const { postId, quickEdit = false } = location.params;
-	const [ selection, setSelection ] = useState( postId.split( ',' ) );
+	const [ selection, setSelection ] = useState( postId?.split( ',' ) ?? [] );
 	const onChangeSelection = useCallback(
 		( items ) => {
 			setSelection( items );


### PR DESCRIPTION
Related #55101 

## What?

This PR allows using the "quick edit" panel when bulk selecting multiple items.

## How?

 - The `postId` in the url can now be an array of ids like `1,2`... Is this the right format?
 - If there are multiple items selected, the quick edit form is empty by default.

## Testing Instructions

1- Enable the "quick edit" experiment.
2- Select multiple pages in the pages dataviews (table view)
3- Try modifying the title and saving.