### PR TITLE
Format Library: Polish inline image format popover

### DIFF
--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -76,19 +76,20 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 					event.preventDefault();
 				} }
 			>
-				<HStack alignment="bottom" spacing="0">
+				<HStack alignment="bottom">
 					<NumberControl
-						className="block-editor-format-toolbar__image-container-value"
 						label={ __( 'Width' ) }
 						value={ width }
 						min={ 1 }
 						onChange={ ( newWidth ) => setWidth( newWidth ) }
+						size="__unstable-large"
 					/>
 					<Button
 						className="block-editor-format-toolbar__image-container-button"
 						icon={ keyboardReturn }
 						label={ __( 'Apply' ) }
 						type="submit"
+						size="compact"
 					/>
 				</HStack>
 			</form>

--- a/packages/format-library/src/image/index.js
+++ b/packages/format-library/src/image/index.js
@@ -85,11 +85,10 @@ function InlineUI( { value, onChange, activeObjectAttributes, contentRef } ) {
 						size="__unstable-large"
 					/>
 					<Button
-						className="block-editor-format-toolbar__image-container-button"
 						icon={ keyboardReturn }
 						label={ __( 'Apply' ) }
 						type="submit"
-						size="compact"
+						__next40pxDefaultSize
 					/>
 				</HStack>
 			</form>

--- a/packages/format-library/src/image/style.scss
+++ b/packages/format-library/src/image/style.scss
@@ -5,8 +5,4 @@
 		width: 200px;
 		padding: $grid-unit-20;
 	}
-
-	.block-editor-format-toolbar__image-container-button {
-		margin-bottom: $grid-unit-05;
-	}
 }

--- a/packages/format-library/src/image/style.scss
+++ b/packages/format-library/src/image/style.scss
@@ -1,15 +1,12 @@
 .block-editor-format-toolbar__image-popover {
 	z-index: z-index(".block-editor-format-toolbar__image-popover");
 
-	.block-editor-format-toolbar__image-container-value {
-		margin: $grid-unit-10 - $border-width;
-		min-width: 150px;
-		max-width: 500px;
+	.block-editor-format-toolbar__image-container-content {
+		width: 200px;
+		padding: $grid-unit-20;
 	}
 
 	.block-editor-format-toolbar__image-container-button {
-		height: $grid-unit-10 * 4 - ($border-width * 2);
-		margin-bottom: $grid-unit-10;
-		margin-right: $grid-unit-10;
+		margin-bottom: $grid-unit-05;
 	}
 }


### PR DESCRIPTION
## What?

This PR improves the popover UI for applying widths to inline image.

## Why?

The current UI is not consistent compared to other UIs.

## How?

I have standardized all sizes and spacing to 8px grid units.

Note: In the future, I aim to add a textarea for `alt` attribute, as suggested by #63323.

## Testing Instructions

Insert an inline image and click it.

## Screenshots or screencast <!-- if applicable -->

| | Before | After |
|--------|--------|--------|
| Default | ![before](https://github.com/user-attachments/assets/f75b8064-dc15-499b-8df7-4470c41d42e4) | ![after](https://github.com/user-attachments/assets/d8bcbb68-6ecd-4858-a36b-daa0eae3f3f9) |
| Submit button focuses | ![before-submit-button-focused](https://github.com/user-attachments/assets/dba660fe-7db9-475e-a511-3d9a4e73e640) | ![afuter-submit-button-focused](https://github.com/user-attachments/assets/abc50c87-34ad-4894-b711-133b218e4463) |

