### PR TITLE
Global styles: consolidate theme.json ref and URI resolution

### DIFF
--- a/packages/block-editor/src/components/global-styles/test/theme-file-uri-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/theme-file-uri-utils.js
@@ -1,10 +1,7 @@
 /**
  * Internal dependencies
  */
-import {
-	setThemeFileUris,
-	getResolvedThemeFilePath,
-} from '../theme-file-uri-utils';
+import { getResolvedThemeFilePath } from '../theme-file-uri-utils';
 
 const themeFileURIs = [
 	{
@@ -18,28 +15,6 @@ const themeFileURIs = [
 		target: "styles.blocks.['core/group].background.backgroundImage.url",
 	},
 ];
-
-describe( 'setThemeFileUris()', () => {
-	const themeJson = {
-		styles: {
-			background: {
-				backgroundImage: {
-					url: 'file:./assets/image.jpg',
-				},
-			},
-		},
-	};
-
-	it( 'should replace relative paths with resolved URIs if found in themeFileURIs', () => {
-		const newThemeJson = setThemeFileUris( themeJson, themeFileURIs );
-		expect(
-			newThemeJson.styles.background.backgroundImage.url ===
-				'https://wordpress.org/assets/image.jpg'
-		).toBe( true );
-		// Object reference should be the same as the function is mutating the object.
-		expect( newThemeJson ).toEqual( themeJson );
-	} );
-} );
 
 describe( 'getResolvedThemeFilePath()', () => {
 	it.each( [

--- a/packages/block-editor/src/components/global-styles/test/utils.js
+++ b/packages/block-editor/src/components/global-styles/test/utils.js
@@ -86,7 +86,7 @@ describe( 'editor utils', () => {
 				{
 					name: 'file:./assets/other/image.jpg',
 					href: 'https://wordpress.org/assets/other/image.jpg',
-					target: "styles.blocks.['core/group].background.backgroundImage.url",
+					target: "styles.blocks.['core/group'].background.backgroundImage.url",
 				},
 			],
 		},

--- a/packages/block-editor/src/components/global-styles/test/utils.js
+++ b/packages/block-editor/src/components/global-styles/test/utils.js
@@ -7,6 +7,9 @@ import {
 	getPresetVariableFromValue,
 	getValueFromVariable,
 	scopeFeatureSelectors,
+	getResolvedThemeFilePath,
+	getResolvedRefValue,
+	getResolvedValue,
 } from '../utils';
 
 describe( 'editor utils', () => {
@@ -51,6 +54,41 @@ describe( 'editor utils', () => {
 					secondary: 'var(--wp--preset--color--secondary)',
 				},
 			},
+		},
+		styles: {
+			background: {
+				backgroundImage: {
+					url: 'file:./assets/image.jpg',
+				},
+				backgroundAttachment: 'fixed',
+				backgroundPosition: 'top left',
+			},
+			blocks: {
+				'core/group': {
+					background: {
+						backgroundImage: {
+							ref: 'styles.background.backgroundImage',
+						},
+					},
+					dimensions: {
+						minHeight: '100px',
+					},
+				},
+			},
+		},
+		_links: {
+			'wp:theme-file': [
+				{
+					name: 'file:./assets/image.jpg',
+					href: 'https://wordpress.org/assets/image.jpg',
+					target: 'styles.background.backgroundImage.url',
+				},
+				{
+					name: 'file:./assets/other/image.jpg',
+					href: 'https://wordpress.org/assets/other/image.jpg',
+					target: "styles.blocks.['core/group].background.backgroundImage.url",
+				},
+			],
 		},
 		isGlobalStylesUserThemeJSON: true,
 	};
@@ -365,5 +403,87 @@ describe( 'editor utils', () => {
 				},
 			} );
 		} );
+	} );
+
+	describe( 'getResolvedThemeFilePath()', () => {
+		it.each( [
+			[
+				'file:./assets/image.jpg',
+				'https://wordpress.org/assets/image.jpg',
+				'Should return absolute URL if found in themeFileURIs',
+			],
+			[
+				'file:./misc/image.jpg',
+				'file:./misc/image.jpg',
+				'Should return value if not found in themeFileURIs',
+			],
+			[
+				'https://wordpress.org/assets/image.jpg',
+				'https://wordpress.org/assets/image.jpg',
+				'Should not match absolute URLs',
+			],
+		] )(
+			'Given file %s and return value %s: %s',
+			( file, returnedValue ) => {
+				expect(
+					getResolvedThemeFilePath(
+						file,
+						themeJson._links[ 'wp:theme-file' ]
+					) === returnedValue
+				).toBe( true );
+			}
+		);
+	} );
+
+	describe( 'getResolvedRefValue()', () => {
+		it.each( [
+			[ 'blue', 'blue', null ],
+			[ 0, 0, themeJson ],
+			[
+				{ ref: 'styles.background.backgroundImage' },
+				{ url: 'file:./assets/image.jpg' },
+				themeJson,
+			],
+			[
+				{
+					ref: 'styles.blocks.core/group.background.backgroundImage',
+				},
+				undefined,
+				themeJson,
+			],
+		] )(
+			'Given ruleValue %s return expected value of %s',
+			( ruleValue, returnedValue, tree ) => {
+				expect( getResolvedRefValue( ruleValue, tree ) ).toEqual(
+					returnedValue
+				);
+			}
+		);
+	} );
+
+	describe( 'getResolvedValue()', () => {
+		it.each( [
+			[ 'blue', 'blue', null ],
+			[ 0, 0, themeJson ],
+			[
+				{ ref: 'styles.background.backgroundImage' },
+				{ url: 'https://wordpress.org/assets/image.jpg' },
+				themeJson,
+			],
+			[
+				{
+					ref: 'styles.blocks.core/group.background.backgroundImage',
+				},
+				undefined,
+				themeJson,
+			],
+		] )(
+			'Given ruleValue %s return expected value of %s',
+			( ruleValue, returnedValue, tree ) => {
+				expect( getResolvedValue( ruleValue, tree ) ).toEqual(
+					returnedValue
+				);
+			}
+		);
 	} );
 } );

