### PR TITLE
Fixed the style to make the pattern with floating cotent selectable.

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -247,6 +247,13 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		box-shadow: 0 0 0 1px var(--wp-admin-theme-color);
 	}
 
+	// Clear floats internal synced pattern.
+	&.is-reusable::after {
+		content: "";
+		clear: both;
+		display: table;
+	}
+
 	// Clear floats.
 	&[data-clear="true"] {
 		float: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixed the style to make the pattern with floating cotent selectable.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

fix #64131

If the synced pattern is floating, the height of the `data-title="Pattern"` will be zero, so we cannot click on it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Fixed the style to make the pattern with floating cotent selectable.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a block supported float.
3. Set Align left or right
4. Create patten on the block.
5. Click the block and check selected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
