### PR TITLE
Site Editor: Clarify that the site icon is a back button using an animation

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -64,6 +64,18 @@ const toggleHomeIconVariants = {
 	},
 };
 
+const siteIconVariants = {
+	edit: {
+		clipPath: 'inset(0% round 0)',
+	},
+	hover: {
+		clipPath: 'inset( 22% round 2px )',
+	},
+	tap: {
+		clipPath: 'inset(0% round 0)',
+	},
+};
+
 export default function EditSiteEditor( { isPostsList = false } ) {
 	const disableMotion = useReducedMotion();
 	const { params } = useLocation();
@@ -79,6 +91,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		showIconLabels,
 		editorCanvasView,
 		currentPostIsTrashed,
+		hasSiteIcon,
 	} = useSelect( ( select ) => {
 		const {
 			getEditorCanvasContainerView,
@@ -89,8 +102,9 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 			getEditedPostId,
 		} = unlock( select( editSiteStore ) );
 		const { get } = select( preferencesStore );
-		const { getCurrentTheme } = select( coreDataStore );
+		const { getCurrentTheme, getEntityRecord } = select( coreDataStore );
 		const _context = getEditedPostContext();
+		const siteData = getEntityRecord( 'root', '__unstableBase', undefined );
 
 		// The currently selected entity to display.
 		// Typically template or template part in the site editor.
@@ -107,6 +121,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 			currentPostIsTrashed:
 				select( editorStore ).getCurrentPostAttribute( 'status' ) ===
 				'trash',
+			hasSiteIcon: !! siteData?.site_icon_url,
 		};
 	}, [] );
 	useEditorTitle();
@@ -193,43 +208,8 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		getEditorCanvasContainerTitleAndIcon( editorCanvasView );
 
 	const isReady = ! isLoading;
