### PR TITLE
Image: Make Placeholder white when there is a <Spinner /> on top

### DIFF
--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -162,22 +162,6 @@
 	}
 }
 
-@mixin placeholder-style() {
-	border-radius: $radius-block-ui;
-
-	&::before {
-		content: "";
-		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
-		pointer-events: none;
-		background: currentColor;
-		opacity: 0.1;
-	}
-}
-
 /**
  * Allows users to opt-out of animations via OS-level preferences.
  */

--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -52,7 +52,7 @@
 			left: 0;
 			pointer-events: none;
 			border: $border-width dashed currentColor;
-			@include placeholder-style();
+			border-radius: $radius-block-ui;
 		}
 
 		.block-editor-inserter {

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -43,7 +43,7 @@
 		pointer-events: none;
 		min-height: $grid-unit-60 - $border-width - $border-width;
 		border: $border-width dashed currentColor;
-		@include placeholder-style();
+		border-radius: $radius-block-ui;
 	}
 
 	// Let the parent be selectable in the placeholder area.

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -80,6 +80,11 @@ figure.wp-block-image:not(.wp-block) {
 		background: $white;
 		opacity: 0.8;
 	}
+
+	// Reduce opacity of diagonal stroke so that it doesn't obscure the spinner.
+	.components-placeholder__illustration {
+		opacity: 0.1;
+	}
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -74,6 +74,12 @@ figure.wp-block-image:not(.wp-block) {
 // Shown while image is being uploded but cannot be previewed.
 .wp-block-image__placeholder {
 	aspect-ratio: 4 / 3;
+
+	// Make placeholder background white so that you can see the spinner on top of it.
+	&.has-illustration::before {
+		background: $white;
+		opacity: 0.8;
+	}
 }
 
 // This is necessary for the editor resize handles to accurately work on a non-floated, non-resized, small image.

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -67,6 +67,8 @@ figure.wp-block-image:not(.wp-block) {
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%);
+		margin: 0;
+		z-index: 2;
 	}
 }
 

--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -68,7 +68,6 @@ figure.wp-block-image:not(.wp-block) {
 		left: 50%;
 		transform: translate(-50%, -50%);
 		margin: 0;
-		z-index: 2;
 	}
 }
 

--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -287,7 +287,6 @@ $color-control-label-height: 20px;
 		left: 0;
 		pointer-events: none;
 		border: $border-width dashed currentColor;
