### PR TITLE
Reuse `useToolsPanelDropdownMenuProps` util

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -45,10 +45,11 @@ import { isBlobURL } from '@wordpress/blob';
 /**
  * Internal dependencies
  */
-import { useToolsPanelDropdownMenuProps, getResolvedValue } from './utils';
+import { getResolvedValue } from './utils';
 import { setImmutably } from '../../utils/object';
 import MediaReplaceFlow from '../media-replace-flow';
 import { store as blockEditorStore } from '../../store';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 
 import {
 	globalStylesDataKey,

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -18,7 +18,8 @@ import { __ } from '@wordpress/i18n';
  */
 import BorderRadiusControl from '../border-radius-control';
 import { useColorsPerOrigin } from './hooks';
-import { getValueFromVariable, useToolsPanelDropdownMenuProps } from './utils';
+import { getValueFromVariable } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 import { setImmutably } from '../../utils/object';
 import { useBorderPanelLabel } from '../../hooks/border';
 import { ShadowPopover, useShadowPresets } from './shadow-panel-components';

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -27,7 +27,8 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import ColorGradientControl from '../colors-gradients/control';
 import { useColorsPerOrigin, useGradientsPerOrigin } from './hooks';
-import { getValueFromVariable, useToolsPanelDropdownMenuProps } from './utils';
+import { getValueFromVariable } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 import { setImmutably } from '../../utils/object';
 import { unlock } from '../../lock-unlock';
 

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -22,7 +22,8 @@ import { useCallback, useState, Platform } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getValueFromVariable, useToolsPanelDropdownMenuProps } from './utils';
+import { getValueFromVariable } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 import SpacingSizesControl from '../spacing-sizes-control';
 import HeightControl from '../height-control';
 import ChildLayoutControl from '../child-layout-control';

