### PR TITLE
Fix 'Preferences' and 'Shortcuts' commands in StrictMode

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -89,7 +89,8 @@ function useEditorCommandLoader() {
 		name: 'core/open-shortcut-help',
 		label: __( 'Keyboard shortcuts' ),
 		icon: keyboard,
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			openModal( 'editor/keyboard-shortcut-help' );
 		},
 	} );
@@ -108,7 +109,8 @@ function useEditorCommandLoader() {
 	commands.push( {
 		name: 'core/open-preferences',
 		label: __( 'Editor preferences' ),
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			openModal( 'editor/preferences' );
 		},
 	} );


### PR DESCRIPTION
## What?
Closes #64004.

PR fixes a bug where the "Editor Preferences" or "Keyboard shortcuts" modal will close immediately when opening from the command palette. There's no modal flash, so it looks like the commands never run.

Note: While this fix is correct, it still fixes a symptom, not the actual cause. I've included more details below.

## Why?
I noticed that `onRequestClose` callbacks are called for both models as soon as they open. This led me to "dismissers" logic in the Modal component, introduced in #51602. If I comment on the logic for "dismissers," the modal opens correctly. It seems that this side effect isn't resilient for the [StrictMode](https://react.dev/reference/react/StrictMode).

https://github.com/WordPress/gutenberg/blob/159d01a01b61ee76159ab67bc94d0d7cb3d90b35/packages/components/src/modal/index.tsx#L152-L166

## How?
Explicitly close the command palette dialog before opening other models. This matches other `callback` calls in the file.

## Testing Instructions
1. Enable StictMode - `WP_DEBUG = true` and `SCRIPT_DEBUG = true`.
2. Launch the command palette.
3. Run "Editor Preferences" or "Keyboard shortcuts" commands.

### Testing Instructions for Keyboard
Same
