### PR TITLE
CustomSelectControl: Restore `describedBy` functionality

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `CustomSelectControl`: Restore `describedBy` functionality ([#63957](https://github.com/WordPress/gutenberg/pull/63957)).
+
 ### Internal
 
 -   `DropdownMenuV2`: break menu item help text on multiple lines for better truncation. ([#63916](https://github.com/WordPress/gutenberg/pull/63916)).

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -41,6 +42,15 @@ function applyOptionDeprecations( {
 	};
 }
 
+function getDescribedBy( currentValue: string, describedBy?: string ) {
+	if ( describedBy ) {
+		return describedBy;
+	}
+
+	// translators: %s: The selected option.
+	return sprintf( __( 'Currently selected: %s' ), currentValue );
+}
+
 function CustomSelectControl( props: CustomSelectProps ) {
 	const {
 		__next40pxDefaultSize = false,
@@ -60,7 +70,7 @@ function CustomSelectControl( props: CustomSelectProps ) {
 	);
 
 	// Forward props + store from v2 implementation
-	const store = Ariakit.useSelectStore( {
+	const store = Ariakit.useSelectStore< string >( {
 		async setValue( nextValue ) {
 			const nextOption = options.find(
 				( item ) => item.name === nextValue
@@ -128,9 +138,9 @@ function CustomSelectControl( props: CustomSelectProps ) {
 			);
 		} );
 
-	const renderSelectedValueHint = () => {
-		const { value: currentValue } = store.getState();
+	const { value: currentValue } = store.getState();
 
+	const renderSelectedValueHint = () => {
 		const selectedOptionHint = options
 			?.map( applyOptionDeprecations )
 			?.find( ( { name } ) => currentValue === name )?.hint;
@@ -182,11 +192,11 @@ function CustomSelectControl( props: CustomSelectProps ) {
 			>
 				{ children }
 			</_CustomSelect>
-			{ describedBy && (
-				<VisuallyHidden>
-					<span id={ descriptionId }>{ describedBy }</span>
-				</VisuallyHidden>
-			) }
+			<VisuallyHidden>
+				<span id={ descriptionId }>
+					{ getDescribedBy( currentValue, describedBy ) }
+				</span>
+			</VisuallyHidden>
 		</>
 	);
 }

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -5,12 +5,18 @@ import * as Ariakit from '@ariakit/react';
 import clsx from 'clsx';
 
 /**
+ * WordPress dependencies
+ */
+import { useInstanceId } from '@wordpress/compose';
+
+/**
  * Internal dependencies
  */
 import _CustomSelect from '../custom-select-control-v2/custom-select';
 import CustomSelectItem from '../custom-select-control-v2/item';
 import * as Styled from '../custom-select-control-v2/styles';
 import type { CustomSelectProps } from './types';
+import { VisuallyHidden } from '../visually-hidden';
 
 function useDeprecatedProps( {
 	__experimentalShowSelectedHint,
@@ -47,6 +53,11 @@ function CustomSelectControl( props: CustomSelectProps ) {
 		showSelectedHint = false,
 		...restProps
 	} = useDeprecatedProps( props );
+
+	const descriptionId = useInstanceId(
+		CustomSelectControl,
+		'custom-select-control__description'
+	);
 
 	// Forward props + store from v2 implementation
 	const store = Ariakit.useSelectStore( {
@@ -153,23 +164,30 @@ function CustomSelectControl( props: CustomSelectProps ) {
 	} )();
 
 	return (
-		<_CustomSelect
-			aria-describedby={ describedBy }
-			renderSelectedValue={
-				showSelectedHint ? renderSelectedValueHint : undefined
-			}
-			size={ translatedSize }
-			store={ store }
-			className={ clsx(
-				// Keeping the classname for legacy reasons
-				'components-custom-select-control',
-				classNameProp
+		<>
+			<_CustomSelect
+				aria-describedby={ descriptionId }
+				renderSelectedValue={
+					showSelectedHint ? renderSelectedValueHint : undefined
+				}
+				size={ translatedSize }
+				store={ store }
+				className={ clsx(
+					// Keeping the classname for legacy reasons
+					'components-custom-select-control',
+					classNameProp
+				) }
+				isLegacy
+				{ ...restProps }
+			>
+				{ children }
+			</_CustomSelect>
+			{ describedBy && (
+				<VisuallyHidden>
+					<span id={ descriptionId }>{ describedBy }</span>
+				</VisuallyHidden>
 			) }
-			isLegacy
-			{ ...restProps }
-		>
-			{ children }
-		</_CustomSelect>
+		</>
 	);
 }
 

--- a/packages/components/src/custom-select-control/test/index.tsx
+++ b/packages/components/src/custom-select-control/test/index.tsx
@@ -670,5 +670,17 @@ describe.each( [
 			expect( currentSelectedItem ).not.toHaveFocus();
 			expect( onBlurMock ).toHaveBeenCalledTimes( 1 );
 		} );
+
+		it( 'should render the describedBy text', async () => {
+			const describedByText = 'My description.';
+
+			render(
+				<Component { ...props } describedBy={ describedByText } />
+			);
+
+			expect(
+				screen.getByRole( 'combobox' )
+			).toHaveAccessibleDescription( describedByText );
+		} );
 	} );
 } );

--- a/packages/components/src/custom-select-control/test/index.tsx
+++ b/packages/components/src/custom-select-control/test/index.tsx
@@ -671,7 +671,7 @@ describe.each( [
 			expect( onBlurMock ).toHaveBeenCalledTimes( 1 );
 		} );
 
-		it( 'should render the describedBy text', async () => {
+		it( 'should render the describedBy text when specified', async () => {
 			const describedByText = 'My description.';
 
 			render(
@@ -681,6 +681,16 @@ describe.each( [
 			expect(
 				screen.getByRole( 'combobox' )
 			).toHaveAccessibleDescription( describedByText );
+		} );
+
+		it( 'should render the default ARIA description when describedBy is not specified', async () => {
+			render( <Component { ...props } /> );
+
+			expect(
+				screen.getByRole( 'combobox' )
+			).toHaveAccessibleDescription(
+				`Currently selected: ${ props.options[ 0 ].name }`
+			);
 		} );
 	} );
 } );


### PR DESCRIPTION
Fixes #63568

## What?

Restores the `describedBy` functionality in CustomSelectControl (v1) that was broken when we switched the underlying implementation in #63258.

## How?

See code comments.

## Testing Instructions

New unit tests should pass. You can also manually inspect the rendered HTML in Storybook.
