### PR TITLE
Block Variations: Have `getActiveBlockVariation` fall back to default variation

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -162,7 +162,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 				return {
 					activeBlockVariation: getActiveBlockVariation(
 						name,
-						getBlockAttributes( blockClientId )
+						getBlockAttributes( blockClientId ),
+						'transform'
 					),
 					variations: name && getBlockVariations( name, 'transform' ),
 					isContentOnly:

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -298,8 +298,9 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 
 	// If no variation matches the isActive condition, we return the default variation,
 	// but only if it doesn't have an isActive condition that wasn't matched.
-	// This fallback is only applied for 'block' scope to avoid affecting block name display.
-	if ( ! match && scope === 'block' ) {
+	// This fallback is only applied for the 'block' and 'transform' scopes but not to
+	// the 'inserter', to avoid affecting block name display there.
+	if ( ! match && [ 'block', 'transform' ].includes( scope ) ) {
 		match = variations.find(
 			( variation ) =>
 				variation?.isDefault && ! Object.hasOwn( variation, 'isActive' )

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -298,7 +298,8 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 
 	// If no variation matches the isActive condition, we return the default variation,
 	// but only if it doesn't have an isActive condition that wasn't matched.
-	if ( ! match ) {
+	// This fallback is only applied for 'block' scope to avoid affecting block name display.
+	if ( ! match && scope === 'block' ) {
 		match = variations.find(
 			( variation ) =>
 				variation?.isDefault && ! Object.hasOwn( variation, 'isActive' )

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -295,6 +295,11 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 			return match || variation;
 		}
 	}
+
+	// If no variation matches the isActive condition, we return the default variation.
+	if ( ! match ) {
+		match = variations.find( ( { isDefault } ) => !! isDefault );
+	}
 	return match;
 }
 

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -296,9 +296,13 @@ export function getActiveBlockVariation( state, blockName, attributes, scope ) {
 		}
 	}
 
-	// If no variation matches the isActive condition, we return the default variation.
+	// If no variation matches the isActive condition, we return the default variation,
+	// but only if it doesn't have an isActive condition that wasn't matched.
 	if ( ! match ) {
-		match = variations.find( ( { isDefault } ) => !! isDefault );
+		match = variations.find(
+			( variation ) =>
+				variation?.isDefault && ! Object.hasOwn( variation, 'isActive' )
+		);
 	}
 	return match;
 }

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -822,6 +822,85 @@ describe( 'selectors', () => {
 					} )
 				).toEqual( variations[ 1 ] );
 			} );
+			it( 'should fall back to default variation if no other variation matches', () => {
+				const variations = [
+					{
+						name: 'variation-1',
+						attributes: {
+							testAttribute: 1,
+						},
+						isDefault: true,
+					},
+					{
+						name: 'variation-2',
+						attributes: {
+							testAttribute: 2,
+						},
+						isActive: ( blockAttributes, variationAttributes ) => {
+							return (
+								blockAttributes.testAttribute ===
+								variationAttributes.testAttribute
+							);
+						},
+					},
+					{
+						name: 'variation-3',
+						attributes: {
+							firstTestAttribute: 3,
+						},
+						isActive: [ 'testAttribute' ],
+					},
+				];
+
+				const state =
+					createBlockVariationsStateWithTestBlockType( variations );
+
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						testAttribute: 55,
+					} )
+				).toEqual( variations[ 0 ] );
+			} );
+			it( 'should return undefined if no variation matches, including the default one', () => {
+				const variations = [
+					{
+						name: 'variation-1',
+						attributes: {
+							testAttribute: 1,
+						},
+						isDefault: true,
+						isActive: [ 'testAttribute' ],
+					},
+					{
+						name: 'variation-2',
+						attributes: {
+							testAttribute: 2,
+						},
+						isActive: ( blockAttributes, variationAttributes ) => {
+							return (
+								blockAttributes.testAttribute ===
+								variationAttributes.testAttribute
+							);
+						},
+					},
+					{
+						name: 'variation-3',
+						attributes: {
+							firstTestAttribute: 3,
+						},
+						isActive: [ 'testAttribute' ],
+					},
+				];
+
+				const state =
+					createBlockVariationsStateWithTestBlockType( variations );
+
+				expect(
+					getActiveBlockVariation( state, blockName, {
+						testAttribute: 55,
+					} )
+				).toBeUndefined();
+			} );
 		} );
 		describe( 'getDefaultBlockVariation', () => {
 			it( 'should return the default variation when set', () => {

--- a/packages/blocks/src/store/test/selectors.js
+++ b/packages/blocks/src/store/test/selectors.js
@@ -822,7 +822,7 @@ describe( 'selectors', () => {
 					} )
 				).toEqual( variations[ 1 ] );
 			} );
-			it( 'should fall back to default variation if no other variation matches', () => {
+			it( 'should fall back to default variation if no other variation matches and scope is "block"', () => {
 				const variations = [
 					{
 						name: 'variation-1',
@@ -856,9 +856,14 @@ describe( 'selectors', () => {
 					createBlockVariationsStateWithTestBlockType( variations );
 
 				expect(
-					getActiveBlockVariation( state, blockName, {
-						testAttribute: 55,
-					} )
+					getActiveBlockVariation(
+						state,
+						blockName,
+						{
+							testAttribute: 55,
+						},
+						'block'
+					)
 				).toEqual( variations[ 0 ] );
 			} );
 			it( 'should return undefined if no variation matches, including the default one', () => {
@@ -896,9 +901,14 @@ describe( 'selectors', () => {
 					createBlockVariationsStateWithTestBlockType( variations );
 
 				expect(
-					getActiveBlockVariation( state, blockName, {
-						testAttribute: 55,
-					} )
+					getActiveBlockVariation(
+						state,
+						blockName,
+						{
+							testAttribute: 55,
+						},
+						'block'
+					)
 				).toBeUndefined();
 			} );
 		} );


### PR DESCRIPTION
## What?
If a block doesn't match any of the block type's variations, return the variation that has `isDefault` set to `true` (as long as it doesn't have an `isActive` field, as that would mean that it didn't match the latter).

## Why?
See https://github.com/WordPress/gutenberg/pull/63100#issuecomment-2245358898.

## How?
Explained above :)

## Testing Instructions
Cherry-pick ecedae03d349c21d53b41aea14938420a42417ca (from https://github.com/WordPress/gutenberg/pull/63100) on top of this PR.

Then, in the editor, insert multiple Group blocks, choosing a different variation each time. Save your post and reload the editor. Verify that the block inspector reflects the correct variation for each block.

<img width="263" alt="unnamed" src="https://github.com/WordPress/gutenberg/assets/96308/ea034214-bfe3-442a-b682-99edd7ceaa57">
