### PR TITLE
Improve zoom transition

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -3,3 +3,8 @@
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }
+
+@mixin editor-canvas-resize-animation() {
+	transition: all 0.5s cubic-bezier(0.65, 0, 0.45, 1);
+	@include reduce-motion("transition");
+}

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -4,4 +4,5 @@ iframe[name="editor-canvas"] {
 	height: 100%;
 	display: block;
 	background-color: transparent;
+	@include editor-canvas-resize-animation;
 }

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -22,11 +22,9 @@
 }
 
 .block-editor-iframe__html {
-	$beizer: cubic-bezier(0.65, 0, 0.45, 1);
-	$duration: 0.5s;
 	border: 0 solid $gray-300;
 	transform-origin: top center;
-	transition: transform $duration $beizer, background $duration $beizer, border $duration $beizer, margin $duration $beizer;
+	transition: all  0.5s cubic-bezier(0.65, 0, 0.45, 1);
 	@include reduce-motion("transition");
 }
 
@@ -56,7 +54,6 @@
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 		display: flex;
 		flex-direction: column;
-
 
 		> .is-root-container:not(.wp-block-post-content) {
 			flex: 1;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -24,8 +24,7 @@
 .block-editor-iframe__html {
 	border: 0 solid $gray-300;
 	transform-origin: top center;
-	transition: all  0.5s cubic-bezier(0.65, 0, 0.45, 1);
-	@include reduce-motion("transition");
+	@include editor-canvas-resize-animation;
 }
 
 .block-editor-iframe__html.is-zoomed-out {

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -21,10 +21,9 @@
 	margin-left: calc(-1 * (#{$prev-container-width} - #{$container-width}) / 2);
 }
 
-$beizer: cubic-bezier(0.65, 0, 0.45, 1);
-$duration: 0.5s;
-
 .block-editor-iframe__html {
+	$beizer: cubic-bezier(0.65, 0, 0.45, 1);
+	$duration: 0.5s;
 	border: 0 solid $gray-300;
 	transform-origin: top center;
 	transition: transform $duration $beizer, background $duration $beizer, border $duration $beizer, margin $duration $beizer;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -21,9 +21,13 @@
 	margin-left: calc(-1 * (#{$prev-container-width} - #{$container-width}) / 2);
 }
 
+$beizer: cubic-bezier(0.65, 0, 0.45, 1);
+$duration: 0.5s;
+
 .block-editor-iframe__html {
+	border: 0 solid $gray-300;
 	transform-origin: top center;
-	transition: transform 0.3s;
+	transition: transform $duration $beizer, background $duration $beizer, border $duration $beizer, margin $duration $beizer;
 	@include reduce-motion("transition");
 }
 
@@ -53,6 +57,7 @@
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 		display: flex;
 		flex-direction: column;
+
 
 		> .is-root-container:not(.wp-block-post-content) {
 			flex: 1;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -380,7 +380,6 @@ function Iframe( {
 				style={ {
 					...props.style,
 					height: props.style?.height,
-					transition: 'all 0.5s cubic-bezier(0.65, 0, 0.45, 1)', // Maps to the .block-editor-iframe__html transition.
 				} }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -378,10 +378,9 @@ function Iframe( {
 			<iframe
 				{ ...props }
 				style={ {
-					border: 0,
 					...props.style,
 					height: props.style?.height,
-					transition: 'all .3s',
+					transition: 'all 0.5s cubic-bezier(0.65, 0, 0.45, 1)', // Maps to the .block-editor-iframe__html transition.
 				} }
 				ref={ useMergeRefs( [ ref, setRef ] ) }
 				tabIndex={ tabIndex }

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -305,7 +305,7 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 
-		const maxWidth = 800;
+		const maxWidth = 750;
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
 			scale === 'default'

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -62,8 +62,6 @@ export default function useResizeCanvas( deviceType ) {
 					marginLeft: marginHorizontal,
 					marginRight: marginHorizontal,
 					height,
-					borderRadius: '2px 2px 2px 2px',
-					border: '1px solid #ddd',
 					overflowY: 'auto',
 				};
 			default:

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -43,7 +43,7 @@ export default function useResizeCanvas( deviceType ) {
 		return deviceWidth < actualWidth ? deviceWidth : actualWidth;
 	};
 
-	const marginValue = () => ( window.innerHeight < 800 ? 36 : 72 );
+	const marginValue = () => ( window.innerHeight < 800 ? 36 : 64 );
 
 	const contentInlineStyles = ( device ) => {
 		const height = device === 'Mobile' ? '768px' : '1024px';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Makes zooming out much smoother. I'd also like to apply the same transitions to when you switch to an alternate device preview (Tablet and Mobile). Currently those transitions are formed elsewhere. 

## Why?
The current transition is choppy, transitioning some attributes—but not all. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Open Global Styles > "Browse Styles".
3. See change.

## Visuals

### Trunk

Note that this UI is from https://github.com/WordPress/gutenberg/pull/63870, but the transitions are from trunk. The background color is applied without transition, as well as the initial placement to give zoom out spacing from the editor editor. 

https://github.com/user-attachments/assets/c2729ac7-bdd9-4fc6-bb30-11a440c28eb8

### Proposal 

All elements transition together and slowed down just a little—overall, less jarring. 

https://github.com/user-attachments/assets/efe66ce4-10d4-49a3-beab-23f820f45e8d