### PR TITLE
Data Views: Don't render action modal when there are no eligible items

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -89,6 +89,11 @@ function ActionWithModal< Item >( {
 	const onCloseModal = useCallback( () => {
 		setActionWithModal( undefined );
 	}, [ setActionWithModal ] );
+
+	if ( ! eligibleItems.length ) {
+		return null;
+	}
+
 	const label =
 		typeof action.label === 'string'
 			? action.label


### PR DESCRIPTION
## What?
PR prevents errors when deleting a Pattern or Template Part using "Bulk Edit" actions.

## Why?
It looks like `ActionWithModal` renders after deletion and before the modal with an empty item list.

Note: I noticed that the error only happens for template parts when there is more than one user-created template part.

## How?
Don't render an action modal when there are no eligible items.

## Testing Instructions
1. Navigate to Site Editor > Patterns > My patterns.
2. Select a pattern.
3. Delete it using "Bulk edit"
4. Confirm no error was triggered.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-05 at 13 49 36](https://github.com/user-attachments/assets/bf679544-b0e0-4866-9bcd-473a1b3b084b)
