### PR TITLE
Site Editor: Fix Template Parts post type preload path

### DIFF
--- a/backport-changelog/6.7/7179.md
+++ b/backport-changelog/6.7/7179.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7179
+
+* https://github.com/WordPress/gutenberg/pull/64401

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * PHP and WordPress configuration compatibility functions for the Gutenberg
+ * editor plugin changes related to REST API.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Silence is golden.' );
+}
+
+/**
+ * Update the preload paths registered in Core (`site-editor.php` or `edit-form-blocks.php`).
+ *
+ * @param array                   $paths REST API paths to preload.
+ * @param WP_Block_Editor_Context $context Current block editor context.
+ * @return array Filtered preload paths.
+ */
+function gutenberg_block_editor_preload_paths_6_7( $paths, $context ) {
+	if ( 'core/edit-site' === $context->name ) {
+		// Fixes post type name. It should be `type/wp_template_part`.
+		$parts_key = array_search( '/wp/v2/types/wp_template-part?context=edit', $paths, true );
+		if ( false !== $parts_key ) {
+			$paths[ $parts_key ] = '/wp/v2/types/wp_template_part?context=edit';
+		}
+	}
+
+	return $paths;
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_7', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -40,6 +40,9 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php';
 	require __DIR__ . '/compat/wordpress-6.6/rest-api.php';
 
+	// WordPress 6.7 compat.
+	require __DIR__ . '/compat/wordpress-6.7/rest-api.php';
+
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';
 	require_once __DIR__ . '/class-wp-rest-edit-site-export-controller-gutenberg.php';


### PR DESCRIPTION
## What?
PR fixes a typo in the Template Parts post-type preload path. This type has been around since the beginning—#36488.

## Why?
Incorrect preload paths result in a silent WP error, and noting gets preloaded. I only noticed this because I was checking REST API responses and was curious where `WP_Error` originated.

Maybe `rest_preload_api_request` should log a `_doing_it_wrong()` when a provided path resolves with an error.

## Testing Instructions
1. Navigate to `site-editor.php?postType=wp_template_part`.
2. The app shouldn't make a `types/wp_template_part` request. It does on the trunk.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-09 at 17 17 11](https://github.com/user-attachments/assets/306cc2b8-3d18-41d4-bc24-49bee1869c3c)
