### PR TITLE
Document bar: Fix long title with no spaces causing layout issue

### DIFF
--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -34,7 +34,7 @@
 }
 
 .editor-document-bar__title {
-	flex-grow: 1;
+	flex: 1;
 	overflow: hidden;
 	color: $gray-900;
 	gap: $grid-unit-05;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
FIxes: #63329 

## Why?
The command palette shortcut text is pushed to the right when you insert a long piece of text without spaces.

## Testing Instructions
1. Create a Post
2. Give a long post title
3. Check the command palette

## Screenshots or screencast <!-- if applicable -->
<img width="500" alt="image" src="https://github.com/user-attachments/assets/578bf7c4-b4b2-42c3-b91e-31275332f014">
