### PR TITLE
Fix modal dismissers in development mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `ColorPalette`: Remove extra bottom margin when `CircularOptionPicker` is unneeded ([#63961](https://github.com/WordPress/gutenberg/pull/63961)).
 -   `CustomSelectControl`: Restore `describedBy` functionality ([#63957](https://github.com/WordPress/gutenberg/pull/63957)).
+-   `Modal`: Fix the dismissal logic for React development mode ([#64132](https://github.com/WordPress/gutenberg/pull/64132)).
 
 ### Enhancements
 

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -2,12 +2,7 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type {
-	ForwardedRef,
-	KeyboardEvent,
-	MutableRefObject,
-	UIEvent,
-} from 'react';
+import type { ForwardedRef, KeyboardEvent, RefObject, UIEvent } from 'react';
 
 /**
  * WordPress dependencies
@@ -44,9 +39,10 @@ import type { ModalProps } from './types';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 
 // Used to track and dismiss the prior modal when another opens unless nested.
-const ModalContext = createContext<
-	MutableRefObject< ModalProps[ 'onRequestClose' ] | undefined >[]
->( [] );
+type Dismissers = Set<
+	RefObject< ModalProps[ 'onRequestClose' ] | undefined >
+>;
+const ModalContext = createContext< Dismissers >( new Set() );
 
 // Used to track body class names applied while modals are open.
 const bodyOpenClasses = new Map< string, number >();
@@ -147,23 +143,28 @@ function UnforwardedModal(
 	// one should remain open at a time and the list enables closing prior ones.
 	const dismissers = useContext( ModalContext );
 	// Used for the tracking and dismissing any nested modals.
-	const nestedDismissers = useRef< typeof dismissers >( [] );
+	const [ nestedDismissers ] = useState< Dismissers >( () => new Set() );
 
 	// Updates the stack tracking open modals at this level and calls
 	// onRequestClose for any prior and/or nested modals as applicable.
 	useEffect( () => {
-		dismissers.push( refOnRequestClose );
-		const [ first, second ] = dismissers;
-		if ( second ) {
-			first?.current?.();
+		// add this modal instance to the dismissers set
+		dismissers.add( refOnRequestClose );
+		// request that all the other modals close themselves
+		for ( const dismisser of dismissers ) {
+			if ( dismisser !== refOnRequestClose ) {
+				dismisser.current?.();
+			}
 		}
-
-		const nested = nestedDismissers.current;
 		return () => {
-			nested[ 0 ]?.current?.();
-			dismissers.shift();
+			// request that all the nested modals close themselves
+			for ( const dismisser of nestedDismissers ) {
+				dismisser.current?.();
+			}
+			// remove this modal instance from the dismissers set
+			dismissers.delete( refOnRequestClose );
 		};
-	}, [ dismissers ] );
+	}, [ dismissers, nestedDismissers ] );
 
 	// Adds/removes the value of bodyOpenClassName to body element.
 	useEffect( () => {
@@ -350,7 +351,7 @@ function UnforwardedModal(
 	);
 
 	return createPortal(
-		<ModalContext.Provider value={ nestedDismissers.current }>
+		<ModalContext.Provider value={ nestedDismissers }>
 			{ modal }
 		</ModalContext.Provider>,
 		document.body

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -89,7 +89,8 @@ function useEditorCommandLoader() {
 		name: 'core/open-shortcut-help',
 		label: __( 'Keyboard shortcuts' ),
 		icon: keyboard,
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			openModal( 'editor/keyboard-shortcut-help' );
 		},
 	} );
@@ -108,7 +109,8 @@ function useEditorCommandLoader() {
 	commands.push( {
 		name: 'core/open-preferences',
 		label: __( 'Editor preferences' ),
-		callback: () => {
+		callback: ( { close } ) => {
+			close();
 			openModal( 'editor/preferences' );
 		},
 	} );

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -89,8 +89,7 @@ function useEditorCommandLoader() {
 		name: 'core/open-shortcut-help',
 		label: __( 'Keyboard shortcuts' ),
 		icon: keyboard,
-		callback: ( { close } ) => {
-			close();
+		callback: () => {
 			openModal( 'editor/keyboard-shortcut-help' );
 		},
 	} );
@@ -109,8 +108,7 @@ function useEditorCommandLoader() {
 	commands.push( {
 		name: 'core/open-preferences',
 		label: __( 'Editor preferences' ),
-		callback: ( { close } ) => {
-			close();
+		callback: () => {
 			openModal( 'editor/preferences' );
 		},
 	} );


### PR DESCRIPTION
Followup to #64019 that addresses the root cause.

Apparently @stokesman was working on the same task in parallel, creating #64075 🙂 

Both fixes have one part in common: a modal never calls its own dismisser.

My PR additionally converts the array to a set. I think it makes the logic more reliable, as it makes the modal effect cleanup always remove only its own dismisser. When calling `dismissers.shift()`, I'm not so sure what I'm actually removing from the start of the array.