### PR TITLE
DataForm: provide a better default for render when field has elements

### DIFF
--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import getFieldTypeDefinition from './field-types';
-import type { Field, NormalizedField, ItemRecord } from './types';
+import type { Field, NormalizedField } from './types';
 
 /**
  * Apply default values and normalize the fields config.
@@ -18,7 +18,7 @@ export function normalizeFields< Item >(
 
 		const getValue =
 			field.getValue ||
-			( ( { item }: { item: ItemRecord } ) => item[ field.id ] );
+			( ( { item }: { item: Item } ) => item[ field.id as keyof Item ] );
 
 		const sort =
 			field.sort ??
@@ -41,11 +41,22 @@ export function normalizeFields< Item >(
 
 		const Edit = field.Edit || fieldTypeDefinition.Edit;
 
+		const renderFromElements = ( { item }: { item: Item } ) => {
+			const value = getValue( { item } );
+			return (
+				field?.elements?.find( ( element ) => element.value === value )
+					?.label || getValue( { item } )
+			);
+		};
+
+		const render =
+			field.render || ( field.elements ? renderFromElements : getValue );
+
 		return {
 			...field,
 			label: field.label || field.id,
 			getValue,
-			render: field.render || getValue,
+			render,
 			sort,
 			isValid,
 			Edit,

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -43,10 +43,13 @@ export function normalizeFields< Item >(
 
 		const renderFromElements = ( { item }: { item: Item } ) => {
 			const value = getValue( { item } );
-			return (
-				field?.elements?.find( ( element ) => element.value === value )
-					?.label || getValue( { item } )
-			);
+			const label = field?.elements?.find( ( element ) => {
+				// Intentionally using == here to allow for type coercion.
+				// eslint-disable-next-line eqeqeq
+				return element.value == value;
+			} )?.label;
+
+			return label || value;
 		};
 
 		const render =


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/55101
Follow-up to https://github.com/WordPress/gutenberg/pull/64299#discussion_r1706906095

## What?

Provide a better default `render` function when the field has declared `elements`.

## Why?

Note how the `author` and `status` fields are rendered in the before/after.

Before:

https://github.com/user-attachments/assets/35471e35-eb1b-4684-9aae-1ccc0bdddc73

After:


https://github.com/user-attachments/assets/7a99de35-263d-4409-86f7-072422aa64bb



## Testing Instructions

`npm install && npm run storybook:dev` and verify `author` and `status` are properly rendered.
