### PR TITLE
DataViews Extensibility: Allow unregistering the duplicate template part action

### DIFF
--- a/packages/editor/src/dataviews/actions/duplicate-template-part.tsx
+++ b/packages/editor/src/dataviews/actions/duplicate-template-part.tsx
@@ -1,0 +1,70 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { __, sprintf, _x } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { useMemo } from '@wordpress/element';
+// @ts-ignore
+import { parse } from '@wordpress/blocks';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_PART_POST_TYPE } from '../../store/constants';
+import { CreateTemplatePartModalContents } from '../../components/create-template-part-modal';
+import { getItemTitle } from './utils';
+import type { TemplatePart } from '../types';
+
+const duplicateTemplatePart: Action< TemplatePart > = {
+	id: 'duplicate-template-part',
+	label: _x( 'Duplicate', 'action label' ),
+	isEligible: ( item ) => item.type === TEMPLATE_PART_POST_TYPE,
+	modalHeader: _x( 'Duplicate template part', 'action label' ),
+	RenderModal: ( { items, closeModal } ) => {
+		const [ item ] = items;
+		const blocks = useMemo( () => {
+			return (
+				item.blocks ??
+				parse(
+					typeof item.content === 'string'
+						? item.content
+						: item.content.raw,
+					{
+						__unstableSkipMigrationLogs: true,
+					}
+				)
+			);
+		}, [ item.content, item.blocks ] );
+		const { createSuccessNotice } = useDispatch( noticesStore );
+		function onTemplatePartSuccess() {
+			createSuccessNotice(
+				sprintf(
+					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
+					__( '"%s" duplicated.' ),
+					getItemTitle( item )
+				),
+				{ type: 'snackbar', id: 'edit-site-patterns-success' }
+			);
+			closeModal?.();
+		}
+		return (
+			<CreateTemplatePartModalContents
+				blocks={ blocks }
+				defaultArea={ item.area }
+				defaultTitle={ sprintf(
+					/* translators: %s: Existing template part title */
+					__( '%s (Copy)' ),
+					getItemTitle( item )
+				) }
+				onCreate={ onTemplatePartSuccess }
+				onError={ closeModal }
+				confirmLabel={ _x( 'Duplicate', 'action label' ) }
+				closeModal={ closeModal }
+			/>
+		);
+	},
+};
+
+export default duplicateTemplatePart;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -10,6 +10,7 @@ import { doAction } from '@wordpress/hooks';
  */
 import deletePost from '../actions/delete-post';
 import duplicatePattern from '../actions/duplicate-pattern';
+import duplicateTemplatePart from '../actions/duplicate-template-part';
 import exportPattern from '../actions/export-pattern';
 import resetPost from '../actions/reset-post';
 import trashPost from '../actions/trash-post';
@@ -81,8 +82,15 @@ export const registerPostTypeActions =
 				kind: 'postType',
 				name: postType,
 			} );
+		const currentTheme = await registry
+			.resolveSelect( coreStore )
+			.getCurrentTheme();
 
 		const actions = [
+			postTypeConfig.slug === 'wp_template_part' &&
+				canCreate &&
+				currentTheme?.is_block_theme &&
+				duplicateTemplatePart,
 			canCreate && postTypeConfig.slug === 'wp_block'
 				? duplicatePattern
 				: undefined,

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -10,8 +10,10 @@ type PostStatus =
 export interface BasePost {
 	status?: PostStatus;
 	title: string | { rendered: string } | { raw: string };
+	content: string | { raw: string; rendered: string };
 	type: string;
 	id: string | number;
+	blocks?: Object[];
 }
 
 export interface Template extends BasePost {
@@ -27,12 +29,12 @@ export interface TemplatePart extends BasePost {
 	source: string;
 	has_theme_file: boolean;
 	id: string;
+	area: string;
 }
 
 export interface Pattern extends BasePost {
 	slug: string;
 	title: { raw: string };
-	content: { raw: string } | string;
 	wp_pattern_sync_status: string;
 }
 


### PR DESCRIPTION
Related #61084 
Similar to #62647 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions. The current PR explore the possibility to use the API to register one action: "duplicate template part". 

## Testing Instructions

1- Open the template parts dataviews.
2- You should be able to see the "duplicate" action in the actions dropdown.
3- you can try to use the action.