### PR TITLE
Add `comment_status` field to quick edit

### DIFF
--- a/packages/dataviews/src/components/dataform-controls/index.tsx
+++ b/packages/dataviews/src/components/dataform-controls/index.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import type { ComponentType } from 'react';
+
+/**
+ * Internal dependencies
+ */
+import type {
+	DataFormControlProps,
+	Field,
+	FieldTypeDefinition,
+} from '../../types';
+import radio from './radio';
+
+interface FormControls {
+	[ key: string ]: ComponentType< DataFormControlProps< any > >;
+}
+
+const FORM_CONTROLS: FormControls = {
+	radio,
+};
+
+export function getControl< Item >(
+	field: Field< Item >,
+	fieldTypeDefinition: FieldTypeDefinition< Item >
+) {
+	if ( typeof field.Edit === 'function' ) {
+		return field.Edit;
+	}
+
+	let control;
+	if ( typeof field.Edit === 'string' ) {
+		control = getControlByType( field.Edit );
+	}
+
+	return control || fieldTypeDefinition.Edit;
+}
+
+export function getControlByType( type: string ) {
+	if ( Object.keys( FORM_CONTROLS ).includes( type ) ) {
+		return FORM_CONTROLS[ type ];
+	}
+
+	return null;
+}

--- a/packages/dataviews/src/components/dataform-controls/radio.tsx
+++ b/packages/dataviews/src/components/dataform-controls/radio.tsx
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { RadioControl } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormControlProps } from '../../types';
+
+export default function Edit< Item >( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+}: DataFormControlProps< Item > ) {
+	const { id, label } = field;
+	const value = field.getValue( { item: data } );
+
+	const onChangeControl = useCallback(
+		( newValue: string ) =>
+			onChange( ( prevItem: Item ) => ( {
+				...prevItem,
+				[ id ]: newValue,
+			} ) ),
+		[ id, onChange ]
+	);
+
+	if ( field.elements ) {
+		return (
+			<RadioControl
+				label={ label }
+				onChange={ onChangeControl }
+				options={ field.elements }
+				selected={ value }
+				hideLabelFromVision={ hideLabelFromVision }
+			/>
+		);
+	}
+
+	return null;
+}

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -57,6 +57,17 @@ const fields = [
 		],
 	},
 	{
+		id: 'reviewer',
+		label: 'Reviewer',
+		type: 'text' as const,
+		Edit: 'radio' as const,
+		elements: [
+			{ value: 'fulano', label: 'Fulano' },
+			{ value: 'mengano', label: 'Mengano' },
+			{ value: 'zutano', label: 'Zutano' },
+		],
+	},
+	{
 		id: 'status',
 		label: 'Status',
 		type: 'text' as const,
@@ -73,12 +84,21 @@ export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
 		order: 2,
 		author: 1,
 		status: 'draft',
+		reviewer: 'fulano',
 		date: '2021-01-01T12:00:00',
 		birthdate: '1950-02-23T12:00:00',
 	} );
 
 	const form = {
-		fields: [ 'title', 'order', 'author', 'status', 'date', 'birthdate' ],
+		fields: [
+			'title',
+			'order',
+			'author',
+			'reviewer',
+			'status',
+			'date',
+			'birthdate',
+		],
 	};
 
 	return (

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -1,11 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	SelectControl,
-	TextControl,
-	RadioControl,
-} from '@wordpress/components';
+import { SelectControl, TextControl } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -52,18 +48,6 @@ function Edit< Item >( {
 			} ) ),
 		[ id, onChange ]
 	);
-
-	if ( field.elements && field.editAs === 'radio' ) {
-		return (
-			<RadioControl
-				label={ label }
-				onChange={ onChangeControl }
-				options={ field.elements }
-				selected={ value }
-				hideLabelFromVision={ hideLabelFromVision }
-			/>
-		);
-	}
 
 	if ( field.elements ) {
 		const elements = [

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { SelectControl, TextControl } from '@wordpress/components';
+import {
+	SelectControl,
+	TextControl,
+	RadioControl,
+} from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
@@ -48,6 +52,18 @@ function Edit< Item >( {
 			} ) ),
 		[ id, onChange ]
 	);
