### PR TITLE
Comment Date: Add Border Support

### DIFF
--- a/packages/block-library/src/comment-date/block.json
+++ b/packages/block-library/src/comment-date/block.json
@@ -47,6 +47,19 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
-	}
+	},
+	"style": "wp-block-comment-date"
 }

--- a/packages/block-library/src/comment-date/style.scss
+++ b/packages/block-library/src/comment-date/style.scss
@@ -1,0 +1,4 @@
+.wp-block-comment-date {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -10,6 +10,7 @@
 @import "./comments/style.scss";
 @import "./comments-pagination/style.scss";
 @import "./comment-template/style.scss";
+@import "./comment-date/style.scss";
 @import "./cover/style.scss";
 @import "./details/style.scss";
 @import "./embed/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Comment Date` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Comment Date` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Comment Date` block's border is Configurable via Global Styles.
- Edit template/page, Add  `Comment Date` block and Apply the border Styles.
- Verify that `Comment Date` block styles take precedence over global Styles.
- Verify that `Comment Date` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->
 

https://github.com/user-attachments/assets/cb270f32-83bc-47c4-b04d-de5b0688d548

