### PR TITLE
Site Icon: Add back filter effect to make it work for all kind of site icons

### DIFF
--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -72,5 +72,7 @@
 
 	&.has-site-icon {
 		background-color: hsla(0, 0%, 100%, 0.6);
+		-webkit-backdrop-filter: saturate(180%) blur(15px);
+		backdrop-filter: saturate(180%) blur(15px);
 	}
 }


### PR DESCRIPTION
Follow up to #63986 

## What?

Adds a background filter to the hover effect of the site icon. This makes it look better no matter the colors used in the site icon itself.

## Testing instructions

- Pick a site icon
- Open the site editor
- Click the preview
- Hover the site icon on the top left