### PR TITLE
Template Part: Fix 'can user edit' check

### DIFF
--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -128,7 +128,7 @@ export default function TemplatePartEdit( {
 		area,
 		onNavigateToEntityRecord,
 		title,
-		canEditTemplate,
+		canUserEdit,
 	} = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } =
@@ -151,10 +151,13 @@ export default function TemplatePartEdit( {
 				  )
 				: false;
 
-			const _canEditTemplate = select( coreStore ).canUser( 'create', {
-				kind: 'postType',
-				name: 'wp_template_part',
-			} );
+			const _canUserEdit = hasResolvedEntity
+				? select( coreStore ).canUser( 'update', {
+						kind: 'postType',
+						name: 'wp_template_part',
+						id: templatePartId,
+				  } )
+				: false;
 
 			return {
 				hasInnerBlocks: getBlockCount( clientId ) > 0,
@@ -167,7 +170,7 @@ export default function TemplatePartEdit( {
 				onNavigateToEntityRecord:
 					getSettings().onNavigateToEntityRecord,
 				title: entityRecord?.title,
-				canEditTemplate: !! _canEditTemplate,
+				canUserEdit: !! _canUserEdit,
 			};
 		},
 		[ templatePartId, attributes.area, clientId ]
@@ -237,7 +240,7 @@ export default function TemplatePartEdit( {
 			<RecursionProvider uniqueId={ templatePartId }>
 				{ isEntityAvailable &&
 					onNavigateToEntityRecord &&
-					canEditTemplate && (
+					canUserEdit && (
 						<BlockControls group="other">
 							<ToolbarButton
 								onClick={ () =>


### PR DESCRIPTION
## What?

PR contains the following fixes and improvements for the Template Part block:

* Use the correct action and template part ID when checking the user's edit capabilities.
* Only call the `canUser` selector after resolving the template part entity. This prevents making additional `OPTIONS` requests (see #63430). The block controls are only rendered after the entity finishes resolution.

## Testing Instructions
1. Navigate to a template with multiple template parts.
2. Open the DevTools > Network.
3. Confirm no `OPTIONS` request is made for template parts. You can use `template-parts` as a filter.
4. Confirm that the "Edit" button is still available in the block toolbar when selecting a template part.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-31 at 15 08 02](https://github.com/user-attachments/assets/b584606e-63e3-4af2-8cc0-8c99e346c312)
