### PR TITLE
Zoom Out: Use the block editor for insertion point data

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
 
 /**
@@ -16,8 +16,9 @@ function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
 	const {
 		hasSelection,
+		blockInsertionPoint,
 		blockOrder,
-		insertionPoint,
+		blockInsertionPointVisible,
 		setInserterIsOpened,
 		sectionRootClientId,
 		selectedBlockClientId,
@@ -25,23 +26,19 @@ function ZoomOutModeInserters() {
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
+			getBlockInsertionPoint,
 			getBlockOrder,
 			getSelectionStart,
 			getSelectedBlockClientId,
 			getHoveredBlockClientId,
+			isBlockInsertionPointVisible,
 		} = select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
-		// To do: move ZoomOutModeInserters to core/editor.
-		// Or we perhaps we should move the insertion point state to the
-		// block-editor store. I'm not sure what it was ever moved to the editor
-		// store, because all the inserter components all live in the
-		// block-editor package.
-		// eslint-disable-next-line @wordpress/data-no-store-string-literals
-		const editor = select( 'core/editor' );
 		return {
 			hasSelection: !! getSelectionStart().clientId,
+			blockInsertionPoint: getBlockInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
-			insertionPoint: unlock( editor ).getInsertionPoint(),
+			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 			sectionRootClientId: root,
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
@@ -49,6 +46,8 @@ function ZoomOutModeInserters() {
 			hoveredBlockClientId: getHoveredBlockClientId(),
 		};
 	}, [] );
+
+	const blockEditorDispatch = useDispatch( blockEditorStore );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {
@@ -65,14 +64,8 @@ function ZoomOutModeInserters() {
 	}
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
-		const shouldRenderInserter = insertionPoint.insertionIndex !== index;
-
 		const shouldRenderInsertionPoint =
-			insertionPoint.insertionIndex === index;
-
-		if ( ! shouldRenderInserter && ! shouldRenderInsertionPoint ) {
-			return null;
-		}
+			blockInsertionPointVisible && blockInsertionPoint.index === index;
 
 		const previousClientId = clientId;
 		const nextClientId = blockOrder[ index ];
@@ -85,6 +78,8 @@ function ZoomOutModeInserters() {
 		const isHovered =
 			hoveredBlockClientId === previousClientId ||
 			hoveredBlockClientId === nextClientId;
+
+		const { showInsertionPoint } = unlock( blockEditorDispatch );
 
 		return (
 			<BlockPopoverInbetween
@@ -104,7 +99,7 @@ function ZoomOutModeInserters() {
 						className="block-editor-block-list__insertion-point-indicator"
 					/>
 				) }
-				{ shouldRenderInserter && (
+				{ ! shouldRenderInsertionPoint && (
 					<ZoomOutModeInserterButton
 						isVisible={ isSelected || isHovered }
 						onClick={ () => {
@@ -113,6 +108,9 @@ function ZoomOutModeInserters() {
 								insertionIndex: index,
 								tab: 'patterns',
 								category: 'all',
+							} );
+							showInsertionPoint( sectionRootClientId, index, {
+								operation: 'insert',
 							} );
 						} }
 					/>

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -79,7 +79,7 @@ function ZoomOutModeInserters() {
 			hoveredBlockClientId === previousClientId ||
 			hoveredBlockClientId === nextClientId;
 
-		const { showInsertionPoint } = unlock( blockEditorDispatch );
+		const { showInsertionPoint } = blockEditorDispatch;
 
 		return (
 			<BlockPopoverInbetween


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
We should be using the insertion point information from the block editor store, not the editor store.

## Why?
I'm not sure why it was done this way, but getting it from the block editor store means that we can respond to drag and drop events which will help with https://github.com/WordPress/gutenberg/pull/63896.

## How?
Replace `insertionPoint` from the editor store with  `getBlockInsertionPoint` from the block editor store.

## Testing Instructions
1. Open the Site Editor
2. Open the inserter, select the patterns tab and select a category
3. Click on a [+] between sections in zoom out mode
4. Check that the big blue insertion point marker shows
5. Check that block insertion continues to work as expected.

## Screenshot
<img width="849" alt="Screenshot 2024-07-25 at 12 58 14" src="https://github.com/user-attachments/assets/dce131c5-dfdb-4f4e-ae56-02feb44a2b0b">

