### PR TITLE
Zoom Out: Don't hide the insertion point when hovering patterns

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -109,6 +109,7 @@ function InserterMenu(
 
 	const onInsertPattern = useCallback(
 		( blocks, patternName ) => {
+			onToggleInsertionPoint( false );
 			onInsertBlocks( blocks, { patternName } );
 			onSelect();
 		},
@@ -121,13 +122,6 @@ function InserterMenu(
 			setHoveredItem( item );
 		},
 		[ onToggleInsertionPoint, setHoveredItem ]
-	);
-
-	const onHoverPattern = useCallback(
-		( item ) => {
-			onToggleInsertionPoint( !! item );
-		},
-		[ onToggleInsertionPoint ]
 	);
 
 	const onClickPatternCategory = useCallback(
@@ -176,7 +170,6 @@ function InserterMenu(
 						filterValue={ delayedFilterValue }
 						onSelect={ onSelect }
 						onHover={ onHover }
-						onHoverPattern={ onHoverPattern }
 						rootClientId={ rootClientId }
 						clientId={ clientId }
 						isAppender={ isAppender }
@@ -199,7 +192,6 @@ function InserterMenu(
 		delayedFilterValue,
 		onSelect,
 		onHover,
-		onHoverPattern,
 		shouldFocusBlock,
 		clientId,
 		rootClientId,
@@ -249,7 +241,6 @@ function InserterMenu(
 					<PatternCategoryPreviews
 						rootClientId={ destinationRootClientId }
 						onInsert={ onInsertPattern }
-						onHover={ onHoverPattern }
 						category={ selectedPatternCategory }
 						patternFilter={ patternFilter }
 						showTitlesAsTooltip
@@ -259,7 +250,6 @@ function InserterMenu(
 		);
 	}, [
 		destinationRootClientId,
-		onHoverPattern,
 		onInsertPattern,
 		onClickPatternCategory,
 		patternFilter,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This disables the behaviour that makes the insertion point invisible on hover.

## Why?
I'm not sure why we have this behaviour - it seems unhelpful! It was initially added in https://github.com/WordPress/gutenberg/pull/47693 but that doesn't seem to have been reintroduced with this.

## How?
Just remove the code.

## Testing Instructions
1. Open the Site Editor
2. Open the inserter and select the patterns tab
3. Switch to zoom out using the preview drop down
4. Click on the [+] between the sections to set an insertion point
5. Hover a pattern.
6. Notice that the insertion point is still visibile
7. Click a pattern
8. Notice that the pattern is inserted and the insertion point is no longer visible

## Screenshots or screencast <!-- if applicable -->
Trunk:
https://github.com/user-attachments/assets/e6f3b5de-2784-4838-9c59-fe660023be1c

This branch:
https://github.com/user-attachments/assets/376d2688-2dce-4cbf-823b-b4a704a057b4

