### PR TITLE
Adds experimental blocks flag

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -43,12 +43,28 @@ add_action( 'admin_init', 'gutenberg_enable_experiments' );
 
 /**
  * Sets a global JS variable used to trigger the availability of form & input blocks.
+ *
+ * @deprecated 19.0.0 Use gutenberg_enable_block_experiments().
  */
 function gutenberg_enable_form_input_blocks() {
+	_deprecated_function( __FUNCTION__, 'Gutenberg 19.0.0', 'gutenberg_enable_block_experiments' );
+}
+
+/**
+ * Sets global JS variables used to enable various block experiments.
+ */
+function gutenberg_enable_block_experiments() {
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
+
+	// Experimental form blocks.
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-form-blocks', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableFormBlocks = true', 'before' );
 	}
+
+	// General experimental blocks that are not in the default block library.
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-experiments', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockExperiments = true', 'before' );
+	}
 }
 
-add_action( 'admin_init', 'gutenberg_enable_form_input_blocks' );
+add_action( 'admin_init', 'gutenberg_enable_block_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -80,6 +80,18 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
+		'gutenberg-block-experiments',
+		__( 'Experimental blocks', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable experimental blocks.<p class="description">(Warning: these blocks may have significant changes during development that cause validation errors and display issues.)</p>', 'gutenberg' ),
+			'id'    => 'gutenberg-block-experiments',
+		)
+	);
+
+	add_settings_field(
 		'gutenberg-form-blocks',
 		__( 'Form and input blocks ', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -95,6 +95,7 @@ $GLOBALS['wp_tests_options'] = array(
 		'gutenberg-widget-experiments' => '1',
 		'gutenberg-full-site-editing'  => 1,
 		'gutenberg-form-blocks'        => 1,
+		'gutenberg-block-experiments'  => 1,
 	),
 );
 


### PR DESCRIPTION
## What?

Adds a new flag on the Gutenberg > Experiments wp-admin page for experimental blocks.

I plan to use this for https://github.com/WordPress/gutenberg/pull/63689, but created a separate PR here so it can be used by others, as well, before that PR is merged.

## Why?

Blocks in development may not be ready for general use. By having users opt in to an experiment to test these blocks, we can iterate without worrying about writing multiple block deprecations.

Once a block is stable, it can be promoted from the experiment to being included by default in block-library.

## How?

Adds `gutenberg-block-experiments` setting included on the `gutenberg-experiments` wp-admin page.

To add a new block to the experiment, conditionally add it in https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/index.js using `window?.__experimentalEnableBlockExperiments` (see the existing form/input blocks in that file as an example).

## Testing Instructions

- Open `/wp-admin/admin.php?page=gutenberg-experiments` and see an option for "Experimental blocks"
- Check the box and reload the page to turn it on (no additional blocks are included in this PR)
- Verify that the existing "Form and input blocks" experiment still works, that the form block is available in the editor when the experiment is on

### Testing Instructions for Keyboard

n/a

## Screenshots or screencast <!-- if applicable -->

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/3adf02e4-40c9-4648-b7cc-c5de60f90547">
