### PR TITLE
Update: chevron to home icon.

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -22,7 +22,7 @@ import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { decodeEntities } from '@wordpress/html-entities';
-import { Icon, chevronLeft } from '@wordpress/icons';
+import { Icon, homeButton } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -292,7 +292,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 											) }
 											variants={ toggleHomeIconVariants }
 										>
-											<Icon icon={ chevronLeft } />
+											<Icon icon={ homeButton } />
 										</motion.div>
 									</motion.div>
 								)

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -117,6 +117,7 @@ export { default as helpFilled } from './library/help-filled';
 export { default as inbox } from './library/inbox';
 export { default as institution } from './library/institution';
 export { default as home } from './library/home';
+export { default as homeButton } from './library/home-button';
 export { default as html } from './library/html';
 export { default as image } from './library/image';
 export { default as info } from './library/info';

--- a/packages/icons/src/library/home-button.js
+++ b/packages/icons/src/library/home-button.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const homeButton = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fill-rule="evenodd"
+			clip-rule="evenodd"
+			d="M4.25 7A2.75 2.75 0 0 1 7 4.25h10A2.75 2.75 0 0 1 19.75 7v10A2.75 2.75 0 0 1 17 19.75H7A2.75 2.75 0 0 1 4.25 17V7ZM7 5.75c-.69 0-1.25.56-1.25 1.25v10c0 .69.56 1.25 1.25 1.25h10c.69 0 1.25-.56 1.25-1.25V7c0-.69-.56-1.25-1.25-1.25H7Z"
+		/>
+	</SVG>
+);
+
+export default homeButton;


### PR DESCRIPTION
## What?

Followup to https://github.com/WordPress/gutenberg/pull/63986#issuecomment-2260675610: adds a home button icon to the back flow:
![Screenshot 2024-08-01 at 08 50 57](https://github.com/user-attachments/assets/5410d391-a58b-448b-9dd1-6dcde5e9663a)

## Testing Instructions

Go to the site editor and observe the new home button icon when hovering the site icon.