### PR TITLE
Tweak Block Locking UI

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -217,12 +217,20 @@ export default function BlockLockModal( { clientId, onClose } ) {
 					expanded={ false }
 				>
 					<FlexItem>
-						<Button variant="tertiary" onClick={ onClose }>
+						<Button
+							variant="tertiary"
+							onClick={ onClose }
+							__next40pxDefaultSize
+						>
 							{ __( 'Cancel' ) }
 						</Button>
 					</FlexItem>
 					<FlexItem>
-						<Button variant="primary" type="submit">
+						<Button
+							variant="primary"
+							type="submit"
+							__next40pxDefaultSize
+						>
 							{ __( 'Apply' ) }
 						</Button>
 					</FlexItem>

--- a/packages/block-editor/src/components/block-lock/style.scss
+++ b/packages/block-editor/src/components/block-lock/style.scss
@@ -8,13 +8,9 @@
 	}
 }
 
-.block-editor-block-lock-modal__options {
-	margin-top: $grid-unit-20;
-
-	legend {
-		margin-bottom: $grid-unit-20;
-		padding: 0;
-	}
+.block-editor-block-lock-modal__options legend {
+	margin-bottom: $grid-unit-20;
+	padding: 0;
 }
 
 .block-editor-block-lock-modal__checklist {
@@ -52,7 +48,7 @@
 .block-editor-block-lock-modal__template-lock {
 	border-top: $border-width solid $gray-300;
 	margin-top: $grid-unit-20;
-	padding: $grid-unit-15 0;
+	padding-top: $grid-unit-20;
 }
 
 .block-editor-block-lock-modal__actions {


### PR DESCRIPTION
## What?

This PR adjusts the button size and spacing in the Block Locking Modal.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4eef89bc-5fab-4b00-a335-05379e0a63da) | ![after](https://github.com/user-attachments/assets/057be486-d844-41dd-a963-99fae1fa2542) |

Change the `12px` top and bottom padding applied to the toggle to `16px` top padding.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/3ad48447-1d03-4338-859f-c2ce4ae5d072) | ![after_padding](https://github.com/user-attachments/assets/2d099c2a-6b47-4f20-9170-d69ecd38fc15) |


## Why?

For design consistency.

## Testing Instructions

Open the Block Locking Modal and check the button size and the spacing above and below the toggle.
