### PR TITLE
DropdownMenuV2: Try non-modal

### DIFF
--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -194,7 +194,8 @@ const UnconnectedDropdownMenu = (
 		gutter,
 		children,
 		shift,
-		modal = true,
+		modal = false,
+		portal = true,
 
 		// From internal components context
 		variant,
@@ -314,6 +315,7 @@ const UnconnectedDropdownMenu = (
 			<Styled.DropdownMenu
 				{ ...otherProps }
 				modal={ modal }
+				portal={ portal }
 				store={ dropdownMenuStore }
 				// Root menu has an 8px distance from its trigger,
 				// otherwise 0 (which causes the submenu to slightly overlap)

--- a/packages/components/src/dropdown-menu-v2/types.ts
+++ b/packages/components/src/dropdown-menu-v2/types.ts
@@ -45,9 +45,16 @@ export interface DropdownMenuProps {
 	 * outside elements will be disabled and only menu content will be visible to
 	 * screen readers.
 	 *
-	 * @default true
+	 * @default false
 	 */
 	modal?: boolean;
+	/**
+	 * Whether the element should be rendered as a React Portal.
+	 * When set to true will render the element at the end of the body element.
+	 *
+	 * @default true
+	 */
+	portal?: boolean;
 	/**
 	 * The placement of the dropdown menu popover.
 	 *


### PR DESCRIPTION
## What?
This PR is a quick demonstration of making the `DropdownMenuV2` non-modal by default. We're also enabling `portal` to solve some potential z-indexing issues - this is something we'll most likely need for non-modal popover components.

DO NOT MERGE - this PR is not ready for merge, it serves demonstration purposes.

## Why?
To help the discussion in https://github.com/WordPress/gutenberg/issues/63674 with understanding the concepts we're discussing.

## How?
* Making `DropdownMenuV2` non-modal by default.
* Making `DropdownMenuV2` render through a portal by default. 

## Testing Instructions
* Open the site editor
* Click on "Pages"
* Click on the "View Options" menu
* Verify the menu works well.
* While the options dropdown menu is opened:
  * Verify the menu appears well in terms of z-index (above everything else)
  * Verify the rest of the element tree is NOT inert
  * Verify you can scroll the body up and down.

Alternatively:
* Spin-up Storybook: `npm run storybook:dev`
* Open `DropdownMenuV2`: http://localhost:50240/?path=/docs/components-experimental-dropdownmenu-v2--docs
* Interact with the dropdown menu trigger.
* Verify the menu works well.
* While the dropdown menu is opened:
  * Verify the menu appears well in terms of z-index (above everything else)
  * Verify the rest of the element tree is NOT inert
  * Verify you can scroll the body up and down.

### Testing Instructions for Keyboard
* `TAB` into the dropdown menu to focus it
* Press `SPACE`, `ENTER`, `ARROWUP` or `ARROWDOWN` to open the menu.
* Navigate between items with the up/down arrows.

## Screenshots or screencast <!-- if applicable -->
None
