### PR TITLE
Stabilize the PreSavePost and SavePost filters

### DIFF
--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -8,7 +8,7 @@ import {
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
-import { addFilter } from '@wordpress/hooks';
+import { addAction } from '@wordpress/hooks';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -478,21 +478,14 @@ export const initializeMetaBoxes =
 		metaBoxesInitialized = true;
 
 		// Save metaboxes on save completion, except for autosaves.
-		addFilter(
-			'editor.__unstableSavePost',
+		addAction(
+			'editor.savePost',
 			'core/edit-post/save-metaboxes',
-			( previous, options ) =>
-				previous.then( () => {
-					if ( options.isAutosave ) {
-						return;
-					}
-
-					if ( ! select.hasMetaBoxes() ) {
-						return;
-					}
-
-					return dispatch.requestMetaBoxUpdates();
-				} )
+			async ( options ) => {
+				if ( ! options.isAutosave && select.hasMetaBoxes() ) {
+					await dispatch.requestMetaBoxUpdates();
+				}
+			}
 		);
 
 		dispatch( {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -200,7 +200,7 @@ export const savePost =
 		let error = false;
 		try {
 			edits = await applyFilters(
-				'editor.PreSavePost',
+				'editor.preSavePost',
 				Promise.resolve( edits ),
 				options
 			);
@@ -252,7 +252,7 @@ export const savePost =
 		if ( ! error ) {
 			try {
 				await applyFilters(
-					'editor.SavePost',
+					'editor.savePost',
 					Promise.resolve(),
 					options
 				);

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -12,7 +12,11 @@ import {
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
-import { applyFilters } from '@wordpress/hooks';
+import {
+	applyFilters,
+	applyFiltersAsync,
+	doActionAsync,
+} from '@wordpress/hooks';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { __ } from '@wordpress/i18n';
 
@@ -199,9 +203,9 @@ export const savePost =
 
 		let error = false;
 		try {
-			edits = await applyFilters(
+			edits = await applyFiltersAsync(
 				'editor.preSavePost',
-				Promise.resolve( edits ),
+				edits,
 				options
 			);
 		} catch ( err ) {
@@ -251,11 +255,7 @@ export const savePost =
 
 		if ( ! error ) {
 			try {
-				await applyFilters(
-					'editor.savePost',
-					Promise.resolve(),
-					options
-				);
+				await doActionAsync( 'editor.savePost', options );
 			} catch ( err ) {
 				error = err;
 			}


### PR DESCRIPTION
Followup to #58022 which stabilizes the filter names as `editor.preSavePost` and `editor.savePost`, removing the `__unstable` prefixes. The old `editor.__unstableSavePost` filter continues to work because it's been there for some time.

I'm also changing the behavior a little bit:
- passing `edits` as the first parameter of the filter
- the return value of the filter are filtered `edits`, not an error. You need to throw or return a rejected promise to signal error.

This example from #58022 no longer works:
```js
wp.hooks.addFilter( 'editor.PreSavePost', 'editor', () => {
  return Promise.resolve( { message: "This is the error message." } );
} );
```
The right thing to do is now:
```js
wp.hooks.addFilter( 'editor.preSavePost', 'editor', ( edits ) => {
  return Promise.reject( { message: "This is the error message." } );
} );
```
or (the same thing with different syntax:
```js
wp.hooks.addFilter( 'editor.PreSavePost', 'editor', async ( edits ) => {
  throw { message: "This is the error message." };
} );
```

Now when the `hooks` package supports [async hooks](https://github.com/WordPress/gutenberg/pull/64204), I also turned the `preSavePost` filter into an async filter, and `savePost` can now be an action. Because it doesn't need to pass the promise from the previous handler and wait for it, it's all handled by the framework in `doAsyncAction`.