### PR TITLE
Fix animation when expanding images with borders

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -11,12 +11,16 @@
 		box-sizing: border-box;
 
 		@media (prefers-reduced-motion: no-preference) {
+			& {
+				transition: opacity 0.4s ease;
+			}
+
 			&.hide {
-				visibility: hidden;
+				opacity: 0;
 			}
 
 			&.show {
-				animation: show-content-image 0.4s;
+				opacity: 1;
 			}
 		}
 	}

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -52,13 +52,16 @@ const { state, actions, callbacks } = store(
 				);
 			},
 			get imgStyles() {
-				return (
-					state.overlayOpened &&
-					`${ state.currentImage.imgStyles?.replace(
-						/;$/,
-						''
-					) }; object-fit:cover;`
-				);
+				const styles = state.currentImage.imgStyles
+					.split( ';' )
+					.filter( ( style ) => !! style )
+					.map( ( style ) =>
+						style.startsWith( 'border-width:' )
+							? 'border-width: 0'
+							: style
+					)
+					.join( ';' );
+				return state.overlayOpened && `${ styles }; object-fit:cover;`;
 			},
 			get imageButtonRight() {
 				const { imageId } = getContext();
@@ -195,11 +198,20 @@ const { state, actions, callbacks } = store(
 				let {
 					naturalWidth,
 					naturalHeight,
-					offsetWidth: originalWidth,
-					offsetHeight: originalHeight,
+					clientWidth: originalWidth,
+					clientHeight: originalHeight,
 				} = state.currentImage.imageRef;
 				let { x: screenPosX, y: screenPosY } =
 					state.currentImage.imageRef.getBoundingClientRect();
+				const computedStyle = window.getComputedStyle(
+					state.currentImage.imageRef
+				);
+				screenPosX +=
+					parseFloat( computedStyle.borderLeftWidth ) +
+					parseFloat( computedStyle.paddingLeft );
+				screenPosY +=
+					parseFloat( computedStyle.borderTopWidth ) +
+					parseFloat( computedStyle.paddingTop );
 
 				// Natural ratio of the image clicked to open the lightbox.
 				const naturalRatio = naturalWidth / naturalHeight;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is an attempt to fix the animation bug for expanding images with borders described in https://github.com/WordPress/gutenberg/issues/63567.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Images with borders have jumpy animation when enabling "Expand on click" (lightbox effect).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The code is still ad-hoc and WIP.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/11c688ce-ef75-48df-994d-4cd970db1683