### PR TITLE
Several Typo Correction in Inline Doc

### DIFF
--- a/docs/reference-guides/data/data-core.md
+++ b/docs/reference-guides/data/data-core.md
@@ -755,7 +755,7 @@ _Parameters_
 
 ### receiveThemeSupports
 
-> **Deprecated** since WP 5.9, this is not useful anymore, use the selector direclty.
+> **Deprecated** since WP 5.9, this is not useful anymore, use the selector directly.
 
 Returns an action object used in signalling that the index has been received.
 

--- a/packages/core-data/README.md
+++ b/packages/core-data/README.md
@@ -264,7 +264,7 @@ _Parameters_
 
 ### receiveThemeSupports
 
-> **Deprecated** since WP 5.9, this is not useful anymore, use the selector direclty.
+> **Deprecated** since WP 5.9, this is not useful anymore, use the selector directly.
 
 Returns an action object used in signalling that the index has been received.
 

--- a/packages/core-data/src/actions.js
+++ b/packages/core-data/src/actions.js
@@ -200,7 +200,7 @@ export function __experimentalReceiveThemeGlobalStyleVariations(
 /**
  * Returns an action object used in signalling that the index has been received.
  *
- * @deprecated since WP 5.9, this is not useful anymore, use the selector direclty.
+ * @deprecated since WP 5.9, this is not useful anymore, use the selector directly.
  *
  * @return {Object} Action object.
  */


### PR DESCRIPTION
Corrected Typo in Inline Documents in the Following Files:

Replaced `direclty` with `directly` :

1. `docs/reference-guides/data/data-core.md` on line 758
2. `packages/core-data/README.md` on line 267
3. `packages/core-data/src/actions.js` on line 203