### PR TITLE
Editor: Remove resolvers hack for post actions

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -681,25 +681,17 @@ export const duplicateTemplatePartAction = {
 };
 
 export function usePostActions( { postType, onActionPerformed, context } ) {
-	const {
-		defaultActions,
-		postTypeObject,
-		userCanCreatePostType,
-		cachedCanUserResolvers,
-	} = useSelect(
+	const { defaultActions, postTypeObject, userCanCreatePostType } = useSelect(
 		( select ) => {
-			const { getPostType, canUser, getCachedResolvers } =
-				select( coreStore );
+			const { getPostType, canUser } = select( coreStore );
 			const { getEntityActions } = unlock( select( editorStore ) );
-			const _postTypeObject = getPostType( postType );
 			return {
-				postTypeObject: _postTypeObject,
+				postTypeObject: getPostType( postType ),
 				defaultActions: getEntityActions( 'postType', postType ),
 				userCanCreatePostType: canUser( 'create', {
 					kind: 'postType',
 					name: postType,
 				} ),
-				cachedCanUserResolvers: getCachedResolvers()?.canUser,
 			};
 		},
 		[ postType ]
@@ -798,9 +790,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		}
 
 		return actions;
-		// We are making this use memo depend on cachedCanUserResolvers as a way to make the component using this hook re-render
-		// when user capabilities are resolved. This makes sure the isEligible functions of actions dependent on capabilities are re-evaluated.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		defaultActions,
 		userCanCreatePostType,
@@ -814,6 +803,5 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		supportsRevisions,
 		supportsTitle,
 		context,
-		cachedCanUserResolvers,
 	] );
 }


### PR DESCRIPTION
## What?
PR removes the leftover `cachedCanUserResolvers` hack from the `usePostActions`. It is no-longer needed after #63923.

## Testing Instructions
1. Open a post or page.
2. Confirm post actions work as before.

### Testing Instructions for Keyboard
Same.