--- a/packages/block-editor/src/components/global-styles/theme-file-uri-utils.js
+++ b/packages/block-editor/src/components/global-styles/theme-file-uri-utils.js
@@ -1,9 +1,4 @@
 /**
- * Internal dependencies
- */
-import { getValueFromObjectPath } from '../../utils/object';
-
-/**
  * Looks up a theme file URI based on a relative path.
  *
  * @param {string}        file          A relative path.
@@ -20,58 +15,4 @@ export function getResolvedThemeFilePath( file, themeFileURIs = [] ) {
 	}
 
 	return uri?.href;
-}
-
-/**
- * Mutates an object by settings a value at the provided path.
- *
- * @param {Object}              object Object to set a value in.
- * @param {number|string|Array} path   Path in the object to modify.
- * @param {*}                   value  New value to set.
- * @return {Object} Object with the new value set.
- */
-function setMutably( object, path, value ) {
-	path = path.split( '.' );
-	const finalValueKey = path.pop();
-	let prev = object;
-
-	for ( const key of path ) {
-		const current = prev[ key ];
-		prev = current;
-	}
-
-	prev[ finalValueKey ] = value;
-
-	return object;
-}
-
-/**
- * Resolves any relative paths if a corresponding theme file URI is available.
- * Note: this function mutates the object and is specifically to be used in
- * an async styles build context in useGlobalStylesOutput
- *
- * @param {Object}        themeJson     Theme.json/Global styles tree.
- * @param {Array<Object>} themeFileURIs A collection of absolute theme file URIs and their corresponding file paths.
- * @return {Object} Returns mutated object.
- */
-export function setThemeFileUris( themeJson, themeFileURIs ) {
-	if ( ! themeJson?.styles || ! themeFileURIs ) {
-		return themeJson;
-	}
-
-	themeFileURIs.forEach( ( { name, href, target } ) => {
-		const value = getValueFromObjectPath( themeJson, target );
-		if ( value === name ) {
-			/*
-			 * The object must not be updated immutably here because the
-			 * themeJson is a reference to the global styles tree used as a dependency in the
-			 * useGlobalStylesOutputWithConfig() hook. If we don't mutate the object,
-			 * the hook will detect the change and re-render the component, resulting
-			 * in a maximum depth exceeded error.
-			 */
-			themeJson = setMutably( themeJson, target, href );
-		}
-	} );
-
-	return themeJson;
 }

