### PR TITLE
Grid: Prevent highlight of cells when dragging a block if block type can't be dropped into grid

### DIFF
--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -206,8 +206,12 @@ function useGridVisualizerDropZone(
 	gridInfo,
 	setHighlightedRect
 ) {
-	const { getBlockAttributes, getBlockRootClientId } =
-		useSelect( blockEditorStore );
+	const {
+		getBlockAttributes,
+		getBlockRootClientId,
+		canInsertBlockType,
+		getBlockName,
+	} = useSelect( blockEditorStore );
 	const {
 		updateBlockAttributes,
 		moveBlocksToPosition,
@@ -221,6 +225,10 @@ function useGridVisualizerDropZone(
 
 	return useDropZoneWithValidation( {
 		validateDrag( srcClientId ) {
+			const blockName = getBlockName( srcClientId );
+			if ( ! canInsertBlockType( blockName, gridClientId ) ) {
+				return false;
+			}
 			const attributes = getBlockAttributes( srcClientId );
 			const rect = new GridRect( {
 				columnStart: column,


### PR DESCRIPTION
## What?
Fixes #63979

## Why?
This brings consistency with the rest of the editor where insertion points aren't shown if the block type doesn't support being inserted.

## How?
Use the `canInsertBlockType` selector to check block validity in the `validateDrag` function.

## Testing Instructions
1. Try dragging a button into a grid
2. Notice that in this PR the grid cells aren't highlighted
3. Try dragging a paragraph into a gird
4. The cells should still be highlighted as normal

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6d72d114-4536-4b12-8085-5372623f2ede

