### PR TITLE
DataViews Extensibility: Allow unregistering trash post action

### DIFF
--- a/packages/editor/src/dataviews/actions/index.ts
+++ b/packages/editor/src/dataviews/actions/index.ts
@@ -9,6 +9,7 @@ import { type StoreDescriptor, dispatch } from '@wordpress/data';
 import deletePost from './delete-post';
 import exportPattern from './export-pattern';
 import resetPost from './reset-post';
+import trashPost from './trash-post';
 
 // @ts-ignore
 import { store as editorStore } from '../../store';
@@ -22,4 +23,5 @@ export default function registerDefaultActions() {
 	registerEntityAction( 'postType', 'wp_block', exportPattern );
 	registerEntityAction( 'postType', '*', resetPost );
 	registerEntityAction( 'postType', '*', deletePost );
+	registerEntityAction( 'postType', '*', trashPost );
 }

--- a/packages/editor/src/dataviews/actions/trash-post.tsx
+++ b/packages/editor/src/dataviews/actions/trash-post.tsx
@@ -1,0 +1,196 @@
+/**
+ * WordPress dependencies
+ */
+import { trash } from '@wordpress/icons';
+import { useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useState } from '@wordpress/element';
+import {
+	Button,
+	__experimentalText as Text,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { getItemTitle, isTemplateOrTemplatePart } from './utils';
+import type { CoreDataError, PostWithPermissions } from '../types';
+
+const trashPost: Action< PostWithPermissions > = {
+	id: 'move-to-trash',
+	label: __( 'Move to Trash' ),
+	isPrimary: true,
+	icon: trash,
+	isEligible( item ) {
+		if ( isTemplateOrTemplatePart( item ) || item.type === 'wp_block' ) {
+			return false;
+		}
+
+		return (
+			!! item.status &&
+			! [ 'auto-draft', 'trash' ].includes( item.status ) &&
+			item.permissions?.delete
+		);
+	},
+	supportsBulk: true,
+	hideModalHeader: true,
+	RenderModal: ( { items, closeModal, onActionPerformed } ) => {
+		const [ isBusy, setIsBusy ] = useState( false );
+		const { createSuccessNotice, createErrorNotice } =
+			useDispatch( noticesStore );
+		const { deleteEntityRecord } = useDispatch( coreStore );
+		return (
+			<VStack spacing="5">
+				<Text>
+					{ items.length === 1
+						? sprintf(
+								// translators: %s: The item's title.
+								__(
+									'Are you sure you want to move to trash "%s"?'
+								),
+								getItemTitle( items[ 0 ] )
+						  )
+						: sprintf(
+								// translators: %d: The number of items (2 or more).
+								_n(
+									'Are you sure you want to move to trash %d item?',
+									'Are you sure you want to move to trash %d items?',
+									items.length
+								),
+								items.length
+						  ) }
+				</Text>
+				<HStack justify="right">
+					<Button
+						variant="tertiary"
+						onClick={ closeModal }
+						disabled={ isBusy }
+						accessibleWhenDisabled
+					>
+						{ __( 'Cancel' ) }
+					</Button>
+					<Button
+						variant="primary"
+						onClick={ async () => {
+							setIsBusy( true );
+							const promiseResult = await Promise.allSettled(
+								items.map( ( item ) =>
+									deleteEntityRecord(
+										'postType',
+										item.type,
+										item.id.toString(),
+										{},
+										{ throwOnError: true }
+									)
+								)
+							);
+							// If all the promises were fulfilled with success.
+							if (
+								promiseResult.every(
+									( { status } ) => status === 'fulfilled'
+								)
+							) {
+								let successMessage;
+								if ( promiseResult.length === 1 ) {
+									successMessage = sprintf(
+										/* translators: The item's title. */
+										__( '"%s" moved to trash.' ),
+										getItemTitle( items[ 0 ] )
+									);
+								} else {
+									successMessage = sprintf(
+										/* translators: The number of items. */
+										_n(
+											'%s item moved to trash.',
+											'%s items moved to trash.',
+											items.length
+										),
+										items.length
+									);
+								}
+								createSuccessNotice( successMessage, {
+									type: 'snackbar',
+									id: 'move-to-trash-action',
+								} );
+							} else {
+								// If there was at least one failure.
+								let errorMessage;
+								// If we were trying to delete a single item.
+								if ( promiseResult.length === 1 ) {
+									const typedError = promiseResult[ 0 ] as {
+										reason?: CoreDataError;
+									};
+									if ( typedError.reason?.message ) {
+										errorMessage =
+											typedError.reason.message;
+									} else {
+										errorMessage = __(
+											'An error occurred while moving to trash the item.'
+										);
+									}
+									// If we were trying to delete multiple items.
+								} else {
+									const errorMessages = new Set();
+									const failedPromises = promiseResult.filter(
+										( { status } ) => status === 'rejected'
+									);
+									for ( const failedPromise of failedPromises ) {
+										const typedError = failedPromise as {
+											reason?: CoreDataError;
+										};
+										if ( typedError.reason?.message ) {
+											errorMessages.add(
+												typedError.reason.message
+											);
+										}
+									}
+									if ( errorMessages.size === 0 ) {
+										errorMessage = __(
+											'An error occurred while moving to trash the items.'
+										);
+									} else if ( errorMessages.size === 1 ) {
+										errorMessage = sprintf(
+											/* translators: %s: an error message */
+											__(
+												'An error occurred while moving to trash the item: %s'
+											),
+											[ ...errorMessages ][ 0 ]
+										);
+									} else {
+										errorMessage = sprintf(
+											/* translators: %s: a list of comma separated error messages */
+											__(
+												'Some errors occurred while moving to trash the items: %s'
+											),
+											[ ...errorMessages ].join( ',' )
+										);
+									}
+								}
+								createErrorNotice( errorMessage, {
+									type: 'snackbar',
+								} );
+							}
+							if ( onActionPerformed ) {
+								onActionPerformed( items );
+							}
+							setIsBusy( false );
+							closeModal?.();
+						} }
+						isBusy={ isBusy }
+						disabled={ isBusy }
+						accessibleWhenDisabled
+					>
+						{ __( 'Trash' ) }
+					</Button>
+				</HStack>
+			</VStack>
+		);
+	},
+};
+
+export default trashPost;

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -29,5 +29,12 @@ export interface Pattern extends BasePost {
 
 export type Post = TemplateOrTemplatePart | Pattern | BasePost;
 
+export type PostWithPermissions = Post & {
+	permissions: {
+		delete: boolean;
+		update: boolean;
+	};
+};
+
 // Will be unnecessary after typescript 5.0 upgrade.
 export type CoreDataError = { message?: string; code?: string };


### PR DESCRIPTION
Related #61084 
Similar to #62647 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions. The current PR explore the possibility to use the API to register one action: "trash post". 

## Testing Instructions

1- Open the pages dataviews and try moving a page to the trash.
2- You should be able to see the "move to trash" action in the actions dropdown menu
3- you can try to use the action.