### PR TITLE
List Item: Add anchor support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -426,7 +426,7 @@ An individual item within a list. ([Source](https://github.com/WordPress/gutenbe
 -	**Category:** text
 -	**Parent:** core/list
 -	**Allowed Blocks:** core/list
--	**Supports:** color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
+-	**Supports:** anchor, color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), splitting, typography (fontSize, lineHeight), ~~className~~
 -	**Attributes:** content, placeholder
 
 ## Login/out

--- a/packages/block-library/src/list-item/block.json
+++ b/packages/block-library/src/list-item/block.json
@@ -20,6 +20,7 @@
 		}
 	},
 	"supports": {
+		"anchor": true,
 		"className": false,
 		"splitting": true,
 		"color": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Added anchor support for list items.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Sometimes it is necessary to specify an anchor for a list item.

Fixes #29838

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add `anchor:true` to supports in `block.json`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

 1. Open a post or page.
 2. Insert a list-item block.
 3. Open Settings panel.
 4. Enter an anchor in `HTML ANCHOR` in `Advanced`

## Screenshots or screencast <!-- if applicable -->
![FireShot Capture 094 - Edit Post “list test” ‹ Gutenberg Develop — WordPress - localhost](https://github.com/user-attachments/assets/63b803fa-27b1-427b-8730-879384f7446a)

