### PR TITLE
Improve `Button` matrix in visual regression test

### DIFF
--- a/packages/components/src/button/stories/e2e/index.story.tsx
+++ b/packages/components/src/button/stories/e2e/index.story.tsx
@@ -31,49 +31,110 @@ export const VariantStates: StoryFn< typeof Button > = (
 		'link',
 	];
 
-	return (
-		<div style={ { display: 'flex', flexDirection: 'column', gap: 24 } }>
-			{ variants.map( ( variant ) => (
-				<div
-					style={ { display: 'flex', gap: 8 } }
-					key={ variant ?? 'undefined' }
+	const VariantsRow = ( {
+		buttonProps,
+		name,
+	}: {
+		buttonProps?: ButtonAsButtonProps;
+		name: string;
+	} ) => {
+		return (
+			<tr>
+				<th
+					style={ {
+						fontSize: 13,
+						fontWeight: 'normal',
+						padding: 8,
+						background: '#f3f4f5',
+					} }
 				>
-					<Button { ...props } variant={ variant } />
-					{ /* eslint-disable-next-line no-restricted-syntax */ }
-					<Button { ...props } variant={ variant } disabled />
-					<Button
-						{ ...props }
-						variant={ variant }
-						disabled
-						accessibleWhenDisabled
-					/>
-					<Button { ...props } variant={ variant } isBusy />
-					<Button
-						{ ...props }
-						variant={ variant }
-						isBusy
-						disabled
-						accessibleWhenDisabled
-					/>
-					<Button { ...props } variant={ variant } isDestructive />
-					<Button
-						{ ...props }
-						variant={ variant }
-						isDestructive
-						disabled
-						accessibleWhenDisabled
-					/>
-					<Button { ...props } variant={ variant } isPressed />
-					<Button
-						{ ...props }
-						variant={ variant }
-						isPressed
-						disabled
-						accessibleWhenDisabled
-					/>
-				</div>
-			) ) }
-		</div>
+					{ name }
+				</th>
+				{ variants.map( ( variant ) => (
+					<td key={ variant ?? 'undefined' } style={ { padding: 4 } }>
+						<Button
+							{ ...props }
+							variant={ variant }
+							{ ...buttonProps }
+						/>
+					</td>
+				) ) }
+			</tr>
+		);
+	};
+
+	return (
+		<table>
+			<thead>
+				<tr style={ { background: '#f3f4f5' } }>
+					<th />
+					{ variants.map( ( variant ) => (
+						<th
+							key={ variant ?? 'undefined' }
+							style={ { padding: 8 } }
+						>
+							{ variant ?? '(default)' }
+						</th>
+					) ) }
+				</tr>
+			</thead>
+			<tbody>
+				<VariantsRow name="(default)" />
+				<VariantsRow
+					name="disabled"
+					buttonProps={ { disabled: true } }
+				/>
+				<VariantsRow
+					name="focusable disabled"
+					buttonProps={ {
+						accessibleWhenDisabled: true,
+						disabled: true,
+					} }
+				/>
+				<VariantsRow
+					name="isBusy"
+					buttonProps={ {
+						isBusy: true,
+					} }
+				/>
+				<VariantsRow
+					name="isBusy disabled"
+					buttonProps={ {
+						isBusy: true,
+						accessibleWhenDisabled: true,
+						disabled: true,
+					} }
+				/>
+				<VariantsRow
+					name="isDestructive"
+					buttonProps={ {
+						isDestructive: true,
+					} }
+				/>
+				<VariantsRow
+					name="isDestructive disabled"
+					buttonProps={ {
+						isDestructive: true,
+						accessibleWhenDisabled: true,
+						disabled: true,
+					} }
+				/>
+				<VariantsRow
+					name="isPressed"
+					buttonProps={ {
+						isPressed: true,
+					} }
+				/>
+				<VariantsRow
+					name="isPressed disabled"
+					buttonProps={ {
+						isPressed: true,
+						accessibleWhenDisabled: true,
+						disabled: true,
+					} }
+				/>
+			</tbody>
+		</table>
 	);
 };
 VariantStates.args = {

--- a/packages/components/src/button/stories/e2e/index.story.tsx
+++ b/packages/components/src/button/stories/e2e/index.story.tsx
@@ -48,8 +48,29 @@ export const VariantStates: StoryFn< typeof Button > = (
 						accessibleWhenDisabled
 					/>
 					<Button { ...props } variant={ variant } isBusy />
+					<Button
+						{ ...props }
+						variant={ variant }
+						isBusy
+						disabled
+						accessibleWhenDisabled
+					/>
 					<Button { ...props } variant={ variant } isDestructive />
+					<Button
+						{ ...props }
+						variant={ variant }
+						isDestructive
+						disabled
+						accessibleWhenDisabled
+					/>
 					<Button { ...props } variant={ variant } isPressed />
+					<Button
+						{ ...props }
+						variant={ variant }
+						isPressed
+						disabled
+						accessibleWhenDisabled
+					/>
 				</div>
 			) ) }
 		</div>

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -1,3 +1,10 @@
+/**
+ * For easier testing of potential regressions, you can use a Button variant matrix
+ * available in a special Storybook instance by running `npm run storybook:e2e:dev`.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/trunk/test/storybook-playwright/README.md
+ */
+
 .components-button {
 	display: inline-flex;
 	text-decoration: none;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/62480#issuecomment-2259126312

## What?

Convert the Button variant matrix into a more easily viewable table, and add the following missing prop combinations:

- disabled `isBusy`
- disabled `isDestructive`
- disabled `isPressed`

## Why?

Adding these prop combinations helped catch potential regressions in #62480.

Also, it was getting harder to understand which button was what, so it needed some better labeling.

## Testing Instructions

`npm run storybook:e2e:dev` and see the Button ▸ Variant States story.

See [readme](https://github.com/WordPress/gutenberg/blob/fix/disabled-button-focus-style/test/storybook-playwright/README.md) if you need more detail.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img width="740" alt="Button matrix, before" src="https://github.com/user-attachments/assets/e9558d06-fd6d-4e18-8981-56d2f343abaa">|<img width="777" alt="Button matrix, after" src="https://github.com/user-attachments/assets/3955e8b3-7a78-4959-92d3-d7d2c87bbce5">|
