### PR TITLE
Grid perf: Avoid iterating auto grid inner blocks unless mode specifically changed

### DIFF
--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -124,8 +124,8 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 				};
 			}
 		} else {
-			// When in switching from manual to auto mode,
-			// remove all of the columnStart and rowStart values.
+			// Remove all of the columnStart and rowStart values
+			// when switching from manual to auto mode,
 			if ( previousIsManualPlacement === true ) {
 				for ( const clientId of blockOrder ) {
 					const attributes = getBlockAttributes( clientId );

--- a/packages/block-editor/src/components/grid/use-grid-layout-sync.js
+++ b/packages/block-editor/src/components/grid/use-grid-layout-sync.js
@@ -37,6 +37,9 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 	);
 
 	const previouslySelectedBlockRect = usePrevious( selectedBlockRect );
+	const previousIsManualPlacement = usePrevious(
+		gridLayout.isManualPlacement
+	);
 
 	useEffect( () => {
 		const updates = {};
@@ -121,19 +124,22 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 				};
 			}
 		} else {
-			// When in auto mode, remove all of the columnStart and rowStart values.
-			for ( const clientId of blockOrder ) {
-				const attributes = getBlockAttributes( clientId );
-				const { columnStart, rowStart, ...layout } =
-					attributes.style?.layout ?? {};
-				// Only update attributes if columnStart or rowStart are set.
-				if ( columnStart || rowStart ) {
-					updates[ clientId ] = {
-						style: {
-							...attributes.style,
-							layout,
-						},
-					};
+			// When in switching from manual to auto mode,
+			// remove all of the columnStart and rowStart values.
+			if ( previousIsManualPlacement === true ) {
+				for ( const clientId of blockOrder ) {
+					const attributes = getBlockAttributes( clientId );
+					const { columnStart, rowStart, ...layout } =
+						attributes.style?.layout ?? {};
+					// Only update attributes if columnStart or rowStart are set.
+					if ( columnStart || rowStart ) {
+						updates[ clientId ] = {
+							style: {
+								...attributes.style,
+								layout,
+							},
+						};
+					}
 				}
 			}
 
@@ -162,6 +168,7 @@ export function useGridLayoutSync( { clientId: gridClientId } ) {
 		gridLayout,
 		blockOrder,
 		previouslySelectedBlockRect,
+		previousIsManualPlacement,
 		// These won't change, but the linter thinks they might:
 		__unstableMarkNextChangeAsNotPersistent,
 		getBlockAttributes,


### PR DESCRIPTION
## What?
I noticed when working on #64186 that the code always iterates through `innerBlocks` in Auto grid mode to check whether the `rowIndex` and `columnIndex` attributes should be unset.

In practice the attributes only need to be unset when the grid mode changes from 'Manual' to 'Auto' (`gridLayout.isManualPlacement` value), so I think there's a little performance gain that can be made here.

## How?
Tracks the previous grid mode using `usePrevious`, and then only executes the iteration and unsetting of the attribute when `isManualPlacement` is `false` but was `true`.

An alternative option (probably better?) might be to move this code out of `useGridLayoutSync` and into the `onChange` callback of the grid mode toggle? I only just thought of that though and I've already written this code, so I'll wait to see what the PR feedback is. 😄 

## Testing Instructions
It should work exactly like in `trunk`:
1. Add a grid block
2. Set the grid block to 'Manual' mode
3. Add some blocks to the grid
4. In the code editor, note that the blocks you added have rowStart and columnStart attributes
5. Go back to visual editor mode and switch to 'Auto' mode
6. In the code editor mode, note that the blocks no longer have rowStart and columnStart attributes

