### PR TITLE
DataViews Extensibility: Allow unregistering permanently delete post action

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -81,97 +81,6 @@ function isTemplateRemovable( template ) {
 	);
 }
 
-const permanentlyDeletePostAction = {
-	id: 'permanently-delete',
-	label: __( 'Permanently delete' ),
-	supportsBulk: true,
-	isEligible( { status, permissions } ) {
-		return status === 'trash' && permissions?.delete;
-	},
-	async callback( posts, { registry, onActionPerformed } ) {
-		const { createSuccessNotice, createErrorNotice } =
-			registry.dispatch( noticesStore );
-		const { deleteEntityRecord } = registry.dispatch( coreStore );
-		const promiseResult = await Promise.allSettled(
-			posts.map( ( post ) => {
-				return deleteEntityRecord(
-					'postType',
-					post.type,
-					post.id,
-					{ force: true },
-					{ throwOnError: true }
-				);
-			} )
-		);
-		// If all the promises were fulfilled with success.
-		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
-			let successMessage;
-			if ( promiseResult.length === 1 ) {
-				successMessage = sprintf(
-					/* translators: The posts's title. */
-					__( '"%s" permanently deleted.' ),
-					getItemTitle( posts[ 0 ] )
-				);
-			} else {
-				successMessage = __( 'The posts were permanently deleted.' );
-			}
-			createSuccessNotice( successMessage, {
-				type: 'snackbar',
-				id: 'permanently-delete-post-action',
-			} );
-			onActionPerformed?.( posts );
-		} else {
-			// If there was at lease one failure.
-			let errorMessage;
-			// If we were trying to permanently delete a single post.
-			if ( promiseResult.length === 1 ) {
-				if ( promiseResult[ 0 ].reason?.message ) {
-					errorMessage = promiseResult[ 0 ].reason.message;
-				} else {
-					errorMessage = __(
-						'An error occurred while permanently deleting the post.'
-					);
-				}
-				// If we were trying to permanently delete multiple posts
-			} else {
-				const errorMessages = new Set();
-				const failedPromises = promiseResult.filter(
-					( { status } ) => status === 'rejected'
-				);
-				for ( const failedPromise of failedPromises ) {
-					if ( failedPromise.reason?.message ) {
-						errorMessages.add( failedPromise.reason.message );
-					}
-				}
-				if ( errorMessages.size === 0 ) {
-					errorMessage = __(
-						'An error occurred while permanently deleting the posts.'
-					);
-				} else if ( errorMessages.size === 1 ) {
-					errorMessage = sprintf(
-						/* translators: %s: an error message */
-						__(
-							'An error occurred while permanently deleting the posts: %s'
-						),
-						[ ...errorMessages ][ 0 ]
-					);
-				} else {
-					errorMessage = sprintf(
-						/* translators: %s: a list of comma separated error messages */
-						__(
-							'Some errors occurred while permanently deleting the posts: %s'
-						),
-						[ ...errorMessages ].join( ',' )
-					);
-				}
-			}
-			createErrorNotice( errorMessage, {
-				type: 'snackbar',
-			} );
-		}
-	},
-};
-
 const restorePostAction = {
 	id: 'restore',
 	label: __( 'Restore' ),
@@ -826,9 +735,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 			supportsTitle && renamePostAction,
 			reorderPagesAction,
 			! isTemplateOrTemplatePart && ! isPattern && restorePostAction,
-			! isTemplateOrTemplatePart &&
-				! isPattern &&
-				permanentlyDeletePostAction,
 			...defaultActions,
 		].filter( Boolean );
 		// Filter actions based on provided context. If not provided

--- a/packages/editor/src/dataviews/actions/index.ts
+++ b/packages/editor/src/dataviews/actions/index.ts
@@ -10,6 +10,7 @@ import deletePost from './delete-post';
 import exportPattern from './export-pattern';
 import resetPost from './reset-post';
 import trashPost from './trash-post';
+import permanentlyDeletePost from './permanently-delete-post';
 
 // @ts-ignore
 import { store as editorStore } from '../../store';
