### PR TITLE
Improve inline page parent docs.

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -222,12 +222,10 @@ function PostParentToggle( { isOpen, onClick } ) {
 }
 
 export function ParentRow() {
-	const { homeUrl } = useSelect( ( select ) => {
-		const { getUnstableBase } = select( coreStore );
-		return {
-			homeUrl: getUnstableBase()?.home,
-		};
-	}, [] );
+	const homeUrl = useSelect(
+		( select ) => select( coreStore ).getUnstableBase()?.home,
+		[]
+	);
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -262,14 +262,14 @@ export function ParentRow() {
 								sprintf(
 									/* translators: %1$s The home URL of the WordPress installation without the scheme. */
 									__(
-										'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be <span>%1$s</span><wbr />/services<wbr />/pricing.'
+										'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be %1$s<wbr />/services<wbr />/pricing.'
 									),
-									filterURLForDisplay( homeUrl )
+									filterURLForDisplay( homeUrl ).replace(
+										/([/.])/g,
+										'<wbr />$1'
+									)
 								),
 								{
-									span: (
-										<span className="editor-post-parent__panel-dialog__example-url" />
-									),
 									wbr: <wbr />,
 								}
 							) }

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -268,7 +268,7 @@ export function ParentRow() {
 								),
 								{
 									span: (
-										<span className="editor-post-parent__panel-dialog_example-url" />
+										<span className="editor-post-parent__panel-dialog__example-url" />
 									),
 									wbr: <wbr />,
 								}

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -217,6 +217,12 @@ function PostParentToggle( { isOpen, onClick } ) {
 }
 
 export function ParentRow() {
+	const { homeUrl } = useSelect( ( select ) => {
+		const { getUnstableBase } = select( coreStore );
+		return {
+			homeUrl: getUnstableBase()?.home,
+		};
+	}, [] );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -249,12 +255,15 @@ export function ParentRow() {
 							onClose={ onClose }
 						/>
 						<div>
-							{
-								/* translators: The domain name should be a reserved domain name to prevent linking to third party sites outside the WordPress project's control. You may also wish to use wordpress.org or a wordpress.org sub-domain. */
+							{ sprintf(
+								/* translators: %1$s The home URL of the WordPress installation without the scheme. */
 								__(
-									'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be example.org/services/pricing.'
-								)
-							}
+									'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be %1$s/services/pricing.'
+								),
+								homeUrl
+									.replace( /^https?:\/\//, '' )
+									.replace( /\/$/, '' )
+							) }
 							<p>
 								{ __(
 									'They also show up as sub-items in the default navigation menu. '

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -19,6 +19,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import { __experimentalInspectorPopoverHeader as InspectorPopoverHeader } from '@wordpress/block-editor';
+import { filterURLForDisplay } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -260,9 +261,7 @@ export function ParentRow() {
 								__(
 									'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be %1$s/services/pricing.'
 								),
-								homeUrl
-									.replace( /^https?:\/\//, '' )
-									.replace( /\/$/, '' )
+								filterURLForDisplay( homeUrl )
 							) }
 							<p>
 								{ __(

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -14,7 +14,11 @@ import {
 	ExternalLink,
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
-import { useState, useMemo } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useState,
+	useMemo,
+} from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
@@ -256,12 +260,20 @@ export function ParentRow() {
 							onClose={ onClose }
 						/>
 						<div>
-							{ sprintf(
-								/* translators: %1$s The home URL of the WordPress installation without the scheme. */
-								__(
-									'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be %1$s/services/pricing.'
+							{ createInterpolateElement(
+								sprintf(
+									/* translators: %1$s The home URL of the WordPress installation without the scheme. */
+									__(
+										'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be <span>%1$s</span><wbr />/services<wbr />/pricing.'
+									),
+									filterURLForDisplay( homeUrl )
 								),
-								filterURLForDisplay( homeUrl )
+								{
+									span: (
+										<span className="editor-post-parent__panel-dialog_example-url" />
+									),
+									wbr: <wbr />,
+								}
 							) }
 							<p>
 								{ __(

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -252,7 +252,7 @@ export function ParentRow() {
 							{
 								/* translators: The domain name should be a reserved domain name to prevent linking to third party sites outside the WordPress project's control. You may also wish to use wordpress.org or a wordpress.org sub-domain. */
 								__(
-									"Child pages inherit characteristics from their parent, such as URL structure. For instance, if 'Web Design' is a child of 'Services', its URL would be example.org/services/web-design."
+									'Child pages inherit characteristics from their parent, such as URL structure. For instance, if "Pricing" is a child of "Services", its URL would be example.org/services/pricing.'
 								)
 							}
 							<p>

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -18,6 +18,6 @@
 	}
 }
 
-.editor-post-parent__panel-dialog_example-url {
+.editor-post-parent__panel-dialog__example-url {
 	word-break: break-word;
 }

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -17,7 +17,3 @@
 		min-width: 320px;
 	}
 }
-
-.editor-post-parent__panel-dialog__example-url {
-	word-break: break-word;
-}

--- a/packages/editor/src/components/page-attributes/style.scss
+++ b/packages/editor/src/components/page-attributes/style.scss
@@ -17,3 +17,7 @@
 		min-width: 320px;
 	}
 }
+
+.editor-post-parent__panel-dialog_example-url {
+	word-break: break-word;
+}


### PR DESCRIPTION
## What?

* Uses an industry generic example of parent/child page relationship in page parent inline docs, updates the string to follow the WordPress documentation standards.
* Uses `homeURL` in place of example domain -- this was initially considered during #63154 but ultimately reverted pending feedback from the copy team

Fixes #63158

## Why?

The current example of "Web Design" being a child of "Services" is specific to one industry.

## How?

* Replaces example with "Pricing" is a child page of "Services"
* Uses double quotes per docs standards https://make.wordpress.org/docs/style-guide/punctuation/quotation-marks/
* Replace example domain with placeholder


## Testing Instructions

1. Create New Page
2. Click `Parent None` button
3. Review inline documentation in popup.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-08-06 at 8 27 51 AM](https://github.com/user-attachments/assets/a199efee-828e-4337-9419-c7a853ff4e60)


