### PR TITLE
Zoom Out: Always go to edit mode when inserting a single block

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
-
+import { useSelect, useDispatch } from '@wordpress/data';
 /**
  * Internal dependencies
  */
@@ -19,16 +18,15 @@ export function useZoomOut( zoomOut = true ) {
 	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 
 	const originalEditingMode = useRef( null );
-	const mode = __unstableGetEditorMode();
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
 		if ( ! originalEditingMode.current ) {
-			originalEditingMode.current = mode;
+			originalEditingMode.current = __unstableGetEditorMode();
 		}
 
 		return () => {
-			// We need to use  __unstableGetEditorMode() here and not `mode`, as mode may not update on unmount
+			// Restore the original mode on unmount if it was changed to 'zoom-out'
 			if (
 				__unstableGetEditorMode() === 'zoom-out' &&
 				__unstableGetEditorMode() !== originalEditingMode.current
@@ -36,18 +34,17 @@ export function useZoomOut( zoomOut = true ) {
 				__unstableSetEditorMode( originalEditingMode.current );
 			}
 		};
-	}, [] );
+	}, [ __unstableGetEditorMode, __unstableSetEditorMode ] );
 
-	// The effect opens the zoom-out view if we want it open and it's not currently in zoom-out mode.
 	useEffect( () => {
-		if ( zoomOut && mode !== 'zoom-out' ) {
+		if ( zoomOut && __unstableGetEditorMode() !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
 		} else if (
 			! zoomOut &&
 			__unstableGetEditorMode() === 'zoom-out' &&
-			originalEditingMode.current !== mode
+			originalEditingMode.current !== __unstableGetEditorMode()
 		) {
 			__unstableSetEditorMode( originalEditingMode.current );
 		}
-	}, [ __unstableSetEditorMode, zoomOut ] );
+	}, [ zoomOut, __unstableGetEditorMode, __unstableSetEditorMode ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -49,5 +49,5 @@ export function useZoomOut( zoomOut = true ) {
 		) {
 			__unstableSetEditorMode( originalEditingMode.current );
 		}
-	}, [ __unstableSetEditorMode, zoomOut, mode ] );
+	}, [ __unstableSetEditorMode, zoomOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -25,18 +25,6 @@ export function useZoomOut( zoomOut = true ) {
 			originalEditingMode.current = __unstableGetEditorMode();
 		}
 
-		return () => {
-			// Restore the original mode on unmount if it was changed to 'zoom-out'
-			if (
-				__unstableGetEditorMode() === 'zoom-out' &&
-				__unstableGetEditorMode() !== originalEditingMode.current
-			) {
-				__unstableSetEditorMode( originalEditingMode.current );
-			}
-		};
-	}, [ __unstableGetEditorMode, __unstableSetEditorMode ] );
-
-	useEffect( () => {
 		if ( zoomOut && __unstableGetEditorMode() !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
 		} else if (
@@ -46,5 +34,15 @@ export function useZoomOut( zoomOut = true ) {
 		) {
 			__unstableSetEditorMode( originalEditingMode.current );
 		}
+
+		return () => {
+			// Restore the original mode on unmount if it was changed to 'zoom-out'
+			if (
+				__unstableGetEditorMode() === 'zoom-out' &&
+				__unstableGetEditorMode() !== originalEditingMode.current
+			) {
+				__unstableSetEditorMode( originalEditingMode.current );
+			}
+		};
 	}, [ zoomOut, __unstableGetEditorMode, __unstableSetEditorMode ] );
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1800,6 +1800,15 @@ export function editorMode( state = 'edit', action ) {
 		return 'edit';
 	}
 
+	// Let inserting a single block always trigger Edit mode.
+	if (
+		action.type === 'INSERT_BLOCKS' &&
+		action.blocks.length === 1 &&
+		action.blocks[ 0 ].innerBlocks.length === 0
+	) {
+		return 'edit';
+	}
+
 	if ( action.type === 'SET_EDITOR_MODE' ) {
 		return action.mode;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Switch to edit mode (i.e. close zoom out mode or navigation mode) when inserting a single block.

## Why?
When users get dropped into Zoom Out mode (for example in https://github.com/WordPress/gutenberg/pull/61489) this drops them back into normal editing mode without them needing to find the zoom out controls.

## How?
Update the `editorMode` reducer to respond to `INSERT_BLOCKS`.

## Testing Instructions
1. Enable the `Enable zoomed out view when selecting a pattern category in the main inserter. ` experiment.
2. Open the new page flow: wp-admin/post-new.php?post_type=page
3. Open the patterns inserter - you should be put into zoom out mode
4. Select a pattern - you'll stay in zoom out mode
5. Focus the page title
6. Enter a page title
7. Hit enter
8. You'll now leave zoom out mode.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c40d8ae2-7986-423a-a705-4dca1346bf48

