### PR TITLE
Post Excerpt: Add border block support

### DIFF
--- a/packages/block-library/src/post-excerpt/block.json
+++ b/packages/block-library/src/post-excerpt/block.json
@@ -56,6 +56,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-post-excerpt-editor",

--- a/packages/block-library/src/post-excerpt/style.scss
+++ b/packages/block-library/src/post-excerpt/style.scss
@@ -1,5 +1,8 @@
 // Lowest specificity on wrapper margins to avoid overriding layout styles.
 :where(.wp-block-post-excerpt) {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+
 	margin-top: var(--wp--style--block-gap);
 	margin-bottom: var(--wp--style--block-gap);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Post Excerpt` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Excerpt` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that `Post Excerpt` block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add `Post Excerpt`  block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend

Please refer to the attached video for more information.

## Screenshots or screencast <!-- if applicable -->
 
  
[Blog-Home-‹-Template-‹-gutenberg-‹-Editor-—-WordPress (11).webm](https://github.com/user-attachments/assets/576f2702-215e-4779-a7c0-c17cd65281df)
