### PR TITLE
Block Insertion: Clear the insertion point when selecting a different block or clearing block selection

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, SearchControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -82,6 +82,8 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
+	const { showInsertionPoint } = useDispatch( blockEditorStore );
+
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
@@ -91,6 +93,7 @@ export default function QuickInserter( {
 			filterValue,
 			onSelect,
 		} );
+		showInsertionPoint( rootClientId, insertionIndex );
 	};
 
 	let maxBlockPatterns = 0;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1624,6 +1624,8 @@ export function insertionPoint( state = null, action ) {
 		}
 
 		case 'HIDE_INSERTION_POINT':
+		case 'CLEAR_SELECTED_BLOCK':
+		case 'SELECT_BLOCK':
 			return null;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1624,8 +1624,8 @@ export function insertionPoint( state = null, action ) {
 		}
 
 		case 'HIDE_INSERTION_POINT':
-		case 'CLEAR_SELECTED_BLOCK':
 		case 'SELECT_BLOCK':
+		case 'CLEAR_SELECTED_BLOCK':
 			return null;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1625,7 +1625,6 @@ export function insertionPoint( state = null, action ) {
 
 		case 'HIDE_INSERTION_POINT':
 		case 'SELECT_BLOCK':
-		case 'CLEAR_SELECTED_BLOCK':
 			return null;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1624,6 +1624,7 @@ export function insertionPoint( state = null, action ) {
 		}
 
 		case 'HIDE_INSERTION_POINT':
+		case 'CLEAR_SELECTED_BLOCK':
 		case 'SELECT_BLOCK':
 			return null;
 	}

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -22,15 +22,17 @@ const { PrivateInserterLibrary } = unlock( blockEditorPrivateApis );
 
 export default function InserterSidebar() {
 	const {
+		blockInsertionPoint,
 		blockSectionRootClientId,
 		inserterSidebarToggleRef,
-		blockInsertionPoint,
+		insertionPoint,
 		showMostUsedBlocks,
 		sidebarIsOpened,
 	} = useSelect( ( select ) => {
 		const {
-			getInserterSidebarToggleRef,
 			getBlockInsertionPoint,
+			getInserterSidebarToggleRef,
+			getInsertionPoint,
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
 		const { getBlockRootClientId, __unstableGetEditorMode, getSettings } =
@@ -47,8 +49,9 @@ export default function InserterSidebar() {
 			return getBlockRootClientId();
 		};
 		return {
-			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			blockInsertionPoint: getBlockInsertionPoint(),
+			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
+			insertionPoint: getInsertionPoint(),
 			showMostUsedBlocks: get( 'core', 'mostUsedBlocks' ),
 			blockSectionRootClientId: getBlockSectionRootClientId(),
 			sidebarIsOpened: !! (
@@ -87,13 +90,11 @@ export default function InserterSidebar() {
 				rootClientId={
 					blockSectionRootClientId ?? blockInsertionPoint.rootClientId
 				}
-				__experimentalInsertionIndex={
-					blockInsertionPoint.insertionIndex
-				}
-				onSelect={ blockInsertionPoint.onSelect }
-				__experimentalInitialTab={ blockInsertionPoint.tab }
-				__experimentalInitialCategory={ blockInsertionPoint.category }
-				__experimentalFilterValue={ blockInsertionPoint.filterValue }
+				__experimentalInsertionIndex={ blockInsertionPoint.index }
+				onSelect={ insertionPoint.onSelect }
+				__experimentalInitialTab={ insertionPoint.tab }
+				__experimentalInitialCategory={ insertionPoint.category }
+				__experimentalFilterValue={ insertionPoint.filterValue }
 				onPatternCategorySelection={
 					sidebarIsOpened
 						? () => disableComplementaryArea( 'core' )

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -24,13 +24,13 @@ export default function InserterSidebar() {
 	const {
 		blockSectionRootClientId,
 		inserterSidebarToggleRef,
-		insertionPoint,
+		blockInsertionPoint,
 		showMostUsedBlocks,
 		sidebarIsOpened,
 	} = useSelect( ( select ) => {
 		const {
 			getInserterSidebarToggleRef,
-			getInsertionPoint,
+			getBlockInsertionPoint,
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
 		const { getBlockRootClientId, __unstableGetEditorMode, getSettings } =
@@ -48,7 +48,7 @@ export default function InserterSidebar() {
 		};
 		return {
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
-			insertionPoint: getInsertionPoint(),
+			blockInsertionPoint: getBlockInsertionPoint(),
 			showMostUsedBlocks: get( 'core', 'mostUsedBlocks' ),
 			blockSectionRootClientId: getBlockSectionRootClientId(),
 			sidebarIsOpened: !! (
@@ -85,13 +85,15 @@ export default function InserterSidebar() {
 				showInserterHelpPanel
 				shouldFocusBlock={ isMobileViewport }
 				rootClientId={
-					blockSectionRootClientId ?? insertionPoint.rootClientId
+					blockSectionRootClientId ?? blockInsertionPoint.rootClientId
 				}
-				__experimentalInsertionIndex={ insertionPoint.insertionIndex }
-				onSelect={ insertionPoint.onSelect }
-				__experimentalInitialTab={ insertionPoint.tab }
-				__experimentalInitialCategory={ insertionPoint.category }
-				__experimentalFilterValue={ insertionPoint.filterValue }
+				__experimentalInsertionIndex={
+					blockInsertionPoint.insertionIndex
+				}
+				onSelect={ blockInsertionPoint.onSelect }
+				__experimentalInitialTab={ blockInsertionPoint.tab }
+				__experimentalInitialCategory={ blockInsertionPoint.category }
+				__experimentalFilterValue={ blockInsertionPoint.filterValue }
 				onPatternCategorySelection={
 					sidebarIsOpened
 						? () => disableComplementaryArea( 'core' )

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -30,13 +30,16 @@ export default function InserterSidebar() {
 		sidebarIsOpened,
 	} = useSelect( ( select ) => {
 		const {
-			getBlockInsertionPoint,
 			getInserterSidebarToggleRef,
 			getInsertionPoint,
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
-		const { getBlockRootClientId, __unstableGetEditorMode, getSettings } =
-			select( blockEditorStore );
+		const {
+			getBlockInsertionPoint,
+			getBlockRootClientId,
+			__unstableGetEditorMode,
+			getSettings,
+		} = select( blockEditorStore );
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const getBlockSectionRootClientId = () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds additional situations in which we clear the block insertion point. Fixes https://github.com/WordPress/gutenberg/issues/63866

## Why?
When a block is selected, it would be expected that the insertion point would also update to reflect the newly selected block, so we should reset the insertion point in this case.

## How?
Add more actions to the insertion point reducer so that it detects when a block is selected.

## Testing Instructions
1. Open the Site Editor
2. Enter zoom out mode (this isn't necessary but it makes it much easier to test) - you can enter zoom out by selecting a pattern category in the inserter
3. Click one on the [+] in the canvas, to set an insertion point. Notice that a wide blue line appears between the two blocks.
4. Select another block, or clear block selection. Notice that that wide blue line disappears.
5. Now select a pattern in the canvas. This pattern should be inserted after the newly selected block, not at the place where the old insertion point was.
6. Create an insertion point by clicking the [+]. Hover a pattern in the inserter. You should still see the wide blue line in the canvas.
7. Now click the pattern. It should be added to the place that the insertion point indicator was.

## Screenshots or screencast <!-- if applicable -->
Trunk

https://github.com/user-attachments/assets/727647e2-eb15-4fa5-a942-84f10dba3d85




This branch

https://github.com/user-attachments/assets/32e8e071-e170-42c0-bdba-d36db42b0f11

