### PR TITLE
Core Data: Remove leftover 'todo' comment

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -407,7 +407,6 @@ export const canUser =
 			resourcePath =
 				entityConfig.baseURL + ( resource.id ? '/' + resource.id : '' );
 		} else {
-			// @todo: Maybe warn when detecting a legacy usage.
 			resourcePath = `/wp/v2/${ resource }` + ( id ? '/' + id : '' );
 		}
 


### PR DESCRIPTION
## What?
This is a minor follow-up to #63322.

PR removes a `@todo` comment to mark string-based resources as deprecated/legacy in the future.

## Why?
Using string REST API resource is still valid for some packages like `block-directory` or when exposing a resource as an entity doesn't make sense.

https://github.com/WordPress/gutenberg/blob/fb1f9a9295c573dac04884d3e811ffb3b660caa8/packages/block-directory/src/components/downloadable-blocks-panel/index.js#L29-L32

## Testing Instructions
None - I just deleted an inline comment.
