### PR TITLE
Fix flaky DataViews list layout e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
+++ b/test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
@@ -76,10 +76,15 @@ test.describe( 'Dataviews List Layout', () => {
 		await page.keyboard.press( 'Tab' );
 		await page.keyboard.press( 'Tab' );
 
+		const firstItem = page
+			.getByRole( 'grid' )
+			.getByRole( 'button' )
+			.first();
+
 		// Make sure the items have loaded before reaching for the 1st item in the list.
 		await expect( page.getByRole( 'grid' ) ).toBeVisible();
 		await page.keyboard.press( 'Tab' );
-		await expect( page.getByLabel( 'Privacy Policy' ) ).toBeFocused();
+		await expect( firstItem ).toBeFocused();
 
 		// Go to the preview.
 		await page.keyboard.press( 'Tab' );
@@ -91,7 +96,7 @@ test.describe( 'Dataviews List Layout', () => {
 
 		// Go back to the items list using SHIFT+TAB.
 		await page.keyboard.press( 'Shift+Tab' );
-		await expect( page.getByLabel( 'Privacy Policy' ) ).toBeFocused();
+		await expect( firstItem ).toBeFocused();
 	} );
 
 	test( 'Navigates the items list via UP/DOWN arrow keys', async ( {


### PR DESCRIPTION
## What?
Fixes #62434.

PR fixes a flaky test in the `dataviews-list-layout-keyboard.spec.js` test suite.

## Why?
The order in which test pages are created is different sometimes, which can happen when making parallel requests.

## How?
The test doesn't need to know the page title; it only cares if the first page gets focused on the start and the focus returns to it at the end. I've updated the test to match these expectations.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/dataviews-list-layout-keyboard.spec.js
```

## Screenshots or screencast <!-- if applicable -->
![test-failed-1](https://github.com/user-attachments/assets/250c5f3c-6b44-40fb-bf4c-0150505155ce)
