### PR TITLE
Upgrade Playwright to v1.46

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.45.1",
+				"@playwright/test": "1.46.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6950,12 +6950,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
-			"integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
+			"integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.45.1"
+				"playwright": "1.46.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41083,12 +41083,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-			"integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
+			"integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.45.1"
+				"playwright-core": "1.46.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41101,9 +41101,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
-			"integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
+			"integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -54585,7 +54585,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.45.1",
+				"@playwright/test": "^1.46.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60001,12 +60001,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.45.1.tgz",
-			"integrity": "sha512-Wo1bWTzQvGA7LyKGIZc8nFSTFf2TkthGIFBR+QVNilvwouGzFd4PYukZe3rvf5PSqjHi1+1NyKSDZKcQWETzaA==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
+			"integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.45.1"
+				"playwright": "1.46.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -87337,19 +87337,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.45.1.tgz",
-			"integrity": "sha512-Hjrgae4kpSQBr98nhCj3IScxVeVUixqj+5oyif8TdIn2opTCPEzqAqNMeK42i3cWDCVu9MI+ZsGWw+gVR4ISBg==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
+			"integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.45.1"
+				"playwright-core": "1.46.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.45.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.45.1.tgz",
-			"integrity": "sha512-LF4CUUtrUu2TCpDw4mcrAIuYrEjVDfT1cHbJMfwnE2+1b8PZcFzPNgvZCvq2JfQ4aTjRCCHw5EJ2tmr2NSzdPg==",
+			"version": "1.46.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
+			"integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.45.1",
+		"@playwright/test": "1.46.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -93,7 +93,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.45.1",
+		"@playwright/test": "^1.46.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -119,7 +119,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		expect( count ).toBe( 1 );
 	} );
 
-	test( 'should return focus when pressing formatting button', async ( {
+	test( 'should return focus when pressing formatting button (-firefox)', async ( {
 		page,
 		editor,
 	} ) => {
@@ -415,7 +415,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		] );
 	} );
 
-	test( 'should update internal selection after fresh focus', async ( {
+	test( 'should update internal selection after fresh focus (-firefox)', async ( {
 		page,
 		editor,
 		pageUtils,

--- a/test/e2e/specs/editor/various/rich-text.spec.js
+++ b/test/e2e/specs/editor/various/rich-text.spec.js
@@ -119,7 +119,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		expect( count ).toBe( 1 );
 	} );
 
-	test( 'should return focus when pressing formatting button (-firefox)', async ( {
+	test( 'should return focus when pressing formatting button', async ( {
 		page,
 		editor,
 	} ) => {
@@ -415,7 +415,7 @@ test.describe( 'RichText (@firefox, @webkit)', () => {
 		] );
 	} );
 
-	test( 'should update internal selection after fresh focus (-firefox)', async ( {
+	test( 'should update internal selection after fresh focus', async ( {
 		page,
 		editor,
 		pageUtils,


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.46

## What's new?
https://playwright.dev/docs/release-notes#version-146

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.