### PR TITLE
DataForm: Update the style of the datetime fields to match the other types.

### DIFF
--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { BaseControl, TimePicker } from '@wordpress/components';
+import { BaseControl, TimePicker, VisuallyHidden } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
 
 /**
@@ -13,6 +13,7 @@ export default function DateTime< Item >( {
 	data,
 	field,
 	onChange,
+	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label } = field;
 	const value = field.getValue( { item: data } );
@@ -23,10 +24,15 @@ export default function DateTime< Item >( {
 	);
 
 	return (
-		<fieldset>
-			<BaseControl.VisualLabel as="legend">
-				{ label }
-			</BaseControl.VisualLabel>
+		<fieldset className="dataviews-controls__datetime">
+			{ ! hideLabelFromVision && (
+				<BaseControl.VisualLabel as="legend">
+					{ label }
+				</BaseControl.VisualLabel>
+			) }
+			{ hideLabelFromVision && (
+				<VisuallyHidden as="legend">{ label }</VisuallyHidden>
+			) }
 			<TimePicker
 				currentTime={ value }
 				onChange={ onChangeControl }

--- a/packages/dataviews/src/dataform-controls/style.scss
+++ b/packages/dataviews/src/dataform-controls/style.scss
@@ -1,0 +1,4 @@
+.dataviews-controls__datetime {
+	border: none;
+	padding: 0;
+}

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -11,4 +11,5 @@
 @import "./dataviews-layouts/list/style.scss";
 @import "./dataviews-layouts/table/style.scss";
 
+@import "./dataform-controls/style.scss";
 @import "./dataforms-layouts/panel/style.scss";


### PR DESCRIPTION
Related #59745 
Follow-up to #64267

## What?

This PR applies small tweaks to the datetime field type to make it match the other field types:

 - No border or padding around the control
 - When used in a "panel" DataForm, hide the label.

<img width="971" alt="Screenshot 2024-08-12 at 1 04 53 PM" src="https://github.com/user-attachments/assets/aef9b5b8-4f51-4505-8fa1-8be2b76a91ae">



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

 - You can test this one in storybook, run `npm run storybook:dev`
 - Check the "date" field in the DataForm story and compare how it looks in both panel and regular types.
