### PR TITLE
Add new wrapContents prop to PluginSidebar

### DIFF
--- a/packages/editor/CHANGELOG.md
+++ b/packages/editor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add `wrapContents` prop to `PluginSidebar` to wrap the inner contents in a `<PanelBody>` component ([#64273](https://github.com/WordPress/gutenberg/pull/64273))
+
 ## 14.4.0 (2024-07-24)
 
 ### Deprecations

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -918,6 +918,7 @@ _Parameters_
 -   _props_ `Object`: Element props.
 -   _props.name_ `string`: A string identifying the sidebar. Must be unique for every sidebar registered within the scope of your plugin.
 -   _props.className_ `[string]`: An optional class name added to the sidebar body.
+-   _props.wrapContents_ `[string]`: Should the content of the panel be wrapped in a `PanelBody` component. Default is `false`.
 -   _props.title_ `string`: Title displayed at the top of the sidebar.
 -   _props.isPinnable_ `[boolean]`: Whether to allow to pin sidebar to the toolbar. When set to `true` it also automatically renders a corresponding menu item.
 -   _props.icon_ `[WPBlockTypeIconRender]`: The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.

--- a/packages/editor/src/components/plugin-sidebar/index.js
+++ b/packages/editor/src/components/plugin-sidebar/index.js
@@ -5,6 +5,7 @@ import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { ComplementaryArea } from '@wordpress/interface';
+import { PanelBody } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ import { store as editorStore } from '../../store';
  * @param {Object}                props                                 Element props.
  * @param {string}                props.name                            A string identifying the sidebar. Must be unique for every sidebar registered within the scope of your plugin.
  * @param {string}                [props.className]                     An optional class name added to the sidebar body.
+ * @param {string}                [props.wrapContents]                  Should the content of the panel be wrapped in a `PanelBody` component. Default is `false`.
  * @param {string}                props.title                           Title displayed at the top of the sidebar.
  * @param {boolean}               [props.isPinnable=true]               Whether to allow to pin sidebar to the toolbar. When set to `true` it also automatically renders a corresponding menu item.
  * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The [Dashicon](https://developer.wordpress.org/resource/dashicons/) icon slug string, or an SVG WP element, to be rendered when the sidebar is pinned to toolbar.
@@ -76,7 +78,11 @@ import { store as editorStore } from '../../store';
  * );
  * ```
  */
-export default function PluginSidebar( { className, ...props } ) {
+export default function PluginSidebar( {
+	className,
+	wrapContents = false,
+	...props
+} ) {
 	const { postTitle, shortcut } = useSelect( ( select ) => {
 		return {
 			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
@@ -85,6 +91,7 @@ export default function PluginSidebar( { className, ...props } ) {
 			).getShortcutRepresentation( 'core/editor/toggle-sidebar' ),
 		};
 	}, [] );
+
 	return (
 		<ComplementaryArea
 			panelClassName={ className }
@@ -93,6 +100,12 @@ export default function PluginSidebar( { className, ...props } ) {
 			scope="core"
 			toggleShortcut={ shortcut }
 			{ ...props }
-		/>
+		>
+			{ wrapContents ? (
+				<PanelBody>{ props.children }</PanelBody>
+			) : (
+				props.children
+			) }
+		</ComplementaryArea>
 	);
 }


### PR DESCRIPTION
## What?
This PR is an attempt at the implement for the solution proposed in #64272 to allow developers to define a basic UI wrapper for the content of a PluginSidebar.

## Why?
As mentioned in #64272 this is a much better developer experience.

## How?

I have added a new `wrapContents` prop that if true, will wrap the `children` of the `<ComplementaryArea />` component in a `<PanelBody>` component. `wrapContents` is false by default for backwards compatibility with existing implementations.

## Testing Instructions
1. Checkout this branch
2. Register a new PluginSidebar ( code I tested with is below )
3. Confirm that when `wrapContents` is `true`, the content are wrapped (see screenshot below)
4. Confirm that when `wrapContents` is `false`, the content are NOT wrapped (see screenshot below)

### Code 

```jsx
import { registerPlugin } from '@wordpress/plugins';
import { PluginSidebar } from '@wordpress/editor';
import { __ } from '@wordpress/i18n';
import { Button, TextControl, SelectControl } from '@wordpress/components';
import { useState } from '@wordpress/element';

registerPlugin( 'wraps-content', {
	render: () => {
		const [ text, setText ] = useState( '' );
		const [ select, setSelect ] = useState( 'a' );

		return (
			<PluginSidebar
				name="wraps-content"
				title="My sidebar title"
				wrapContents
			>
				<h2>
					{ __( 'This is a heading for the PluginSidebar example.' ) }
				</h2>
				<p>
					{ __(
						'This is some example text for the PluginSidebar example.'
					) }
				</p>
				<TextControl
					label={ __( 'Text Control' ) }
					value={ text }
					onChange={ ( newText ) => setText( newText ) }
				/>
				<SelectControl
					label={ __( 'Select Control' ) }
					value={ select }
					options={ [
						{ value: 'a', label: 'Option A' },
						{ value: 'b', label: 'Option B' },
						{ value: 'c', label: 'Option C' },
					] }
					onChange={ ( newSelect ) => setSelect( newSelect ) }
				/>
				<Button variant="primary">{ __( 'Primary Button' ) } </Button>
			</PluginSidebar>
		);
	},
} );
```

### wrapContents is true
![Cursor_and_Edit_Post_“BlockEditChildren”_‹_Gutenberg-works_—_WordPress](https://github.com/user-attachments/assets/6bce0ecc-da20-4f22-8f5f-2fc30e6d5cc9)

### wrapContents is false
![Cursor_and_Edit_Post_“BlockEditChildren”_‹_Gutenberg-works_—_WordPress_and_index_js_—_gutenberg-no-upstream2__Workspace_](https://github.com/user-attachments/assets/141b5101-8288-40c1-a4bf-f9a8cfb98ad4)
st 

