### PR TITLE
Zoom Out: Escape when clicking directly on the canvas or pressing enter on the canvas

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -130,8 +130,8 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
-	const { __unstableGetEditorMode, __unstableSetEditorMode } =
-		useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -22,7 +22,7 @@ import {
 	useDisabled,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -130,6 +130,7 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -429,6 +430,16 @@ function Iframe( {
 								'editor-styles-wrapper',
 								...bodyClasses
 							) }
+							onClick={ ( event ) => {
+								if ( event.target === event.currentTarget ) {
+									__unstableSetEditorMode( 'edit' );
+								}
+							} }
+							onKeyDown={ ( event ) => {
+								if ( event.key === 'Enter' ) {
+									__unstableSetEditorMode( 'edit' );
+								}
+							} }
 						>
 							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -130,7 +130,8 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __unstableGetEditorMode, __unstableSetEditorMode } =
+		useDispatch( blockEditorStore );
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -431,12 +432,18 @@ function Iframe( {
 								...bodyClasses
 							) }
 							onClick={ ( event ) => {
-								if ( event.target === event.currentTarget ) {
+								if (
+									__unstableGetEditorMode() === 'zoom-out' &&
+									event.target === event.currentTarget
+								) {
 									__unstableSetEditorMode( 'edit' );
 								}
 							} }
 							onKeyDown={ ( event ) => {
-								if ( event.key === 'Enter' ) {
+								if (
+									__unstableGetEditorMode() === 'zoom-out' &&
+									event.key === 'Enter'
+								) {
 									__unstableSetEditorMode( 'edit' );
 								}
 							} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is exploring some options for how to escape zoom out mode

## Why?
In https://github.com/WordPress/gutenberg/pull/61489 we are trying the idea of landing users directly in zoom out flow. Because of this, we need a way that they can leave zoom out without clicking on the zoom out UI. Instead we want to try to guess that they want to leave zoom out by their key press events, or the mouse interactions

## How?
Add two event listeners to the iframe body:
- onClick - if the user clicks on the canvas, on a part that has no other blocks in it (i.e the empty part of the canvas) then exit zoom out
- onKeyDown - if the user presses enter while on the canvas then exit zoom out.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
This makes more sense in the context of https://github.com/WordPress/gutenberg/pull/61489, but you can test it independently:

1. Create a new page from the dashnboard
2. Close the starter content modal
3. Switch to zoom out mode using the device preview dropdown
4. Click on the post title - notice that you stay in zoom out
5. Type a post title and press enter - notice that you go to edit mode
6. Switch to zoom out mode using the device preview dropdown
7.  Click on the empty part of the canvas - notice that you go to edit mode 

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e9403545-165c-4a87-b5aa-6a6bd706b8c5

