### PR TITLE
Update field line height across grid / list layouts

### DIFF
--- a/packages/dataviews/src/layouts/grid/style.scss
+++ b/packages/dataviews/src/layouts/grid/style.scss
@@ -64,8 +64,7 @@
 		.dataviews-view-grid__field-value:not(:empty) {
 			min-height: $grid-unit-30;
 			line-height: $grid-unit-05 * 5;
-			display: flex;
-			align-items: center;
+			padding-top: $grid-unit-05 / 2;
 		}
 
 		.dataviews-view-grid__field {

--- a/packages/dataviews/src/layouts/grid/style.scss
+++ b/packages/dataviews/src/layouts/grid/style.scss
@@ -61,6 +61,13 @@
 			padding: 0 0 $grid-unit-15;
 		}
 
+		.dataviews-view-grid__field-value:not(:empty) {
+			min-height: $grid-unit-30;
+			line-height: $grid-unit-05 * 5;
+			display: flex;
+			align-items: center;
+		}
+
 		.dataviews-view-grid__field {
 			align-items: flex-start;
 			min-height: $grid-unit-30;

--- a/packages/dataviews/src/layouts/list/style.scss
+++ b/packages/dataviews/src/layouts/list/style.scss
@@ -179,7 +179,10 @@
 		}
 
 		.dataviews-view-list__field-value {
-			line-height: $grid-unit-05 * 6;
+			min-height: $grid-unit-30;
+			line-height: $grid-unit-05 * 5;
+			display: flex;
+			align-items: center;
 		}
 	}
 


### PR DESCRIPTION
## What?
Update field line height across grid / list layouts.

## Why?
They often render at similar widths, and the font size is the same. It doesn't make sense for the `line-height` to be different in each case.

Currently in List layout the line height is `24px`. In Grid layout it inherits the default line height: `1.4`. This PR updates all field values to use a `20px` line height.

## Testing Instructions
1. In a data view like Templates toggle between List and Grid layouts
2. Ensure the field values have equal line-height across, and display is consistent. The template description is a good field to check with.
3. Ensure there are no regressions.

| Before | After |
| --- | --- |
| <img width="323" alt="Screenshot 2024-07-25 at 15 17 15" src="https://github.com/user-attachments/assets/5f8dc797-dd7a-4c66-b183-ceb3c98f9f4b"> | <img width="339" alt="Screenshot 2024-07-25 at 15 15 52" src="https://github.com/user-attachments/assets/267739a8-d549-4fde-a7c4-c4c243ee2998"> |
| <img width="386" alt="Screenshot 2024-07-25 at 15 17 09" src="https://github.com/user-attachments/assets/0e74b264-4685-470d-ba59-4c410035d59b"> | <img width="380" alt="Screenshot 2024-07-25 at 15 16 07" src="https://github.com/user-attachments/assets/d51511ed-602a-493a-bf99-35181391b127"> |




