### PR TITLE
Post Terms: Add border block support

### DIFF
--- a/packages/block-library/src/post-terms/block.json
+++ b/packages/block-library/src/post-terms/block.json
@@ -60,6 +60,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-post-terms"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Post Terms` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Terms` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that `Post Terms` block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add `Post Terms`  block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend

Watch attached video for more information.

## Screenshots or screencast <!-- if applicable -->
 
  
 
[Blog-Home-‹-Template-‹-gutenberg-‹-Editor-—-WordPress.webm](https://github.com/user-attachments/assets/c74ef19d-cd25-4c3c-aa39-26b1e597c55a)


