### PR TITLE
Components: Update the TextControl padding to match the rest of the controls

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Modal`: Fix the dismissal logic for React development mode ([#64132](https://github.com/WordPress/gutenberg/pull/64132)).
 -   `Autocompleter UI`: Fix text color when hovering selected item ([#64294](https://github.com/WordPress/gutenberg/pull/64294)).
 -   `Heading`: Add the missing `size` prop to the component's props type ([#64299](https://github.com/WordPress/gutenberg/pull/64299)).
+-   `TextControl`: Fix the padding of the component to be consistent with the rest of the controls. ([#64326](https://github.com/WordPress/gutenberg/pull/64326)).
 
 ### Enhancements
 

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -20,5 +20,7 @@
 
 	&.is-next-40px-default-size {
 		height: $grid-unit-50;
+		padding-left: $grid-unit-20;
+		padding-right: $grid-unit-20;
 	}
 }

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -20,6 +20,9 @@
 
 	&.is-next-40px-default-size {
 		height: $grid-unit-50;
+
+		// Subtract 1px to account for the border, which isn't included on the element
+		// on newer components like InputControl, SelectControl, etc.
 		padding-left: $grid-unit-20;
 		padding-right: $grid-unit-20;
 	}


### PR DESCRIPTION
Related #57394 

## What?

I noticed that the TextControl component has a different padding than Number and Select controls (when used with the 40px size). This PR tries to fix that.

I'm not entirely sure that this PR fixes all the cases raised in the issue above, it only focuses on TextControl.

## Why?

Consistency of the design system.

## Testing Instructions

- Run storybook `npm run storybook:dev`
- Open the DataForms story
- Notice that the padding is the same for all the 40px size controls.