### PR TITLE
Core Data: Add new useEntityRecordsWithPermissions hook

### DIFF
--- a/packages/core-data/src/footnotes/get-rich-text-values-cached.js
+++ b/packages/core-data/src/footnotes/get-rich-text-values-cached.js
@@ -6,7 +6,7 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 /**
  * Internal dependencies
  */
-import { unlock } from '../private-apis';
+import { unlock } from '../lock-unlock';
 
 // TODO: The following line should have been:
 //

--- a/packages/core-data/src/hooks/use-entity-records.ts
+++ b/packages/core-data/src/hooks/use-entity-records.ts
@@ -13,6 +13,7 @@ import useQuerySelect from './use-query-select';
 import { store as coreStore } from '../';
 import type { Options } from './use-entity-record';
 import type { Status } from './constants';
+import { unlock } from '../lock-unlock';
 
 interface EntityRecordsResolution< RecordType > {
 	/** The requested entity record */
@@ -179,22 +180,12 @@ export function useEntityRecordsWithPermissions< RecordType >(
 		[ data, entityConfig?.key ]
 	);
 
-	// Todo: this selector is not memoized properly.
 	const permissions = useSelect(
 		( select ) => {
-			const { canUser } = select( coreStore );
-			return ids.map( ( id ) => ( {
-				delete: canUser( 'delete', {
-					kind,
-					name,
-					id,
-				} ),
-				update: canUser( 'update', {
-					kind,
-					name,
-					id,
-				} ),
-			} ) );
+			const { getEntityRecordsPermissions } = unlock(
+				select( coreStore )
+			);
+			return getEntityRecordsPermissions( kind, name, ids );
 		},
 		[ ids, kind, name ]
 	);

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -18,7 +18,7 @@ import {
 	getMethodName,
 } from './entities';
 import { STORE_NAME } from './name';
-import { unlock } from './private-apis';
+import { unlock } from './lock-unlock';
 
 // The entity selectors/resolvers and actions are shortcuts to their generic equivalents
 // (getEntityRecord, getEntityRecords, updateEntityRecord, updateEntityRecords)

--- a/packages/core-data/src/index.js
+++ b/packages/core-data/src/index.js
@@ -86,3 +86,4 @@ export * from './entity-provider';
 export * from './entity-types';
 export * from './fetch';
 export * from './hooks';
+export * from './private-apis';

--- a/packages/core-data/src/lock-unlock.js
+++ b/packages/core-data/src/lock-unlock.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+
+export const { lock, unlock } =
+	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
+		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
+		'@wordpress/core-data'
+	);

--- a/packages/core-data/src/private-apis.js
+++ b/packages/core-data/src/private-apis.js
@@ -1,10 +1,10 @@
 /**
- * WordPress dependencies
+ * Internal dependencies
  */
-import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
+import { useEntityRecordsWithPermissions } from './hooks/use-entity-records';
+import { lock } from './lock-unlock';
 
-export const { lock, unlock } =
-	__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/core-data'
-	);
+export const privateApis = {};
+lock( privateApis, {
+	useEntityRecordsWithPermissions,
+} );

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -6,6 +6,7 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
 /**
  * Internal dependencies
  */
+import { canUser } from './selectors';
 import type { State } from './selectors';
 import { STORE_NAME } from './name';
 
@@ -49,4 +50,25 @@ export const getBlockPatternsForPostType = createRegistrySelector(
 					),
 			() => [ select( STORE_NAME ).getBlockPatterns() ]
 		)
+);
+
+/**
+ * Returns the entity records permissions for the given entity record ids.
+ */
+export const getEntityRecordsPermissions = createSelector(
+	( state: State, kind: string, name: string, ids: string[] ) => {
+		return ids.map( ( id ) => ( {
+			delete: canUser( state, 'delete', {
+				kind,
+				name,
+				id,
+			} ),
+			update: canUser( state, 'update', {
+				kind,
+				name,
+				id,
+			} ),
+		} ) );
+	},
+	( state ) => [ state.userPermissions ]
 );

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -6,7 +6,6 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { canUser } from './selectors';
 import type { State } from './selectors';
 import { STORE_NAME } from './name';
 
@@ -55,20 +54,22 @@ export const getBlockPatternsForPostType = createRegistrySelector(
 /**
  * Returns the entity records permissions for the given entity record ids.
  */
-export const getEntityRecordsPermissions = createSelector(
-	( state: State, kind: string, name: string, ids: string[] ) => {
-		return ids.map( ( id ) => ( {
-			delete: canUser( state, 'delete', {
-				kind,
-				name,
-				id,
-			} ),
-			update: canUser( state, 'update', {
-				kind,
-				name,
-				id,
-			} ),
-		} ) );
-	},
-	( state ) => [ state.userPermissions ]
+export const getEntityRecordsPermissions = createRegistrySelector( ( select ) =>
+	createSelector(
+		( state: State, kind: string, name: string, ids: string[] ) => {
+			return ids.map( ( id ) => ( {
+				delete: select( STORE_NAME ).canUser( 'delete', {
+					kind,
+					name,
+					id,
+				} ),
+				update: select( STORE_NAME ).canUser( 'update', {
+					kind,
+					name,
+					id,
+				} ),
+			} ) );
+		},
+		( state ) => [ state.userPermissions ]
+	)
 );

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import {
+	store as coreStore,
+	privateApis as coreDataPrivateApis,
+} from '@wordpress/core-data';
 import { useState, useMemo, useCallback, useEffect } from '@wordpress/element';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -33,6 +36,7 @@ import usePostFields from '../post-fields';
 
 const { usePostActions } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
+const { useEntityRecordsWithPermissions } = unlock( coreDataPrivateApis );
 const EMPTY_ARRAY = [];
 
 function useView( postType ) {
@@ -199,7 +203,7 @@ export default function PostList( { postType } ) {
 		isResolving: isLoadingMainEntities,
 		totalItems,
 		totalPages,
-	} = useEntityRecords( 'postType', postType, queryArgs );
+	} = useEntityRecordsWithPermissions( 'postType', postType, queryArgs );
 
 	const ids = records?.map( ( record ) => getItemId( record ) ) ?? [];
 	const prevIds = usePrevious( ids ) ?? [];


### PR DESCRIPTION
Related #55083 

## What?

In different dataviews, we need a way to check whether the user has the right permissions to edit or delete a given item, we've tried an approach by dynamically updating the "action" object's is Eligible but that was bad for several reasons:

 - Unclear how to retrigger a re-render when the permission resolves.
 - Unable to register actions globally.
 - Data and permissions not loaded at the same moment.

As discussed in slack, the right approach might be to embed the permissions within the "data". https://wordpress.slack.com/archives/C02QB2JS7/p1721732016850379

The current PR adds a new `useEntityRecordsWithPermissions` to `core-data` to be able to do that in an easy way. I'm not updating the actions yet, so in reality the current PR has no impact but it's the first step towards achieving that goal.

## Testing Instructions

Nothing to test really at the moment.