### PR TITLE
Fix: [Mobile] Empty gap between block settings panel and post title #63847

### DIFF
--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -40,7 +40,7 @@
 
 	// This helps ensure the correct panel height, including the border, avoiding subpixel rounding issues.
 	box-sizing: content-box;
-	height: $grid-unit-60 - $border-width;
+	height: $grid-unit-60;
 
 	h2 {
 		margin: 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Fix Issue - https://github.com/WordPress/gutenberg/issues/63847

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This PR removes the extra gap that is present between top panel and block controls, due to less height of the header panel.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- We have a height defined as `48px`, but in the style there it was added as `47px` by subtracting the border width that was not needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open any post.
2. Add any block.
3. Select the block and inspect the mobile view.
4. Open the side panel for block controls and scroll.
5. You would not see the gap between the header panel and the block control.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9ad59e47-f632-4279-bd55-30dc9abf236e
