### PR TITLE
Fix grid resizer drag over embed

### DIFF
--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -119,8 +119,13 @@ function GridItemResizerInner( {
 				} }
 				bounds={ bounds }
 				boundsByDirection
-				// Captures the pointer to avoid hiccups while dragging over objects like iframes.
 				onPointerDown={ ( { target, pointerId } ) => {
+					/*
+					 * Captures the pointer to avoid hiccups while dragging over objects
+					 * like iframes and ensures that the event to end the drag is
+					 * captured by the target (resize handle) whether or not it’s under
+					 * the pointer.
+					 */
 					target.setPointerCapture( pointerId );
 				} }
 				onResizeStart={ ( event, direction ) => {
@@ -130,21 +135,6 @@ function GridItemResizerInner( {
 					 * so that it resizes in the right direction.
 					 */
 					setResizeDirection( direction );
-
-					/*
-					 * The mouseup event on the resize handle doesn't trigger if the mouse
-					 * isn't directly above the handle, so we try to detect if it happens
-					 * outside the grid and dispatch a mouseup event on the handle.
-					 */
-					blockElement.ownerDocument.addEventListener(
-						'mouseup',
-						() => {
-							event.target.dispatchEvent(
-								new Event( 'mouseup', { bubbles: true } )
-							);
-						},
-						{ once: true }
-					);
 				} }
 				onResizeStop={ ( event, direction, boxElement ) => {
 					const columnGap = parseFloat(

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -119,6 +119,10 @@ function GridItemResizerInner( {
 				} }
 				bounds={ bounds }
 				boundsByDirection
+				// Captures the pointer to avoid hiccups while dragging over objects like iframes.
+				onPointerDown={ ( { target, pointerId } ) => {
+					target.setPointerCapture( pointerId );
+				} }
 				onResizeStart={ ( event, direction ) => {
 					/*
 					 * The container justification and alignment need to be set


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A bug fix for grid resizing.

## Why?
To fix #63279 where dragging to resize grid items is impeded if the grid item is an object/embed/iframe.

## How?
Uses [`setPointerCapture`](https://developer.mozilla.org/en-US/docs/Web/API/Element/setPointerCapture)

## Testing Instructions

### No flaky drag over embed with iframe
1. Add a Grid block to a post or template;
2. Add a YouTube block inside it, and resize it to take up two columns;
3. Try to resize the block back down to one column and note the dragging responds as expected.

### No regression of stuck dragging when releasing the drag with the pointer off of the drag handle
4. Resize the block and be sure to release the drag somewhere that the drag handle is not under the pointer

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9cdf84cc-6866-40bc-9c66-2914048592d5
