### PR TITLE
Pages: update `useView` logic

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -44,13 +44,12 @@ function useView( postType ) {
 		params: { activeView = 'all', isCustom = 'false', layout },
 	} = useLocation();
 	const history = useHistory();
-	const DEFAULT_VIEWS = useDefaultViews( { postType } );
+
+	const defaultViews = useDefaultViews( { postType } );
 	const selectedDefaultView = useMemo( () => {
 		const defaultView =
 			isCustom === 'false' &&
-			DEFAULT_VIEWS[ postType ].find(
-				( { slug } ) => slug === activeView
-			)?.view;
+			defaultViews.find( ( { slug } ) => slug === activeView )?.view;
 		if ( isCustom === 'false' && layout ) {
 			return {
 				...defaultView,
@@ -59,7 +58,7 @@ function useView( postType ) {
 			};
 		}
 		return defaultView;
-	}, [ isCustom, activeView, layout, postType, DEFAULT_VIEWS ] );
+	}, [ isCustom, activeView, layout, defaultViews ] );
 	const [ view, setView ] = useState( selectedDefaultView );
 
 	useEffect( () => {
@@ -131,8 +130,9 @@ function useView( postType ) {
 	} else if ( isCustom === 'true' && customView ) {
 		return [ customView, setCustomView ];
 	}
-	// Loading state where no the view was not found on custom views or default views.
-	return [ DEFAULT_VIEWS[ postType ][ 0 ].view, setDefaultViewAndUpdateUrl ];
+
+	// No view was found.
+	return [ defaultViews[ 0 ].view, setDefaultViewAndUpdateUrl ];
 }
 
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -26,7 +26,6 @@ import {
 	OPERATOR_IS_ANY,
 	OPERATOR_IS_NONE,
 	LAYOUT_LIST,
-	LAYOUT_TABLE,
 } from '../../utils/constants';
 
 import AddNewPostModal from '../add-new-post';
@@ -97,13 +96,13 @@ function useView( postType ) {
 		if ( isCustom === 'true' ) {
 			return (
 				getCustomView( editedEntityRecord ) ?? {
-					type: layout ?? LAYOUT_TABLE,
+					type: layout ?? LAYOUT_LIST,
 				}
 			);
 		}
 		return (
 			getDefaultView( defaultViews, activeView ) ?? {
-				type: layout ?? LAYOUT_TABLE,
+				type: layout ?? LAYOUT_LIST,
 			}
 		);
 	} );
@@ -132,13 +131,16 @@ function useView( postType ) {
 				);
 			}
 		},
-		[ history, isCustom, editedEntityRecord?.id ]
+		[ history, isCustom, editEntityRecord, editedEntityRecord?.id ]
 	);
 
 	// When layout URL param changes, update the view type
 	// without affecting any other config.
 	useEffect( () => {
-		setView( ( prevView ) => ( { ...prevView, type: layout } ) );
+		setView( ( prevView ) => ( {
+			...prevView,
+			type: layout ?? LAYOUT_LIST,
+		} ) );
 	}, [ layout ] );
 
 	// When activeView or isCustom URL parameters change,
@@ -156,7 +158,7 @@ function useView( postType ) {
 		}
 	}, [ activeView, isCustom, defaultViews, editedEntityRecord ] );
 
