### PR TITLE
Icons: Remove hardcoded color from sidesAxial and sidesBottom icons

### DIFF
--- a/packages/icons/src/library/sides-axial.js
+++ b/packages/icons/src/library/sides-axial.js
@@ -6,12 +6,9 @@ import { SVG, Path } from '@wordpress/primitives';
 const sidesAxial = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
 			d="M8.2 5.3h8V3.8h-8v1.5zm0 14.5h8v-1.5h-8v1.5zm3.5-6.5h1v-1h-1v1zm1-6.5h-1v.5h1v-.5zm-1 4.5h1v-1h-1v1zm0-2h1v-1h-1v1zm0 7.5h1v-.5h-1v.5zm1-2.5h-1v1h1v-1zm-8.5 1.5h1.5v-8H4.2v8zm14.5-8v8h1.5v-8h-1.5zm-5 4.5v-1h-1v1h1zm-6.5 0h.5v-1h-.5v1zm3.5-1v1h1v-1h-1zm6 1h.5v-1h-.5v1zm-8-1v1h1v-1h-1zm6 0v1h1v-1h-1z"
-			style={ {
-				fill: '#1e1e1e',
-				fillRule: 'evenodd',
-				clipRule: 'evenodd',
-			} }
 		/>
 	</SVG>
 );

--- a/packages/icons/src/library/sides-bottom.js
+++ b/packages/icons/src/library/sides-bottom.js
@@ -9,7 +9,7 @@ const sidesBottom = (
 			d="m7.5 6h9v-1.5h-9zm0 13.5h9v-1.5h-9zm-3-3h1.5v-9h-1.5zm13.5-9v9h1.5v-9z"
 			style={ { opacity: 0.25 } }
 		/>
-		<Path d="m16.5 19.5h-9v-1.5h9z" style={ { fill: '#1e1e1e' } } />
+		<Path d="m16.5 19.5h-9v-1.5h9z" />
 	</SVG>
 );
 


### PR DESCRIPTION
Found this while testing #64130

## What?

This PR removes the hardcoded colors from the `sidesAxial` and `sidesBottom` icons.

Note: The following styles have been temporarily applied via the browser developer tools:

```css
svg {
    fill: red;
}
```

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7e7b5df8-e5fd-4da0-b1b7-e329054bbae3) | ![image](https://github.com/user-attachments/assets/5bc3e92f-2dd2-40a3-9088-f36b5ee5c92a) | 

## Why?

Icons should not have hardcoded colors.

## Testing Instructions

- Run `storybook:dev`.
- Access `http://localhost:50240/?path=/story/icons-icon--library`.
- To temporarily test the color change, add the following code to the Styles tab in your developer tools:
  ```css
  svg {
    fill: red;
  }
  ```
- All paths should now be rendered in red.
