### PR TITLE
remove: speak from device menu selection

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -21,7 +21,6 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { store as editorStore } from '../../store';
 import PostPreviewButton from '../post-preview-button';
-import { speak } from '@wordpress/a11y';
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const { deviceType, homeUrl, isTemplate, isViewable, showIconLabels } =
@@ -110,13 +109,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	 */
 	const onSelect = ( value ) => {
 		setDeviceType( value );
-		if ( value === 'Desktop' ) {
-			speak( __( 'Desktop selected' ), 'assertive' );
-		} else if ( value === 'Tablet' ) {
-			speak( __( 'Tablet selected' ), 'assertive' );
-		} else {
-			speak( __( 'Mobile selected' ), 'assertive' );
-		}
 	};
 
 	return (

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -102,15 +102,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		selectedChoice = choices[ 0 ];
 	}
 
-	/**
-	 * Handles the selection of a device type.
-	 *
-	 * @param {string} value The device type.
-	 */
-	const onSelect = ( value ) => {
-		setDeviceType( value );
-	};
-
 	return (
 		<DropdownMenu
 			className="editor-preview-dropdown"
@@ -127,7 +118,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuItemsChoice
 							choices={ choices }
 							value={ selectedChoice.value }
-							onSelect={ onSelect }
+							onSelect={ setDeviceType }
 						/>
 					</MenuGroup>
 					{ isTemplate && (


### PR DESCRIPTION
## Why?
- removed `speak` from device selection as suggested by @jeryj in this PR: https://github.com/WordPress/gutenberg/pull/63958#discussion_r1697028432
