### PR TITLE
DataForm: Fix SelectControl size and spacing

### DIFF
--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -67,6 +67,8 @@ function Edit< Item >( {
 				value={ value }
 				options={ elements }
 				onChange={ onChangeControl }
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
 			/>
 		);
 	}


### PR DESCRIPTION
Related #59745 

## What?

Small PR to improve the consistency of the size and spacing of the controls that are generated by the DataForm component. Specifically this fixes the size and spacing for the "select" control for string fields.

**Before**
<img width="970" alt="Screenshot 2024-08-07 at 12 45 46 PM" src="https://github.com/user-attachments/assets/afaffe5f-f12c-4550-b637-6043037bd302">

**After**
<img width="967" alt="Screenshot 2024-08-07 at 12 48 56 PM" src="https://github.com/user-attachments/assets/95fb2057-eed0-46e9-a54b-d53f227e5442">

Check the size and spacing of the status control.