### PR TITLE
Fix toggle help indentation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `ComboboxControl`: Fix ComboboxControl reset button when using the keyboard. ([#63410](https://github.com/WordPress/gutenberg/pull/63410))
 -   `Button`: Never apply `aria-disabled` to anchor ([#63376](https://github.com/WordPress/gutenberg/pull/63376)).
 -   `SelectControl`: Fix hover/focus color in wp-admin ([#63855](https://github.com/WordPress/gutenberg/pull/63855)).
+-   `ToggleControl`: Fix indentation ([#63903](https://github.com/WordPress/gutenberg/pull/63903)).
 
 ### Enhancements
 

--- a/packages/components/src/toggle-control/index.tsx
+++ b/packages/components/src/toggle-control/index.tsx
@@ -88,7 +88,13 @@ export function ToggleControl(
 	return (
 		<BaseControl
 			id={ id }
-			help={ helpLabel }
+			help={
+				helpLabel && (
+					<span className="components-toggle-control__help">
+						{ helpLabel }
+					</span>
+				)
+			}
 			className={ classes }
 			__nextHasNoMarginBottom
 		>

--- a/packages/components/src/toggle-control/index.tsx
+++ b/packages/components/src/toggle-control/index.tsx
@@ -88,13 +88,7 @@ export function ToggleControl(
 	return (
 		<BaseControl
 			id={ id }
-			help={
-				helpLabel && (
-					<span className="components-toggle-control__help">
-						{ helpLabel }
-					</span>
-				)
-			}
+			help={ helpLabel }
 			className={ classes }
 			__nextHasNoMarginBottom
 		>

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -6,6 +6,7 @@
 	}
 }
 
-.components-base-control__help {
-	margin-left: $toggle-width + $grid-unit-10;
+.components-toggle-control__help {
+	display: inline-block;
+	margin-inline-start: $toggle-width + $grid-unit-10;
 }

--- a/packages/components/src/toggle-control/style.scss
+++ b/packages/components/src/toggle-control/style.scss
@@ -6,6 +6,6 @@
 	}
 }
 
-.components-toggle-control__help {
+.components-base-control__help {
 	margin-left: $toggle-width + $grid-unit-10;
 }


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/63490.

## What?
Fix indentation when help text spans several lines.

## Why?
Improves appearance.

## Testing Instructions
1. Observe a `ToggleControl` with longer help text, e.g. the 'Inner blocks use content width' option on Group blocks.
2. Notice the help text is correctly indented.

| Before | After |
| --- | --- |
| <img width="277" alt="Screenshot 2024-07-24 at 13 42 14" src="https://github.com/user-attachments/assets/95494324-07d3-4d58-95ec-1e95aa1a1d33"> | <img width="279" alt="Screenshot 2024-07-24 at 13 38 52" src="https://github.com/user-attachments/assets/c874e0e6-e4da-44e5-981f-ba87cf37ccc0"> |

