### PR TITLE
Zoom out: Get store action outside the loop

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -47,7 +47,7 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	const blockEditorDispatch = useDispatch( blockEditorStore );
+	const { showInsertionPoint } = useDispatch( blockEditorStore );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {
@@ -78,8 +78,6 @@ function ZoomOutModeInserters() {
 		const isHovered =
 			hoveredBlockClientId === previousClientId ||
 			hoveredBlockClientId === nextClientId;
-
-		const { showInsertionPoint } = blockEditorDispatch;
 
 		return (
 			<BlockPopoverInbetween


### PR DESCRIPTION
## What?
A small follow-up to #63934.

We can safely get store actions earlier in the component when not working with private actions.

## Testing Instructions
None. PR just moves code around.