### PR TITLE
Fix the shadows Range control accessibility and usability

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -13,14 +13,13 @@ import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalInputControl as InputControl,
 	__experimentalUnitControl as UnitControl,
-	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
+	__experimentalGrid as Grid,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	__experimentalUseNavigator as useNavigator,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Dropdown,
-	RangeControl,
 	Button,
 	Flex,
 	FlexItem,
@@ -34,7 +33,6 @@ import {
 	plus,
 	shadow as shadowIcon,
 	reset,
-	settings,
 	moreVertical,
 } from '@wordpress/icons';
 import { useState, useMemo } from '@wordpress/element';
@@ -50,7 +48,6 @@ import {
 	getShadowParts,
 	shadowStringToObject,
 	shadowObjectToString,
-	CUSTOM_VALUE_SETTINGS,
 } from './shadow-utils';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
@@ -463,8 +460,7 @@ function ShadowPopover( { shadowObj, onChange } ) {
 					label={ __( 'Inset' ) }
 				/>
 			</ToggleGroupControl>
-			<VStack gap={ 4 }>
-				>
+			<Grid columns={ 2 } gap={ 4 }>
 				<ShadowInputControl
 					label={ __( 'X Position' ) }
 					value={ shadowObj.x }
@@ -488,21 +484,12 @@ function ShadowPopover( { shadowObj, onChange } ) {
 					hasNegativeRange
 					onChange={ ( value ) => onShadowChange( 'spread', value ) }
 				/>
-			</VStack>
+			</Grid>
 		</VStack>
 	);
 }
 
