### PR TITLE
RichText: make readOnly prop work properly

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   RichText: make readOnly prop work properly ([#todo](https://github.com/WordPress/gutenberg/pull/todo)).
+-   RichText: make readOnly prop work properly ([#64114](https://github.com/WordPress/gutenberg/pull/64114)).
 
 ## 13.4.0 (2024-07-24)
 

--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   RichText: make readOnly prop work properly ([#todo](https://github.com/WordPress/gutenberg/pull/todo)).
+
 ## 13.4.0 (2024-07-24)
 
 ## 13.3.0 (2024-07-10)

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -515,7 +515,7 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 		);
 	}
 
-	return <PrivateRichText ref={ ref } { ...props } readOnly={ false } />;
+	return <PrivateRichText ref={ ref } { ...props } />;
 } );
 
 PublicForwardedRichTextContainer.Content = Content;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #64112

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To make `readOnly` prop  of `RichText` component work properly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removed the hard-coded `readOnly={ false }`.

I thought it might be an error to hard-code like this. If it's intended, please feel free to close this PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
