### PR TITLE
Don't overlap canvas with inserter panel at large screens

### DIFF
--- a/packages/base-styles/_variables.scss
+++ b/packages/base-styles/_variables.scss
@@ -79,7 +79,7 @@ $sidebar-width: 280px;
 $content-width: 840px;
 $wide-content-width: 1100px;
 $widget-area-width: 700px;
-
+$secondary-sidebar-width: 350px;
 
 /**
  * Block & Editor UI.

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -8,6 +8,7 @@ import {
 	FlexBlock,
 	privateApis as componentsPrivateApis,
 	__unstableMotion as motion,
+	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
@@ -68,31 +69,33 @@ function CategoryTabs( {
 				) ) }
 			</Tabs.TabList>
 			{ selectedCategory && (
-				<motion.div
-					className="block-editor-inserter__category-panel"
-					initial="closed"
-					animate="open"
-					exit="closed"
-					variants={ {
-						open: {
-							transform: 'translateX( 0 )',
-						},
-						closed: {
-							transform: 'translateX( -100% )',
-						},
-					} }
-					transition={ defaultTransition }
-				>
-					{ categories.map( ( category ) => (
-						<Tabs.TabPanel
-							key={ category.name }
-							tabId={ category.name }
-							focusable={ false }
-						>
-							{ children }
-						</Tabs.TabPanel>
-					) ) }
-				</motion.div>
+				<AnimatePresence initial={ false }>
+					<motion.div
+						className="block-editor-inserter__category-panel"
+						initial="closed"
+						animate="open"
+						exit="closed"
+						variants={ {
+							open: {
+								transform: 'translateX( 0 )',
+							},
+							closed: {
+								transform: 'translateX( -100% )',
+							},
+						} }
+						transition={ defaultTransition }
+					>
+						{ categories.map( ( category ) => (
+							<Tabs.TabPanel
+								key={ category.name }
+								tabId={ category.name }
+								focusable={ false }
+							>
+								{ children }
+							</Tabs.TabPanel>
+						) ) }
+					</motion.div>
+				</AnimatePresence>
 			) }
 		</Tabs>
 	);

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -1,11 +1,13 @@
 /**
  * WordPress dependencies
  */
