### PR TITLE
DataViews: Optimize the patterns dataviews by extracting the fields definition

### DIFF
--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -54,7 +54,7 @@ function PreviewWrapper( { item, onClick, ariaDescribedBy, children } ) {
 	);
 }
 
-function Preview( { item } ) {
+function PreviewField( { item } ) {
 	const descriptionId = useId();
 	const description = item.description || item?.excerpt?.raw;
 	const isUserPattern = item.type === PATTERN_TYPES.user;
@@ -108,11 +108,11 @@ function Preview( { item } ) {
 export const previewField = {
 	label: __( 'Preview' ),
 	id: 'preview',
-	render: ( { item } ) => <Preview item={ item } />,
+	render: PreviewField,
 	enableSorting: false,
 };
 
-function Title( { item } ) {
+function TitleField( { item } ) {
 	const isUserPattern = item.type === PATTERN_TYPES.user;
 	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
 	const { onClick } = useLink( {
@@ -163,7 +163,7 @@ export const titleField = {
 	label: __( 'Title' ),
 	id: 'title',
 	getValue: ( { item } ) => item.title?.raw || item.title,
-	render: ( { item } ) => <Title item={ item } />,
+	render: TitleField,
 	enableHiding: false,
 };
 
@@ -211,7 +211,7 @@ export const patternStatusField = {
 	enableSorting: false,
 };
 
-function Author( { item } ) {
+function AuthorField( { item } ) {
 	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
 	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
 
@@ -244,9 +244,7 @@ export const templatePartAuthorField = {
 	label: __( 'Author' ),
 	id: 'author',
 	getValue: ( { item } ) => item.author_text,
-	render: ( { item } ) => {
-		return <Author item={ item } />;
-	},
+	render: AuthorField,
 	filterBy: {
 		isPrimary: true,
 	},

--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -1,0 +1,253 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	Button,
+	Tooltip,
+	Flex,
+} from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import { useState, useMemo, useId } from '@wordpress/element';
+import {
+	BlockPreview,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { Icon, lockSmall } from '@wordpress/icons';
+import { parse } from '@wordpress/blocks';
+import { decodeEntities } from '@wordpress/html-entities';
+
+/**
+ * Internal dependencies
+ */
+import { Async } from '../async';
+import {
+	PATTERN_TYPES,
+	TEMPLATE_PART_POST_TYPE,
+	PATTERN_SYNC_TYPES,
+	OPERATOR_IS,
+} from '../../utils/constants';
+import { unlock } from '../../lock-unlock';
+import { useLink } from '../routes/link';
+import { useAddedBy } from '../page-templates/hooks';
+import { defaultGetTitle } from './search-items';
+
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
+
+function PreviewWrapper( { item, onClick, ariaDescribedBy, children } ) {
+	return (
+		<button
+			className="page-patterns-preview-field__button"
+			type="button"
+			onClick={ item.type !== PATTERN_TYPES.theme ? onClick : undefined }
+			aria-label={ item.title }
+			aria-describedby={ ariaDescribedBy }
+			aria-disabled={ item.type === PATTERN_TYPES.theme }
+		>
+			{ children }
+		</button>
+	);
+}
+
+function Preview( { item } ) {
+	const descriptionId = useId();
+	const description = item.description || item?.excerpt?.raw;
+	const isUserPattern = item.type === PATTERN_TYPES.user;
+	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
+	const { onClick } = useLink( {
+		postType: item.type,
+		postId: isUserPattern || isTemplatePart ? item.id : item.name,
+		canvas: 'edit',
+	} );
+	const blocks = useMemo( () => {
+		return (
+			item.blocks ??
+			parse( item.content.raw, {
+				__unstableSkipMigrationLogs: true,
+			} )
+		);
+	}, [ item?.content?.raw, item.blocks ] );
+	const isEmpty = ! blocks?.length;
+
+	return (
+		<div
+			className="page-patterns-preview-field"
+			style={ { backgroundColor } }
+		>
+			<PreviewWrapper
+				item={ item }
+				onClick={ onClick }
+				ariaDescribedBy={ !! description ? descriptionId : undefined }
+			>
+				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
+				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
+				{ ! isEmpty && (
+					<Async>
+						<BlockPreview
+							blocks={ blocks }
+							viewportWidth={ item.viewportWidth }
+						/>
+					</Async>
+				) }
+			</PreviewWrapper>
+			{ !! description && (
+				<div hidden id={ descriptionId }>
+					{ description }
+				</div>
+			) }
+		</div>
+	);
+}
+
+export const previewField = {
+	label: __( 'Preview' ),
+	id: 'preview',
+	render: ( { item } ) => <Preview item={ item } />,
+	enableSorting: false,
+};
+
+function Title( { item } ) {
+	const isUserPattern = item.type === PATTERN_TYPES.user;
+	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
+	const { onClick } = useLink( {
+		postType: item.type,
+		postId: isUserPattern || isTemplatePart ? item.id : item.name,
+		canvas: 'edit',
+	} );
+	const title = decodeEntities( defaultGetTitle( item ) );
+	return (
+		<HStack alignment="center" justify="flex-start" spacing={ 2 }>
+			<Flex
+				as="div"
+				gap={ 0 }
+				justify="left"
+				className="edit-site-patterns__pattern-title"
+			>
+				{ item.type === PATTERN_TYPES.theme ? (
+					title
+				) : (
+					<Button
+						variant="link"
+						onClick={ onClick }
+						// Required for the grid's roving tab index system.
+						// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
+						tabIndex="-1"
+					>
+						{ title }
+					</Button>
+				) }
+			</Flex>
+			{ item.type === PATTERN_TYPES.theme && (
+				<Tooltip
+					placement="top"
+					text={ __( 'This pattern cannot be edited.' ) }
+				>
+					<Icon
+						className="edit-site-patterns__pattern-lock-icon"
+						icon={ lockSmall }
+						size={ 24 }
+					/>
+				</Tooltip>
+			) }
+		</HStack>
+	);
+}
+
+export const titleField = {
+	label: __( 'Title' ),
+	id: 'title',
+	getValue: ( { item } ) => item.title?.raw || item.title,
+	render: ( { item } ) => <Title item={ item } />,
+	enableHiding: false,
+};
+
+const SYNC_FILTERS = [
+	{
+		value: PATTERN_SYNC_TYPES.full,
+		label: _x( 'Synced', 'pattern (singular)' ),
+		description: __( 'Patterns that are kept in sync across the site.' ),
+	},
+	{
+		value: PATTERN_SYNC_TYPES.unsynced,
+		label: _x( 'Not synced', 'pattern (singular)' ),
+		description: __(
+			'Patterns that can be changed freely without affecting the site.'
+		),
+	},
+];
+
+export const patternStatusField = {
+	label: __( 'Sync status' ),
+	id: 'sync-status',
+	render: ( { item } ) => {
+		const syncStatus =
+			'wp_pattern_sync_status' in item
+				? item.wp_pattern_sync_status || PATTERN_SYNC_TYPES.full
+				: PATTERN_SYNC_TYPES.unsynced;
+		// User patterns can have their sync statuses checked directly.
+		// Non-user patterns are all unsynced for the time being.
+		return (
+			<span
+				className={ `edit-site-patterns__field-sync-status-${ syncStatus }` }
+			>
+				{
+					SYNC_FILTERS.find( ( { value } ) => value === syncStatus )
+						.label
+				}
+			</span>
+		);
+	},
+	elements: SYNC_FILTERS,
+	filterBy: {
+		operators: [ OPERATOR_IS ],
+		isPrimary: true,
+	},
+	enableSorting: false,
+};
+
+function Author( { item } ) {
+	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
+	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
+
+	return (
+		<HStack alignment="left" spacing={ 0 }>
+			{ imageUrl && (
+				<div
+					className={ clsx( 'page-templates-author-field__avatar', {
+						'is-loaded': isImageLoaded,
+					} ) }
+				>
+					<img
+						onLoad={ () => setIsImageLoaded( true ) }
+						alt=""
+						src={ imageUrl }
+					/>
+				</div>
+			) }
+			{ ! imageUrl && (
+				<div className="page-templates-author-field__icon">
+					<Icon icon={ icon } />
+				</div>
+			) }
+			<span className="page-templates-author-field__name">{ text }</span>
+		</HStack>
+	);
+}
+
+export const templatePartAuthorField = {
+	label: __( 'Author' ),
+	id: 'author',
+	getValue: ( { item } ) => item.author_text,
+	render: ( { item } ) => {
+		return <Author item={ item } />;
+	},
+	filterBy: {
+		isPrimary: true,
+	},
+};

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -1,59 +1,39 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
-import {
-	__experimentalHStack as HStack,
-	Button,
-	Tooltip,
-	Flex,
-} from '@wordpress/components';
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useState, useMemo, useId, useEffect } from '@wordpress/element';
-import {
-	BlockPreview,
-	privateApis as blockEditorPrivateApis,
-} from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
-import { Icon, lockSmall } from '@wordpress/icons';
 import { usePrevious } from '@wordpress/compose';
 import { useEntityRecords } from '@wordpress/core-data';
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { parse } from '@wordpress/blocks';
-import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
-import { Async } from '../async';
 import Page from '../page';
 import {
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
-	LAYOUT_LIST,
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
-	PATTERN_SYNC_TYPES,
 	PATTERN_DEFAULT_CATEGORY,
-	OPERATOR_IS,
 } from '../../utils/constants';
 import usePatternSettings from './use-pattern-settings';
 import { unlock } from '../../lock-unlock';
 import usePatterns from './use-patterns';
 import PatternsHeader from './header';
-import { useLink } from '../routes/link';
-import { useAddedBy } from '../page-templates/hooks';
 import { useEditPostAction } from '../dataviews-actions';
-import { defaultGetTitle } from './search-items';
+import {
+	patternStatusField,
+	previewField,
+	titleField,
+	templatePartAuthorField,
+} from './fields';
 
-const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
-	blockEditorPrivateApis
-);
+const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { usePostActions } = unlock( editorPrivateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
@@ -90,164 +70,6 @@ const DEFAULT_VIEW = {
 	filters: [],
 };
 
-const SYNC_FILTERS = [
-	{
-		value: PATTERN_SYNC_TYPES.full,
-		label: _x( 'Synced', 'pattern (singular)' ),
-		description: __( 'Patterns that are kept in sync across the site.' ),
-	},
-	{
-		value: PATTERN_SYNC_TYPES.unsynced,
-		label: _x( 'Not synced', 'pattern (singular)' ),
-		description: __(
-			'Patterns that can be changed freely without affecting the site.'
-		),
-	},
-];
-
-function PreviewWrapper( { item, onClick, ariaDescribedBy, children } ) {
-	return (
-		<button
-			className="page-patterns-preview-field__button"
-			type="button"
-			onClick={ item.type !== PATTERN_TYPES.theme ? onClick : undefined }
-			aria-label={ item.title }
-			aria-describedby={ ariaDescribedBy }
-			aria-disabled={ item.type === PATTERN_TYPES.theme }
-		>
-			{ children }
-		</button>
-	);
-}
-
-function Preview( { item, viewType } ) {
-	const descriptionId = useId();
-	const description = item.description || item?.excerpt?.raw;
-	const isUserPattern = item.type === PATTERN_TYPES.user;
-	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
-	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
-	const { onClick } = useLink( {
-		postType: item.type,
-		postId: isUserPattern || isTemplatePart ? item.id : item.name,
-		canvas: 'edit',
-	} );
-	const blocks = useMemo( () => {
-		return (
-			item.blocks ??
-			parse( item.content.raw, {
-				__unstableSkipMigrationLogs: true,
-			} )
-		);
-	}, [ item?.content?.raw, item.blocks ] );
-	const isEmpty = ! blocks?.length;
-
-	return (
-		<div
-			className={ `page-patterns-preview-field is-viewtype-${ viewType }` }
-			style={ { backgroundColor } }
-		>
-			<PreviewWrapper
-				item={ item }
-				onClick={ onClick }
-				ariaDescribedBy={ !! description ? descriptionId : undefined }
-			>
-				{ isEmpty && isTemplatePart && __( 'Empty template part' ) }
-				{ isEmpty && ! isTemplatePart && __( 'Empty pattern' ) }
-				{ ! isEmpty && (
-					<Async>
-						<BlockPreview
-							blocks={ blocks }
-							viewportWidth={ item.viewportWidth }
-						/>
-					</Async>
-				) }
-			</PreviewWrapper>
-			{ !! description && (
-				<div hidden id={ descriptionId }>
-					{ description }
-				</div>
-			) }
-		</div>
-	);
-}
-
-function Author( { item, viewType } ) {
-	const [ isImageLoaded, setIsImageLoaded ] = useState( false );
-	const { text, icon, imageUrl } = useAddedBy( item.type, item.id );
-	const withIcon = viewType !== LAYOUT_LIST;
-
-	return (
-		<HStack alignment="left" spacing={ 0 }>
-			{ withIcon && imageUrl && (
-				<div
-					className={ clsx( 'page-templates-author-field__avatar', {
-						'is-loaded': isImageLoaded,
-					} ) }
-				>
-					<img
-						onLoad={ () => setIsImageLoaded( true ) }
-						alt=""
-						src={ imageUrl }
-					/>
-				</div>
-			) }
-			{ withIcon && ! imageUrl && (
-				<div className="page-templates-author-field__icon">
-					<Icon icon={ icon } />
-				</div>
-			) }
-			<span className="page-templates-author-field__name">{ text }</span>
-		</HStack>
-	);
-}
-
-function Title( { item } ) {
-	const isUserPattern = item.type === PATTERN_TYPES.user;
-	const isTemplatePart = item.type === TEMPLATE_PART_POST_TYPE;
-	const { onClick } = useLink( {
-		postType: item.type,
-		postId: isUserPattern || isTemplatePart ? item.id : item.name,
-		canvas: 'edit',
-	} );
-	const title = decodeEntities( defaultGetTitle( item ) );
-	return (
-		<HStack alignment="center" justify="flex-start" spacing={ 2 }>
-			<Flex
-				as="div"
-				gap={ 0 }
-				justify="left"
-				className="edit-site-patterns__pattern-title"
-			>
-				{ item.type === PATTERN_TYPES.theme ? (
-					title
-				) : (
-					<Button
-						variant="link"
-						onClick={ onClick }
-						// Required for the grid's roving tab index system.
-						// See https://github.com/WordPress/gutenberg/pull/51898#discussion_r1243399243.
-						tabIndex="-1"
-					>
-						{ title }
-					</Button>
-				) }
-			</Flex>
-			{ item.type === PATTERN_TYPES.theme && (
-				<Tooltip
-					placement="top"
-					text={ __( 'This pattern cannot be edited.' ) }
-				>
-					<Icon
-						className="edit-site-patterns__pattern-lock-icon"
-						icon={ lockSmall }
-						size={ 24 }
-					/>
-				</Tooltip>
-			) }
-		</HStack>
-	);
-}
-
 export default function DataviewsPatterns() {
 	const {
 		params: { postType, categoryId: categoryIdFromURL },
@@ -267,6 +89,7 @@ export default function DataviewsPatterns() {
 	const { records } = useEntityRecords( 'postType', TEMPLATE_PART_POST_TYPE, {
 		per_page: -1,
 	} );
+
 	const authors = useMemo( () => {
 		if ( ! records ) {
 			return EMPTY_ARRAY;
@@ -282,72 +105,19 @@ export default function DataviewsPatterns() {
 	}, [ records ] );
 
 	const fields = useMemo( () => {
-		const _fields = [
-			{
-				label: __( 'Preview' ),
-				id: 'preview',
-				render: ( { item } ) => (
-					<Preview item={ item } viewType={ view.type } />
-				),
-				enableSorting: false,
-			},
-			{
-				label: __( 'Title' ),
-				id: 'title',
-				getValue: ( { item } ) => item.title?.raw || item.title,
-				render: ( { item } ) => <Title item={ item } />,
-				enableHiding: false,
-			},
-		];
+		const _fields = [ previewField, titleField ];
 
 		if ( type === PATTERN_TYPES.user ) {
-			_fields.push( {
-				label: __( 'Sync status' ),
-				id: 'sync-status',
-				render: ( { item } ) => {
-					const syncStatus =
-						'wp_pattern_sync_status' in item
-							? item.wp_pattern_sync_status ||
-							  PATTERN_SYNC_TYPES.full
-							: PATTERN_SYNC_TYPES.unsynced;
-					// User patterns can have their sync statuses checked directly.
-					// Non-user patterns are all unsynced for the time being.
-					return (
-						<span
-							className={ `edit-site-patterns__field-sync-status-${ syncStatus }` }
-						>
-							{
-								SYNC_FILTERS.find(
-									( { value } ) => value === syncStatus
-								).label
-							}
-						</span>
-					);
-				},
-				elements: SYNC_FILTERS,
-				filterBy: {
-					operators: [ OPERATOR_IS ],
-					isPrimary: true,
-				},
-				enableSorting: false,
-			} );
+			_fields.push( patternStatusField );
 		} else if ( type === TEMPLATE_PART_POST_TYPE ) {
 			_fields.push( {
-				label: __( 'Author' ),
-				id: 'author',
-				getValue: ( { item } ) => item.author_text,
-				render: ( { item } ) => {
-					return <Author viewType={ view.type } item={ item } />;
-				},
+				...templatePartAuthorField,
 				elements: authors,
-				filterBy: {
-					isPrimary: true,
-				},
 			} );
 		}
 
 		return _fields;
-	}, [ view.type, type, authors ] );
+	}, [ type, authors ] );
 
 	// Reset the page number when the category changes.
 	useEffect( () => {

--- a/packages/edit-site/src/components/page-patterns/style.scss
+++ b/packages/edit-site/src/components/page-patterns/style.scss
@@ -1,10 +1,92 @@
+.edit-site-patterns__delete-modal {
+	width: $modal-width-small;
+}
+
+.page-patterns-preview-field {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+
+	.dataviews-view-table & {
+		width: 96px;
+		flex-grow: 0;
+		border-radius: 2px;
+
+		.page-patterns-preview-field__button {
+			border-radius: 2px;
+		}
+	}
+
+	.page-patterns-preview-field__button {
+		box-shadow: none;
+		border: none;
+		padding: 0;
+		background-color: unset;
+		box-sizing: border-box;
+		cursor: pointer;
+		overflow: hidden;
+		height: 100%;
+		border-radius: $grid-unit-05;
+
+		&:focus-visible {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
+		}
+
+		&[aria-disabled="true"] {
+			cursor: default;
+		}
+	}
+}
+
+.edit-site-patterns__pattern-icon {
+	fill: var(--wp-block-synced-color);
+	flex-shrink: 0;
+}
+
+.edit-site-patterns__pattern-lock-icon {
+	min-width: min-content;
+}
+
 .edit-site-patterns__section-header {
+	border-bottom: 1px solid #f0f0f0;
+	padding: $grid-unit-20 $grid-unit-60;
+	position: sticky;
+	top: 0;
+	z-index: 2;
+	flex-shrink: 0;
+	transition: padding ease-out 0.1s;
+	@include reduce-motion("transition");
+	min-height: $grid-unit-50;
+
+	.edit-site-patterns__title {
+		min-height: $grid-unit-50;
+
+		.components-heading {
+			flex-grow: 1;
+			flex-basis: 0;
+			white-space: nowrap;
+		}
+	}
+
+	.edit-site-patterns__sub-title {
+		margin-bottom: $grid-unit-10;
+	}
+
 	.screen-reader-shortcut:focus {
 		top: 0;
 	}
 }
 
 .edit-site-patterns__pattern-title {
+	display: block;
+	width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	color: inherit;
+
 	.is-link {
 		text-decoration: none;
 		color: $gray-200;
@@ -26,93 +108,7 @@
 	}
 }
 
-.edit-site-patterns__delete-modal {
-	width: $modal-width-small;
-}
-
 .edit-site-page-patterns-dataviews {
-	.page-patterns-preview-field {
-		display: flex;
-		flex-direction: column;
-		height: 100%;
-
-		&.is-viewtype-table {
-			width: 96px;
-			flex-grow: 0;
-			border-radius: 2px;
-
-			.page-patterns-preview-field__button {
-				border-radius: 2px;
-			}
-		}
-
-		.page-patterns-preview-field__button {
-			box-shadow: none;
-			border: none;
-			padding: 0;
-			background-color: unset;
-			box-sizing: border-box;
-			cursor: pointer;
-			overflow: hidden;
-			height: 100%;
-			border-radius: $grid-unit-05;
-
-			&:focus-visible {
-				box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-				// Windows High Contrast mode will show this outline, but not the box-shadow.
-				outline: 2px solid transparent;
-			}
-
-			&[aria-disabled="true"] {
-				cursor: default;
-			}
-		}
-	}
-
-	.edit-site-patterns__pattern-icon {
-		fill: var(--wp-block-synced-color);
-		flex-shrink: 0;
-	}
-
-	.edit-site-patterns__pattern-lock-icon {
-		min-width: min-content;
-	}
-
-	.edit-site-patterns__section-header {
-		border-bottom: 1px solid #f0f0f0;
-		padding: $grid-unit-20 $grid-unit-60;
-		position: sticky;
-		top: 0;
-		z-index: 2;
-		flex-shrink: 0;
-		transition: padding ease-out 0.1s;
-		@include reduce-motion("transition");
-		min-height: $grid-unit-50;
-
-		.edit-site-patterns__title {
-			min-height: $grid-unit-50;
-
-			.components-heading {
-				flex-grow: 1;
-				flex-basis: 0;
-				white-space: nowrap;
-			}
-		}
-
-		.edit-site-patterns__sub-title {
-			margin-bottom: $grid-unit-10;
-		}
-	}
-
-	.edit-site-patterns__pattern-title {
-		display: block;
-		width: 100%;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
-		color: inherit;
-	}
-
 	.dataviews-pagination {
 		z-index: z-index(".edit-site-patterns__dataviews-list-pagination");
 	}


### PR DESCRIPTION
Related #55083 

## What?

When working on #63923 I noticed that the dataviews fields all "remount" when the fields "render" function instance change. This was not visible for us before but it can happen very often as you filter, switch views... 

What it means is that "fields" definition should ideally be a top level module variable rather than something defined within components and that creates a new instance very often. It also forces us to think about fields more consistently across layouts...

This PR optimizes the "patterns" (and template parts) dataviews by moving the fields definition outside the component and into their own file.

I'm not entirely sure that we'll see an impact on our numbers right away but I'm sure this will benefit users and the feeling of performance as you interact with the data views.

## Testing Instructions

The current PR focuses on the "patterns" and "template parts" dataviews, so just ensure there's no regressions there. Especially UI/design regressions for the different fields.