### PR TITLE
Icons: Fix invalid prop for `homeButton` icon

### DIFF
--- a/packages/icons/src/library/home-button.js
+++ b/packages/icons/src/library/home-button.js
@@ -6,8 +6,8 @@ import { SVG, Path } from '@wordpress/primitives';
 const homeButton = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
-			fill-rule="evenodd"
-			clip-rule="evenodd"
+			fillRule="evenodd"
+			clipRule="evenodd"
 			d="M4.25 7A2.75 2.75 0 0 1 7 4.25h10A2.75 2.75 0 0 1 19.75 7v10A2.75 2.75 0 0 1 17 19.75H7A2.75 2.75 0 0 1 4.25 17V7ZM7 5.75c-.69 0-1.25.56-1.25 1.25v10c0 .69.56 1.25 1.25 1.25h10c.69 0 1.25-.56 1.25-1.25V7c0-.69-.56-1.25-1.25-1.25H7Z"
 		/>
 	</SVG>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes invalid prop for `homeButton` icon.

![image](https://github.com/user-attachments/assets/9cf429e1-2c4e-4e22-aca0-80e1dea1eb41)

## Why?

Since this is actually a React element, `fill-rule` and `clip-rule` will cause a browser warning. We'll need to replace them with `fillRule` and `clipRule`.

## Testing Instructions

Open the site editor and verify that there are no errors displayed in the browser console.