### PR TITLE
Fix: Deleting a pattern throws a notice saying undefined deleted.

### DIFF
--- a/packages/editor/src/store/private-actions.js
+++ b/packages/editor/src/store/private-actions.js
@@ -393,10 +393,14 @@ export const removeTemplates =
 			if ( items.length === 1 ) {
 				// Depending on how the entity was retrieved its title might be
 				// an object or simple string.
-				const title =
-					typeof items[ 0 ].title === 'string'
-						? items[ 0 ].title
-						: items[ 0 ].title?.rendered;
+				let title;
+				if ( typeof items[ 0 ].title === 'string' ) {
+					title = items[ 0 ].title;
+				} else if ( typeof items[ 0 ].title?.rendered === 'string' ) {
+					title = items[ 0 ].title?.rendered;
+				} else if ( typeof items[ 0 ].title?.raw === 'string' ) {
+					title = items[ 0 ].title?.raw;
+				}
 				successMessage = isResetting
 					? sprintf(
 							/* translators: The template/part's name. */


### PR DESCRIPTION

When a user-created pattern is deleted, the success message currently reads "undefined deleted." This occurs because the title in patterns is "title?.raw," while "title?.rendered" is undefined. This PR addresses this issue by adding logic to the deleteTemplates action.

## Testing Instructions
1. Navigate to the patterns section and click on "My patterns."
2. If you don't have any user patterns, duplicate an existing pattern.
3. Attempt to delete a user pattern.
4. Verify that the success message now reads "User pattern deleted," and does not display "undefined deleted" as seen in the trunk version.