### PR TITLE
Style Book: clearly denote heading levels

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -155,6 +155,10 @@ function getExamples() {
 				content: __( 'Heading 5' ),
 				level: 5,
 			} ),
+			createBlock( 'core/heading', {
+				content: __( 'Heading 6' ),
+				level: 6,
+			} ),
 		],
 	};
 

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -136,23 +136,23 @@ function getExamples() {
 		category: 'text',
 		blocks: [
 			createBlock( 'core/heading', {
-				content: __( 'Code Is Poetry' ),
+				content: __( 'Heading 1' ),
 				level: 1,
 			} ),
 			createBlock( 'core/heading', {
-				content: __( 'Code Is Poetry' ),
+				content: __( 'Heading 2' ),
 				level: 2,
 			} ),
 			createBlock( 'core/heading', {
-				content: __( 'Code Is Poetry' ),
+				content: __( 'Heading 3' ),
 				level: 3,
 			} ),
 			createBlock( 'core/heading', {
-				content: __( 'Code Is Poetry' ),
+				content: __( 'Heading 4' ),
 				level: 4,
 			} ),
 			createBlock( 'core/heading', {
-				content: __( 'Code Is Poetry' ),
+				content: __( 'Heading 5' ),
 				level: 5,
 			} ),
 		],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?


Resolves https://github.com/WordPress/gutenberg/issues/64033

Uses Heading descriptors — `"Heading 1", "Heading 2"` etc, to describe the heading variants in the style book

Adds a Heading 6 example, which corresponds to the maximum heading level available in the typography tools panels.




## Why?

So that the example has text that describes what it is.

## How?

Copy paste, a bit of typing.

## Testing Instructions

1. Fire up this branch and head to the Site Editor
2. Open up the Style Book. Look for the 👁️ icon!
3. Check that the Heading 1, 2, 3... copy is there in the place of "Code is Poetry"


## Screenshots or screencast <!-- if applicable -->


<img width="1390" alt="Screenshot 2024-07-29 at 10 55 42 AM" src="https://github.com/user-attachments/assets/1c7701ba-f312-4b06-826a-3a3feda07748">

