### PR TITLE
Add radius scale

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -102,12 +102,12 @@ $border-width: 1px;
 $border-width-focus-fallback: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
 $border-width-tab: 1.5px;
 $helptext-font-size: 12px;
-$radius-block-ui: 2px;
 $radio-input-size: 16px;
 $radio-input-size-sm: 24px; // Width & height for small viewports.
 
 // Deprecated, please avoid using these.
 $block-padding: 14px; // Used to define space between block footprint and surrouding borders.
+$radius-block-ui: $radius-small;
 
 
 /**

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -44,12 +44,12 @@ $grid-unit-80: 8 * $grid-unit;		// 64px
  * Radius scale.
  */
 
-$radius-x-small: 1px;   // Applied to contained elements within primitives like inputs or buttons. E.g. the selected item in a ToggleGroupControl, or the unit selector in UnitControl.
-$radius-small: 2px;     // Applied to primitive components like Badges, Buttons, Inputs, Checkboxes.
-$radius-medium: 4px;    // Applied to containers with smaller padding, e.g. Menus, Notices, Snackbars, Block toolbar. Also used for focus rings on primitive components.
-$radius-large: 8px;     // Applied to containers with larger padding, e.g. Modals, Pages, and the Preview Frame.
-$radius-full: 9999px;   // For lozenges
-$radius-round: 50%;     // For circles and ovals
+$radius-x-small: 1px;   // Applied to elements like buttons nested within primitives like inputs.
+$radius-small: 2px;     // Applied to most primitives.
+$radius-medium: 4px;    // Applied to containers with smaller padding.
+$radius-large: 8px;     // Applied to containers with larger padding.
+$radius-full: 9999px;   // For lozenges.
+$radius-round: 50%;     // For circles and ovals.
 
 /**
  * Dimensions.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -44,10 +44,10 @@ $grid-unit-80: 8 * $grid-unit;		// 64px
  * Radius scale.
  */
 
-$radius-xs: 1px;
-$radius-s: 2px;
-$radius-m: 4px;
-$radius-l: 8px;
+$radius-x-small: 1px;
+$radius-small: 2px;
+$radius-medium: 4px;
+$radius-large: 8px;
 $radius-full: 9999px; // For lozenges
 $radius-round: 50%; // For circles and ovals
 

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -41,6 +41,17 @@ $grid-unit-70: 7 * $grid-unit;		// 56px
 $grid-unit-80: 8 * $grid-unit;		// 64px
 
 /**
+ * Radius scale.
+ */
+
+$radius-xs: 1px;
+$radius-s: 2px;
+$radius-m: 4px;
+$radius-l: 8px;
+$radius-full: 9999px; // For lozenges
+$radius-round: 50%; // For circles and ovals
+
+/**
  * Dimensions.
  */
 
@@ -91,7 +102,6 @@ $border-width: 1px;
 $border-width-focus-fallback: 2px; // This exists as a fallback, and is ideally overridden by var(--wp-admin-border-width-focus) unless in some SASS math cases.
 $border-width-tab: 1.5px;
 $helptext-font-size: 12px;
-$radius-round: 50%;
 $radius-block-ui: 2px;
 $radio-input-size: 16px;
 $radio-input-size-sm: 24px; // Width & height for small viewports.

--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -44,12 +44,12 @@ $grid-unit-80: 8 * $grid-unit;		// 64px
  * Radius scale.
  */
 
-$radius-x-small: 1px;
-$radius-small: 2px;
-$radius-medium: 4px;
-$radius-large: 8px;
-$radius-full: 9999px; // For lozenges
-$radius-round: 50%; // For circles and ovals
+$radius-x-small: 1px;   // Applied to contained elements within primitives like inputs or buttons. E.g. the selected item in a ToggleGroupControl, or the unit selector in UnitControl.
+$radius-small: 2px;     // Applied to primitive components like Badges, Buttons, Inputs, Checkboxes.
+$radius-medium: 4px;    // Applied to containers with smaller padding, e.g. Menus, Notices, Snackbars, Block toolbar. Also used for focus rings on primitive components.
+$radius-large: 8px;     // Applied to containers with larger padding, e.g. Modals, Pages, and the Preview Frame.
+$radius-full: 9999px;   // For lozenges
+$radius-round: 50%;     // For circles and ovals
 
 /**
  * Dimensions.


### PR DESCRIPTION
## What?
<img width="1312" alt="radii" src="https://github.com/user-attachments/assets/fe99cb1b-19d8-49ff-9d65-1c0e324d51fc">

Adds variables for the radius scale as described in https://github.com/WordPress/gutenberg/issues/63703. 

**Guidelines**

- `$radius-x-small`: The smallest radius. Applied to contained elements within primitives like inputs or buttons. E.g. the selected item in a `ToggleGroupControl`, or the unit selector in `UnitControl`.
- `$radius-small`: Applied to primitive components like Badges, Buttons, Inputs, Checkboxes.
- `$radius-medium`: Applied to containers with smaller padding, e.g. Menus, Notices, Snackbars, Block toolbar. Also used for focus rings on primitive components.
- `$radius-large`: Applied to containers with larger padding, e.g. Modals, Pages, and the Preview Frame.
- `$radius-full`: For creating lozenges.
- `$radius-round`: For creating circles or ovals. (This variable already exists).

## Why?

Utilising a consistent scale across will add polish to the UI and reduce maintenance overheads. The diagram below demonstrates how elements would nest neatly inside one another once the scale has been adopted, from the individual button in a `ToggleGroupControl` up to the outer container. The visuals are intentionally abstract to draw focus onto the radius, not the overall appearance. 

<img width="821" alt="radius2" src="https://github.com/user-attachments/assets/ca31cb2a-2be0-4875-9ca1-165e46bde0d0">

The values could change when they're applied (in a separate effort). For now they are based on the existing convention which is a `2px` radius applied to virtually everything. For this PR the important detail to concentrate on is the scale itself. 

- Are there are enough values?
- Do the guidelines make sense?
- Is the naming convention appropriate?
- Should we note the guidelines in `_variables.scss`?