### PR TITLE
Text case: Change "No Title" to "No title".

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -73,7 +73,7 @@ export default function PostTitleEdit( {
 		titleElement = userCanEdit ? (
 			<PlainText
 				tagName={ TagName }
-				placeholder={ __( 'No Title' ) }
+				placeholder={ __( 'No title' ) }
 				value={ rawTitle }
 				onChange={ setTitle }
 				__experimentalVersion={ 2 }
@@ -96,7 +96,7 @@ export default function PostTitleEdit( {
 					href={ link }
 					target={ linkTarget }
 					rel={ rel }
-					placeholder={ ! rawTitle.length ? __( 'No Title' ) : null }
+					placeholder={ ! rawTitle.length ? __( 'No title' ) : null }
 					value={ rawTitle }
 					onChange={ setTitle }
 					__experimentalVersion={ 2 }

--- a/packages/editor/src/components/blog-title/index.js
+++ b/packages/editor/src/components/blog-title/index.js
@@ -111,7 +111,7 @@ export default function BlogTitle() {
 							onClose={ onClose }
 						/>
 						<InputControl
-							placeholder={ __( 'No Title' ) }
+							placeholder={ __( 'No title' ) }
 							size="__unstable-large"
 							value={ postsPageTitle }
 							onChange={ debounce( setPostsPageTitle, 300 ) }

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -200,7 +200,7 @@ export default function DocumentBar( props ) {
 						>
 							{ title
 								? decodeEntities( title )
-								: __( 'No Title' ) }
+								: __( 'No title' ) }
 						</Text>
 					</motion.div>
 					<span className="editor-document-bar__shortcut">

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -101,7 +101,7 @@ export default function PostCardPanel( { actions } ) {
 					as="h2"
 					lineHeight="20px"
 				>
-					{ title ? decodeEntities( title ) : __( 'No Title' ) }
+					{ title ? decodeEntities( title ) : __( 'No title' ) }
 					{ isFrontPage && (
 						<span className="editor-post-card-panel__title-badge">
 							{ __( 'Homepage' ) }

--- a/test/e2e/specs/editor/various/sidebar.spec.js
+++ b/test/e2e/specs/editor/various/sidebar.spec.js
@@ -111,7 +111,7 @@ test.describe( 'Sidebar', () => {
 			.getByRole( 'heading', { level: 2 } );
 
 		await expect( documentSettingsPanels ).toHaveText( [
-			'No Title',
+			'No title',
 			'Categories',
 			'Tags',
 		] );


### PR DESCRIPTION
## What?

There are some inconsistencies in title case vs. sentence case:


![Screenshot 2024-08-02 at 09 27 31](https://github.com/user-attachments/assets/221819d2-b258-4d55-91c2-dadbf01518b6)

![Screenshot 2024-08-02 at 09 33 08](https://github.com/user-attachments/assets/b602164b-3b7c-4228-9684-4f449239c71f)

The established best practice is sentence case with capital proper nouns. This PR fixes that:

![Screenshot 2024-08-02 at 09 30 01](https://github.com/user-attachments/assets/21940646-2c83-4d0d-b213-6cb2dd5b725e)

## Testing Instructions

Test the editor(s) and create a new page or post with an empty title. The text case should be "No title".