### PR TITLE
Update useTaxonomies hook to check for taxonomies for passed post type

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -136,11 +136,15 @@ export const usePostTypes = () => {
 export const useTaxonomies = ( postType ) => {
 	const taxonomies = useSelect(
 		( select ) => {
-			const { getTaxonomies } = select( coreStore );
-			return getTaxonomies( {
-				type: postType,
-				per_page: -1,
-			} );
+			const { getTaxonomies, getPostType } = select( coreStore );
+			// Does the post type have taxonomies?
+			if ( getPostType( postType )?.taxonomies?.length > 0 ) {
+				return getTaxonomies( {
+					type: postType,
+					per_page: -1,
+				} );
+			}
+			return [];
 		},
 		[ postType ]
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR does a check to see that the passed postType has associated taxonomies before requesting them.

Closes #64144

## Why?
This addresses 403 errors being fired when accessing the Page post type in the Query Loop block specifically but is good for any uses of the hook.

## How?
Before calling `getTaxonomies` we check that the postType has taxonomies using `getPostType `and checking the `taxonomies.length`

## Testing Instructions
1. Create a new post
2. Add the Query Loop block and change Query Type to Custom
3. Change the Post Type to Page
4. Confirm that are no errors are fired in the Console or Network tab
5. Confirm Taxonomies filter does not appear
6. Register a new taxonomy and associate it with Pages (I used the code below)
7. Repeat the 1 - 3 and confirm that the Taxonomies filter appears and displays the registered taxonomy

### Taxonomy code
```php
function wpdocs_register_private_taxonomy() {
	$args = array(
	   'label'        => __( 'Genre', 'textdomain' ),
	   'public'       => true,
	   'rewrite'      => false,
	   'hierarchical' => true,
	   'show_in_rest' => true,
   );

   register_taxonomy( 'genre', 'page', $args );
}
add_action( 'init', 'wpdocs_register_private_taxonomy', 0 );

```
