### PR TITLE
WIP: Revert "Adds experimental blocks flag for blocks that may not be ready for general use (#64121)"

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -43,28 +43,12 @@ add_action( 'admin_init', 'gutenberg_enable_experiments' );
 
 /**
  * Sets a global JS variable used to trigger the availability of form & input blocks.
- *
- * @deprecated 19.0.0 Use gutenberg_enable_block_experiments().
  */
 function gutenberg_enable_form_input_blocks() {
-	_deprecated_function( __FUNCTION__, 'Gutenberg 19.0.0', 'gutenberg_enable_block_experiments' );
-}
-
-/**
- * Sets global JS variables used to enable various block experiments.
- */
-function gutenberg_enable_block_experiments() {
 	$gutenberg_experiments = get_option( 'gutenberg-experiments' );
-
-	// Experimental form blocks.
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-form-blocks', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableFormBlocks = true', 'before' );
 	}
-
-	// General experimental blocks that are not in the default block library.
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-experiments', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableBlockExperiments = true', 'before' );
-	}
 }
 
-add_action( 'admin_init', 'gutenberg_enable_block_experiments' );
+add_action( 'admin_init', 'gutenberg_enable_form_input_blocks' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -80,18 +80,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-block-experiments',
-		__( 'Experimental blocks', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable experimental blocks.<p class="description">(Warning: these blocks may have significant changes during development that cause validation errors and display issues.)</p>', 'gutenberg' ),
-			'id'    => 'gutenberg-block-experiments',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-form-blocks',
 		__( 'Form and input blocks ', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -95,7 +95,6 @@ $GLOBALS['wp_tests_options'] = array(
 		'gutenberg-widget-experiments' => '1',
 		'gutenberg-full-site-editing'  => 1,
 		'gutenberg-form-blocks'        => 1,
-		'gutenberg-block-experiments'  => 1,
 	),
 );
 


### PR DESCRIPTION
## What?

This PR reverts the experimental flag for blocks added in #64121.

> [!NOTE]
> Note: This PR is not guaranteed to be merged, but was prepared in advance to prevent #64121 from shipping in Gutenberg version 19.0.

## Why?

#64121 was added for a reason:

> Blocks in development may not be ready for general use. By having users opt in to an experiment to test these blocks, we can iterate without worrying about writing multiple block deprecations.
> Once a block is stable, it can be promoted from the experiment to being included by default in block-library.

However, the following opinion exists:

> A single block is usually well scoped and when it's quite close to land, but we're not sure if it's going to be stable for a WP release, we have the "__experimental" flag in block's metadata (block.json). In all other cases, the block should be tested in the respective PR and not add extra unfinished code in the repo.

We probably shouldn't add such an option until we have a clear rule of ​​how to handle "experimental" blocks in the Gutenberg plugin.