### PR TITLE
Edit Site: Use `structuredClone` for deep cloning

### DIFF
--- a/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
+++ b/packages/edit-site/src/hooks/push-changes-to-global-styles/index.js
@@ -26,7 +26,6 @@ import { store as coreStore } from '@wordpress/core-data';
  */
 import { useSupportedStyles } from '../../components/global-styles/hooks';
 import { unlock } from '../../lock-unlock';
-import cloneDeep from '../../utils/clone-deep';
 import setNestedValue from '../../utils/set-nested-value';
 
 const { cleanEmptyObject, GlobalStylesContext } = unlock(
@@ -259,8 +258,8 @@ function PushChangesToGlobalStylesControl( {
 		if ( changes.length > 0 ) {
 			const { style: blockStyles } = attributes;
 
-			const newBlockStyles = cloneDeep( blockStyles );
-			const newUserConfig = cloneDeep( userConfig );
+			const newBlockStyles = structuredClone( blockStyles );
+			const newUserConfig = structuredClone( userConfig );
 
 			for ( const { path, value } of changes ) {
 				setNestedValue( newBlockStyles, path, undefined );

--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -11,7 +11,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import cloneDeep from '../../utils/clone-deep';
 import { unlock } from '../../lock-unlock';
 
 const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
@@ -91,7 +90,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig(
 	const propertiesAsString = properties.toString();
 
 	return useMemo( () => {
-		const clonedUserVariation = cloneDeep( userVariation );
+		const clonedUserVariation = structuredClone( userVariation );
 
 		// Get user variation and remove the settings for the given property.
 		const userVariationWithoutProperties = removePropertiesFromObject(
@@ -167,7 +166,7 @@ export const filterObjectByProperties = ( object, properties ) => {
  */
 export function isVariationWithProperties( variation, properties ) {
 	const variationWithProperties = filterObjectByProperties(
-		cloneDeep( variation ),
+		structuredClone( variation ),
 		properties
 	);
 

--- a/packages/edit-site/src/utils/clone-deep.js
+++ b/packages/edit-site/src/utils/clone-deep.js
@@ -1,8 +1,0 @@
-/**
- * Makes a copy of an object without storing any references to the original object.
- * @param {Object} object
- * @return {Object} The cloned object.
- */
-export default function cloneDeep( object ) {
-	return ! object ? {} : JSON.parse( JSON.stringify( object ) );
-}


### PR DESCRIPTION
## What?
This PR replaces our custom deep cloning utility that was using the `JSON.parse( JSON.stringify( x ) )` dance with the globally available [`structuredClone`](https://developer.mozilla.org/en-US/docs/Web/API/structuredClone) that is currently [fully supported](https://caniuse.com/?search=structuredClone) by all browsers we support.

## Why?
There's no need to use the JSON dance when we can use a built-in function, that also better supports more value types.

We're following up on #43631 and cleaning up the custom utility we built back then which is now unnecessary.

## How?
We're essentially deleting the custom `cloneDeep` utility and replacing it with `structuredClone`.

## Testing Instructions
* Open the site editor
* Select a paragraph and change some styles (font-size, line-height, etc.)
* In the block inspector controls, open "Advanced" and click the "Apply globally" button.
* Go to global styles, open "Blocks" > "Paragraph" and verify the changes were applied correctly.
* Verify #62469 still tests well
* Verify #62847 still tests well.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None