### PR TITLE
Composite: add Hover and Typeahead subcomponents

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features
 
 -   `Composite`: add stable version of the component ([#63564](https://github.com/WordPress/gutenberg/pull/63564)).
+-   `Composite`: add `Hover` and `Typeahead` subcomponents ([#64399](https://github.com/WordPress/gutenberg/pull/64399)).
 
 ### Enhancements
 

--- a/packages/components/src/composite/README.md
+++ b/packages/components/src/composite/README.md
@@ -248,4 +248,16 @@ Determines if the composite item should lose focus when the mouse leaves. By def
 
 ### `Composite.Typeahead`
 
-TODO
+Renders a component that adds typeahead functionality to composite components. Hitting printable character keys will move focus to the next composite item that begins with the input characters.
+
+##### `render`: `RenderProp<React.HTMLAttributes<any> & { ref?: React.Ref<any> | undefined; }> | React.ReactElement<any, string | React.JSXElementConstructor<any>>`
+
+Allows the component to be rendered as a different HTML element or React component. The value can be a React element or a function that takes in the original component props and gives back a React element with the props merged.
+
+-   Required: no
+
+##### `children`: `React.ReactNode`
+
+The contents of the component.
+
+-   Required: no

--- a/packages/components/src/composite/README.md
+++ b/packages/components/src/composite/README.md
@@ -216,3 +216,11 @@ Allows the component to be rendered as a different HTML element or React compone
 The contents of the component.
 
 -   Required: no
+
+### `Composite.Hover`
+
+TODO
+
+### `Composite.Typeahead`
+
+TODO

--- a/packages/components/src/composite/README.md
+++ b/packages/components/src/composite/README.md
@@ -219,7 +219,7 @@ The contents of the component.
 
 ### `Composite.Hover`
 
-Renders an element in a composite widget that receives focus on mouse move and loses focus to the composite base element on mouse leave. This should be combined with the `Composite.Item` component. The `focusOnHover` and `blurOnHoverEnd` props can be used to customize the behavior.
+Renders an element in a composite widget that receives focus on mouse move and loses focus to the composite base element on mouse leave. This should be combined with the `Composite.Item` component.
 
 ##### `render`: `RenderProp<React.HTMLAttributes<any> & { ref?: React.Ref<any> | undefined; }> | React.ReactElement<any, string | React.JSXElementConstructor<any>>`
 
@@ -230,19 +230,6 @@ Allows the component to be rendered as a different HTML element or React compone
 ##### `children`: `React.ReactNode`
 
 The contents of the component.
-
--   Required: no
-
-##### `focusOnHover`: `boolean | React.MouseEvent<HTMLElement, MouseEvent>`
-
-Determines if the composite item should be focused when hovered over. Note that the actual DOM focus will stay on the composite element. This item will get the `data-active-item` attribute so it can be styled as if it's focused.
-
--   Required: no
--   Default: `true`
-
-##### `blurOnHoverEnd`: `boolean | React.MouseEvent<HTMLElement, MouseEvent>`
-
-Determines if the composite item should lose focus when the mouse leaves. By default, this is set to true if `focusOnHover` is true.
 
 -   Required: no
 

--- a/packages/components/src/composite/README.md
+++ b/packages/components/src/composite/README.md
@@ -219,7 +219,32 @@ The contents of the component.
 
 ### `Composite.Hover`
 
-TODO
+Renders an element in a composite widget that receives focus on mouse move and loses focus to the composite base element on mouse leave. This should be combined with the `Composite.Item` component. The `focusOnHover` and `blurOnHoverEnd` props can be used to customize the behavior.
+
+##### `render`: `RenderProp<React.HTMLAttributes<any> & { ref?: React.Ref<any> | undefined; }> | React.ReactElement<any, string | React.JSXElementConstructor<any>>`
+
+Allows the component to be rendered as a different HTML element or React component. The value can be a React element or a function that takes in the original component props and gives back a React element with the props merged.
+
+-   Required: no
+
+##### `children`: `React.ReactNode`
+
+The contents of the component.
+
+-   Required: no
+
+##### `focusOnHover`: `boolean | React.MouseEvent<HTMLElement, MouseEvent>`
+
+Determines if the composite item should be focused when hovered over. Note that the actual DOM focus will stay on the composite element. This item will get the `data-active-item` attribute so it can be styled as if it's focused.
+
+-   Required: no
+-   Default: `true`
+
+##### `blurOnHoverEnd`: `boolean | React.MouseEvent<HTMLElement, MouseEvent>`
+
+Determines if the composite item should lose focus when the mouse leaves. By default, this is set to true if `focusOnHover` is true.
+
+-   Required: no
 
 ### `Composite.Typeahead`
 

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -242,9 +242,8 @@ export const Composite = Object.assign(
 		Hover,
 		/**
 		 * Renders a component that adds typeahead functionality to composite
-		 * components. When the `typeahead` prop is enabled, which it is by default,
-		 * hitting printable character keys will move focus to the next composite item
-		 * that begins with the input characters.
+		 * components. Hitting printable character keys will move focus to the next
+		 * composite item that begins with the input characters.
 		 * @see https://ariakit.org/reference/composite-typeahead
 		 * @example
 		 * ```jsx

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -243,7 +243,7 @@ export const Composite = Object.assign(
 		 * Renders a component that adds typeahead functionality to composite
 		 * components. Hitting printable character keys will move focus to the next
 		 * composite item that begins with the input characters.
-		 * @see https://ariakit.org/reference/composite-typeahead
+		 *
 		 * @example
 		 * ```jsx
 		 * const store = useCompositeStore();

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -29,6 +29,8 @@ import type {
 	CompositeGroupLabelProps,
 	CompositeItemProps,
 	CompositeRowProps,
+	CompositeHoverProps,
+	CompositeTypeaheadProps,
 } from './types';
 
 /**
@@ -97,6 +99,22 @@ const Row = forwardRef<
 	return <Ariakit.CompositeRow { ...props } ref={ ref } />;
 } );
 Row.displayName = 'Composite.Row';
+
+const Hover = forwardRef<
+	HTMLDivElement,
+	WordPressComponentProps< CompositeHoverProps, 'div', false >
+>( function CompositeHover( props, ref ) {
+	return <Ariakit.CompositeHover { ...props } ref={ ref } />;
+} );
+Hover.displayName = 'Composite.Hover';
+
+const Typeahead = forwardRef<
+	HTMLDivElement,
+	WordPressComponentProps< CompositeTypeaheadProps, 'div', false >
+>( function CompositeTypeahead( props, ref ) {
+	return <Ariakit.CompositeTypeahead { ...props } ref={ ref } />;
+} );
+Typeahead.displayName = 'Composite.Typeahead';
 
 /**
  * Renders a widget based on the WAI-ARIA [`composite`](https://w3c.github.io/aria/#composite)
@@ -202,5 +220,41 @@ export const Composite = Object.assign(
 		 * ```
 		 */
 		Row,
+		/**
+		 * Renders an element in a composite widget that receives focus on mouse move
+		 * and loses focus to the composite base element on mouse leave. This should
+		 * be combined with the `Composite.Item` component. The `focusOnHover` and
+		 * `blurOnHoverEnd` props can be used to customize the behavior.
+		 * @see https://ariakit.org/reference/composite-hover
+		 * @example
+		 * ```jsx
+		 * const store = useCompositeStore();
+		 * <Composite store={store}>
+		 *   <Composite.Hover render={ <Composite.Item /> }>
+		 *     Item 1
+		 *   </Composite.Hover>
+		 *   <Composite.Hover render={ <Composite.Item /> }>
+		 *     Item 2
+		 *   </Composite.Hover>
+		 * </Composite>
+		 * ```
+		 */
+		Hover,
+		/**
+		 * Renders a component that adds typeahead functionality to composite
+		 * components. When the `typeahead` prop is enabled, which it is by default,
+		 * hitting printable character keys will move focus to the next composite item
+		 * that begins with the input characters.
+		 * @see https://ariakit.org/reference/composite-typeahead
+		 * @example
+		 * ```jsx
+		 * const store = useCompositeStore();
+		 * <Composite store={store} render={ <CompositeTypeahead /> }>
+		 *   <Composite.Item>Item 1</Composite.Item>
+		 *   <Composite.Item>Item 2</Composite.Item>
+		 * </Composite>
+		 * ```
+		 */
+		Typeahead,
 	}
 );

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -227,6 +227,8 @@ export const Composite = Object.assign(
 		 *
 		 * @example
 		 * ```jsx
+		 * import { Composite, useCompositeStore } from '@wordpress/components';
+		 *
 		 * const store = useCompositeStore();
 		 * <Composite store={store}>
 		 *   <Composite.Hover render={ <Composite.Item /> }>
@@ -246,6 +248,8 @@ export const Composite = Object.assign(
 		 *
 		 * @example
 		 * ```jsx
+		 * import { Composite, useCompositeStore } from '@wordpress/components';
+		 *
 		 * const store = useCompositeStore();
 		 * <Composite store={store} render={ <CompositeTypeahead /> }>
 		 *   <Composite.Item>Item 1</Composite.Item>

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -223,9 +223,8 @@ export const Composite = Object.assign(
 		/**
 		 * Renders an element in a composite widget that receives focus on mouse move
 		 * and loses focus to the composite base element on mouse leave. This should
-		 * be combined with the `Composite.Item` component. The `focusOnHover` and
-		 * `blurOnHoverEnd` props can be used to customize the behavior.
-		 * @see https://ariakit.org/reference/composite-hover
+		 * be combined with the `Composite.Item` component.
+		 *
 		 * @example
 		 * ```jsx
 		 * const store = useCompositeStore();

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -231,34 +231,7 @@ This only affects the composite widget behavior. You still need to set \`dir="rt
 					'Composite.GroupLabel': commonArgTypes,
 					'Composite.Row': commonArgTypes,
 					'Composite.Item': commonArgTypes,
-					'Composite.Hover': {
-						...commonArgTypes,
-						focusOnHover: {
-							name: 'focusOnHover',
-							description:
-								"Determines if the composite item should be focused when hovered over. Note that the actual DOM focus will stay on the composite element. This item will get the `data-active-item` attribute so it can be styled as if it's focused.",
-							table: {
-								defaultValue: {
-									summary: 'true',
-								},
-								type: {
-									summary:
-										'boolean | React.MouseEvent<HTMLElement, MouseEvent>',
-								},
-							},
-						},
-						blurOnHoverEnd: {
-							name: 'blurOnHoverEnd',
-							description:
-								'Determines if the composite item should lose focus when the mouse leaves. By default, this is set to true if `focusOnHover` is true.',
-							table: {
-								type: {
-									summary:
-										'boolean | React.MouseEvent<HTMLElement, MouseEvent>',
-								},
-							},
-						},
-					},
+					'Composite.Hover': commonArgTypes,
 					'Composite.Typeahead': commonArgTypes,
 				};
 

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -233,7 +233,31 @@ This only affects the composite widget behavior. You still need to set \`dir="rt
 					'Composite.Item': commonArgTypes,
 					'Composite.Hover': {
 						...commonArgTypes,
-						// TODO
+						focusOnHover: {
+							name: 'focusOnHover',
+							description:
+								"Determines if the composite item should be focused when hovered over. Note that the actual DOM focus will stay on the composite element. This item will get the `data-active-item` attribute so it can be styled as if it's focused.",
+							table: {
+								defaultValue: {
+									summary: 'true',
+								},
+								type: {
+									summary:
+										'boolean | React.MouseEvent<HTMLElement, MouseEvent>',
+								},
+							},
+						},
+						blurOnHoverEnd: {
+							name: 'blurOnHoverEnd',
+							description:
+								'Determines if the composite item should lose focus when the mouse leaves. By default, this is set to true if `focusOnHover` is true.',
+							table: {
+								type: {
+									summary:
+										'boolean | React.MouseEvent<HTMLElement, MouseEvent>',
+								},
+							},
+						},
 					},
 					'Composite.Typeahead': {
 						...commonArgTypes,
@@ -370,4 +394,11 @@ export const Hover: StoryFn< typeof UseCompositeStorePlaceholder > = (
 			</Composite.Hover>
 		</Composite>
 	);
+};
+Hover.parameters = {
+	docs: {
+		description: {
+			story: 'Elements in the composite widget will receive focus on mouse move and lose focus to the composite base element on mouse leave.',
+		},
+	},
 };

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -28,6 +28,10 @@ const meta: Meta< typeof UseCompositeStorePlaceholder > = {
 		'Composite.Row': Composite.Row,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		'Composite.Item': Composite.Item,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Composite.Hover': Composite.Hover,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'Composite.Typeahead': Composite.Typeahead,
 	},
 	argTypes: {
 		activeId: { control: 'text' },
@@ -227,6 +231,14 @@ This only affects the composite widget behavior. You still need to set \`dir="rt
 					'Composite.GroupLabel': commonArgTypes,
 					'Composite.Row': commonArgTypes,
 					'Composite.Item': commonArgTypes,
+					'Composite.Hover': {
+						...commonArgTypes,
+						// TODO
+					},
+					'Composite.Typeahead': {
+						...commonArgTypes,
+						// TODO
+					},
 				};
 
 				const name = component.displayName ?? '';

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -249,6 +249,41 @@ This only affects the composite widget behavior. You still need to set \`dir="rt
 			},
 		},
 	},
+	decorators: [
+		( Story ) => {
+			return (
+				<>
+					{ /* Visually style the active composite item  */ }
+					<style>{ `
+						[data-active-item] {
+							background-color: #ffc0b5;
+						}
+					` }</style>
+					<Story />
+					<div
+						style={ {
+							marginTop: '2em',
+							fontSize: '12px',
+							fontStyle: 'italic',
+						} }
+					>
+						{ /* eslint-disable-next-line no-restricted-syntax */ }
+						<p id="list-title">Notes</p>
+						<ul aria-labelledby="list-title">
+							<li>
+								The active composite item is highlighted with a
+								different background color;
+							</li>
+							<li>
+								A composite item can be the active item even
+								when it doesn&apos;t have keyboard focus.
+							</li>
+						</ul>
+					</div>
+				</>
+			);
+		},
+	],
 };
 export default meta;
 
