### PR TITLE
Fix: Filters are reset when switching layout on the pages view.

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -39,6 +39,10 @@ function useView( postType ) {
 	const {
 		params: { activeView = 'all', isCustom = 'false', layout },
 	} = useLocation();
+	const previousIsCustom = usePrevious( isCustom );
+	const previousLayout = usePrevious( layout );
+	const previousActiveView = usePrevious( activeView );
+	const previousPostType = usePrevious( postType );
 	const history = useHistory();
 	const DEFAULT_VIEWS = useDefaultViews( { postType } );
 	const selectedDefaultView = useMemo( () => {
@@ -59,10 +63,28 @@ function useView( postType ) {
 	const [ view, setView ] = useState( selectedDefaultView );
 
 	useEffect( () => {
-		if ( selectedDefaultView ) {
-			setView( selectedDefaultView );
+		if (
+			selectedDefaultView &&
+			( previousIsCustom !== isCustom ||
+				( previousLayout !== layout && layout !== view.type ) ||
+				previousActiveView !== activeView ||
+				previousPostType !== postType )
+		) {
+			setView( { ...view, ...selectedDefaultView } );
 		}
-	}, [ selectedDefaultView ] );
+	}, [
+		activeView,
+		isCustom,
+		layout,
+		postType,
+		previousActiveView,
+		previousIsCustom,
+		previousLayout,
+		previousPostType,
+		selectedDefaultView,
+		setView,
+		view,
+	] );
 	const editedViewRecord = useSelect(
 		( select ) => {
 			if ( isCustom !== 'true' ) {


### PR DESCRIPTION
Fixes an issue noticed by @youknowriad at https://github.com/WordPress/gutenberg/pull/63203#issuecomment-2244993764.

Right now, on the pages list when we switch layouts the filters are reset. That happens because an effect to synchronize URL parameters with the view was not taking into account the already existing possible customizations of the view.
This PR fixes the issue.

## Testing Instructions
I opened the pages list view.
I added some filters.
I switched the layout and verified the filters I added were kept.
I switched the view e.g.: to published I verified the correct published filters, were applied and the previous layout I selected was kept.
