### PR TITLE
Avoid errors for post types without a 'menu_icon'

### DIFF
--- a/packages/edit-site/src/components/add-new-template/utils.js
+++ b/packages/edit-site/src/components/add-new-template/utils.js
@@ -166,9 +166,11 @@ export function usePostTypeArchiveMenuItems() {
 						// `icon` is the `menu_icon` property of a post type. We
 						// only handle `dashicons` for now, even if the `menu_icon`
 						// also supports urls and svg as values.
-						icon: postType.icon?.startsWith( 'dashicons-' )
-							? postType.icon.slice( 10 )
-							: archive,
+						icon:
+							typeof postType.icon === 'string' &&
+							postType.icon.startsWith( 'dashicons-' )
+								? postType.icon.slice( 10 )
+								: archive,
 						templatePrefix: 'archive',
 					};
 				} ) || [],
@@ -272,9 +274,11 @@ export const usePostTypeMenuItems = ( onClickMenuItem ) => {
 						// `icon` is the `menu_icon` property of a post type. We
 						// only handle `dashicons` for now, even if the `menu_icon`
 						// also supports urls and svg as values.
-						icon: icon?.startsWith( 'dashicons-' )
-							? icon.slice( 10 )
-							: post,
+						icon:
+							typeof icon === 'string' &&
+							icon.startsWith( 'dashicons-' )
+								? icon.slice( 10 )
+								: post,
 						templatePrefix: templatePrefixes[ slug ],
 				  };
 			const hasEntities = postTypesInfo?.[ slug ]?.hasEntities;

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -110,7 +110,10 @@ export const getPostIcon = createRegistrySelector(
 			// `icon` is the `menu_icon` property of a post type. We
 			// only handle `dashicons` for now, even if the `menu_icon`
 			// also supports urls and svg as values.
-			if ( postTypeEntity?.icon?.startsWith( 'dashicons-' ) ) {
+			if (
+				typeof postTypeEntity?.icon === 'string' &&
+				postTypeEntity.icon.startsWith( 'dashicons-' )
+			) {
 				return postTypeEntity.icon.slice( 10 );
 			}
 			return pageIcon;


### PR DESCRIPTION
## What?
Fixes https://core.trac.wordpress.org/ticket/61751.

PR prevents editors from crashing when a CPT explicitly sets the `menu_icon` property to `false`.

## Why?
Calling `startsWith` on non-string values will trigger an error.

## Testing Instructions
1. Register a custom post type. You can use one of these [examples](https://developer.wordpress.org/reference/functions/register_post_type/#user-contributed-notes).
2. Explicitly set the `menu_icon` property to `false`.
3. Create a new post for this post type.
4. The editor shouldn't crash due to an error. Doing the same on `trunk` will crash the editor.
5. Navigate to Site Editor > Templates.
6. Click "Add New Template"
7. There should be no JS errors.

### Testing Instructions for Keyboard
Same.
