### PR TITLE
Stop unwanted drag and drop operations within section Patterns in Zoom Out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -38,6 +38,7 @@ function InbetweenInsertionPointPopover( {
 		isInserterShown,
 		isDistractionFree,
 		isNavigationMode,
+		isZoomOutMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockOrder,
@@ -48,6 +49,7 @@ function InbetweenInsertionPointPopover( {
 			getNextBlockClientId,
 			getSettings,
 			isNavigationMode: _isNavigationMode,
+			__unstableGetEditorMode,
 		} = select( blockEditorStore );
 		const insertionPoint = getBlockInsertionPoint();
 		const order = getBlockOrder( insertionPoint.rootClientId );
@@ -79,6 +81,7 @@ function InbetweenInsertionPointPopover( {
 			isNavigationMode: _isNavigationMode(),
 			isDistractionFree: settings.isDistractionFree,
 			isInserterShown: insertionPoint?.__unstableWithInserter,
+			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
 		};
 	}, [] );
 	const { getBlockEditingMode } = useSelect( blockEditorStore );
@@ -142,6 +145,14 @@ function InbetweenInsertionPointPopover( {
 	};
 
 	if ( isDistractionFree && ! isNavigationMode ) {
+		return null;
+	}
+
+	// Zoom out mode should only show the insertion point for the insert operation.
+	// Other operations such as "group" are when the editor tries to create a row
+	// block by grouping the block being dragged with the block it's being dropped
+	// onto.
+	if ( isZoomOutMode && operation !== 'insert' ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -206,13 +206,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getSettings,
 			} = unlock( select( blockEditorStore ) );
 			let _isDropZoneDisabled;
-			// In zoom out mode, we want to disable the drop zone for the sections.
-			// The inner blocks belonging to the section drop zone is
-			// already disabled by the blocks themselves being disabled.
-			if ( __unstableGetEditorMode() === 'zoom-out' ) {
-				const { sectionRootClientId } = unlock( getSettings() );
-				_isDropZoneDisabled = clientId !== sectionRootClientId;
-			}
+
 			if ( ! clientId ) {
 				return { isDropZoneDisabled: _isDropZoneDisabled };
 			}
@@ -225,8 +219,15 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const parentClientId = getBlockRootClientId( clientId );
 			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
 
-			if ( _isDropZoneDisabled !== undefined ) {
-				_isDropZoneDisabled = blockEditingMode === 'disabled';
+			_isDropZoneDisabled = blockEditingMode === 'disabled';
+
+			if ( __unstableGetEditorMode() === 'zoom-out' ) {
+				// In zoom out mode, we want to disable the drop zone for the sections.
+				// The inner blocks belonging to the section drop zone is
+				// already disabled by the blocks themselves being disabled.
+				const { sectionRootClientId } = unlock( getSettings() );
+
+				_isDropZoneDisabled = clientId !== sectionRootClientId;
 			}
 
 			return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Blocks the ability to drag patterns inside existing top level patterns in Zoom Out mode. Patterns should only be insertable at the top level.

Also disable ability for horizontal insertion at the topmost level.

Closes https://github.com/WordPress/gutenberg/issues/63862

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Zoom Out is about composing Pages from Patterns as sections. These "sections" are the building blocks of the page. As a result when constructing a page using drag and drop it is confusing if

- dropzones appear _within_ existing sections 
- dropzones appear to the left/right of the existing sections.

Both of these interactions also make the experience prone to error.

What we need is for the top level sections to be selectable (`blockEditingMode === 'default'`) but to _disable_ the ability to drag and drop inside of them. This is a hybrid state, specific to Zoom Out mode, which means we need to add special conditions.

In addition to this, drag and drop interactions can have an "operation" which can be `insert` or `group`. Insert is standard "insert block(s) here". Group however, is for special interactions such as allowing for the creation of "Row" layouts by dragging one group to the left/right of another group.

In Zoom Out mode we are composing sections and thus such "grouping" operations are undesirable. 





## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change the order of the conditionals that govern the availability of drop zones, so that when in Zoom Out mode, _all_ dropzones (except those at the section root) are disabled. This means that you cannot drag and drop _inside_ the individual section blocks, but you _can_ drag and drop between them.

Moreover, we hide the insertion points at the topmost level if/when the drag/drop operation type is `group`.




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create a new Page.
- Dismiss the modal "New Page" overlay.
- Enter Zoom Out compose mode by opening the Patterns tab of the global inserter.
- Add a few patterns. 
- Try and drag and drop patterns into the canvas.
- You should only be able to drag inbetween the top level patterns.
- You should not be able to:
    - drag _inside_ an existing pattern
    - drag patterns to the left/right of an existing pattern (creation of "Row").
- Repeat the above steps in the Site Editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before
https://github.com/user-attachments/assets/651461fb-caea-4784-a726-e81b48908a5d

### After
https://github.com/user-attachments/assets/2391cd6b-79e6-460a-85af-97265d7c39f1


Co-authored-by: Maggie Cabrera <3593343+MaggieCabrera@users.noreply.github.com>
Co-authored-by: scruffian <scruffian@git.wordpress.org>

