### PR TITLE
Footnotes: only replace attribute if footnotes were detected

### DIFF
--- a/packages/core-data/src/footnotes/index.js
+++ b/packages/core-data/src/footnotes/index.js
@@ -72,6 +72,8 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 					? RichTextData.fromHTMLString( value )
 					: new RichTextData( value );
 
+			let hasFootnotes = false;
+
 			richTextValue.replacements.forEach( ( replacement ) => {
 				if ( replacement.type === 'core/footnote' ) {
 					const id = replacement.attributes[ 'data-fn' ];
@@ -92,13 +94,16 @@ export function updateFootnotesFromMeta( blocks, meta ) {
 					replacement.innerHTML = toHTMLString( {
 						value: countValue,
 					} );
+					hasFootnotes = true;
 				}
 			} );
 
-			attributes[ key ] =
-				typeof value === 'string'
-					? richTextValue.toHTMLString()
-					: richTextValue;
+			if ( hasFootnotes ) {
+				attributes[ key ] =
+					typeof value === 'string'
+						? richTextValue.toHTMLString()
+						: richTextValue;
+			}
 		}
 
 		return attributes;

--- a/test/e2e/specs/editor/various/footnotes.spec.js
+++ b/test/e2e/specs/editor/various/footnotes.spec.js
@@ -456,4 +456,36 @@ test.describe( 'Footnotes', () => {
 			'1 ↩︎'
 		);
 	} );
+
+	test( 'should leave alone other block attributes', async ( {
+		editor,
+		page,
+	} ) => {
+		await page.evaluate( () => {
+			window.wp.blocks.registerBlockType( 'core/test-block-string', {
+				apiVersion: 3,
+				title: 'Block with string attribute',
+				attributes: { string: { type: 'string' } },
+				edit: () => null,
+				save: () => null,
+			} );
+		} );
+		await editor.insertBlock( {
+			name: 'core/test-block-string',
+			attributes: { string: 'a\nb' },
+		} );
+
+		await editor.insertBlock( { name: 'core/paragraph' } );
+		await page.keyboard.type( 'a' );
+		await editor.showBlockToolbar();
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.locator( 'button:text("Footnote")' ).click();
+		await page.keyboard.type( '1' );
+
+		expect( ( await editor.getBlocks() )[ 0 ] ).toMatchObject( {
+			name: 'core/test-block-string',
+			// This should NOT be 'a<br>b'!
+			attributes: { string: 'a\nb' },
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently the function `updateFootnotesFromMeta` (which updates footnotes order when block order changes) seems to always update the block attribute if it's a string or RichTextData instance, even if no footnotes were detected. This is causing some issues with blocks that plain text string with new lines, which RichText will read as line break, and then serialise the line breaks in HTML. To prevent this, we can check if footnotes were detected at all.

An alternative fix is to stop processing string attributes, and only process RichTextData attributes. Footnotes were added before we had this new data type, at the time rich text attributes were also plain strings. But I think some more work is needed to guarantee that rich text attributes are always RichTextData instances.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Install this plugin: https://wordpress.org/plugins/syntaxhighlighter/

Add this in the code editor:

```html
<!-- wp:syntaxhighlighter/code -->
<pre class="wp-block-syntaxhighlighter-code">This is a SyntaxHighlighter code block

1 > 0</pre>
<!-- /wp:syntaxhighlighter/code -->

<!-- wp:paragraph -->
<p>This is a paragraph.</p>
<!-- /wp:paragraph -->
```

Now switch back to visual and add a footnote to the paragraph. The line breaks in the code block should not be converted to BR elements.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
