### PR TITLE
Update column input to be default 40px.

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -33,7 +33,6 @@ function ColumnInspectorControls( { width, setAttributes } ) {
 		<PanelBody title={ __( 'Settings' ) }>
 			<UnitControl
 				label={ __( 'Width' ) }
-				labelPosition="edge"
 				__unstableInputWidth="calc(50% - 8px)"
 				__next40pxDefaultSize
 				value={ width || '' }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -34,7 +34,8 @@ function ColumnInspectorControls( { width, setAttributes } ) {
 			<UnitControl
 				label={ __( 'Width' ) }
 				labelPosition="edge"
-				__unstableInputWidth="80px"
+				__unstableInputWidth="calc(50% - 8px)"
+				__next40pxDefaultSize
 				value={ width || '' }
 				onChange={ ( nextWidth ) => {
 					nextWidth = 0 > parseFloat( nextWidth ) ? '0' : nextWidth;


### PR DESCRIPTION
## What?

The column width input height is incorrect:

![Screenshot 2024-08-02 at 09 54 11](https://github.com/user-attachments/assets/8923e1ad-6bd2-4007-9cad-706ed2e924d3)

This fixes it:

![Screenshot 2024-08-02 at 09 58 31](https://github.com/user-attachments/assets/e5a3b061-6b85-47a7-916e-ec2728613182)

There's a related conversation around width here: https://github.com/WordPress/gutenberg/pull/62742#discussion_r1648923985

## Testing Instructions

Insert a columns block. Select a column, and observe the width input in the inspector.