### PR TITLE
WIP: Fix infinite render of pattern block from call to `setBlockEditingMode`

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2162,16 +2162,16 @@ export const registerInserterMediaCategory =
  */
 export const setBlockEditingMode =
 	( clientId = '', mode ) =>
-	( { select } ) => {
+	( { select, dispatch } ) => {
 		if ( select.getBlockEditingMode( clientId ) === mode ) {
 			return;
 		}
 
-		return {
+		dispatch( {
 			type: 'SET_BLOCK_EDITING_MODE',
 			clientId,
 			mode,
-		};
+		} );
 	};
 
 /**

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2160,13 +2160,19 @@ export const registerInserterMediaCategory =
  *
  * @return {Object} Action object.
  */
-export function setBlockEditingMode( clientId = '', mode ) {
-	return {
-		type: 'SET_BLOCK_EDITING_MODE',
-		clientId,
-		mode,
+export const setBlockEditingMode =
+	( clientId = '', mode ) =>
+	( { select } ) => {
+		if ( select.getBlockEditingMode( clientId ) === mode ) {
+			return;
+		}
+
+		return {
+			type: 'SET_BLOCK_EDITING_MODE',
+			clientId,
+			mode,
+		};
 	};
-}
 
 /**
  * Clears the block editing mode for a given block.


### PR DESCRIPTION
## What?
WIP

Fixes #63909

## Why?


## How?


Then follow these steps:
1. Create a synced pattern that has the verse block
2. Insert the synced pattern into a post

In trunk: The pattern and verse block infinitely re-render causing the editor to hang
In this PR: The editor is usable
