### PR TITLE
Fix: Cancel button in duplicate template part modal doesn't work

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -333,6 +333,7 @@ export const duplicateTemplatePartAction = {
 				onCreate={ onTemplatePartSuccess }
 				onError={ closeModal }
 				confirmLabel={ _x( 'Duplicate', 'action label' ) }
+				closeModal={ closeModal }
 			/>
 		);
 	},


### PR DESCRIPTION
## What?

I noticed that the cancel button on the template part modal isn't working so I fixed it.


https://github.com/user-attachments/assets/9150ea13-0e47-4d99-bd07-cec55fd0f6b7



## How?

The `closeModal` prop was missing, so I added it.

## Testing Instructions

- Go to the Site Editor > Patterns > All template parts
- Try to duplicate one of the patterns.
- Click the Cancel button.
- The modal should close.

