### PR TITLE
Zoom out: Try vertical displacement when dragging a pattern between existing patterns/sections

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -453,3 +453,15 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		margin-bottom: auto;
 	}
 }
+
+.block-editor-block-list__zoom-out-separator {
+	/* same color as the iframe's background */
+	background: $gray-300;
+}
+
+// In Post Editor allow the separator to occupy the full width by ignoring (cancelling out) the global padding.
+.has-global-padding > .block-editor-block-list__zoom-out-separator,
+.block-editor-block-list__layout.is-root-container.has-global-padding > .block-editor-block-list__zoom-out-separator {
+	max-width: none;
+	margin: 0 calc(-1 * var(--wp--style--root--padding-right)) 0 calc(-1 * var(--wp--style--root--padding-left)) !important;
+}

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -457,11 +457,15 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 .block-editor-block-list__zoom-out-separator {
 	/* same color as the iframe's background */
 	background: $gray-300;
+	// Additional -1px is required to avoid sub pixel rounding errors allowing background to show.
+	margin-left: -1px;
+	margin-right: -1px;
 }
 
 // In Post Editor allow the separator to occupy the full width by ignoring (cancelling out) the global padding.
 .has-global-padding > .block-editor-block-list__zoom-out-separator,
 .block-editor-block-list__layout.is-root-container.has-global-padding > .block-editor-block-list__zoom-out-separator {
 	max-width: none;
-	margin: 0 calc(-1 * var(--wp--style--root--padding-right)) 0 calc(-1 * var(--wp--style--root--padding-left)) !important;
+	// Additional -1px is required to avoid sub pixel rounding errors allowing background to show.
+	margin: 0 calc(-1 * var(--wp--style--root--padding-right) - 1px) 0 calc(-1 * var(--wp--style--root--padding-left) - 1px) !important;
 }

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -460,6 +460,11 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	// Additional -1px is required to avoid sub pixel rounding errors allowing background to show.
 	margin-left: -1px;
 	margin-right: -1px;
+	transition: background-color 0.3s ease;
+
+	&.is-dragged-over {
+		background: $gray-400;
+	}
 }
 
 // In Post Editor allow the separator to occupy the full width by ignoring (cancelling out) the global padding.

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -39,6 +39,7 @@ import {
 	DEFAULT_BLOCK_EDIT_CONTEXT,
 } from '../block-edit/context';
 import { useTypingObserver } from '../observe-typing';
+import { ZoomOutSeparator } from './zoom-out-separator';
 import { unlock } from '../../lock-unlock';
 
 export const IntersectionObserver = createContext();
