### PR TITLE
Background image: ensure consistency with defaults and fix reset/remove functionality

### DIFF
--- a/backport-changelog/6.7/7137.md
+++ b/backport-changelog/6.7/7137.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7137
 
 * https://github.com/WordPress/gutenberg/pull/64192
+* https://github.com/WordPress/gutenberg/pull/64328

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -59,17 +59,10 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$background_styles['backgroundRepeat']     = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 	$background_styles['backgroundAttachment'] = $block_attributes['style']['background']['backgroundAttachment'] ?? null;
 	if ( isset( $background_styles['backgroundImage']['id'] ) ) {
-		$inherited_styles                  = gutenberg_get_global_styles();
-		$inherited_block_background_styles = $inherited_styles['blocks'][ $block['blockName'] ]['background'] ?? null;
-		$inherited_background_size         = $inherited_block_background_styles['backgroundSize'] ?? null;
-		if ( ! isset( $background_styles['backgroundSize'] ) && ! $inherited_background_size ) {
-			$background_styles['backgroundSize'] = 'cover';
-		}
+		$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
 		// If the background size is set to `contain` and no position is set, set the position to `center`.
-		if ( 'contain' === $background_styles['backgroundSize'] || ( ! isset( $background_styles['backgroundSize'] ) && 'contain' === $inherited_background_size ) ) {
-			if ( ! isset( $background_styles['backgroundPosition'] ) && ! isset( $global_block_background_styles['backgroundPosition'] ) ) {
-				$background_styles['backgroundPosition'] = '50% 50%';
-			}
+		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {
+			$background_styles['backgroundPosition'] = '50% 50%';
 		}
 	}
 

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -58,7 +58,7 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$background_styles['backgroundPosition']   = $block_attributes['style']['background']['backgroundPosition'] ?? null;
 	$background_styles['backgroundRepeat']     = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 	$background_styles['backgroundAttachment'] = $block_attributes['style']['background']['backgroundAttachment'] ?? null;
-	if ( isset( $background_styles['backgroundImage']['id'] ) ) {
+	if ( isset( $background_styles['backgroundImage'] ) ) {
 		$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
 		// If the background size is set to `contain` and no position is set, set the position to `center`.
 		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -66,7 +66,7 @@ function gutenberg_render_background_support( $block_content, $block ) {
 			$background_styles['backgroundSize'] = 'cover';
 		}
 		// If the background size is set to `contain` and no position is set, set the position to `center`.
-		if ( 'contain' === $background_styles['backgroundSize'] || 'contain' === $inherited_background_size ) {
+		if ( 'contain' === $background_styles['backgroundSize'] || ( ! isset( $background_styles['backgroundSize'] ) && 'contain' === $inherited_background_size ) ) {
 			if ( ! isset( $background_styles['backgroundPosition'] ) && ! isset( $global_block_background_styles['backgroundPosition'] ) ) {
 				$background_styles['backgroundPosition'] = '50% 50%';
 			}

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -58,7 +58,7 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$background_styles['backgroundPosition']   = $block_attributes['style']['background']['backgroundPosition'] ?? null;
 	$background_styles['backgroundRepeat']     = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 	$background_styles['backgroundAttachment'] = $block_attributes['style']['background']['backgroundAttachment'] ?? null;
-	if ( isset( $background_styles['backgroundImage'] ) ) {
+	if ( ! empty( $background_styles['backgroundImage'] ) ) {
 		$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
 		// If the background size is set to `contain` and no position is set, set the position to `center`.
 		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {

--- a/lib/block-supports/background.php
+++ b/lib/block-supports/background.php
@@ -58,11 +58,18 @@ function gutenberg_render_background_support( $block_content, $block ) {
 	$background_styles['backgroundPosition']   = $block_attributes['style']['background']['backgroundPosition'] ?? null;
 	$background_styles['backgroundRepeat']     = $block_attributes['style']['background']['backgroundRepeat'] ?? null;
 	$background_styles['backgroundAttachment'] = $block_attributes['style']['background']['backgroundAttachment'] ?? null;
-	if ( ! empty( $background_styles['backgroundImage'] ) ) {
-		$background_styles['backgroundSize'] = $background_styles['backgroundSize'] ?? 'cover';
+	if ( isset( $background_styles['backgroundImage']['id'] ) ) {
+		$inherited_styles                  = gutenberg_get_global_styles();
+		$inherited_block_background_styles = $inherited_styles['blocks'][ $block['blockName'] ]['background'] ?? null;
+		$inherited_background_size         = $inherited_block_background_styles['backgroundSize'] ?? null;
+		if ( ! isset( $background_styles['backgroundSize'] ) && ! $inherited_background_size ) {
+			$background_styles['backgroundSize'] = 'cover';
+		}
 		// If the background size is set to `contain` and no position is set, set the position to `center`.
-		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {
-			$background_styles['backgroundPosition'] = 'center';
+		if ( 'contain' === $background_styles['backgroundSize'] || 'contain' === $inherited_background_size ) {
+			if ( ! isset( $background_styles['backgroundPosition'] ) && ! isset( $global_block_background_styles['backgroundPosition'] ) ) {
+				$background_styles['backgroundPosition'] = '50% 50%';
+			}
 		}
 	}
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2391,7 +2391,7 @@ class WP_Theme_JSON_Gutenberg {
 					$styles['background']['backgroundSize'] = $styles['background']['backgroundSize'] ?? 'cover';
 					// If the background size is set to `contain` and no position is set, set the position to `center`.
 					if ( 'contain' === $styles['background']['backgroundSize'] && empty( $styles['background']['backgroundPosition'] ) ) {
-						$styles['background']['backgroundPosition'] = 'center';
+						$styles['background']['backgroundPosition'] = '50% 50%';
 					}
 				}
 				$background_styles = gutenberg_style_engine_get_styles( array( 'background' => $styles['background'] ) );

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -583,7 +583,7 @@ function BackgroundSizeControls( {
 		);
 
 	return (
-		<VStack spacing={ 4 } className="single-column">
+		<VStack spacing={ 3 } className="single-column">
 			<FocalPointPicker
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
@@ -681,7 +681,7 @@ function BackgroundToolsPanel( {
 	return (
 		<VStack
 			as={ ToolsPanel }
-			spacing={ 4 }
+			spacing={ 2 }
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -340,9 +340,7 @@ function BackgroundImageControls( {
 					 * This is to increase the chance that the image's focus point is visible.
 					 * This is in-editor only to assist with the user experience.
 					 */
-					! positionValue &&
-					media.id &&
-					( 'auto' === sizeValue || ! sizeValue )
+					! positionValue && ( 'auto' === sizeValue || ! sizeValue )
 						? '50% 0'
 						: positionValue,
 				backgroundSize: sizeValue,
@@ -379,7 +377,9 @@ function BackgroundImageControls( {
 
 	const onRemove = () =>
 		onChange(
-			setImmutably( style, [ 'background', 'backgroundImage' ], 'none' )
+			setImmutably( style, [ 'background' ], {
+				backgroundImage: 'none',
+			} )
 		);
 	const canRemove = ! hasValue && hasBackgroundImageValue( inheritedValue );
 	const imgLabel =
@@ -461,9 +461,7 @@ function BackgroundSizeControls( {
 	const imageValue =
 		style?.background?.backgroundImage?.url ||
 		inheritedValue?.background?.backgroundImage?.url;
-	const isUploadedImage =
-		style?.background?.backgroundImage?.id ||
-		inheritedValue?.background?.backgroundImage?.id;
+	const isUploadedImage = style?.background?.backgroundImage?.id;
 	const positionValue =
 		style?.background?.backgroundPosition ||
 		inheritedValue?.background?.backgroundPosition;
@@ -750,7 +748,7 @@ export default function BackgroundPanel( {
 				) }
 			>
 				<ToolsPanelItem
-					hasValue={ () => hasBackgroundImageValue( value ) }
+					hasValue={ () => !! value?.background }
 					label={ __( 'Image' ) }
 					onDeselect={ resetBackground }
 					isShownByDefault={ defaultControls.backgroundImage }

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -320,24 +320,9 @@ function BackgroundImageControls( {
 			return;
 		}
 
-		/*
-		 * Only apply a default size value if
-		 * one doesn't exist on the block styles,
-		 * or in global styles. We should never
-		 * save an already-inherited style to the
-		 * block styles.
-		 */
-		const newSizeValue =
-			style?.background?.backgroundSize ||
-			( ! inheritedValue?.background?.backgroundSize
-				? defaultValues?.backgroundSize
-				: undefined );
-		const positionValue =
-			style?.background?.backgroundPosition ||
-			inheritedValue?.background?.backgroundPosition;
-		// sizeValue is used to test whether to set a background position.
 		const sizeValue =
-			newSizeValue || inheritedValue?.background?.backgroundSize;
+			style?.background?.backgroundSize || defaultValues?.backgroundSize;
+		const positionValue = style?.background?.backgroundPosition;
 		onChange(
 			setImmutably( style, [ 'background' ], {
 				...style?.background,
@@ -359,8 +344,8 @@ function BackgroundImageControls( {
 					media.id &&
 					( 'auto' === sizeValue || ! sizeValue )
 						? '50% 0'
-						: style?.background?.backgroundPosition,
-				backgroundSize: newSizeValue,
+						: positionValue,
+				backgroundSize: sizeValue,
 			} )
 		);
 	};

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -334,8 +334,7 @@ function BackgroundImageControls( {
 				},
 				backgroundPosition:
 					/*
-					 * A background image uploaded and set in the editor (an image with a record id),
-					 * receives a default background position of '50% 0',
+					 * A background image uploaded and set in the editor receives a default background position of '50% 0',
 					 * when the background image size is the equivalent of "Tile".
 					 * This is to increase the chance that the image's focus point is visible.
 					 * This is in-editor only to assist with the user experience.

--- a/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/test/use-global-styles-output.js
@@ -1061,7 +1061,7 @@ describe( 'global styles renderer', () => {
 				)
 			).toEqual( [
 				"background-image: url( 'https://wordpress.org/assets/image.jpg' )",
-				'background-position: center',
+				'background-position: 50% 50%',
 				'background-size: contain',
 			] );
 		} );

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -24,7 +24,7 @@ import {
 export const BACKGROUND_SUPPORT_KEY = 'background';
 
 // Initial control values.
-const BACKGROUND_DEFAULT_VALUES = {
+export const BACKGROUND_BLOCK_DEFAULT_VALUES = {
 	backgroundSize: 'cover',
 	backgroundPosition: '50% 50%', // used only when backgroundSize is 'contain'.
 };
@@ -59,38 +59,39 @@ export function setBackgroundStyleDefaults(
 	backgroundStyle,
 	inheritedBackgroundStyle = {}
 ) {
-	if ( ! backgroundStyle || ! backgroundStyle?.backgroundImage?.id ) {
+	if (
+		! backgroundStyle ||
+		! backgroundStyle?.backgroundImage?.id ||
+		! backgroundStyle?.backgroundImage?.url
+	) {
 		return;
 	}
 
-	const backgroundImage = backgroundStyle?.backgroundImage;
 	let backgroundStylesWithDefaults;
 
 	// Set block background defaults.
-	if ( !! backgroundImage?.url ) {
+	if (
+		! backgroundStyle?.backgroundSize &&
+		! inheritedBackgroundStyle?.backgroundSize
+	) {
+		backgroundStylesWithDefaults = {
+			backgroundSize: BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundSize,
+		};
+	}
+
+	if (
+		'contain' === backgroundStyle?.backgroundSize ||
+		( ! backgroundStyle?.backgroundSize &&
+			'contain' === inheritedBackgroundStyle?.backgroundSize )
+	) {
 		if (
-			! backgroundStyle?.backgroundSize &&
-			! inheritedBackgroundStyle?.backgroundSize
+			! backgroundStyle?.backgroundPosition &&
+			! inheritedBackgroundStyle?.backgroundPosition
 		) {
 			backgroundStylesWithDefaults = {
-				backgroundSize: BACKGROUND_DEFAULT_VALUES.backgroundSize,
+				backgroundPosition:
+					BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
 			};
-		}
-
-		if (
-			'contain' === backgroundStyle?.backgroundSize ||
-			( ! backgroundStyle?.backgroundSize &&
-				'contain' === inheritedBackgroundStyle?.backgroundSize )
-		) {
-			if (
-				! backgroundStyle?.backgroundPosition &&
-				! inheritedBackgroundStyle?.backgroundPosition
-			) {
-				backgroundStylesWithDefaults = {
-					backgroundPosition:
-						BACKGROUND_DEFAULT_VALUES.backgroundPosition,
-				};
-			}
 		}
 	}
 
@@ -211,7 +212,7 @@ export function BackgroundImagePanel( {
 			inheritedValue={ inheritedValue }
 			as={ BackgroundInspectorControl }
 			panelId={ clientId }
-			defaultValues={ BACKGROUND_DEFAULT_VALUES }
+			defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
 			settings={ updatedSettings }
 			onChange={ onChange }
 			value={ style }

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -56,11 +56,7 @@ export function hasBackgroundSupport( blockName, feature = 'any' ) {
 }
 
 export function setBackgroundStyleDefaults( backgroundStyle ) {
-	if (
-		! backgroundStyle ||
-		! backgroundStyle?.backgroundImage?.id ||
-		! backgroundStyle?.backgroundImage?.url
-	) {
+	if ( ! backgroundStyle || ! backgroundStyle?.backgroundImage?.url ) {
 		return;
 	}
 

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -55,10 +55,7 @@ export function hasBackgroundSupport( blockName, feature = 'any' ) {
 	return !! support?.[ feature ];
 }
 
-export function setBackgroundStyleDefaults(
-	backgroundStyle,
-	inheritedBackgroundStyle = {}
-) {
+export function setBackgroundStyleDefaults( backgroundStyle ) {
 	if (
 		! backgroundStyle ||
 		! backgroundStyle?.backgroundImage?.id ||
@@ -70,41 +67,25 @@ export function setBackgroundStyleDefaults(
 	let backgroundStylesWithDefaults;
 
 	// Set block background defaults.
-	if (
-		! backgroundStyle?.backgroundSize &&
-		! inheritedBackgroundStyle?.backgroundSize
-	) {
+	if ( ! backgroundStyle?.backgroundSize ) {
 		backgroundStylesWithDefaults = {
 			backgroundSize: BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundSize,
 		};
 	}
 
 	if (
-		'contain' === backgroundStyle?.backgroundSize ||
-		( ! backgroundStyle?.backgroundSize &&
-			'contain' === inheritedBackgroundStyle?.backgroundSize )
+		'contain' === backgroundStyle?.backgroundSize &&
+		! backgroundStyle?.backgroundPosition
 	) {
-		if (
-			! backgroundStyle?.backgroundPosition &&
-			! inheritedBackgroundStyle?.backgroundPosition
-		) {
-			backgroundStylesWithDefaults = {
-				backgroundPosition:
-					BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
-			};
-		}
+		backgroundStylesWithDefaults = {
+			backgroundPosition:
+				BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
+		};
 	}
-
 	return backgroundStylesWithDefaults;
 }
 
 function useBlockProps( { name, style } ) {
-	const inheritedValue = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings()[ globalStylesDataKey ]
-				?.blocks?.[ name ],
-		[ name ]
-	);
 	if (
 		! hasBackgroundSupport( name ) ||
 		! style?.background?.backgroundImage
@@ -112,10 +93,7 @@ function useBlockProps( { name, style } ) {
 		return;
 	}
 
-	const backgroundStyles = setBackgroundStyleDefaults(
-		style?.background,
-		inheritedValue?.background
-	);
+	const backgroundStyles = setBackgroundStyleDefaults( style?.background );
 
 	if ( ! backgroundStyles ) {
 		return;

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -73,7 +73,7 @@ export function setBackgroundStyleDefaults(
 			! inheritedBackgroundStyle?.backgroundSize
 		) {
 			backgroundStylesWithDefaults = {
-				backgroundSize: 'cover',
+				backgroundSize: BACKGROUND_DEFAULT_VALUES.backgroundSize,
 			};
 		}
 
@@ -87,7 +87,8 @@ export function setBackgroundStyleDefaults(
 				! inheritedBackgroundStyle?.backgroundPosition
 			) {
 				backgroundStylesWithDefaults = {
-					backgroundPosition: '50% 50%',
+					backgroundPosition:
+						BACKGROUND_DEFAULT_VALUES.backgroundPosition,
 				};
 			}
 		}

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -68,7 +68,6 @@ export function setBackgroundStyleDefaults(
 
 	// Set block background defaults.
 	if ( !! backgroundImage?.url ) {
-		// if style is set, it MUST override inherited style
 		if (
 			! backgroundStyle?.backgroundSize &&
 			! inheritedBackgroundStyle?.backgroundSize
@@ -76,20 +75,12 @@ export function setBackgroundStyleDefaults(
 			backgroundStylesWithDefaults = {
 				backgroundSize: 'cover',
 			};
-			return backgroundStylesWithDefaults;
-		}
-
-		// Don't process position defaults for any other value other than "contain".
-		if (
-			!! backgroundStyle?.backgroundSize &&
-			backgroundStyle?.backgroundSize !== 'contain'
-		) {
-			return backgroundStylesWithDefaults;
 		}
 
 		if (
-			'contain' === inheritedBackgroundStyle?.backgroundSize ||
-			'contain' === backgroundStyle?.backgroundSize
+			'contain' === backgroundStyle?.backgroundSize ||
+			( ! backgroundStyle?.backgroundSize &&
+				'contain' === inheritedBackgroundStyle?.backgroundSize )
 		) {
 			if (
 				! backgroundStyle?.backgroundPosition &&

--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -55,7 +55,7 @@ export function hasBackgroundSupport( blockName, feature = 'any' ) {
 }
 
 export function setBackgroundStyleDefaults( backgroundStyle ) {
-	if ( ! backgroundStyle ) {
+	if ( ! backgroundStyle || !! backgroundStyle?.backgroundImage?.id ) {
 		return;
 	}
 
@@ -75,7 +75,7 @@ export function setBackgroundStyleDefaults( backgroundStyle ) {
 			! backgroundStyle?.backgroundPosition
 		) {
 			backgroundStylesWithDefaults = {
-				backgroundPosition: 'center',
+				backgroundPosition: '50% 50%',
 			};
 		}
 	}

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -1,0 +1,106 @@
+/**
+ * Internal dependencies
+ */
+import {
+	setBackgroundStyleDefaults,
+	BACKGROUND_BLOCK_DEFAULT_VALUES,
+} from '../background';
+
+describe( 'background', () => {
+	describe( 'setBackgroundStyleDefaults', () => {
+		const backgroundStyles = {
+			backgroundImage: { id: 123, url: 'image.png' },
+		};
+		const backgroundStylesContain = {
+			backgroundImage: { id: 123, url: 'image.png' },
+			backgroundSize: 'contain',
+		};
+		const backgroundStylesNoId = { backgroundImage: { id: 123 } };
+		const backgroundStylesNoURL = { backgroundImage: { url: 'image.png' } };
+		it.each( [
+			[
+				'return background size default',
+				backgroundStyles,
+				undefined,
+				{
+					backgroundSize:
+						BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundSize,
+				},
+			],
+			[
+				'not apply default size value if one exists in inherited styles',
+				backgroundStyles,
+				{
+					backgroundSize: 'auto',
+				},
+				undefined,
+			],
+			[
+				'return early if no styles are passed',
+				undefined,
+				undefined,
+				undefined,
+			],
+			[
+				'return early if images has no id',
+				backgroundStylesNoId,
+				undefined,
+				undefined,
+			],
+			[
+				'return early if images has no URL',
+				backgroundStylesNoURL,
+				undefined,
+				undefined,
+			],
+			[
+				'return background position default',
+				backgroundStylesContain,
+				undefined,
+				{
+					backgroundPosition:
+						BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
+				},
+			],
+			[
+				'return background position default if inherited size is contain',
+				backgroundStyles,
+				{ backgroundSize: 'contain' },
+				{
+					backgroundPosition:
+						BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
+				},
+			],
+			[
+				'not apply background position when background size is not contain and inherited value is contain',
+				{
+					...backgroundStyles,
+					backgroundSize: 'cover',
+				},
+				{ backgroundSize: 'contain' },
+				undefined,
+			],
+			[
+				'not apply background position value if one already exists in styles',
+				{
+					...backgroundStylesContain,
+					backgroundPosition: 'center',
+				},
+				undefined,
+				undefined,
+			],
+			[
+				'not apply background position value if one exists in inherited styles',
+				backgroundStylesContain,
+				{ backgroundPosition: 'center' },
+				undefined,
+			],
+		] )( 'should %s', ( message, styles, inheritedStyles, expected ) => {
+			const result = setBackgroundStyleDefaults(
+				styles,
+				inheritedStyles
+			);
+			expect( result ).toEqual( expected );
+		} );
+	} );
+} );

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -21,64 +21,29 @@ describe( 'background', () => {
 			[
 				'return background size default',
 				backgroundStyles,
-				undefined,
 				{
 					backgroundSize:
 						BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundSize,
 				},
 			],
-			[
-				'not apply default size value if one exists in inherited styles',
-				backgroundStyles,
-				{
-					backgroundSize: 'auto',
-				},
-				undefined,
-			],
-			[
-				'return early if no styles are passed',
-				undefined,
-				undefined,
-				undefined,
-			],
+			[ 'return early if no styles are passed', undefined, undefined ],
 			[
 				'return early if images has no id',
 				backgroundStylesNoId,
-				undefined,
 				undefined,
 			],
 			[
 				'return early if images has no URL',
 				backgroundStylesNoURL,
 				undefined,
-				undefined,
 			],
 			[
 				'return background position default',
 				backgroundStylesContain,
-				undefined,
 				{
 					backgroundPosition:
 						BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
 				},
-			],
-			[
-				'return background position default if inherited size is contain',
-				backgroundStyles,
-				{ backgroundSize: 'contain' },
-				{
-					backgroundPosition:
-						BACKGROUND_BLOCK_DEFAULT_VALUES.backgroundPosition,
-				},
-			],
-			[
-				'not apply background position when background size is not contain and inherited value is contain',
-				{
-					...backgroundStyles,
-					backgroundSize: 'cover',
-				},
-				{ backgroundSize: 'contain' },
-				undefined,
 			],
 			[
 				'not apply background position value if one already exists in styles',
@@ -87,19 +52,9 @@ describe( 'background', () => {
 					backgroundPosition: 'center',
 				},
 				undefined,
-				undefined,
 			],
-			[
-				'not apply background position value if one exists in inherited styles',
-				backgroundStylesContain,
-				{ backgroundPosition: 'center' },
-				undefined,
-			],
-		] )( 'should %s', ( message, styles, inheritedStyles, expected ) => {
-			const result = setBackgroundStyleDefaults(
-				styles,
-				inheritedStyles
-			);
+		] )( 'should %s', ( message, styles, expected ) => {
+			const result = setBackgroundStyleDefaults( styles );
 			expect( result ).toEqual( expected );
 		} );
 	} );

--- a/packages/block-editor/src/hooks/test/background.js
+++ b/packages/block-editor/src/hooks/test/background.js
@@ -15,8 +15,7 @@ describe( 'background', () => {
 			backgroundImage: { id: 123, url: 'image.png' },
 			backgroundSize: 'contain',
 		};
-		const backgroundStylesNoId = { backgroundImage: { id: 123 } };
-		const backgroundStylesNoURL = { backgroundImage: { url: 'image.png' } };
+		const backgroundStylesNoURL = { backgroundImage: { id: 123 } };
 		it.each( [
 			[
 				'return background size default',
@@ -29,7 +28,7 @@ describe( 'background', () => {
 			[ 'return early if no styles are passed', undefined, undefined ],
 			[
 				'return early if images has no id',
-				backgroundStylesNoId,
+				backgroundStylesNoURL,
 				undefined,
 			],
 			[

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -25,9 +25,10 @@ import {
 	VariationsPanel,
 } from './variations/variations-panel';
 
-// Initial control values where no block style is set.
+// Initial control values.
 const BACKGROUND_BLOCK_DEFAULT_VALUES = {
 	backgroundSize: 'cover',
+	backgroundPosition: '50% 50%', // used only when backgroundSize is 'contain'.
 };
 
 function applyFallbackStyle( border ) {

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -122,7 +122,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 	 */
 	public function data_background_block_support() {
 		return array(
-			'background image style is applied' => array(
+			'background image style is applied to uploaded images' => array(
 				'theme_name'          => 'block-theme-child-with-fluid-typography',
 				'block_name'          => 'test/background-rules-are-output',
 				'background_settings' => array(
@@ -130,8 +130,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				),
 				'background_style'    => array(
 					'backgroundImage' => array(
-						'url'    => 'https://example.com/image.jpg',
-						'source' => 'file',
+						'url' => 'https://example.com/image.jpg',
+						'id'  => 123,
 					),
 				),
 				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
@@ -146,7 +146,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'background_style'    => array(
 					'backgroundImage' => "url('https://example.com/image.jpg')",
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, attachment, and repeat is applied' => array(
@@ -157,14 +157,14 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				),
 				'background_style'    => array(
 					'backgroundImage'      => array(
-						'url'    => 'https://example.com/image.jpg',
-						'source' => 'file',
+						'url' => 'https://example.com/image.jpg',
+						'id'  => 123,
 					),
 					'backgroundRepeat'     => 'no-repeat',
 					'backgroundSize'       => 'contain',
 					'backgroundAttachment' => 'fixed',
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:center;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-position:50% 50%;background-repeat:no-repeat;background-size:contain;background-attachment:fixed;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style is appended if a style attribute already exists' => array(
@@ -175,8 +175,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				),
 				'background_style'    => array(
 					'backgroundImage' => array(
-						'url'    => 'https://example.com/image.jpg',
-						'source' => 'file',
+						'url' => 'https://example.com/image.jpg',
+						'id'  => 123,
 					),
 				),
 				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
@@ -190,8 +190,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				),
 				'background_style'    => array(
 					'backgroundImage' => array(
-						'url'    => 'https://example.com/image.jpg',
-						'source' => 'file',
+						'url' => 'https://example.com/image.jpg',
+						'id'  => 123,
 					),
 				),
 				'expected_wrapper'    => '<div class="wp-block-test has-background" style="color: red;font-size: 15px;background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
@@ -205,8 +205,8 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				),
 				'background_style'    => array(
 					'backgroundImage' => array(
-						'url'    => 'https://example.com/image.jpg',
-						'source' => 'file',
+						'url' => 'https://example.com/image.jpg',
+						'id'  => 123,
 					),
 				),
 				'expected_wrapper'    => '<div>Content</div>',

--- a/phpunit/block-supports/background-test.php
+++ b/phpunit/block-supports/background-test.php
@@ -146,7 +146,7 @@ class WP_Block_Supports_Background_Test extends WP_UnitTestCase {
 				'background_style'    => array(
 					'backgroundImage' => "url('https://example.com/image.jpg')",
 				),
-				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);">Content</div>',
+				'expected_wrapper'    => '<div class="has-background" style="background-image:url(&#039;https://example.com/image.jpg&#039;);background-size:cover;">Content</div>',
 				'wrapper'             => '<div>Content</div>',
 			),
 			'background image style with contain, position, attachment, and repeat is applied' => array(

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4900,7 +4900,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 		);
 
-		$quote_styles = ":root :where(.wp-block-quote){background-image: url('http://example.org/quote.png');background-position: center;background-size: contain;}";
+		$quote_styles = ":root :where(.wp-block-quote){background-image: url('http://example.org/quote.png');background-position: 50% 50%;background-size: contain;}";
 		$this->assertSameCSS( $quote_styles, $theme_json->get_styles_for_block( $quote_node ), 'Styles returned from "::get_styles_for_block()" with core/quote default background styles do not match expectations' );
 
 		$verse_node = array(


### PR DESCRIPTION
Follow up to:

- https://github.com/WordPress/gutenberg/pull/64192


## What and how?

Block background styles will be part of WordPress 6.7.

This PR fixes miscellaneous bugs in the background image default values and controls. It:

- ensures that inherited values are shown in the controls
- ensures that any default values for **uploaded images** are represented in the controls
- ~~blocks should honour any inherited styles. That means, defaults should not overwrite styles defined in theme.json or global styles~~
- changes the default values of "center" to "50% 50%" so that it is represented in the focus picker control values. 
- ensures "resetting" an block's styles resets any current styles (at the moment it does not)
- ensures "removing" an image resets any current styles and remove access to the background controls



## Why?

To address a lot of inconsistencies in the way defaults are applied to block background styles.


## Testing Instructions

This might take some time, sorry!

Using a theme with background images set on blocks (see example theme.json), add some blocks to the editor (see example blocks).

Ensure that you can see inherited styles in the controls and that no background default values are applied.

Now upload/add your own images to these blocks.

1. The background size value should be set to "cover"
2. When toggling between background sizes, the defaults should be visible, E.g., Switch to "contain" and the image should be centered ("50% 50%"), and the value reflected in the controls.
3. Save and reset the image. Make sure that all values on the image have been reset.
4. Change the background size or other value for the inherited image. 
5. Now, "remove" the image so that the background is none. All properties, expect "background-image:none" should be gone.

Ensure that the frontend matches what you're seeing in the editor.

Site-wide background images should operate as before and be unaffected by any defaults aside from the existing position of `50% 0` position when switching to tiled.


<details>

<summary>Example block HTML</summary>
```html
<!-- wp:quote {"style":{"background":{"backgroundImage":"none"}}} -->
<blockquote class="wp-block-quote"><!-- wp:paragraph {"style":{"color":{"text":"#f8f8f8"},"elements":{"link":{"color":{"text":"#f8f8f8"}}},"typography":{"fontSize":"51px"}}} -->
<p class="has-text-color has-link-color" style="color:#f8f8f8;font-size:51px">Quote</p>
<!-- /wp:paragraph --></blockquote>
<!-- /wp:quote -->

<!-- wp:verse {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}},"typography":{"fontSize":"61px"},"background":{"backgroundImage":{"url":"http://localhost:8888/wp-content/uploads/2024/08/rampant-onion.jpg","id":24,"source":"file","title":"rampant-onion"},"backgroundSize":"cover"}},"textColor":"white"} -->
<pre class="wp-block-verse has-white-color has-text-color has-link-color" style="font-size:61px">Verse</pre>
<!-- /wp:verse -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"color":{"text":"#fefefe"},"elements":{"link":{"color":{"text":"#fefefe"}}},"typography":{"fontSize":"59px"}}} -->
<p class="has-text-color has-link-color" style="color:#fefefe;font-size:59px">Group</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
</details>

<details>

<summary>example theme.json</summary>

```json

{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px",
			"wideSize": "1100px"
		}
	},
	"styles": {

		"background": {
			"backgroundImage": {
				"url": "https://images.pexels.com/photos/105819/pexels-photo-105819.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr="
			}
		},
		"blocks": {
			"core/verse": {
				"background": {
					"backgroundImage": {
						"url": "https://images.pexels.com/photos/27332202/pexels-photo-27332202/free-photo-of-surfer.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
					},
					"backgroundSize": "contain"
				},
				"dimensions": {
					"minHeight": "100px"
				}
			},
			"core/quote": {
				"background": {
					"backgroundImage": {
						"url": "https://images.pexels.com/photos/22484288/pexels-photo-22484288/free-photo-of-the-circular-stone-terraces-of-the-inca-ruins.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
					}
				},
				"dimensions": {
					"minHeight": "100px"
				}
			},
			"core/group": {
				"background": {
					"backgroundImage": {
						"url": "https://images.pexels.com/photos/27101553/pexels-photo-27101553/free-photo-of-a-cocktail-with-mint-and-lime-in-it.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=2"
					}
				},
				"dimensions": {
					"minHeight": "111px"
				}
			}
		}
	}
}

```

</details>


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->



https://github.com/user-attachments/assets/8e04f760-9811-42e7-8a2a-dca698aa73d9




## TODO

- [ ] The UI is getting complicated. We probably need E2E tests in a follow up.

