### PR TITLE
Add `status` to quick edit

### DIFF
--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -65,12 +65,13 @@ function PostEditForm( { postType, postId } ) {
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {
 			if (
-				edits.status === 'future' &&
+				edits.status !== 'future' &&
+				record.status === 'future' &&
 				new Date( record.date ) > new Date()
 			) {
 				edits.date = null;
 			}
-			if ( edits.status === 'private' ) {
+			if ( edits.status === 'private' && record.password ) {
 				edits.password = '';
 			}
 			editEntityRecord( 'postType', postType, id, edits );

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -64,6 +64,9 @@ function PostEditForm( { postType, postId } ) {
 	};
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {
+			if ( edits.status === 'publish' ) {
+				edits.date = null;
+			}
 			editEntityRecord( 'postType', postType, id, edits );
 			if ( ids.length > 1 ) {
 				setMultiEdits( ( prev ) => ( {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -60,7 +60,7 @@ function PostEditForm( { postType, postId } ) {
 	);
 	const form = {
 		type: 'panel',
-		fields: [ 'title', 'author', 'date', 'comment_status', 'status' ],
+		fields: [ 'title', 'status', 'date', 'author', 'comment_status' ],
 	};
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -45,7 +45,7 @@ function PostEditForm( { postType, postId } ) {
 	const { fields } = usePostFields();
 	const form = {
 		type: 'panel',
-		fields: [ 'title', 'author', 'date', 'comment_status' ],
+		fields: [ 'title', 'author', 'date', 'comment_status', 'status' ],
 	};
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -64,8 +64,14 @@ function PostEditForm( { postType, postId } ) {
 	};
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {
-			if ( edits.status === 'publish' ) {
+			if (
+				edits.status === 'future' &&
+				new Date( record.date ) > new Date()
+			) {
 				edits.date = null;
+			}
+			if ( edits.status === 'private' ) {
+				edits.password = '';
 			}
 			editEntityRecord( 'postType', postType, id, edits );
 			if ( ids.length > 1 ) {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -42,7 +42,22 @@ function PostEditForm( { postType, postId } ) {
 	);
 	const [ multiEdits, setMultiEdits ] = useState( {} );
 	const { editEntityRecord } = useDispatch( coreDataStore );
-	const { fields } = usePostFields();
+	const { fields: _fields } = usePostFields();
+	const fields = useMemo(
+		() =>
+			_fields?.map( ( field ) => {
+				if ( field.id === 'status' ) {
+					return {
+						...field,
+						elements: field.elements.filter(
+							( element ) => element.value !== 'trash'
+						),
+					};
+				}
+				return field;
+			} ),
+		[ _fields ]
+	);
 	const form = {
 		type: 'panel',
 		fields: [ 'title', 'author', 'date', 'comment_status', 'status' ],

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -261,6 +261,7 @@ function usePostFields( viewType ) {
 				type: 'text',
 				elements: STATUSES,
 				render: PostStatusField,
+				Edit: 'radio',
 				enableSorting: false,
 				filterBy: {
 					operators: [ OPERATOR_IS_ANY ],

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -258,6 +258,7 @@ function usePostFields( viewType ) {
 			{
 				label: __( 'Status' ),
 				id: 'status',
+				type: 'text',
 				getValue: ( { item } ) =>
 					STATUSES.find( ( { value } ) => value === item.status )
 						?.label ?? item.status,

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -259,9 +259,6 @@ function usePostFields( viewType ) {
 				label: __( 'Status' ),
 				id: 'status',
 				type: 'text',
-				getValue: ( { item } ) =>
-					STATUSES.find( ( { value } ) => value === item.status )
-						?.label ?? item.status,
 				elements: STATUSES,
 				render: PostStatusField,
 				enableSorting: false,

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -42,11 +42,36 @@ import Media from '../media';
 // See https://github.com/WordPress/gutenberg/issues/55886
 // We do not support custom statutes at the moment.
 const STATUSES = [
-	{ value: 'draft', label: __( 'Draft' ), icon: drafts },
-	{ value: 'future', label: __( 'Scheduled' ), icon: scheduled },
-	{ value: 'pending', label: __( 'Pending Review' ), icon: pending },
-	{ value: 'private', label: __( 'Private' ), icon: notAllowed },
-	{ value: 'publish', label: __( 'Published' ), icon: published },
+	{
+		value: 'draft',
+		label: __( 'Draft' ),
+		icon: drafts,
+		description: __( 'Not ready to publish.' ),
+	},
+	{
+		value: 'future',
+		label: __( 'Scheduled' ),
+		icon: scheduled,
+		description: __( 'Publish automatically on a chosen date.' ),
+	},
+	{
+		value: 'pending',
+		label: __( 'Pending Review' ),
+		icon: pending,
+		description: __( 'Waiting for review before publishing.' ),
+	},
+	{
+		value: 'private',
+		label: __( 'Private' ),
+		icon: notAllowed,
+		description: __( 'Only visible to site admins and editors.' ),
+	},
+	{
+		value: 'publish',
+		label: __( 'Published' ),
+		icon: published,
+		description: __( 'Visible to everyone.' ),
+	},
 	{ value: 'trash', label: __( 'Trash' ), icon: trash },
 ];
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55101

## What?

Add the `status` field to the quick edit form. Also reorder the fields to mimick the document inspector order.

## How?

- Add status in quick edit 1379f9d9ed604ac1da8bf5404bb9856224364c0a
- Display it properly:
  - Edit order of fields to follow the post inspector 129933950bde07c2bbc11c34b197f8a3f7a0d025
  - Display as radio, not select b14104c92ec4c5fff4dba0199907762e85cc0d5d
  - Do not show trash 5bfb7dd3f5711a7eade8bdbc1f5aecaae229739f
  - Add description to each status ba042c16d2fbd1877fcefa3b62b44dd4f8d37c78
- Misc
  - Remove unused `getValue` 86d15712ea10c2ec6765d571cecb9c7b540a5f96
  - Set date to "now" when status changes to "publish" 6f9dd3e51d950f4effa3036d95bbbbcf1ce341da

## Testing Instructions

- Enable the quick edit experiment in Gutenberg > Experiments.
- Go to pages, set layout to table and click the quick edit action (top-level, next to view config/settings).
- Select an item.

Modify the status and verify that it works properly.