### PR TITLE
Fix: Stabilize border block support keys 

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -17,7 +17,7 @@ function gutenberg_register_border_support( $block_type ) {
 		$block_type->attributes = array();
 	}
 
-	if ( block_has_support( $block_type, array( '__experimentalBorder' ) ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
+	if ( block_has_support( $block_type, array( 'border' ) ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
 		);
@@ -52,7 +52,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'radius' ) &&
 		isset( $block_attributes['style']['border']['radius'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'radius' )
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'radius' )
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
@@ -67,7 +67,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
 		isset( $block_attributes['style']['border']['style'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'style' )
 	) {
 		$border_block_styles['style'] = $block_attributes['style']['border']['style'];
 	}
@@ -76,7 +76,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		$has_border_width_support &&
 		isset( $block_attributes['style']['border']['width'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' )
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'width' )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
 
@@ -91,7 +91,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	// Border color.
 	if (
 		$has_border_color_support &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'color' )
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
 		$custom_border_color          = $block_attributes['style']['border']['color'] ?? null;
@@ -103,9 +103,9 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
 			$border                       = $block_attributes['style']['border'][ $side ] ?? null;
 			$border_side_values           = array(
-				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,
-				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,
-				'style' => isset( $border['style'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' ) ? $border['style'] : null,
+				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, 'border', 'width' ) ? $border['width'] : null,
+				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, 'border', 'color' ) ? $border['color'] : null,
+				'style' => isset( $border['style'] ) && ! wp_should_skip_block_supports_serialization( $block_type, 'border', 'style' ) ? $border['style'] : null,
 			);
 			$border_block_styles[ $side ] = $border_side_values;
 		}
@@ -143,7 +143,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 function gutenberg_has_border_feature_support( $block_type, $feature, $default_value = false ) {
 	// Check if all border support features have been opted into via `"__experimentalBorder": true`.
 	if ( $block_type instanceof WP_Block_Type ) {
-		$block_type_supports_border = $block_type->supports['__experimentalBorder'] ?? $default_value;
+		$block_type_supports_border = $block_type->supports['border'] ?? $default_value;
 		if ( true === $block_type_supports_border ) {
 			return true;
 		}
@@ -151,7 +151,7 @@ function gutenberg_has_border_feature_support( $block_type, $feature, $default_v
 
 	// Check if the specific feature has been opted into individually
 	// via nested flag under `__experimentalBorder`.
-	return block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default_value );
+	return block_has_support( $block_type, array( 'border', $feature ), $default_value );
 }
 
 // Register the block support.

--- a/lib/compat/wordpress-6.7/blocks.php
+++ b/lib/compat/wordpress-6.7/blocks.php
@@ -43,3 +43,25 @@ function gutenberg_filter_block_type_metadata_settings_allow_variations_php_file
 	return $settings;
 }
 add_filter( 'block_type_metadata_settings', 'gutenberg_filter_block_type_metadata_settings_allow_variations_php_file', 10, 2 );
+
+/**
+ * Filters the block type arguments during registration to stabilize experimental block supports.
+ *
+ * This is a temporary compatibility shim as the approach in core is for this to be handled
+ * within the WP_Block_Type class rather than requiring a filter.
+ *
+ * @param array $args Array of arguments for registering a block type.
+ * @return array Array of arguments for registering a block type.
+ */
+function gutenberg_stabilize_experimental_block_supports( $args ) {
+
+	if ( empty( $args['supports']['__experimentalBorder'] ) ) {
+		return $args;
+	}
+
+	$args['supports']['border'] = $args['supports']['__experimentalBorder'];
+
+	return $args;
+}
+
+add_filter( 'register_block_type_args', 'gutenberg_stabilize_experimental_block_supports', PHP_INT_MAX, 1 );

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -31,7 +31,7 @@ import {
 import { store as blockEditorStore } from '../store';
 import { __ } from '@wordpress/i18n';
 
-export const BORDER_SUPPORT_KEY = '__experimentalBorder';
+export const BORDER_SUPPORT_KEY = 'border';
 export const SHADOW_SUPPORT_KEY = 'shadow';
 
 const getColorByProperty = ( colors, property, value ) => {

--- a/packages/block-editor/src/hooks/supports.js
+++ b/packages/block-editor/src/hooks/supports.js
@@ -6,7 +6,7 @@ import { Platform } from '@wordpress/element';
 
 const ALIGN_SUPPORT_KEY = 'align';
 const ALIGN_WIDE_SUPPORT_KEY = 'alignWide';
-const BORDER_SUPPORT_KEY = '__experimentalBorder';
+const BORDER_SUPPORT_KEY = 'border';
 const COLOR_SUPPORT_KEY = 'color';
 const CUSTOM_CLASS_NAME_SUPPORT_KEY = 'customClassName';
 const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -58,12 +58,12 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	borderColor: {
 		value: [ 'border', 'color' ],
-		support: [ '__experimentalBorder', 'color' ],
+		support: [ 'border', 'color' ],
 		useEngine: true,
 	},
 	borderRadius: {
 		value: [ 'border', 'radius' ],
-		support: [ '__experimentalBorder', 'radius' ],
+		support: [ 'border', 'radius' ],
 		properties: {
 			borderTopLeftRadius: 'topLeft',
 			borderTopRightRadius: 'topRight',
@@ -74,72 +74,72 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	borderStyle: {
 		value: [ 'border', 'style' ],
-		support: [ '__experimentalBorder', 'style' ],
+		support: [ 'border', 'style' ],
 		useEngine: true,
 	},
 	borderWidth: {
 		value: [ 'border', 'width' ],
-		support: [ '__experimentalBorder', 'width' ],
+		support: [ 'border', 'width' ],
 		useEngine: true,
 	},
 	borderTopColor: {
 		value: [ 'border', 'top', 'color' ],
-		support: [ '__experimentalBorder', 'color' ],
+		support: [ 'border', 'color' ],
 		useEngine: true,
 	},
 	borderTopStyle: {
 		value: [ 'border', 'top', 'style' ],
-		support: [ '__experimentalBorder', 'style' ],
+		support: [ 'border', 'style' ],
 		useEngine: true,
 	},
 	borderTopWidth: {
 		value: [ 'border', 'top', 'width' ],
-		support: [ '__experimentalBorder', 'width' ],
+		support: [ 'border', 'width' ],
 		useEngine: true,
 	},
 	borderRightColor: {
 		value: [ 'border', 'right', 'color' ],
-		support: [ '__experimentalBorder', 'color' ],
+		support: [ 'border', 'color' ],
 		useEngine: true,
 	},
 	borderRightStyle: {
 		value: [ 'border', 'right', 'style' ],
-		support: [ '__experimentalBorder', 'style' ],
+		support: [ 'border', 'style' ],
 		useEngine: true,
 	},
 	borderRightWidth: {
 		value: [ 'border', 'right', 'width' ],
-		support: [ '__experimentalBorder', 'width' ],
+		support: [ 'border', 'width' ],
 		useEngine: true,
 	},
 	borderBottomColor: {
 		value: [ 'border', 'bottom', 'color' ],
-		support: [ '__experimentalBorder', 'color' ],
+		support: [ 'border', 'color' ],
 		useEngine: true,
 	},
 	borderBottomStyle: {
 		value: [ 'border', 'bottom', 'style' ],
-		support: [ '__experimentalBorder', 'style' ],
+		support: [ 'border', 'style' ],
 		useEngine: true,
 	},
 	borderBottomWidth: {
 		value: [ 'border', 'bottom', 'width' ],
-		support: [ '__experimentalBorder', 'width' ],
+		support: [ 'border', 'width' ],
 		useEngine: true,
 	},
 	borderLeftColor: {
 		value: [ 'border', 'left', 'color' ],
-		support: [ '__experimentalBorder', 'color' ],
+		support: [ 'border', 'color' ],
 		useEngine: true,
 	},
 	borderLeftStyle: {
 		value: [ 'border', 'left', 'style' ],
-		support: [ '__experimentalBorder', 'style' ],
+		support: [ 'border', 'style' ],
 		useEngine: true,
 	},
 	borderLeftWidth: {
 		value: [ 'border', 'left', 'width' ],
-		support: [ '__experimentalBorder', 'width' ],
+		support: [ 'border', 'width' ],
 		useEngine: true,
 	},
 	color: {


### PR DESCRIPTION
This commit references the PR - https://github.com/WordPress/wordpress-develop/pull/7069/files, which aims to stablise the typogrpahy supports. Based on the PR added this commit to stablise the supports for the border. Since we does not have the border options as experimental, instead we have border as experimiental hence we stablised the main key and this makes us not to touch the inner border supports as they were not defined as experimental.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Issue - https://github.com/WordPress/gutenberg/issues/64312

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
