### PR TITLE
Fix: Add a column count class on the columns block - Issue #64234

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -108,7 +108,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 -	**Category:** design
 -	**Allowed Blocks:** core/column
 -	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isStackedOnMobile, templateLock, verticalAlignment
+-	**Attributes:** columnsCount, isStackedOnMobile, templateLock, verticalAlignment
 
 ## Comment Author Avatar (deprecated)
 

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -18,6 +18,9 @@
 		"templateLock": {
 			"type": [ "string", "boolean" ],
 			"enum": [ "all", "insert", "contentOnly", false ]
+		},
+		"columnsCount": {
+			"type": "number"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -44,11 +44,14 @@ const DEFAULT_BLOCK = {
 	name: 'core/column',
 };
 
-function ColumnInspectorControls( {
-	clientId,
-	setAttributes,
-	isStackedOnMobile,
-} ) {
+/**
+ * Creates a custom hook to use columns block data in multiple components.
+ *
+ * @param {string} clientId The blocks client id.
+ *
+ * @return {Object} The columns block data.
+ */
+function useColumnsBlockData( clientId ) {
 	const { count, canInsertColumnBlock, minCount } = useSelect(
 		( select ) => {
 			const {
@@ -82,6 +85,17 @@ function ColumnInspectorControls( {
 		},
 		[ clientId ]
 	);
+
+	return { count, canInsertColumnBlock, minCount };
+}
+
+function ColumnInspectorControls( {
+	clientId,
+	setAttributes,
+	isStackedOnMobile,
+} ) {
+	const { count, canInsertColumnBlock, minCount } =
+		useColumnsBlockData( clientId );
 	const { getBlocks } = useSelect( blockEditorStore );
 	const { replaceInnerBlocks } = useDispatch( blockEditorStore );
 
@@ -189,13 +203,18 @@ function ColumnInspectorControls( {
 function ColumnsEditContainer( { attributes, setAttributes, clientId } ) {
 	const { isStackedOnMobile, verticalAlignment, templateLock } = attributes;
 	const registry = useRegistry();
+	const { count } = useColumnsBlockData( clientId );
 	const { getBlockOrder } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const classes = clsx( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `wp-block-columns-${ count }` ]: true,
 	} );
+
+	// Update the columns count attribute to columns count we get.
+	setAttributes( { columnsCount: count } );
 
 	const blockProps = useBlockProps( {
 		className: classes,

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -9,11 +9,12 @@ import clsx from 'clsx';
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const { isStackedOnMobile, verticalAlignment, columnsCount } = attributes;
 
 	const className = clsx( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		[ `is-not-stacked-on-mobile` ]: ! isStackedOnMobile,
+		[ `wp-block-columns-${ columnsCount }` ]: true,
 	} );
 
 	const blockProps = useBlockProps.save( { className } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - #64234 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Needed to add the columns count class so that we can target specific CSS on block based theme to match the intended breakpoint.
- For more see - #64234

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR adds, the `wp-block-columns-{ innerColumnCount }` class on `edit.js` and `save.js` to fix the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open any post/page.
2. Add the columns block and insert the column.
3. Save the page, check the frontend and inspect the columns div.
4. You would see the class `wp-block-columns-{n}`, where `n` is the number of column being added inside columns block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- NIL

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/77a75f9c-b7b5-43a9-a3cf-3cd112209733



