### PR TITLE
`ColorPalette`: partial support of `color-mix()` CSS colors

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Enhancements
 
+- `ColorPalette`: partial support of `color-mix()` CSS colors ([#64224](https://github.com/WordPress/gutenberg/pull/64224)).
 -   `TimeInput`: Expose as subcomponent of `TimePicker` ([#63145](https://github.com/WordPress/gutenberg/pull/63145)).
 -   `RadioControl`: add support for option help text ([#63751](https://github.com/WordPress/gutenberg/pull/63751)).
 -   `Guide`: Add `__next40pxDefaultSize` to buttons ([#64181](https://github.com/WordPress/gutenberg/pull/64181)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Enhancements
 
-- `ColorPalette`: partial support of `color-mix()` CSS colors ([#64224](https://github.com/WordPress/gutenberg/pull/64224)).
+-   `ColorPalette`: partial support of `color-mix()` CSS colors ([#64224](https://github.com/WordPress/gutenberg/pull/64224)).
 -   `TimeInput`: Expose as subcomponent of `TimePicker` ([#63145](https://github.com/WordPress/gutenberg/pull/63145)).
 -   `RadioControl`: add support for option help text ([#63751](https://github.com/WordPress/gutenberg/pull/63751)).
 -   `Guide`: Add `__next40pxDefaultSize` to buttons ([#64181](https://github.com/WordPress/gutenberg/pull/64181)).

--- a/packages/components/src/color-palette/utils.ts
+++ b/packages/components/src/color-palette/utils.ts
@@ -72,6 +72,18 @@ export const isMultiplePaletteArray = (
 };
 
 /**
+ * Checks if a color value is a simple CSS color.
+ *
+ * @param value The color value to check.
+ * @return A boolean indicating whether the color value is a simple CSS color.
+ */
+const isSimpleCSSColor = ( value: string | undefined ): boolean => {
+	const valueIsCssVariable = /var\(/.test( value ?? '' );
+	const valueIsColorMix = /color-mix\(/.test( value ?? '' );
+	return ! valueIsCssVariable && ! valueIsColorMix;
+};
+
+/**
  * Transform a CSS variable used as background color into the color value itself.
  *
  * @param value   The color value that may be a CSS variable.
@@ -82,10 +94,7 @@ export const normalizeColorValue = (
 	value: string | undefined,
 	element: HTMLElement | null
 ) => {
-	const valueIsCssVariable = /var\(/.test( value ?? '' );
-	const valueIsColorMix = /color-mix\(/.test( value ?? '' );
-
-	const valueIsSimpleColor = ! valueIsCssVariable && ! valueIsColorMix;
+	const valueIsSimpleColor = isSimpleCSSColor( value );
 
 	if ( valueIsSimpleColor || element === null ) {
 		return value;

--- a/packages/components/src/color-palette/utils.ts
+++ b/packages/components/src/color-palette/utils.ts
@@ -27,7 +27,7 @@ export const extractColorNameFromCurrentValue = (
 	}
 
 	const currentValueIsCssVariable = /^var\(/.test( currentValue );
-	const currentValueIsColorMix = /^color-mix\(.*\)$/.test( currentValue );
+	const currentValueIsColorMix = /color-mix\(/.test( currentValue );
 	const normalizedCurrentValue =
 		currentValueIsCssVariable || currentValueIsColorMix
 			? currentValue
@@ -82,9 +82,12 @@ export const normalizeColorValue = (
 	value: string | undefined,
 	element: HTMLElement | null
 ) => {
-	const currentValueIsCssVariable = /^var\(/.test( value ?? '' );
+	const valueIsCssVariable = /var\(/.test( value ?? '' );
+	const valueIsColorMix = /color-mix\(/.test( value ?? '' );
 
-	if ( ! currentValueIsCssVariable || element === null ) {
+	const valueIsSimpleColor = ! valueIsCssVariable && ! valueIsColorMix;
+
+	if ( valueIsSimpleColor || element === null ) {
 		return value;
 	}
 

--- a/packages/components/src/color-palette/utils.ts
+++ b/packages/components/src/color-palette/utils.ts
@@ -27,9 +27,11 @@ export const extractColorNameFromCurrentValue = (
 	}
 
 	const currentValueIsCssVariable = /^var\(/.test( currentValue );
-	const normalizedCurrentValue = currentValueIsCssVariable
-		? currentValue
-		: colord( currentValue ).toHex();
+	const currentValueIsColorMix = /^color-mix\(.*\)$/.test( currentValue );
+	const normalizedCurrentValue =
+		currentValueIsCssVariable || currentValueIsColorMix
+			? currentValue
+			: colord( currentValue ).toHex();
 
 	// Normalize format of `colors` to simplify the following loop
 	type normalizedPaletteObject = { colors: ColorObject[] };
@@ -38,9 +40,10 @@ export const extractColorNameFromCurrentValue = (
 		: [ { colors: colors as ColorObject[] } ];
 	for ( const { colors: paletteColors } of colorPalettes ) {
 		for ( const { name: colorName, color: colorValue } of paletteColors ) {
-			const normalizedColorValue = currentValueIsCssVariable
-				? colorValue
-				: colord( colorValue ).toHex();
+			const normalizedColorValue =
+				currentValueIsCssVariable || currentValueIsColorMix
+					? colorValue
+					: colord( colorValue ).toHex();
 
 			if ( normalizedCurrentValue === normalizedColorValue ) {
 				return colorName;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Why?
Users were facing issue with `ColorGradientsControl` showing incorrect labels using `color-mix` 

### What ? 

Related to https://github.com/WordPress/gutenberg/issues/64195

## How?
Solved this issue by adding `const currentValueIsColorMix = /^color-mix\(.*\)$/.test( currentValue );` to check for color-mix and using it logically in `normalizedCurrentValue` instead of converting `color-mix` value to hex which was giving the same label as only the transparency was changing but the color was same i.e `#000000`


## Testing Instructions
Copy the [color palette](https://github.com/WordPress/gutenberg/issues/64195) snippet in this issue to the theme.json.
Go to block editor (e.g. edit a page)
Select a block and try to change its color.
Try switching between the new colors and the selected label will always show 10% of Current Text.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/356e8015-316d-4660-9f8b-e2550926fe19

