### PR TITLE
TemplateContentPanel: Fix the 'getBlocksByName' selector call

### DIFF
--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -45,8 +45,8 @@ export default function DisableNonPageContentBlocks() {
 	);
 	const disabledIds = useSelect( ( select ) => {
 		const { getBlocksByName, getBlockOrder } = select( blockEditorStore );
-		return getBlocksByName( [ 'core/template-part' ] ).flatMap(
-			( clientId ) => getBlockOrder( clientId )
+		return getBlocksByName( 'core/template-part' ).flatMap( ( clientId ) =>
+			getBlockOrder( clientId )
 		);
 	}, [] );
 


### PR DESCRIPTION
## What?
PR updates the `getBlocksByName` selector call and passes the block name as a string. The selector supports both strings and an array of strings as arguments.

## Why?
The `getBlocksByName` is a memoized selector passing a new array on each call, will unnecessarily invalidate the cache.

## Testing Instructions
1. Edit a page in the Site Editor.
2. Confirm template part editing is disabled.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-25 at 11 59 40](https://github.com/user-attachments/assets/abce9630-ee09-464f-84df-ebc25d45a885)