-function ShadowInputControl( { label, value, onChange, hasNegativeRange } ) {
-	const [ isCustomInput, setIsCustomInput ] = useState( false );
-	const [ parsedQuantity, parsedUnit ] =
-		parseQuantityAndUnitFromRawValue( value );
-
-	const sliderOnChange = ( next ) => {
-		onChange(
-			next !== undefined ? [ next, parsedUnit || 'px' ].join( '' ) : '0px'
-		);
-	};
+function ShadowInputControl( { label, value, onChange } ) {
 	const onValueChange = ( next ) => {
 		const isNumeric = next !== undefined && ! isNaN( parseFloat( next ) );
 		const nextValue = isNumeric ? next : '0px';
@@ -511,54 +498,13 @@ function ShadowInputControl( { label, value, onChange, hasNegativeRange } ) {
 
 	return (
 		<HStack align="flex-end">
-			{ isCustomInput ? (
-				<UnitControl
-					label={ label }
-					__next40pxDefaultSize
-					value={ value }
-					onChange={ onValueChange }
-					className="edit-site-global-styles__shadow-editor-control"
-				/>
-			) : (
-				<RangeControl
-					label={ label }
-					value={ parsedQuantity ?? 0 }
-					onChange={ sliderOnChange }
-					withInputField={ false }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-					min={
-						hasNegativeRange
-							? -(
-									CUSTOM_VALUE_SETTINGS[ parsedUnit ?? 'px' ]
-										?.max ?? 10
-							  )
-							: 0
-					}
-					max={
-						CUSTOM_VALUE_SETTINGS[ parsedUnit ?? 'px' ]?.max ?? 10
-					}
-					step={
-						CUSTOM_VALUE_SETTINGS[ parsedUnit ?? 'px' ]?.step ?? 0.1
-					}
-					className="edit-site-global-styles__shadow-editor-control"
-				/>
-			) }
-			<Flex
-				expanded={ false }
-				align="center"
-				className="edit-site-global-styles__shadow-editor-control-toggle-wrapper"
-			>
-				<Button
-					label={ __( 'Use custom size' ) }
-					icon={ settings }
-					onClick={ () => {
-						setIsCustomInput( ! isCustomInput );
-					} }
-					isPressed={ isCustomInput }
-					size="small"
-				/>
-			</Flex>
+			<UnitControl
+				label={ label }
+				__next40pxDefaultSize
+				value={ value }
+				onChange={ onValueChange }
+				className="edit-site-global-styles__shadow-editor-control"
+			/>
 		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -14,7 +14,6 @@ import {
 	__experimentalInputControl as InputControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
-	__experimentalGrid as Grid,
 	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	__experimentalUseNavigator as useNavigator,
 	__experimentalToggleGroupControl as ToggleGroupControl,
@@ -464,7 +463,8 @@ function ShadowPopover( { shadowObj, onChange } ) {
 					label={ __( 'Inset' ) }
 				/>
 			</ToggleGroupControl>
-			<Grid columns={ 2 } gap={ 4 }>
+			<VStack gap={ 4 }>
+				>
 				<ShadowInputControl
 					label={ __( 'X Position' ) }
 					value={ shadowObj.x }
@@ -488,7 +488,7 @@ function ShadowPopover( { shadowObj, onChange } ) {
 					hasNegativeRange
 					onChange={ ( value ) => onShadowChange( 'spread', value ) }
 				/>
-			</Grid>
+			</VStack>
 		</VStack>
 	);
 }
@@ -510,29 +510,18 @@ function ShadowInputControl( { label, value, onChange, hasNegativeRange } ) {
 	};
 
 	return (
-		<VStack justify="flex-start">
-			<HStack justify="space-between">
-				<Subtitle>{ label }</Subtitle>
-				<Button
-					label={ __( 'Use custom size' ) }
-					icon={ settings }
-					onClick={ () => {
-						setIsCustomInput( ! isCustomInput );
-					} }
-					isPressed={ isCustomInput }
-					size="small"
-				/>
-			</HStack>
+		<HStack align="flex-end">
 			{ isCustomInput ? (
 				<UnitControl
 					label={ label }
-					hideLabelFromVision
 					__next40pxDefaultSize
 					value={ value }
 					onChange={ onValueChange }
+					className="edit-site-global-styles__shadow-editor-control"
 				/>
 			) : (
 				<RangeControl
+					label={ label }
 					value={ parsedQuantity ?? 0 }
 					onChange={ sliderOnChange }
 					withInputField={ false }
@@ -552,8 +541,24 @@ function ShadowInputControl( { label, value, onChange, hasNegativeRange } ) {
 					step={
 						CUSTOM_VALUE_SETTINGS[ parsedUnit ?? 'px' ]?.step ?? 0.1
 					}
+					className="edit-site-global-styles__shadow-editor-control"
 				/>
 			) }
-		</VStack>
+			<Flex
+				expanded={ false }
+				align="center"
+				className="edit-site-global-styles__shadow-editor-control-toggle-wrapper"
+			>
+				<Button
+					label={ __( 'Use custom size' ) }
+					icon={ settings }
+					onClick={ () => {
+						setIsCustomInput( ! isCustomInput );
+					} }
+					isPressed={ isCustomInput }
+					size="small"
+				/>
+			</Flex>
+		</HStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -497,14 +497,11 @@ function ShadowInputControl( { label, value, onChange } ) {
 	};
 
 	return (
-		<HStack align="flex-end">
-			<UnitControl
-				label={ label }
-				__next40pxDefaultSize
-				value={ value }
-				onChange={ onValueChange }
-				className="edit-site-global-styles__shadow-editor-control"
-			/>
-		</HStack>
+		<UnitControl
+			label={ label }
+			__next40pxDefaultSize
+			value={ value }
+			onChange={ onValueChange }
+		/>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -464,13 +464,11 @@ function ShadowPopover( { shadowObj, onChange } ) {
 				<ShadowInputControl
 					label={ __( 'X Position' ) }
 					value={ shadowObj.x }
-					hasNegativeRange
 					onChange={ ( value ) => onShadowChange( 'x', value ) }
 				/>
 				<ShadowInputControl
 					label={ __( 'Y Position' ) }
 					value={ shadowObj.y }
-					hasNegativeRange
 					onChange={ ( value ) => onShadowChange( 'y', value ) }
 				/>
 				<ShadowInputControl
@@ -481,7 +479,6 @@ function ShadowPopover( { shadowObj, onChange } ) {
 				<ShadowInputControl
 					label={ __( 'Spread' ) }
 					value={ shadowObj.spread }
-					hasNegativeRange
 					onChange={ ( value ) => onShadowChange( 'spread', value ) }
 				/>
 			</Grid>

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -142,15 +142,6 @@
 .edit-site-global-styles__shadow-editor-panel {
 	// because tooltip of the range control is too close to the edge and creates overflow
 	margin-bottom: $grid-unit-05;
-
-	.edit-site-global-styles__shadow-editor-control {
-		flex-grow: 1;
-	}
-
-	.edit-site-global-styles__shadow-editor-control-toggle-wrapper {
-		// Make the button wrapper height the same as the adjacent input height.
-		height: $button-size-next-default-40px;
-	}
 }
 
 .edit-site-global-styles__shadow-editor__dropdown {

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -142,6 +142,15 @@
 .edit-site-global-styles__shadow-editor-panel {
 	// because tooltip of the range control is too close to the edge and creates overflow
 	margin-bottom: $grid-unit-05;
+
+	.edit-site-global-styles__shadow-editor-control {
+		flex-grow: 1;
+	}
+
+	.edit-site-global-styles__shadow-editor-control-toggle-wrapper {
+		// Make the button wrapper height the same as the adjacent input height.
+		height: $button-size-next-default-40px;
+	}
 }
 
 .edit-site-global-styles__shadow-editor__dropdown {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/63899

## What?
<!-- In a few words, what is the PR actually doing? -->
The sliders (Range controls) in the popover to edit the global styles Shadows are unlabeled.
Also, the design is inconsistent: the toggle button to switch to the 'custom value' input is placed after the visual labels. This is inconsistent as in many other similar controls the toggle button is placed after the control.

It appears this has been done only for visual purposes, to lay out the 4 controls in a 2 x 2 grid. Which is arguable because the length of the sliders is very small and setting accurately a specific value may be a difficult task for some users. These sliders need more horizontal room.

Also to mention: the visual labels are actually H2 headings and have a slightly different styling (e.g. the color) compared to the labels used in similar controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All controls must be labeled.
For better usability and accessibility, controls should be used consistently and avoid custom design.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the headings that were used as visusal labels in favor of real label elements.
Removes the 2 x 2 grid layout in favor od displaying the controls full widh in 4 rows.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site editor > Styles > Shadows
- Select a shadow and open the popover to edit the shadow.
- Observe the 4 sliders are properly labeled.
- Switch the sliders to the 'custom value' inputs and observe the inputs are properly labeled.
- Observe the controls don't use a grid layout any longer.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before and after:

![Screenshot 2024-07-24 at 17 08 06](https://github.com/user-attachments/assets/639eebd1-f5d1-4b76-8755-2c1f0152d95d)

