### PR TITLE
Theme JSON: Update core theme json resolver class use to Gutenberg version

### DIFF
--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -33,7 +33,7 @@ add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 
 /**
  * Adds the post classes to the REST API response.
  *
- * @param  array $post  The response object data.
+ * @param  array $post The response object data.
  *
  * @return array
  */

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -33,7 +33,7 @@ add_filter( 'register_post_type_args', 'wp_api_template_access_controller', 10, 
 /**
  * Adds the post classes to the REST API response.
  *
- * @param  array  $post  The response object data.
+ * @param  array $post  The response object data.
  *
  * @return array
  */
@@ -169,7 +169,7 @@ function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
 	if ( 'core/edit-post' === $context->name ) {
 		$paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet();
 		$paths[] = '/wp/v2/themes?context=edit&status=active';
-		$paths[] = '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver::get_user_global_styles_post_id() . '?context=edit';
+		$paths[] = '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id() . '?context=edit';
 	}
 	return $paths;
 }

--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -29,7 +29,7 @@ function gutenberg_posts_dashboard() {
 	);
 
 	$editor_settings         = get_block_editor_settings( $custom_settings, $block_editor_context );
-	$active_global_styles_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	$active_global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	$active_theme            = get_stylesheet();
 
 	$preload_paths = array(

--- a/packages/e2e-tests/plugins/delete-installed-fonts.php
+++ b/packages/e2e-tests/plugins/delete-installed-fonts.php
@@ -56,7 +56,7 @@ function gutenberg_delete_installed_fonts() {
 	}
 
 	// Delete any installed fonts from global styles.
-	$global_styles_post_id = WP_Theme_JSON_Resolver::get_user_global_styles_post_id();
+	$global_styles_post_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	$request               = new WP_REST_Request( 'POST', '/wp/v2/global-styles/' . $global_styles_post_id );
 	$request->set_body_params( array( 'settings' => array( 'typography' => array( 'fontFamilies' => array() ) ) ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updates some calls to the core `WP_Theme_JSON_Resolver` class with its core equivalent: `WP_Theme_JSON_Resolver_Gutenberg`

## Why?

- Makes sure that the code in Gutenberg is using the Gutenberg resolver class
- Consistency

## How?

Append `_Gutenberg` to the core class name.

## Testing Instructions

1. Turn on the new post dataviews page experiment
2. Navigate to Gutenberg > Posts
3. Ensure that Global Styles are correctly displayed in the post preview
4. Double check all e2es are passing

