### PR TITLE
Primitives: Add missing peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54192,6 +54192,9 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0"
 			}
 		},
 		"packages/priority-queue": {

--- a/packages/primitives/package.json
+++ b/packages/primitives/package.json
@@ -35,6 +35,9 @@
 		"@wordpress/element": "file:../element",
 		"clsx": "^2.1.1"
 	},
+	"peerDependencies": {
+		"react": "^18.0.0"
+	},
 	"publishConfig": {
 		"access": "public"
 	}


### PR DESCRIPTION
## What?
Resolves #62250.

Add `react` peer dependency to the `@wordpress/primitives` package.


## Testing Instructions
Verify that the change makes sense.