--- a/packages/block-editor/src/components/global-styles/filters-panel.js
+++ b/packages/block-editor/src/components/global-styles/filters-panel.js
@@ -28,7 +28,8 @@ import { useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { getValueFromVariable, useToolsPanelDropdownMenuProps } from './utils';
+import { getValueFromVariable } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 import { setImmutably } from '../../utils/object';
 
 const EMPTY_ARRAY = [];

--- a/packages/block-editor/src/components/global-styles/image-settings-panel.js
+++ b/packages/block-editor/src/components/global-styles/image-settings-panel.js
@@ -11,7 +11,7 @@ import { __, _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useToolsPanelDropdownMenuProps } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 
 export function useHasImageSettingsPanel( name, value, inheritedValue ) {
 	// Note: If lightbox `value` exists, that means it was

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -21,7 +21,8 @@ import TextAlignmentControl from '../text-alignment-control';
 import TextTransformControl from '../text-transform-control';
 import TextDecorationControl from '../text-decoration-control';
 import WritingModeControl from '../writing-mode-control';
-import { getValueFromVariable, useToolsPanelDropdownMenuProps } from './utils';
+import { getValueFromVariable } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 import { setImmutably } from '../../utils/object';
 import {
 	getMergedFontFamiliesAndFontFamilyFaces,

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -6,7 +6,6 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 /**
  * WordPress dependencies
  */
-import { useViewportMatch } from '@wordpress/compose';
 import { getCSSValueFromRawStyle } from '@wordpress/style-engine';
 
 /**
@@ -141,19 +140,6 @@ export const STYLE_PATH_TO_PRESET_BLOCK_ATTRIBUTE = {
 	'typography.fontSize': 'fontSize',
 	'typography.fontFamily': 'fontFamily',
 };
-
-export function useToolsPanelDropdownMenuProps() {
-	const isMobile = useViewportMatch( 'medium', '<' );
-	return ! isMobile
-		? {
-				popoverProps: {
-					placement: 'left-start',
-					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
-					offset: 259,
-				},
-		  }
-		: {};
-}
 
 function findInPresetsBy(
 	features,

--- a/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
+++ b/packages/block-editor/src/components/inspector-controls/block-support-tools-panel.js
@@ -10,7 +10,7 @@ import { useCallback } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../../store';
 import { cleanEmptyObject } from '../../hooks/utils';
-import { useToolsPanelDropdownMenuProps } from '../global-styles/utils';
+import { useToolsPanelDropdownMenuProps } from '../../utils/use-tools-panel-dropdown-menu-props';
 
 export default function BlockSupportToolsPanel( { children, group, label } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -27,7 +27,11 @@ import {
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
+<<<<<<< HEAD
 import { useBlockBindingsUtils } from '../utils/block-bindings';
+=======
+import { useToolsPanelDropdownMenuProps } from '../utils/use-tools-panel-dropdown-menu-props';
+>>>>>>> fcd2c19c62 (Remove old utils)
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -38,6 +42,7 @@ const {
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
+<<<<<<< HEAD
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );
 	return ! isMobile
@@ -55,6 +60,14 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 	const { getBlockBindingsSources } = unlock( blocksPrivateApis );
 	const registeredSources = getBlockBindingsSources();
 	const { updateBlockBindings } = useBlockBindingsUtils();
+=======
+function BlockBindingsPanelDropdown( {
+	fieldsList,
+	addConnection,
+	attribute,
+	binding,
+} ) {
+>>>>>>> fcd2c19c62 (Remove old utils)
 	const currentKey = binding?.args?.key;
 	return (
 		<>

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -27,11 +27,8 @@ import {
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
-<<<<<<< HEAD
-import { useBlockBindingsUtils } from '../utils/block-bindings';
-=======
 import { useToolsPanelDropdownMenuProps } from '../utils/use-tools-panel-dropdown-menu-props';
->>>>>>> fcd2c19c62 (Remove old utils)
+import { useBlockBindingsUtils } from '../utils/block-bindings';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -42,32 +39,10 @@ const {
 	DropdownMenuSeparatorV2: DropdownMenuSeparator,
 } = unlock( componentsPrivateApis );
 
-<<<<<<< HEAD
-const useToolsPanelDropdownMenuProps = () => {
-	const isMobile = useViewportMatch( 'medium', '<' );
-	return ! isMobile
-		? {
-				popoverProps: {
-					placement: 'left-start',
-					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
-					offset: 259,
-				},
-		  }
-		: {};
-};
-
 function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 	const { getBlockBindingsSources } = unlock( blocksPrivateApis );
 	const registeredSources = getBlockBindingsSources();
 	const { updateBlockBindings } = useBlockBindingsUtils();
-=======
-function BlockBindingsPanelDropdown( {
-	fieldsList,
-	addConnection,
-	attribute,
-	binding,
-} ) {
->>>>>>> fcd2c19c62 (Remove old utils)
 	const currentKey = binding?.args?.key;
 	return (
 		<>

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -33,6 +33,7 @@ import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
 import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
+import { useToolsPanelDropdownMenuProps } from './utils/use-tools-panel-dropdown-menu-props';
 import {
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -95,4 +95,5 @@ lock( privateApis, {
 	__unstableBlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
 	useBlockBindingsUtils,
+	useToolsPanelDropdownMenuProps,
 } );

--- a/packages/block-editor/src/utils/use-tools-panel-dropdown-menu-props.js
+++ b/packages/block-editor/src/utils/use-tools-panel-dropdown-menu-props.js
@@ -1,0 +1,17 @@
+/**
+ * WordPress dependencies
+ */
+import { useViewportMatch } from '@wordpress/compose';
+
+export function useToolsPanelDropdownMenuProps() {
+	const isMobile = useViewportMatch( 'medium', '<' );
+	return ! isMobile
+		? {
+				popoverProps: {
+					placement: 'left-start',
+					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
+					offset: 259,
+				},
+		  }
+		: {};
+}

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -51,11 +51,11 @@ import { Caption } from '../utils/caption';
 /**
  * Module constants
  */
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 import { MIN_SIZE, ALLOWED_MEDIA_TYPES } from './constants';
 import { evalAspectRatio } from './utils';
 
-const { DimensionsTool, ResolutionTool } = unlock( blockEditorPrivateApis );
+const { DimensionsTool, ResolutionTool, useToolsPanelDropdownMenuProps } =
+	unlock( blockEditorPrivateApis );
 
 const scaleOptions = [
 	{

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -46,9 +46,10 @@ import {
 	TEMPLATE,
 } from './constants';
 import { unlock } from '../lock-unlock';
-import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
-const { ResolutionTool } = unlock( blockEditorPrivateApis );
+const { ResolutionTool, useToolsPanelDropdownMenuProps } = unlock(
+	blockEditorPrivateApis
+);
 
 // this limits the resize to a safe zone to avoid making broken layouts
 const applyWidthConstraints = ( width ) =>

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -38,9 +38,10 @@ import {
 	isControlAllowed,
 	useTaxonomies,
 } from '../../utils';
-import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 
-const { BlockInfo } = unlock( blockEditorPrivateApis );
+const { BlockInfo, useToolsPanelDropdownMenuProps } = unlock(
+	blockEditorPrivateApis
+);
 
 export default function QueryInspectorControls( props ) {
 	const { attributes, setQuery, setDisplayLayout, setAttributes, clientId } =

--- a/packages/block-library/src/utils/hooks.js
+++ b/packages/block-library/src/utils/hooks.js
@@ -6,7 +6,6 @@ import { useLayoutEffect, useEffect, useRef } from '@wordpress/element';
 import { getBlobByURL, isBlobURL, revokeBlobURL } from '@wordpress/blob';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
-import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Returns whether the current user can edit the given entity.
@@ -87,17 +86,4 @@ export function useUploadMediaFromBlobURL( args = {} ) {
 			},
 		} );
 	}, [ getSettings ] );
-}
-
-export function useToolsPanelDropdownMenuProps() {
-	const isMobile = useViewportMatch( 'medium', '<' );
-	return ! isMobile
-		? {
-				popoverProps: {
-					placement: 'left-start',
-					// For non-mobile, inner sidebar width (248px) - button width (24px) - border (1px) + padding (16px) + spacing (20px)
-					offset: 259,
-				},
-		  }
-		: {};
 }


### PR DESCRIPTION
## What?
As discussed [here](https://github.com/WordPress/gutenberg/pull/62880/files#r1687837965), it seems that each time we are using the ToolsPanel component, we are using the same `useToolsPanelDropdownMenuProps` util. However, it has been created in different places with exactly the same code.

I'm creating this pull request to try to have a unique declaration that is reused across the codebase.

## Why?
It can be used in the future for new use cases and we don't need to maintain duplicated code.

## How?
I'm creating a new private util in the `@wordpress/block-editor` package, removed the old declarations, and changed the imports to use this new one.

I wasn't sure if the `block-editor` package was the right place, but util is used in that package and in `block-library` so far. I'm happy to hear other suggestions.

## Testing Instructions
Nothing new. Automated tests should pass.
