### PR TITLE
DataForm: add author to quick edit page/post list

### DIFF
--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -9,6 +9,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import {
 	TextControl,
 	__experimentalNumberControl as NumberControl,
+	SelectControl,
 } from '@wordpress/components';
 import { useCallback, useMemo } from '@wordpress/element';
 
@@ -66,7 +67,6 @@ function DataFormNumberControl< Item >( {
 }: DataFormControlProps< Item > ) {
 	const { id, label, description } = field;
 	const value = field.getValue( { item: data } );
-
 	const onChangeControl = useCallback(
 		( newValue: string | undefined ) =>
 			onChange( ( prevItem: Item ) => ( {
@@ -75,6 +75,17 @@ function DataFormNumberControl< Item >( {
 			} ) ),
 		[ id, onChange ]
 	);
+
+	if ( field.elements ) {
+		return (
+			<SelectControl
+				label={ label }
+				value={ value }
+				options={ field.elements }
+				onChange={ onChangeControl }
+			/>
+		);
+	}
 
 	return (
 		<NumberControl

--- a/packages/dataviews/src/components/dataform/index.tsx
+++ b/packages/dataviews/src/components/dataform/index.tsx
@@ -11,6 +11,7 @@ import {
 	__experimentalNumberControl as NumberControl,
 	SelectControl,
 } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 import { useCallback, useMemo } from '@wordpress/element';
 
 /**
@@ -66,7 +67,7 @@ function DataFormNumberControl< Item >( {
 	onChange,
 }: DataFormControlProps< Item > ) {
 	const { id, label, description } = field;
-	const value = field.getValue( { item: data } );
+	const value = field.getValue( { item: data } ) ?? '';
 	const onChangeControl = useCallback(
 		( newValue: string | undefined ) =>
 			onChange( ( prevItem: Item ) => ( {
@@ -77,11 +78,23 @@ function DataFormNumberControl< Item >( {
 	);
 
 	if ( field.elements ) {
+		const elements = [
+			/*
+			 * Value can be undefined when:
+			 *
+			 * - the field is not required
+			 * - in bulk editing
+			 *
+			 */
+			{ label: __( 'Select item' ), value: '' },
+			...field.elements,
+		];
+
 		return (
 			<SelectControl
 				label={ label }
 				value={ value }
-				options={ field.elements }
+				options={ elements }
 				onChange={ onChangeControl }
 			/>
 		);

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -25,16 +25,26 @@ const fields = [
 		label: 'Order',
 		type: 'integer' as const,
 	},
+	{
+		id: 'author',
+		label: 'Author',
+		type: 'integer' as const,
+		elements: [
+			{ value: 1, label: 'Jane' },
+			{ value: 2, label: 'John' },
+		],
+	},
 ];
 
 export const Default = () => {
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
 		order: 2,
+		author: 1,
 	} );
 
 	const form = {
-		visibleFields: [ 'title', 'order' ],
+		visibleFields: [ 'title', 'order', 'author' ],
 	};
 
 	return (

--- a/packages/dataviews/src/test/validation.ts
+++ b/packages/dataviews/src/test/validation.ts
@@ -60,4 +60,21 @@ describe( 'validation', () => {
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( false );
 	} );
+
+	it( 'field is invalid if value is not one of the elements', () => {
+		const item = { id: 1, author: 3 };
+		const fields: Field< {} >[] = [
+			{
+				id: 'author',
+				type: 'integer',
+				elements: [
+					{ value: 1, label: 'Jane' },
+					{ value: 2, label: 'John' },
+				],
+			},
+		];
+		const form = { visibleFields: [ 'author' ] };
+		const result = isItemValid( item, fields, form );
+		expect( result ).toBe( false );
+	} );
 } );

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -27,6 +27,13 @@ export function isItemValid< Item >(
 			return false;
 		}
 
