### PR TITLE
Autocompleter UI: Fix text color when hovering selected item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `CustomSelectControl`: Restore `describedBy` functionality ([#63957](https://github.com/WordPress/gutenberg/pull/63957)).
 -   `Button`: Improve the aria-disabled focus style ([#62480](https://github.com/WordPress/gutenberg/pull/62480)).
 -   `Modal`: Fix the dismissal logic for React development mode ([#64132](https://github.com/WordPress/gutenberg/pull/64132)).
+-   `Autocompleter UI`: Fix text color when hovering selected item ([#64294](https://github.com/WordPress/gutenberg/pull/64294)).
 
 ### Enhancements
 

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -62,11 +62,9 @@ function ListBox( {
 					disabled={ option.isDisabled }
 					className={ clsx(
 						'components-autocomplete__result',
-						className,
-						{
-							'is-selected': index === selectedIndex,
-						}
+						className
 					) }
+					variant={ index === selectedIndex ? 'primary' : undefined }
 					onClick={ () => onSelect( option ) }
 				>
 					{ option.label }

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -62,7 +62,11 @@ function ListBox( {
 					disabled={ option.isDisabled }
 					className={ clsx(
 						'components-autocomplete__result',
-						className
+						className,
+						{
+							// Unused, for backwards compatibility.
+							'is-selected': index === selectedIndex,
+						}
 					) }
 					variant={ index === selectedIndex ? 'primary' : undefined }
 					onClick={ () => onSelect( option ) }

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -13,10 +13,4 @@
 	&:focus:not(:disabled) {
 		@include block-toolbar-button-style__focus();
 	}
-
-	&.is-selected,
-	&:not(:disabled,[aria-disabled="true"]):active {
-		background: $components-color-accent;
-		color: $white;
-	}
 }


### PR DESCRIPTION
Related to #62480

## What?

This PR fixes the text color when a selected item is hovered in Autocompleter UI.

![image](https://github.com/user-attachments/assets/620869df-7a53-46d5-aa52-7125f6992548)


## Why?

In #62480, some CSS selector changes were made to improve button focus styles.

As a result, when an item is selected within the Autocompleter UI, i.e. when the background color is the primary color, the text color also changes to the primary color, making the text and icon invisible.

![focus-style](https://github.com/user-attachments/assets/b159edf3-8504-4dbb-ab9d-889876312ce4)

## How?

I think the fundamental problem is that Autocompleter UI uses a unique selector called `is-selected` to indicate that an item is selected, which may conflict with the style of the Button component.

We should be able to achieve a similar look without using this selector by setting the `variant` prop to `primary`. As a secondary benefit, it also allows for hover styling that is not currently applied (the background color becomes slightly darker).

## Testing Instructions

- In the block editor, use the slash inserter.
- Select one of the item (don't insert the block itself)
- Hover over the item.
- The text color should stay the same, but the background color should get a little darker.

Additionally, to test our own autocomplete, install the following plugin and enter the character `~`:

[fruit-autocompleter.zip](https://github.com/user-attachments/files/16506807/fruit-autocompleter.zip)

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/c78a2eb0-893b-42b9-a990-2f283d6661b3

### After

https://github.com/user-attachments/assets/684c913e-bba9-4a16-84fa-41a9e5457413