@@ -312,6 +347,27 @@ export const Grid: StoryFn< typeof UseCompositeStorePlaceholder > = (
 				<Composite.Item role="gridcell">Item C2</Composite.Item>
 				<Composite.Item role="gridcell">Item C3</Composite.Item>
 			</Composite.Row>
+		</Composite>
+	);
+};
+
+export const Hover: StoryFn< typeof UseCompositeStorePlaceholder > = (
+	storeProps
+) => {
+	const rtl = isRTL();
+	const store = useCompositeStore( { rtl, ...storeProps } );
+
+	return (
+		<Composite store={ store }>
+			<Composite.Hover render={ <Composite.Item /> }>
+				Hover item one
+			</Composite.Hover>
+			<Composite.Hover render={ <Composite.Item /> }>
+				Hover item two
+			</Composite.Hover>
+			<Composite.Hover render={ <Composite.Item /> }>
+				Hover item three
+			</Composite.Hover>
 		</Composite>
 	);
 };

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -259,10 +259,7 @@ This only affects the composite widget behavior. You still need to set \`dir="rt
 							},
 						},
 					},
-					'Composite.Typeahead': {
-						...commonArgTypes,
-						// TODO
-					},
+					'Composite.Typeahead': commonArgTypes,
 				};
 
 				const name = component.displayName ?? '';
@@ -399,6 +396,28 @@ Hover.parameters = {
 	docs: {
 		description: {
 			story: 'Elements in the composite widget will receive focus on mouse move and lose focus to the composite base element on mouse leave.',
+		},
+	},
+};
+
+export const Typeahead: StoryFn< typeof UseCompositeStorePlaceholder > = (
+	storeProps
+) => {
+	const rtl = isRTL();
+	const store = useCompositeStore( { rtl, ...storeProps } );
+
+	return (
+		<Composite store={ store } render={ <Composite.Typeahead /> }>
+			<Composite.Item>Apple</Composite.Item>
+			<Composite.Item>Banana</Composite.Item>
+			<Composite.Item>Peach</Composite.Item>
+		</Composite>
+	);
+};
+Typeahead.parameters = {
+	docs: {
+		description: {
+			story: 'When focus in on the composite widget, hitting printable character keys will move focus to the next composite item that begins with the input characters.',
 		},
 	},
 };

--- a/packages/components/src/composite/types.ts
+++ b/packages/components/src/composite/types.ts
@@ -209,7 +209,6 @@ export type CompositeHoverProps = {
 	blurOnHoverEnd?: Ariakit.CompositeHoverProps[ 'blurOnHoverEnd' ];
 };
 
-// TODO: check that props make sense
 export type CompositeTypeaheadProps = {
 	/**
 	 * Allows the component to be rendered as a different HTML element or React

--- a/packages/components/src/composite/types.ts
+++ b/packages/components/src/composite/types.ts
@@ -205,8 +205,6 @@ export type CompositeHoverProps = {
 	 * The contents of the component.
 	 */
 	children?: Ariakit.CompositeHoverProps[ 'children' ];
-	focusOnHover?: Ariakit.CompositeHoverProps[ 'focusOnHover' ];
-	blurOnHoverEnd?: Ariakit.CompositeHoverProps[ 'blurOnHoverEnd' ];
 };
 
 export type CompositeTypeaheadProps = {

--- a/packages/components/src/composite/types.ts
+++ b/packages/components/src/composite/types.ts
@@ -192,3 +192,34 @@ export type CompositeRowProps = {
 	 */
 	children?: Ariakit.CompositeRowProps[ 'children' ];
 };
+
+export type CompositeHoverProps = {
+	/**
+	 * Allows the component to be rendered as a different HTML element or React
+	 * component. The value can be a React element or a function that takes in the
+	 * original component props and gives back a React element with the props
+	 * merged.
+	 */
+	render?: Ariakit.CompositeHoverProps[ 'render' ];
+	/**
+	 * The contents of the component.
+	 */
+	children?: Ariakit.CompositeHoverProps[ 'children' ];
+	focusOnHover?: Ariakit.CompositeHoverProps[ 'focusOnHover' ];
+	blurOnHoverEnd?: Ariakit.CompositeHoverProps[ 'blurOnHoverEnd' ];
+};
+
+// TODO: check that props make sense
+export type CompositeTypeaheadProps = {
+	/**
+	 * Allows the component to be rendered as a different HTML element or React
+	 * component. The value can be a React element or a function that takes in the
+	 * original component props and gives back a React element with the props
+	 * merged.
+	 */
+	render?: Ariakit.CompositeTypeaheadProps[ 'render' ];
+	/**
+	 * The contents of the component.
+	 */
+	children?: Ariakit.CompositeTypeaheadProps[ 'children' ];
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #63564

Add `Composite.Hover` and `Composite.Typeahead` components

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve the offering of the `Composite` component.

These components are also already used in the repository (imported directly from `ariakit`). Adding them to `Composite` will allow us to replace those imports with imports from `@wordpress/components`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- added the components (based of the ariakit counterparts)
- added storybook examples (the remaining Storybook improvements are underway at #64397)
- added JSDocs, types, Storybook docs, and updated README.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open Storybook, go to the `Composite` component, and play around with the new `Hover` and `Typeahead` examples
- Check the code
- Check the docs

This PR doesn't include runtime changes to the actual component.