--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -381,21 +381,40 @@ export function getStylesDeclarations(
 	);
 
 	/*
-	 * Set background defaults.
-	 * Applies to all background styles except the top-level site background.
+	 * Preprocess background image values.
+	 *
+	 * Note: As we absorb more and more styles into the engine, we could simplify this function.
+	 * A refactor is for the style engine to handle ref resolution (and possibly defaults)
+	 * via a public util used internally and externally. Theme.json tree and defaults could be passed
+	 * as options.
 	 */
-	if ( ! isRoot && !! blockStyles.background ) {
-		blockStyles = {
-			...blockStyles,
-			background: {
-				...blockStyles.background,
-				...setBackgroundStyleDefaults( blockStyles.background ),
-			},
-		};
+	if ( !! blockStyles.background ) {
+		/*
+		 * Resolve dynamic values before they are compiled by the style engine,
+		 * which doesn't (yet) resolve dynamic values.
+		 */
+		if ( blockStyles.background?.backgroundImage ) {
+			blockStyles.background.backgroundImage = getResolvedValue(
+				blockStyles.background.backgroundImage,
+				tree
+			);
+		}
+
+		/*
+		 * Set default values for block background styles.
+		 * Top-level styles are an exception as they are applied to the body.
+		 */
+		if ( ! isRoot ) {
+			blockStyles = {
+				...blockStyles,
+				background: {
+					...blockStyles.background,
+					...setBackgroundStyleDefaults( blockStyles.background ),
+				},
+			};
+		}
 	}
 
-	// The goal is to move everything to server side generated engine styles
-	// This is temporary as we absorb more and more styles into the engine.
 	const extraRules = getCSSRules( blockStyles );
 	extraRules.forEach( ( rule ) => {
 		// Don't output padding properties if padding variables are set or if we're not editing a full template.


### PR DESCRIPTION

## What?

Part of

- https://github.com/WordPress/gutenberg/issues/54336

Requirement for

- https://github.com/WordPress/gutenberg/pull/64182

Consolidate theme.json/global styles value resolution.

## Why?

While laying the ground work for https://github.com/WordPress/gutenberg/pull/64128, I noticed that much of the resolution code could be brought together.

Some theme.json/global styles paths need resolving:

1. "ref" values, that point to other values in the theme.json tree
2. relative URI paths defined in theme.json, e.g., relative paths to theme images

Both these operations are performed every time the editor builds global styles CSS, however in two different locations:

1. `getStylesDeclarations()`
2. `useGlobalStylesOutputWithConfig()`

## How?

This PR consolidates resolution logic into a function `getResolvedValue()`, which is called in one place: `getStylesDeclarations()`

## Testing Instructions

There should be no regressions in the way "ref" or relative path resolution takes place in the editor.

1. theme.json refs should still work (with the exception of background styles, which will receive support in https://github.com/WordPress/gutenberg/pull/64128)
2. relative path background image URIs should display in the editor, including in the background style controls

To test, create a theme.json file with some ref pointers and a relative path background image. Here are some examples:

<details>

<summary>Example block.html</summary>

```html

<!-- wp:verse {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"textColor":"white","fontSize":"large"} -->
<pre class="wp-block-verse has-white-color has-text-color has-link-color has-large-font-size">Verse</pre>
<!-- /wp:verse -->

<!-- wp:quote -->
<blockquote class="wp-block-quote"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"textColor":"white","fontSize":"large"} -->
<p class="has-white-color has-text-color has-link-color has-large-font-size">Quote</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

```

</details>


<details>

<summary>Example theme.json</summary>

```json

{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"color": {
			"text": "Salmon",
			"background": "DodgerBlue"
		},
		"blocks": {
			"core/verse": {
				"color": {
					"text": {
						"ref": "styles.color.background"
					},
					"background": {
						"ref": "styles.color.text"
					}
				}
			},
			"core/quote": {
				"color": {
					"text": {
						"ref": "styles.color.text"
					}
				},
				"background": {
					"backgroundImage": {
						"url": "file:./img/1024x768_emptytheme_test_image.jpg"
					}
				},
				"dimensions": {
					"minHeight": "100px"
				}
			}
		}
	}
}


```

</details>

Then check the post and site editors.

Can you:

- See the resolved styles/images?
- Still update global and block styles as expected?



Also, run the tests!

```
npm run test:unit packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
npm run test:unit packages/block-editor/src/components/global-styles/test/utils.js 
npm run test:unit packages/style-engine/src/test  
```
