### PR TITLE
Patterns: enable cross-browser support for pattern uploading

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -173,9 +173,15 @@ export default function AddNewPattern() {
 						// When we're not handling template parts, we should
 						// add or create the proper pattern category.
 						if ( postType !== TEMPLATE_PART_POST_TYPE ) {
-							const currentCategory = categoryMap
-								.values()
-								.find( ( term ) => term.name === categoryId );
+							/*
+							 * categoryMap.values() returns an iterator, not an array.
+							 * Iterator.find() is not yet widely supported.
+							 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find
+							 * Convert to array to use the find method.
+							 */
+							const currentCategory = Array.from(
+								categoryMap.values()
+							).find( ( term ) => term.name === categoryId );
 							if ( currentCategory ) {
 								currentCategoryId =
 									currentCategory.id ||

--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -174,10 +174,9 @@ export default function AddNewPattern() {
 						// add or create the proper pattern category.
 						if ( postType !== TEMPLATE_PART_POST_TYPE ) {
 							/*
-							 * categoryMap.values() returns an iterator, not an array.
-							 * Iterator.find() is not yet widely supported.
-							 * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find
-							 * Convert to array to use the find method.
+							 * categoryMap.values() returns an iterator.
+							 * Iterator.prototype.find() is not yet widely supported.
+							 * Convert to array to use the Array.prototype.find method.
 							 */
 							const currentCategory = Array.from(
 								categoryMap.values()


### PR DESCRIPTION
## What?


It's not possible to upload patterns in Firefox and Safari and other browsers that don't yet support [Iterator.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find).

Props to @juliacanzani for spotting this! 


## Why?

Uploading pattern JSON files was triggering an error in Firefox and Safari: 

`"categoryMap.values().find  is not a function".`

[categoryMap.values()](https://github.com/WordPress/gutenberg/blob/f08bc21600cde54986f19d22584e667649e0c0e1/packages/edit-site/src/components/add-new-pattern/index.js#L182-L182) returns an Iterator.


[Iterator.prototype.find()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/find) doesn't have wide browser support.


## How?

Let's covert the `categoryMap.values()` iterator to an array to allow the use of `Array.prototype.find()`

## Testing Instructions

1. Fire up this branch in the site editor using Firefox or Safari (both preferably)
2. Either have a pattern JSON handy or duplicate an existing TT4 pattern and download it.
3. Now upload your pattern in the patterns view page.
4. It should upload.
5. Things should still work in Chrome!



https://github.com/user-attachments/assets/046261d1-2c68-4555-8c7c-e2e14ad0d1ae


