### PR TITLE
Inserter: Try improving pattern loading

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -42,11 +42,8 @@ export function PatternCategoryPreviews( {
 	category,
 	showTitlesAsTooltip,
 } ) {
-	const [ allPatterns, , onClickPattern ] = usePatternsState(
-		onInsert,
-		rootClientId,
-		category?.name
-	);
+	const [ allPatterns, , onClickPattern, hasResolvingRequests ] =
+		usePatternsState( onInsert, rootClientId, category?.name );
 	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
 
@@ -178,6 +175,7 @@ export function PatternCategoryPreviews( {
 					showTitlesAsTooltip={ showTitlesAsTooltip }
 					patternFilter={ patternSourceFilter }
 					pagingProps={ pagingProps }
+					hasResolvingRequests={ hasResolvingRequests }
 				/>
 			) }
 		</>

--- a/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-patterns-state.js
@@ -23,18 +23,25 @@ import { INSERTER_PATTERN_TYPES } from '../block-patterns-tab/utils';
  * @return {Array} Returns the patterns state. (patterns, categories, onSelect handler)
  */
 const usePatternsState = ( onInsert, rootClientId, selectedCategory ) => {
-	const { patternCategories, patterns, userPatternCategories } = useSelect(
+	const {
+		patternCategories,
+		patterns,
+		userPatternCategories,
+		hasResolvingRequests,
+	} = useSelect(
 		( select ) => {
 			const { __experimentalGetAllowedPatterns, getSettings } =
 				select( blockEditorStore );
 			const {
 				__experimentalUserPatternCategories,
 				__experimentalBlockPatternCategories,
+				__experimentalHasResolvingRequests,
 			} = getSettings();
 			return {
 				patterns: __experimentalGetAllowedPatterns( rootClientId ),
 				userPatternCategories: __experimentalUserPatternCategories,
 				patternCategories: __experimentalBlockPatternCategories,
+				hasResolvingRequests: __experimentalHasResolvingRequests,
 			};
 		},
 		[ rootClientId ]
@@ -94,7 +101,7 @@ const usePatternsState = ( onInsert, rootClientId, selectedCategory ) => {
 		[ createSuccessNotice, onInsert, selectedCategory ]
 	);
 
-	return [ patterns, allCategories, onClickPattern ];
+	return [ patterns, allCategories, onClickPattern, hasResolvingRequests ];
 };
 
 export default usePatternsState;

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -120,6 +120,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		userPatternCategories,
 		restBlockPatternCategories,
 		sectionRootClientId,
+		hasResolvingRequests,
 	} = useSelect(
 		( select ) => {
 			const {
@@ -128,6 +129,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				getEntityRecord,
 				getUserPatternCategories,
 				getBlockPatternCategories,
+				hasResolvingSelectors,
 			} = select( coreStore );
 			const { get } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
@@ -184,6 +186,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				userPatternCategories: getUserPatternCategories(),
 				restBlockPatternCategories: getBlockPatternCategories(),
 				sectionRootClientId: getSectionRootBlock(),
+				hasResolvingRequests: hasResolvingSelectors(),
 			};
 		},
 		[ postType, postId, isLargeViewport, renderingMode ]
@@ -325,6 +328,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
+			__experimentalHasResolvingRequests: hasResolvingRequests,
 		};
 		lock( blockEditorSettings, {
 			sectionRootClientId,
@@ -354,6 +358,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		sectionRootClientId,
 		globalStylesData,
 		globalStylesLinksData,
+		hasResolvingRequests,
 	] );
 }
 


### PR DESCRIPTION
## What?
We're experimenting with concealing the pattern loading sequence so pattern previews are displayed when ready. 

This is a rather unfinished experiment, and it's **not ready to be merged**.

## Why?
Currently, pattern previews will render multiple different temporary states until fully loaded. This causes jumping and clunkiness, which, ideally, the user shouldn't see. 

See https://github.com/WordPress/gutenberg/issues/44750 for more information.

## How?
Considering that patterns are usually accessed after the editor loads, we rely on tracking currently resolving requests, and if there are any, we consider they're querying data needed to render the patterns. We're doing some visual modifications and rendering a spinner while loading. 

## Testing Instructions
* Start a new post.
* Open the inserter from the toolbar.
* Click "Patterns"
* Go through categories and see how patterns load. 
* Loading should now happen behind the screen, and patterns will be displayed when ready to be displayed without any of the jumping and intermediary semi-loaded renders.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
Before:

https://github.com/user-attachments/assets/0fea9e31-c926-46c1-928f-0dd56e9c4cf7



After:


https://github.com/user-attachments/assets/267cda2a-ce9d-4612-bf88-db309b88b31c