+import { useReducedMotion } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 import {
 	__experimentalHStack as HStack,
 	FlexBlock,
 	privateApis as componentsPrivateApis,
+	__unstableMotion as motion,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
@@ -22,6 +24,14 @@ function CategoryTabs( {
 	onSelectCategory,
 	children,
 } ) {
+	// Copied from InterfaceSkeleton.
+	const ANIMATION_DURATION = 0.25;
+	const disableMotion = useReducedMotion();
+	const defaultTransition = {
+		type: 'tween',
+		duration: disableMotion ? 0 : ANIMATION_DURATION,
+		ease: [ 0.6, 0, 0.4, 1 ],
+	};
 	return (
 		<Tabs
 			className="block-editor-inserter__category-tabs"
@@ -57,16 +67,33 @@ function CategoryTabs( {
 					</Tabs.Tab>
 				) ) }
 			</Tabs.TabList>
-			{ categories.map( ( category ) => (
-				<Tabs.TabPanel
-					key={ category.name }
-					tabId={ category.name }
-					focusable={ false }
+			{ selectedCategory && (
+				<motion.div
 					className="block-editor-inserter__category-panel"
+					initial="closed"
+					animate="open"
+					exit="closed"
+					variants={ {
+						open: {
+							transform: 'translateX( 0 )',
+						},
+						closed: {
+							transform: 'translateX( -100% )',
+						},
+					} }
+					transition={ defaultTransition }
 				>
-					{ children }
-				</Tabs.TabPanel>
-			) ) }
+					{ categories.map( ( category ) => (
+						<Tabs.TabPanel
+							key={ category.name }
+							tabId={ category.name }
+							focusable={ false }
+						>
+							{ children }
+						</Tabs.TabPanel>
+					) ) }
+				</motion.div>
+			) }
 		</Tabs>
 	);
 }

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -78,9 +78,13 @@ function CategoryTabs( {
 						variants={ {
 							open: {
 								transform: 'translateX( 0 )',
+								transitionEnd: {
+									zIndex: '1',
+								},
 							},
 							closed: {
 								transform: 'translateX( -100% )',
+								zIndex: '-1',
 							},
 						} }
 						transition={ defaultTransition }

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -68,8 +68,8 @@ function CategoryTabs( {
 					</Tabs.Tab>
 				) ) }
 			</Tabs.TabList>
-			{ selectedCategory && (
-				<AnimatePresence initial={ false }>
+			<AnimatePresence initial={ false }>
+				{ selectedCategory && (
 					<motion.div
 						className="block-editor-inserter__category-panel"
 						initial="closed"
@@ -95,8 +95,8 @@ function CategoryTabs( {
 							</Tabs.TabPanel>
 						) ) }
 					</motion.div>
-				</AnimatePresence>
-			) }
+				) }
+			</AnimatePresence>
 		</Tabs>
 	);
 }

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -1,14 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useReducedMotion } from '@wordpress/compose';
+import { usePrevious, useReducedMotion } from '@wordpress/compose';
 import { isRTL } from '@wordpress/i18n';
 import {
 	__experimentalHStack as HStack,
 	FlexBlock,
 	privateApis as componentsPrivateApis,
 	__unstableMotion as motion,
-	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { Icon, chevronRight, chevronLeft } from '@wordpress/icons';
 
@@ -33,6 +32,9 @@ function CategoryTabs( {
 		duration: disableMotion ? 0 : ANIMATION_DURATION,
 		ease: [ 0.6, 0, 0.4, 1 ],
 	};
+
+	const previousSelectedCategory = usePrevious( selectedCategory );
+
 	return (
 		<Tabs
 			className="block-editor-inserter__category-tabs"
@@ -68,13 +70,18 @@ function CategoryTabs( {
 					</Tabs.Tab>
 				) ) }
 			</Tabs.TabList>
-			<AnimatePresence initial={ false }>
-				{ selectedCategory && (
+			{ categories.map( ( category ) => (
+				<Tabs.TabPanel
+					key={ category.name }
+					tabId={ category.name }
+					focusable={ false }
+				>
 					<motion.div
 						className="block-editor-inserter__category-panel"
-						initial="closed"
+						initial={
+							! previousSelectedCategory ? 'closed' : 'open'
+						}
 						animate="open"
-						exit="closed"
 						variants={ {
 							open: {
 								transform: 'translateX( 0 )',
@@ -89,18 +96,10 @@ function CategoryTabs( {
 						} }
 						transition={ defaultTransition }
 					>
-						{ categories.map( ( category ) => (
-							<Tabs.TabPanel
-								key={ category.name }
-								tabId={ category.name }
-								focusable={ false }
-							>
-								{ children }
-							</Tabs.TabPanel>
-						) ) }
+						{ children }
 					</motion.div>
-				) }
-			</AnimatePresence>
+				</Tabs.TabPanel>
+			) ) }
 		</Tabs>
 	);
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -1,6 +1,5 @@
 $block-inserter-preview-height: 350px;
-$block-inserter-width: 350px;
-$block-inserter-panel-width: 300px;
+$block-quick-inserter-width: 350px;
 $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter {
@@ -19,8 +18,8 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__menu.show-panel {
-	@include break-large() {
-		width: $block-inserter-width + $block-inserter-panel-width;
+	@include break-medium() {
+		width: $secondary-sidebar-width + $sidebar-width;
 	}
 }
 
@@ -308,7 +307,7 @@ $block-inserter-tabs-height: 44px;
 	@include break-medium {
 		border-left: $border-width solid $gray-200;
 		padding: 0;
-		left: 100%;
+		left: $secondary-sidebar-width;
 		width: 300px;
 		position: absolute;
 		top: -$border-width;
@@ -321,10 +320,6 @@ $block-inserter-tabs-height: 44px;
 		.block-editor-block-patterns-list {
 			padding: 0 $grid-unit-30 $grid-unit-20;
 		}
-	}
-
-	@include break-large {
-		left: $block-inserter-width;
 	}
 }
 
@@ -379,7 +374,7 @@ $block-inserter-tabs-height: 44px;
 	max-width: 100%;
 
 	@include break-medium {
-		width: $block-inserter-width;
+		width: $block-quick-inserter-width;
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -16,12 +16,6 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__menu.show-panel {
-	@include break-medium() {
-		width: $secondary-sidebar-width + $sidebar-width;
-	}
-}
-
 .block-editor-inserter__main-area {
 	height: 100%;
 	gap: $grid-unit-20;
@@ -29,6 +23,12 @@ $block-inserter-tabs-height: 44px;
 
 	&.show-as-tabs {
 		gap: 0;
+	}
+
+	.block-editor-tabbed-sidebar {
+		@include break-medium() {
+			width: $secondary-sidebar-width;
+		}
 	}
 }
 
@@ -91,6 +91,12 @@ $block-inserter-tabs-height: 44px;
 	height: 100%;
 	position: relative;
 	overflow: visible;
+
+	&.show-panel {
+		@include break-medium() {
+			width: $secondary-sidebar-width + $sidebar-width;
+		}
+	}
 }
 
 .block-editor-inserter__inline-elements {
@@ -306,7 +312,7 @@ $block-inserter-tabs-height: 44px;
 		border-left: $border-width solid $gray-200;
 		padding: 0;
 		left: $secondary-sidebar-width;
-		width: 300px;
+		width: $sidebar-width;
 		position: absolute;
 		top: -$border-width;
 		height: calc(100% + #{$border-width});

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -26,6 +26,8 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	.block-editor-tabbed-sidebar {
+		background-color: $white;
+
 		@include break-medium() {
 			width: $secondary-sidebar-width;
 		}
@@ -319,6 +321,7 @@ $block-inserter-tabs-height: 44px;
 		background: $gray-100;
 		border-top: $border-width solid $gray-200;
 		box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		z-index: -1;
 
 		.block-editor-inserter__media-list,
 		.block-editor-block-patterns-list {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -1,5 +1,6 @@
 $block-inserter-preview-height: 350px;
 $block-inserter-width: 350px;
+$block-inserter-panel-width: 300px;
 $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter {
@@ -14,7 +15,15 @@ $block-inserter-tabs-height: 44px;
 	@include break-medium {
 		position: relative;
 	}
+
 }
+
+.block-editor-inserter__menu.show-panel {
+	@include break-large() {
+		width: $block-inserter-width + $block-inserter-panel-width;
+	}
+}
+
 
 .block-editor-inserter__main-area {
 	height: 100%;
@@ -312,6 +321,10 @@ $block-inserter-tabs-height: 44px;
 		.block-editor-block-patterns-list {
 			padding: 0 $grid-unit-30 $grid-unit-20;
 		}
+	}
+
+	@include break-large {
+		left: $block-inserter-width;
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -26,8 +26,6 @@ $block-inserter-tabs-height: 44px;
 	}
 
 	.block-editor-tabbed-sidebar {
-		background-color: $white;
-
 		@include break-medium() {
 			width: $secondary-sidebar-width;
 		}

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -319,7 +319,6 @@ $block-inserter-tabs-height: 44px;
 		background: $gray-100;
 		border-top: $border-width solid $gray-200;
 		box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
-		z-index: -1;
 
 		.block-editor-inserter__media-list,
 		.block-editor-block-patterns-list {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -318,7 +318,6 @@ $block-inserter-tabs-height: 44px;
 		height: calc(100% + #{$border-width});
 		background: $gray-100;
 		border-top: $border-width solid $gray-200;
-		box-shadow: $border-width $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 
 		.block-editor-inserter__media-list,
 		.block-editor-block-patterns-list {
@@ -690,12 +689,6 @@ $block-inserter-tabs-height: 44px;
 			width: 300px;
 			height: 100%;
 		}
-	}
-
-	// Remove doubled-up shadow that occurs when categories panel is opened, only in zoom out.
-	// Shadow cannot be removed from the source, as it is required when not zoomed out.
-	.block-editor-inserter__category-panel {
-		box-shadow: none;
 	}
 }
 

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -14,7 +14,6 @@ $block-inserter-tabs-height: 44px;
 	@include break-medium {
 		position: relative;
 	}
-
 }
 
 .block-editor-inserter__menu.show-panel {
@@ -22,7 +21,6 @@ $block-inserter-tabs-height: 44px;
 		width: $secondary-sidebar-width + $sidebar-width;
 	}
 }
-
 
 .block-editor-inserter__main-area {
 	height: 100%;

--- a/packages/block-editor/src/components/tabbed-sidebar/style.scss
+++ b/packages/block-editor/src/components/tabbed-sidebar/style.scss
@@ -4,10 +4,6 @@
 	flex-direction: column;
 	flex-grow: 1;
 	overflow: hidden;
-
-	@include break-medium() {
-		width: 350px;
-	}
 }
 
 .block-editor-tabbed-sidebar__tablist-and-close-button {

--- a/packages/block-editor/src/components/tabbed-sidebar/style.scss
+++ b/packages/block-editor/src/components/tabbed-sidebar/style.scss
@@ -1,4 +1,5 @@
 .block-editor-tabbed-sidebar {
+	background-color: $white;
 	height: 100%;
 	display: flex;
 	flex-direction: column;

--- a/packages/editor/src/components/list-view-sidebar/style.scss
+++ b/packages/editor/src/components/list-view-sidebar/style.scss
@@ -1,5 +1,9 @@
 .editor-list-view-sidebar {
 	height: 100%;
+
+	@include break-medium {
+		width: $secondary-sidebar-width;
+	}
 }
 
 .editor-list-view-sidebar__list-view-panel-content,

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -178,6 +178,7 @@ function InterfaceSkeleton(
 					<AnimatePresence initial={ false }>
 						{ !! secondarySidebar && (
 							<NavigableRegion
+								layout
 								className="interface-interface-skeleton__secondary-sidebar"
 								ariaLabel={ mergedLabels.secondarySidebar }
 								as={ motion.div }
@@ -187,31 +188,46 @@ function InterfaceSkeleton(
 								}
 								exit="closed"
 								variants={ {
-									open: { width: secondarySidebarSize.width },
+									open: {
+										width: secondarySidebarSize.width,
+									},
 									closed: { width: 0 },
 									mobileOpen: { width: '100vw' },
 								} }
 								transition={ defaultTransition }
 							>
-								<div
+								<motion.div
 									style={ {
 										position: 'absolute',
 										width: isMobileViewport
 											? '100vw'
 											: 'fit-content',
 										height: '100%',
-										right: 0,
+										left: 0,
 									} }
+									initial="closed"
+									animate="open"
+									exit="closed"
+									variants={ {
+										open: {
+											transform: 'translateX( 0 )',
+										},
+										closed: {
+											transform: 'translateX( -100% )',
+										},
+									} }
+									transition={ defaultTransition }
 								>
 									{ secondarySidebarResizeListener }
 									{ secondarySidebar }
-								</div>
+								</motion.div>
 							</NavigableRegion>
 						) }
 					</AnimatePresence>
 					<NavigableRegion
 						className="interface-interface-skeleton__content"
 						ariaLabel={ mergedLabels.body }
+						layout
 					>
 						{ content }
 					</NavigableRegion>
@@ -219,6 +235,7 @@ function InterfaceSkeleton(
 						<NavigableRegion
 							className="interface-interface-skeleton__sidebar"
 							ariaLabel={ mergedLabels.sidebar }
+							layout
 						>
 							{ sidebar }
 						</NavigableRegion>

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -199,9 +199,6 @@ function InterfaceSkeleton(
 										height: '100%',
 										left: 0,
 									} }
-									initial="closed"
-									animate="open"
-									exit="closed"
 									variants={ {
 										open: { x: 0 },
 										closed: { x: '-100%' },

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -180,22 +180,17 @@ function InterfaceSkeleton(
 							<NavigableRegion
 								className="interface-interface-skeleton__secondary-sidebar"
 								ariaLabel={ mergedLabels.secondarySidebar }
-								style={ {
-									width: isMobileViewport
-										? '100vw'
-										: secondarySidebarSize.width,
-								} }
 								as={ motion.div }
 								initial="closed"
 								animate="open"
 								exit="closed"
 								variants={ {
-									open: { x: 0 },
-									closed: { x: '-100%' },
+									open: { width: secondarySidebarSize.width },
+									closed: { width: 0 },
 								} }
 								transition={ defaultTransition }
 							>
-								<div
+								<motion.div
 									style={ {
 										position: 'absolute',
 										width: isMobileViewport
@@ -204,17 +199,24 @@ function InterfaceSkeleton(
 										height: '100%',
 										left: 0,
 									} }
+									initial="closed"
+									animate="open"
+									exit="closed"
+									variants={ {
+										open: { x: 0 },
+										closed: { x: '-100%' },
+									} }
+									transition={ defaultTransition }
 								>
 									{ secondarySidebarResizeListener }
 									{ secondarySidebar }
-								</div>
+								</motion.div>
 							</NavigableRegion>
 						) }
 					</AnimatePresence>
 					<NavigableRegion
 						className="interface-interface-skeleton__content"
 						ariaLabel={ mergedLabels.body }
-						layout
 					>
 						{ content }
 					</NavigableRegion>
@@ -222,7 +224,6 @@ function InterfaceSkeleton(
 						<NavigableRegion
 							className="interface-interface-skeleton__sidebar"
 							ariaLabel={ mergedLabels.sidebar }
-							layout
 						>
 							{ sidebar }
 						</NavigableRegion>

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -121,6 +121,19 @@ function InterfaceSkeleton(
 
 	const mergedLabels = { ...defaultLabels, ...labels };
 
+	const navigableRegionVariants = {
+		open: {
+			width: secondarySidebarSize.width,
+		},
+		closed: { width: 0 },
+		mobileOpen: { width: '100vw' },
+	};
+	const secondarySidebarVariants = {
+		open: { x: 0 },
+		closed: { x: -100 },
+		mobileOpen: { x: 0 },
+	};
+
 	return (
 		<div
 			{ ...( enableRegionNavigation ? navigateRegionsProps : {} ) }
@@ -187,13 +200,7 @@ function InterfaceSkeleton(
 									isMobileViewport ? 'mobileOpen' : 'open'
 								}
 								exit="closed"
-								variants={ {
-									open: {
-										width: secondarySidebarSize.width,
-									},
-									closed: { width: 0 },
-									mobileOpen: { width: '100vw' },
-								} }
+								variants={ navigableRegionVariants }
 								transition={ defaultTransition }
 							>
 								<motion.div
@@ -205,17 +212,7 @@ function InterfaceSkeleton(
 										height: '100%',
 										left: 0,
 									} }
-									initial="closed"
-									animate="open"
-									exit="closed"
-									variants={ {
-										open: {
-											transform: 'translateX( 0 )',
-										},
-										closed: {
-											transform: 'translateX( -100% )',
-										},
-									} }
+									variants={ secondarySidebarVariants }
 									transition={ defaultTransition }
 								>
 									{ secondarySidebarResizeListener }

--- a/packages/interface/src/components/interface-skeleton/index.js
+++ b/packages/interface/src/components/interface-skeleton/index.js
@@ -121,19 +121,6 @@ function InterfaceSkeleton(
 
 	const mergedLabels = { ...defaultLabels, ...labels };
 
-	const navigableRegionVariants = {
-		open: {
-			width: secondarySidebarSize.width,
-		},
-		closed: { width: 0 },
-		mobileOpen: { width: '100vw' },
-	};
-	const secondarySidebarVariants = {
-		open: { x: 0 },
-		closed: { x: -100 },
-		mobileOpen: { x: 0 },
-	};
-
 	return (
 		<div
 			{ ...( enableRegionNavigation ? navigateRegionsProps : {} ) }
@@ -191,19 +178,24 @@ function InterfaceSkeleton(
 					<AnimatePresence initial={ false }>
 						{ !! secondarySidebar && (
 							<NavigableRegion
-								layout
 								className="interface-interface-skeleton__secondary-sidebar"
 								ariaLabel={ mergedLabels.secondarySidebar }
+								style={ {
+									width: isMobileViewport
+										? '100vw'
+										: secondarySidebarSize.width,
+								} }
 								as={ motion.div }
 								initial="closed"
-								animate={
-									isMobileViewport ? 'mobileOpen' : 'open'
-								}
+								animate="open"
 								exit="closed"
-								variants={ navigableRegionVariants }
+								variants={ {
+									open: { x: 0 },
+									closed: { x: '-100%' },
+								} }
 								transition={ defaultTransition }
 							>
-								<motion.div
+								<div
 									style={ {
 										position: 'absolute',
 										width: isMobileViewport
@@ -212,12 +204,10 @@ function InterfaceSkeleton(
 										height: '100%',
 										left: 0,
 									} }
-									variants={ secondarySidebarVariants }
-									transition={ defaultTransition }
 								>
 									{ secondarySidebarResizeListener }
 									{ secondarySidebar }
-								</motion.div>
+								</div>
 							</NavigableRegion>
 						) }
 					</AnimatePresence>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
At larger screen sizes, resize the canvas when the pattern category panel is open. 

Fixes #63510

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allow the full canvas to be visible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When the pattern category is open, manually increase the width of the sidebar. Added a new base variable called `$secondary-sidebar-width` to use in list view and inserter sidebars and remove it from the tabbed sidebar component. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the inserter
- Go to Pattern Tab
- Click a category
- Canvas should resize to allow the category panel to display


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/ee3e4c07-44f1-4d33-aa8c-6567322c92b6


