### PR TITLE
DataViews: sort author by name + allow custom sort function

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -23,6 +23,7 @@ export const data = [
 		type: 'Not a planet',
 		categories: [ 'Space', 'NASA' ],
 		satellites: 0,
+		satellites_no_type: 0,
 	},
 	{
 		id: 2,
@@ -32,6 +33,7 @@ export const data = [
 		type: 'Not a planet',
 		categories: [ 'Space' ],
 		satellites: 0,
+		satellites_no_type: 0,
 	},
 	{
 		id: 3,
@@ -41,6 +43,7 @@ export const data = [
 		type: 'Not a planet',
 		categories: [ 'NASA' ],
 		satellites: 0,
+		satellites_no_type: 0,
 	},
 	{
 		id: 4,
@@ -50,6 +53,7 @@ export const data = [
 		type: 'Ice giant',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 14,
+		satellites_no_type: 14,
 	},
 	{
 		id: 5,
@@ -59,6 +63,7 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
+		satellites_no_type: 0,
 	},
 	{
 		id: 6,
@@ -68,6 +73,7 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
+		satellites_no_type: 0,
 	},
 	{
 		id: 7,
@@ -77,6 +83,7 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 1,
+		satellites_no_type: 1,
 	},
 	{
 		id: 8,
@@ -86,6 +93,7 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 2,
+		satellites_no_type: 2,
 	},
 	{
 		id: 9,
@@ -95,6 +103,7 @@ export const data = [
 		type: 'Gas giant',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 95,
+		satellites_no_type: 95,
 	},
 	{
 		id: 10,
@@ -104,6 +113,7 @@ export const data = [
 		type: 'Gas giant',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 146,
+		satellites_no_type: 146,
 	},
 	{
 		id: 11,
@@ -113,6 +123,7 @@ export const data = [
 		type: 'Ice giant',
 		categories: [ 'Space', 'Ice giant', 'Solar system' ],
 		satellites: 28,
+		satellites_no_type: 28,
 	},
 ];
 
@@ -189,6 +200,12 @@ export const fields = [
 	{
 		label: 'Satellites',
 		id: 'satellites',
+		type: 'integer',
+		enableSorting: true,
+	},
+	{
+		label: 'Satellites (no type)',
+		id: 'satellites_no_type',
 		enableSorting: true,
 	},
 	{

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { default as integer } from './integer';
+import type { FieldType } from '../types';
+
+/**
+ *
+ * @param {FieldType} type The field type definition to get.
+ *
+ * @return A field type definition.
+ */
+export default function getFieldTypeDefinition( type?: FieldType ) {
+	if ( 'integer' === type ) {
+		return integer;
+	}
+
+	// TODO: What's the default when the type is undefined?
+	return {
+		sort: () => 0,
+	};
+}

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -15,7 +15,7 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 		return integer;
 	}
 
-	// TODO: What's the default when the type is undefined?
+	// If no type found, the sort function doesn't do anything.
 	return {
 		sort: () => 0,
 	};

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -4,15 +4,17 @@
 import type { SortDirection } from '../types';
 
 function sort< Item >(
-	itemA: Item,
-	itemB: Item,
-	direction: SortDirection,
-	getValue: ( args: { item: Item } ) => any
+	a: {
+		item: Item;
+		value: any;
+	},
+	b: {
+		item: Item;
+		value: any;
+	},
+	direction: SortDirection
 ) {
-	const valueA = getValue( { item: itemA } );
-	const valueB = getValue( { item: itemB } );
-
-	return direction === 'asc' ? valueA - valueB : valueB - valueA;
+	return direction === 'asc' ? a.value - b.value : b.value - a.value;
 }
 
 export default {

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -1,0 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import type { SortDirection } from '../types';
+
+export default {
+	sort: ( a: number, b: number, direction: SortDirection ) =>
+		direction === 'asc' ? a - b : b - a,
+};

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -7,10 +7,10 @@ function sort< Item >(
 	itemA: Item,
 	itemB: Item,
 	direction: SortDirection,
-	field: any
+	getValue: ( args: { item: Item } ) => any
 ) {
-	const valueA = field.getValue( { item: itemA } );
-	const valueB = field.getValue( { item: itemB } );
+	const valueA = getValue( { item: itemA } );
+	const valueB = getValue( { item: itemB } );
 
 	return direction === 'asc' ? valueA - valueB : valueB - valueA;
 }

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -4,6 +4,10 @@
 import type { SortDirection } from '../types';
 
 export default {
-	sort: ( a: number, b: number, direction: SortDirection ) =>
-		direction === 'asc' ? a - b : b - a,
+	sort: ( itemA: any, itemB: any, direction: SortDirection, field: any ) => {
+		const valueA = field.getValue( { item: itemA } );
+		const valueB = field.getValue( { item: itemB } );
+
+		return direction === 'asc' ? valueA - valueB : valueB - valueA;
+	},
 };

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -3,18 +3,8 @@
  */
 import type { SortDirection } from '../types';
 
-function sort< Item >(
-	a: {
-		item: Item;
-		value: any;
-	},
-	b: {
-		item: Item;
-		value: any;
-	},
-	direction: SortDirection
-) {
-	return direction === 'asc' ? a.value - b.value : b.value - a.value;
+function sort( a: any, b: any, direction: SortDirection ) {
+	return direction === 'asc' ? a - b : b - a;
 }
 
 export default {

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -3,11 +3,18 @@
  */
 import type { SortDirection } from '../types';
 
-export default {
-	sort: ( itemA: any, itemB: any, direction: SortDirection, field: any ) => {
-		const valueA = field.getValue( { item: itemA } );
-		const valueB = field.getValue( { item: itemB } );
+function sort< Item >(
+	itemA: Item,
+	itemB: Item,
+	direction: SortDirection,
+	field: any
+) {
+	const valueA = field.getValue( { item: itemA } );
+	const valueB = field.getValue( { item: itemB } );
 
-		return direction === 'asc' ? valueA - valueB : valueB - valueA;
-	},
+	return direction === 'asc' ? valueA - valueB : valueB - valueA;
+}
+
+export default {
+	sort,
 };

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -145,7 +145,7 @@ export function filterSortAndPaginate< Item >(
 						a,
 						b,
 						view.sort?.direction ?? 'desc',
-						fieldToSort
+						fieldToSort.getValue
 					);
 				}
 

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -140,18 +140,24 @@ export function filterSortAndPaginate< Item >(
 		} );
 		if ( fieldToSort ) {
 			filteredData.sort( ( a, b ) => {
+				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
+				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
+
 				if ( fieldToSort.type === 'integer' ) {
 					return fieldToSort.sort(
-						a,
-						b,
-						view.sort?.direction ?? 'desc',
-						fieldToSort.getValue
+						{
+							item: a,
+							value: valueA,
+						},
+						{
+							item: b,
+							value: valueB,
+						},
+						view.sort?.direction ?? 'desc'
 					);
 				}
 
 				// When/if types become required, we can remove the following logic.
-				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
-				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
 				if (
 					typeof valueA === 'number' &&
 					typeof valueB === 'number'

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -145,14 +145,8 @@ export function filterSortAndPaginate< Item >(
 
 				if ( fieldToSort.type === 'integer' ) {
 					return fieldToSort.sort(
-						{
-							item: a,
-							value: valueA,
-						},
-						{
-							item: b,
-							value: valueB,
-						},
+						a,
+						b,
 						view.sort?.direction ?? 'desc'
 					);
 				}

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -143,6 +143,15 @@ export function filterSortAndPaginate< Item >(
 				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
 				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
 
+				if ( fieldToSort.type === 'integer' ) {
+					// TODO: should we pass the item instead of the resolved value?
+					return fieldToSort.sort(
+						valueA,
+						valueB,
+						view.sort?.direction ?? 'desc'
+					);
+				}
+
 				if (
 					typeof valueA === 'number' &&
 					typeof valueB === 'number'

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -140,18 +140,18 @@ export function filterSortAndPaginate< Item >(
 		} );
 		if ( fieldToSort ) {
 			filteredData.sort( ( a, b ) => {
-				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
-				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
-
 				if ( fieldToSort.type === 'integer' ) {
-					// TODO: should we pass the item instead of the resolved value?
 					return fieldToSort.sort(
-						valueA,
-						valueB,
-						view.sort?.direction ?? 'desc'
+						a,
+						b,
+						view.sort?.direction ?? 'desc',
+						fieldToSort
 					);
 				}
 
+				// When/if types become required, we can remove the following logic.
+				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
+				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
 				if (
 					typeof valueA === 'number' &&
 					typeof valueB === 'number'

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -20,7 +20,15 @@ export function normalizeFields< Item >(
 			field.getValue ||
 			( ( { item }: { item: ItemRecord } ) => item[ field.id ] );
 
-		const sort = field.sort || fieldTypeDefinition.sort;
+		const sort =
+			field.sort ??
+			function sort( a, b, direction ) {
+				return fieldTypeDefinition.sort(
+					getValue( { item: a } ),
+					getValue( { item: b } ),
+					direction
+				);
+			};
 
 		return {
 			...field,

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -1,6 +1,7 @@
 /**
  * Internal dependencies
  */
+import getFieldTypeDefinition from './field-types';
 import type { Field, NormalizedField, ItemRecord } from './types';
 
 /**
@@ -13,15 +14,20 @@ export function normalizeFields< Item >(
 	fields: Field< Item >[]
 ): NormalizedField< Item >[] {
 	return fields.map( ( field ) => {
+		const fieldTypeDefinition = getFieldTypeDefinition( field.type );
+
 		const getValue =
 			field.getValue ||
 			( ( { item }: { item: ItemRecord } ) => item[ field.id ] );
+
+		const sort = field.sort || fieldTypeDefinition.sort;
 
 		return {
 			...field,
 			label: field.label || field.id,
 			getValue,
 			render: field.render || getValue,
+			sort,
 		};
 	} );
 }

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -257,6 +257,21 @@ describe( 'sorting', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
 			{
+				sort: { field: 'satellites_no_type', direction: 'desc' },
+			},
+			fields
+		);
+
+		expect( result ).toHaveLength( 11 );
+		expect( result[ 0 ].title ).toBe( 'Saturn' );
+		expect( result[ 1 ].title ).toBe( 'Jupiter' );
+		expect( result[ 2 ].title ).toBe( 'Uranus' );
+	} );
+
+	it( 'should sort by type integer', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
 				sort: { field: 'satellites', direction: 'desc' },
 			},
 			fields

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -83,7 +83,12 @@ export type Field< Item > = {
 	/**
 	 * Callback used to sort the field.
 	 */
-	sort?: ( a: any, b: any, direction: SortDirection, field?: any ) => number;
+	sort?: (
+		a: Item,
+		b: Item,
+		direction: SortDirection,
+		field?: any
+	) => number;
 
 	/**
 	 * Whether the field is sortable.
@@ -129,7 +134,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	label: string;
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
-	sort: ( a: any, b: any, direction: SortDirection, field?: any ) => number;
+	sort: ( a: Item, b: Item, direction: SortDirection, field?: any ) => number;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -83,7 +83,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to sort the field.
 	 */
-	sort?: ( a: any, b: any, direction: SortDirection ) => number;
+	sort?: ( a: any, b: any, direction: SortDirection, field?: any ) => number;
 
 	/**
 	 * Whether the field is sortable.
@@ -129,7 +129,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	label: string;
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
-	sort: ( a: any, b: any, direction: SortDirection ) => number;
+	sort: ( a: any, b: any, direction: SortDirection, field?: any ) => number;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -81,6 +81,11 @@ export type Field< Item > = {
 	render?: ComponentType< { item: Item } >;
 
 	/**
+	 * Callback used to sort the field.
+	 */
+	sort?: ( a: any, b: any, direction: SortDirection ) => number;
+
+	/**
 	 * Whether the field is sortable.
 	 */
 	enableSorting?: boolean;
@@ -124,6 +129,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	label: string;
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
+	sort: ( a: any, b: any, direction: SortDirection ) => number;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -87,7 +87,7 @@ export type Field< Item > = {
 		a: Item,
 		b: Item,
 		direction: SortDirection,
-		field?: any
+		getValue: ( args: { item: Item } ) => any
 	) => number;
 
 	/**
@@ -134,7 +134,12 @@ export type NormalizedField< Item > = Field< Item > & {
 	label: string;
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
-	sort: ( a: Item, b: Item, direction: SortDirection, field?: any ) => number;
+	sort: (
+		a: Item,
+		b: Item,
+		direction: SortDirection,
+		getValue: ( args: { item: Item } ) => any
+	) => number;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -84,10 +84,15 @@ export type Field< Item > = {
 	 * Callback used to sort the field.
 	 */
 	sort?: (
-		a: Item,
-		b: Item,
-		direction: SortDirection,
-		getValue: ( args: { item: Item } ) => any
+		a: {
+			item: Item;
+			value: any;
+		},
+		b: {
+			item: Item;
+			value: any;
+		},
+		direction: SortDirection
 	) => number;
 
 	/**
@@ -135,10 +140,15 @@ export type NormalizedField< Item > = Field< Item > & {
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
 	sort: (
-		a: Item,
-		b: Item,
-		direction: SortDirection,
-		getValue: ( args: { item: Item } ) => any
+		a: {
+			item: Item;
+			value: any;
+		},
+		b: {
+			item: Item;
+			value: any;
+		},
+		direction: SortDirection
 	) => number;
 };
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -83,17 +83,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to sort the field.
 	 */
-	sort?: (
-		a: {
-			item: Item;
-			value: any;
-		},
-		b: {
-			item: Item;
-			value: any;
-		},
-		direction: SortDirection
-	) => number;
+	sort?: ( a: Item, b: Item, direction: SortDirection ) => number;
 
 	/**
 	 * Whether the field is sortable.
@@ -139,17 +129,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	label: string;
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
-	sort: (
-		a: {
-			item: Item;
-			value: any;
-		},
-		b: {
-			item: Item;
-			value: any;
-		},
-		direction: SortDirection
-	) => number;
+	sort: ( a: Item, b: Item, direction: SortDirection ) => number;
 };
 
 /**

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -242,11 +242,9 @@ function usePostFields( viewType ) {
 						label: name,
 					} ) ) || [],
 				render: PostAuthorField,
-				sort: ( a, b, direction ) => {
-					const nameA =
-						authors.find( ( { id } ) => id === a )?.name || '';
-					const nameB =
-						authors.find( ( { id } ) => id === b )?.name || '';
+				sort: ( fieldA, fieldB, direction ) => {
+					const nameA = fieldA._embedded?.author?.[ 0 ]?.name || '';
+					const nameB = fieldB._embedded?.author?.[ 0 ]?.name || '';
 
 					return direction === 'asc'
 						? nameA.localeCompare( nameB )

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -242,6 +242,16 @@ function usePostFields( viewType ) {
 						label: name,
 					} ) ) || [],
 				render: PostAuthorField,
+				sort: ( a, b, direction ) => {
+					const nameA =
+						authors.find( ( { id } ) => id === a )?.name || '';
+					const nameB =
+						authors.find( ( { id } ) => id === b )?.name || '';
+
+					return direction === 'asc'
+						? nameA.localeCompare( nameB )
+						: nameB.localeCompare( nameA );
+				},
 			},
 			{
 				label: __( 'Status' ),

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -242,7 +242,7 @@ function usePostFields( viewType ) {
 						label: name,
 					} ) ) || [],
 				render: PostAuthorField,
-				sort: ( { item: a }, { item: b }, direction ) => {
+				sort: ( a, b, direction ) => {
 					const nameA = a._embedded?.author?.[ 0 ]?.name || '';
 					const nameB = b._embedded?.author?.[ 0 ]?.name || '';
 

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -242,9 +242,9 @@ function usePostFields( viewType ) {
 						label: name,
 					} ) ) || [],
 				render: PostAuthorField,
-				sort: ( fieldA, fieldB, direction ) => {
-					const nameA = fieldA._embedded?.author?.[ 0 ]?.name || '';
-					const nameB = fieldB._embedded?.author?.[ 0 ]?.name || '';
+				sort: ( { item: a }, { item: b }, direction ) => {
+					const nameA = a._embedded?.author?.[ 0 ]?.name || '';
+					const nameB = b._embedded?.author?.[ 0 ]?.name || '';
 
 					return direction === 'asc'
 						? nameA.localeCompare( nameB )

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -200,7 +200,7 @@ export default function PostList( { postType } ) {
 	}, [ view ] );
 	const {
 		records,
-		isResolving: isLoadingMainEntities,
+		isResolving: isLoadingData,
 		totalItems,
 		totalPages,
 	} = useEntityRecordsWithPermissions( 'postType', postType, queryArgs );
@@ -295,7 +295,7 @@ export default function PostList( { postType } ) {
 				fields={ fields }
 				actions={ actions }
 				data={ records || EMPTY_ARRAY }
-				isLoading={ isLoadingMainEntities || isLoadingFields }
+				isLoading={ isLoadingData || isLoadingFields }
 				view={ view }
 				onChangeView={ setView }
 				selection={ selection }

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -208,10 +208,17 @@ export default function PostList( { postType } ) {
 	} = useEntityRecordsWithPermissions( 'postType', postType, queryArgs );
 
 	// The REST API sort the authors by ID, but we want to sort them by name.
-	const data =
-		! isLoadingFields && view?.sort?.field === 'author'
-			? filterSortAndPaginate( records, view, fields ).data
-			: records;
+	const data = useMemo( () => {
+		if ( ! isLoadingFields && view?.sort?.field === 'author' ) {
+			return filterSortAndPaginate(
+				records,
+				{ sort: { ...view.sort } },
+				fields
+			).data;
+		}
+
+		return records;
+	}, [ records, fields, isLoadingFields, view?.sort ] );
 
 	const ids = data?.map( ( record ) => getItemId( record ) ) ?? [];
 	const prevIds = usePrevious( ids ) ?? [];


### PR DESCRIPTION
## What?

This PR sorts author by name instead of id. It does so by also allowing fields to provide a custom sort function.

## Why?

Author ids don't mean anything to users, we should sort it by name.

Note that the REST API allows sorting by author but it really sorts by "author id". The wp-admin doesn't allow sorting the post/page list by author.

## How?

- Formalizes the Field type `integer`, which provides a default sorting function.
- Allows any integer field to provide its own custom function.

## Testing Instructions

- Create three users, in this order:
  - alpha with role admin
  - gamma with role admin
  - beta with role admin
- Create three pages and assign each to a different author.
- Go to "Site editor > Pages" and sort by author.

The expected result is that the order is pages created by alpha, then beta, then gamma. In `trunk`, the order is by id (this is: alpha, gamma, beta).
