### PR TITLE
fix: Set empty default `block` settings value

### DIFF
--- a/packages/block-editor/src/components/global-styles/test/use-global-styles-context.native.js
+++ b/packages/block-editor/src/components/global-styles/test/use-global-styles-context.native.js
@@ -414,6 +414,7 @@ describe( 'getGlobalStyles', () => {
 		expect( globalStyles ).toEqual(
 			expect.objectContaining( {
 				__experimentalFeatures: {
+					blocks: {},
 					color: {
 						palette: RAW_FEATURES.color.palette,
 						gradients,

--- a/packages/block-editor/src/components/global-styles/use-global-styles-context.native.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-context.native.js
@@ -410,6 +410,9 @@ export function getColorsAndGradients(
 	return {
 		__experimentalGlobalStylesBaseStyles: null,
 		__experimentalFeatures: {
+			// Set an empty object to avoid errors from shared web components relying
+			// upon block settings. E.g., the Gallery block.
+			blocks: {},
 			color: {
 				...( ! features?.color
 					? {
@@ -455,6 +458,9 @@ export function getGlobalStyles( rawStyles, rawFeatures ) {
 
 	return {
 		__experimentalFeatures: {
+			// Set an empty object to avoid errors from shared web components relying
+			// upon block settings. E.g., the Gallery block.
+			blocks: {},
 			color: {
 				palette: colors?.palette,
 				gradients,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Prevent native mobile editor exceptions thrown within the Gallery block
component, which is shared between web and native mobile.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currently, `__experimentalFeatures` is only partially implemented for
the native mobile editor. Recent changes to the shared Gallery block
component included a reference to this missing key via the `useSettings`
Hook. Setting a default, empty value ensure exceptions are not thrown.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Set an empty, default value for `__experimentalFeatures.blocks`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert a Gallery block in the native mobile editor.
1. Verify the editor does not crash.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
