### PR TITLE
Post: add a max length to the post password protected field

### DIFF
--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -254,6 +254,7 @@ export default function PostStatus() {
 														id={ passwordInputId }
 														__next40pxDefaultSize
 														__nextHasNoMarginBottom
+														maxLength={ 255 }
 													/>
 												</div>
 											) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes: https://github.com/WordPress/gutenberg/issues/64155

Limits the post password protected field to 255 chars.

## Why?

To avoid the database error:

<img width="1570" alt="Screenshot 2024-08-01 at 12 51 52 PM" src="https://github.com/user-attachments/assets/ce9c9e1e-b3a3-4a92-946b-fd2065da613a">

See explanation in https://github.com/WordPress/gutenberg/issues/64155


## How?
`maxlength` HTML attribute.

## Testing Instructions

The following password has 258 characters.

`glom-our-stir-bespeak-normalcy-wavelet-spitz-alsatian-miami-gizmo-sibling-riflemen-fugal-caiman-guy-tern-flick-nearer-dow-patch-grudge-prawn-debuting-scorch-brunei-waif-hibachi-beijing-tweet-share-homeward-ratline-postal-dissent-tigris-baldpate-clumsy-centre`

Paste it into the password field and confirm that it's truncated to 255:

`glom-our-stir-bespeak-normalcy-wavelet-spitz-alsatian-miami-gizmo-sibling-riflemen-fugal-caiman-guy-tern-flick-nearer-dow-patch-grudge-prawn-debuting-scorch-brunei-waif-hibachi-beijing-tweet-share-homeward-ratline-postal-dissent-tigris-baldpate-clumsy-cen`

Save and check that the password work on the frontend to unlock the post.

<img width="647" alt="Screenshot 2024-08-01 at 12 47 10 PM" src="https://github.com/user-attachments/assets/cbcb9142-e7f5-4dbc-a7ef-15f1ea7e5efc">


