### PR TITLE
Fix density slider minus to be correct.

### DIFF
--- a/packages/dataviews/src/layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/layouts/grid/density-picker.tsx
@@ -4,7 +4,7 @@
 import { RangeControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { plus, lineSolid } from '@wordpress/icons';
+import { plus, reset } from '@wordpress/icons';
 import { useEffect } from '@wordpress/element';
 
 const viewportBreaks = {
@@ -90,7 +90,7 @@ export default function DensityPicker( {
 		<>
 			<Button
 				size="compact"
-				icon={ lineSolid }
+				icon={ reset }
 				disabled={ rangeValue <= 0 }
 				accessibleWhenDisabled
 				label={ __( 'Decrease size' ) }


### PR DESCRIPTION
## What?

The icon for the minus in the new density slider is incorrect:

![Screenshot 2024-08-02 at 09 36 43](https://github.com/user-attachments/assets/cb2b1674-9d7e-4432-929d-36716c814692)

It's too big. It's a line, not a minus.

This PR updates it to be the correct one:

![Screenshot 2024-08-02 at 09 36 51](https://github.com/user-attachments/assets/f77ab821-856a-4581-806c-da6e2c4989ab)

That's the "reset" icon, which is designed to be a minus that matches the add/plus icon.

## Testing Instructions

Go to the site editor > Templates, view the new density slider with the correct minus icon.