### PR TITLE
Update README.md

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/README.md
+++ b/packages/block-editor/src/components/block-variation-picker/README.md
@@ -26,7 +26,7 @@ import {
 const MyBlockVariationPicker = ( { blockName } ) => {
 	const variations = useSelect(
 		( select ) => {
-			const { getBlockVariations } = select( blocksStore );
+			const { getBlockVariations } = select( blockEditorStore );
 			return getBlockVariations( blockName, 'block' );
 		},
 		[ blockName ]


### PR DESCRIPTION
## What?
updated imported store alias in `select()` function  line 29
- from: `blocksStore`
- to: `blockEditorStore`

<img width="810" alt="image" src="https://github.com/user-attachments/assets/840e8462-1a0e-404e-b43a-9472944d0f95">

