### PR TITLE
Zoom Out: Default the inserter to the patterns tab when in zoom out

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,9 +67,16 @@ function InserterMenu(
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
-	const [ selectedTab, setSelectedTab ] = useState(
-		__experimentalInitialTab
-	);
+	function getInitialTab() {
+		if ( __experimentalInitialTab ) {
+			return __experimentalInitialTab;
+		}
+
+		if ( isZoomOutMode ) {
+			return 'patterns';
+		}
+	}
+	const [ selectedTab, setSelectedTab ] = useState( getInitialTab() );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Change the default inserter tab to Patterns when in Zoom Out mode.

## Why?
Suggested in https://github.com/WordPress/gutenberg/pull/63870. Zoom Out mode is optimised for adding patterns, so it makes sense to default to the patterns tab in this instance.

## How?
If an `__experimentalInitialCategory` is not supplied, and zoom out mode is set, set the default state of the inserter to `patterns`.

## Testing Instructions
1. Open the Site Editor
2. Open Global Styles
3. Open Browse Styles
4. Zoom out mode should be invoked
5. Open the inserter
6. The patterns should be open

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9a4a9279-7dc8-44b6-97a2-771649ab039d

