### PR TITLE
Fix: tab navigation issue of `cover` block

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -331,6 +331,7 @@ const v13 = {
 			<Tag { ...useBlockProps.save( { className: classes, style } ) }>
 				<span
 					aria-hidden="true"
+					tabIndex={ 0 }
 					className={ clsx(
 						'wp-block-cover__background',
 						overlayColorClass,
@@ -493,6 +494,7 @@ const v12 = {
 			<Tag { ...useBlockProps.save( { className: classes, style } ) }>
 				<span
 					aria-hidden="true"
+					tabIndex={ 0 }
 					className={ clsx(
 						'wp-block-cover__background',
 						overlayColorClass,
@@ -642,6 +644,7 @@ const v11 = {
 			<div { ...useBlockProps.save( { className: classes, style } ) }>
 				<span
 					aria-hidden="true"
+					tabIndex={ 0 }
 					className={ clsx(
 						'wp-block-cover__background',
 						overlayColorClass,
@@ -782,6 +785,7 @@ const v10 = {
 			<div { ...useBlockProps.save( { className: classes, style } ) }>
 				<span
 					aria-hidden="true"
+					tabIndex={ 0 }
 					className={ clsx(
 						'wp-block-cover__background',
 						overlayColorClass,
@@ -917,6 +921,7 @@ const v9 = {
 			<div { ...useBlockProps.save( { className: classes, style } ) }>
 				<span
 					aria-hidden="true"
+					tabIndex={ 0 }
 					className={ clsx(
 						'wp-block-cover__background',
 						overlayColorClass,
@@ -1047,6 +1052,7 @@ const v8 = {
 			<div { ...useBlockProps.save( { className: classes, style } ) }>
 				<span
 					aria-hidden="true"
+					tabIndex={ 0 }
 					className={ clsx(
 						overlayColorClass,
 						dimRatioToClass( dimRatio ),
@@ -1202,6 +1208,7 @@ const v7 = {
 				{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 					<span
 						aria-hidden="true"
+						tabIndex={ 0 }
 						className={ clsx(
 							'wp-block-cover__gradient-background',
 							gradientClass
@@ -1353,6 +1360,7 @@ const v6 = {
 				{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 					<span
 						aria-hidden="true"
+						tabIndex={ 0 }
 						className={ clsx(
 							'wp-block-cover__gradient-background',
 							gradientClass
@@ -1452,6 +1460,7 @@ const v5 = {
 				{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 					<span
 						aria-hidden="true"
+						tabIndex={ 0 }
 						className={ clsx(
 							'wp-block-cover__gradient-background',
 							gradientClass
@@ -1549,6 +1558,7 @@ const v4 = {
 				{ url && ( gradient || customGradient ) && dimRatio !== 0 && (
 					<span
 						aria-hidden="true"
+						tabIndex={ 0 }
 						className={ clsx(
 							'wp-block-cover__gradient-background',
 							gradientClass

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -503,6 +503,7 @@ function CoverEdit( {
 				{ showOverlay && (
 					<span
 						aria-hidden="true"
+						tabIndex={ 0 }
 						className={ clsx(
 							'wp-block-cover__background',
 							dimRatioToClass( dimRatio ),

--- a/packages/block-library/src/cover/save.js
+++ b/packages/block-library/src/cover/save.js
@@ -106,6 +106,7 @@ export default function save( { attributes } ) {
 		<Tag { ...useBlockProps.save( { className: classes, style } ) }>
 			<span
 				aria-hidden="true"
+				tabIndex={ 0 }
 				className={ clsx(
 					'wp-block-cover__background',
 					overlayColorClass,

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -58,6 +58,15 @@
 		opacity: 0.5;
 	}
 
+	/**
+	 * To support key board navigation, focus styles are added to the cover block.
+	 */
+	&:focus,
+	&:focus-visible,
+	&:focus-within {
+		outline: -webkit-focus-ring-color auto 1px;
+	}
+
 	// The following styles are needed to support legacy blocks added prior to the update
 	// that moved opacity to a nested span.
 	// https://github.com/WordPress/gutenberg/pull/35065


### PR DESCRIPTION

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/64035

## How?
- added `tabIndex=0` so that cover block supports tab navigation.
- still keeping `aria-hidden="true"` so that screen readers don't pronounce it.

## Testing Instructions
- add cover block in to editor & add background image
- check on editor tab navigation is working
- now check same on front end tab navigation is working save as editor

### Testing Instructions for Keyboard
- press tab key and check cover block in editor & check same on front end.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/cc3f48d2-dbc6-4494-82e7-547b134e33b0