-
-	const toggleVariants = {
-		edit: {
-			width: 60,
-			height: 60,
-			top: 0,
-			left: 0,
-			borderRadius: '0px',
-			boxShadow: 'none',
-			transition: {
-				delay: 0.1,
-				duration: disableMotion ? 0 : 0.2,
-				type: 'tween',
-				stiffness: 400,
-			},
-		},
-	};
-
-	const siteIconVariants = {
-		edit: {
-			clipPath: 'inset(0% round 0)',
-			transition: {
-				duration: disableMotion ? 0 : 0.2,
-			},
-		},
-		hover: {
-			clipPath: 'inset( 22% round 2px )',
-			transition: {
-				duration: disableMotion ? 0 : 0.2,
-			},
-		},
-		tap: {
-			clipPath: 'inset(0% round 0)',
-			transition: {
-				delay: disableMotion ? 0 : 0.1,
-			},
-		},
+	const transition = {
+		duration: disableMotion ? 0 : 0.2,
 	};
 
 	return (
@@ -271,7 +251,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 								length <= 1 && (
 									<motion.div
 										className="edit-site-editor__view-mode-toggle"
-										variants={ toggleVariants }
+										transition={ transition }
 										animate="edit"
 										initial="edit"
 										whileHover="hover"
@@ -303,7 +283,13 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 											</motion.div>
 										</Button>
 										<motion.div
-											className="edit-site-editor__back-icon"
+											className={ clsx(
+												'edit-site-editor__back-icon',
+												{
+													'has-site-icon':
+														hasSiteIcon,
+												}
+											) }
 											variants={ toggleHomeIconVariants }
 										>
 											<Icon icon={ chevronLeft } />

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { useDispatch, useSelect } from '@wordpress/data';
-import { Button } from '@wordpress/components';
+import { Button, __unstableMotion as motion } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
 	EditorKeyboardShortcutsRegister,
@@ -22,6 +22,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { decodeEntities } from '@wordpress/html-entities';
+import { Icon, chevronLeft } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -50,6 +51,53 @@ import { useIsSiteEditorLoading } from '../layout/hooks';
 const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
+
+const toggleVariants = {
+	edit: {
+		width: 60,
+		height: 60,
+		top: 0,
+		left: 0,
+		borderRadius: '0px',
+		boxShadow: 'none',
+		transition: {
+			delay: 0.1,
+			duration: 0.2,
+			type: 'tween',
+			stiffness: 400,
+		},
+	},
+};
+
+const siteIconVariants = {
+	edit: {
+		clipPath: 'inset(0% round 0)',
+	},
+	hover: {
+		clipPath: 'inset( 22% round 2px )',
+		transition: {
+			duration: 0.2,
+		},
+	},
+	tap: {
+		clipPath: 'inset(0% round 0)',
+		transition: {
+			delay: 0.1,
+		},
+	},
+};
+
+const toggleHomeIconVariants = {
+	edit: {
+		opacity: 0,
+		scale: 0.2,
+	},
+	hover: {
+		opacity: 1,
+		scale: 1,
+		clipPath: 'inset( 22% round 2px )',
+	},
+};
 
 export default function EditSiteEditor( { isPostsList = false } ) {
 	const { params } = useLocation();
@@ -217,26 +265,46 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 						<BackButton>
 							{ ( { length } ) =>
 								length <= 1 && (
-									<Button
-										label={ __( 'Open Navigation' ) }
-										className="edit-site-layout__view-mode-toggle"
-										onClick={ () => {
-											setCanvasMode( 'view' );
-											// TODO: this is a temporary solution to navigate to the posts list if we are
-											// come here through `posts list` and are in focus mode editing a template, template part etc..
-											if (
-												isPostsList &&
-												params?.focusMode
-											) {
-												history.push( {
-													page: 'gutenberg-posts-dashboard',
-													postType: 'post',
-												} );
-											}
-										} }
+									<motion.div
+										className="edit-site-editor__view-mode-toggle"
+										variants={ toggleVariants }
+										animate="edit"
+										initial="edit"
+										whileHover="hover"
+										whileTap="tap"
 									>
-										<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
-									</Button>
+										<Button
+											label={ __( 'Open Navigation' ) }
+											showTooltip
+											tooltipPosition="middle right"
+											onClick={ () => {
+												setCanvasMode( 'view' );
+												// TODO: this is a temporary solution to navigate to the posts list if we are
+												// come here through `posts list` and are in focus mode editing a template, template part etc..
+												if (
+													isPostsList &&
+													params?.focusMode
+												) {
+													history.push( {
+														page: 'gutenberg-posts-dashboard',
+														postType: 'post',
+													} );
+												}
+											} }
+										>
+											<motion.div
+												variants={ siteIconVariants }
+											>
+												<SiteIcon className="edit-site-editor__view-mode-toggle-icon" />
+											</motion.div>
+										</Button>
+										<motion.div
+											className="edit-site-editor__back-icon"
+											variants={ toggleHomeIconVariants }
+										>
+											<Icon icon={ chevronLeft } />
+										</motion.div>
+									</motion.div>
 								)
 							}
 						</BackButton>

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -8,7 +8,7 @@ import clsx from 'clsx';
  */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { Button, __unstableMotion as motion } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
+import { useInstanceId, useReducedMotion } from '@wordpress/compose';
 import {
 	EditorKeyboardShortcutsRegister,
 	privateApis as editorPrivateApis,
@@ -52,41 +52,6 @@ const { Editor, BackButton } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 
-const toggleVariants = {
-	edit: {
-		width: 60,
-		height: 60,
-		top: 0,
-		left: 0,
-		borderRadius: '0px',
-		boxShadow: 'none',
-		transition: {
-			delay: 0.1,
-			duration: 0.2,
-			type: 'tween',
-			stiffness: 400,
-		},
-	},
-};
-
-const siteIconVariants = {
-	edit: {
-		clipPath: 'inset(0% round 0)',
-	},
-	hover: {
-		clipPath: 'inset( 22% round 2px )',
-		transition: {
-			duration: 0.2,
-		},
-	},
-	tap: {
-		clipPath: 'inset(0% round 0)',
-		transition: {
-			delay: 0.1,
-		},
-	},
-};
-
 const toggleHomeIconVariants = {
 	edit: {
 		opacity: 0,
@@ -100,6 +65,7 @@ const toggleHomeIconVariants = {
 };
 
 export default function EditSiteEditor( { isPostsList = false } ) {
+	const disableMotion = useReducedMotion();
 	const { params } = useLocation();
 	const isLoading = useIsSiteEditorLoading();
 	const {
@@ -227,6 +193,44 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		getEditorCanvasContainerTitleAndIcon( editorCanvasView );
 
 	const isReady = ! isLoading;
+
+	const toggleVariants = {
+		edit: {
+			width: 60,
+			height: 60,
+			top: 0,
+			left: 0,
+			borderRadius: '0px',
+			boxShadow: 'none',
+			transition: {
+				delay: 0.1,
+				duration: disableMotion ? 0 : 0.2,
+				type: 'tween',
+				stiffness: 400,
+			},
+		},
+	};
+
+	const siteIconVariants = {
+		edit: {
+			clipPath: 'inset(0% round 0)',
+			transition: {
+				duration: disableMotion ? 0 : 0.2,
+			},
+		},
+		hover: {
+			clipPath: 'inset( 22% round 2px )',
+			transition: {
+				duration: disableMotion ? 0 : 0.2,
+			},
+		},
+		tap: {
+			clipPath: 'inset(0% round 0)',
+			transition: {
+				delay: disableMotion ? 0 : 0.1,
+			},
+		},
+	};
 
 	return (
 		<>

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -1,7 +1,7 @@
 .edit-site-editor__editor-interface {
 	opacity: 1;
 	transition: opacity 0.1s ease-out;
-	@include reduce-motion("transition");
+	@include reduce-motion( "transition" );
 
 	&.is-loading {
 		opacity: 0;
@@ -23,7 +23,8 @@
 	view-transition-name: toggle;
 	/* stylelint-enable */
 	position: fixed;
-	top: $canvas-padding;
+	top: 0;
+	left: 0;
 	height: $header-height;
 	width: $header-height;
 	z-index: 100;
@@ -66,8 +67,10 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	-webkit-backdrop-filter: saturate(180%) blur(15px);
-	backdrop-filter: saturate(180%) blur(15px);
-	background-color: hsla(0, 0%, 100%, 0.6);
+	background-color: hsla(0, 0%, 80%);
 	pointer-events: none;
+
+	&.has-site-icon {
+		background-color: hsla(0, 0%, 100%, 0.6);
+	}
 }

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -17,3 +17,57 @@
 	display: flex;
 	justify-content: center;
 }
+
+.edit-site-editor__view-mode-toggle {
+	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
+	view-transition-name: toggle;
+	/* stylelint-enable */
+	position: fixed;
+	top: $canvas-padding;
+	height: $header-height;
+	width: $header-height;
+	z-index: 100;
+
+	.components-button {
+		color: $white;
+		height: 100%;
+		width: 100%;
+		border-radius: 0;
+		overflow: hidden;
+		padding: 0;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		&:hover,
+		&:active {
+			color: $white;
+		}
+
+		&:focus {
+			box-shadow: none;
+		}
+	}
+
+	.edit-site-editor__view-mode-toggle-icon {
+		svg,
+		img {
+			background: $gray-900;
+			display: block;
+		}
+	}
+}
+
+.edit-site-editor__back-icon {
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 60px;
+	height: 60px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	-webkit-backdrop-filter: saturate(180%) blur(15px);
+	backdrop-filter: saturate(180%) blur(15px);
+	background-color: hsla(0, 0%, 100%, 0.6);
+	pointer-events: none;
+}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -148,6 +148,14 @@
 html.canvas-mode-edit-transition::view-transition-group(toggle) {
 	animation-delay: 255ms;
 }
+
+@media (prefers-reduced-motion) {
+	::view-transition-group(*),
+	::view-transition-old(*),
+	::view-transition-new(*) {
+		animation: none !important;
+	}
+}
 /* stylelint-enable  */
 
 .edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region .edit-site-layout__view-mode-toggle {

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -14,6 +14,7 @@
 	height: 100%;
 	object-fit: cover;
 	background: #333;
+	aspect-ratio: 1 / 1;
 
 	.edit-site-layout.is-full-canvas & {
 		border-radius: 0;

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -1,9 +1,11 @@
 .edit-site-site-icon__icon {
 	fill: currentColor;
+	width: 100%;
+	height: 100%;
 
 	.edit-site-layout.is-full-canvas & {
 		// Make the WordPress icon not so big in full canvas.
-		padding: $grid-unit-15 * 0.5; // 6px.
+		padding: $grid-unit-15;
 	}
 }
 


### PR DESCRIPTION
This is extracted and reworked based on #58924 

## What?

The idea here is to add a hover animation to the site icon in the editor to clarify its role as a back button. 

**Notes**

- Animation in and out of the editor only works in browsers that support View Transitions: Latest Safari, Chrome, Edge, Opera. (Not yet on Firefox)
- The animation in and out when not site icon is set is not perfect (I believe it's the same in trunk though)


https://github.com/user-attachments/assets/04cd6012-265e-4043-a336-6ca8be79bdc9

So while this is not perfect, it seems like a nice improvement over trunk.
