### PR TITLE
DataViews: Action label function not execute in bulk editing menu

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -23,6 +23,7 @@ const {
 	DropdownMenuGroupV2: DropdownMenuGroup,
 	DropdownMenuItemV2: DropdownMenuItem,
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
+	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
 } = unlock( componentsPrivateApis );
 
 interface ActionWithModalProps< Item > {
@@ -123,6 +124,11 @@ function BulkActionItem< Item >( {
 
 	const shouldShowModal = 'RenderModal' in action;
 
+	const label =
+		typeof action.label === 'string'
+			? action.label
+			: action.label( eligibleItems );
+
 	return (
 		<DropdownMenuItem
 			key={ action.id }
@@ -136,7 +142,7 @@ function BulkActionItem< Item >( {
 			} }
 			suffix={ eligibleItems.length }
 		>
-			{ action.label }
+			<DropdownMenuItemLabel>{ label }</DropdownMenuItemLabel>
 		</DropdownMenuItem>
 	);
 }


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/63873

## What?
This PR fix the bulk editing menu in the dataviews the label not shows if the label is type of function.

## Testing Instructions
- Register the action with `registerEntityAction` 
- Add the `supportsBulk: true,`
- Use the label as function like `label: ( posts ) => {` and add any custom component

E.g.

```js
import { registerEntityAction } from '@wordpress/editor'
import {
        __experimentalText as Text,
        __experimentalHStack as HStack,
        Path,
        SVG
} from '@wordpress/components'

registerEntityAction('postType', 'page', {
    id: 'hello-world-id',
    supportsBulk: true,
    label: ( posts ) => {
        return (
            <HStack justify="left">
                <SVG xmlns="http://www.w3.org/2000/svg" viewBox="-2 -2 24 24" width="24" height="24" aria-hidden="true" focusable="false">
                    <Path d="M20 10c0-5.51-4.49-10-10-10C4.48 0 0 4.49 0 10c0 5.52 4.48 10 10 10 5.51 0 10-4.48 10-10zM7.78 15.37L4.37 6.22c.55-.02 1.17-.08 1.17-.08.5-.06.44-1.13-.06-1.11 0 0-1.45.11-2.37.11-.18 0-.37 0-.58-.01C4.12 2.69 6.87 1.11 10 1.11c2.33 0 4.45.87 6.05 2.34-.68-.11-1.65.39-1.65 1.58 0 .74.45 1.36.9 2.1.35.61.55 1.36.55 2.46 0 1.49-1.4 5-1.4 5l-3.03-8.37c.54-.02.82-.17.82-.17.5-.05.44-1.25-.06-1.22 0 0-1.44.12-2.38.12-.87 0-2.33-.12-2.33-.12-.5-.03-.56 1.2-.06 1.22l.92.08 1.26 3.41zM17.41 10c.24-.64.74-1.87.43-4.25.7 1.29 1.05 2.71 1.05 4.25 0 3.29-1.73 6.24-4.4 7.78.97-2.59 1.94-5.2 2.92-7.78zM6.1 18.09C3.12 16.65 1.11 13.53 1.11 10c0-1.3.23-2.48.72-3.59C3.25 10.3 4.67 14.2 6.1 18.09zm4.03-6.63l2.58 6.98c-.86.29-1.76.45-2.71.45-.79 0-1.57-.11-2.29-.33.81-2.38 1.62-4.74 2.42-7.1z" />
                </SVG>
                <Text>Hello World</Text>
            </HStack>
        )
    },
    callback(posts, context) {
        console.log('posts: ', posts)
        console.log('context: ', context)
    },
})
```

Here, Added the custom SVG icon and text.

### Problem

With above code the svg and text shows as expected in action menu list as:

![image](https://github.com/user-attachments/assets/e2d655f7-ce78-4c4f-a003-97b3f2c99912)

But, In bulk edit menu list it shows the blank label as:

![image](https://github.com/user-attachments/assets/2defb85f-a6e9-4075-8c18-1af3803e3ab1)

### Solution

If we switch to this branch then you can see the label in bulk edit menu list as:

![image](https://github.com/user-attachments/assets/64e67dd9-b391-453c-b614-8178e384eca5)
