### PR TITLE
DropdownMenuV2: break menu item help text on multiple lines for better truncation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   `DropdownMenuV2`: break menu item help text on multiple lines for better truncation. ([#63916](https://github.com/WordPress/gutenberg/pull/63916)).
+
 ## 28.4.0 (2024-07-24)
 
 ### Deprecations

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -344,6 +344,7 @@ export const DropdownMenuItemHelpText = styled( Truncate )`
 	font-size: ${ font( 'helpText.fontSize' ) };
 	line-height: 16px;
 	color: ${ COLORS.gray[ '700' ] };
+	word-break: break-all;
 
 	[data-active-item]:not( [data-focus-visible] ) *:not( ${ DropdownMenu } ) &,
 	[aria-disabled='true'] *:not( ${ DropdownMenu } ) & {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allow menu item help text in `DropdownMenuV2` to break more deliberately to avoid unexpected un-truncated text

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because otherwise a menu item's help text could not be truncated in case its contents don't break to a new line

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding `word-break: break all`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Apply the following changes to the component's Storybook example:

```diff
diff --git a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
index a2fc476cd8..3ddb269c6d 100644
--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -78,10 +78,11 @@ export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
 			<DropdownMenuItemHelpText>Help text</DropdownMenuItemHelpText>
 		</DropdownMenuItem>
 		<DropdownMenuItem>
-			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
+			<DropdownMenuItemLabel>
+				https://m.media-amazon.com/images/M/MV5BOTI5ZTNkYWQtNDg2Mi00MTBmLTliMGItNTI5YWI5OTZkM2Y2XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_QL75_UX500_CR0,47,500,281_.jpg
+			</DropdownMenuItemLabel>
 			<DropdownMenuItemHelpText>
-				The menu item help text is automatically truncated when there
-				are more than two lines of text
+				https://m.media-amazon.com/images/M/MV5BOTI5ZTNkYWQtNDg2Mi00MTBmLTliMGItNTI5YWI5OTZkM2Y2XkEyXkFqcGdeQXVyNzU1NzE3NTg@._V1_QL75_UX500_CR0,47,500,281_.jpg
 			</DropdownMenuItemHelpText>
 		</DropdownMenuItem>
 		<DropdownMenuItem hideOnClick={ false }>

```

2. On trunk, notice how the help text would cause the menu to scroll horizontally, since the text can't be correctly truncated
3. On this PR's branch, notice how the text gets truncated correctly

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-07-25 at 01 49 42](https://github.com/user-attachments/assets/6ba00488-6556-4d01-8f14-6013294e8e72) | ![Screenshot 2024-07-25 at 01 49 22](https://github.com/user-attachments/assets/5647be6d-68fd-4669-ae32-102aa27ec4fe) |
