### PR TITLE
Core Data: Fix 'getEntityRecordPermissions' memoization

### DIFF
--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -57,7 +57,8 @@ export const getBlockPatternsForPostType = createRegistrySelector(
 export const getEntityRecordsPermissions = createRegistrySelector( ( select ) =>
 	createSelector(
 		( state: State, kind: string, name: string, ids: string[] ) => {
-			return ids.map( ( id ) => ( {
+			const normalizedIds = Array.isArray( ids ) ? ids : [ ids ];
+			return normalizedIds.map( ( id ) => ( {
 				delete: select( STORE_NAME ).canUser( 'delete', {
 					kind,
 					name,
@@ -90,5 +91,5 @@ export function getEntityRecordPermissions(
 	name: string,
 	id: string
 ) {
-	return getEntityRecordsPermissions( state, kind, name, [ id ] )[ 0 ];
+	return getEntityRecordsPermissions( state, kind, name, id )[ 0 ];
 }


### PR DESCRIPTION
## What?
PR fixes memoization for the `getEntityRecordPermissions` private selector.

## Why?
It was passing a new array of IDs on every call, which invalidated memoization.

## Testing Instructions
1. Open a post or page.
2. Confirm there's no warning logged in the console.
3. Confirm that the "Move to Trash" action is still visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-30 at 14 03 18](https://github.com/user-attachments/assets/f8afacd1-b0a1-4cd9-b57b-05626c543ecd)
