### PR TITLE
Grid layout: Try moving resizer popover slot to fix display on mobile

### DIFF
--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -98,7 +98,7 @@ function GridItemResizerInner( {
 		<BlockPopoverCover
 			className="block-editor-grid-item-resizer"
 			clientId={ clientId }
-			__unstablePopoverSlot="block-toolbar"
+			__unstablePopoverSlot="__unstable-block-tools-after"
 			additionalStyles={ styles }
 		>
 			<ResizableBox


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #57478, might fix https://github.com/WordPress/gutenberg/issues/63275

Similar to https://github.com/WordPress/gutenberg/pull/63389, try updating the Grid resizer to use a different popover slot, that is after the editor canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed that as of #63389, the grid visualizer doesn't erroneously appear on mobile when the list view is open. It seems that if we update the resizer to use the same popover slot, then it'll also no longer appear when the list view is open and a child of a grid block is selected.

Note: I'm not too sure if there are any downsides to this approach, so pinging @noisysocks for a second opinion here 🙂

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the popover to use the `"__unstable-block-tools-after"` slot.
* You can see where this slot is output [here](https://github.com/WordPress/gutenberg/blob/6dfaf0de958e1a1defddc1fa4ff82bfa30bf9639/packages/block-editor/src/components/block-tools/index.js#L251)
* And example usage of that component, where you can see that the editor iframe is passed down as `children` to `BlockTools` [here](https://github.com/WordPress/gutenberg/blob/c57b5e43bc27bacf967326d12a5aa1e58c7ac730/packages/block-editor/src/components/block-canvas/index.js#L59)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable the Grid interactivity experiment in the Gutenberg plugin settings menu
2. Add a Grid block and set it to Manual
3. Give it a bunch of Columns and Rows
4. Add a few paragraph blocks to the Grid block
5. Select one of them
6. Reduce the viewport to mobile screen size and open the list view
7. With a child of the Grid block selected, you should no longer see the resizer box poking through (see screenshots below for an example)
8. Double check that the resizer is otherwise functioning as it is on `trunk`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="407" alt="image" src="https://github.com/user-attachments/assets/dd0e1511-f520-401b-a7cf-630737668cd1"> | <img width="409" alt="image" src="https://github.com/user-attachments/assets/782af82a-82cd-49d1-8571-fba5f7eca72b"> |