### PR TITLE
Fix Custom Select describedBy

### DIFF
--- a/packages/components/src/custom-select-control-v2/custom-select.tsx
+++ b/packages/components/src/custom-select-control-v2/custom-select.tsx
@@ -8,6 +8,7 @@ import * as Ariakit from '@ariakit/react';
  */
 import { createContext, useCallback, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -95,6 +96,7 @@ function _CustomSelect(
 		store,
 		className,
 		isLegacy = false,
+		describedBy,
 		...restProps
 	} = props;
 
@@ -109,6 +111,8 @@ function _CustomSelect(
 		);
 
 	const contextValue = useMemo( () => ( { store, size } ), [ store, size ] );
+	const instanceId = useInstanceId( _CustomSelect );
+	const describedByID = `custom-select-described-by-${ instanceId }`;
 
 	return (
 		// Where should `restProps` be forwarded to?
@@ -138,7 +142,13 @@ function _CustomSelect(
 					store={ store }
 					// Match legacy behavior (move selection rather than open the popover)
 					showOnKeyDown={ ! isLegacy }
+					aria-describedby={ describedBy ? describedByID : undefined }
 				/>
+				{ describedBy && (
+					<div id={ describedByID } hidden>
+						{ describedBy }
+					</div>
+				) }
 				<Styled.SelectPopover
 					gutter={ 12 }
 					store={ store }

--- a/packages/components/src/custom-select-control-v2/types.ts
+++ b/packages/components/src/custom-select-control-v2/types.ts
@@ -77,6 +77,10 @@ export type _CustomSelectProps = CustomSelectButtonProps & {
 	 * Accessible label for the control.
 	 */
 	label: string;
+	/**
+	 * Described by.
+	 */
+	describedBy?: string;
 };
 
 export type CustomSelectProps = _CustomSelectProps & CustomSelectSize;

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -154,7 +154,6 @@ function CustomSelectControl( props: CustomSelectProps ) {
 
 	return (
 		<_CustomSelect
-			aria-describedby={ describedBy }
 			renderSelectedValue={
 				showSelectedHint ? renderSelectedValueHint : undefined
 			}
@@ -166,6 +165,7 @@ function CustomSelectControl( props: CustomSelectProps ) {
 				classNameProp
 			) }
 			isLegacy
+			describedBy={ describedBy }
 			{ ...restProps }
 		>
 			{ children }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix describedBy implementation of CustomSelectControl.
Fixes https://github.com/WordPress/gutenberg/issues/63568

## Why?
To Correct the implementation of aria-describedby of CustomSelectControl for Accessibility.

## How?
Added a div element that contains the describedBy description and give unique ID to this, this unique ID is then added to `aria-describedby` to reference the div.

## Testing Instructions
Select a Group block
Go to the block Inspector > Styles, and activate the Appearance settings in the Typography options.
Set a font appearance value e.g. 'Medium',
Inspect the CustomSelectControl toggle button source.

### Testing Instructions for Keyboard

## Screenshots or screencast <!-- if applicable -->
<img width="1469" alt="aria-describedby" src="https://github.com/user-attachments/assets/09cacabe-dffb-4166-b6d5-e1d0d6944260">

