### PR TITLE
Query Title: Add `levelOptions` attribute to control available heading levels

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -775,7 +775,7 @@ Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/t
 -	**Name:** core/query-title
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, showPrefix, showSearchTerm, textAlign, type
+-	**Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
 
 ## Quote
 

--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -17,6 +17,9 @@
 			"type": "number",
 			"default": 1
 		},
+		"levelOptions": {
+			"type": "array"
+		},
 		"showPrefix": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/query-title/edit.js
+++ b/packages/block-library/src/query-title/edit.js
@@ -25,7 +25,14 @@ import { useArchiveLabel } from './use-archive-label';
 const SUPPORTED_TYPES = [ 'archive', 'search' ];
 
 export default function QueryTitleEdit( {
-	attributes: { type, level, textAlign, showPrefix, showSearchTerm },
+	attributes: {
+		type,
+		level,
+		levelOptions,
+		textAlign,
+		showPrefix,
+		showSearchTerm,
+	},
 	setAttributes,
 } ) {
 	const { archiveTypeLabel, archiveNameLabel } = useArchiveLabel();
@@ -130,6 +137,7 @@ export default function QueryTitleEdit( {
 			<BlockControls group="block">
 				<HeadingLevelDropdown
 					value={ level }
+					options={ levelOptions }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Followup to https://github.com/WordPress/gutenberg/pull/63535

## What?
This PR adds a `levelOptions` attribute to the Query Title block that allows developers to control which heading levels are available in the UI.

## Why?
Being able to restrict the available heading levels is crucial in many situations, whether it be general Editor curation, accessibility, block governance, SEO, etc.

## How?
This PR adds a `levelOptions` attribute to the Query Title block that allows developers to define which heading levels should be displayed in the Heading dropdown UI. The approach is very simple and does not require a depreciation. Any previously set heading levels are respected in the markup. 

With this new attribute, you can restrict the UI in many different ways, making this approach very flexible and powerful. For example, you could restrict options directly in block markup for a pattern or template. Try copying and pasting the following in the Editor.

```
<!-- wp:query-title {"type":"archive","level":3,"levelOptions":[3,4,5]} /-->
```

Or you could modify the attribute programmatically via filters. The following will disable h1 globally. You could also add conditionals for post type, user permissions, etc. There are filters for both PHP and JavaScript so the applications are endless.

```
function example_modify_heading_levels_globally( $args, $block_type ) {
	
	if ( 'core/query-title' !== $block_type ) {
		return $args;
	}

	// Remove H1.
	$args['attributes']['levelOptions']['default'] = [ 2, 3, 4, 5, 6 ];
	
	return $args;
}
add_filter( 'register_block_type_args', 'example_modify_heading_levels_globally', 10, 2 );
```

## Testing Instructions

- Use any block theme with this PR enabled. You can also test in [Playground](https://playground.wordpress.net/gutenberg.html).
- Try copying the block code above into the Code Editor, then switch to the Editor View to see the restricted Heading levels UI
- Try copying the filter code into the `functions.php` file of your theme and see that `h1` is disabled.


## Screenshots or screencast 
With restrictions applied:
<img width="762" alt="image" src="https://github.com/user-attachments/assets/30bd88b4-5d22-482b-9c99-cf9ddc2c2136">
