### PR TITLE
Zoom out: Disable 'Desktop (50%)' option in the non-iframed editor

### DIFF
--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -143,6 +143,7 @@ export default function EditorInterface( {
 						forceDisableBlockTools={ forceDisableBlockTools }
 						title={ title }
 						icon={ icon }
+						disableIframe={ disableIframe }
 					/>
 				)
 			}

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -47,6 +47,7 @@ function Header( {
 	setEntitiesSavedStatesCallback,
 	title,
 	icon,
+	disableIframe = false,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -136,6 +137,7 @@ function Header( {
 				<PreviewDropdown
 					forceIsAutosaveable={ forceIsDirty }
 					disabled={ isNestedEntity }
+					disableIframe={ disableIframe }
 				/>
 				<PostPreviewButton
 					className="editor-header__post-preview-button"

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -29,7 +29,11 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 import PostPreviewButton from '../post-preview-button';
 
-export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
+export default function PreviewDropdown( {
+	forceIsAutosaveable,
+	disabled,
+	disableIframe = false,
+} ) {
 	const {
 		deviceType,
 		editorMode,
@@ -111,7 +115,9 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Desktop' ),
 			icon: desktop,
 		},
-		{
+		// The "Desktop (50%)" option only works in the iframe editor,
+		// so disable it in the non-iframe editor.
+		! disableIframe && {
 			value: 'ZoomOut',
 			label: __( 'Desktop (50%)' ),
 			icon: desktop,
@@ -126,7 +132,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Mobile' ),
 			icon: mobile,
 		},
-	];
+	].filter( Boolean );
 
 	const previewValue = editorMode === 'zoom-out' ? 'ZoomOut' : deviceType;
 


### PR DESCRIPTION
Fixes #64259

## What?
This PR will disable the "Desktop (50%)" option if the editor is not iframed.

## Why?

The "Desktop (50%)" view is a zoom-out mode. The zoom-out mode does not work properly if the editor is not an iframe.

From my understanding, it is difficult or requires significant modifications to make the zoom-out mode work in a non-iframe editor. Therefore, I think it is best to leave it disabled for now.

## How?

We can determine if the editor is an iframe by checking the `disableIframe`. If this is `true`, exclude the "Desktop (50%)" option.

## Testing Instructions

This option is available if the custom field is disabled, otherwise it should not be visible.