### PR TITLE
Add WP Studio to list of tools in docs

### DIFF
--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -54,7 +54,7 @@ Refer to the [Get started with `wp-env`](/docs/getting-started/devenv/get-starte
 This list is not exhaustive, but here are several additional options to choose from if you prefer not to use `wp-env`:
 
 - [Local](https://localwp.com/)
+- [WP Studio](https://developer.wordpress.com/studio/)
 - [XAMPP](https://www.apachefriends.org/)
 - [MAMP](https://www.mamp.info/en/mamp/mac/)
 - [Varying Vagrant Vagrants](https://varyingvagrantvagrants.org/) (VVV)
-- [WP Studio](https://developer.wordpress.com/studio/)

--- a/docs/getting-started/devenv/README.md
+++ b/docs/getting-started/devenv/README.md
@@ -57,3 +57,4 @@ This list is not exhaustive, but here are several additional options to choose f
 - [XAMPP](https://www.apachefriends.org/)
 - [MAMP](https://www.mamp.info/en/mamp/mac/)
 - [Varying Vagrant Vagrants](https://varyingvagrantvagrants.org/) (VVV)
+- [WP Studio](https://developer.wordpress.com/studio/)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes issue number: https://github.com/WordPress/gutenberg/issues/64322

## How?
Added [WP Studio](https://developer.wordpress.com/studio/) to list of tools to set up a WordPress development environment in `README.md`

## Screenshots or screencast <!-- if applicable -->
<img width="789" alt="Screenshot 2024-08-07 at 7 37 57 AM" src="https://github.com/user-attachments/assets/cc495612-faeb-444c-8d0d-bb304c0c6668">

