### PR TITLE
DataForm: if a field of type `text` declare `elements`, render it as a `SelectControl` in `edit`

### DIFF
--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -34,6 +34,15 @@ const fields = [
 			{ value: 2, label: 'John' },
 		],
 	},
+	{
+		id: 'status',
+		label: 'Status',
+		type: 'text' as const,
+		elements: [
+			{ value: 'draft', label: 'Draft' },
+			{ value: 'published', label: 'Published' },
+		],
+	},
 ];
 
 export const Default = () => {
@@ -41,10 +50,11 @@ export const Default = () => {
 		title: 'Hello, World!',
 		order: 2,
 		author: 1,
+		status: 'draft',
 	} );
 
 	const form = {
-		visibleFields: [ 'title', 'order', 'author' ],
+		visibleFields: [ 'title', 'order', 'author', 'status' ],
 	};
 
 	return (

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -1,8 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { TextControl } from '@wordpress/components';
+import { SelectControl, TextControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -46,6 +47,29 @@ function Edit< Item >( {
 			} ) ),
 		[ id, onChange ]
 	);
+
+	if ( field.elements ) {
+		const elements = [
+			/*
+			 * Value can be undefined when:
+			 *
+			 * - the field is not required
+			 * - in bulk editing
+			 *
+			 */
+			{ label: __( 'Select item' ), value: '' },
+			...field.elements,
+		];
+
+		return (
+			<SelectControl
+				label={ label }
+				value={ value }
+				options={ elements }
+				onChange={ onChangeControl }
+			/>
+		);
+	}
 
 	return (
 		<TextControl


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/59745
Follow-up to https://github.com/WordPress/gutenberg/pull/63983

## What?

For `text` fields that have `elements`, this PR renders a SelectControl with the elements — like the integer type does.

## How?

- Render as `SelectControl` if field has elements. 04039f8a36f1030146c5ae12c806e67b5e758640
- Updates the `DataForm` storybook to include a field with `elements` whose type is `text`.

## Testing Instructions

Visit the storybook (`npm install && npm run storybook:dev`), go to the `DataForm` component and verify it has a `status` field rendered as a `SelectControl`.
