### PR TITLE
Template Part: Fix capability checks for inner blocks

### DIFF
--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -129,15 +129,17 @@ export default function TemplatePartInnerBlocks( {
 			return {
 				canViewTemplatePart: !! select( coreStore ).canUser( 'read', {
 					kind: 'postType',
-					name: 'wp_template',
+					name: 'wp_template_part',
+					id,
 				} ),
-				canEditTemplatePart: !! select( coreStore ).canUser( 'create', {
+				canEditTemplatePart: !! select( coreStore ).canUser( 'update', {
 					kind: 'postType',
-					name: 'wp_template',
+					name: 'wp_template_part',
+					id,
 				} ),
 			};
 		},
-		[]
+		[ id ]
 	);
 
 	if ( ! canViewTemplatePart ) {


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/60326#discussion_r1679112251.

PR fixes user capability checks in the `TemplatePartInnerBlocks` component.

## Why?
The selectors were referencing the wrong entity and missing the template part ID.

## Testing Instructions
1. Navigate to a template with multiple template parts.
2. Confirm template part blocks are editable.
3. Open DevTools > Network.
4. Confirm no `OPTIONS` request is made for template parts. You can use `template-parts` as a filter.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-07-31 at 15 08 02](https://github.com/user-attachments/assets/0565385f-8c2c-400c-9b49-dead57a1ebab)
