### PR TITLE
Editor: Display empty option when post author is missing

### DIFF
--- a/packages/editor/src/components/post-author/hook.js
+++ b/packages/editor/src/components/post-author/hook.js
@@ -46,17 +46,24 @@ export function useAuthorsQuery( search ) {
 			( { value } ) => postAuthor?.id === value
 		);
 
+		let currentAuthor = [];
 		if ( foundAuthor < 0 && postAuthor ) {
-			return [
+			currentAuthor = [
 				{
 					value: postAuthor.id,
 					label: decodeEntities( postAuthor.name ),
 				},
-				...fetchedAuthors,
+			];
+		} else if ( foundAuthor < 0 && ! postAuthor ) {
+			currentAuthor = [
+				{
+					value: 0,
+					label: '',
+				},
 			];
 		}
 
-		return fetchedAuthors;
+		return [ ...currentAuthor, ...fetchedAuthors ];
 	}, [ authors, postAuthor ] );
 
 	return { authorId, authorOptions, postAuthor };

--- a/packages/editor/src/components/post-author/hook.js
+++ b/packages/editor/src/components/post-author/hook.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
@@ -58,7 +59,7 @@ export function useAuthorsQuery( search ) {
 			currentAuthor = [
 				{
 					value: 0,
-					label: '',
+					label: __( '(No author)' ),
 				},
 			];
 		}

--- a/packages/editor/src/components/post-author/panel.js
+++ b/packages/editor/src/components/post-author/panel.js
@@ -4,6 +4,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Dropdown } from '@wordpress/components';
 import { useState, useMemo } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
 
 /**
@@ -16,7 +17,8 @@ import { useAuthorsQuery } from './hook';
 
 function PostAuthorToggle( { isOpen, onClick } ) {
 	const { postAuthor } = useAuthorsQuery();
-	const authorName = postAuthor?.name || '';
+	const authorName =
+		decodeEntities( postAuthor?.name ) || __( '(No author)' );
 	return (
 		<Button
 			size="compact"


### PR DESCRIPTION
## What?
Fixes #64163.

PR updates `useAuthorsQuery` to include an empty option in the author list when a current post author is missing.

## Why?
It allows changing a missing post author when the dropdown only has one option (only one user remains on the site).

When `SelectControl` or `Combobox` has only one option and doesn't match the provided value, it will be automatically selected, and the user can't trigger a change event.

## Testing Instructions
1. Create a post with the test user.
2. Delete a user without re-assigning their content.
3. Restore the trashed post and open it.
4. Open the author dropdown.
5. Confirm that the empty option is selected.
6. Confirm you can change the author.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

**Dropdown**
![CleanShot 2024-08-01 at 13 19 53](https://github.com/user-attachments/assets/84e74d4c-2e86-4b85-a699-a6283701d283)

**Combobox**
![CleanShot 2024-08-01 at 13 20 45](https://github.com/user-attachments/assets/c9bb4600-9917-4098-a1d3-5cc3dc1f4941)
