### PR TITLE
Block Editor: Don't hide the toolbar for an empty default block in HTML mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -20,6 +20,7 @@ export function useShowBlockTools() {
 			getSelectedBlockClientId,
 			getFirstMultiSelectedBlockClientId,
 			getBlock,
+			getBlockMode,
 			getSettings,
 			hasMultiSelection,
 			__unstableGetEditorMode,
@@ -33,7 +34,9 @@ export function useShowBlockTools() {
 		const editorMode = __unstableGetEditorMode();
 		const hasSelectedBlock = !! clientId && !! block;
 		const isEmptyDefaultBlock =
-			hasSelectedBlock && isUnmodifiedDefaultBlock( block );
+			hasSelectedBlock &&
+			isUnmodifiedDefaultBlock( block ) &&
+			getBlockMode( clientId ) !== 'html';
 		const _showEmptyBlockSideInserter =
 			clientId &&
 			! isTyping() &&


### PR DESCRIPTION
## What?
Fixes #14036.

PR updates the `isEmptyDefaultBlock` condition for block tools to account for HTML editing mode.

## Why?
Allows users to switch to visual editing even after they delete all the content.

## Testing Instructions
1. Open a post or page.
2. Add a paragraph with some text.
3. Edit as HTML.
4. Delete all content.
5. Move focus to the title and return to the block textarea.
6. Confirm that the toolbar is visible.
7. Confirm that the inserter button isn't visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/7c677792-5cdc-4c60-8dad-0f034e0f87b1

**After**

https://github.com/user-attachments/assets/08f1b5b9-4ebb-490c-a709-e87ae61409b1

