### PR TITLE
DataViews: abandon the ItemRecord type

### DIFF
--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -2,7 +2,7 @@
  * Internal dependencies
  */
 import getFieldTypeDefinition from './field-types';
-import type { Field, NormalizedField, ItemRecord } from './types';
+import type { Field, NormalizedField } from './types';
 
 /**
  * Apply default values and normalize the fields config.
@@ -17,9 +17,7 @@ export function normalizeFields< Item >(
 		const fieldTypeDefinition = getFieldTypeDefinition( field.type );
 
 		const getValue =
-			field.getValue ||
-			// @ts-ignore
-			( ( { item }: { item: ItemRecord } ) => item[ field.id ] );
+			field.getValue || ( ( { item } ) => ( item as any )[ field.id ] );
 
 		const sort =
 			field.sort ??

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -47,8 +47,6 @@ export type Operator =
 	| 'isAll'
 	| 'isNotAll';
 
-export type ItemRecord = Object;
-
 export type FieldType = 'text' | 'integer';
 
 export type ValidationContext = {
@@ -128,21 +126,13 @@ export type Field< Item > = {
 	 * Filter config for the field.
 	 */
 	filterBy?: FilterByConfig | undefined;
-} & ( Item extends ItemRecord
-	? {
-			/**
-			 * Callback used to retrieve the value of the field from the item.
-			 * Defaults to `item[ field.id ]`.
-			 */
-			getValue?: ( args: { item: Item } ) => any;
-	  }
-	: {
-			/**
-			 * Callback used to retrieve the value of the field from the item.
-			 * Defaults to `item[ field.id ]`.
-			 */
-			getValue: ( args: { item: Item } ) => any;
-	  } );
+
+	/**
+	 * Callback used to retrieve the value of the field from the item.
+	 * Defaults to `item[ field.id ]`.
+	 */
+	getValue?: ( args: { item: Item } ) => any;
+};
 
 export type NormalizedField< Item > = Field< Item > & {
 	label: string;


### PR DESCRIPTION
Implements a suggestion from https://github.com/WordPress/gutenberg/pull/64199#discussion_r1709041649:
- remove the `ItemRecord` type
- make `Field.getValue` always optional
- in the default `getValue` implementation, cast `item` to `any` to prevent type errors

This greatly simplified the types, at the cost of slightly decreased type safety. Which is very theoretical anyway and IMO has little impact in practice.

Accessing `item[ field.id ]` will crash if `item` is `undefined` or `null`. It's true that the types don't prevent that, and that ideally they should. But almost all JS values support the property access operator, including primitives like numbers.