### PR TITLE
Font Library: Include a "Select All" options for google fonts

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -25,6 +25,7 @@ import {
 	DropdownMenu,
 	SearchControl,
 	ProgressBar,
+	CheckboxControl,
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
 import { sprintf, __, _x } from '@wordpress/i18n';
@@ -173,6 +174,25 @@ function FontCollection( { slug } ) {
 
 	const resetFontsToInstall = () => {
 		setFontsToInstall( [] );
+	};
+
+	const selectFontCount =
+		fontsToInstall.length > 0 ? fontsToInstall[ 0 ]?.fontFace?.length : 0;
+
+	// Check if any fonts are selected.
+	const isIndeterminate =
+		selectFontCount > 0 &&
+		selectFontCount !== selectedFont?.fontFace?.length;
+
+	// Check if all fonts are selected.
+	const isSelectAllChecked =
+		selectFontCount === selectedFont?.fontFace?.length;
+
+	// Toggle select all fonts.
+	const toggleSelectAll = () => {
+		const newFonts = isSelectAllChecked ? [] : [ selectedFont ];
+
+		setFontsToInstall( newFonts );
 	};
 
 	const handleInstall = async () => {
@@ -400,6 +420,14 @@ function FontCollection( { slug } ) {
 								{ __( 'Select font variants to install.' ) }
 							</Text>
 							<Spacer margin={ 4 } />
+							<CheckboxControl
+								className="font-library-modal__select-all"
+								label={ __( 'Select all' ) }
+								checked={ isSelectAllChecked }
+								onChange={ toggleSelectAll }
+								indeterminate={ isIndeterminate }
+								__nextHasNoMarginBottom
+							/>
 							<VStack spacing={ 0 }>
 								<Spacer margin={ 8 } />
 								{ getSortedFontFaces( selectedFont ).map(

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -186,3 +186,15 @@ button.font-library-modal__upload-area {
 		justify-content: center;
 	}
 }
+
+.font-library-modal__select-all {
+	width: 100%;
+	height: auto;
+	padding: $grid-unit-20;
+
+	.components-checkbox-control__label {
+		padding-left: $grid-unit-20;
+		font-size: 18px;
+		line-height: 1;
+	}
+}

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -187,14 +187,3 @@ button.font-library-modal__upload-area {
 	}
 }
 
-.font-library-modal__select-all {
-	width: 100%;
-	height: auto;
-	padding: $grid-unit-20;
-
-	.components-checkbox-control__label {
-		padding-left: $grid-unit-20;
-		font-size: 18px;
-		line-height: 1;
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Closes https://github.com/WordPress/gutenberg/issues/58011

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Selecting each font individually in the font manager took a lot of time because there was no way to choose them all at once. `Select All` useful to cut down on the procedure.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR updates the font manager's `install font` tab to include a `Select all` option.
 
## Testing Instructions
- Go to global styles setting
- Open font manager
- Go to install fonts tab
- Select fonts to install
- Verify that `Select All` checkbox it available, and make sure it works fine as expected.  

## Screenshots or screencast <!-- if applicable -->
 
[select-all-option-under-for-google-fonts-font-library.webm](https://github.com/user-attachments/assets/f62705ca-8c76-4336-85b6-0138dce7bbae)