### PR TITLE
Site Title: Add `levelOptions` attribute to control available heading levels

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -856,7 +856,7 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 -	**Name:** core/site-title
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, linkTarget, textAlign
+-	**Attributes:** isLink, level, levelOptions, linkTarget, textAlign
 
 ## Social Icon
 

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -11,6 +11,10 @@
 			"type": "number",
 			"default": 1
 		},
+		"levelOptions": {
+			"type": "array",
+			"default": [ 0, 1, 2, 3, 4, 5, 6 ]
+		},
 		"textAlign": {
 			"type": "string"
 		},

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -21,14 +21,12 @@ import { ToggleControl, PanelBody } from '@wordpress/components';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 
-const HEADING_LEVELS = [ 0, 1, 2, 3, 4, 5, 6 ];
-
 export default function SiteTitleEdit( {
 	attributes,
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { level, textAlign, isLink, linkTarget } = attributes;
+	const { level, levelOptions, textAlign, isLink, linkTarget } = attributes;
 	const { canUserEdit, title } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -97,8 +95,8 @@ export default function SiteTitleEdit( {
 		<>
 			<BlockControls group="block">
 				<HeadingLevelDropdown
-					options={ HEADING_LEVELS }
 					value={ level }
+					options={ levelOptions }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}

--- a/test/integration/fixtures/blocks/core__site-title.json
+++ b/test/integration/fixtures/blocks/core__site-title.json
@@ -4,6 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"level": 1,
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,
 			"linkTarget": "_self"
 		},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Followup to https://github.com/WordPress/gutenberg/pull/63535

## What?
This PR adds a `levelOptions` attribute to the Site Title block that allows developers to control which heading levels are available in the UI.

## Why?
Being able to restrict the available heading levels is crucial in many situations, whether it be general Editor curation, accessibility, block governance, SEO, etc.

## How?
This PR adds a `levelOptions` attribute to the Site Title block that allows developers to define which heading levels should be displayed in the Heading dropdown UI. The approach is very simple and does not require a depreciation. Any previously set heading levels are respected in the markup. 

> [!NOTE]
> Note that the available heading levels were previously hardcoded. I've moved these to the `default` property on the `levelOptions` attribute in `block.json`. 

With this new attribute, you can restrict the UI in many different ways, making this approach very flexible and powerful. For example, you could restrict options directly in block markup for a pattern or template. Try copying and pasting the following in the Editor.

```
<!-- wp:site-title {"level":3,"levelOptions":[3,4,5]} /-->
```

Or you could modify the attribute programmatically via filters. The following will disable h1 globally. You could also add conditionals for post type, user permissions, etc. There are filters for both PHP and JavaScript so the applications are endless.

```
function example_modify_heading_levels_globally( $args, $block_type ) {
	
	if ( 'core/site-title' !== $block_type ) {
		return $args;
	}

	// Remove H1.
	$args['attributes']['levelOptions']['default'] = [ 2, 3, 4, 5, 6 ];
	
	return $args;
}
add_filter( 'register_block_type_args', 'example_modify_heading_levels_globally', 10, 2 );
```

## Testing Instructions

- Use any block theme with this PR enabled. You can also test in [Playground](https://playground.wordpress.net/gutenberg.html).
- Try copying the block code above into the Code Editor, then switch to the Editor View to see the restricted Heading levels UI
- Try copying the filter code into the `functions.php` file of your theme and see that `h1` is disabled.

## Screenshots or screencast 
With restrictions applied:
<img width="777" alt="image" src="https://github.com/user-attachments/assets/3d5a1246-2459-42fa-a4bb-6f0bb983b75c">

