### PR TITLE
Editor: Enhance post URL UI

### DIFF
--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -10,7 +10,7 @@ import {
 	ExternalLink,
 	Button,
 	__experimentalInputControl as InputControl,
-	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
@@ -69,7 +69,7 @@ export default function PostURL( { onClose } ) {
 	const { createNotice } = useDispatch( noticesStore );
 	const [ forceEmptyField, setForceEmptyField ] = useState( false );
 	const copyButtonRef = useCopyToClipboard( permalink, () => {
-		createNotice( 'info', __( 'Copied URL to clipboard.' ), {
+		createNotice( 'info', __( 'Copied Permalink to clipboard.' ), {
 			isDismissible: true,
 			type: 'snackbar',
 		} );
@@ -77,98 +77,86 @@ export default function PostURL( { onClose } ) {
 	return (
 		<div className="editor-post-url">
 			<InspectorPopoverHeader
-				title={ __( 'Link' ) }
+				title={ __( 'Permalink' ) }
 				onClose={ onClose }
 			/>
-			<VStack spacing={ 3 }>
+			<VStack spacing={ 4 }>
+				<HStack>
+					<ExternalLink
+						className="editor-post-url__link"
+						href={ postLink }
+						target="_blank"
+					>
+						{ isEditable ? (
+							<>
+								<span className="editor-post-url__link-prefix">
+									{ permalinkPrefix }
+								</span>
+								<span className="editor-post-url__link-slug">
+									{ postSlug }
+								</span>
+								<span className="editor-post-url__link-suffix">
+									{ permalinkSuffix }
+								</span>
+							</>
+						) : (
+							postLink
+						) }
+					</ExternalLink>
+					<Button
+						size="compact"
+						icon={ copySmall }
+						ref={ copyButtonRef }
+						label={ __( 'Copy' ) }
+					/>
+				</HStack>
 				{ isEditable && (
-					<div>
-						{ __( 'Customize the last part of the URL. ' ) }
-						<ExternalLink
-							href={ __(
-								'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
-							) }
-						>
-							{ __( 'Learn more.' ) }
-						</ExternalLink>
-					</div>
-				) }
-				<div>
-					{ isEditable && (
-						<InputControl
-							__next40pxDefaultSize
-							prefix={
-								<InputControlPrefixWrapper>
-									/
-								</InputControlPrefixWrapper>
+					<InputControl
+						__next40pxDefaultSize
+						label={ __( 'Slug' ) }
+						value={ forceEmptyField ? '' : postSlug }
+						autoComplete="off"
+						spellCheck="false"
+						type="text"
+						className="editor-post-url__input"
+						onChange={ ( newValue ) => {
+							editPost( { slug: newValue } );
+							// When we delete the field the permalink gets
+							// reverted to the original value.
+							// The forceEmptyField logic allows the user to have
+							// the field temporarily empty while typing.
+							if ( ! newValue ) {
+								if ( ! forceEmptyField ) {
+									setForceEmptyField( true );
+								}
+								return;
 							}
-							suffix={
-								<Button
-									icon={ copySmall }
-									ref={ copyButtonRef }
-									label={ __( 'Copy' ) }
-								/>
+							if ( forceEmptyField ) {
+								setForceEmptyField( false );
 							}
-							label={ __( 'Link' ) }
-							hideLabelFromVision
-							value={ forceEmptyField ? '' : postSlug }
-							autoComplete="off"
-							spellCheck="false"
-							type="text"
-							className="editor-post-url__input"
-							onChange={ ( newValue ) => {
-								editPost( { slug: newValue } );
-								// When we delete the field the permalink gets
-								// reverted to the original value.
-								// The forceEmptyField logic allows the user to have
-								// the field temporarily empty while typing.
-								if ( ! newValue ) {
-									if ( ! forceEmptyField ) {
-										setForceEmptyField( true );
-									}
-									return;
-								}
-								if ( forceEmptyField ) {
-									setForceEmptyField( false );
-								}
-							} }
-							onBlur={ ( event ) => {
-								editPost( {
-									slug: cleanForSlug( event.target.value ),
-								} );
-								if ( forceEmptyField ) {
-									setForceEmptyField( false );
-								}
-							} }
-							help={
+						} }
+						onBlur={ ( event ) => {
+							editPost( {
+								slug: cleanForSlug( event.target.value ),
+							} );
+							if ( forceEmptyField ) {
+								setForceEmptyField( false );
+							}
+						} }
+						help={
+							<>
+								{ __( 'The last part of the URL. ' ) }
 								<ExternalLink
-									className="editor-post-url__link"
-									href={ postLink }
-									target="_blank"
+									href={ __(
+										'https://wordpress.org/documentation/article/page-post-settings-sidebar/#permalink'
+									) }
 								>
-									<span className="editor-post-url__link-prefix">
-										{ permalinkPrefix }
-									</span>
-									<span className="editor-post-url__link-slug">
-										{ postSlug }
-									</span>
-									<span className="editor-post-url__link-suffix">
-										{ permalinkSuffix }
-									</span>
+									{ __( 'Learn more.' ) }
 								</ExternalLink>
-							}
-						/>
-					) }
-					{ ! isEditable && (
-						<ExternalLink
-							className="editor-post-url__link"
-							href={ postLink }
-							target="_blank"
-						>
-							{ postLink }
-						</ExternalLink>
-					) }
-				</div>
+							</>
+						}
+					/>
+				) }
 			</VStack>
 		</div>
 	);

--- a/packages/editor/src/components/post-url/panel.js
+++ b/packages/editor/src/components/post-url/panel.js
@@ -44,7 +44,7 @@ export default function PostURLPanel() {
 
 	return (
 		<PostURLCheck>
-			<PostPanelRow label={ __( 'Link' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow label={ __( 'Permalink' ) } ref={ setPopoverAnchor }>
 				<Dropdown
 					popoverProps={ popoverProps }
 					className="editor-post-url__panel-dropdown"
@@ -86,8 +86,8 @@ function PostURLToggle( { isOpen, onClick } ) {
 			className="editor-post-url__panel-toggle"
 			variant="tertiary"
 			aria-expanded={ isOpen }
-			// translators: %s: Current post link.
-			aria-label={ sprintf( __( 'Change link: %s' ), decodedSlug ) }
+			// translators: %s: Current post slug.
+			aria-label={ sprintf( __( 'Change slug: %s' ), decodedSlug ) }
 			onClick={ onClick }
 		>
 			<Truncate numberOfLines={ 1 }>

--- a/packages/editor/src/components/post-url/style.scss
+++ b/packages/editor/src/components/post-url/style.scss
@@ -12,19 +12,11 @@
 .editor-post-url__link {
 	direction: ltr;
 	word-break: break-word;
-	margin-top: $grid-unit-05;
-	color: $gray-700;
 }
 /* rtl:end:ignore */
 
 .editor-post-url__link-slug {
 	font-weight: 600;
-}
-
-// TODO: This might indicate a need to update the InputControl itself, as
-// there is no way currently to control the padding when adding prefix/suffix.
-.editor-post-url__input input.components-input-control__input {
-	padding-inline-start: 0 !important;
 }
 
 .editor-post-url__panel-toggle {

--- a/test/e2e/specs/editor/various/sidebar-permalink.spec.js
+++ b/test/e2e/specs/editor/various/sidebar-permalink.spec.js
@@ -34,7 +34,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change link' } )
+			page.getByRole( 'button', { name: 'Change slug' } )
 		).toBeHidden();
 	} );
 
@@ -54,7 +54,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change link' } )
+			page.getByRole( 'button', { name: 'Change slug' } )
 		).toBeHidden();
 	} );
 
@@ -75,7 +75,7 @@ test.describe( 'Sidebar Permalink', () => {
 			.getByRole( 'textbox', { name: 'Add title' } )
 			.fill( 'aaaa (Updated)' );
 		await expect(
-			page.getByRole( 'button', { name: 'Change link' } )
+			page.getByRole( 'button', { name: 'Change slug' } )
 		).toBeVisible();
 	} );
 } );


### PR DESCRIPTION
Fixes #61196, #63700
Related to #63669, #63706

## What?

This PR improves the labels and layout of the post URL UI so that all text, fields, and buttons convey their exact meaning.

## Why?

- The term "Link" is ambiguous as to whether it refers to the slug or the permalink.
- The popover's input field is for editing the slug, but it's incorrectly labelled "Link".
- The Copy button is located to the right of the slug input field, but pressing it copies the permalink, adding to the confusion.

## How?

- Change the label of the post summary panel from "Link" to "Permalink"
- Change the title of the popover from "Link" to "Permalink"
- Give the input field in the popover a visible label: "Slug"
- Remove the custom grey color of the permalink in the popover
- Move the copy button from the input field to next to the permalink (Related to https://github.com/WordPress/gutenberg/issues/63700)
- Move the help text about the slug below the input field

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

Make sure that your screen reader announces the appropriate information when a button or input field receives focus or a popover is opened.

## Screenshots or screencast <!-- if applicable -->

### Permalink Structure: Plain

 | Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/1c3e5194-6bef-4a1e-a697-0e3ba6fe69aa) | ![image](https://github.com/user-attachments/assets/09498c5d-522e-440a-b12c-1a5337b0dddc) | 

### Permalink Structure: Month and name

 | Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2c316ac9-e234-4ddc-824f-a3f1e09f9bf8) | ![image](https://github.com/user-attachments/assets/f8e4e402-90e8-44dc-aedf-35c68b053e0e) |

### Permalink Structure: Post name 

 | Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/65d59c22-0392-4452-8d77-dc26ad4acd56) | ![image](https://github.com/user-attachments/assets/97be610f-df3b-4788-960b-3a37b29e7519) |

### Reading text with NVDA

https://github.com/user-attachments/assets/a243870b-e3a5-4c20-8ccf-18ac23eae5b1

> [!NOTE]
> When merging this PR, please remember to include in the props all the contributors who worked on solving similar issues:
> ```
> Co-authored-by: Rishit30G <rishit30g@git.wordpress.org>
> Co-authored-by: afercia <afercia@git.wordpress.org>
> Co-authored-by: annezazu <annezazu@git.wordpress.org>
> Co-authored-by: richtabor <richtabor@git.wordpress.org>
> Co-authored-by: joedolson <joedolson@git.wordpress.org>
> Co-authored-by: t-hamano <wildworks@git.wordpress.org>
> ```