### PR TITLE
Navigation: Hide loading when overlay menu is selected

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -721,7 +721,7 @@ function Navigation( {
 	);
 
 	const accessibleDescriptionId = `${ clientId }-desc`;
-
+	const isHiddenByDefault = 'always' === overlayMenu;
 	const isManageMenusButtonDisabled =
 		! hasManagePermissions || ! hasResolvedNavigationMenus;
 
@@ -760,7 +760,7 @@ function Navigation( {
 					hasIcon={ hasIcon }
 					icon={ icon }
 					isResponsive={ isResponsive }
-					isHiddenByDefault={ 'always' === overlayMenu }
+					isHiddenByDefault={ isHiddenByDefault }
 					overlayBackgroundColor={ overlayBackgroundColor }
 					overlayTextColor={ overlayTextColor }
 				>
@@ -899,13 +899,13 @@ function Navigation( {
 							: undefined
 					}
 				>
-					{ isLoading && (
+					{ isLoading && ! isHiddenByDefault && (
 						<div className="wp-block-navigation__loading-indicator-container">
 							<Spinner className="wp-block-navigation__loading-indicator" />
 						</div>
 					) }
 
-					{ ! isLoading && (
+					{ ( ! isLoading || isHiddenByDefault ) && (
 						<>
 							<AccessibleMenuDescription
 								id={ accessibleDescriptionId }
@@ -917,7 +917,7 @@ function Navigation( {
 								icon={ icon }
 								isOpen={ isResponsiveMenuOpen }
 								isResponsive={ isResponsive }
-								isHiddenByDefault={ 'always' === overlayMenu }
+								isHiddenByDefault={ isHiddenByDefault }
 								overlayBackgroundColor={
 									overlayBackgroundColor
 								}


### PR DESCRIPTION
## What?
Hides navigation loading spinner when the option to always display the overlay menu is selected.

## Why?
To decrease the amount of jumping caused by the navigation block during the loading process. This is especially valuable for rendering pattern previews when the navigation block is used in a pattern.

Found while working on #44750.

## How?
Right now, if the user has a navigation block with the "always" option set, they'll see a spinner and then a navigation menu. However, we can display the menu icon immediately, and the loading will still happen in the background. This is what this PR suggests. Then, if the user is quick enough to click on the navigation icon in the navigation menu popover, they'll see the loading bar - then, and only then. This doesn't affect the behavior if any of the other "Overlay Menu" options are chosen. 

One other issue I've noticed, and this is pre-existing:
The custom popover implementation that's used to display a preview of the navigation menu will stay behind the block toolbar. I don't think that's expected, and it looks awkward on small devices (as shown in the preview below). Should we use an actual dialog component instead and remove the custom implementation altogether? @WordPress/gutenberg-components thoughts?

## Testing Instructions
* Open a post.
* Insert a Navigation block with the "Overlay Menu" set to "Always".
* Save and refresh.
* Verify you no longer see a spinner, but you immediately see the menu icon.
* Test with the other "Overlay Menu" options.
* Verify they continue to work as before. 

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/user-attachments/assets/7efdfa6a-f55b-485f-be6d-336d8e878cff

After:

https://github.com/user-attachments/assets/60f40cdd-1a14-4718-a1bd-53074f574f3d