### PR TITLE
Centrally align entity in focused edit mode

### DIFF
--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -1,6 +1,6 @@
 .editor-visual-editor {
 	position: relative;
-	display: block;
+	display: flex;
 	background-color: $gray-300;
 
 	// Centralize the editor horizontally (flex-direction is column).


### PR DESCRIPTION
## What?
When the entity is shorter than the container centrally align it on the canvas.

## Why?
Helps communicate the isolated nature of the element and its detachment from any given page. The additional breathing room also improves the edit experience. 

I believe this was a regression from a while ago that never got fixed.

## How?
Apply `display: flex` to `.editor-visual-editor`.

## Testing Instructions
1. Edit a pattern or template part in focus mode, either via the Patterns data view, or by editing a page, selecting the header/footer and clicking 'Edit' in the block toolbar.
2. Observe the centrally aligned entity.
3. Add blocks until the entities grows taller than the container/viewport and ensure everything behaves correctly.
4. Test editing pages, templates, posts, etc, and ensure there are no regressions.

| Before | After |
| --- | --- |
| <img width="1111" alt="Screenshot 2024-07-31 at 15 47 41" src="https://github.com/user-attachments/assets/4bc60635-cfd1-4b2e-b8c0-0260016241d2"> | <img width="1108" alt="Screenshot 2024-07-31 at 15 48 11" src="https://github.com/user-attachments/assets/513a86f0-c8f2-411e-8bff-db73789c14cc"> |


