### PR TITLE
FIX: make whole details clickable

### DIFF
--- a/packages/block-library/src/details/style.scss
+++ b/packages/block-library/src/details/style.scss
@@ -1,7 +1,17 @@
 .wp-block-details {
 	box-sizing: border-box;
+	position: relative;
 }
 
 .wp-block-details summary {
 	cursor: pointer;
+
+	&::after {
+		content: "";
+		position: absolute;
+		top: 0;
+		left: 0;
+		height: 100%;
+		width: 100%;
+	}
 }


### PR DESCRIPTION
## Why?
Fixes https://github.com/WordPress/gutenberg/issues/64116

## How?

```css
.wp-block-details {
	box-sizing: border-box;
	position: relative;
}

.wp-block-details summary {
	cursor: pointer;

	&::after {
		content: "";
		position: absolute;
		top: 0;
		left: 0;
		height: 100%;
		width: 100%;
	}
}

```

Added after to make whole details block clickable.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c30e6e90-2ed3-4eb6-9c3a-0d56777d238d


