### PR TITLE
SelectControl: Fix hover/focus color in wp-admin

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `ComboboxControl`: Fix ComboboxControl reset button when using the keyboard. ([#63410](https://github.com/WordPress/gutenberg/pull/63410))
 -   `Button`: Never apply `aria-disabled` to anchor ([#63376](https://github.com/WordPress/gutenberg/pull/63376)).
+-   `SelectControl`: Fix hover/focus color in wp-admin ([#63855](https://github.com/WordPress/gutenberg/pull/63855)).
 
 ### Enhancements
 

--- a/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
+++ b/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
@@ -120,6 +120,7 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
   box-sizing: border-box;
   border: none;
   box-shadow: none!important;
+  color: currentColor;
   cursor: inherit;
   display: block;
   font-family: inherit;
@@ -405,6 +406,7 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
   box-sizing: border-box;
   border: none;
   box-shadow: none!important;
+  color: currentColor;
   cursor: inherit;
   display: block;
   font-family: inherit;
@@ -700,6 +702,7 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
   box-sizing: border-box;
   border: none;
   box-shadow: none!important;
+  color: currentColor;
   cursor: inherit;
   display: block;
   font-family: inherit;
@@ -1007,6 +1010,7 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
   box-sizing: border-box;
   border: none;
   box-shadow: none!important;
+  color: currentColor;
   cursor: inherit;
   display: block;
   font-family: inherit;

--- a/packages/components/src/select-control/styles/select-control-styles.ts
+++ b/packages/components/src/select-control/styles/select-control-styles.ts
@@ -158,6 +158,7 @@ export const Select = styled.select< SelectProps >`
 		box-sizing: border-box;
 		border: none;
 		box-shadow: none !important;
+		color: currentColor; // Overrides hover/focus styles in forms.css
 		cursor: inherit;
 		display: block;
 		font-family: inherit;


### PR DESCRIPTION
Reported in https://github.com/WordPress/gutenberg/pull/63815#discussion_r1687821184

## What?

Ensures that the focus/hover color styles in the `forms.css` (loaded globally in wp-admin) do not override the intended styles for SelectControl.

## Testing Instructions

In Storybook, use the global CSS injector tool in the toolbar to load the wp-admin styles. For both SelectControl variants (default and minimal), check that the hover/focus styles are as intended.

<img src="https://github.com/user-attachments/assets/b967c3fd-8cd1-484b-a1b2-2a88b8f2b0e4" alt="CSS injector tool" width="255">

## Screenshots or screencast <!-- if applicable -->

## Before

<img src="https://github.com/user-attachments/assets/74a906bc-2239-4972-a575-1c83f7e9d098" alt="Fixed hover styles in SelectControl" width="279">