### PR TITLE
Comment Template: Add Border Block Support

### DIFF
--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -31,6 +31,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-comment-template"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Comment Template` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Comment Template` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Comment Template` block's border is Configurable via Global Styles.
- Edit Template/Page &  Add  `Comment Template` block and Apply the border Styles.
- Verify that `Comment Template` block styles take precedence over global Styles.
- Verify that `Comment Template` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->



https://github.com/user-attachments/assets/a0d06f9c-4fd7-4152-9555-81ffda7d7bbc

