### PR TITLE
Font Library: Fix flaky e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -17,7 +17,10 @@ test.describe( 'Font Library', () => {
 		test( 'should display the "no font installed." message', async ( {
 			page,
 		} ) => {
-			await page.getByRole( 'button', { name: 'Styles' } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
@@ -33,7 +36,10 @@ test.describe( 'Font Library', () => {
 		} );
 
 		test( 'should display the "Add fonts" button', async ( { page } ) => {
-			await page.getByRole( 'button', { name: 'Styles' } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
@@ -57,7 +63,10 @@ test.describe( 'Font Library', () => {
 		test( 'should display the "Manage fonts" button', async ( {
 			page,
 		} ) => {
-			await page.getByRole( 'button', { name: 'Styles' } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
@@ -70,7 +79,10 @@ test.describe( 'Font Library', () => {
 		test( 'should open the "Manage fonts" modal when clicking the "Manage fonts" button', async ( {
 			page,
 		} ) => {
-			await page.getByRole( 'button', { name: 'Styles' } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
@@ -88,7 +100,10 @@ test.describe( 'Font Library', () => {
 		test( 'should show font variant panel when clicking on a font family', async ( {
 			page,
 		} ) => {
-			await page.getByRole( 'button', { name: 'Styles' } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
@@ -134,7 +149,10 @@ test.describe( 'Font Library', () => {
 			page,
 			editor,
 		} ) => {
-			await page.getByRole( 'button', { name: 'Styles' } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
@@ -210,7 +228,10 @@ test.describe( 'Font Library', () => {
 		test( 'clicking on a font in the global styles sidebar should activate the font in the overlay when switching Theme Style variation', async ( {
 			page,
 		} ) => {
-			await page.getByRole( 'button', { name: /styles/i } ).click();
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', { name: 'Styles' } )
+				.click();
 
 			// Click "Browse styles"
 			await page.getByRole( 'button', { name: 'Browse styles' } ).click();

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -9,9 +9,12 @@ test.describe( 'Font Library', () => {
 			await requestUtils.activateTheme( 'emptytheme' );
 		} );
 
-		test.beforeEach( async ( { admin, editor } ) => {
-			await admin.visitSiteEditor();
-			await editor.canvas.locator( 'body' ).click();
+		test.beforeEach( async ( { admin } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//index',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
 		} );
 
 		test( 'should display the "no font installed." message', async ( {
@@ -55,9 +58,12 @@ test.describe( 'Font Library', () => {
 			await requestUtils.activateTheme( 'twentytwentythree' );
 		} );
 
-		test.beforeEach( async ( { admin, editor } ) => {
-			await admin.visitSiteEditor();
-			await editor.canvas.locator( 'body' ).click();
+		test.beforeEach( async ( { admin } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'twentytwentythree//index',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
 		} );
 
 		test( 'should display the "Manage fonts" button', async ( {
@@ -140,9 +146,12 @@ test.describe( 'Font Library', () => {
 			);
 		} );
 
-		test.beforeEach( async ( { admin, editor } ) => {
-			await admin.visitSiteEditor();
-			await editor.canvas.locator( 'body' ).click();
+		test.beforeEach( async ( { admin } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//index',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
 		} );
 
 		test( 'should allow user to add and remove multiple local font files', async ( {
@@ -220,9 +229,12 @@ test.describe( 'Font Library', () => {
 			await requestUtils.activateTheme( 'twentytwentyfour' );
 		} );
 
-		test.beforeEach( async ( { admin, editor } ) => {
-			await admin.visitSiteEditor();
-			await editor.canvas.locator( 'body' ).click();
+		test.beforeEach( async ( { admin } ) => {
+			await admin.visitSiteEditor( {
+				postId: 'twentytwentyfour//home',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
 		} );
 
 		test( 'clicking on a font in the global styles sidebar should activate the font in the overlay when switching Theme Style variation', async ( {


### PR DESCRIPTION
## What?
Fixes #62862.
Fixes #63074.
Fixes #63122.
Fixes #63489.

PR fixes flaky Font Library e2e tests by adding context to the locator. I've also updated the method for accessing the site editor. This improved test performance by 5-10 seconds when running locally.

## Why?
The `getByRole( 'button', { name: 'Styles' } )` locator was matching multiple elements from time to time.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/font-library.spec.js
```
