### PR TITLE
DataViews: formalize text field type definition

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -23,7 +23,6 @@ export const data = [
 		type: 'Not a planet',
 		categories: [ 'Space', 'NASA' ],
 		satellites: 0,
-		satellites_no_type: 0,
 	},
 	{
 		id: 2,
@@ -33,7 +32,6 @@ export const data = [
 		type: 'Not a planet',
 		categories: [ 'Space' ],
 		satellites: 0,
-		satellites_no_type: 0,
 	},
 	{
 		id: 3,
@@ -43,7 +41,6 @@ export const data = [
 		type: 'Not a planet',
 		categories: [ 'NASA' ],
 		satellites: 0,
-		satellites_no_type: 0,
 	},
 	{
 		id: 4,
@@ -53,7 +50,6 @@ export const data = [
 		type: 'Ice giant',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 14,
-		satellites_no_type: 14,
 	},
 	{
 		id: 5,
@@ -63,7 +59,6 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
-		satellites_no_type: 0,
 	},
 	{
 		id: 6,
@@ -73,7 +68,6 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 0,
-		satellites_no_type: 0,
 	},
 	{
 		id: 7,
@@ -83,7 +77,6 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 1,
-		satellites_no_type: 1,
 	},
 	{
 		id: 8,
@@ -93,7 +86,6 @@ export const data = [
 		type: 'Terrestrial',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 2,
-		satellites_no_type: 2,
 	},
 	{
 		id: 9,
@@ -103,7 +95,6 @@ export const data = [
 		type: 'Gas giant',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 95,
-		satellites_no_type: 95,
 	},
 	{
 		id: 10,
@@ -113,7 +104,6 @@ export const data = [
 		type: 'Gas giant',
 		categories: [ 'Space', 'Planet', 'Solar system' ],
 		satellites: 146,
-		satellites_no_type: 146,
 	},
 	{
 		id: 11,
@@ -123,7 +113,6 @@ export const data = [
 		type: 'Ice giant',
 		categories: [ 'Space', 'Ice giant', 'Solar system' ],
 		satellites: 28,
-		satellites_no_type: 28,
 	},
 ];
 
@@ -201,11 +190,6 @@ export const fields = [
 		label: 'Satellites',
 		id: 'satellites',
 		type: 'integer',
-		enableSorting: true,
-	},
-	{
-		label: 'Satellites (no type)',
-		id: 'satellites_no_type',
 		enableSorting: true,
 	},
 	{

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -3,6 +3,7 @@
  */
 import type { FieldType, ValidationContext } from '../types';
 import { default as integer } from './integer';
+import { default as text } from './text';
 
 /**
  *
@@ -13,6 +14,10 @@ import { default as integer } from './integer';
 export default function getFieldTypeDefinition( type?: FieldType ) {
 	if ( 'integer' === type ) {
 		return integer;
+	}
+
+	if ( 'text' === type ) {
+		return text;
 	}
 
 	return {

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -1,8 +1,8 @@
 /**
  * Internal dependencies
  */
-import { default as integer } from './integer';
 import type { FieldType, ValidationContext } from '../types';
+import { default as integer } from './integer';
 
 /**
  *

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import type { FieldType, ValidationContext } from '../types';
+import type { FieldType, SortDirection, ValidationContext } from '../types';
 import { default as integer } from './integer';
 import { default as text } from './text';
 
@@ -21,7 +21,15 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 	}
 
 	return {
-		sort: () => 0,
+		sort: ( a: any, b: any, direction: SortDirection ) => {
+			if ( typeof a === 'number' && typeof b === 'number' ) {
+				return direction === 'asc' ? a - b : b - a;
+			}
+
+			return direction === 'asc'
+				? a.localeCompare( b )
+				: b.localeCompare( a );
+		},
 		isValid: ( value: any, context?: ValidationContext ) => {
 			if ( context?.elements ) {
 				const validValues = context?.elements?.map( ( f ) => f.value );

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import type { SortDirection, ValidationContext } from '../types';
+
+function sort( valueA: any, valueB: any, direction: SortDirection ) {
+	return direction === 'asc'
+		? valueA.localeCompare( valueB )
+		: valueB.localeCompare( valueA );
+}
+
+function isValid( value: any, context?: ValidationContext ) {
+	if ( context?.elements ) {
+		const validValues = context?.elements?.map( ( f ) => f.value );
+		if ( ! validValues.includes( value ) ) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+export default {
+	sort,
+	isValid,
+};

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -140,10 +140,9 @@ export function filterSortAndPaginate< Item >(
 		} );
 		if ( fieldToSort ) {
 			filteredData.sort( ( a, b ) => {
-				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
-				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
-
-				if ( fieldToSort.type === 'integer' ) {
+				if (
+					[ 'integer', 'text' ].includes( fieldToSort.type ?? '' )
+				) {
 					return fieldToSort.sort(
 						a,
 						b,
@@ -152,6 +151,8 @@ export function filterSortAndPaginate< Item >(
 				}
 
 				// When/if types become required, we can remove the following logic.
+				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
+				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
 				if (
 					typeof valueA === 'number' &&
 					typeof valueB === 'number'

--- a/packages/dataviews/src/filter-and-sort-data-view.ts
+++ b/packages/dataviews/src/filter-and-sort-data-view.ts
@@ -140,31 +140,7 @@ export function filterSortAndPaginate< Item >(
 		} );
 		if ( fieldToSort ) {
 			filteredData.sort( ( a, b ) => {
-				if (
-					[ 'integer', 'text' ].includes( fieldToSort.type ?? '' )
-				) {
-					return fieldToSort.sort(
-						a,
-						b,
-						view.sort?.direction ?? 'desc'
-					);
-				}
-
-				// When/if types become required, we can remove the following logic.
-				const valueA = fieldToSort.getValue( { item: a } ) ?? '';
-				const valueB = fieldToSort.getValue( { item: b } ) ?? '';
-				if (
-					typeof valueA === 'number' &&
-					typeof valueB === 'number'
-				) {
-					return view.sort?.direction === 'asc'
-						? valueA - valueB
-						: valueB - valueA;
-				}
-
-				return view.sort?.direction === 'asc'
-					? valueA.localeCompare( valueB )
-					: valueB.localeCompare( valueA );
+				return fieldToSort.sort( a, b, view.sort?.direction ?? 'desc' );
 			} );
 		}
 	}

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -233,7 +233,42 @@ describe( 'filters', () => {
 } );
 
 describe( 'sorting', () => {
-	it( 'should sort by string', () => {
+	it( 'should sort integer field types', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				sort: { field: 'satellites', direction: 'desc' },
+			},
+			fields
+		);
+
+		expect( result ).toHaveLength( 11 );
+		expect( result[ 0 ].title ).toBe( 'Saturn' );
+		expect( result[ 1 ].title ).toBe( 'Jupiter' );
+		expect( result[ 2 ].title ).toBe( 'Uranus' );
+	} );
+
+	it( 'should sort untyped fields if the value is a number', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				sort: { field: 'satellites', direction: 'desc' },
+			},
+			// Remove type information for satellites field to test sorting untyped fields.
+			fields.map( ( field ) =>
+				field.id === 'satellites'
+					? { ...field, type: undefined }
+					: field
+			)
+		);
+
+		expect( result ).toHaveLength( 11 );
+		expect( result[ 0 ].title ).toBe( 'Saturn' );
+		expect( result[ 1 ].title ).toBe( 'Jupiter' );
+		expect( result[ 2 ].title ).toBe( 'Uranus' );
+	} );
+
+	it( 'should sort text field types', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
 			{
@@ -253,34 +288,27 @@ describe( 'sorting', () => {
 		expect( result[ 1 ].title ).toBe( 'Neptune' );
 	} );
 
-	it( 'should sort by number', () => {
+	it( 'should sort untyped fields if the value is string', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
 			{
-				sort: { field: 'satellites_no_type', direction: 'desc' },
+				sort: { field: 'title', direction: 'desc' },
+				filters: [
+					{
+						field: 'type',
+						operator: 'isAny',
+						value: [ 'Ice giant' ],
+					},
+				],
 			},
-			fields
+			// Remove type information for the title field to test sorting untyped fields.
+			fields.map( ( field ) =>
+				field.id === 'title' ? { ...field, type: undefined } : field
+			)
 		);
-
-		expect( result ).toHaveLength( 11 );
-		expect( result[ 0 ].title ).toBe( 'Saturn' );
-		expect( result[ 1 ].title ).toBe( 'Jupiter' );
-		expect( result[ 2 ].title ).toBe( 'Uranus' );
-	} );
-
-	it( 'should sort by type integer', () => {
-		const { data: result } = filterSortAndPaginate(
-			data,
-			{
-				sort: { field: 'satellites', direction: 'desc' },
-			},
-			fields
-		);
-
-		expect( result ).toHaveLength( 11 );
-		expect( result[ 0 ].title ).toBe( 'Saturn' );
-		expect( result[ 1 ].title ).toBe( 'Jupiter' );
-		expect( result[ 2 ].title ).toBe( 'Uranus' );
+		expect( result ).toHaveLength( 2 );
+		expect( result[ 0 ].title ).toBe( 'Uranus' );
+		expect( result[ 1 ].title ).toBe( 'Neptune' );
 	} );
 } );
 

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -248,26 +248,6 @@ describe( 'sorting', () => {
 		expect( result[ 2 ].title ).toBe( 'Uranus' );
 	} );
 
-	it( 'should sort untyped fields if the value is a number', () => {
-		const { data: result } = filterSortAndPaginate(
-			data,
-			{
-				sort: { field: 'satellites', direction: 'desc' },
-			},
-			// Remove type information for satellites field to test sorting untyped fields.
-			fields.map( ( field ) =>
-				field.id === 'satellites'
-					? { ...field, type: undefined }
-					: field
-			)
-		);
-
-		expect( result ).toHaveLength( 11 );
-		expect( result[ 0 ].title ).toBe( 'Saturn' );
-		expect( result[ 1 ].title ).toBe( 'Jupiter' );
-		expect( result[ 2 ].title ).toBe( 'Uranus' );
-	} );
-
 	it( 'should sort text field types', () => {
 		const { data: result } = filterSortAndPaginate(
 			data,
@@ -286,6 +266,26 @@ describe( 'sorting', () => {
 		expect( result ).toHaveLength( 2 );
 		expect( result[ 0 ].title ).toBe( 'Uranus' );
 		expect( result[ 1 ].title ).toBe( 'Neptune' );
+	} );
+
+	it( 'should sort untyped fields if the value is a number', () => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				sort: { field: 'satellites', direction: 'desc' },
+			},
+			// Remove type information for satellites field to test sorting untyped fields.
+			fields.map( ( field ) =>
+				field.id === 'satellites'
+					? { ...field, type: undefined }
+					: field
+			)
+		);
+
+		expect( result ).toHaveLength( 11 );
+		expect( result[ 0 ].title ).toBe( 'Saturn' );
+		expect( result[ 1 ].title ).toBe( 'Jupiter' );
+		expect( result[ 2 ].title ).toBe( 'Uranus' );
 	} );
 
 	it( 'should sort untyped fields if the value is string', () => {

--- a/packages/dataviews/src/test/validation.ts
+++ b/packages/dataviews/src/test/validation.ts
@@ -78,6 +78,23 @@ describe( 'validation', () => {
 		expect( result ).toBe( false );
 	} );
 
+	it( 'text field is invalid if value is not one of the elements', () => {
+		const item = { id: 1, author: 'not-in-elements' };
+		const fields: Field< {} >[] = [
+			{
+				id: 'author',
+				type: 'text',
+				elements: [
+					{ value: 'jane', label: 'Jane' },
+					{ value: 'john', label: 'John' },
+				],
+			},
+		];
+		const form = { visibleFields: [ 'author' ] };
+		const result = isItemValid( item, fields, form );
+		expect( result ).toBe( false );
+	} );
+
 	it( 'untyped field is invalid if value is not one of the elements', () => {
 		const item = { id: 1, author: 'not-in-elements' };
 		const fields: Field< {} >[] = [


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59745

## What?

Follow suit on starting to formalize integer type definition at https://github.com/WordPress/gutenberg/pull/64064 and https://github.com/WordPress/gutenberg/pull/64164 this PR creates a `text` type definition with sorting and validation logic.

## Why?

To centralize more of our logic based on field types.

## How?

Creates a new type definition (`field-types/text.tsx`) and implements sorting & validation logic.

## Testing Instructions

Nothing to test manually. The only field that uses `text` type so far is title. However, it doesn't have any validation rules and sorting for pages/posts happens in the server (it doesn't use our filterSort utility).

Verify automated tests pass.