### PR TITLE
Grid: Unset the rowStart and columnStart attributes when a block is removed from a manual layout

### DIFF
--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -152,7 +152,7 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 						columnSpan,
 						rowSpan,
 						...layout
-					} = attributes?.style?.layout;
+					} = attributes.style?.layout ?? {};
 
 					if ( columnStart || rowStart || columnSpan || rowSpan ) {
 						const hasEmptyLayoutAttribute =
@@ -173,8 +173,8 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 				for ( const clientId of blockOrder ) {
 					const attributes = getBlockAttributes( clientId );
 					const { columnStart, rowStart, ...layout } =
-						attributes?.style?.layout;
-
+						attributes.style?.layout ?? {};
+					// Only update attributes if columnStart or rowStart are set.
 					if ( columnStart || rowStart ) {
 						const hasEmptyLayoutAttribute =
 							Object.keys( layout ).length === 0;
@@ -208,12 +208,14 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			);
 		}
 	}, [
+		// Actual deps to sync:
 		gridClientId,
 		gridLayout,
 		previousBlockOrder,
 		blockOrder,
 		previouslySelectedBlockRect,
 		previousIsManualPlacement,
+		// These won't change, but the linter thinks they might:
 		__unstableMarkNextChangeAsNotPersistent,
 		getBlockAttributes,
 		getBlockRootClientId,

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -11,6 +11,10 @@ import { usePrevious } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../store';
 import { GridRect } from './utils';
 
+const UNSET_GRID_ATTRIBUTES = {
+	style: { layout: { rowStart: undefined, columnStart: undefined } },
+};
+
 export function useGridLayoutSync( { clientId: gridClientId } ) {
 	const { gridLayout, blockOrder, selectedBlockLayout } = useSelect(
 		( select ) => {
@@ -40,6 +44,7 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 	const previousIsManualPlacement = usePrevious(
 		gridLayout.isManualPlacement
 	);
+	const previousBlockOrder = usePrevious( blockOrder );
 
 	useEffect( () => {
 		const updates = {};
@@ -123,6 +128,14 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 					},
 				};
 			}
+
+			// Unset the columnStart/rowStart attributes for blocks removed
+			// from the grid.
+			previousBlockOrder?.forEach( ( clientId ) => {
+				if ( ! blockOrder.includes( clientId ) ) {
+					updates[ clientId ] = UNSET_GRID_ATTRIBUTES;
+				}
+			} );
 		} else {
 			// Remove all of the columnStart and rowStart values
 			// when switching from manual to auto mode,
@@ -166,6 +179,7 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 		// Actual deps to sync:
 		gridClientId,
 		gridLayout,
+		previousBlockOrder,
 		blockOrder,
 		previouslySelectedBlockRect,
 		previousIsManualPlacement,

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -18,15 +18,33 @@ import { GridRect } from './utils';
  * Will return `undefined` when the attributes are already not set indicating
  * there's nothing to do.
  *
- * @param {Object} attributes The current block attributes.
+ * @param {Object}  attributes          The current block attributes.
+ * @param {boolean} unsetSpanAttributes Whether rowSpan and columnSpans should
+ *                                      also be unset.
  *
  * @return {undefined|Object} The attribute updates or `undefined` when the
  *                            attribute are already not set.
  */
-function unsetGridPositionAttributes( attributes ) {
-	const { columnStart, rowStart, columnSpan, rowSpan, ...layout } =
-		attributes.style?.layout ?? {};
-	if ( columnStart || rowStart || columnSpan || rowSpan ) {
+function unsetGridPositionAttributes(
+	attributes,
+	unsetSpanAttributes = false
+) {
+	let layout;
+	let hasUpdate;
+
+	if ( unsetSpanAttributes ) {
+		const { columnStart, rowStart, columnSpan, rowSpan, ...restLayout } =
+			attributes.style?.layout ?? {};
+		layout = restLayout;
+		hasUpdate = !! columnStart || rowStart || columnSpan || rowSpan;
+	} else {
+		const { columnStart, rowStart, ...restLayout } =
+			attributes.style?.layout ?? {};
+		layout = restLayout;
+		hasUpdate = !! columnStart || rowStart;
+	}
+
+	if ( hasUpdate ) {
 		if ( ! Object.keys( layout ).length ) {
 			return { style: { ...attributes.style, layout: undefined } };
 		}
@@ -155,7 +173,11 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			previousBlockOrder?.forEach( ( clientId ) => {
 				if ( ! blockOrder.includes( clientId ) ) {
 					const attributes = getBlockAttributes( clientId );
-					const update = unsetGridPositionAttributes( attributes );
+					const unsetSpanAttributes = true;
+					const update = unsetGridPositionAttributes(
+						attributes,
+						unsetSpanAttributes
+					);
 					if ( update ) {
 						updates[ clientId ] = update;
 					}

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -24,9 +24,9 @@ import { GridRect } from './utils';
  *                            attribute are already not set.
  */
 function unsetGridPositionAttributes( attributes ) {
-	const { columnStart, rowStart, ...layout } = attributes.style?.layout ?? {};
-	// Only update attributes if columnStart or rowStart are set.
-	if ( columnStart || rowStart ) {
+	const { columnStart, rowStart, columnSpan, rowSpan, ...layout } =
+		attributes.style?.layout ?? {};
+	if ( columnStart || rowStart || columnSpan || rowSpan ) {
 		if ( ! Object.keys( layout ).length ) {
 			return { style: { ...attributes.style, layout: undefined } };
 		}

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -128,13 +128,13 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			}
 
 			// Unset grid layout attributes for blocks removed from the grid.
-			previousBlockOrder?.forEach( ( clientId ) => {
+			for ( const clientId of previousBlockOrder ?? [] ) {
 				if ( ! blockOrder.includes( clientId ) ) {
 					const rootClientId = getBlockRootClientId( clientId );
 
 					// Block was removed from the editor, so nothing to do.
 					if ( rootClientId === null ) {
-						return;
+						continue;
 					}
 
 					// Check if the block is being moved to another grid.
@@ -142,7 +142,7 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 					// the attributes.
 					const rootAttributes = getBlockAttributes( rootClientId );
 					if ( rootAttributes?.layout?.type === 'grid' ) {
-						return;
+						continue;
 					}
 
 					const attributes = getBlockAttributes( clientId );
@@ -165,7 +165,7 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 						);
 					}
 				}
-			} );
+			}
 		} else {
 			// Remove all of the columnStart and rowStart values
 			// when switching from manual to auto mode,

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -27,11 +27,11 @@ function unsetGridPositionAttributes( attributes ) {
 	const { columnStart, rowStart, ...layout } = attributes.style?.layout ?? {};
 	// Only update attributes if columnStart or rowStart are set.
 	if ( columnStart || rowStart ) {
+		if ( ! Object.keys( layout ).length ) {
+			return { style: { ...attributes.style, layout: undefined } };
+		}
 		return {
-			style: {
-				...attributes.style,
-				layout,
-			},
+			style: { ...attributes.style, layout },
 		};
 	}
 }

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -154,14 +154,16 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 						...layout
 					} = attributes?.style?.layout;
 
-					const hasEmptyLayoutAttribute =
-						Object.keys( layout ).length === 0;
+					if ( columnStart || rowStart || columnSpan || rowSpan ) {
+						const hasEmptyLayoutAttribute =
+							Object.keys( layout ).length === 0;
 
-					updates[ clientId ] = setImmutably(
-						attributes,
-						[ 'style', 'layout' ],
-						hasEmptyLayoutAttribute ? undefined : layout
-					);
+						updates[ clientId ] = setImmutably(
+							attributes,
+							[ 'style', 'layout' ],
+							hasEmptyLayoutAttribute ? undefined : layout
+						);
+					}
 				}
 			} );
 		} else {
@@ -173,14 +175,16 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 					const { columnStart, rowStart, ...layout } =
 						attributes?.style?.layout;
 
-					const hasEmptyLayoutAttribute =
-						Object.keys( layout ).length === 0;
+					if ( columnStart || rowStart ) {
+						const hasEmptyLayoutAttribute =
+							Object.keys( layout ).length === 0;
 
-					updates[ clientId ] = setImmutably(
-						attributes,
-						[ 'style', 'layout' ],
-						hasEmptyLayoutAttribute ? undefined : layout
-					);
+						updates[ clientId ] = setImmutably(
+							attributes,
+							[ 'style', 'layout' ],
+							hasEmptyLayoutAttribute ? undefined : layout
+						);
+					}
 				}
 			}
 

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -11,6 +11,18 @@ import { usePrevious } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../store';
 import { GridRect } from './utils';
 
+/**
+ * Returns an attributes 'update' object for unsetting columnStart and rowStart
+ * `styles.layout` attributes.
+ *
+ * Will return `undefined` when the attributes are already not set indicating
+ * there's nothing to do.
+ *
+ * @param {Object} attributes The current block attributes.
+ *
+ * @return {undefined|Object} The attribute updates or `undefined` when the
+ *                            attribute are already not set.
+ */
 function unsetGridPositionAttributes( attributes ) {
 	const { columnStart, rowStart, ...layout } = attributes.style?.layout ?? {};
 	// Only update attributes if columnStart or rowStart are set.

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -137,23 +137,21 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 						return;
 					}
 
+					// Check if the block is being moved to another grid.
+					// If so, do nothing and let the new grid parent handle
+					// the attributes.
 					const rootAttributes = getBlockAttributes( rootClientId );
-					const newLayoutIsGrid =
-						rootAttributes?.layout?.type === 'grid';
+					if ( rootAttributes?.layout?.type === 'grid' ) {
+						return;
+					}
+
 					const attributes = getBlockAttributes( clientId );
-					// If the block is moving from one grid layout to another,
-					// keep the span attributes for use in the target grid.
-					const attributesToUnset = newLayoutIsGrid
-						? [
-								[ 'style', 'layout', 'columnStart' ],
-								[ 'style', 'layout', 'rowStart' ],
-						  ]
-						: [
-								[ 'style', 'layout', 'columnStart' ],
-								[ 'style', 'layout', 'rowStart' ],
-								[ 'style', 'layout', 'columnSpan' ],
-								[ 'style', 'layout', 'rowSpan' ],
-						  ];
+					const attributesToUnset = [
+						[ 'style', 'layout', 'columnStart' ],
+						[ 'style', 'layout', 'rowStart' ],
+						[ 'style', 'layout', 'columnSpan' ],
+						[ 'style', 'layout', 'rowSpan' ],
+					];
 					const updatedAttributes = attributesToUnset.reduce(
 						( attrs, path ) =>
 							setImmutably( attrs, path, undefined ),

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -146,18 +146,22 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 					}
 
 					const attributes = getBlockAttributes( clientId );
-					const attributesToUnset = [
-						[ 'style', 'layout', 'columnStart' ],
-						[ 'style', 'layout', 'rowStart' ],
-						[ 'style', 'layout', 'columnSpan' ],
-						[ 'style', 'layout', 'rowSpan' ],
-					];
-					const updatedAttributes = attributesToUnset.reduce(
-						( attrs, path ) =>
-							setImmutably( attrs, path, undefined ),
-						attributes
+					const {
+						columnStart,
+						rowStart,
+						columnSpan,
+						rowSpan,
+						...layout
+					} = attributes?.style?.layout;
+
+					const hasEmptyLayoutAttribute =
+						Object.keys( layout ).length === 0;
+
+					updates[ clientId ] = setImmutably(
+						attributes,
+						[ 'style', 'layout' ],
+						hasEmptyLayoutAttribute ? undefined : layout
 					);
-					updates[ clientId ] = updatedAttributes;
 				}
 			} );
 		} else {
@@ -166,16 +170,17 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			if ( previousIsManualPlacement === true ) {
 				for ( const clientId of blockOrder ) {
 					const attributes = getBlockAttributes( clientId );
-					const attributesToUnset = [
-						[ 'style', 'layout', 'columnStart' ],
-						[ 'style', 'layout', 'rowStart' ],
-					];
-					const updatedAttributes = attributesToUnset.reduce(
-						( attrs, path ) =>
-							setImmutably( attrs, path, undefined ),
-						attributes
+					const { columnStart, rowStart, ...layout } =
+						attributes?.style?.layout;
+
+					const hasEmptyLayoutAttribute =
+						Object.keys( layout ).length === 0;
+
+					updates[ clientId ] = setImmutably(
+						attributes,
+						[ 'style', 'layout' ],
+						hasEmptyLayoutAttribute ? undefined : layout
 					);
-					updates[ clientId ] = updatedAttributes;
 				}
 			}
 
@@ -199,16 +204,15 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 			);
 		}
 	}, [
-		// Actual deps to sync:
 		gridClientId,
 		gridLayout,
 		previousBlockOrder,
 		blockOrder,
 		previouslySelectedBlockRect,
 		previousIsManualPlacement,
-		// These won't change, but the linter thinks they might:
 		__unstableMarkNextChangeAsNotPersistent,
 		getBlockAttributes,
+		getBlockRootClientId,
 		updateBlockAttributes,
 	] );
 }


### PR DESCRIPTION
## What?
Fixes #63973

Unset the rowStart and columnStart attributes when a block is removed from a manual grid layout.

## How?
Employs `usePrevious` to keep track of the previous `blockOrder`, then looks for blocks that were there but aren't any longer in the `useGridLayoutSync` effect.

## Testing Instructions
1. Add a grid block
2. Set the grid block to 'Manual' mode
3. Add some blocks to the grid
4. In the code editor, note that the blocks you added have rowStart and columnStart attributes
5. Go back to visual editor mode and remove the inner blocks from the grid
6. In the code editor mode, note that the blocks no longer have rowStart and columnStart attributes

Other things to try
- Dragging from one grid to another
