### PR TITLE
DataViews: consider layout url parameter when loading a default/custom view

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -93,18 +93,22 @@ function useView( postType ) {
 		[ activeView, isCustom ]
 	);
 	const [ view, setView ] = useState( () => {
+		let initialView;
 		if ( isCustom === 'true' ) {
-			return (
-				getCustomView( editedEntityRecord ) ?? {
-					type: layout ?? LAYOUT_LIST,
-				}
-			);
-		}
-		return (
-			getDefaultView( defaultViews, activeView ) ?? {
+			initialView = getCustomView( editedEntityRecord ) ?? {
 				type: layout ?? LAYOUT_LIST,
-			}
-		);
+			};
+		} else {
+			initialView = getDefaultView( defaultViews, activeView ) ?? {
+				type: layout ?? LAYOUT_LIST,
+			};
+		}
+
+		const type = layout ?? initialView.type;
+		return {
+			...initialView,
+			type,
+		};
 	} );
 
 	const setViewWithUrlUpdate = useCallback(
@@ -146,8 +150,7 @@ function useView( postType ) {
 		} ) );
 	}, [ layout ] );
 
-	// When activeView or isCustom URL parameters change,
-	// reset the view & update the layout URL param to match the view's type.
+	// When activeView or isCustom URL parameters change, reset the view.
 	useEffect( () => {
 		let newView;
 		if ( isCustom === 'true' ) {
@@ -157,9 +160,13 @@ function useView( postType ) {
 		}
 
 		if ( newView ) {
-			setViewWithUrlUpdate( newView );
+			const type = layout ?? newView.type;
+			setView( {
+				...newView,
+				type,
+			} );
 		}
-	}, [ activeView, isCustom, defaultViews, editedEntityRecord ] );
+	}, [ activeView, isCustom, layout, defaultViews, editedEntityRecord ] );
 
 	return [ view, setViewWithUrlUpdate, setViewWithUrlUpdate ];
 }

--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -29,7 +29,7 @@ export default function DataViewItem( {
 	suffix,
 } ) {
 	const {
-		params: { postType, layout },
+		params: { postType },
 	} = useLocation();
 
 	const iconToUse =
@@ -41,7 +41,7 @@ export default function DataViewItem( {
 	}
 	const linkInfo = useLink( {
 		postType,
-		layout,
+		layout: type,
 		activeView,
 		isCustom: isCustom ? 'true' : undefined,
 	} );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/63889

## What?

In the Pages page, consider the `layout` parameter when loading a view.

## Why?

URLs represent (partially) the state of DataViews, and it needs to load properly.

## How?

- Update the sidebar links to use the view.type, not the existing layout parameter. dc9015619e31f7dda9e2ed55345a3538046b7558
- Do not trigger a layout URL update when activeView/isCustom change. 23ea90590280316455813fb4a6acd005832a861a

## Testing Instructions

Visit the Pages page in Site Editor and verify a few flows:

- load any default/custom view and verify that it works as expected
  - the trash default view uses table
  - any other default view uses list
- change to new layout do not reset any other view config
- change to new layout and then reload the URL actually loads the layout defined in the URL
