### PR TITLE
Start adding lint rules for 40px default size

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -315,7 +315,8 @@ module.exports = {
 						'DimensionControl',
 						'FontSizePicker',
 					].map( ( componentName ) => ( {
-						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
+						// Falsy `__next40pxDefaultSize` without a non-default `size` prop.
+						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
 						message:
 							componentName +
 							' should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -278,7 +278,6 @@ module.exports = {
 			},
 		},
 		{
-			// Temporary rules until we're ready to officially deprecate the bottom margins.
 			files: [ 'packages/*/src/**/*.[tj]s?(x)' ],
 			excludedFiles: [
 				'packages/components/src/**/@(test|stories)/**',
@@ -289,6 +288,7 @@ module.exports = {
 					'error',
 					...restrictedSyntax,
 					...restrictedSyntaxComponents,
+					// Temporary rules until we're ready to officially deprecate the bottom margins.
 					...[
 						'CheckboxControl',
 						'ComboboxControl',
@@ -307,6 +307,18 @@ module.exports = {
 						message:
 							componentName +
 							' should have the `__nextHasNoMarginBottom` prop to opt-in to the new margin-free styles.',
+					} ) ),
+					// Temporary rules until we're ready to officially default to the new size.
+					...[
+						'BorderBoxControl',
+						'BorderControl',
+						'DimensionControl',
+						'FontSizePicker',
+					].map( ( componentName ) => ( {
+						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
+						message:
+							componentName +
+							' should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
 					} ) ),
 				],
 			},


### PR DESCRIPTION
Part of #63871

## What?

Adds lint rules for `__next40pxDefaultSize` prop adherence on the following components:

- BorderBoxControl
- BorderControl
- DimensionControl
- FontSizePicker

## Why?

These components currently don't have any violations, so this prevents accidental backslides when new instances are newly introduced into the codebase.

## Testing Instructions

See code comments.