### PR TITLE
Bump AGP to `8.5.1`

### DIFF
--- a/packages/react-native-aztec/android/settings.gradle
+++ b/packages/react-native-aztec/android/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.8.0'
-    gradle.ext.agpVersion = '8.1.0'
+    gradle.ext.agpVersion = '8.5.1'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
 
     plugins {

--- a/packages/react-native-bridge/android/settings.gradle
+++ b/packages/react-native-bridge/android/settings.gradle
@@ -1,6 +1,6 @@
 pluginManagement {
     gradle.ext.kotlinVersion = '1.8.0'
-    gradle.ext.agpVersion = '8.1.0'
+    gradle.ext.agpVersion = '8.5.1'
     gradle.ext.automatticPublishToS3Version = '0.8.0'
 
     plugins {

--- a/packages/react-native-editor/android/build.gradle
+++ b/packages/react-native-editor/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext {
-        gradlePluginVersion = '8.1.0'
+        gradlePluginVersion = '8.5.1'
         kotlinVersion = '1.8.0'
         buildToolsVersion = "34.0.0"
         minSdkVersion = 24


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Bump Android Gradle Plugin used by react-native-bridge/android to version 8.5.1

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- to keep out tooling up to date
- to keep composite builds setup working with WordPress-Android project (see: https://github.com/wordpress-mobile/WordPress-Android/pull/21082)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Bump version in `settings.gradle`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- try running Gutenberg Mobile as a composite build in WordPress Android with version from this PR: https://github.com/wordpress-mobile/WordPress-Android/pull/21082
- run Gutenberg Mobile as _not_ a composite build, but as an artifact published to our S3 instance to verify that obfuscation works correctly. Take the artifact from https://github.com/wordpress-mobile/gutenberg-mobile/pull/7010

Perform both tests in `release` variant.

### Comment
AGP in version `8.4.0` brings changes to how libraries are obfuscated. I don't suspect any issues here as it's a standalone SDK (not a library module) and `enableProguardInReleaseBuilds` value is set to `false`. Anyway, it's good to double-check this.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
