### PR TITLE
Site Logo: Move tooltip to middle right.

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -687,7 +687,7 @@ export default function LogoEdit( {
 								variant="primary"
 								label={ __( 'Choose logo' ) }
 								showTooltip
-								tooltipPosition="bottom center"
+								tooltipPosition="middle right"
 								onClick={ () => {
 									open();
 								} }


### PR DESCRIPTION
## What?

Fixes #63327.

Moves the tooltip to the middle right position for the Site Logo, resolving the last issue reported there. 

Before:

![before](https://github.com/user-attachments/assets/e5a0d9b0-f5d8-4603-b837-ca32d59775d0)

After:

![Screenshot 2024-08-06 at 10 25 41](https://github.com/user-attachments/assets/50d1051d-386a-44d4-8d09-7c08abf0dd3d)


## Testing Instructions

Insert a Site Logo block. Reset if it has an image. Hover the upload button and observe the tooltip. With this PR applied, the tooltip should be on the right.