### PR TITLE
DataForm: move validation logic to the field type definition

### DIFF
--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { default as integer } from './integer';
-import type { FieldType } from '../types';
+import type { FieldType, Option } from '../types';
 
 /**
  *
@@ -15,8 +15,17 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 		return integer;
 	}
 
-	// If no type found, the sort function doesn't do anything.
 	return {
 		sort: () => 0,
+		isValid: ( value: any, elements?: Option[] ) => {
+			if ( elements ) {
+				const validValues = elements.map( ( f ) => f.value );
+				if ( ! validValues.includes( value ) ) {
+					return false;
+				}
+			}
+
+			return true;
+		},
 	};
 }

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import { default as integer } from './integer';
-import type { FieldType, Option } from '../types';
+import type { FieldType, ValidationContext } from '../types';
 
 /**
  *
@@ -17,9 +17,9 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 
 	return {
 		sort: () => 0,
-		isValid: ( value: any, elements?: Option[] ) => {
-			if ( elements ) {
-				const validValues = elements.map( ( f ) => f.value );
+		isValid: ( value: any, context?: ValidationContext ) => {
+			if ( context?.elements ) {
+				const validValues = context?.elements?.map( ( f ) => f.value );
 				if ( ! validValues.includes( value ) ) {
 					return false;
 				}

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -1,12 +1,33 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection } from '../types';
+import type { SortDirection, Option } from '../types';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? a - b : b - a;
 }
 
+function isValid( value: any, elements?: Option[] ) {
+	// TODO: this implicitely means the value is required.
+	if ( value === '' ) {
+		return false;
+	}
+
+	if ( ! Number.isInteger( Number( value ) ) ) {
+		return false;
+	}
+
+	if ( elements ) {
+		const validValues = elements.map( ( f ) => f.value );
+		if ( ! validValues.includes( Number( value ) ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
 export default {
 	sort,
+	isValid,
 };

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -1,13 +1,13 @@
 /**
  * Internal dependencies
  */
-import type { SortDirection, Option } from '../types';
+import type { SortDirection, ValidationContext } from '../types';
 
 function sort( a: any, b: any, direction: SortDirection ) {
 	return direction === 'asc' ? a - b : b - a;
 }
 
