### PR TITLE
Keep top level block selection if entering zoom out mode

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1689,7 +1689,7 @@ export const __unstableSetEditorMode =
 						sectionClientId = firstSelectedClientId;
 					} else {
 						// If the selected block is not a section block, find
-						// the parent section that contains the selected block
+						// the parent section that contains the selected block.
 						sectionClientId = select
 							.getBlockParents( firstSelectedClientId )
 							.find( ( parent ) =>

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1683,11 +1683,19 @@ export const __unstableSetEditorMode =
 				if ( sectionRootClientId ) {
 					const sectionClientIds =
 						select.getBlockOrder( sectionRootClientId );
-					sectionClientId = select
-						.getBlockParents( firstSelectedClientId )
-						.find( ( parent ) =>
-							sectionClientIds.includes( parent )
-						);
+
+					// If the selected block is a section block, use it
+					if ( sectionClientIds?.includes( firstSelectedClientId ) ) {
+						sectionClientId = firstSelectedClientId;
+					} else {
+						// If the selected block is not a section block, find
+						// the parent section that contains the selected block
+						sectionClientId = select
+							.getBlockParents( firstSelectedClientId )
+							.find( ( parent ) =>
+								sectionClientIds.includes( parent )
+							);
+					}
 				} else {
 					sectionClientId = select.getBlockHierarchyRootClientId(
 						firstSelectedClientId

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1684,7 +1684,7 @@ export const __unstableSetEditorMode =
 					const sectionClientIds =
 						select.getBlockOrder( sectionRootClientId );
 
-					// If the selected block is a section block, use it
+					// If the selected block is a section block, use it.
 					if ( sectionClientIds?.includes( firstSelectedClientId ) ) {
 						sectionClientId = firstSelectedClientId;
 					} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/64177

## What?
<!-- In a few words, what is the PR actually doing? -->
Checks if a valid top-level section block is selected before clearing block selection.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
A top level section block is a valid zoom out mode selection. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Before looking for the parent of the block, check if the current block selection is a valid section block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Turn on the zoom out mode experiment
- Have or add sections to the top level of a site editor template
- Using the list view, select a group within the main/top-level content section
- Go to Patterns > Select a category to enter zoom out mode
- Block selection should remain the same

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
