### PR TITLE
Fix: firefox gallery image issue

### DIFF
--- a/packages/block-library/src/gallery/style.scss
+++ b/packages/block-library/src/gallery/style.scss
@@ -115,7 +115,7 @@ figure.wp-block-gallery.has-nested-images {
 		img {
 			width: 100%;
 			flex: 1 0 0%;
-			height: 100%;
+			height: auto;
 			object-fit: cover;
 		}
 	}


### PR DESCRIPTION
## Why?
Fixes https://github.com/WordPress/gutenberg/issues/64348

## How?
- remove `height: 100%` and replace it with `height: auto`


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/be4a77a2-f93e-4557-901f-68050477cbad

