### PR TITLE
Site Icon: Fix position in distraction free mode

### DIFF
--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -22,7 +22,6 @@
 	/* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 	view-transition-name: toggle;
 	/* stylelint-enable */
-	position: fixed;
 	top: 0;
 	left: 0;
 	height: $header-height;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/63986#discussion_r1702051426

## What?
In distraction free mode, the site icon (in the site editor) was not positioned properly after the hover animation was added in #63986 

## Testing Instructions

Check the position of the site icon (or W button) in the site editor in distraction free mode and without distraction free mode as well.