### PR TITLE
Font Library: Remove unused font library experiment

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -32,8 +32,7 @@ function ScreenTypography() {
 			/>
 			<div className="edit-site-global-styles-screen">
 				<VStack spacing={ 7 }>
-					{ ! window.__experimentalDisableFontLibrary &&
-						fontLibraryEnabled && <FontFamilies /> }
+					{ fontLibraryEnabled && <FontFamilies /> }
 					<TypographyElements />
 					<TypographyVariations title={ __( 'Presets' ) } />
 					<FontSizesCount />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This experiment has been removed so this check isn't needed anymore.

## Why?
Clean code is easier to maintain.

## How?
Removing dead code.

## Testing Instructions
1. Open the Site Editor > Global Styles > Typography
2. Check that you can still see the font library

## Screenshots or screencast
<img width="309" alt="Screenshot 2024-07-24 at 09 18 38" src="https://github.com/user-attachments/assets/590fe0df-d25f-4fec-955a-c5f93ad23b73">
cable -->
