### PR TITLE
Fix Modal’s dismiss effect in StrictMode

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -153,9 +153,9 @@ function UnforwardedModal(
 	// onRequestClose for any prior and/or nested modals as applicable.
 	useEffect( () => {
 		dismissers.push( refOnRequestClose );
-		const [ first, second ] = dismissers;
-		if ( second ) {
-			first?.current?.();
+		const [ prior ] = dismissers;
+		if ( prior && prior !== refOnRequestClose ) {
+			prior.current?.();
 		}
 
 		const nested = nestedDismissers.current;

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -89,8 +89,7 @@ function useEditorCommandLoader() {
 		name: 'core/open-shortcut-help',
 		label: __( 'Keyboard shortcuts' ),
 		icon: keyboard,
-		callback: ( { close } ) => {
-			close();
+		callback: () => {
 			openModal( 'editor/keyboard-shortcut-help' );
 		},
 	} );
@@ -109,8 +108,7 @@ function useEditorCommandLoader() {
 	commands.push( {
 		name: 'core/open-preferences',
 		label: __( 'Editor preferences' ),
-		callback: ( { close } ) => {
-			close();
+		callback: () => {
 			openModal( 'editor/preferences' );
 		},
 	} );


### PR DESCRIPTION
## What?

A bug fix and follow up to #64019 which worked around the issue #64004 where in StrictMode an effect can force a Modal to dismiss itself immediately.

## Why?

The effect to dismiss other Modal’s should work properly whether or not StrictMode is active.

## How?

- Add a condition to the effect so that it can’t dismiss the same Modal that triggers it.
- Revert the workaround changes of #64019

## Testing Instructions
1. Enable StrictMode - `WP_DEBUG = true` and `SCRIPT_DEBUG = true`.
2. Launch the command palette.
3. Run "Editor Preferences" or "Keyboard shortcuts" commands.
4. Launch the command palette again via the keyboard shortcut <kbd><kbd>⌘</kbd><kbd>k</kbd></kbd>.
5. Launch the "Keyboard shortcuts" modal via the keyboard shortcut <kbd><kbd >⌃</kbd><kbd>⌥</kbd><kbd>h</kbd></kbd>
6. Repeat the test without StrictMode

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast 

https://github.com/user-attachments/assets/5de0586b-a62a-46d3-b2b7-f207eb8f2744