@@ -174,49 +175,55 @@ function Items( {
 	// function on every render.
 	const hasAppender = CustomAppender !== false;
 	const hasCustomAppender = !! CustomAppender;
-	const { order, selectedBlocks, visibleBlocks, shouldRenderAppender } =
-		useSelect(
-			( select ) => {
-				const {
-					getSettings,
-					getBlockOrder,
-					getSelectedBlockClientId,
-					getSelectedBlockClientIds,
-					__unstableGetVisibleBlocks,
-					getTemplateLock,
-					getBlockEditingMode,
-					__unstableGetEditorMode,
-				} = select( blockEditorStore );
+	const {
+		order,
+		isZoomOut,
+		selectedBlocks,
+		visibleBlocks,
+		shouldRenderAppender,
+	} = useSelect(
+		( select ) => {
+			const {
+				getSettings,
+				getBlockOrder,
+				getSelectedBlockClientId,
+				getSelectedBlockClientIds,
+				__unstableGetVisibleBlocks,
+				getTemplateLock,
+				getBlockEditingMode,
+				__unstableGetEditorMode,
+			} = select( blockEditorStore );
 
-				const _order = getBlockOrder( rootClientId );
+			const _order = getBlockOrder( rootClientId );
 
-				if ( getSettings().__unstableIsPreviewMode ) {
-					return {
-						order: _order,
-						selectedBlocks: EMPTY_ARRAY,
-						visibleBlocks: EMPTY_SET,
-					};
-				}
-
-				const selectedBlockClientId = getSelectedBlockClientId();
+			if ( getSettings().__unstableIsPreviewMode ) {
 				return {
 					order: _order,
-					selectedBlocks: getSelectedBlockClientIds(),
-					visibleBlocks: __unstableGetVisibleBlocks(),
-					shouldRenderAppender:
-						hasAppender &&
-						__unstableGetEditorMode() !== 'zoom-out' &&
-						( hasCustomAppender
-							? ! getTemplateLock( rootClientId ) &&
-							  getBlockEditingMode( rootClientId ) !== 'disabled'
-							: rootClientId === selectedBlockClientId ||
-							  ( ! rootClientId &&
-									! selectedBlockClientId &&
-									! _order.length ) ),
+					selectedBlocks: EMPTY_ARRAY,
+					visibleBlocks: EMPTY_SET,
 				};
-			},
-			[ rootClientId, hasAppender, hasCustomAppender ]
-		);
+			}
+
+			const selectedBlockClientId = getSelectedBlockClientId();
+			return {
+				order: _order,
+				selectedBlocks: getSelectedBlockClientIds(),
+				visibleBlocks: __unstableGetVisibleBlocks(),
+				isZoomOut: __unstableGetEditorMode() === 'zoom-out',
+				shouldRenderAppender:
+					hasAppender &&
+					__unstableGetEditorMode() !== 'zoom-out' &&
+					( hasCustomAppender
+						? ! getTemplateLock( rootClientId ) &&
+						  getBlockEditingMode( rootClientId ) !== 'disabled'
+						: rootClientId === selectedBlockClientId ||
+						  ( ! rootClientId &&
+								! selectedBlockClientId &&
+								! _order.length ) ),
+			};
+		},
+		[ rootClientId, hasAppender, hasCustomAppender ]
+	);
 
 	return (
 		<LayoutProvider value={ layout }>
@@ -230,10 +237,24 @@ function Items( {
 						! selectedBlocks.includes( clientId )
 					}
 				>
+					{ isZoomOut && (
+						<ZoomOutSeparator
+							clientId={ clientId }
+							rootClientId={ rootClientId }
+							position="top"
+						/>
+					) }
 					<BlockListBlock
 						rootClientId={ rootClientId }
 						clientId={ clientId }
 					/>
+					{ isZoomOut && (
+						<ZoomOutSeparator
+							clientId={ clientId }
+							rootClientId={ rootClientId }
+							position="bottom"
+						/>
+					) }
 				</AsyncModeProvider>
 			) ) }
 			{ order.length < 1 && placeholder }

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -87,6 +87,7 @@ export function ZoomOutSeparator( {
 						ease: [ 0.6, 0, 0.4, 1 ],
 					} }
 					className="block-editor-block-list__zoom-out-separator"
+					data-is-zoom-out-separator="true"
 				></motion.div>
 			) }
 		</AnimatePresence>

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -44,6 +44,7 @@ export function ZoomOutSeparator( {
 	}, [] );
 
 	const isReducedMotion = useReducedMotion();
+
 	if ( ! clientId ) {
 		return;
 	}
