### PR TITLE
Try using Popover API to implement responsive navigation menu instead of using Interactivity API

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -108,8 +108,7 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function is_interactive( $attributes, $inner_blocks ) {
 		$has_submenus       = static::has_submenus( $inner_blocks );
-		$is_responsive_menu = static::is_responsive( $attributes );
-		return ( $has_submenus && ( $attributes['openSubmenusOnClick'] || $attributes['showSubmenuIcon'] ) ) || $is_responsive_menu;
+		return ( $has_submenus && ( $attributes['openSubmenusOnClick'] || $attributes['showSubmenuIcon'] ) );
 	}
 
 	/**
@@ -489,50 +488,34 @@ class WP_Navigation_Block_Renderer {
 		$toggle_aria_label_close     = $should_display_icon_label ? 'aria-label="' . __( 'Close menu' ) . '"' : ''; // Close button label.
 
 		// Add Interactivity API directives to the markup if needed.
-		$open_button_directives          = '';
-		$responsive_container_directives = '';
-		$responsive_dialog_directives    = '';
-		$close_button_directives         = '';
+		$open_button_directives                  = '';
+		$responsive_container_directives         = '';
+		$responsive_dialog_directives            = '';
+		$close_button_directives                 = '';
+		$responsive_container_content_directives = '';
 		if ( $is_interactive ) {
-			$open_button_directives                  = '
-				data-wp-on-async--click="actions.openMenuOnClick"
-				data-wp-on--keydown="actions.handleMenuKeydown"
-			';
-			$responsive_container_directives         = '
-				data-wp-class--has-modal-open="state.isMenuOpen"
-				data-wp-class--is-menu-open="state.isMenuOpen"
-				data-wp-watch="callbacks.initMenu"
-				data-wp-on--keydown="actions.handleMenuKeydown"
-				data-wp-on-async--focusout="actions.handleMenuFocusout"
-				tabindex="-1"
-			';
-			$responsive_dialog_directives            = '
-				data-wp-bind--aria-modal="state.ariaModal"
-				data-wp-bind--aria-label="state.ariaLabel"
-				data-wp-bind--role="state.roleAttribute"
-			';
-			$close_button_directives                 = '
-				data-wp-on-async--click="actions.closeMenuOnClick"
-			';
-			$responsive_container_content_directives = '
-				data-wp-watch="callbacks.focusFirstElement"
-			';
+			$open_button_directives                  = '';
+			$responsive_container_directives         = '';
+			$responsive_dialog_directives            = '';
+			$close_button_directives                 = '';
+			$responsive_container_content_directives = '';
 		}
 
 		$overlay_inline_styles = esc_attr( safecss_filter_attr( $colors['overlay_inline_styles'] ) );
 
+		// TODO: This does not implement focus trap! To achieve this the popover can't be used since it is non-modal, whereas a <dialog> is a modal but it cannot be opened without JavaScript. To declaratively open a <dialog> we'll need invoker commands: https://open-ui.org/components/invokers.explainer/
 		return sprintf(
-			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s>%8$s</button>
-				<div class="%5$s" %7$s id="%1$s" %11$s>
+			'<button aria-haspopup="dialog" %3$s class="%6$s" %10$s popovertarget="%1$s" popovertargetaction="show">%8$s</button>
+				<dialog class="%5$s" %7$s id="%1$s" %11$s popover>
 					<div class="wp-block-navigation__responsive-close" tabindex="-1">
 						<div class="wp-block-navigation__responsive-dialog" %12$s>
-							<button %4$s class="wp-block-navigation__responsive-container-close" %13$s>%9$s</button>
+							<button %4$s class="wp-block-navigation__responsive-container-close" %13$s popovertarget="%1$s" popovertargetaction="hide">%9$s</button>
 							<div class="wp-block-navigation__responsive-container-content" %14$s id="%1$s-content">
 								%2$s
 							</div>
 						</div>
 					</div>
-				</div>',
+				</dialog>',
 			esc_attr( $modal_unique_id ),
 			$inner_blocks_html,
 			$toggle_aria_label_open,
@@ -829,7 +812,6 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu" }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
-		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );
 
 		// This is a fix for Safari. Without it, Safari doesn't change the active
 		// element when the user clicks on a button. It can be removed once we add

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -464,12 +464,14 @@ button.wp-block-navigation-item__content {
 	}
 }
 .wp-block-navigation__responsive-container {
-	display: none;
 	position: fixed;
 	top: 0;
 	left: 0;
 	right: 0;
 	bottom: 0;
+	width: auto;
+	height: auto;
+	border: 0;
 
 	// Low specificity so that themes can override.
 	& :where(.wp-block-navigation-item a) {
@@ -486,7 +488,7 @@ button.wp-block-navigation-item__content {
 
 	// If the responsive wrapper is present but overlay is not open,
 	// overlay styles shouldn't apply.
-	&:not(.is-menu-open.is-menu-open) {
+	&:not(:popover-open:popover-open) {
 		color: inherit !important;
 		background-color: inherit !important;
 	}
@@ -496,7 +498,7 @@ button.wp-block-navigation-item__content {
 	// Inherit as much as we can regarding colors, fonts, sizes,
 	// but otherwise provide a baseline.
 	// In a future version, we can explore more customizability.
-	&.is-menu-open {
+	&:popover-open {
 		display: flex; // Needs to be set to override "none".
 		flex-direction: column;
 		background-color: inherit;
@@ -609,7 +611,7 @@ button.wp-block-navigation-item__content {
 
 	@include break-small() {
 		&:not(.hidden-by-default) {
-			&:not(.is-menu-open) {
+			&:not(:popover-open) {
 				display: block;
 				width: 100%;
 				position: relative;
@@ -622,7 +624,7 @@ button.wp-block-navigation-item__content {
 			}
 		}
 
-		&.is-menu-open {
+		&:popover-open {
 			// Override breakpoint-inherited submenu rules.
 			.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container.wp-block-navigation__submenu-container {
 				left: 0;
@@ -633,12 +635,12 @@ button.wp-block-navigation-item__content {
 
 // Default menu background and font color.
 .wp-block-navigation:not(.has-background)
-.wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation__responsive-container:popover-open {
 	background-color: #fff;
 }
 
 .wp-block-navigation:not(.has-text-color)
-.wp-block-navigation__responsive-container.is-menu-open {
+.wp-block-navigation__responsive-container:popover-open {
 	color: #000;
 }
 
@@ -725,9 +727,9 @@ button.wp-block-navigation-item__content {
 	}
 }
 
-.is-menu-open .wp-block-navigation__responsive-close,
-.is-menu-open .wp-block-navigation__responsive-dialog,
-.is-menu-open .wp-block-navigation__responsive-container-content {
+.wp-block-navigation__responsive-container:popover-open .wp-block-navigation__responsive-close,
+.wp-block-navigation__responsive-container:popover-open .wp-block-navigation__responsive-dialog,
+.wp-block-navigation__responsive-container:popover-open .wp-block-navigation__responsive-container-content {
 	box-sizing: border-box;
 }
 
@@ -736,8 +738,8 @@ button.wp-block-navigation-item__content {
 }
 
 // Adjust open dialog top margin when admin-bar is visible.
-// Needs to be scoped to .is-menu-open, or it will shift the position of any other navigations that may be present.
-.has-modal-open .admin-bar .is-menu-open .wp-block-navigation__responsive-dialog {
+// Needs to be scoped to :popover-open, or it will shift the position of any other navigations that may be present.
+.admin-bar .wp-block-navigation__responsive-container:popover-open .wp-block-navigation__responsive-dialog {
 	margin-top: $admin-bar-height-big;
 
 	// Handle smaller admin-bar.
@@ -747,6 +749,6 @@ button.wp-block-navigation-item__content {
 }
 
 // Prevent scrolling of the parent content when the modal is open.
-html.has-modal-open {
-	overflow: hidden;
-}
+//html.has-modal-open {
+//	overflow: hidden;
+//}

--- a/packages/block-library/src/navigation/view.js
+++ b/packages/block-library/src/navigation/view.js
@@ -77,16 +77,6 @@ const { state, actions } = store(
 					actions.closeMenu( 'hover' );
 				}
 			},
-			openMenuOnClick() {
-				const ctx = getContext();
-				const { ref } = getElement();
-				ctx.previousFocus = ref;
-				actions.openMenu( 'click' );
-			},
-			closeMenuOnClick() {
-				actions.closeMenu( 'click' );
-				actions.closeMenu( 'focus' );
-			},
 			openMenuOnFocus() {
 				actions.openMenu( 'focus' );
 			},
@@ -104,38 +94,6 @@ const { state, actions } = store(
 				} else {
 					ctx.previousFocus = ref;
 					actions.openMenu( 'click' );
-				}
-			},
-			handleMenuKeydown( event ) {
-				const { type, firstFocusableElement, lastFocusableElement } =
-					getContext();
-				if ( state.menuOpenedBy.click ) {
-					// If Escape close the menu.
-					if ( event?.key === 'Escape' ) {
-						actions.closeMenu( 'click' );
-						actions.closeMenu( 'focus' );
-						return;
-					}
-
-					// Trap focus if it is an overlay (main menu).
-					if ( type === 'overlay' && event.key === 'Tab' ) {
-						// If shift + tab it change the direction.
-						if (
-							event.shiftKey &&
-							window.document.activeElement ===
-								firstFocusableElement
-						) {
-							event.preventDefault();
-							lastFocusableElement.focus();
-						} else if (
-							! event.shiftKey &&
-							window.document.activeElement ===
-								lastFocusableElement
-						) {
-							event.preventDefault();
-							firstFocusableElement.focus();
-						}
-					}
 				}
 			},
 			handleMenuFocusout( event ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

In Core-50182, I [commented](https://core.trac.wordpress.org/ticket/50182#comment:9):

> Related: I was on a slow connection and I loaded the WCEU site but the JavaScript was taking a long time to load. I could see the nav menu button but when I tapped it nothing would happen. Even tapping it 50 times yielded no results (😜). Ideally we wouldn't need JavaScript to open the menu in the first place, which I think is now a real possibility thanks to the Popover API which can be entirely declarative.

This PR attempts to replace the use of the Interactivity API with the native [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) instead. It was pretty easy to implement, however there is one key problem: there is no focus trap for popovers since they are non-modal. In contrast, the `dialog` element _is_ a modal, but it currently requires opening with JavaScript. See [comparison of dialog vs popover](https://web.dev/blog/popover-api). In order to leverage this, I believe we have to wait for [invoker commands](https://open-ui.org/components/invokers.explainer/) to land in the web platform. See also [An update on invokers: Invoker commands in HTML](https://utilitybend.com/blog/an-update-on-invokers-invoker-commands-in-html).

## Screenshots or screencast <!-- if applicable -->

[Screen recording 2024-07-24 17.56.31.webm](https://github.com/user-attachments/assets/40325026-1f69-47f5-9430-5e02d3aa7c68)
