### PR TITLE
TypesetButton: Check if variations exist before running logic

### DIFF
--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -60,7 +60,7 @@ function TypesetButton() {
 			return activeVariation.title;
 		}
 		return allFontFamilies.map( ( font ) => font?.name ).join( ', ' );
-	}, [ userTypographyConfig, variations ] );
+	}, [ allFontFamilies, userTypographyConfig, variations ] );
 
 	return (
 		hasFonts && (

--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -49,7 +49,7 @@ function TypesetButton() {
 		if ( Object.keys( userTypographyConfig ).length === 0 ) {
 			return __( 'Default' );
 		}
-		const activeVariation = variations.find( ( variation ) => {
+		const activeVariation = variations?.find( ( variation ) => {
 			return (
 				JSON.stringify(
 					filterObjectByProperties( variation, 'typography' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a check for Style Variations before running a `find()` on them.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes a potential error, `TypeError: Cannot read properties of undefined (reading 'find')`, when there are no variations available. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Checks if `variations` are available before running logic on them. I've also updated the dependency array for `title` to fix a lint warning.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Ensure the font library e2e test passes by running `npm run test:e2e -- test/e2e/specs/site-editor/font-library.spec.js`
2. Ensure testing instructions in https://github.com/WordPress/gutenberg/pull/62539 still work correctly for TT4, and that no Typesets are shown for Empty Theme.
