### PR TITLE
Global Styles: Move background panel under color panel

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -264,6 +264,16 @@ function ScreenBlock( { name, variation } ) {
 					settings={ settings }
 				/>
 			) }
+			{ hasBackgroundPanel && (
+				<StylesBackgroundPanel
+					inheritedValue={ inheritedStyle }
+					value={ style }
+					onChange={ setStyle }
+					settings={ settings }
+					defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
+					themeFileURIs={ _links?.[ 'wp:theme-file' ] }
+				/>
+			) }
 			{ hasTypographyPanel && (
 				<StylesTypographyPanel
 					inheritedValue={ inheritedStyle }
@@ -303,17 +313,6 @@ function ScreenBlock( { name, variation } ) {
 					onChange={ onChangeLightbox }
 					value={ userSettings }
 					inheritedValue={ settings }
-				/>
-			) }
-
-			{ hasBackgroundPanel && (
-				<StylesBackgroundPanel
-					inheritedValue={ inheritedStyle }
-					value={ style }
-					onChange={ setStyle }
-					settings={ settings }
-					defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
-					themeFileURIs={ _links?.[ 'wp:theme-file' ] }
 				/>
 			) }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Moves the background panel to beneath the color panel matching the location decided upon for the block inspector in https://github.com/WordPress/gutenberg/pull/63551.

## Why?

- Consistency
- The background panel is somewhat related in purpose to the background in the color panel

## How?

- Move the background panel under the color panel.
- The background panel will still only display if a block supports background images and the UI control is enabled in theme.json.

## Testing Instructions

1. Open the site editor
2. Navigate to Styles > Blocks > Paragraph
3. Confirm there is no background image panel shown
4. Select a Pullquote or Verse block
5. Confirm the background image panel appears below the color panel

## Screenshots or screencast <!-- if applicable -->

| Paragraph | Verse | Pullquote |
|---|---|---|
| <img width="272" alt="Screenshot 2024-07-24 at 3 43 55 PM" src="https://github.com/user-attachments/assets/e8741602-fbe1-4e83-837a-4dffb6bc759e"> | <img width="279" alt="Screenshot 2024-07-24 at 3 43 08 PM" src="https://github.com/user-attachments/assets/12ca5e74-cc7c-4e26-beb1-4eeb759fff2f"> | <img width="275" alt="Screenshot 2024-07-24 at 3 43 35 PM" src="https://github.com/user-attachments/assets/fbfa61c1-f9fb-4e02-a301-5841259b96b8"> |

