### PR TITLE
Style Book: Fix critical error when heading block is not registered

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -13,6 +13,7 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	getCategories,
+	getBlockType,
 	getBlockTypes,
 	getBlockFromExample,
 	createBlock,
@@ -128,41 +129,7 @@ function isObjectEmpty( object ) {
 }
 
 function getExamples() {
-	// Use our own example for the Heading block so that we can show multiple
-	// heading levels.
-	const headingsExample = {
-		name: 'core/heading',
-		title: __( 'Headings' ),
-		category: 'text',
-		blocks: [
-			createBlock( 'core/heading', {
-				content: __( 'Heading 1' ),
-				level: 1,
-			} ),
-			createBlock( 'core/heading', {
-				content: __( 'Heading 2' ),
-				level: 2,
-			} ),
-			createBlock( 'core/heading', {
-				content: __( 'Heading 3' ),
-				level: 3,
-			} ),
-			createBlock( 'core/heading', {
-				content: __( 'Heading 4' ),
-				level: 4,
-			} ),
-			createBlock( 'core/heading', {
-				content: __( 'Heading 5' ),
-				level: 5,
-			} ),
-			createBlock( 'core/heading', {
-				content: __( 'Heading 6' ),
-				level: 6,
-			} ),
-		],
-	};
-
-	const otherExamples = getBlockTypes()
+	const nonHeadingBlockExamples = getBlockTypes()
 		.filter( ( blockType ) => {
 			const { name, example, supports } = blockType;
 			return (
@@ -178,7 +145,31 @@ function getExamples() {
 			blocks: getBlockFromExample( blockType.name, blockType.example ),
 		} ) );
 
-	return [ headingsExample, ...otherExamples ];
+	const isHeadingBlockRegistered = !! getBlockType( 'core/heading' );
+
+	if ( ! isHeadingBlockRegistered ) {
+		return nonHeadingBlockExamples;
+	}
+
+	// Use our own example for the Heading block so that we can show multiple
+	// heading levels.
+	const headingsExample = {
+		name: 'core/heading',
+		title: __( 'Headings' ),
+		category: 'text',
+		blocks: [ 1, 2, 3, 4, 5, 6 ].map( ( level ) => {
+			return createBlock( 'core/heading', {
+				content: sprintf(
+					// translators: %d: heading level e.g: "1", "2", "3"
+					__( 'Heading %d' ),
+					level
+				),
+				level,
+			} );
+		} ),
+	};
+
+	return [ headingsExample, ...nonHeadingBlockExamples ];
 }
 
 function StyleBook( {


### PR DESCRIPTION
Discovered this while reviewing #64038

## What?

This PR fixes a critical error in the Style Book screen when the heading block is not registered.

![style-book](https://github.com/user-attachments/assets/90363b25-51fe-48ff-96b4-3f051416db1b)

## Why?

This is because a non-existent block is being created via `createBlock()`.

## How?

Use the `getBlockType()` selector to pre-check if a heading block exists, and if not, return non-heading block examples.

## Testing Instructions

- Run the following code in your browser console: `wp.blocks.unregisterBlockType('core/heading')`
- Open the StyleBook.
- You won’t see the heading block, but the StyleBook should display fine.
