### PR TITLE
Add text-shadow support to blocks via theme.json

### DIFF
--- a/docs/reference-guides/theme-json-reference/theme-json-living.md
+++ b/docs/reference-guides/theme-json-reference/theme-json-living.md
@@ -192,6 +192,7 @@ Settings related to typography.
 | textAlign | Allow users to set the text align. | `boolean` | `true` |
 | textColumns | Allow users to set the number of text columns. | `boolean` | `false` |
 | textDecoration | Allow users to set custom text decorations. | `boolean` | `true` |
+| textShadow | Allow users to set text shadow. | `boolean` | `false` |
 | writingMode | Allow users to set the writing mode. | `boolean` | `false` |
 | textTransform | Allow users to set custom text transforms. | `boolean` | `true` |
 | dropCap | Enable drop cap. | `boolean` | `true` |
@@ -328,6 +329,7 @@ Typography styles.
 | textDecoration | Sets the `text-decoration` CSS property. | `string`, `{ ref }` |
 | writingMode | Sets the `writing-mode` CSS property. | `string`, `{ ref }` |
 | textTransform | Sets the `text-transform` CSS property. | `string`, `{ ref }` |
+| textShadow | Sets the `text-shadow` CSS property. | `string`, `{ ref }` |
 
 ---
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -223,6 +223,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.2.0 Added `outline-*`, and `min-height` properties.
 	 * @since 6.3.0 Added `writing-mode` property.
 	 * @since 6.6.0 Added `background-[image|position|repeat|size]` properties.
+	 * @since 6.7.0 Added `text-shadow` property.
 	 *
 	 * @var array
 	 */
@@ -288,6 +289,7 @@ class WP_Theme_JSON_Gutenberg {
 		'text-transform'                    => array( 'typography', 'textTransform' ),
 		'filter'                            => array( 'filter', 'duotone' ),
 		'box-shadow'                        => array( 'shadow' ),
+		'text-shadow'                       => array( 'typography', 'textShadow' ),
 		'writing-mode'                      => array( 'typography', 'writingMode' ),
 	);
 
@@ -376,6 +378,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @since 6.3.0 Removed `layout.definitions`. Added `typography.writingMode`.
 	 * @since 6.4.0 Added `layout.allowEditing`.
 	 * @since 6.4.0 Added `lightbox`.
+	 * @since 6.7.0 Added `typography.textShadow`.
 	 * @var array
 	 */
 	const VALID_SETTINGS = array(
@@ -458,6 +461,7 @@ class WP_Theme_JSON_Gutenberg {
 			'textColumns'      => null,
 			'textDecoration'   => null,
 			'textTransform'    => null,
+			'textShadow'       => null,
 			'writingMode'      => null,
 		),
 	);
@@ -555,6 +559,7 @@ class WP_Theme_JSON_Gutenberg {
 			'textColumns'    => null,
 			'textDecoration' => null,
 			'textTransform'  => null,
+			'textShadow'     => null,
 			'writingMode'    => null,
 		),
 		'css'        => null,

--- a/lib/theme.json
+++ b/lib/theme.json
@@ -309,6 +309,7 @@
 			"textColumns": false,
 			"textDecoration": true,
 			"textTransform": true,
+			"textShadow": false,
 			"writingMode": false
 		},
 		"blocks": {

--- a/packages/style-engine/src/styles/typography/index.ts
+++ b/packages/style-engine/src/styles/typography/index.ts
@@ -112,6 +112,18 @@ const textTransform = {
 	},
 };
 
+const textShadow = {
+	name: 'textShadow',
+	generate: ( style: Style, options: StyleOptions ) => {
+		return generateRule(
+			style,
+			options,
+			[ 'typography', 'textShadow' ],
+			'textShadow'
+		);
+	},
+};
+
 const writingMode = {
 	name: 'writingMode',
 	generate: ( style: Style, options: StyleOptions ) => {
@@ -134,5 +146,6 @@ export default [
 	textColumns,
 	textDecoration,
 	textTransform,
+	textShadow,
 	writingMode,
 ];

--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -598,6 +598,11 @@
 							"type": "boolean",
 							"default": true
 						},
+						"textShadow": {
+							"description": "Allow users to set text shadow.",
+							"type": "boolean",
+							"default": false
+						},
 						"writingMode": {
 							"description": "Allow users to set the writing mode.",
 							"type": "boolean",
@@ -1664,6 +1669,13 @@
 						},
 						"textTransform": {
 							"description": "Sets the `text-transform` CSS property.",
+							"oneOf": [
+								{ "type": "string" },
+								{ "$ref": "#/definitions/refComplete" }
+							]
+						},
+						"textShadow": {
+							"description": "Sets the `text-shadow` CSS property.",
 							"oneOf": [
 								{ "type": "string" },
 								{ "$ref": "#/definitions/refComplete" }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change allows to set text shadow to blocks via `theme.json` typography definition.

<img width="565" alt="image" src="https://github.com/user-attachments/assets/b963eceb-6d05-4fb3-896e-8aee18130171">

<img width="306" alt="image" src="https://github.com/user-attachments/assets/75a1c2df-f1a0-400b-a883-a05bef12e8cf">

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In `theme.json` under typography settings of any block, set the new property `textShadow` to a valid shadow value.
2. Shadow should be applied and visible in both editor and site frontend.

## Related Issues:

This is a first iteration of #47904
