### PR TITLE
Update postcss-prefixwrap dependency to 1.51.0 to fix prefixing in `:where` selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41754,14 +41754,6 @@
 			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
 			"dev": true
 		},
-		"node_modules/postcss-prefixwrap": {
-			"version": "1.41.0",
-			"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.41.0.tgz",
-			"integrity": "sha512-gmwwAEE+ci3/ZKjUZppTETINlh1QwihY8gCstInuS7ohk353KYItU4d64hvnUvO2GUy29hBGPHz4Ce+qJRi90A==",
-			"peerDependencies": {
-				"postcss": "*"
-			}
-		},
 		"node_modules/postcss-reduce-initial": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
@@ -52237,7 +52229,7 @@
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
 				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
+				"postcss-prefixwrap": "^1.51.0",
 				"postcss-urlrebase": "^1.4.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^5.0.6",
@@ -52250,6 +52242,15 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
+			}
+		},
+		"packages/block-editor/node_modules/postcss-prefixwrap": {
+			"version": "1.51.0",
+			"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.51.0.tgz",
+			"integrity": "sha512-PuP4md5zFSY921dUcLShwSLv2YyyDec0dK9/puXl/lu7ZNvJ1U59+ZEFRMS67xwfNg5nIIlPXnAycPJlhA/Isw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"postcss": "*"
 			}
 		},
 		"packages/block-editor/node_modules/postcss-urlrebase": {
@@ -67255,13 +67256,18 @@
 				"fast-deep-equal": "^3.1.3",
 				"memize": "^2.1.0",
 				"postcss": "^8.4.21",
-				"postcss-prefixwrap": "^1.41.0",
+				"postcss-prefixwrap": "^1.51.0",
 				"postcss-urlrebase": "^1.4.0",
 				"react-autosize-textarea": "^7.1.0",
 				"react-easy-crop": "^5.0.6",
 				"remove-accents": "^0.5.0"
 			},
 			"dependencies": {
+				"postcss-prefixwrap": {
+					"version": "1.51.0",
+					"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.51.0.tgz",
+					"integrity": "sha512-PuP4md5zFSY921dUcLShwSLv2YyyDec0dK9/puXl/lu7ZNvJ1U59+ZEFRMS67xwfNg5nIIlPXnAycPJlhA/Isw=="
+				},
 				"postcss-urlrebase": {
 					"version": "1.4.0",
 					"resolved": "https://registry.npmjs.org/postcss-urlrebase/-/postcss-urlrebase-1.4.0.tgz",
@@ -87819,11 +87825,6 @@
 					"dev": true
 				}
 			}
-		},
-		"postcss-prefixwrap": {
-			"version": "1.41.0",
-			"resolved": "https://registry.npmjs.org/postcss-prefixwrap/-/postcss-prefixwrap-1.41.0.tgz",
-			"integrity": "sha512-gmwwAEE+ci3/ZKjUZppTETINlh1QwihY8gCstInuS7ohk353KYItU4d64hvnUvO2GUy29hBGPHz4Ce+qJRi90A=="
 		},
 		"postcss-reduce-initial": {
 			"version": "6.0.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -73,7 +73,7 @@
 		"fast-deep-equal": "^3.1.3",
 		"memize": "^2.1.0",
 		"postcss": "^8.4.21",
-		"postcss-prefixwrap": "^1.41.0",
+		"postcss-prefixwrap": "^1.51.0",
 		"postcss-urlrebase": "^1.4.0",
 		"react-autosize-textarea": "^7.1.0",
 		"react-easy-crop": "^5.0.6",

--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -242,6 +242,23 @@ describe( 'transformStyles', () => {
 
 			expect( output ).toEqual( expected );
 		} );
+
+		it( 'should not try to prefix pseudo elements on `:where` selectors', () => {
+			const input = `:where(.wp-element-button, .wp-block-button__link)::before { color: blue; }`;
+			const prefix = '.my-namespace';
+			const expected = [ `${ prefix } ${ input }` ];
+
+			const output = transformStyles(
+				[
+					{
+						css: input,
+					},
+				],
+				prefix
+			);
+
+			expect( output ).toEqual( expected );
+		} );
 	} );
 
 	it( 'should not break with data urls', () => {

--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -125,6 +125,21 @@ describe( 'transformStyles', () => {
 			expect( output ).toMatchSnapshot();
 		} );
 
+		it( `should not try to replace 'body' in the middle of a classname`, () => {
+			const prefix = '.my-namespace';
+			const input = `.has-body-text { color: red; }`;
+			const output = transformStyles(
+				[
+					{
+						css: input,
+					},
+				],
+				prefix
+			);
+
+			expect( output ).toEqual( [ `${ prefix } ${ input }` ] );
+		} );
+
 		it( 'should ignore keyframes', () => {
 			const input = `
 			@keyframes edit-post__fade-in-animation {
@@ -209,6 +224,23 @@ describe( 'transformStyles', () => {
 			);
 
 			expect( output ).toMatchSnapshot();
+		} );
+
+		it( 'should not try to wrap items within `:where` selectors', () => {
+			const input = `:where(.wp-element-button:active, .wp-block-button__link:active) { color: blue; }`;
+			const prefix = '.my-namespace';
+			const expected = [ `${ prefix } ${ input }` ];
+
+			const output = transformStyles(
+				[
+					{
+						css: input,
+					},
+				],
+				prefix
+			);
+
+			expect( output ).toEqual( expected );
 		} );
 	} );
 


### PR DESCRIPTION
## What?
Fixes #63829
Fixes #64395
Alternative to #63972

Fixes the bug reported in the above issues by updating to the latest version of postcss-prefixwrap so that it includes the fix for this issue - https://github.com/dbtedman/postcss-prefixwrap/issues/515.

## Testing Instructions
Note: Make sure you run `npm i` after checking out this PR locally.

1. Activate TT4 (which has button styles) and navigate to the post editor
2. Ensure the editor is not iframed. This can be done by enabling the Custom Fields preference via the top right menu More > Preferences > Custom Fields, then reloading the editor.
3. Edit a post and add some buttons, then save
4. Inspect the buttons and find the matched style with the following selector:
`.editor-styles-wrapper :where(.wp-element-button, .editor-styles-wrapper .wp-block-button__link)`

In trunk: Note the injection of the second `.editor-styles-wrapper` within that
In this PR: The style should be `.editor-styles-wrapper :where(.wp-element-button, .wp-block-button__link)`
