### PR TITLE
Update www.w3.org/2000/svg from `http` to `https`

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -114,7 +114,7 @@
 		// If a browser supports it, we will switch to using a circular SVG mask.
 		@supports (mask-image: none) or (-webkit-mask-image: none) {
 			/* stylelint-disable-next-line function-url-quotes -- We need quotes for the data URL to use the SVG inline. */
-			mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
+			mask-image: url('data:image/svg+xml;utf8,<svg viewBox="0 0 100 100" xmlns="https://www.w3.org/2000/svg"><circle cx="50" cy="50" r="50"/></svg>');
 			mask-mode: alpha;
 			mask-repeat: no-repeat;
 			mask-size: contain;


### PR DESCRIPTION
##Trac Ticket:

https://core.trac.wordpress.org/ticket/61777

## What?
This PR will update www.w3.org/2000/svg from `http` to `https` because of this in Windows defender Trojan error for `wp-includes\dist\block-library\style.min.css`

## Why?
This PR is necessary because it will Windows defender Trojan error we are getting for `wp-includes\dist\block-library\style.min.css` 

## How?
This PR will change `http://www.w3.org/2000/svg` to `https://www.w3.org/2000/svg` which will fix the issue.

## Testing Instructions
1. Just downloaded and unpacked the latest version (6.6.1) from https://wordpress.org/download/  
2. windows defender removed `wp-includes\dist\block-library\style.min.css` stating it was a trojan. 

## Screenshots or screencast

![trac_error](https://github.com/user-attachments/assets/e09d85cf-2c4d-494a-adaf-5aef90cf66ff)

