### PR TITLE
DataViews: Conditionally shows the description field in Template Grid layout

### DIFF
--- a/packages/dataviews/src/layouts/grid/index.tsx
+++ b/packages/dataviews/src/layouts/grid/index.tsx
@@ -124,38 +124,49 @@ function GridItem< Item >( {
 			{ !! visibleFields?.length && (
 				<VStack className="dataviews-view-grid__fields" spacing={ 1 }>
 					{ visibleFields.map( ( field ) => {
-						return (
-							<Flex
-								className={ clsx(
-									'dataviews-view-grid__field',
-									columnFields?.includes( field.id )
-										? 'is-column'
-										: 'is-row'
-								) }
-								key={ field.id }
-								gap={ 1 }
-								justify="flex-start"
-								expanded
-								style={ { height: 'auto' } }
-								direction={
-									columnFields?.includes( field.id )
-										? 'column'
-										: 'row'
-								}
-							>
-								<>
-									<FlexItem className="dataviews-view-grid__field-name">
-										{ field.label }
-									</FlexItem>
-									<FlexItem
-										className="dataviews-view-grid__field-value"
-										style={ { maxHeight: 'none' } }
-									>
-										<field.render item={ item } />
-									</FlexItem>
-								</>
-							</Flex>
-						);
+						const isDescriptionField = field.id === 'description';
+						const hasDescription =
+							isDescriptionField &&
+							( item as { description?: string } ).description;
+						if (
+							field.id === 'author' ||
+							! isDescriptionField ||
+							hasDescription
+						) {
+							return (
+								<Flex
+									className={ clsx(
+										'dataviews-view-grid__field',
+										columnFields?.includes( field.id )
+											? 'is-column'
+											: 'is-row'
+									) }
+									key={ field.id }
+									gap={ 1 }
+									justify="flex-start"
+									expanded
+									style={ { height: 'auto' } }
+									direction={
+										columnFields?.includes( field.id )
+											? 'column'
+											: 'row'
+									}
+								>
+									<>
+										<FlexItem className="dataviews-view-grid__field-name">
+											{ field.label }
+										</FlexItem>
+										<FlexItem
+											className="dataviews-view-grid__field-value"
+											style={ { maxHeight: 'none' } }
+										>
+											<field.render item={ item } />
+										</FlexItem>
+									</>
+								</Flex>
+							);
+						}
+						return null;
 					} ) }
 				</VStack>
 			) }

--- a/packages/dataviews/src/layouts/grid/index.tsx
+++ b/packages/dataviews/src/layouts/grid/index.tsx
@@ -124,49 +124,38 @@ function GridItem< Item >( {
 			{ !! visibleFields?.length && (
 				<VStack className="dataviews-view-grid__fields" spacing={ 1 }>
 					{ visibleFields.map( ( field ) => {
-						const isDescriptionField = field.id === 'description';
-						const hasDescription =
-							isDescriptionField &&
-							( item as { description?: string } ).description;
-						if (
-							field.id === 'author' ||
-							! isDescriptionField ||
-							hasDescription
-						) {
-							return (
-								<Flex
-									className={ clsx(
-										'dataviews-view-grid__field',
-										columnFields?.includes( field.id )
-											? 'is-column'
-											: 'is-row'
-									) }
-									key={ field.id }
-									gap={ 1 }
-									justify="flex-start"
-									expanded
-									style={ { height: 'auto' } }
-									direction={
-										columnFields?.includes( field.id )
-											? 'column'
-											: 'row'
-									}
-								>
-									<>
-										<FlexItem className="dataviews-view-grid__field-name">
-											{ field.label }
-										</FlexItem>
-										<FlexItem
-											className="dataviews-view-grid__field-value"
-											style={ { maxHeight: 'none' } }
-										>
-											<field.render item={ item } />
-										</FlexItem>
-									</>
-								</Flex>
-							);
-						}
-						return null;
+						return (
+							<Flex
+								className={ clsx(
+									'dataviews-view-grid__field',
+									columnFields?.includes( field.id )
+										? 'is-column'
+										: 'is-row'
+								) }
+								key={ field.id }
+								gap={ 1 }
+								justify="flex-start"
+								expanded
+								style={ { height: 'auto' } }
+								direction={
+									columnFields?.includes( field.id )
+										? 'column'
+										: 'row'
+								}
+							>
+								<>
+									<FlexItem className="dataviews-view-grid__field-name">
+										{ field.label }
+									</FlexItem>
+									<FlexItem
+										className="dataviews-view-grid__field-value"
+										style={ { maxHeight: 'none' } }
+									>
+										<field.render item={ item } />
+									</FlexItem>
+								</>
+							</Flex>
+						);
 					} ) }
 				</VStack>
 			) }

--- a/packages/dataviews/src/layouts/grid/style.scss
+++ b/packages/dataviews/src/layouts/grid/style.scss
@@ -71,10 +71,6 @@
 			align-items: flex-start;
 			min-height: $grid-unit-30;
 
-			&:has(.dataviews-view-grid__field-value:not(:empty)) {
-				display: flex;
-			}
-
 			&:not(:has(.dataviews-view-grid__field-value:not(:empty))) {
 				display: none;
 			}

--- a/packages/dataviews/src/layouts/grid/style.scss
+++ b/packages/dataviews/src/layouts/grid/style.scss
@@ -71,6 +71,14 @@
 			align-items: flex-start;
 			min-height: $grid-unit-30;
 
+			&:has(.dataviews-view-grid__field-value:not(:empty)) {
+				display: flex;
+			}
+
+			&:not(:has(.dataviews-view-grid__field-value:not(:empty))) {
+				display: none;
+			}
+
 			&:not(.is-column) {
 				align-items: center;
 


### PR DESCRIPTION
## What?
Fixes: #63943 

## Why?
In Grid layout the template description field renders when empty, which isn't making sense.

## How?
Conditionally shows the description.

## Testing Instructions
1. Go to Appearance > Editor > Templates.
2. Create a new template without providing any description.
3. Check the **Templates** page, you will see that the description label is not displayed.
4. Now, add a description and check the **Templates** page again. This time, both the description label and the description should be visible.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/a3056982-9f48-448d-be18-45e2aeced40d
