### PR TITLE
Slash Inserter: Restrict block list to allowed blocks only

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -60,7 +60,8 @@ function createBlockCompleter() {
 				}, [] );
 			const [ items, categories, collections ] = useBlockTypesState(
 				rootClientId,
-				noop
+				noop,
+				true
 			);
 
 			const filteredItems = useMemo( () => {


### PR DESCRIPTION
## What?
Fixes #64411 

This PR forces the `WPCompleter` block list to show insertable blocks only and fixes a regression introduced by #62169.

## Why?
See #64411 

#62169 enabled all blocks to be visible in the block list. The `WPCompleter` component should be restricted to relevant blocks like the `QuickInserter`

## How?
afa0d6e03a76e59bf31bb57c855ae207365bf665 added a `isQuick` parameter to the `useBlockTypesState()` call to restrict the quick inserter to a list of relevant blocks. Setting this to true when used in the `WPCompleter` component forces it to act like a `QuickInsterter` and only shows relevant blocks.


## Testing Instructions
1. Create a block that allows for a subset of blocks including the `core/paragraph` block as child blocks
2. Insert the paragraph block
3. Type `/` to start searching for other blocks


## Screenshots or screencast <!-- if applicable -->

### Before Gutenberg version 18.5.0
![image](https://github.com/user-attachments/assets/cc74c37b-8afe-4828-9d09-02acf1318d16)


### Gutenberg version ^18.5.0
![image](https://github.com/user-attachments/assets/0945c583-be2b-403a-9683-0731ef2ec5c5)
