### PR TITLE
DataViews: update `renderFormElements` to make sure the value respects the type

### DIFF
--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -53,7 +53,7 @@ function Edit< Item >( {
 		( newValue: string | undefined ) =>
 			onChange( ( prevItem: Item ) => ( {
 				...prevItem,
-				[ id ]: newValue,
+				[ id ]: Number( newValue ),
 			} ) ),
 		[ id, onChange ]
 	);

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -42,13 +42,10 @@ export function normalizeFields< Item >(
 
 		const renderFromElements = ( { item }: { item: Item } ) => {
 			const value = getValue( { item } );
-			const label = field?.elements?.find( ( element ) => {
-				// Intentionally using == here to allow for type coercion.
-				// eslint-disable-next-line eqeqeq
-				return element.value == value;
-			} )?.label;
-
-			return label || value;
+			return (
+				field?.elements?.find( ( element ) => element.value === value )
+					?.label || getValue( { item } )
+			);
 		};
 
 		const render =


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/64338

## What?

Make sure the updated value for integer fields remains a number and not a string.

## Why?

We want the value to respect the field type.

## Testing Instructions

Go to DataForm's storybook and change the author value to something else. Using panel or regular layout. It should always display the name, never the number.
