### PR TITLE
Block Bindings: Create utils to update or remove bindings

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -47,6 +47,7 @@ import { PrivatePublishDateTimePicker } from './components/publish-date-time-pic
 import useSpacingSizes from './components/spacing-sizes-control/hooks/use-spacing-sizes';
 import useBlockDisplayTitle from './components/block-title/use-block-display-title';
 import TabbedSidebar from './components/tabbed-sidebar';
+import { useBlockBindingsUtils } from './utils/block-bindings';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -93,4 +94,5 @@ lock( privateApis, {
 	useBlockDisplayTitle,
 	__unstableBlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
+	useBlockBindingsUtils,
 } );

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -12,10 +12,37 @@ import { useBlockEditContext } from '../components/block-edit';
 export function useBlockBindingsUtils() {
 	const { clientId } = useBlockEditContext();
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	// TODO: Review if this is correct.
 	const { getBlockAttributes } = useSelect( blockEditorStore );
 
-	// TODO: Add docs.
+	/**
+	 * Updates the value of the bindings connected to block attributes.
+	 * It removes the binding when the new value is `undefined`.
+	 *
+	 * @param {Object} bindings        Bindings including the attributes to update and the new object.
+	 * @param {string} bindings.source The source name to connect to.
+	 * @param {Object} [bindings.args] Object containing the arguments needed by the source.
+	 *
+	 * @example
+	 * ```js
+	 * import { useBlockBindingsUtils } from '@wordpress/block-editor'
+	 *
+	 * const { removeAllBlockBindings } = useBlockBindingsUtils();
+	 * updateBlockBindings( {
+	 *     url: {
+	 *         source: 'core/post-meta',
+	 *         args: {
+	 *             key: 'url_custom_field',
+	 *         },
+	 * 	   },
+	 *     alt: {
+	 *         source: 'core/post-meta',
+	 *         args: {
+	 *             key: 'text_custom_field',
+	 *         },
+	 * 	   }
+	 * } );
+	 * ```
+	 */
 	const updateBlockBindings = ( bindings ) => {
 		const { metadata } = getBlockAttributes( clientId );
 		const newBindings = { ...metadata?.bindings };
@@ -43,7 +70,18 @@ export function useBlockBindingsUtils() {
 					: newMetadata,
 		} );
 	};
-	// TODO: Add docs.
+
+	/**
+	 * Removes the bindings property of the `metadata` attribute.
+	 *
+	 * @example
+	 * ```js
+	 * import { useBlockBindingsUtils } from '@wordpress/block-editor'
+	 *
+	 * const { removeAllBlockBindings } = useBlockBindingsUtils();
+	 * removeAllBlockBindings();
+	 * ```
+	 */
 	const removeAllBlockBindings = () => {
 		const { metadata } = getBlockAttributes( clientId );
 		const newMetadata = { ...metadata };

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -26,7 +26,7 @@ export function useBlockBindingsUtils() {
 	 * ```js
 	 * import { useBlockBindingsUtils } from '@wordpress/block-editor'
 	 *
-	 * const { removeAllBlockBindings } = useBlockBindingsUtils();
+	 * const { updateBlockBindings } = useBlockBindingsUtils();
 	 * updateBlockBindings( {
 	 *     url: {
 	 *         source: 'core/post-meta',

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as blockEditorStore } from '../store';
+import { useBlockEditContext } from '../components/block-edit';
+
+export function useBlockBindingsUtils() {
+	const { clientId } = useBlockEditContext();
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	// TODO: Review if this is correct.
+	const { getBlockAttributes } = useSelect( blockEditorStore );
+
+	// TODO: Add docs.
+	const updateBlockBindings = ( bindings ) => {
+		const { metadata } = getBlockAttributes( clientId );
+		const newBindings = { ...metadata?.bindings };
+		Object.entries( bindings ).forEach( ( [ attribute, binding ] ) => {
+			if ( ! binding && newBindings[ attribute ] ) {
+				delete newBindings[ attribute ];
+				return;
+			}
+			newBindings[ attribute ] = binding;
+		} );
+
+		const newMetadata = {
+			...metadata,
+			bindings: newBindings,
+		};
+
+		if ( Object.keys( newMetadata.bindings ).length === 0 ) {
+			delete newMetadata.bindings;
+		}
+
+		updateBlockAttributes( clientId, {
+			metadata:
+				Object.keys( newMetadata ).length === 0
+					? undefined
+					: newMetadata,
+		} );
+	};
+	// TODO: Add docs.
+	const removeAllBlockBindings = () => {
+		const { metadata } = getBlockAttributes( clientId );
+		const newMetadata = { ...metadata };
+		delete newMetadata.bindings;
+		updateBlockAttributes( clientId, {
+			metadata:
+				Object.keys( newMetadata ).length === 0
+					? undefined
+					: newMetadata,
+		} );
+	};
+
+	return { updateBlockBindings, removeAllBlockBindings };
+}


### PR DESCRIPTION
## What?
This pull requests explores the idea of exposing two new block bindings utils to easily add/remove/update bindings in the editor:
* updateBlockBindings: It tries to follow the same approach as `updateBlockAttributes`. You pass an object with all the bindings to update, and to remove one users can pass `undefined`.
* removeAllBlockBindings: It just removes all the existing bindings of a block.

## Why?
The same code was used for the custom fields UI and pattern overrides. Additionally, it could be useful for external developers in case they want to create their own UIs.

## How?
Creating a `useBlockBindingsUtils` hook that return the needed function. It is inspired by other hooks like [useGradient](https://github.com/WordPress/gutenberg/blob/9373c1447da400019f3a6494029a9a1b60faa4f6/packages/block-editor/src/components/gradients/use-gradient.js#L57).

## Testing Instructions
It doesn't add new functionalities. Automated tests should pass.