### PR TITLE
LineHeightControl: Hard deprecate bottom margin

### DIFF
--- a/packages/block-editor/CHANGELOG.md
+++ b/packages/block-editor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `LineHeightControl`: Remove deprecated `__nextHasNoMarginBottom` prop and promote to default behavior ([#64281](https://github.com/WordPress/gutenberg/pull/64281)).
+
 ## 13.4.0 (2024-07-24)
 
 ## 13.3.0 (2024-07-10)

--- a/packages/block-editor/src/components/global-styles/typography-panel.js
+++ b/packages/block-editor/src/components/global-styles/typography-panel.js
@@ -474,7 +474,6 @@ export default function TypographyPanel( {
 					panelId={ panelId }
 				>
 					<LineHeightControl
-						__nextHasNoMarginBottom
 						__unstableInputWidth="auto"
 						value={ lineHeight }
 						onChange={ setLineHeight }

--- a/packages/block-editor/src/components/line-height-control/README.md
+++ b/packages/block-editor/src/components/line-height-control/README.md
@@ -18,7 +18,6 @@ const MyLineHeightControl = () => (
 	<LineHeightControl
 		value={ lineHeight }
 		onChange={ onChange }
-		__nextHasNoMarginBottom={ true }
 	/>
 );
 ```
@@ -36,13 +35,6 @@ The value of the line height.
 -   **Type:** `Function`
 
 A callback function that handles the application of the line height value.
-
-#### `__nextHasNoMarginBottom`
-
--   **Type:** `boolean`
--   **Default:** `false`
-
-Start opting into the new margin-free styles that will become the default in a future version, currently scheduled to be WordPress 6.4. (The prop can be safely removed once this happens.)
 
 ## Related components
 

--- a/packages/block-editor/src/components/line-height-control/index.js
+++ b/packages/block-editor/src/components/line-height-control/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import deprecated from '@wordpress/deprecated';
 import { __ } from '@wordpress/i18n';
 import { __experimentalNumberControl as NumberControl } from '@wordpress/components';
 
@@ -19,8 +18,6 @@ import {
 const LineHeightControl = ( {
 	value: lineHeight,
 	onChange,
-	/** Start opting into the new margin-free styles that will become the default in a future version. */
-	__nextHasNoMarginBottom = false,
 	__unstableInputWidth = '60px',
 	...otherProps
 } ) => {
@@ -76,20 +73,6 @@ const LineHeightControl = ( {
 
 	const value = isDefined ? lineHeight : RESET_VALUE;
 
-	if ( ! __nextHasNoMarginBottom ) {
-		deprecated(
-			'Bottom margin styles for wp.blockEditor.LineHeightControl',
-			{
-				since: '6.0',
-				version: '6.4',
-				hint: 'Set the `__nextHasNoMarginBottom` prop to true to start opting into the new styles, which will become the default in a future version',
-			}
-		);
-	}
-	const deprecatedStyles = __nextHasNoMarginBottom
-		? undefined
-		: { marginBottom: 24 };
-
 	const handleOnChange = ( nextValue, { event } ) => {
 		if ( nextValue === '' ) {
 			onChange();
@@ -105,10 +88,7 @@ const LineHeightControl = ( {
 	};
 
 	return (
-		<div
-			className="block-editor-line-height-control"
-			style={ deprecatedStyles }
-		>
+		<div className="block-editor-line-height-control">
 			<NumberControl
 				{ ...otherProps }
 				__unstableInputWidth={ __unstableInputWidth }

--- a/packages/block-editor/src/components/line-height-control/stories/index.story.js
+++ b/packages/block-editor/src/components/line-height-control/stories/index.story.js
@@ -22,7 +22,6 @@ const Template = ( props ) => {
 
 export const Default = Template.bind( {} );
 Default.args = {
-	__nextHasNoMarginBottom: true,
 	__unstableInputWidth: '100px',
 };
 

--- a/packages/block-editor/src/components/line-height-control/test/index.js
+++ b/packages/block-editor/src/components/line-height-control/test/index.js
@@ -19,13 +19,7 @@ const SPIN = STEP * SPIN_FACTOR;
 
 const ControlledLineHeightControl = () => {
 	const [ value, setValue ] = useState();
-	return (
-		<LineHeightControl
-			value={ value }
-			onChange={ setValue }
-			__nextHasNoMarginBottom
-		/>
-	);
+	return <LineHeightControl value={ value } onChange={ setValue } />;
 };
 
 describe( 'LineHeightControl', () => {

--- a/packages/block-editor/src/hooks/line-height.js
+++ b/packages/block-editor/src/hooks/line-height.js
@@ -39,7 +39,6 @@ export function LineHeightEdit( props ) {
 	return (
 		<LineHeightControl
 			__unstableInputWidth="100%"
-			__nextHasNoMarginBottom
 			value={ style?.typography?.lineHeight }
 			onChange={ onChange }
 			size="__unstable-large"


### PR DESCRIPTION
Part of #38730 

## What?

Promotes `__nextHasNoMarginBottom` on `LineHeightControl` to the default behavior.

## Why?

The deprecation grace period has elapsed.

## Testing Instructions

In the Storybook for LineHeightControl, turn on the [margin checker tool](https://github.com/WordPress/gutenberg/assets/555336/f4fcf334-7c27-47ad-acba-e9b3a5f6f734) in the toolbar. The margin-free styles should now be the default, and the `__nextHasNoMarginBottom` prop should not be listed in the props table.