### PR TITLE
Update api-reference.md

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -55,7 +55,7 @@ The `wp-interactive` directive "activates" the interactivity for the DOM element
   data-wp-interactive="myPlugin"
   data-wp-context='{ "myColor" : "red", "myBgColor": "yellow" }'
 >
-  <p>I'm interactive now, <span data-wp-style--background-color="context.myBgColor">>and I can use directives!</span></p>
+  <p>I'm interactive now, <span data-wp-style--background-color="context.myBgColor">and I can use directives!</span></p>
   <div>
     <p>I'm also interactive, <span data-wp-style--color="context.myColor">and I can also use directives!</span></p>
   </div>
@@ -66,7 +66,7 @@ The `wp-interactive` directive "activates" the interactivity for the DOM element
   data-wp-interactive='{ "namespace": "myPlugin" }'
   data-wp-context='{ "myColor" : "red", "myBgColor": "yellow" }'
 >
-  <p>I'm interactive now, <span data-wp-style--background-color="context.myBgColor">>and I can use directives!</span></p>
+  <p>I'm interactive now, <span data-wp-style--background-color="context.myBgColor">and I can use directives!</span></p>
   <div>
     <p>I'm also interactive, <span data-wp-style--color="context.myColor">and I can also use directives!</span></p>
   </div>


### PR DESCRIPTION
minor code example correction. Removed duplicate HTML span element closing tags `>>` on lines 58 and 69 [wp-interactive API](<https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#wp-interactive>) documentation

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Code example syntax correction - duplicate HTML span element closing tags `>>` on lines 58 and 69

## Why?
Documentation house cleaning

## How?
Correcting assumed code syntax oversight

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-08-07 at 9 24 03 pm](https://github.com/user-attachments/assets/fb6bb445-5d47-4071-8a63-b77e3fd7b5c8)