### PR TITLE
Docs: Interactivity API: Add wp_interactivity_state() clarification

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1152,7 +1152,7 @@ store('mySliderPlugin', {
 
 ## Server functions
 
-The Interactivity API comes with handy functions that allow you to initialize and reference configuration options on the server. This is a great way to leverage many of WordPress's APIs, like nonces, AJAX, and translations.
+The Interactivity API comes with handy functions that allow you to initialize and reference configuration options on the server. This is necessary to feed the initial data that the Server Directive Processing will use to modify the HTML markup before it's send to the browser. It is also a great way to leverage many of WordPress's APIs, like nonces, AJAX, and translations.
 
 ### wp_interactivity_config
 

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1204,10 +1204,28 @@ wp_interactivity_state(
 ```
 
 ```js
+// view.js
+
 const { state } = store( 'myPlugin', {
-	console.log( state.ajaxUrl );
-	// Expected output: https://yoursite.com/wp-admin/admin-ajax.php
-}
+	actions: {
+		*doSomething() {
+			try {
+				const formData = new FormData();
+				formData.append( 'action', 'do_something' );
+				formData.append( '_ajax_nonce', state.nonce );
+
+				const data = yield fetch( state.ajaxUrl, {
+					method: 'POST',
+					body: formData,
+				} ).then( ( response ) => response.json() );
+					console.log( 'Server data!', data );
+				} catch ( e ) {
+					// Something went wrong!
+				}
+			},
+		},
+	}
+);
 ```
 
 ### wp_interactivity_process_directives

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1183,7 +1183,7 @@ const { showLikeButton } = getConfig();
 
 ### wp_interactivity_state
 
-`wp_interactivity_state` allows the initialization of state on the server, which will be merged with with any stores defined in `view.js`.
+`wp_interactivity_state` allows the initialization of the global state on the server, which will be used to process the directives on the server and then will be merged with any global state defined in the client.
 
 Initializing state on the server allows you to use many critical WordPress APIs, including [AJAX](https://developer.wordpress.org/plugins/javascript/ajax/), or [nonces](https://developer.wordpress.org/plugins/javascript/enqueuing/#nonce).
 

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1185,7 +1185,7 @@ const { showLikeButton } = getConfig();
 
 `wp_interactivity_state` allows the initialization of the global state on the server, which will be used to process the directives on the server and then will be merged with any global state defined in the client.
 
-Initializing state on the server allows you to use many critical WordPress APIs, including [AJAX](https://developer.wordpress.org/plugins/javascript/ajax/), or [nonces](https://developer.wordpress.org/plugins/javascript/enqueuing/#nonce).
+Initializing the global state on the server also allows you to use many critical WordPress APIs, including [AJAX](https://developer.wordpress.org/plugins/javascript/ajax/), or [nonces](https://developer.wordpress.org/plugins/javascript/enqueuing/#nonce).
 
 The `wp_interactivity_state` function receives two arguments, a string with the namespace that will be used as a reference and an associative array containing the values.
 

--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -1152,7 +1152,7 @@ store('mySliderPlugin', {
 
 ## Server functions
 
-The Interactivity API comes with handy functions on the PHP part. Apart from [setting the store via server](#on-the-server-side), there is also a function to get and set Interactivity related config variables.
+The Interactivity API comes with handy functions that allow you to initialize and reference configuration options on the server. This is a great way to leverage many of WordPress's APIs, like nonces, AJAX, and translations.
 
 ### wp_interactivity_config
 
@@ -1179,6 +1179,35 @@ This config can be retrieved on the client:
 // view.js
 
 const { showLikeButton } = getConfig();
+```
+
+### wp_interactivity_state
+
+`wp_interactivity_state` allows the initialization of state on the server, which will be merged with with any stores defined in `view.js`.
+
+Initializing state on the server allows you to use many critical WordPress APIs, including [AJAX](https://developer.wordpress.org/plugins/javascript/ajax/), or [nonces](https://developer.wordpress.org/plugins/javascript/enqueuing/#nonce).
+
+The `wp_interactivity_state` function receives two arguments, a string with the namespace that will be used as a reference and an associative array containing the values.
+
+Here is an example of passing the WP Admin AJAX endpoint with a nonce.
+
+```php
+// render.php
+
+wp_interactivity_state(
+	'myPlugin',
+	array(
+		'ajaxUrl' => admin_url( 'admin-ajax.php' ),
+		'nonce'   => wp_create_nonce( 'myPlugin_nonce' ),
+	),
+);
+```
+
+```js
+const { state } = store( 'myPlugin', {
+	console.log( state.ajaxUrl );
+	// Expected output: https://yoursite.com/wp-admin/admin-ajax.php
+}
 ```
 
 ### wp_interactivity_process_directives


### PR DESCRIPTION
## What?
Addresses #63672 by adding the `wp_interactivity_state()` under the [Server Functions](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#server-functions) section of the Interactivity API docs.

## Why?
There is existing mention of the `wp_interactivity_state()` under [The Store](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#the-store) > [Setting the store](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#setting-the-store) > On the server side

However, having its own listing under the Server Functions makes sense, while also allowing it to show up in the "In this article" sidebar (desktop) table of contents. Overall, it is better visibility and having multiple breadcrumbs to find the information is never a bad thing.

## How?
Adds a unique reference to the `wp_interactivity_state()` function and offers another code example of its possible utility.
