### PR TITLE
Several Typo Correction in Inline Doc

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -547,7 +547,7 @@ _Returns_
 
 > **Deprecated**
 
-This function was accidentially exposed for mobile/native usage.
+This function was accidentally exposed for mobile/native usage.
 
 _Returns_
 

--- a/packages/block-editor/src/utils/get-editor-region.js
+++ b/packages/block-editor/src/utils/get-editor-region.js
@@ -23,7 +23,7 @@ export default function getEditorRegion( editor ) {
 			return iframeDocument === editor.ownerDocument;
 		} ) ?? editor;
 
-	// The region is provivided by the editor, not the block-editor.
+	// The region is provided by the editor, not the block-editor.
 	// We should send focus to the region if one is available to reuse the
 	// same interface for navigating landmarks. If no region is available,
 	// use the canvas instead.

--- a/packages/block-editor/src/utils/get-px-from-css-unit.js
+++ b/packages/block-editor/src/utils/get-px-from-css-unit.js
@@ -1,5 +1,5 @@
 /**
- * This function was accidentially exposed for mobile/native usage.
+ * This function was accidentally exposed for mobile/native usage.
  *
  * @deprecated
  *


### PR DESCRIPTION
Corrected Typo in Inline Documents in the Following Files:

1. packages/block-editor/src/utils/get-editor-region.js Line no 26 
- Replaced `provivided` with `provided` 

2. packages/block-editor/src/utils/get-px-from-css-unit.js Line no 2 
- Replaced `accidentially` with `accidentally` 

