### PR TITLE
Comment Pagination Next: Add Border and Spacing Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -207,7 +207,7 @@ Displays the next comment's page link. ([Source](https://github.com/WordPress/gu
 -	**Name:** core/comments-pagination-next
 -	**Category:** theme
 -	**Parent:** core/comments-pagination
--	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Comments Page Numbers

--- a/packages/block-library/src/comments-pagination-next/block.json
+++ b/packages/block-library/src/comments-pagination-next/block.json
@@ -41,19 +41,17 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		},
 		"__experimentalBorder": {
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true,
-			"__experimentalDefaultControls": {
-				"radius": true,
-				"color": true,
-				"width": true,
-				"style": true
-			}
+			"style": true
 		}
 	},
 	"style": "wp-block-comments-pagination-next"

--- a/packages/block-library/src/comments-pagination-next/block.json
+++ b/packages/block-library/src/comments-pagination-next/block.json
@@ -38,6 +38,23 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
-	}
+	},
+	"style": "wp-block-comments-pagination-next"
 }

--- a/packages/block-library/src/comments-pagination-next/style.scss
+++ b/packages/block-library/src/comments-pagination-next/style.scss
@@ -1,0 +1,4 @@
+.wp-block-comments-pagination-next {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -61,5 +61,6 @@
 @import "./verse/style.scss";
 @import "./video/style.scss";
 @import "./footnotes/style.scss";
+@import "./comments-pagination-next/style.scss";
 
 @import "common.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add Border and Spacing support to the `Comments Pagination Next` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Comments Pagination Next` block is missing border and Spacing support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the Border and Spacing support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Comments Pagination Next` block's border and Spacing is Configurable via Global Styles.
- Edit Template/ Single Post Template &  Add `Comments Pagination Next` block and Apply the border Styles and Spacing.
- Verify that `Comments Pagination Next` block styles take precedence over global Styles.
- Verify that `Comments Pagination Next` block borders and Spacing display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/56b796e1-9230-411c-8a34-980a26a4d857