-function isValid( value: any, elements?: Option[] ) {
+function isValid( value: any, context?: ValidationContext ) {
 	// TODO: this implicitely means the value is required.
 	if ( value === '' ) {
 		return false;
@@ -17,8 +17,8 @@ function isValid( value: any, elements?: Option[] ) {
 		return false;
 	}
 
-	if ( elements ) {
-		const validValues = elements.map( ( f ) => f.value );
+	if ( context?.elements ) {
+		const validValues = context?.elements.map( ( f ) => f.value );
 		if ( ! validValues.includes( Number( value ) ) ) {
 			return false;
 		}

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -30,12 +30,22 @@ export function normalizeFields< Item >(
 				);
 			};
 
+		const isValid =
+			field.isValid ??
+			function isValid( item, elements ) {
+				return fieldTypeDefinition.isValid(
+					getValue( { item } ),
+					elements
+				);
+			};
+
 		return {
 			...field,
 			label: field.label || field.id,
 			getValue,
 			render: field.render || getValue,
 			sort,
+			isValid,
 		};
 	} );
 }

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -32,10 +32,10 @@ export function normalizeFields< Item >(
 
 		const isValid =
 			field.isValid ??
-			function isValid( item, elements ) {
+			function isValid( item, context ) {
 				return fieldTypeDefinition.isValid(
 					getValue( { item } ),
-					elements
+					context
 				);
 			};
 

--- a/packages/dataviews/src/test/validation.ts
+++ b/packages/dataviews/src/test/validation.ts
@@ -61,7 +61,7 @@ describe( 'validation', () => {
 		expect( result ).toBe( false );
 	} );
 
-	it( 'field is invalid if value is not one of the elements', () => {
+	it( 'integer field is invalid if value is not one of the elements', () => {
 		const item = { id: 1, author: 3 };
 		const fields: Field< {} >[] = [
 			{
@@ -76,5 +76,39 @@ describe( 'validation', () => {
 		const form = { visibleFields: [ 'author' ] };
 		const result = isItemValid( item, fields, form );
 		expect( result ).toBe( false );
+	} );
+
+	it( 'untyped field is invalid if value is not one of the elements', () => {
+		const item = { id: 1, author: 'not-in-elements' };
+		const fields: Field< {} >[] = [
+			{
+				id: 'author',
+				elements: [
+					{ value: 'jane', label: 'Jane' },
+					{ value: 'john', label: 'John' },
+				],
+			},
+		];
+		const form = { visibleFields: [ 'author' ] };
+		const result = isItemValid( item, fields, form );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'fields can provide its own isValid function', () => {
+		const item = { id: 1, order: 'd' };
+		const fields: Field< {} >[] = [
+			{
+				id: 'order',
+				type: 'integer',
+				elements: [
+					{ value: 'a', label: 'A' },
+					{ value: 'b', label: 'B' },
+				],
+				isValid: () => true, // Overrides the validation provided for integer types.
+			},
+		];
+		const form = { visibleFields: [ 'order' ] };
+		const result = isItemValid( item, fields, form );
+		expect( result ).toBe( true );
 	} );
 } );

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -86,6 +86,11 @@ export type Field< Item > = {
 	sort?: ( a: Item, b: Item, direction: SortDirection ) => number;
 
 	/**
+	 * Callback used to validate the field.
+	 */
+	isValid?: ( item: Item, elements?: Option[] ) => boolean;
+
+	/**
 	 * Whether the field is sortable.
 	 */
 	enableSorting?: boolean;
@@ -130,6 +135,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
 	sort: ( a: Item, b: Item, direction: SortDirection ) => number;
+	isValid: ( item: Item, elements?: Option[] ) => boolean;
 };
 
 /**

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -46,6 +46,10 @@ export type ItemRecord = Record< string, unknown >;
 
 export type FieldType = 'text' | 'integer';
 
+export type ValidationContext = {
+	elements?: Option[];
+};
+
 /**
  * A dataview field for a specific property of a data type.
  */
@@ -88,7 +92,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to validate the field.
 	 */
-	isValid?: ( item: Item, elements?: Option[] ) => boolean;
+	isValid?: ( item: Item, context?: ValidationContext ) => boolean;
 
 	/**
 	 * Whether the field is sortable.
@@ -135,7 +139,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
 	sort: ( a: Item, b: Item, direction: SortDirection ) => number;
-	isValid: ( item: Item, elements?: Option[] ) => boolean;
+	isValid: ( item: Item, context?: ValidationContext ) => boolean;
 };
 
 /**

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -13,28 +13,6 @@ export function isItemValid< Item >(
 		fields.filter( ( { id } ) => !! form.visibleFields?.includes( id ) )
 	);
 	return _fields.every( ( field ) => {
-		const value = field.getValue( { item } );
-
-		// TODO: this implicitely means the value is required.
-		if ( field.type === 'integer' && value === '' ) {
-			return false;
-		}
-
-		if (
-			field.type === 'integer' &&
-			! Number.isInteger( Number( value ) )
-		) {
-			return false;
-		}
-
-		if ( field.elements ) {
-			const validValues = field.elements.map( ( f ) => f.value );
-			if ( ! validValues.includes( Number( value ) ) ) {
-				return false;
-			}
-		}
-
-		// Nothing to validate.
-		return true;
+		return field.isValid( item, field.elements );
 	} );
 }

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -13,6 +13,6 @@ export function isItemValid< Item >(
 		fields.filter( ( { id } ) => !! form.visibleFields?.includes( id ) )
 	);
 	return _fields.every( ( field ) => {
-		return field.isValid( item, field.elements );
+		return field.isValid( item, { elements: field.elements } );
 	} );
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59745
Follow-up to https://github.com/WordPress/gutenberg/pull/64064

## What?

This PR is a refactor, it doesn't modify any behavior. It moves the DataForm's validation logic into the corresponding field type definition.

## Why?

With the introduction of field type definitions at https://github.com/WordPress/gutenberg/pull/64064 we are now able to centralize more parts of the logic there.

## How?

Extracts logic from `validation.ts` into the corresponding field type definition.

## Testing Instructions

Verify the order modal still works as before:

https://github.com/user-attachments/assets/023b2b7d-e1c9-4c71-85a9-7bf2492aae3f


