### PR TITLE
Fix empty space in Post editor’s header with DFM

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -49,7 +49,7 @@ function Header( {
 	icon,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
-	const isLessThanMediumViewport = useViewportMatch( 'medium', '<' );
+	const isLargeViewport = useViewportMatch( 'medium' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
 		isTextEditor,
@@ -84,7 +84,7 @@ function Header( {
 		useState( true );
 
 	const hasDocumentOrCollapsedBlockToolbars =
-		! isDistractionFree || ! isLessThanMediumViewport;
+		! isDistractionFree || isLargeViewport;
 	const hasCenter = isBlockToolsCollapsed && ! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 
@@ -112,7 +112,7 @@ function Header( {
 							forceDisableBlockTools || isTextEditor
 						}
 					/>
-					{ hasFixedToolbar && ! isLessThanMediumViewport && (
+					{ hasFixedToolbar && isLargeViewport && (
 						<CollapsibleBlockToolbar
 							isCollapsed={ isBlockToolsCollapsed }
 							onToggle={ setIsBlockToolsCollapsed }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -49,7 +49,7 @@ function Header( {
 	icon,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
-	const isLargeViewport = useViewportMatch( 'medium' );
+	const isLessThanMediumViewport = useViewportMatch( 'medium', '<' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
 		isTextEditor,
@@ -58,6 +58,7 @@ function Header( {
 		hasFixedToolbar,
 		isNestedEntity,
 		isZoomedOutView,
+		isDistractionFree,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -75,12 +76,15 @@ function Header( {
 			isNestedEntity:
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
 			isZoomedOutView: __unstableGetEditorMode() === 'zoom-out',
+			isDistractionFree: getPreference( 'core', 'distractionFree' ),
 		};
 	}, [] );
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
+	const hasDocumentOrCollapsedBlockToolbars =
+		! isDistractionFree || ! isLessThanMediumViewport;
 	const hasCenter = isBlockToolsCollapsed && ! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 
@@ -97,21 +101,25 @@ function Header( {
 					<BackButton.Slot />
 				</motion.div>
 			) }
-			<motion.div
-				variants={ toolbarVariations }
-				className="editor-header__toolbar"
-				transition={ { type: 'tween' } }
-			>
-				<DocumentTools
-					disableBlockTools={ forceDisableBlockTools || isTextEditor }
-				/>
-				{ hasFixedToolbar && isLargeViewport && (
-					<CollapsibleBlockToolbar
-						isCollapsed={ isBlockToolsCollapsed }
-						onToggle={ setIsBlockToolsCollapsed }
+			{ hasDocumentOrCollapsedBlockToolbars && (
+				<motion.div
+					variants={ toolbarVariations }
+					className="editor-header__toolbar"
+					transition={ { type: 'tween' } }
+				>
+					<DocumentTools
+						disableBlockTools={
+							forceDisableBlockTools || isTextEditor
+						}
 					/>
-				) }
-			</motion.div>
+					{ hasFixedToolbar && ! isLessThanMediumViewport && (
+						<CollapsibleBlockToolbar
+							isCollapsed={ isBlockToolsCollapsed }
+							onToggle={ setIsBlockToolsCollapsed }
+						/>
+					) }
+				</motion.div>
+			) }
 			{ hasCenter && (
 				<motion.div
 					className="editor-header__center"

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -24,24 +24,26 @@
 	}
 }
 
+// When there is no back button keeps the first child off the starting edge.
+.editor-header > :first-child:not(.editor-header__back-button) {
+	margin-inline-start: $grid-unit-20;
+}
+
+// At less than mobile the header’s `gap` is zero and whatever element follows the back button
+// needs a margin to keep the space between it and the back button. The margin is applied to a
+// child to allow the parent to collapse completely i.e. occupy no space.
+@media (max-width: #{$break-mobile - 1}) {
+	.editor-header__back-button + * > :first-child {
+		margin-inline-start: $grid-unit-20;
+	}
+}
+
 .editor-header__toolbar {
 	grid-column: 1 / 3;
-	// When there is no back button or the viewport is <= mobile the margin keeps the content off
-	// the starting edge.
-	> :first-child {
-		margin-inline: $grid-unit-20 0;
-	}
 
 	// This is the typical case, the back button takes up the first column.
 	.editor-header__back-button + & {
 		grid-column: 2 / 3;
-
-		@include break-mobile {
-			// Clears the margin; at this breakpoint the parent’s `gap` takes its place.
-			> :first-child {
-				margin-inline: 0;
-			}
-		}
 	}
 	display: flex;
 	// Make narrowing to less than content width possible. Block toolbar will hide overflow and allow scrolling on fixed toolbar.
@@ -73,6 +75,15 @@
 
 .editor-header__center {
 	grid-column: 3 / 4;
+	.editor-header__back-button + & {
+		grid-column-start: 2;
+	}
+	// This is the first child when in Distraction Free mode, without a back button and at less
+	// than medium breakpoint. Currently its applicable in the Post editor.
+	&:first-child {
+		grid-column-start: 1;
+		justify-content: start;
+	}
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -80,10 +91,13 @@
 	min-width: 0;
 	// Clip the box while leaving room for focus rings.
 	clip-path: inset(-2px);
-	// At less than mobile the header’s `gap` is zero so margins are added to create a smaller
-	// gap around the center’s contents.
+	// At less than mobile the header’s `gap` is zero so margins are added to keep a smaller
+	// space around __center’s contents. Applying the margin on children instead of the __center
+	// itself allows __center to collapse completely, i.e. to occupy no space.
 	@media (max-width: #{$break-mobile - 1}) {
-		> :first-child {
+		// The start side should only apply when the __center follows __toolbar. A case where it
+		// doesn’t is in the Post Editor with Distraction Free mode on.
+		.editor-header__toolbar + & > :first-child {
 			margin-inline-start: $grid-unit;
 		}
 		> :last-child {

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -96,7 +96,7 @@
 	// itself allows __center to collapse completely, i.e. to occupy no space.
 	@media (max-width: #{$break-mobile - 1}) {
 		// The start side should only apply when the __center follows __toolbar. A case where it
-		// doesn’t is in the Post Editor with Distraction Free mode on.
+		// doesn’t is in the Post Editor with Distraction Free mode on at less than medium breakpoint.
 		.editor-header__toolbar + & > :first-child {
 			margin-inline-start: $grid-unit;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to #62636.

## Why?
I overlooked Distraction Free mode in the previous PR and it caused there to be an empty space before the Document Bar when in the Post editor with DFM and at less than medium breakpoint.

I suppose it’s not too grave a problem but it wasn’t intended.

## How?
- Omit rendering the document tools/collapsible block toolbar if in Distraction free mode and at less than medium breakpoint.
- Revise the header styles to account for the conditional lack of the toolbar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| <img width="781" alt="image" src="https://github.com/user-attachments/assets/c836be7c-dfc5-4554-94f4-082ed9e3135b"> | <img width="781" alt="image" src="https://github.com/user-attachments/assets/c748f69a-8d9f-479c-b75f-28fb8894cf23"> | 