### PR TITLE
Update help text for sticky control in Query loop

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -20,7 +20,7 @@ export default function StickyControl( { value, onChange } ) {
 			value={ value }
 			onChange={ onChange }
 			help={ __(
-				'Blog posts can be “stickied”, a feature that places them at the top of the front page of posts. Multiple posts can be sticky at the same time.'
+				'Sticky posts always appear first, regardless of their publish date.'
 			) }
 		/>
 	);

--- a/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/sticky-control.js
@@ -20,7 +20,7 @@ export default function StickyControl( { value, onChange } ) {
 			value={ value }
 			onChange={ onChange }
 			help={ __(
-				'Blog posts can be “stickied”, a feature that places them at the top of the front page of posts, keeping it there until new sticky posts are published.'
+				'Blog posts can be “stickied”, a feature that places them at the top of the front page of posts. Multiple posts can be sticky at the same time.'
 			) }
 		/>
 	);


### PR DESCRIPTION
## What?
Fixes: #63998

## Why?
The current copy for the "Sticky Posts" control in the Query Loop block is inaccurate.

## How?
Modifies the help text.