### PR TITLE
Edit Post: Avoid unnecessary post-template ID lookup

### DIFF
--- a/packages/edit-post/src/store/private-selectors.js
+++ b/packages/edit-post/src/store/private-selectors.js
@@ -50,8 +50,11 @@ export const getEditedPostTemplateId = createRegistrySelector(
 		} else {
 			slugToCheck = postType === 'page' ? 'page' : `single-${ postType }`;
 		}
-		return select( coreStore ).getDefaultTemplateId( {
-			slug: slugToCheck,
-		} );
+
+		if ( postType ) {
+			return select( coreStore ).getDefaultTemplateId( {
+				slug: slugToCheck,
+			} );
+		}
 	}
 );


### PR DESCRIPTION
## What?
PR updates the `getEditedPostTemplateId` selector to avoid making unnecessary post-template ID lookups while the post type is undefined.

## Why?
Reduces the number of HTTP requests made while loading the editor.

## Testing Instructions
1. Open a post.
2. Inspect Network requests for `/templates/lookup`.
3. Confirm that only a single request is made.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
**Before**
![CleanShot 2024-08-12 at 12 34 05](https://github.com/user-attachments/assets/766eb956-6bc6-40a7-961b-0ced77b4f294)

**After**
![CleanShot 2024-08-12 at 12 34 30](https://github.com/user-attachments/assets/5335187f-4793-4115-96f3-a46d79da7998)