+
+	if ( field.elements && field.editAs === 'radio' ) {
+		return (
+			<RadioControl
+				label={ label }
+				onChange={ onChangeControl }
+				options={ field.elements }
+				selected={ value }
+				hideLabelFromVision={ hideLabelFromVision }
+			/>
+		);
+	}
 
 	if ( field.elements ) {
 		const elements = [

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -3,6 +3,7 @@
  */
 import getFieldTypeDefinition from './field-types';
 import type { Field, NormalizedField } from './types';
+import { getControl } from './components/dataform-controls';
 
 /**
  * Apply default values and normalize the fields config.
@@ -38,7 +39,7 @@ export function normalizeFields< Item >(
 				);
 			};
 
-		const Edit = field.Edit || fieldTypeDefinition.Edit;
+		const Edit = getControl( field, fieldTypeDefinition );
 
 		const renderFromElements = ( { item }: { item: Item } ) => {
 			const value = getValue( { item } );

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -93,6 +93,11 @@ export type Field< Item > = {
 	Edit?: ComponentType< DataFormControlProps< Item > >;
 
 	/**
+	 * Optional config for editing the field.
+	 */
+	editAs?: 'radio';
+
+	/**
 	 * Callback used to sort the field.
 	 */
 	sort?: ( a: Item, b: Item, direction: SortDirection ) => number;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -54,6 +54,26 @@ export type ValidationContext = {
 };
 
 /**
+ * An abstract interface for Field based on the field type.
+ */
+export type FieldTypeDefinition< Item > = {
+	/**
+	 * Callback used to sort the field.
+	 */
+	sort: ( a: Item, b: Item, direction: SortDirection ) => number;
+
+	/**
+	 * Callback used to validate the field.
+	 */
+	isValid: ( item: Item, context?: ValidationContext ) => boolean;
+
+	/**
+	 * Callback used to render an edit control for the field.
+	 */
+	Edit: ComponentType< DataFormControlProps< Item > >;
+};
+
+/**
  * A dataview field for a specific property of a data type.
  */
 export type Field< Item > = {
@@ -90,12 +110,7 @@ export type Field< Item > = {
 	/**
 	 * Callback used to render an edit control for the field.
 	 */
-	Edit?: ComponentType< DataFormControlProps< Item > >;
-
-	/**
-	 * Optional config for editing the field.
-	 */
-	editAs?: 'radio';
+	Edit?: ComponentType< DataFormControlProps< Item > > | 'radio';
 
 	/**
 	 * Callback used to sort the field.

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -46,8 +46,8 @@ function PostEditForm( { postType, postId } ) {
 	const { saveEntityRecord } = useDispatch( coreDataStore );
 	const { fields } = usePostFields();
 	const form = {
-		type: 'panel',
-		fields: [ 'title', 'author', 'date' ],
+		type: 'regular',
+		fields: [ 'title', 'author', 'date', 'comment_status' ],
 	};
 	const [ edits, setEdits ] = useState( initialEdits );
 	const itemWithEdits = useMemo( () => {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -46,7 +46,7 @@ function PostEditForm( { postType, postId } ) {
 	const { saveEntityRecord } = useDispatch( coreDataStore );
 	const { fields } = usePostFields();
 	const form = {
-		type: 'regular',
+		type: 'panel',
 		fields: [ 'title', 'author', 'date', 'comment_status' ],
 	};
 	const [ edits, setEdits ] = useState( initialEdits );

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -345,6 +345,16 @@ function usePostFields( viewType ) {
 					return <time>{ getFormattedDate( item.date ) }</time>;
 				},
 			},
+			{
+				id: 'comment_status',
+				label: __( 'Discussion' ),
+				type: 'text',
+				editAs: 'radio',
+				elements: [
+					{ value: 'open', label: __( 'Open' ) },
+					{ value: 'closed', label: __( 'Closed' ) },
+				],
+			},
 		],
 		[ authors, viewType, frontPageId, postsPageId ]
 	);

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -349,7 +349,7 @@ function usePostFields( viewType ) {
 				id: 'comment_status',
 				label: __( 'Discussion' ),
 				type: 'text',
-				editAs: 'radio',
+				Edit: 'radio',
 				enableSorting: false,
 				filterBy: {
 					operators: [],

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -351,8 +351,20 @@ function usePostFields( viewType ) {
 				type: 'text',
 				editAs: 'radio',
 				elements: [
-					{ value: 'open', label: __( 'Open' ) },
-					{ value: 'closed', label: __( 'Closed' ) },
+					{
+						value: 'open',
+						label: __( 'Open' ),
+						description: __(
+							'Visitors can add new comments and replies.'
+						),
+					},
+					{
+						value: 'closed',
+						label: __( 'Closed' ),
+						description: __(
+							'Visitors cannot add new comments or replies. Existing comments remain visible.'
+						),
+					},
 				],
 			},
 		],

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -350,6 +350,10 @@ function usePostFields( viewType ) {
 				label: __( 'Discussion' ),
 				type: 'text',
 				editAs: 'radio',
+				enableSorting: false,
+				filterBy: {
+					operators: [],
+				},
 				elements: [
 					{
 						value: 'open',


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55101 https://github.com/WordPress/gutenberg/issues/59745

## What?

Adds `comment_status` (Discussion) field to quick edit.

## How?

- Even if it seems a boolean, the data source ([REST API](https://developer.wordpress.org/rest-api/reference/pages/#create-a-page)) models it as a `text` field with two elements (open & close). That's how the field is added as well.
- Introduces a `editAs` function that enables the consumer to configure the Edit function.

## Testing Instructions

- Visit the Pages page in the site editor with the quick edit experiment enabled. 
- Select one item and change its "Discussion" status.
- Go to the editor and verify that it was changed.
