### PR TITLE
Site Tagline: Add `levelOptions` attribute to control available heading levels

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -847,7 +847,7 @@ Describe in a few words what the site is about. The tagline can be used in searc
 -	**Name:** core/site-tagline
 -	**Category:** theme
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** level, textAlign
+-	**Attributes:** level, levelOptions, textAlign
 
 ## Site Title
 

--- a/packages/block-library/src/site-tagline/block.json
+++ b/packages/block-library/src/site-tagline/block.json
@@ -14,6 +14,10 @@
 		"level": {
 			"type": "number",
 			"default": 0
+		},
+		"levelOptions": {
+			"type": "array",
+			"default": [ 0, 1, 2, 3, 4, 5, 6 ]
 		}
 	},
 	"example": {

--- a/packages/block-library/src/site-tagline/edit.js
+++ b/packages/block-library/src/site-tagline/edit.js
@@ -18,14 +18,12 @@ import {
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
-const HEADING_LEVELS = [ 0, 1, 2, 3, 4, 5, 6 ];
-
 export default function SiteTaglineEdit( {
 	attributes,
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { textAlign, level } = attributes;
+	const { textAlign, level, levelOptions } = attributes;
 	const { canUserEdit, tagline } = useSelect( ( select ) => {
 		const { canUser, getEntityRecord, getEditedEntityRecord } =
 			select( coreStore );
@@ -82,8 +80,8 @@ export default function SiteTaglineEdit( {
 		<>
 			<BlockControls group="block">
 				<HeadingLevelDropdown
-					options={ HEADING_LEVELS }
 					value={ level }
+					options={ levelOptions }
 					onChange={ ( newLevel ) =>
 						setAttributes( { level: newLevel } )
 					}

--- a/test/integration/fixtures/blocks/core__site-tagline.json
+++ b/test/integration/fixtures/blocks/core__site-tagline.json
@@ -3,7 +3,8 @@
 		"name": "core/site-tagline",
 		"isValid": true,
 		"attributes": {
-			"level": 0
+			"level": 0,
+			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ]
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Followup to https://github.com/WordPress/gutenberg/pull/63535

## What?
This PR adds a `levelOptions` attribute to the Site Tagline block that allows developers to control which heading levels are available in the UI.

## Why?
Being able to restrict the available heading levels is crucial in many situations, whether it be general Editor curation, accessibility, block governance, SEO, etc.

## How?
This PR adds a `levelOptions` attribute to the Site Tagline block that allows developers to define which heading levels should be displayed in the Heading dropdown UI. The approach is very simple and does not require a depreciation. Any previously set heading levels are respected in the markup. 

> [!NOTE]
> Note that the available heading levels were previously hardcoded. I've moved these to the `default` property on the `levelOptions` attribute in `block.json`. 

With this new attribute, you can restrict the UI in many different ways, making this approach very flexible and powerful. For example, you could restrict options directly in block markup for a pattern or template. Try copying and pasting the following in the Editor.

```
<!-- wp:site-tagline {"level":3,"levelOptions":[3,4,5]} /-->
```

Or you could modify the attribute programmatically via filters. The following will disable h1 globally. You could also add conditionals for post type, user permissions, etc. There are filters for both PHP and JavaScript so the applications are endless.

```
function example_modify_heading_levels_globally( $args, $block_type ) {
	
	if ( 'core/site-tagline' !== $block_type ) {
		return $args;
	}

	// Remove H1.
	$args['attributes']['levelOptions']['default'] = [ 2, 3, 4, 5, 6 ];
	
	return $args;
}
add_filter( 'register_block_type_args', 'example_modify_heading_levels_globally', 10, 2 );
```

## Testing Instructions

- Use any block theme with this PR enabled. You can also test in [Playground](https://playground.wordpress.net/gutenberg.html).
- Try copying the block code above into the Code Editor, then switch to the Editor View to see the restricted Heading levels UI
- Try copying the filter code into the `functions.php` file of your theme and see that `h1` is disabled.


## Screenshots or screencast 
With restrictions applied:

<img width="557" alt="image" src="https://github.com/user-attachments/assets/5b480323-75d2-433a-9154-e0f4e613fda6">
