### PR TITLE
BlockDraggable: Remove invalid aria-hidden attribute from button

### DIFF
--- a/packages/block-editor/src/components/block-mover/index.js
+++ b/packages/block-editor/src/components/block-mover/index.js
@@ -89,7 +89,6 @@ function BlockMover( {
 						<Button
 							icon={ dragHandle }
 							className="block-editor-block-mover__drag-handle"
-							aria-hidden="true"
 							label={ __( 'Drag' ) }
 							// Should not be able to tab to drag handle as this
 							// button can only be used with a pointer device.

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -259,7 +259,6 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 								<Button
 									icon={ dragHandle }
 									className="block-selection-button_drag-handle"
-									aria-hidden="true"
 									label={ dragHandleLabel }
 									// Should not be able to tab to drag handle as this
 									// button can only be used with a pointer device.

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -100,7 +100,6 @@ export default function ZoomOutToolbar( { clientId, rootClientId } ) {
 						<Button
 							icon={ dragHandle }
 							className="block-selection-button_drag-handle zoom-out-toolbar-button"
-							aria-hidden="true"
 							label={ __( 'Drag' ) }
 							iconSize={ 24 }
 							size="compact"


### PR DESCRIPTION
## What?

This PR fixes the following browser console error that occurs when interacting with a block drag handle with the mouse:

```
Blocked aria-hidden on a <button> element because the element that just received focus must not be hidden from assistive technology users.
Avoid using aria-hidden on a focused element or its ancestor.
Consider using the inert attribute instead, which will also prevent focus. For more details, see the aria-hidden section of the WAI-ARIA specification at https://w3c.github.io/aria/#aria-hidden. 
```

_Note:_ I saw this warning in Google Chrome 127.0.6533.89, and I don't understand why it's only happening now, since [this code](https://github.com/WordPress/gutenberg/blob/79b075293de8a763a5ea892406e53d92bfd2c63a/packages/block-editor/src/components/block-mover/index.js#L92) has been around for several years 🤷‍♂️ `StrictMode` enabled in #61943 does not appear to be related to this issue.

https://github.com/user-attachments/assets/f41c3943-085f-4920-8bf6-b55892f06224

## Why?

We should not apply `aria-hidden="true"` to focusable elements.

## How?

Delete `aria-hidden="true"`. Since `tabIndex` is `-1`, we should not be able to tab to the drag handle as before.

## Testing Instructions

- Beforehand, enable "Enable zoomed out view when patterns are browsed in the inserter" on the experiment page.
- Verify that the browser does not display a warning when moving the block drag handle with the mouse in these three scenarios:
  - In edit mode
  - After inserting a pattern
  - In select mode 