### PR TITLE
Add eslint rule for unlabeled RangeControl

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -278,7 +278,6 @@ module.exports = {
 			},
 		},
 		{
-			// Temporary rules until we're ready to officially deprecate the bottom margins.
 			files: [ 'packages/*/src/**/*.[tj]s?(x)' ],
 			excludedFiles: [
 				'packages/components/src/**/@(test|stories)/**',
@@ -289,6 +288,7 @@ module.exports = {
 					'error',
 					...restrictedSyntax,
 					...restrictedSyntaxComponents,
+					// Temporary rules until we're ready to officially deprecate the bottom margins.
 					...[
 						'CheckboxControl',
 						'ComboboxControl',
@@ -301,6 +301,12 @@ module.exports = {
 						message:
 							componentName +
 							' should have the `__nextHasNoMarginBottom` prop to opt-in to the new margin-free styles.',
+					} ) ),
+					// Accessibility rules for components.
+					...[ 'RangeControl' ].map( ( componentName ) => ( {
+						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="label"]))`,
+						message:
+							'Component must be accessibly labeled with a `label` prop. Use the `hideLabelFromVision` prop if desired. Only ignore this error if the component is correctly associated with a separate `<label>` element.',
 					} ) ),
 				],
 			},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -306,7 +306,7 @@ module.exports = {
 					...[ 'RangeControl' ].map( ( componentName ) => ( {
 						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="label"]))`,
 						message:
-							'Component must be accessibly labeled with a `label` prop. Use the `hideLabelFromVision` prop if desired. Only ignore this error if the component is correctly associated with a separate `<label>` element.',
+							'Component must be accessibly labeled with a `label` prop. Use the `hideLabelFromVision` prop if desired. Only ignore this error if you chose another means of accessible labeling, and confirmed it in the rendered accessibility tree.',
 					} ) ),
 				],
 			},


### PR DESCRIPTION
🚧 Waiting on #63908 to merge

Part of #51740

## What?

Adds an eslint rule for `RangeControl` usage without a `label` prop.

## Why?

This is a quick way to prevent unintentionally unlabeled controls in the Gutenberg app. Unfortunately there are quite a few that get past code review.

Additional components to be added to this lint list should be assessed on a case-by-case basis, but in general I don't foresee too many false positives (e.g. proper usage of a separate `<label>` element).

## Testing Instructions

`npm run lint:js -- --quiet` should surface violations in RangeControl instances.

🚧 Current violations must be fixed before merging