### PR TITLE
Fix: accessibility issue of device preview options

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -78,18 +78,21 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuItem
 							onClick={ () => setDeviceType( 'Desktop' ) }
 							icon={ deviceType === 'Desktop' && check }
+							aria-label={ __( 'Desktop View' ) }
 						>
 							{ __( 'Desktop' ) }
 						</MenuItem>
 						<MenuItem
 							onClick={ () => setDeviceType( 'Tablet' ) }
 							icon={ deviceType === 'Tablet' && check }
+							aria-label={ __( 'Tablet View' ) }
 						>
 							{ __( 'Tablet' ) }
 						</MenuItem>
 						<MenuItem
 							onClick={ () => setDeviceType( 'Mobile' ) }
 							icon={ deviceType === 'Mobile' && check }
+							aria-label={ __( 'Mobile View' ) }
 						>
 							{ __( 'Mobile' ) }
 						</MenuItem>
@@ -118,6 +121,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 								className="editor-preview-dropdown__button-external"
 								role="menuitem"
 								forceIsAutosaveable={ forceIsAutosaveable }
+								aria-label={ __( 'Preview in new tab' ) }
 								textContent={
 									<>
 										{ __( 'Preview in new tab' ) }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -6,11 +6,12 @@ import {
 	DropdownMenu,
 	MenuGroup,
 	MenuItem,
+	MenuItemsChoice,
 	VisuallyHidden,
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check, desktop, mobile, tablet, external } from '@wordpress/icons';
+import { desktop, mobile, tablet, external } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -62,6 +63,54 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		desktop,
 	};
 
+	/**
+	 * The choices for the device type.
+	 *
+	 * @type {Array}
+	 */
+	const choices = [
+		{
+			value: 'Desktop',
+			label: __( 'Desktop' ),
+			icon: desktop,
+		},
+		{
+			value: 'Tablet',
+			label: __( 'Tablet' ),
+			icon: tablet,
+		},
+		{
+			value: 'Mobile',
+			label: __( 'Mobile' ),
+			icon: mobile,
+		},
+	];
+
+	/**
+	 * The selected choice.
+	 *
+	 * @type {Object}
+	 */
+	let selectedChoice = choices.find(
+		( choice ) => choice.value === deviceType
+	);
+
+	/**
+	 * If no selected choice is found, default to the first
+	 */
+	if ( ! selectedChoice ) {
+		selectedChoice = choices[ 0 ];
+	}
+
+	/**
+	 * Handles the selection of a device type.
+	 *
+	 * @param {string} value The device type.
+	 */
+	const onSelect = ( value ) => {
+		setDeviceType( value );
+	};
+
 	return (
 		<DropdownMenu
 			className="editor-preview-dropdown"
@@ -75,39 +124,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			{ ( { onClose } ) => (
 				<>
 					<MenuGroup>
-						<MenuItem
-							onClick={ () => setDeviceType( 'Desktop' ) }
-							icon={ deviceType === 'Desktop' && check }
-							aria-label={
-								deviceType === 'Desktop'
-									? __( 'Desktop Selected' )
-									: __( 'Desktop' )
-							}
-						>
-							{ __( 'Desktop' ) }
-						</MenuItem>
-						<MenuItem
-							onClick={ () => setDeviceType( 'Tablet' ) }
-							icon={ deviceType === 'Tablet' && check }
-							aria-label={
-								deviceType === 'Tablet'
-									? __( 'Tablet Selected' )
-									: __( 'Tablet' )
-							}
-						>
-							{ __( 'Tablet' ) }
-						</MenuItem>
-						<MenuItem
-							onClick={ () => setDeviceType( 'Mobile' ) }
-							icon={ deviceType === 'Mobile' && check }
-							aria-label={
-								deviceType === 'Mobile'
-									? __( 'Mobile Selected' )
-									: __( 'Mobile' )
-							}
-						>
-							{ __( 'Mobile' ) }
-						</MenuItem>
+						<MenuItemsChoice
+							choices={ choices }
+							value={ selectedChoice.value }
+							onSelect={ onSelect }
+						/>
 					</MenuGroup>
 					{ isTemplate && (
 						<MenuGroup>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -21,6 +21,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { store as editorStore } from '../../store';
 import PostPreviewButton from '../post-preview-button';
+import { speak } from '@wordpress/a11y';
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const { deviceType, homeUrl, isTemplate, isViewable, showIconLabels } =
@@ -109,6 +110,13 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	 */
 	const onSelect = ( value ) => {
 		setDeviceType( value );
+		if ( value === 'Desktop' ) {
+			speak( __( 'Desktop selected' ), 'assertive' );
+		} else if ( value === 'Tablet' ) {
+			speak( __( 'Tablet selected' ), 'assertive' );
+		} else {
+			speak( __( 'Mobile selected' ), 'assertive' );
+		}
 	};
 
 	return (

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -78,21 +78,33 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuItem
 							onClick={ () => setDeviceType( 'Desktop' ) }
 							icon={ deviceType === 'Desktop' && check }
-							aria-label={ __( 'Desktop View' ) }
+							aria-label={
+								deviceType === 'Desktop'
+									? __( 'Desktop Selected' )
+									: __( 'Desktop' )
+							}
 						>
 							{ __( 'Desktop' ) }
 						</MenuItem>
 						<MenuItem
 							onClick={ () => setDeviceType( 'Tablet' ) }
 							icon={ deviceType === 'Tablet' && check }
-							aria-label={ __( 'Tablet View' ) }
+							aria-label={
+								deviceType === 'Tablet'
+									? __( 'Tablet Selected' )
+									: __( 'Tablet' )
+							}
 						>
 							{ __( 'Tablet' ) }
 						</MenuItem>
 						<MenuItem
 							onClick={ () => setDeviceType( 'Mobile' ) }
 							icon={ deviceType === 'Mobile' && check }
-							aria-label={ __( 'Mobile View' ) }
+							aria-label={
+								deviceType === 'Mobile'
+									? __( 'Mobile Selected' )
+									: __( 'Mobile' )
+							}
 						>
 							{ __( 'Mobile' ) }
 						</MenuItem>


### PR DESCRIPTION

## What?
- added `aria-label` to desktop, tablet, mobile & preview links.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/63910


## Testing Instructions
- open editor and click on view to resize now check with screenreader selected view will be accessible.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/973d0f2f-aa37-4461-85b2-bdac7405fb60

