### PR TITLE
Updated query {} example to include the selector key

### DIFF
--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -333,11 +333,13 @@ Attribute definition:
 				type: 'string',
 				source: 'attribute',
 				attribute: 'src',
+                                selector: '[src]'
 			},
 			alt: {
 				type: 'string',
 				source: 'attribute',
 				attribute: 'alt',
+                                selector: '[alt]'
 			},
 		}
 	}


### PR DESCRIPTION
## What?
Adding the 'selector' key into the query {} source definition.

## Why?
Following the example directly from the current documentation (saved content and attribute definition), the data returned is null when using GraphQL queries for block data. Adding in the `selector` key fixes the issue.

## How?
N/A

## Testing Instructions

- Create a new block (my use case is ACF blocks).
- Within the block, add the "Saved content:" code into the PHP file.
- Copy the "Attribute definition:" into an 'attributes' node within the block.json file.
- Add the block to a page.
- Query the page using GraphQL (plugins needed WPGraphQL, WPGraphQL for ACF & WPGraphQL Content Blocks) and add in the attributes to query for the block.
- Returned data will be null.
- Add in the 'selector: [src]' and 'selector: [alt]' to the relevant parts of block.json.
- Query the page again, see the returned data.
