### PR TITLE
Try: 1.5px styles icon circle.

### DIFF
--- a/packages/icons/src/library/styles.js
+++ b/packages/icons/src/library/styles.js
@@ -5,7 +5,11 @@ import { Path, SVG } from '@wordpress/primitives';
 
 export const styles = (
 	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-		<Path d="M12 4c-4.4 0-8 3.6-8 8v.1c0 4.1 3.2 7.5 7.2 7.9h.8c4.4 0 8-3.6 8-8s-3.6-8-8-8zm0 15V5c3.9 0 7 3.1 7 7s-3.1 7-7 7z" />
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M20 12a8 8 0 1 1-16 0 8 8 0 0 1 16 0Zm-1.5 0a6.5 6.5 0 0 1-6.5 6.5v-13a6.5 6.5 0 0 1 6.5 6.5Z"
+		/>
 	</SVG>
 );
 


### PR DESCRIPTION
## What?

Draft. This one is not as obvious as it seems. 

What I noticed was that the Styles icon uses a 1px stroke-width for the outer circle:

![Screenshot 2024-08-02 at 09 41 54](https://github.com/user-attachments/assets/cf3c3605-62c0-4192-96b4-2dab1eb054af)

This is a divergence from the standard 1.5px stroke-width we apply in general to outline icons:

![Screenshot 2024-08-02 at 09 43 03](https://github.com/user-attachments/assets/3fc5df62-d17a-4ff9-810b-a6ce12ae82f7)

And yet, there's something about this icon that isn't necessarily obviously improved by making this stroke-width the same 1.5px size as others:

![Screenshot 2024-08-02 at 09 42 15](https://github.com/user-attachments/assets/d8827a28-cdc4-49eb-bc16-2b798ed4f1ee)

This is mostly visible in context. Before:

![before](https://github.com/user-attachments/assets/ca017ad3-b3e0-4ef6-ba1d-610cb4b1bd99)

After:

![after](https://github.com/user-attachments/assets/ce791298-de50-46fd-89c6-39760e705aa8)


## Why?

I tend to think that this one feels awkward to me primarily because we've been looking at the old icon so much at this point. That objectively the correct stroke width of 1.5px is a better fit in context of the icons next to it (I can't unsee the differential now), but that subjectively, the icon loses a little bit of character with the thicker stroke-width.

What do you think?

Personal take: we should do it. It seems likely to eventually be a non-issue, since I expect the global styles sidebar to evolve and shift in how it's invoked, and that the consistency across is probably worth it. But it's not a strong opinion.

## Testing Instructions

Go to the site editor, observe the global styles icon.