### PR TITLE
Image Block Lightbox: Fix warning error when resizing

### DIFF
--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -188,7 +188,7 @@ const { state, actions, callbacks } = store(
 		},
 		callbacks: {
 			setOverlayStyles() {
-				if ( ! state.currentImage.imageRef ) {
+				if ( ! state?.currentImage?.imageRef ) {
 					return;
 				}
 

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -188,7 +188,7 @@ const { state, actions, callbacks } = store(
 		},
 		callbacks: {
 			setOverlayStyles() {
-				if ( ! state?.currentImage?.imageRef ) {
+				if ( ! state.overlayEnabled ) {
 					return;
 				}
 


### PR DESCRIPTION
Discovered while testing #62906

## What?

This PR fixes a browser warning error that occurs when changing the browser width when the lightbox is not yet open:

```
TypeError: Cannot read properties of undefined (reading 'imageRef') at setOverlayStyles (view.js:191:31)
```

## Why?

From what I understand, when the lightbox is not open, `state.currentImage` is undefined.

## How?

Use optional chaining.

Alternatively, since overlay style calculations should not be necessary when the lightbox is not open and should be recalculated when the lightbox is opened, the following approach also works:

```javascript
setOverlayStyles() {
	if ( ! state.overlayEnabled ) {
		return;
	}
}
```


## Testing Instructions

- Apply a lightbox to an image block.
- On the frontend, change the browser width without opening the lightbox.
