### PR TITLE
Post Template: Add Border and Spacing Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -662,6 +662,8 @@ Contains the block elements used to render a post, like the title, date, feature
 -	**Category:** theme
 -	**Ancestor:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Parent:** core/query
+-	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Post Terms
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -660,7 +660,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Parent:** core/query
+-	**Ancestor:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Post Terms

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -660,8 +660,6 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Ancestor:** core/query
--	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Parent:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -49,7 +49,6 @@
 @import "./template-part/editor.scss";
 @import "./text-columns/editor.scss";
 @import "./video/editor.scss";
-@import "./post-template/editor.scss";
 @import "./query/editor.scss";
 @import "./query-pagination/editor.scss";
 @import "./query-pagination-numbers/editor.scss";

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -26,6 +26,12 @@
 			"margin": true,
 			"padding": true
 		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -26,12 +26,6 @@
 			"margin": true,
 			"padding": true
 		},
-		"__experimentalBorder": {
-			"radius": true,
-			"color": true,
-			"width": true,
-			"style": true
-		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -43,6 +43,8 @@
 			}
 		},
 		"spacing": {
+			"margin": true,
+			"padding": true,
 			"blockGap": {
 				"__experimentalDefault": "1.25em"
 			},
@@ -52,6 +54,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-post-template",

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -49,7 +49,9 @@
 				"__experimentalDefault": "1.25em"
 			},
 			"__experimentalDefaultControls": {
-				"blockGap": true
+				"blockGap": true,
+				"padding" : false,
+				"margin" : false
 			}
 		},
 		"interactivity": {
@@ -59,13 +61,7 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true,
-			"__experimentalDefaultControls": {
-				"radius": true,
-				"color": true,
-				"width": true,
-				"style": true
-			}
+			"style": true
 		}
 	},
 	"style": "wp-block-post-template",

--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -3,5 +3,6 @@
 		padding-left: 0;
 		margin-left: 0;
 		list-style: none;
+		box-sizing: border-box;
 	}
 }

--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -3,6 +3,5 @@
 		padding-left: 0;
 		margin-left: 0;
 		list-style: none;
-		box-sizing: border-box;
 	}
 }

--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -1,5 +1,0 @@
-.editor-styles-wrapper {
-	ul.wp-block-post-template {
-		list-style: none;
-	}
-}

--- a/packages/block-library/src/post-template/editor.scss
+++ b/packages/block-library/src/post-template/editor.scss
@@ -1,7 +1,5 @@
 .editor-styles-wrapper {
 	ul.wp-block-post-template {
-		padding-left: 0;
-		margin-left: 0;
 		list-style: none;
 	}
 }

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -4,6 +4,7 @@
 	max-width: 100%;
 	list-style: none;
 	padding: 0;
+	box-sizing: border-box;
 
 	// These rules no longer apply but should be kept for backwards compatibility.
 	&.is-flex-container {

--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -4,6 +4,7 @@
 	max-width: 100%;
 	list-style: none;
 	padding: 0;
+	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
 	// These rules no longer apply but should be kept for backwards compatibility.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add Border and Spacing support to the `Post Template` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Template` block is missing border support and spacing support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border and spacing support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Post Template` (Inside in Query Loop) block's border and spacing is Configurable via Global Styles.
- Edit All Archives Template & Edit  `Post Template` (In Query Loop) and Apply the border Styles & Spacing.
- Verify that `Post Template` block styles take precedence over global Styles.
- Verify that `Post Template` block borders & spacing display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->


https://github.com/user-attachments/assets/c262a311-8f28-4350-b15f-98edfd035b9b


