### PR TITLE
Comments Title: Add `levelOptions` attribute to control available heading levels

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -237,7 +237,7 @@ Displays a title with the number of comments. ([Source](https://github.com/WordP
 -	**Category:** theme
 -	**Ancestor:** core/comments
 -	**Supports:** align, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~anchor~~, ~~html~~
--	**Attributes:** level, showCommentsCount, showPostTitle, textAlign
+-	**Attributes:** level, levelOptions, showCommentsCount, showPostTitle, textAlign
 
 ## Cover
 

--- a/packages/block-library/src/comments-title/block.json
+++ b/packages/block-library/src/comments-title/block.json
@@ -23,6 +23,9 @@
 		"level": {
 			"type": "number",
 			"default": 2
+		},
+		"levelOptions": {
+			"type": "array"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/comments-title/edit.js
+++ b/packages/block-library/src/comments-title/edit.js
@@ -23,7 +23,13 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 
 export default function Edit( {
-	attributes: { textAlign, showPostTitle, showCommentsCount, level },
+	attributes: {
+		textAlign,
+		showPostTitle,
+		showCommentsCount,
+		level,
+		levelOptions,
+	},
 	setAttributes,
 	context: { postType, postId },
 } ) {
@@ -95,6 +101,7 @@ export default function Edit( {
 			/>
 			<HeadingLevelDropdown
 				value={ level }
+				options={ levelOptions }
 				onChange={ ( newLevel ) =>
 					setAttributes( { level: newLevel } )
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Followup to https://github.com/WordPress/gutenberg/pull/63535

## What?
This PR adds a `levelOptions` attribute to the Comments Title block that allows developers to control which heading levels are available in the UI.

## Why?
Being able to restrict the available heading levels is crucial in many situations, whether it be general Editor curation, accessibility, block governance, SEO, etc.

## How?
This PR adds a `levelOptions` attribute to the Comments Title block that allows developers to define which heading levels should be displayed in the Heading dropdown UI. The approach is very simple and does not require a depreciation. Any previously set heading levels are respected in the markup. 

With this new attribute, you can restrict the UI in many different ways, making this approach very flexible and powerful. For example, you could restrict options directly in block markup for a pattern or template. Try copying and pasting the following in the Editor.

```
<!-- wp:comments-title {"level":3,"levelOptions":[3,4,5]} /-->
```

Or you could modify the attribute programmatically via filters. The following will disable h1 globally. You could also add conditionals for post type, user permissions, etc. There are filters for both PHP and JavaScript so the applications are endless.

```
function example_modify_heading_levels_globally( $args, $block_type ) {
	
	if ( 'core/comments-title' !== $block_type ) {
		return $args;
	}

	// Remove H1.
	$args['attributes']['levelOptions']['default'] = [ 2, 3, 4, 5, 6 ];
	
	return $args;
}
add_filter( 'register_block_type_args', 'example_modify_heading_levels_globally', 10, 2 );
```

## Testing Instructions

- Use any block theme with this PR enabled. You can also test in [Playground](https://playground.wordpress.net/gutenberg.html).
- Try copying the block code above into the Code Editor, then switch to the Editor View to see the restricted Heading levels UI
- Try copying the filter code into the `functions.php` file of your theme and see that `h1` is disabled.

## Screenshots or screencast <!-- if applicable -->

With restrictions applied: 

<img width="802" alt="image" src="https://github.com/user-attachments/assets/71729223-0aa4-496d-bd2c-7e295092cf23">

