### PR TITLE
Fix: Data Views: bulk deleting causes a countdown experience in modal

### DIFF
--- a/packages/editor/src/dataviews/actions/trash-post.tsx
+++ b/packages/editor/src/dataviews/actions/trash-post.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import {
 	Button,
 	__experimentalText as Text,
@@ -44,10 +44,11 @@ const trashPost: Action< PostWithPermissions > = {
 		const { createSuccessNotice, createErrorNotice } =
 			useDispatch( noticesStore );
 		const { deleteEntityRecord } = useDispatch( coreStore );
+		const initialItemCount = useRef( items.length );
 		return (
 			<VStack spacing="5">
 				<Text>
-					{ items.length === 1
+					{ initialItemCount.current === 1
 						? sprintf(
 								// translators: %s: The item's title.
 								__(
@@ -60,9 +61,9 @@ const trashPost: Action< PostWithPermissions > = {
 								_n(
 									'Are you sure you want to move %d item to the trash ?',
 									'Are you sure you want to move %d items to the trash ?',
-									items.length
+									initialItemCount.current
 								),
-								items.length
+								initialItemCount.current
 						  ) }
 				</Text>
 				<HStack justify="right">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR is intended to fix: https://github.com/WordPress/gutenberg/issues/64405

## Why?
When bulk deleting items, the loading state numbers should not be changed in the modal 

## How?
`initialItemCount` is a ref that holds the initial number of items. The value of a ref persists across re-renders, so even if `items.length` changes, initialItemCount.current will still hold the original number of items.

## Testing Instructions
Test on a site with at least 100+ pages. [Here's a playground link](https://href.li/?https://playground.wordpress.net/#%7B%20%22landingPage%22:%20%22/wp-admin/site-editor.php%22,%20%22preferredVersions%22:%20%7B%20%22php%22:%20%227.4%22,%20%22wp%22:%20%226.5.5%22%20%7D,%20%22phpExtensionBundles%22:%20%5B%20%22kitchen-sink%22%20%5D,%20%22features%22:%20%7B%20%22networking%22:%20true%20%7D,%20%22steps%22:%20%5B%20%7B%20%22step%22:%20%22login%22,%20%22username%22:%20%22admin%22,%20%22password%22:%20%22password%22%20%7D,%20%7B%20%22step%22:%20%22importWordPressFiles%22,%20%22wordPressFilesZip%22:%20%7B%20%22resource%22:%20%22url%22,%20%22url%22:%20%22https://block-museum.com/wp-content/uploads/2024/07/wordpress-playground-200-pages.zip%22%20%7D%20%7D,%20%7B%20%22step%22:%20%22installPlugin%22,%20%22pluginZipFile%22:%20%7B%20%22resource%22:%20%22wordpress.org/plugins%22,%20%22slug%22:%20%22gutenberg%22%20%7D,%20%22options%22:%20%7B%20%22activate%22:%20true%20%7D%20%7D%20%5D%20%7D) that will spin up a version.
Open the Site Editor > Pages.
Switch to Grid layout.
Bulk edit and select all.
Move the items to trash.
Notice the modal counts down from 20.

## Screenshots or screencast 

https://github.com/user-attachments/assets/e01127c4-9da2-4189-b251-62bfe2d6b452



