### PR TITLE
Comment Edit Link: Add Border Block Support

### DIFF
--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -30,7 +30,11 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		},
 		"typography": {
 			"fontSize": true,
@@ -52,13 +56,7 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true,
-			"__experimentalDefaultControls": {
-				"radius": true,
-				"color": true,
-				"width": true,
-				"style": true
-			}
+			"style": true
 		}
 	},
 	"style": "wp-block-comment-edit-link"

--- a/packages/block-library/src/comment-edit-link/block.json
+++ b/packages/block-library/src/comment-edit-link/block.json
@@ -47,6 +47,19 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
-	}
+	},
+	"style": "wp-block-comment-edit-link"
 }

--- a/packages/block-library/src/comment-edit-link/style.scss
+++ b/packages/block-library/src/comment-edit-link/style.scss
@@ -1,0 +1,4 @@
+.wp-block-comment-edit-link {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -13,6 +13,7 @@
 @import "./comment-date/style.scss";
 @import "./comment-content/style.scss";
 @import "./comment-author-name/style.scss";
+@import "./comment-edit-link/style.scss";
 @import "./cover/style.scss";
 @import "./details/style.scss";
 @import "./embed/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Comment Edit Link` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Comment Edit Link` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Comment Edit Link` block's border is Configurable via Global Styles.
- Edit Template/Page &  Add  `Comment Edit Link` block and Apply the border Styles.
- Verify that `Comment Edit Link` block styles take precedence over global Styles.
- Verify that `Comment Edit Link` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/dc53e8ed-bbda-478f-b5f6-5429f1e856fc

