### PR TITLE
Fix blurry edge along editor header with Distraction Free

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -70,7 +70,7 @@
 	// Raise the specificity.
 	&.components-accessible-toolbar {
 		border: none;
-		border-bottom: $border-width solid $gray-200;
+		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 		border-radius: 0;
 	}
 

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -240,9 +240,13 @@
 
 	.editor-header {
 		background-color: $white;
-		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
-		position: absolute;
 		width: 100%;
+
+		@include break-medium {
+			box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+			position: absolute;
+		}
+
 
 		// hide some parts
 		& > .edit-post-header__settings > .edit-post-header__post-preview-button {

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -228,7 +228,7 @@
 }
 
 .editor-header__post-preview-button {
-	@include break-mobile {
+	@include break-small {
 		display: none;
 	}
 }
@@ -240,13 +240,9 @@
 
 	.editor-header {
 		background-color: $white;
+		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+		position: absolute;
 		width: 100%;
-
-		@include break-medium {
-			border-bottom: 1px solid #e0e0e0;
-			position: absolute;
-		}
-
 
 		// hide some parts
 		& > .edit-post-header__settings > .edit-post-header__post-preview-button {

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -228,7 +228,7 @@
 }
 
 .editor-header__post-preview-button {
-	@include break-small {
+	@include break-mobile {
 		display: none;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The editor header has a fixed color border, leading to blurred edges when it is overlaid a block/site with a background color. 

## Why?
The editor interface should build confidence, presented with an air of polish. 

## How?
Using the same shadow that was applied to the other editor panels in https://github.com/WordPress/gutenberg/pull/61835. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Start with a background color on the site other than white. 
2. Open a page, or the Site Editor. 
3. Turn on Distraction Free. 
4. See change. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Open each in a new tab and you'll see the "blurry" effect vs. not: 

### Before 

![CleanShot 2024-08-05 at 17 01 25](https://github.com/user-attachments/assets/582df85c-c7ed-4339-927c-52fdfe520449)

### After

![CleanShot 2024-08-05 at 17 01 43](https://github.com/user-attachments/assets/37930f17-6f0b-4adc-9caa-7cb863b43824)
