### PR TITLE
Column: Enable border radius support

### DIFF
--- a/packages/block-library/src/column/block.json
+++ b/packages/block-library/src/column/block.json
@@ -48,10 +48,12 @@
 		},
 		"__experimentalBorder": {
 			"color": true,
+			"radius": true,
 			"style": true,
 			"width": true,
 			"__experimentalDefaultControls": {
 				"color": true,
+				"radius": true,
 				"style": true,
 				"width": true
 			}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/41345

## What?

Enables border-radius support for individual Column blocks.

_Note: This PR does not add any automatic clipping of overflow content as [discussed](https://github.com/WordPress/gutenberg/issues/41345#issuecomment-2249253785) on the original issue. This will bring the Column block in line with the Group block._

## Why?

To unlock more design possibilities and reduce the need for unnecessary wrapping of content in Group blocks to achieve the same end.

## How?

Enable border-radius block support.

## Testing Instructions

1. Open the site editor and navigate to Styles > Blocks > Column
2. Add a global border radius for Column blocks
3. Add some columns with background color to the page or post and ensure radius is displayed correctly
4. Save and confirm the radius is applied correctly on the frontend
5. Back in the editor select a Column block instance
6. Tweak that instance's border radii and confirm those values override the global styles
7. Save and confirm display on the frontend.

## Screenshots or screencast <!-- if applicable -->
<img width="731" alt="Screenshot 2024-07-25 at 6 26 40 PM" src="https://github.com/user-attachments/assets/a1fdb0ee-6e92-4633-8d63-409238d3b1ab">
