### PR TITLE
Try: Enforce selected item icon colors on autocomplete.

### DIFF
--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -15,8 +15,9 @@
 	}
 
 	&.is-selected,
+	&.is-selected .has-colors,
 	&:not(:disabled,[aria-disabled="true"]):active {
 		background: $components-color-accent;
-		color: $white;
+		color: $white !important; // !important to override any plugin custom colors when selected.
 	}
 }


### PR DESCRIPTION
## What?

Plugins sometimes provide a spot color for block icons. This is fine, but in this auto-complete it means a lack of contrast:

![green on selected blue](https://github.com/user-attachments/assets/da812689-2e20-40f5-900c-52f612cbefb7)

This PR enforces the highlight color, overriding a plugin supplied color:

![white on selected blue](https://github.com/user-attachments/assets/8289bb93-0458-480c-ab8a-36ba8aaef7d3)

## Why?

This ensures color contrast, while still affording plugin icon colors.

## Testing Instructions

Install the Jetpack plugin. Then in any editor use the slash command to earch for a Jetpack block, such as `/pay`. Observe sufficient contrast still in the highlighted state.