### PR TITLE
DataViews Extensibility: Allow unregistering the duplicate pattern action

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -9,7 +9,6 @@ import { store as coreStore } from '@wordpress/core-data';
 import { __, sprintf, _x } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { useMemo, useState, useEffect } from '@wordpress/element';
-import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { parse } from '@wordpress/blocks';
 import { DataForm } from '@wordpress/dataviews';
 import {
@@ -30,10 +29,6 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { CreateTemplatePartModalContents } from '../create-template-part-modal';
 import { getItemTitle } from '../../dataviews/actions/utils';
-
-// Patterns.
-const { CreatePatternModalContents, useDuplicatePatternProps } =
-	unlock( patternsPrivateApis );
 
 // TODO: this should be shared with other components (see post-fields in edit-site).
 const fields = [
@@ -268,27 +263,6 @@ const useDuplicatePostAction = ( postType ) => {
 	);
 };
 
-export const duplicatePatternAction = {
-	id: 'duplicate-pattern',
-	label: _x( 'Duplicate', 'action label' ),
-	isEligible: ( item ) => item.type !== TEMPLATE_PART_POST_TYPE,
-	modalHeader: _x( 'Duplicate pattern', 'action label' ),
-	RenderModal: ( { items, closeModal } ) => {
-		const [ item ] = items;
-		const duplicatedProps = useDuplicatePatternProps( {
-			pattern: item,
-			onSuccess: () => closeModal(),
-		} );
-		return (
-			<CreatePatternModalContents
-				onClose={ closeModal }
-				confirmLabel={ _x( 'Duplicate', 'action label' ) }
-				{ ...duplicatedProps }
-			/>
-		);
-	},
-};
-
 export const duplicateTemplatePartAction = {
 	id: 'duplicate-template-part',
 	label: _x( 'Duplicate', 'action label' ),
@@ -383,7 +357,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 			isTemplateOrTemplatePart &&
 				userCanCreatePostType &&
 				duplicateTemplatePartAction,
-			isPattern && userCanCreatePostType && duplicatePatternAction,
 			...defaultActions,
 		].filter( Boolean );
 		// Filter actions based on provided context. If not provided

--- a/packages/editor/src/dataviews/actions/duplicate-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/duplicate-pattern.tsx
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { _x } from '@wordpress/i18n';
+// @ts-ignore
+import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import type { Pattern } from '../types';
+
+// Patterns.
+const { CreatePatternModalContents, useDuplicatePatternProps } =
+	unlock( patternsPrivateApis );
+
+const duplicatePattern: Action< Pattern > = {
+	id: 'duplicate-pattern',
+	label: _x( 'Duplicate', 'action label' ),
+	isEligible: ( item ) => item.type !== 'wp_template_part',
+	modalHeader: _x( 'Duplicate pattern', 'action label' ),
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
+		const duplicatedProps = useDuplicatePatternProps( {
+			pattern: item,
+			onSuccess: () => closeModal?.(),
+		} );
+		return (
+			<CreatePatternModalContents
+				onClose={ closeModal }
+				confirmLabel={ _x( 'Duplicate', 'action label' ) }
+				{ ...duplicatedProps }
+			/>
+		);
+	},
+};
+
+export default duplicatePattern;

--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -37,7 +37,7 @@ const exportPattern: Action< Pattern > = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	supportsBulk: true,
-	isEligible: ( item ) => item.type === 'wp_block',
+	isEligible: ( item ) => item.type !== 'wp_template_part',
 	callback: async ( items ) => {
 		if ( items.length === 1 ) {
 			return downloadBlob(

--- a/packages/editor/src/dataviews/actions/export-pattern.tsx
+++ b/packages/editor/src/dataviews/actions/export-pattern.tsx
@@ -37,7 +37,7 @@ const exportPattern: Action< Pattern > = {
 	id: 'export-pattern',
 	label: __( 'Export as JSON' ),
 	supportsBulk: true,
-	isEligible: ( item ) => item.type !== 'wp_template_part',
+	isEligible: ( item ) => item.type === 'wp_block',
 	callback: async ( items ) => {
 		if ( items.length === 1 ) {
 			return downloadBlob(

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -9,6 +9,7 @@ import { doAction } from '@wordpress/hooks';
  * Internal dependencies
  */
 import deletePost from '../actions/delete-post';
+import duplicatePattern from '../actions/duplicate-pattern';
 import exportPattern from '../actions/export-pattern';
 import resetPost from '../actions/reset-post';
 import trashPost from '../actions/trash-post';
@@ -74,7 +75,17 @@ export const registerPostTypeActions =
 			.resolveSelect( coreStore )
 			.getPostType( postType ) ) as PostType;
 
+		const canCreate = await registry
+			.resolveSelect( coreStore )
+			.canUser( 'create', {
+				kind: 'postType',
+				name: postType,
+			} );
+
 		const actions = [
+			canCreate && postTypeConfig.slug === 'wp_block'
+				? duplicatePattern
+				: undefined,
 			postTypeConfig.supports?.title ? renamePost : undefined,
 			postTypeConfig?.supports?.[ 'page-attributes' ]
 				? reorderPage


### PR DESCRIPTION
Related #61084 
Similar to #62647 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions. The current PR explore the possibility to use the API to register one action: "duplicate pattern". 

## Testing Instructions

1- Open the patterns dataviews.
2- You should be able to see the "duplicate" action in the actions dropdown menu for theme and user patterns.
3- you can try to use the action.