### PR TITLE
Small Typo Correction in Inline Document

### DIFF
--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Temporary compatibility code for new functionalitites/changes related to block bindings APIs present in Gutenberg.
+ * Temporary compatibility code for new functionalities/changes related to block bindings APIs present in Gutenberg.
  *
  * @package gutenberg
  */


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/63951