### PR TITLE
Update: Move item size control to the new view config UI.

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -30,11 +30,17 @@ import warning from '@wordpress/warning';
 /**
  * Internal dependencies
  */
-import { SORTING_DIRECTIONS, sortIcons, sortLabels } from '../../constants';
+import {
+	SORTING_DIRECTIONS,
+	LAYOUT_GRID,
+	sortIcons,
+	sortLabels,
+} from '../../constants';
 import { VIEW_LAYOUTS, getMandatoryFields } from '../../dataviews-layouts';
 import type { SupportedLayouts } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
+import DensityPicker from '../../dataviews-layouts/grid/density-picker';
 
 const {
 	DropdownMenuV2: DropdownMenu,
@@ -99,10 +105,6 @@ function ViewTypeMenu( {
 			} ) }
 		</DropdownMenu>
 	);
-}
-
-interface ViewActionsProps {
-	defaultLayouts?: SupportedLayouts;
 }
 
 function SortFieldControl() {
@@ -305,7 +307,14 @@ function SettingsSection( {
 	);
 }
 
-function DataviewsViewConfigContent() {
+function DataviewsViewConfigContent( {
+	density,
+	setDensity,
+}: {
+	density: number;
+	setDensity: React.Dispatch< React.SetStateAction< number > >;
+} ) {
+	const { view } = useContext( DataViewsContext );
 	return (
 		<VStack className="dataviews-view-config" spacing={ 6 }>
 			<SettingsSection title={ __( 'Appearance' ) }>
@@ -313,6 +322,12 @@ function DataviewsViewConfigContent() {
 					<SortFieldControl />
 					<SortDirectionControl />
 				</HStack>
+				{ view.type === LAYOUT_GRID && (
+					<DensityPicker
+						density={ density }
+						setDensity={ setDensity }
+					/>
+				) }
 				<ItemsPerPageControl />
 			</SettingsSection>
 			<SettingsSection title={ __( 'Properties' ) }>
@@ -323,8 +338,14 @@ function DataviewsViewConfigContent() {
 }
 
 function _DataViewsViewConfig( {
+	density,
+	setDensity,
 	defaultLayouts = { list: {}, grid: {}, table: {} },
-}: ViewActionsProps ) {
+}: {
+	density: number;
+	setDensity: React.Dispatch< React.SetStateAction< number > >;
+	defaultLayouts?: SupportedLayouts;
+} ) {
 	const [ isShowingViewPopover, setIsShowingViewPopover ] =
 		useState< boolean >( false );
 
@@ -346,7 +367,10 @@ function _DataViewsViewConfig( {
 						} }
 						focusOnMount
 					>
-						<DataviewsViewConfigContent />
+						<DataviewsViewConfigContent
+							density={ density }
+							setDensity={ setDensity }
+						/>
 					</Popover>
 				) }
 			</div>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -133,12 +133,6 @@ export default function DataViews< Item >( {
 							isShowingFilter={ isShowingFilter }
 						/>
 					</HStack>
-					{ view.type === LAYOUT_GRID && (
-						<DensityPicker
-							density={ density }
-							setDensity={ setDensity }
-						/>
-					) }
 					<DataViewsBulkActions />
 					<HStack
 						spacing={ 1 }
@@ -147,6 +141,8 @@ export default function DataViews< Item >( {
 					>
 						<DataViewsViewConfig
 							defaultLayouts={ defaultLayouts }
+							density={ density }
+							setDensity={ setDensity }
 						/>
 						{ header }
 					</HStack>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -27,8 +27,6 @@ import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
-import DensityPicker from '../../dataviews-layouts/grid/density-picker';
-import { LAYOUT_GRID } from '../../constants';
 
 type ItemWithId = { id: string };
 

--- a/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
@@ -74,7 +74,6 @@ export default function DensityPicker( {
 			__nextHasNoMarginBottom
 			__next40pxDefaultSize
 			showTooltip={ false }
-			className="dataviews-density-picker__range-control"
 			label={ __( 'Preview size' ) }
 			value={ breakValues.max + breakValues.min - densityToUse }
 			min={ breakValues.min }

--- a/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
@@ -76,12 +76,12 @@ export default function DensityPicker( {
 			showTooltip={ false }
 			className="dataviews-density-picker__range-control"
 			label={ __( 'Preview size' ) }
-			value={ densityToUse }
+			value={ breakValues.max + breakValues.min - densityToUse }
 			min={ breakValues.min }
 			max={ breakValues.max }
 			withInputField={ false }
 			onChange={ ( value = 0 ) => {
-				setDensity( value );
+				setDensity( breakValues.max + breakValues.min - value );
 			} }
 			step={ 1 }
 		/>

--- a/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
@@ -1,16 +1,10 @@
 /**
  * WordPress dependencies
  */
-import {
-	BaseControl,
-	RangeControl,
-	Button,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { plus, reset } from '@wordpress/icons';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 
 const viewportBreaks = {
 	xhuge: { min: 3, max: 6, default: 5 },
@@ -83,64 +77,54 @@ export default function DensityPicker( {
 			return _density;
 		} );
 	}, [ setDensity, viewport ] );
-	if ( ! viewport ) {
-		return null;
-	}
-	const breakValues = viewportBreaks[ viewport ];
+	const breakValues = viewportBreaks[ viewport || 'mobile' ];
 	const densityToUse = density || breakValues.default;
 	const rangeValue = getRangeValue( densityToUse, breakValues );
 
 	const step = 100 / ( breakValues.max - breakValues.min + 1 );
+	const marks = useMemo(
+		() =>
+			Array.from(
+				{ length: breakValues.max - breakValues.min + 1 },
+				( _, i ) => {
+					const value = getRangeValue(
+						i + breakValues.min,
+						breakValues
+					);
+					return {
+						value,
+					};
+				}
+			),
+		[ breakValues ]
+	);
+	if ( ! viewport ) {
+		return null;
+	}
 	return (
-		<BaseControl>
-			<BaseControl.VisualLabel>
-				{ __( 'Item size' ) }
-			</BaseControl.VisualLabel>
-			<HStack>
-				<Button
-					size="compact"
-					icon={ reset }
-					disabled={ rangeValue <= 0 }
-					accessibleWhenDisabled
-					label={ __( 'Decrease size' ) }
-					onClick={ () => {
-						setDensity( densityToUse + 1 );
-					} }
-				/>
-				<RangeControl
-					__nextHasNoMarginBottom
-					showTooltip={ false }
-					className="dataviews-density-picker__range-control"
-					label={ __( 'Item size' ) }
-					hideLabelFromVision
-					value={ rangeValue }
-					min={ 0 }
-					max={ 100 }
-					withInputField={ false }
-					onChange={ ( value = 0 ) => {
-						const inverseValue = 100 - value;
-						setDensity(
-							Math.round(
-								( inverseValue *
-									( breakValues.max - breakValues.min ) ) /
-									100 +
-									breakValues.min
-							)
-						);
-					} }
-					step={ step }
-				/>
-				<Button
-					size="compact"
-					icon={ plus }
-					disabled={ rangeValue >= 100 }
-					accessibleWhenDisabled
-					label={ __( 'Increase size' ) }
-					onClick={ () => {
-						setDensity( densityToUse - 1 );
-					} }
-				/>
-			</HStack>
-		</BaseControl>
+		<RangeControl
+			__nextHasNoMarginBottom
+			__next40pxDefaultSize
+			showTooltip={ false }
+			className="dataviews-density-picker__range-control"
+			label={ __( 'Preview size' ) }
+			value={ rangeValue }
+			min={ 0 }
+			max={ 100 }
+			marks={ marks }
+			withInputField={ false }
+			onChange={ ( value = 0 ) => {
+				const inverseValue = 100 - value;
+				setDensity(
+					Math.round(
+						( inverseValue *
+							( breakValues.max - breakValues.min ) ) /
+							100 +
+							breakValues.min
+					)
+				);
+			} }
+			step={ step }
+		/>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
@@ -1,7 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { RangeControl, Button } from '@wordpress/components';
+import {
+	BaseControl,
+	RangeControl,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { plus, reset } from '@wordpress/icons';
@@ -87,50 +92,55 @@ export default function DensityPicker( {
 
 	const step = 100 / ( breakValues.max - breakValues.min + 1 );
 	return (
-		<>
-			<Button
-				size="compact"
-				icon={ reset }
-				disabled={ rangeValue <= 0 }
-				accessibleWhenDisabled
-				label={ __( 'Decrease size' ) }
-				onClick={ () => {
-					setDensity( densityToUse + 1 );
-				} }
-			/>
-			<RangeControl
-				__nextHasNoMarginBottom
-				showTooltip={ false }
-				className="dataviews-density-picker__range-control"
-				label={ __( 'Item size' ) }
-				hideLabelFromVision
-				value={ rangeValue }
-				min={ 0 }
-				max={ 100 }
-				withInputField={ false }
-				onChange={ ( value = 0 ) => {
-					const inverseValue = 100 - value;
-					setDensity(
-						Math.round(
-							( inverseValue *
-								( breakValues.max - breakValues.min ) ) /
-								100 +
-								breakValues.min
-						)
-					);
-				} }
-				step={ step }
-			/>
-			<Button
-				size="compact"
-				icon={ plus }
-				disabled={ rangeValue >= 100 }
-				accessibleWhenDisabled
-				label={ __( 'Increase size' ) }
-				onClick={ () => {
-					setDensity( densityToUse - 1 );
-				} }
-			/>
-		</>
+		<BaseControl>
+			<BaseControl.VisualLabel>
+				{ __( 'Item size' ) }
+			</BaseControl.VisualLabel>
+			<HStack>
+				<Button
+					size="compact"
+					icon={ reset }
+					disabled={ rangeValue <= 0 }
+					accessibleWhenDisabled
+					label={ __( 'Decrease size' ) }
+					onClick={ () => {
+						setDensity( densityToUse + 1 );
+					} }
+				/>
+				<RangeControl
+					__nextHasNoMarginBottom
+					showTooltip={ false }
+					className="dataviews-density-picker__range-control"
+					label={ __( 'Item size' ) }
+					hideLabelFromVision
+					value={ rangeValue }
+					min={ 0 }
+					max={ 100 }
+					withInputField={ false }
+					onChange={ ( value = 0 ) => {
+						const inverseValue = 100 - value;
+						setDensity(
+							Math.round(
+								( inverseValue *
+									( breakValues.max - breakValues.min ) ) /
+									100 +
+									breakValues.min
+							)
+						);
+					} }
+					step={ step }
+				/>
+				<Button
+					size="compact"
+					icon={ plus }
+					disabled={ rangeValue >= 100 }
+					accessibleWhenDisabled
+					label={ __( 'Increase size' ) }
+					onClick={ () => {
+						setDensity( densityToUse - 1 );
+					} }
+				/>
+			</HStack>
+		</BaseControl>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
@@ -4,7 +4,7 @@
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { useEffect, useMemo } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 const viewportBreaks = {
 	xhuge: { min: 3, max: 6, default: 5 },
@@ -39,7 +39,6 @@ function useViewPortBreakpoint() {
 	return null;
 }
 
-
 export default function DensityPicker( {
 	density,
 	setDensity,
@@ -66,19 +65,6 @@ export default function DensityPicker( {
 	const breakValues = viewportBreaks[ viewport || 'mobile' ];
 	const densityToUse = density || breakValues.default;
 
-	const marks = useMemo(
-		() =>
-			Array.from(
-				{ length: breakValues.max - breakValues.min + 1 },
-				( _, i ) => {
-					return {
-						value: breakValues.min + i,
-					};
-				}
-			),
-		[ breakValues ]
-	);
-
 	if ( ! viewport ) {
 		return null;
 	}
@@ -93,7 +79,6 @@ export default function DensityPicker( {
 			value={ densityToUse }
 			min={ breakValues.min }
 			max={ breakValues.max }
-			marks={ marks }
 			withInputField={ false }
 			onChange={ ( value = 0 ) => {
 				setDensity( value );

--- a/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/density-picker.tsx
@@ -39,20 +39,6 @@ function useViewPortBreakpoint() {
 	return null;
 }
 
-// Value is number from 0 to 100 representing how big an item is in the grid
-// 100 being the biggest and 0 being the smallest.
-// The size is relative to the viewport size, if one a given viewport the
-// number of allowed items in a grid is 3 to 6 a 0 ( the smallest ) will mean that the grid will
-// have 6 items in a row, a 100 ( the biggest ) will mean that the grid will have 3 items in a row.
-// A value of 75 will mean that the grid will have 4 items in a row.
-function getRangeValue(
-	density: number,
-	breakValues: { min: number; max: number; default: number }
-) {
-	const inverseDensity = breakValues.max - density;
-	const max = breakValues.max - breakValues.min;
-	return Math.round( ( inverseDensity * 100 ) / max );
-}
 
 export default function DensityPicker( {
 	density,
@@ -79,28 +65,24 @@ export default function DensityPicker( {
 	}, [ setDensity, viewport ] );
 	const breakValues = viewportBreaks[ viewport || 'mobile' ];
 	const densityToUse = density || breakValues.default;
-	const rangeValue = getRangeValue( densityToUse, breakValues );
 
-	const step = 100 / ( breakValues.max - breakValues.min + 1 );
 	const marks = useMemo(
 		() =>
 			Array.from(
 				{ length: breakValues.max - breakValues.min + 1 },
 				( _, i ) => {
-					const value = getRangeValue(
-						i + breakValues.min,
-						breakValues
-					);
 					return {
-						value,
+						value: breakValues.min + i,
 					};
 				}
 			),
 		[ breakValues ]
 	);
+
 	if ( ! viewport ) {
 		return null;
 	}
+
 	return (
 		<RangeControl
 			__nextHasNoMarginBottom
@@ -108,23 +90,15 @@ export default function DensityPicker( {
 			showTooltip={ false }
 			className="dataviews-density-picker__range-control"
 			label={ __( 'Preview size' ) }
-			value={ rangeValue }
-			min={ 0 }
-			max={ 100 }
+			value={ densityToUse }
+			min={ breakValues.min }
+			max={ breakValues.max }
 			marks={ marks }
 			withInputField={ false }
 			onChange={ ( value = 0 ) => {
-				const inverseValue = 100 - value;
-				setDensity(
-					Math.round(
-						( inverseValue *
-							( breakValues.max - breakValues.min ) ) /
-							100 +
-							breakValues.min
-					)
-				);
+				setDensity( value );
 			} }
-			step={ step }
+			step={ 1 }
 		/>
 	);
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -146,10 +146,6 @@
 	}
 }
 
-.dataviews-density-picker__range-control {
-	width: 200px;
-}
-
 .dataviews-view-grid__field-value:empty,
 .dataviews-view-grid__field:empty {
 	display: none;


### PR DESCRIPTION
This PR moves the item size picker to the new view configuration UI.
Follow up to https://github.com/WordPress/gutenberg/pull/64175.

cc: @WordPress/gutenberg-design 

## Screenshots
<img width="405" alt="Screenshot 2024-08-08 at 17 55 12" src="https://github.com/user-attachments/assets/2841ace4-6abb-4335-9e87-c11d6bd4db21">


## Testing Instructions
I verified the item size picker is only available on the grid layout and still works as expected.
