### PR TITLE
Quote: Prevent block theme styles overriding global border and padding

### DIFF
--- a/packages/block-library/src/quote/theme.scss
+++ b/packages/block-library/src/quote/theme.scss
@@ -10,19 +10,21 @@
 		font-style: normal;
 	}
 
-	&.has-text-align-right {
+	&:where(.has-text-align-right) {
 		border-left: none;
 		border-right: 0.25em solid currentColor;
 		padding-left: 0;
 		padding-right: 1em;
 	}
 
-	&.has-text-align-center {
+	&:where(.has-text-align-center) {
 		border: none;
 		padding-left: 0;
 	}
 	// .is-style-large and .is-large are kept for backwards compatibility.
-	&.is-style-plain,
+	// They are not wrapped in `:where()` to keep specificity as it was before
+	// they were deprecated.
+	&:where(.is-style-plain),
 	&.is-style-large,
 	&.is-large {
 		border: none;


### PR DESCRIPTION
Addresses: https://github.com/WordPress/gutenberg/pull/63544#issuecomment-2252278726

## What?

Fixes an issue where the Quote block's theme styles have higher specificity than global styles preventing the recently adopted border support styles from applying correctly when the quote block is center or right-aligned.

This fix now also allows global styles padding for the quote block to apply as expected when the block is aligned.

## Why?

Provides the expected styling behaviour for the Quote block.

## How?

- Wraps the chained alignment (and block style) classes with `:where` so the resulting selector has `0-1-0` specificity to match global styles

## Testing Instructions

1. Before checking out this PR, add some Quote blocks to a page or post. Then apply center and right alignments to a couple of them. For convenience check out the snippet below:
```html
<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:quote {"className":"is-style-default"} -->
<blockquote class="wp-block-quote is-style-default"><!-- wp:paragraph -->
<p>Wise words of wisdom - no alignment</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:quote {"textAlign":"left","className":"is-style-default"} -->
<blockquote class="wp-block-quote has-text-align-left is-style-default"><!-- wp:paragraph -->
<p>Wise words of wisdom - left aligned</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:quote {"textAlign":"center","className":"is-style-default"} -->
<blockquote class="wp-block-quote has-text-align-center is-style-default"><!-- wp:paragraph -->
<p>Wise words of wisdom - center aligned</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:quote {"textAlign":"right","className":"is-style-default"} -->
<blockquote class="wp-block-quote has-text-align-right is-style-default"><!-- wp:paragraph -->
<p>Wise words of wisdom - right aligned</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote --></div>
```
2. In the Site Editor, navigate to Styles > Blocks > Quote. Add a border and some custom padding
3. Save and check your quote blocks to see the center and right aligned blocks displaying incorrect borders/padding.
4. Apply the "Plain" block style to one of the blocks and see the border disappear
5. Apply this PR's changes and reload the editor.
6. Confirm the styles now display correctly in the editor and frontend.


## Screenshots or screencast <!-- if applicable -->


| Before | After |
|---|---|
| <img width="896" alt="Screenshot 2024-07-29 at 5 31 21 PM" src="https://github.com/user-attachments/assets/8dce27a1-7ca5-43b2-819d-cbf7c186203b"> | <img width="888" alt="Screenshot 2024-07-29 at 5 32 00 PM" src="https://github.com/user-attachments/assets/166769d1-4682-42d8-99e3-5e3fd870e252"> |