-	return [ view, setViewWithUrlUpdate ];
+	return [ view, setViewWithUrlUpdate, setViewWithUrlUpdate ];
 }
 
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -111,7 +111,10 @@ function useView( postType ) {
 		( newView ) => {
 			const { params } = history.getLocationWithParams();
 
-			if ( newView.type !== params?.layout ) {
+			if ( newView.type === LAYOUT_LIST && ! params?.layout ) {
+				// Skip updating the layout URL param if
+				// it is not present and the newView.type is LAYOUT_LIST.
+			} else if ( newView.type !== params?.layout ) {
 				history.push( {
 					...params,
 					layout: newView.type,

--- a/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/add-new-view.js
@@ -29,7 +29,7 @@ function AddNewItemModalContent( { type, setIsAdding } ) {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const [ title, setTitle ] = useState( '' );
 	const [ isSaving, setIsSaving ] = useState( false );
-	const DEFAULT_VIEWS = useDefaultViews( { postType: type } );
+	const defaultViews = useDefaultViews( { postType: type } );
 	return (
 		<form
 			onSubmit={ async ( event ) => {
@@ -61,9 +61,7 @@ function AddNewItemModalContent( { type, setIsAdding } ) {
 						title,
 						status: 'publish',
 						wp_dataviews_type: dataViewTaxonomyId,
-						content: JSON.stringify(
-							DEFAULT_VIEWS[ type ][ 0 ].view
-						),
+						content: JSON.stringify( defaultViews[ 0 ].view ),
 					}
 				);
 				const {

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -77,105 +77,103 @@ export function useDefaultViews( { postType } ) {
 		[ postType ]
 	);
 	return useMemo( () => {
-		return {
-			[ postType ]: [
-				{
-					title: labels?.all_items || __( 'All items' ),
-					slug: 'all',
-					icon: pages,
-					view: DEFAULT_POST_BASE,
+		return [
+			{
+				title: labels?.all_items || __( 'All items' ),
+				slug: 'all',
+				icon: pages,
+				view: DEFAULT_POST_BASE,
+			},
+			{
+				title: __( 'Published' ),
+				slug: 'published',
+				icon: published,
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'publish',
+						},
+					],
 				},
-				{
-					title: __( 'Published' ),
-					slug: 'published',
-					icon: published,
-					view: {
-						...DEFAULT_POST_BASE,
-						filters: [
-							{
-								field: 'status',
-								operator: OPERATOR_IS_ANY,
-								value: 'publish',
-							},
-						],
-					},
+			},
+			{
+				title: __( 'Scheduled' ),
+				slug: 'future',
+				icon: scheduled,
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'future',
+						},
+					],
 				},
-				{
-					title: __( 'Scheduled' ),
-					slug: 'future',
-					icon: scheduled,
-					view: {
-						...DEFAULT_POST_BASE,
-						filters: [
-							{
-								field: 'status',
-								operator: OPERATOR_IS_ANY,
-								value: 'future',
-							},
-						],
-					},
+			},
+			{
+				title: __( 'Drafts' ),
+				slug: 'drafts',
+				icon: drafts,
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'draft',
+						},
+					],
 				},
-				{
-					title: __( 'Drafts' ),
-					slug: 'drafts',
-					icon: drafts,
-					view: {
-						...DEFAULT_POST_BASE,
-						filters: [
-							{
-								field: 'status',
-								operator: OPERATOR_IS_ANY,
-								value: 'draft',
-							},
-						],
-					},
+			},
+			{
+				title: __( 'Pending' ),
+				slug: 'pending',
+				icon: pending,
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'pending',
+						},
+					],
 				},
-				{
-					title: __( 'Pending' ),
-					slug: 'pending',
-					icon: pending,
-					view: {
-						...DEFAULT_POST_BASE,
-						filters: [
-							{
-								field: 'status',
-								operator: OPERATOR_IS_ANY,
-								value: 'pending',
-							},
-						],
-					},
+			},
+			{
+				title: __( 'Private' ),
+				slug: 'private',
+				icon: notAllowed,
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'private',
+						},
+					],
 				},
-				{
-					title: __( 'Private' ),
-					slug: 'private',
-					icon: notAllowed,
-					view: {
-						...DEFAULT_POST_BASE,
-						filters: [
-							{
-								field: 'status',
-								operator: OPERATOR_IS_ANY,
-								value: 'private',
-							},
-						],
-					},
+			},
+			{
+				title: __( 'Trash' ),
+				slug: 'trash',
+				icon: trash,
+				view: {
+					...DEFAULT_POST_BASE,
+					filters: [
+						{
+							field: 'status',
+							operator: OPERATOR_IS_ANY,
+							value: 'trash',
+						},
+					],
 				},
-				{
-					title: __( 'Trash' ),
-					slug: 'trash',
-					icon: trash,
-					view: {
-						...DEFAULT_POST_BASE,
-						filters: [
-							{
-								field: 'status',
-								operator: OPERATOR_IS_ANY,
-								value: 'trash',
-							},
-						],
-					},
-				},
-			],
-		};
-	}, [ labels, postType ] );
+			},
+		];
+	}, [ labels ] );
 }

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -54,7 +54,7 @@ export const defaultLayouts = {
 	},
 };
 
