### PR TITLE
Post Comments Form: Add Border Block Support

### DIFF
--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -37,6 +37,18 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-post-comments-form-editor",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Post Comment Form` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Comment Form` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Post Comment Form` block's border is Configurable via Global Styles.
- Edit template/page, Add  `Post Comment Form` block and Apply the border Styles.
- Verify that `Post Comment Form` block styles take precedence over global Styles.
- Verify that `Post Comment Form` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->
 

https://github.com/user-attachments/assets/0c7085bf-dc53-481d-a801-abd80dfe87a0


