### PR TITLE
Fix typo in 'Verify Core Backport Changelog' job title

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -1,4 +1,4 @@
-name: Verify Core Backport Changlog
+name: Verify Core Backport Changelog
 
 on:
     pull_request:


### PR DESCRIPTION
## What?

Tiny PR fixing a typo in the 'Verify Core Backport Changelog' GitHub job title.