-const DEFAULT_POST_BASE = {
+export const DEFAULT_POST_BASE = {
 	type: LAYOUT_LIST,
 	search: '',
 	filters: [],
@@ -165,6 +165,8 @@ export function useDefaultViews( { postType } ) {
 				icon: trash,
 				view: {
 					...DEFAULT_POST_BASE,
+					type: LAYOUT_TABLE,
+					layout: defaultLayouts[ LAYOUT_TABLE ].layout,
 					filters: [
 						{
 							field: 'status',

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -54,7 +54,7 @@ export const defaultLayouts = {
 	},
 };
 
-export const DEFAULT_POST_BASE = {
+const DEFAULT_POST_BASE = {
 	type: LAYOUT_LIST,
 	search: '',
 	filters: [],

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -52,7 +52,7 @@ export default function DataViewsSidebarContent() {
 		params: { postType, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
 	useSwitchToTableOnTrash();
-	const DEFAULT_VIEWS = useDefaultViews( { postType } );
+	const defaultViews = useDefaultViews( { postType } );
 	if ( ! postType ) {
 		return null;
 	}
@@ -61,7 +61,7 @@ export default function DataViewsSidebarContent() {
 	return (
 		<>
 			<ItemGroup>
-				{ DEFAULT_VIEWS[ postType ].map( ( dataview ) => {
+				{ defaultViews.map( ( dataview ) => {
 					return (
 						<DataViewItem
 							key={ dataview.slug }

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -3,8 +3,6 @@
  */
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useRef, useEffect } from '@wordpress/element';
-import { usePrevious } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -14,44 +12,12 @@ import { unlock } from '../../lock-unlock';
 import DataViewItem from './dataview-item';
 import CustomDataViewsList from './custom-dataviews-list';
 
-const { useLocation, useHistory } = unlock( routerPrivateApis );
-
-/**
- * Hook to switch to table layout when switching to the trash view.
- * When going out of the trash view, it switches back to the previous layout if
- * there was an automatic switch to table layout.
- */
-function useSwitchToTableOnTrash() {
-	const {
-		params: { activeView, layout, ...restParams },
-	} = useLocation();
-	const history = useHistory();
-	const viewToSwitchOutOfTrash = useRef( undefined );
-	const previousActiveView = usePrevious( activeView );
-	useEffect( () => {
-		if ( activeView === 'trash' && previousActiveView !== 'trash' ) {
-			viewToSwitchOutOfTrash.current = layout || 'list';
-			history.push( { ...restParams, layout: 'table', activeView } );
-		} else if (
-			previousActiveView === 'trash' &&
-			activeView !== 'trash' &&
-			viewToSwitchOutOfTrash.current
-		) {
-			history.push( {
-				...restParams,
-				layout: viewToSwitchOutOfTrash.current,
-				activeView,
-			} );
-			viewToSwitchOutOfTrash.current = undefined;
-		}
-	}, [ previousActiveView, activeView, layout, history, restParams ] );
-}
+const { useLocation } = unlock( routerPrivateApis );
 
 export default function DataViewsSidebarContent() {
 	const {
 		params: { postType, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
-	useSwitchToTableOnTrash();
 	const defaultViews = useDefaultViews( { postType } );
 	if ( ! postType ) {
 		return null;

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -438,9 +438,7 @@ test.describe( 'Site Editor Performance', () => {
 				await Promise.all(
 					Array.from( { length: perPage }, async ( el, index ) => {
 						return await page
-							.getByRole( 'link', {
-								name: `Page (${ index })`,
-							} )
+							.getByLabel( `Page (${ index })` )
 							.waitFor( { state: 'attached' } );
 					} )
 				);


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/63854
Raised at https://github.com/WordPress/gutenberg/pull/63203#issuecomment-2244993764

## What?

This PR updates the `useView` hook to do the following:

- Changing layout doesn't reset any other view config.

https://github.com/user-attachments/assets/e086185f-f803-41b8-9058-fc321d93228f

- Selecting a different default or custom view resets everything, including layout choices.

https://github.com/user-attachments/assets/a5b4c23e-949e-4ba6-b718-6dae26879547

- Loading a custom view displays it with the proper layout. In trunk, it displays `list`, no matter the custom view layout.

https://github.com/user-attachments/assets/4525745e-7775-4c7b-afc7-ae2927c59931

- Loading a unknown activeView, loads an empty DataView (in trunk, the site editor doesn't load). `http://localhost:8888/wp-admin/site-editor.php?postType=page&activeView=wrong-key`

https://github.com/user-attachments/assets/44625f6c-0812-4938-9395-8557e5989d61


## Testing Instructions

Verify those work as expected and test default/custom views in general.