### PR TITLE
Remove unnecessary/incorrect `unlock` call in `setEditorMode` action

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -35,7 +35,6 @@ import {
 	privateRemoveBlocks,
 } from './private-actions';
 import { STORE_NAME } from './constants';
-import { unlock } from '../lock-unlock';
 
 /** @typedef {import('../components/use-on-block-drop/types').WPDropOperation} WPDropOperation */
 
@@ -1674,9 +1673,9 @@ export const __unstableSetEditorMode =
 		// When switching to zoom-out mode, we need to select the parent section
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
-			const { sectionRootClientId } = unlock(
-				registry.select( STORE_NAME ).getSettings()
-			);
+			const { sectionRootClientId } = registry
+				.select( STORE_NAME )
+				.getSettings();
 			if ( firstSelectedClientId ) {
 				let sectionClientId;
 


### PR DESCRIPTION
## What?
Small PR that removes an unnecessary `unlock` call.

## Why?
First I noticed that the code is doing it wrong (it should unlock the `select`), but then I noticed that `getSettings` isn't private, so the unlock does nothing (settings is also not locked).

## How?
Deletes it