### PR TITLE
Don't allow duplicating template parts in non-block-based themes

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -339,9 +339,15 @@ export const duplicateTemplatePartAction = {
 };
 
 export function usePostActions( { postType, onActionPerformed, context } ) {
-	const { defaultActions, postTypeObject, userCanCreatePostType } = useSelect(
+	const {
+		defaultActions,
+		postTypeObject,
+		userCanCreatePostType,
+		isBlockBasedTheme,
+	} = useSelect(
 		( select ) => {
-			const { getPostType, canUser } = select( coreStore );
+			const { getPostType, canUser, getCurrentTheme } =
+				select( coreStore );
 			const { getEntityActions } = unlock( select( editorStore ) );
 			return {
 				postTypeObject: getPostType( postType ),
@@ -350,10 +356,12 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 					kind: 'postType',
 					name: postType,
 				} ),
+				isBlockBasedTheme: getCurrentTheme()?.is_block_theme,
 			};
 		},
 		[ postType ]
 	);
+
 	const { registerPostTypeActions } = unlock( useDispatch( editorStore ) );
 	useEffect( () => {
 		registerPostTypeActions( postType );
@@ -382,6 +390,7 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 				: false,
 			isTemplateOrTemplatePart &&
 				userCanCreatePostType &&
+				isBlockBasedTheme &&
 				duplicateTemplatePartAction,
 			isPattern && userCanCreatePostType && duplicatePatternAction,
 			...defaultActions,


### PR DESCRIPTION
Fixes #64344


## What?

This PR prohibits duplicating template parts in classic themes that support template parts. This issue is a regression that occurred in WP6.6.

## Why?

In classic themes that support template parts (hybrid themes), users should only be allowed to edit the template parts provided by the theme. This is because even if a user could duplicate a template part, there would be no way to insert it anywhere in the site editor.

## How?

Check if it is a block theme.

## Testing Instructions

- Visit `localhost:8889/wp-admin` and enable the Emptyhybrid theme.
- Visit Apperance > Patterns.
- Open the action menu of the Header pattern.
- Only "Edit" should be available.
- Open the editor canvas of the Header pattern.
- The ellipsis menu in the sidebar should be disabled.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/fe0d4f82-bec4-49a3-9339-a01e45fcc36f)
![image](https://github.com/user-attachments/assets/bc37c370-5d8b-4e64-8227-7d29d227c746)
