### PR TITLE
Update template description in table layout

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -21,8 +21,6 @@ $default-block-margin: 28px; // This value provides a consistent, contiguous spa
 $text-editor-font-size: 15px;
 $editor-line-height: 1.8;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in".
-$maximum-text-width: 50em;
-
 
 /**
  * Grid System.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -21,6 +21,7 @@ $default-block-margin: 28px; // This value provides a consistent, contiguous spa
 $text-editor-font-size: 15px;
 $editor-line-height: 1.8;
 $mobile-text-min-font-size: 16px; // Any font size below 16px will cause Mobile Safari to "zoom in".
+$maximum-text-width: 50em;
 
 
 /**

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -309,7 +309,9 @@ export default function PageTemplates() {
 				render: ( { item } ) => {
 					return (
 						item.description && (
-							<span className="page-templates-description">
+							<span
+								className={ `page-templates-description is-viewtype-${ view.type }` }
+							>
 								{ decodeEntities( item.description ) }
 							</span>
 						)

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -51,16 +51,14 @@
 	}
 }
 
-.dataviews-view-table {
-	.page-templates-description {
-		margin-bottom: $grid-unit-10;
-	}
-}
-
 .page-templates-description {
 	max-width: 50em;
 	text-wrap: balance; // Fallback for Safari
 	text-wrap: pretty;
+
+	.dataviews-view-table & {
+		margin-bottom: $grid-unit-10;
+	}
 }
 
 .edit-site-page-templates {

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -58,7 +58,6 @@
 }
 
 .page-templates-description {
-	display: block;
 	max-width: 50em;
 	text-wrap: balance; // Fallback for Safari
 	text-wrap: pretty;

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -53,7 +53,7 @@
 
 .page-templates-description {
 	display: block;
-	max-width: $maximum-text-width;
+	max-width: 50em;
 	text-wrap: pretty;
 
 	&.is-viewtype-table {

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -51,15 +51,17 @@
 	}
 }
 
+.dataviews-view-table {
+	.page-templates-description {
+		margin-bottom: $grid-unit-10;
+	}
+}
+
 .page-templates-description {
 	display: block;
 	max-width: 50em;
 	text-wrap: balance; // Fallback for Safari
 	text-wrap: pretty;
-
-	&.is-viewtype-table {
-		margin-bottom: $grid-unit-10;
-	}
 }
 
 .edit-site-page-templates {

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -54,6 +54,7 @@
 .page-templates-description {
 	display: block;
 	max-width: 50em;
+	text-wrap: balance; // Fallback for Safari
 	text-wrap: pretty;
 
 	&.is-viewtype-table {

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -52,7 +52,13 @@
 }
 
 .page-templates-description {
-	white-space: normal;
+	display: block;
+	max-width: $maximum-text-width;
+	text-wrap: pretty;
+
+	&.is-viewtype-table {
+		margin-bottom: $grid-unit-10;
+	}
 }
 
 .edit-site-page-templates {


### PR DESCRIPTION
## What?
Updates some styling details relating to template descriptions in table layout.

## Why?
Improves legibility. Currently descriptions will fill the cell which makes the text troublesome to read on large screens.

## How?
* Adds a `max-width` to `.page-templates-description`.
  * I made a new `$maximum-text-width` var in `_variables.scss` for this purpose as it will likely have applications elsewhere. cc @WordPress/gutenberg-components for thoughts on that.
 * Adds `text-wrap: pretty` to take care of typographical widows.
 * Adds a small margin to `.page-templates-description` in table layout to centrally align the title + description in the cell.

## Testing Instructions
1. Open the Templates data view and switch to Table layout
2. Observe the new template description styling

### Before
<img width="1706" alt="Screenshot 2024-07-25 at 14 40 20" src="https://github.com/user-attachments/assets/542ea7e1-e015-4e84-b4ed-93e6e6f00a06">



### After
<img width="1705" alt="Screenshot 2024-07-25 at 14 40 38" src="https://github.com/user-attachments/assets/2c37fd77-d4d5-49ea-abdd-d8d7a7801cc2">