-		@include placeholder-style();
 
 		// Inherit border radius from style variations.
 		border-radius: inherit;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,7 +23,6 @@
 -   `CheckboxControl`: Slightly reduced footprint. Make label treatment, focus styles, and spacing consistent with `ToggleControl` and `RadioControl`. ([#63490](https://github.com/WordPress/gutenberg/pull/63490)).
 -   `RadioControl`: Slightly reduced footprint. Make label treatment, focus styles, and spacing consistent with `ToggleControl` and `CheckboxControl`. ([#63490](https://github.com/WordPress/gutenberg/pull/63490)).
 -   `FormToggle`: Update spacing and appearance to adhere to 4px baseline, slightly reducing footprint. Make label treatment and focus styles consistent with `RadioControl` and `CheckboxControl`. ([#63490](https://github.com/WordPress/gutenberg/pull/63490)).
--   `Placeholder`: New styling when using `hasIllustration` prop ([#63885](https://github.com/WordPress/gutenberg/pull/63885)).
 
 ### Internal
 
@@ -34,6 +33,7 @@
 -   `Tabs`: Vertical Tabs should be 40px min height. ([#63446](https://github.com/WordPress/gutenberg/pull/63446)).
 -   `ColorPicker`: Use `minimal` variant for `SelectControl` ([#63676](https://github.com/WordPress/gutenberg/pull/63676)).
 -   `Tabs`: keep full opacity of focus ring and remove hover styles on disabled tabs ([#63754](https://github.com/WordPress/gutenberg/pull/63754)).
+-   `Placeholder`: Remove unnecssary `placeholder-style` Sass mixin ([#63885](https://github.com/WordPress/gutenberg/pull/63885)).
 
 ### Documentation
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   `CheckboxControl`: Slightly reduced footprint. Make label treatment, focus styles, and spacing consistent with `ToggleControl` and `RadioControl`. ([#63490](https://github.com/WordPress/gutenberg/pull/63490)).
 -   `RadioControl`: Slightly reduced footprint. Make label treatment, focus styles, and spacing consistent with `ToggleControl` and `CheckboxControl`. ([#63490](https://github.com/WordPress/gutenberg/pull/63490)).
 -   `FormToggle`: Update spacing and appearance to adhere to 4px baseline, slightly reducing footprint. Make label treatment and focus styles consistent with `RadioControl` and `CheckboxControl`. ([#63490](https://github.com/WordPress/gutenberg/pull/63490)).
+-   `Placeholder`: New styling when using `hasIllustration` prop ([#63885](https://github.com/WordPress/gutenberg/pull/63885)).
 
 ### Internal
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -191,7 +191,8 @@
 		bottom: 0;
 		left: 0;
 		pointer-events: none;
-		background: rgba($white, 0.8);
+		background: currentColor;
+		opacity: 0.1;
 	}
 
 	overflow: hidden;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -191,8 +191,9 @@
 		bottom: 0;
 		left: 0;
 		pointer-events: none;
-		background: $gray-900;
-		opacity: 0.7;
+		background: rgba($white, 0.8);
+		z-index: 1;
+		backdrop-filter: blur(4px);
 	}
 
 	overflow: hidden;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -192,7 +192,6 @@
 		left: 0;
 		pointer-events: none;
 		background: rgba($white, 0.8);
-		z-index: 1;
 		backdrop-filter: blur(4px);
 	}
 

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -192,7 +192,6 @@
 		left: 0;
 		pointer-events: none;
 		background: rgba($white, 0.8);
-		backdrop-filter: blur(4px);
 	}
 
 	overflow: hidden;

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -183,8 +183,17 @@
 		}
 	}
 
-	// By painting the borders here, we enable them to be replaced by the Border control.
-	@include placeholder-style();
+	&::before {
+		content: "";
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		pointer-events: none;
+		background: $gray-900;
+		opacity: 0.7;
+	}
 
 	overflow: hidden;
 	.is-selected & {


### PR DESCRIPTION
## What?
Updates the design of the `Placeholder` component when passed the `hasIllustration` flag.

## Why?
Moving to a darker design based on the UI colour so that you can more easily see any `Spinner` placed on top. See https://github.com/WordPress/gutenberg/pull/63643#discussion_r1684103899.

## How?
I did what @jameskoster suggested in https://github.com/WordPress/gutenberg/pull/63643#discussion_r1684103899 😀

I also removed the `placeholder-style` mixin because it isn't really doing anything in most of the places it's used. The mixin adds `&::before` styling and we're often including it into a `&::before` or `&::after` which means there is no effect.

As far as I can tell this styling is only used in `<Placeholder hasIllustration>` which is the media blocks when not selected or when uploading.

## Testing Instructions
If you make these changes locally you can force the `Spinner` to always appear:

```diff
diff --git a/packages/block-library/src/image/image.js b/packages/block-library/src/image/image.js
index 385a740e652..3417b1fc1a8 100644
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -827,7 +827,7 @@ export default function Image( {
 	const isRounded = attributes.className?.includes( 'is-style-rounded' );
 
 	let img =
-		temporaryURL && hasImageErrored ? (
+		true || ( temporaryURL && hasImageErrored ) ? (
 			// Show a placeholder during upload when the blob URL can't be loaded. This can
 			// happen when the user uploads a HEIC image in a browser that doesn't support them.
 			<Placeholder
```

Then:

1. Add an image block.
2. De-select it. You'll see the placeholder there.
3. Upload an image into the image block.
4. You'll see the placeholder there with a `Spinner` on top.

## Screenshots or screencast 

| Before | After |
|--------|--------|
| <img width="1481" alt="Screenshot 2024-07-24 at 15 06 02" src="https://github.com/user-attachments/assets/019b5a32-2624-4d96-84fe-224970108dae"> | <img width="1481" alt="Screenshot 2024-07-24 at 15 04 42" src="https://github.com/user-attachments/assets/f1678dbd-6898-4f67-bef7-768bd80cb3b2"> |