### PR TITLE
Fix: Post Edit Screen Restricted by Metaboxes 

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -466,7 +466,8 @@ function VisualEditor( {
 								renderingMode !== 'post-only' ||
 									isDesignPostType
 									? 'wp-site-blocks'
-									: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
+									: `${ blockListLayoutClass } wp-block-post-content`, // Ensure root level blocks receive default/flow blockGap styling rules.
+								'block-list-padding-bottom'
 							) }
 							layout={ blockListLayout }
 							dropZoneElement={

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -36,3 +36,7 @@
 		}
 	}
 }
+
+.block-list-padding-bottom {
+	padding-bottom: 40vh;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes issue: https://github.com/WordPress/gutenberg/issues/63882

## Why?
Because the metabox on text editor is causing spacing issues 

## How?
This is solved by adding `padding-bottom: 40vh` using class `block-list-padding-bottom` on `BlockList` component

## Testing Instructions
- Add lot of content to the post 
- Enable Yoast SEO plugin 
- Now we see sufficient space below the text and plugin metabox, like metabox wasn't there

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/5f06fff6-d650-4360-ad57-13db3b5f5aea">
