### PR TITLE
DataViews: display published date for pages/posts with published status

### DIFF
--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -292,7 +292,22 @@ function usePostFields( viewType ) {
 						);
 					}
 
-					// Pending & Published posts show the modified date if it's newer.
+					const isPublished = item.status === 'publish';
+					if ( isPublished ) {
+						return createInterpolateElement(
+							sprintf(
+								/* translators: %s: page creation time */
+								__( '<span>Published: <time>%s</time></span>' ),
+								getFormattedDate( item.date )
+							),
+							{
+								span: <span />,
+								time: <time />,
+							}
+						);
+					}
+
+					// Pending posts show the modified date if it's newer.
 					const dateToDisplay =
 						getDate( item.modified ) > getDate( item.date )
 							? item.modified
@@ -304,21 +319,6 @@ function usePostFields( viewType ) {
 							sprintf(
 								/* translators: %s: the newest of created or modified date for the page */
 								__( '<span>Modified: <time>%s</time></span>' ),
-								getFormattedDate( dateToDisplay )
-							),
-							{
-								span: <span />,
-								time: <time />,
-							}
-						);
-					}
-
-					const isPublished = item.status === 'publish';
-					if ( isPublished ) {
-						return createInterpolateElement(
-							sprintf(
-								/* translators: %s: the newest of created or modified date for the page */
-								__( '<span>Published: <time>%s</time></span>' ),
 								getFormattedDate( dateToDisplay )
 							),
 							{


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/61709

## What?

Display the published date for posts/pages with published status. Before it displayed the newest of modified and published date.

## Why?

This is how other parts of the system work (wp-admin post/page list, post/page inspector). It's also how the REST API works, and by not using published date the sort results are visually incoherent with sorting.

In the example below, after installing the theme test data, I edited the "WP 6.1 font size scale" post. In wp-admin and dataviews sorted the list by date descending. This is how it looked everywhere:

| wp-admin | dataviews | inspector |
| --- | --- | --- |
| <img width="2387" alt="Captura de ecrã 2024-07-29, às 11 19 37" src="https://github.com/user-attachments/assets/8bb41187-7b0b-4cc2-b3f4-b8517e2966bd"> | <img width="1658" alt="Captura de ecrã 2024-07-29, às 11 18 44" src="https://github.com/user-attachments/assets/61cca35a-5ec2-47b3-a2d8-e1a35565ea6c"> | <img width="285" alt="Captura de ecrã 2024-07-29, às 11 20 22" src="https://github.com/user-attachments/assets/f4f0338b-d9c5-4387-91cb-ce4ffbcf6d37"> |


## How?

Updates the `render` function of the `date` field to use the `item.date` instead of `item.modified` for published posts/pages.

## Testing Instructions

- Create two Pages: post 1 & post 2, in that order.
- Go to "Site Editor > Pages", switch to table layout and make the date visible. It should display the published date.
- Sort by "Date descending".

The expected result is that "Post 2" is above "Post 1".

- Go and edit "Post 1" and save the changes.
- Go back to the "Site Editor > Pages" and sort by "Date descending".
- It should display the published date.

The expected result is that "Post 2" is still above "Post 1".

