### PR TITLE
Site Editor: Don't trigger template ID resolution for multi-selected posts

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -90,6 +90,11 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 				return undefined;
 			}
 
+			// Don't trigger resolution for multi-selected posts.
+			if ( postId && postId.includes( ',' ) ) {
+				return undefined;
+			}
+
 			const {
 				getEditedEntityRecord,
 				getEntityRecords,


### PR DESCRIPTION
## What?
PR fixes an invalid request triggered by the `useResolveEditedEntityAndContext` hook when a user selects multiple pages.

## Why?
Template resolution only works for a single page or post.

## How?
Check and return early when multiple items are selected.

## Testing Instructions
1. Navigate to Site Editor > Pages.
2. Switch the data view to the Table layout.
3. Select multiple pages.
4. Confirm that the 404 request wasn't triggered.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-05 at 15 24 00](https://github.com/user-attachments/assets/40e89b3e-ddab-4322-91de-f448feb275fb)