@@ -24,4 +25,5 @@ export default function registerDefaultActions() {
 	registerEntityAction( 'postType', '*', resetPost );
 	registerEntityAction( 'postType', '*', deletePost );
 	registerEntityAction( 'postType', '*', trashPost );
+	registerEntityAction( 'postType', '*', permanentlyDeletePost );
 }

--- a/packages/editor/src/dataviews/actions/permanently-delete-post.tsx
+++ b/packages/editor/src/dataviews/actions/permanently-delete-post.tsx
@@ -1,0 +1,116 @@
+/**
+ * WordPress dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { getItemTitle, isTemplateOrTemplatePart } from './utils';
+import type { CoreDataError, PostWithPermissions } from '../types';
+
+const permanentlyDeletePost: Action< PostWithPermissions > = {
+	id: 'permanently-delete',
+	label: __( 'Permanently delete' ),
+	supportsBulk: true,
+	isEligible( item ) {
+		if ( isTemplateOrTemplatePart( item ) || item.type === 'wp_block' ) {
+			return false;
+		}
+		const { status, permissions } = item;
+		return status === 'trash' && permissions?.delete;
+	},
+	async callback( posts, { registry, onActionPerformed } ) {
+		const { createSuccessNotice, createErrorNotice } =
+			registry.dispatch( noticesStore );
+		const { deleteEntityRecord } = registry.dispatch( coreStore );
+		const promiseResult = await Promise.allSettled(
+			posts.map( ( post ) => {
+				return deleteEntityRecord(
+					'postType',
+					post.type,
+					post.id,
+					{ force: true },
+					{ throwOnError: true }
+				);
+			} )
+		);
+		// If all the promises were fulfilled with success.
+		if ( promiseResult.every( ( { status } ) => status === 'fulfilled' ) ) {
+			let successMessage;
+			if ( promiseResult.length === 1 ) {
+				successMessage = sprintf(
+					/* translators: The posts's title. */
+					__( '"%s" permanently deleted.' ),
+					getItemTitle( posts[ 0 ] )
+				);
+			} else {
+				successMessage = __( 'The posts were permanently deleted.' );
+			}
+			createSuccessNotice( successMessage, {
+				type: 'snackbar',
+				id: 'permanently-delete-post-action',
+			} );
+			onActionPerformed?.( posts );
+		} else {
+			// If there was at lease one failure.
+			let errorMessage;
+			// If we were trying to permanently delete a single post.
+			if ( promiseResult.length === 1 ) {
+				const typedError = promiseResult[ 0 ] as {
+					reason?: CoreDataError;
+				};
+				if ( typedError.reason?.message ) {
+					errorMessage = typedError.reason.message;
+				} else {
+					errorMessage = __(
+						'An error occurred while permanently deleting the post.'
+					);
+				}
+				// If we were trying to permanently delete multiple posts
+			} else {
+				const errorMessages = new Set();
+				const failedPromises = promiseResult.filter(
+					( { status } ) => status === 'rejected'
+				);
+				for ( const failedPromise of failedPromises ) {
+					const typedError = failedPromise as {
+						reason?: CoreDataError;
+					};
+					if ( typedError.reason?.message ) {
+						errorMessages.add( typedError.reason.message );
+					}
+				}
+				if ( errorMessages.size === 0 ) {
+					errorMessage = __(
+						'An error occurred while permanently deleting the posts.'
+					);
+				} else if ( errorMessages.size === 1 ) {
+					errorMessage = sprintf(
+						/* translators: %s: an error message */
+						__(
+							'An error occurred while permanently deleting the posts: %s'
+						),
+						[ ...errorMessages ][ 0 ]
+					);
+				} else {
+					errorMessage = sprintf(
+						/* translators: %s: a list of comma separated error messages */
+						__(
+							'Some errors occurred while permanently deleting the posts: %s'
+						),
+						[ ...errorMessages ].join( ',' )
+					);
+				}
+			}
+			createErrorNotice( errorMessage, {
+				type: 'snackbar',
+			} );
+		}
+	},
+};
+
+export default permanentlyDeletePost;


### PR DESCRIPTION
Related #61084 
Similar to #62647 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions. The current PR explore the possibility to use the API to register one action: "permanently delete post". 

## Testing Instructions

1- Open the trashed pages dataviews.
2- You should be able to see the "permanently delete" action in the actions dropdown menu
3- you can try to use the action.