### PR TITLE
Latests Posts: Used ToggleGroupControl instead for Image alignment

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -63,7 +63,7 @@
 		},
 		"featuredImageAlign": {
 			"type": "string",
-			"default": "none"
+			"enum": [ "left", "center", "right" ]
 		},
 		"featuredImageSizeSlug": {
 			"type": "string",

--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -63,7 +63,7 @@
 		},
 		"featuredImageAlign": {
 			"type": "string",
-			"enum": [ "left", "center", "right" ]
+			"default": "none"
 		},
 		"featuredImageSizeSlug": {
 			"type": "string",

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -16,7 +16,7 @@ import {
 	ToggleControl,
 	ToolbarGroup,
 	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { dateI18n, format, getSettings } from '@wordpress/date';
@@ -28,7 +28,15 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { pin, list, grid } from '@wordpress/icons';
+import {
+	pin,
+	list,
+	grid,
+	alignNone,
+	alignLeft,
+	alignCenter,
+	alignRight,
+} from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
 import { useInstanceId } from '@wordpress/compose';
@@ -197,6 +205,29 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		setAttributes( { categories: allCategories } );
 	};
 
+	const imageAlignmentOptions = [
+		{
+			value: 'none',
+			icon: alignNone,
+			label: __( 'None' ),
+		},
+		{
+			value: 'left',
+			icon: alignLeft,
+			label: __( 'Left' ),
+		},
+		{
+			value: 'center',
+			icon: alignCenter,
+			label: __( 'Center' ),
+		},
+		{
+			value: 'right',
+			icon: alignRight,
+			label: __( 'Right' ),
+		},
+	];
+
 	const hasPosts = !! latestPosts?.length;
 	const inspectorControls = (
 		<InspectorControls>
@@ -307,30 +338,27 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 							className="editor-latest-posts-image-alignment-control"
 							__nextHasNoMarginBottom
 							label={ __( 'Image alignment' ) }
-							value={ featuredImageAlign }
+							value={ featuredImageAlign || 'none' }
 							onChange={ ( value ) =>
 								setAttributes( {
-									featuredImageAlign: value,
+									featuredImageAlign:
+										value !== 'none' ? value : undefined,
 								} )
 							}
 							isBlock
 						>
-							<ToggleGroupControlOption
-								value="none"
-								label={ __( 'None' ) }
-							/>
-							<ToggleGroupControlOption
-								value="left"
-								label={ __( 'Left' ) }
-							/>
-							<ToggleGroupControlOption
-								value="center"
-								label={ __( 'Center' ) }
-							/>
-							<ToggleGroupControlOption
-								value="right"
-								label={ __( 'Right' ) }
-							/>
+							{ imageAlignmentOptions.map(
+								( { value, icon, label } ) => {
+									return (
+										<ToggleGroupControlOptionIcon
+											key={ value }
+											value={ value }
+											icon={ icon }
+											label={ label }
+										/>
+									);
+								}
+							) }
 						</ToggleGroupControl>
 						<ToggleControl
 							__nextHasNoMarginBottom

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -346,7 +346,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 										value !== 'none' ? value : undefined,
 								} )
 							}
-							isBlock
 						>
 							{ imageAlignmentOptions.map(
 								( { value, icon, label } ) => {

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -33,9 +33,9 @@ import {
 	list,
 	grid,
 	alignNone,
-	alignLeft,
-	alignCenter,
-	alignRight,
+	positionLeft,
+	positionCenter,
+	positionRight,
 } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
@@ -213,17 +213,17 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 		},
 		{
 			value: 'left',
-			icon: alignLeft,
+			icon: positionLeft,
 			label: __( 'Left' ),
 		},
 		{
 			value: 'center',
-			icon: alignCenter,
+			icon: positionCenter,
 			label: __( 'Center' ),
 		},
 		{
 			value: 'right',
-			icon: alignRight,
+			icon: positionRight,
 			label: __( 'Right' ),
 		},
 	];
@@ -337,6 +337,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 						<ToggleGroupControl
 							className="editor-latest-posts-image-alignment-control"
 							__nextHasNoMarginBottom
+							__next40pxDefaultSize
 							label={ __( 'Image alignment' ) }
 							value={ featuredImageAlign || 'none' }
 							onChange={ ( value ) =>

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	BaseControl,
 	PanelBody,
 	Placeholder,
 	QueryControls,
@@ -16,12 +15,13 @@ import {
 	Spinner,
 	ToggleControl,
 	ToolbarGroup,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { dateI18n, format, getSettings } from '@wordpress/date';
 import {
 	InspectorControls,
-	BlockAlignmentToolbar,
 	BlockControls,
 	__experimentalImageSizeControl as ImageSizeControl,
 	useBlockProps,
@@ -303,21 +303,35 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 								} )
 							}
 						/>
-						<BaseControl className="editor-latest-posts-image-alignment-control">
-							<BaseControl.VisualLabel>
-								{ __( 'Image alignment' ) }
-							</BaseControl.VisualLabel>
-							<BlockAlignmentToolbar
-								value={ featuredImageAlign }
-								onChange={ ( value ) =>
-									setAttributes( {
-										featuredImageAlign: value,
-									} )
-								}
-								controls={ [ 'left', 'center', 'right' ] }
-								isCollapsed={ false }
+						<ToggleGroupControl
+							className="editor-latest-posts-image-alignment-control"
+							__nextHasNoMarginBottom
+							label={ __( 'Image alignment' ) }
+							value={ featuredImageAlign }
+							onChange={ ( value ) =>
+								setAttributes( {
+									featuredImageAlign: value,
+								} )
+							}
+							isBlock
+						>
+							<ToggleGroupControlOption
+								value="none"
+								label={ __( 'None' ) }
 							/>
-						</BaseControl>
+							<ToggleGroupControlOption
+								value="left"
+								label={ __( 'Left' ) }
+							/>
+							<ToggleGroupControlOption
+								value="center"
+								label={ __( 'Center' ) }
+							/>
+							<ToggleGroupControlOption
+								value="right"
+								label={ __( 'Right' ) }
+							/>
+						</ToggleGroupControl>
 						<ToggleControl
 							__nextHasNoMarginBottom
 							label={ __( 'Add link to featured image' ) }

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -9,12 +9,6 @@
 	display: inline;
 }
 
-.editor-latest-posts-image-alignment-control {
-	.components-toolbar {
-		border-radius: $radius-block-ui;
-	}
-}
-
 :root :where(.wp-block-latest-posts) {
 	padding-left: 2.5em;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: #64350 

## Why?
See this [comment](https://github.com/WordPress/gutenberg/issues/64350#issue-2454115382)

## How?
Used ToggleGroupControl for Image alignment

## Testing Instructions
1. Create a post
2. Add `Latest Posts block`
3. Turn on the toggle for `Display featured image`
4. See the `Image alignment` settings

## Screenshots or screencast <!-- if applicable -->
<img width="279" alt="image" src="https://github.com/user-attachments/assets/fadf39c3-eae7-4e69-93dd-9c5b646d0f29">