@@ -61,6 +62,11 @@ export function ZoomOutSeparator( {
 	}
 
 	if ( ! isSectionBlock ) {
+		return null;
+	}
+
+	// Only allow insertion and not grouping in Zoom Out mode.
+	if ( blockInsertionPoint?.operation !== 'insert' ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
+} from '@wordpress/components';
+import { useReducedMotion } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+export function ZoomOutSeparator( {
+	clientId,
+	rootClientId,
+	position = 'top',
+} ) {
+	const {
+		sectionRootClientId,
+		sectionClientIds,
+		blockInsertionPoint,
+		blockInsertionPointVisible,
+	} = useSelect( ( select ) => {
+		const {
+			getSettings,
+			getBlockInsertionPoint,
+			getBlockOrder,
+			isBlockInsertionPointVisible,
+		} = unlock( select( blockEditorStore ) );
+
+		const { sectionRootClientId: root } = unlock( getSettings() );
+		const sectionRootClientIds = getBlockOrder( root );
+		return {
+			sectionRootClientId: root,
+			sectionClientIds: sectionRootClientIds,
+			blockOrder: getBlockOrder( root ),
+			blockInsertionPoint: getBlockInsertionPoint(),
+			blockInsertionPointVisible: isBlockInsertionPointVisible(),
+		};
+	}, [] );
+
+	const isReducedMotion = useReducedMotion();
+	if ( ! clientId ) {
+		return;
+	}
+
+	let isSectionBlock = false;
+	let isVisible = false;
+
+	if (
+		( sectionRootClientId &&
+			sectionClientIds &&
+			sectionClientIds.includes( clientId ) ) ||
+		( clientId && ! rootClientId )
+	) {
+		isSectionBlock = true;
+	}
+
+	if ( ! isSectionBlock ) {
+		return null;
+	}
+
+	if ( position === 'top' ) {
+		isVisible =
+			blockInsertionPointVisible &&
+			blockInsertionPoint.index === 0 &&
+			clientId === sectionClientIds[ blockInsertionPoint.index ];
+	}
+
+	if ( position === 'bottom' ) {
+		isVisible =
+			blockInsertionPointVisible &&
+			clientId === sectionClientIds[ blockInsertionPoint.index - 1 ];
+	}
+
+	return (
+		<AnimatePresence>
+			{ isVisible && (
+				<motion.div
+					layout={ ! isReducedMotion }
+					initial={ { height: 0 } }
+					animate={ { height: '120px' } }
+					exit={ { height: 0 } }
+					transition={ {
+						type: 'tween',
+						duration: 0.2,
+						ease: [ 0.6, 0, 0.4, 1 ],
+					} }
+					className="block-editor-block-list__zoom-out-separator"
+				></motion.div>
+			) }
+		</AnimatePresence>
+	);
+}

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -16,7 +16,7 @@ import { unlock } from '../../lock-unlock';
 
 export function ZoomOutSeparator( {
 	clientId,
-	rootClientId,
+	rootClientId = '',
 	position = 'top',
 } ) {
 	const {
@@ -49,24 +49,14 @@ export function ZoomOutSeparator( {
 		return;
 	}
 
-	let isSectionBlock = false;
 	let isVisible = false;
 
-	if (
-		( sectionRootClientId &&
-			sectionClientIds &&
-			sectionClientIds.includes( clientId ) ) ||
-		( clientId && ! rootClientId )
-	) {
-		isSectionBlock = true;
-	}
+	const isSectionBlock =
+		rootClientId === sectionRootClientId &&
+		sectionClientIds &&
+		sectionClientIds.includes( clientId );
 
 	if ( ! isSectionBlock ) {
-		return null;
-	}
-
-	// Only allow insertion and not grouping in Zoom Out mode.
-	if ( blockInsertionPoint?.operation !== 'insert' ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -87,7 +87,7 @@ export function ZoomOutSeparator( {
 						ease: [ 0.6, 0, 0.4, 1 ],
 					} }
 					className="block-editor-block-list__zoom-out-separator"
-					data-is-zoom-out-separator="true"
+					data-is-insertion-point="true"
 				></motion.div>
 			) }
 		</AnimatePresence>

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import {
@@ -7,6 +12,7 @@ import {
 } from '@wordpress/components';
 import { useReducedMotion } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,6 +25,7 @@ export function ZoomOutSeparator( {
 	rootClientId = '',
 	position = 'top',
 } ) {
+	const [ isDraggedOver, setIsDraggedOver ] = useState( false );
 	const {
 		sectionRootClientId,
 		sectionClientIds,
@@ -77,6 +84,7 @@ export function ZoomOutSeparator( {
 		<AnimatePresence>
 			{ isVisible && (
 				<motion.div
+					as="button"
 					layout={ ! isReducedMotion }
 					initial={ { height: 0 } }
 					animate={ { height: '120px' } }
@@ -86,10 +94,15 @@ export function ZoomOutSeparator( {
 						duration: 0.2,
 						ease: [ 0.6, 0, 0.4, 1 ],
 					} }
-					className="block-editor-block-list__zoom-out-separator"
-					// Indicate that this is an insertion point and should not trigger
-					// dropleave events for any parent drop zone.
+					className={ clsx(
+						'block-editor-block-list__zoom-out-separator',
+						{
+							'is-dragged-over': isDraggedOver,
+						}
+					) }
 					data-is-insertion-point="true"
+					onDragOver={ () => setIsDraggedOver( true ) }
+					onDragLeave={ () => setIsDraggedOver( false ) }
 				></motion.div>
 			) }
 		</AnimatePresence>

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -87,6 +87,8 @@ export function ZoomOutSeparator( {
 						ease: [ 0.6, 0, 0.4, 1 ],
 					} }
 					className="block-editor-block-list__zoom-out-separator"
+					// Indicate that this is an insertion point and should not trigger
+					// dropleave events for any parent drop zone.
 					data-is-insertion-point="true"
 				></motion.div>
 			) }

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -26,13 +26,13 @@ export function ZoomOutSeparator( {
 		blockInsertionPointVisible,
 	} = useSelect( ( select ) => {
 		const {
-			getSettings,
 			getBlockInsertionPoint,
 			getBlockOrder,
 			isBlockInsertionPointVisible,
+			getSectionRootClientId,
 		} = unlock( select( blockEditorStore ) );
 
-		const { sectionRootClientId: root } = unlock( getSettings() );
+		const root = getSectionRootClientId();
 		const sectionRootClientIds = getBlockOrder( root );
 		return {
 			sectionRootClientId: root,

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -202,7 +202,7 @@ export default function BlockTools( {
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div { ...props } onKeyDown={ onKeyDown }>
 			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-				{ ! isTyping && (
+				{ ! isTyping && ! isZoomOutMode && (
 					<InsertionPoint
 						__unstableContentRef={ __unstableContentRef }
 					/>

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -88,18 +88,6 @@ function ZoomOutModeInserters() {
 				previousClientId={ previousClientId }
 				nextClientId={ nextClientId }
 			>
-				{ shouldRenderInsertionPoint && (
-					<div
-						style={ {
-							borderRadius: '0',
-							height: '12px',
-							opacity: 1,
-							transform: 'translateY(-50%)',
-							width: '100%',
-						} }
-						className="block-editor-block-list__insertion-point-indicator"
-					/>
-				) }
 				{ ! shouldRenderInsertionPoint && (
 					<ZoomOutModeInserterButton
 						isVisible={ isSelected || isHovered }

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -515,6 +515,23 @@ export default function useBlockDropZone( {
 		200
 	);
 
+	/**
+	 * Checks if the given element is an insertion point.
+	 *
+	 * @param {EventTarget|null} targetToCheck - The element to check.
+	 * @param {Document}         ownerDocument - The owner document of the element.
+	 * @return {boolean} True if the element is a insertion point, false otherwise.
+	 */
+	function isInsertionPoint( targetToCheck, ownerDocument ) {
+		const { defaultView } = ownerDocument;
+
+		return !! (
+			defaultView &&
+			targetToCheck instanceof defaultView.HTMLElement &&
+			targetToCheck.dataset.isInsertionPoint
+		);
+	}
+
 	return useDropZone( {
 		dropZoneElement,
 		isDisabled,
@@ -525,7 +542,18 @@ export default function useBlockDropZone( {
 			// https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget
 			throttled( event, event.currentTarget.ownerDocument );
 		},
-		onDragLeave() {
+		onDragLeave( event ) {
+			const { ownerDocument } = event.currentTarget;
+
+			// If the drag event is leaving the drop zone and entering an insertion point,
+			// do not hide the insertion point as it is conceptually within the dropzone.
+			if (
+				isInsertionPoint( event.relatedTarget, ownerDocument ) ||
+				isInsertionPoint( event.target, ownerDocument )
+			) {
+				return;
+			}
+
 			throttled.cancel();
 			hideInsertionPoint();
 		},

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -275,6 +275,23 @@ export function isDropTargetValid(
 }
 
 /**
+ * Checks if the given element is an insertion point.
+ *
+ * @param {EventTarget|null} targetToCheck - The element to check.
+ * @param {Document}         ownerDocument - The owner document of the element.
+ * @return {boolean} True if the element is a insertion point, false otherwise.
+ */
+function isInsertionPoint( targetToCheck, ownerDocument ) {
+	const { defaultView } = ownerDocument;
+
+	return !! (
+		defaultView &&
+		targetToCheck instanceof defaultView.HTMLElement &&
+		targetToCheck.dataset.isInsertionPoint
+	);
+}
+
+/**
  * @typedef  {Object} WPBlockDropZoneConfig
  * @property {?HTMLElement} dropZoneElement Optional element to be used as the drop zone.
  * @property {string}       rootClientId    The root client id for the block list.
@@ -514,23 +531,6 @@ export default function useBlockDropZone( {
 		),
 		200
 	);
-
-	/**
-	 * Checks if the given element is an insertion point.
-	 *
-	 * @param {EventTarget|null} targetToCheck - The element to check.
-	 * @param {Document}         ownerDocument - The owner document of the element.
-	 * @return {boolean} True if the element is a insertion point, false otherwise.
-	 */
-	function isInsertionPoint( targetToCheck, ownerDocument ) {
-		const { defaultView } = ownerDocument;
-
-		return !! (
-			defaultView &&
-			targetToCheck instanceof defaultView.HTMLElement &&
-			targetToCheck.dataset.isInsertionPoint
-		);
-	}
 
 	return useDropZone( {
 		dropZoneElement,

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -422,6 +422,10 @@ export default function useBlockDropZone( {
 				const [ targetIndex, operation, nearestSide ] =
 					dropTargetPosition;
 
+				if ( isZoomOutMode() && operation !== 'insert' ) {
+					return;
+				}
+
 				if ( operation === 'group' ) {
 					const targetBlock = blocks[ targetIndex ];
 					const areAllImages = [

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -31,6 +31,18 @@ function useFreshRef( value ) {
 }
 
 /**
+ * Checks if the given element is a zoom out separator.
+ *
+ * @param {EventTarget} maybeZoomOutSeparator - The element to check.
+ * @return {boolean} True if the element is a zoom out separator, false otherwise.
+ */
+const isZoomOutSeparator = ( maybeZoomOutSeparator ) =>
+	maybeZoomOutSeparator &&
+	maybeZoomOutSeparator?.classList.contains(
+		'block-editor-block-list__zoom-out-separator'
+	);
+
+/**
  * A hook to facilitate drag and drop handling.
  *
  * @param {Object}                  props                   Named parameters.
@@ -165,7 +177,17 @@ export default function useDropZone( {
 				// zone.
 				// Note: This is not entirely reliable in Safari due to this bug
 				// https://bugs.webkit.org/show_bug.cgi?id=66547
+
 				if ( isElementInZone( event.relatedTarget ) ) {
+					return;
+				}
+
+				// If we're moving in/out of a ZoomOutSeparator, don't trigger
+				// the onDragLeave event.
+				if (
+					isZoomOutSeparator( event.relatedTarget ) ||
+					isZoomOutSeparator( event.target )
+				) {
 					return;
 				}
 

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -31,18 +31,6 @@ function useFreshRef( value ) {
 }
 
 /**
- * Checks if the given element is a zoom out separator.
- *
- * @param {EventTarget} maybeZoomOutSeparator - The element to check.
- * @return {boolean} True if the element is a zoom out separator, false otherwise.
- */
-const isZoomOutSeparator = ( maybeZoomOutSeparator ) =>
-	maybeZoomOutSeparator &&
-	maybeZoomOutSeparator?.classList.contains(
-		'block-editor-block-list__zoom-out-separator'
-	);
-
-/**
  * A hook to facilitate drag and drop handling.
  *
  * @param {Object}                  props                   Named parameters.
@@ -119,6 +107,24 @@ export default function useDropZone( {
 				return false;
 			}
 
+			/**
+			 * Checks if the given element is a zoom out separator.
+			 *
+			 * @param {EventTarget|null} maybeZoomOutSeparator - The element to check.
+			 * @return {boolean} True if the element is a zoom out separator, false otherwise.
+			 */
+			function isZoomOutSeparator( maybeZoomOutSeparator ) {
+				const { defaultView } = ownerDocument;
+
+				return !! (
+					defaultView &&
+					maybeZoomOutSeparator instanceof defaultView.HTMLElement &&
+					maybeZoomOutSeparator.classList.contains(
+						'block-editor-block-list__zoom-out-separator'
+					)
+				);
+			}
+
 			function maybeDragStart( /** @type {DragEvent} */ event ) {
 				if ( isDragging ) {
 					return;
@@ -183,7 +189,9 @@ export default function useDropZone( {
 				}
 
 				// If we're moving in/out of a ZoomOutSeparator, don't trigger
-				// the onDragLeave event.
+				// the onDragLeave event. This is to prevent the dropzone from
+				// being hidden when the user is dragging a block in/over/around
+				// a block and the separator.
 				if (
 					isZoomOutSeparator( event.relatedTarget ) ||
 					isZoomOutSeparator( event.target )

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -108,22 +108,6 @@ export default function useDropZone( {
 				return false;
 			}
 
-			/**
-			 * Checks if the given element is an insertion point.
-			 *
-			 * @param {EventTarget|null} targetToCheck - The element to check.
-			 * @return {boolean} True if the element is a insertion point, false otherwise.
-			 */
-			function isInsertionPoint( targetToCheck ) {
-				const { defaultView } = ownerDocument;
-
-				return !! (
-					defaultView &&
-					targetToCheck instanceof defaultView.HTMLElement &&
-					targetToCheck.dataset.isInsertionPoint
-				);
-			}
-
 			function maybeDragStart( /** @type {DragEvent} */ event ) {
 				if ( isDragging ) {
 					return;
@@ -184,17 +168,6 @@ export default function useDropZone( {
 				// https://bugs.webkit.org/show_bug.cgi?id=66547
 
 				if ( isElementInZone( event.relatedTarget ) ) {
-					return;
-				}
-
-				// If we're moving in/out of an insertion point then don't trigger
-				// the onDragLeave event. This is to prevent the dropzone from
-				// trigger any unwanted side effects when the user is likely to
-				// be moving the cursor quickly over the insertion point.
-				if (
-					isInsertionPoint( event.relatedTarget ) ||
-					isInsertionPoint( event.target )
-				) {
 					return;
 				}
 

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -86,6 +86,7 @@ export default function useDropZone( {
 			 */
 			function isElementInZone( targetToCheck ) {
 				const { defaultView } = ownerDocument;
+
 				if (
 					! targetToCheck ||
 					! defaultView ||
@@ -108,18 +109,18 @@ export default function useDropZone( {
 			}
 
 			/**
-			 * Checks if the given element is a zoom out separator.
+			 * Checks if the given element is an insertion point.
 			 *
 			 * @param {EventTarget|null} targetToCheck - The element to check.
-			 * @return {boolean} True if the element is a zoom out separator, false otherwise.
+			 * @return {boolean} True if the element is a insertion point, false otherwise.
 			 */
-			function isZoomOutSeparator( targetToCheck ) {
+			function isInsertionPoint( targetToCheck ) {
 				const { defaultView } = ownerDocument;
 
 				return !! (
 					defaultView &&
 					targetToCheck instanceof defaultView.HTMLElement &&
-					targetToCheck.dataset.isZoomOutSeparator
+					targetToCheck.dataset.isInsertionPoint
 				);
 			}
 
@@ -186,13 +187,13 @@ export default function useDropZone( {
 					return;
 				}
 
-				// If we're moving in/out of a ZoomOutSeparator, don't trigger
+				// If we're moving in/out of an insertion point then don't trigger
 				// the onDragLeave event. This is to prevent the dropzone from
 				// being hidden when the user is dragging a block in/over/around
-				// a block and the separator.
+				// a block and a nearby insertion point.
 				if (
-					isZoomOutSeparator( event.relatedTarget ) ||
-					isZoomOutSeparator( event.target )
+					isInsertionPoint( event.relatedTarget ) ||
+					isInsertionPoint( event.target )
 				) {
 					return;
 				}

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -189,8 +189,8 @@ export default function useDropZone( {
 
 				// If we're moving in/out of an insertion point then don't trigger
 				// the onDragLeave event. This is to prevent the dropzone from
-				// being hidden when the user is dragging a block in/over/around
-				// a block and a nearby insertion point.
+				// trigger any unwanted side effects when the user is likely to
+				// be moving the cursor quickly over the insertion point.
 				if (
 					isInsertionPoint( event.relatedTarget ) ||
 					isInsertionPoint( event.target )

--- a/packages/compose/src/hooks/use-drop-zone/index.js
+++ b/packages/compose/src/hooks/use-drop-zone/index.js
@@ -110,18 +110,16 @@ export default function useDropZone( {
 			/**
 			 * Checks if the given element is a zoom out separator.
 			 *
-			 * @param {EventTarget|null} maybeZoomOutSeparator - The element to check.
+			 * @param {EventTarget|null} targetToCheck - The element to check.
 			 * @return {boolean} True if the element is a zoom out separator, false otherwise.
 			 */
-			function isZoomOutSeparator( maybeZoomOutSeparator ) {
+			function isZoomOutSeparator( targetToCheck ) {
 				const { defaultView } = ownerDocument;
 
 				return !! (
 					defaultView &&
-					maybeZoomOutSeparator instanceof defaultView.HTMLElement &&
-					maybeZoomOutSeparator.classList.contains(
-						'block-editor-block-list__zoom-out-separator'
-					)
+					targetToCheck instanceof defaultView.HTMLElement &&
+					targetToCheck.dataset.isZoomOutSeparator
 				);
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/50739

Implements a way to separate blocks in zoom out mode vertically both when we drag in a new pattern in between sections and when we click on the inserters

Co-authored-by: Dave Smith <444434+getdave@users.noreply.github.com>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need a better visual aid to guide the user when building with patterns. Separating section makes it clear where the action is happening

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We are adding some conditional separators in between blocks of the blocklist that appear based on a couple of condition: if the block in question is a sectioning element, and if the insertion point is related to said block. The rendering of this separator is animated to push the sections apart.

This also required updating the drag handling logic to avoid triggering `dragend` events when moving in/out of the zoom out separators. This ensures the separator itself does not re-render if the mouse cursor inadvertently moves into/out of it whilst it is animating. This avoids the "stuttering" animations we were seeing early in the lifecycle of this PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the inserter and select a pattern category
- On the canvas, click on the plus inserters, they should separate the sections correctly
- Select a pattern and it should insert in the area that was opened
- Try and drag and drop a new pattern in between sections
- The sections should animate and separate while dragging in the area

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/73d047cb-44d0-4f4e-9134-a9b848566e81