+		if ( field.elements ) {
+			const validValues = field.elements.map( ( f ) => f.value );
+			if ( ! validValues.includes( value ) ) {
+				return false;
+			}
+		}
+
 		// Nothing to validate.
 		return true;
 	} );

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -29,7 +29,7 @@ export function isItemValid< Item >(
 
 		if ( field.elements ) {
 			const validValues = field.elements.map( ( f ) => f.value );
-			if ( ! validValues.includes( value ) ) {
+			if ( ! validValues.includes( Number( value ) ) ) {
 				return false;
 			}
 		}

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { DataForm } from '@wordpress/dataviews';
+import { DataForm, isItemValid } from '@wordpress/dataviews';
 import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { Button } from '@wordpress/components';
@@ -53,6 +53,11 @@ function PostEditForm( { postType, postId } ) {
 	}, [ initialEdits, edits ] );
 	const onSubmit = async ( event ) => {
 		event.preventDefault();
+
+		if ( ! isItemValid( itemWithEdits, fields, form ) ) {
+			return;
+		}
+
 		const { getEntityRecord } = registry.resolveSelect( coreDataStore );
 		for ( const id of ids ) {
 			const item = await getEntityRecord( 'postType', postType, id );
@@ -64,6 +69,7 @@ function PostEditForm( { postType, postId } ) {
 		setEdits( {} );
 	};
 
+	const isUpdateDisabled = ! isItemValid( itemWithEdits, fields, form );
 	return (
 		<form onSubmit={ onSubmit }>
 			<DataForm
@@ -72,7 +78,12 @@ function PostEditForm( { postType, postId } ) {
 				form={ form }
 				onChange={ setEdits }
 			/>
-			<Button variant="primary" type="submit">
+			<Button
+				variant="primary"
+				type="submit"
+				accessibleWhenDisabled
+				disabled={ isUpdateDisabled }
+			>
 				{ __( 'Update' ) }
 			</Button>
 		</form>

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -42,7 +42,7 @@ function PostEditForm( { postType, postId } ) {
 	const { saveEntityRecord } = useDispatch( coreDataStore );
 	const { fields } = usePostFields();
 	const form = {
-		visibleFields: [ 'title' ],
+		visibleFields: [ 'title', 'author' ],
 	};
 	const [ edits, setEdits ] = useState( {} );
 	const itemWithEdits = useMemo( () => {

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -235,7 +235,7 @@ function usePostFields( viewType ) {
 			{
 				label: __( 'Author' ),
 				id: 'author',
-				getValue: ( { item } ) => item._embedded?.author[ 0 ]?.name,
+				type: 'integer',
 				elements:
 					authors?.map( ( { id, name } ) => ( {
 						value: id,

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -236,6 +236,7 @@ function usePostFields( viewType ) {
 				label: __( 'Author' ),
 				id: 'author',
 				type: 'integer',
+				getValue: ( { item } ) => item._embedded?.author[ 0 ]?.name,
 				elements:
 					authors?.map( ( { id, name } ) => ( {
 						value: id,

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -236,7 +236,6 @@ function usePostFields( viewType ) {
 				label: __( 'Author' ),
 				id: 'author',
 				type: 'integer',
-				getValue: ( { item } ) => item._embedded?.author[ 0 ]?.name,
 				elements:
 					authors?.map( ( { id, name } ) => ( {
 						value: id,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59745
Follow-up to https://github.com/WordPress/gutenberg/pull/63895

## What?

Makes the existing `author` field visible in the quick edit form.

https://github.com/user-attachments/assets/d333fa94-19d9-4d08-b62b-cd7aca74ff7f

## Why?

To continue expanding the quick edit form.

## How?

- Add validation to quick edit form https://github.com/WordPress/gutenberg/pull/63983/commits/271dac7818595af95f351a66df5f526355e83066
- Add author as a form field https://github.com/WordPress/gutenberg/pull/63983/commits/23d3904261bc14831c7409236f1da2cc1f6492a9
- Render the author as a select control https://github.com/WordPress/gutenberg/pull/63983/commits/16cda971420df1b7146a3c9da9c51bc61f07871b
- Consider bulk editing https://github.com/WordPress/gutenberg/pull/63983/commits/d88059f07e34e86223d2405d2faebf18e7d9d17a

## Testing Instructions

- With the "Allow access to a quick edit panel in the pages data views." experiment active, visit the Pages page in edit site.
- Change to table view and select a row. Then, open the quick edit form (right to view actions).
- Verify the correct author is selected and that you can change it. Bulk editing also works.
