### PR TITLE
Editor: Fix preloaded REST API paths

### DIFF
--- a/backport-changelog/6.7/7179.md
+++ b/backport-changelog/6.7/7179.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7179
 
 * https://github.com/WordPress/gutenberg/pull/64401
+* https://github.com/WordPress/gutenberg/pull/64459

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -26,6 +26,24 @@ function gutenberg_block_editor_preload_paths_6_7( $paths, $context ) {
 		}
 	}
 
+	if ( 'core/edit-post' === $context->name ) {
+		$reusable_blocks_key = array_search(
+			add_query_arg(
+				array(
+					'context'  => 'edit',
+					'per_page' => -1,
+				),
+				rest_get_route_for_post_type_items( 'wp_block' )
+			),
+			$paths,
+			true
+		);
+
+		if ( false !== $parts_key ) {
+			unset( $paths[ $reusable_blocks_key ] );
+		}
+	}
+
 	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_7', 10, 2 );


### PR DESCRIPTION
## What?
PR removes user pattern preloading for the post-editors. It was introduced in https://github.com/WordPress/wordpress-develop/pull/2531.

## Why?
The editor is used to load reusable blocks via the [`useBlockEditorSettings` hook](https://github.com/WordPress/gutenberg/blob/a06beb870ef95538b587b29d74ab8ccf913e6e70/packages/editor/src/components/provider/use-block-editor-settings.js#L48-L54) at the top of the post editor React tree, and at the time it made sense to preload this data.

Unfortunately, it never worked. The `rest_preload_api_request` doesn't support unbound queries, and the request was terminated with an error.

Reusable blocks are no longer fetched when the editor loads - #58239.

## Testing Instructions
Confirm that the preload path is correctly removed from the `$paths` array.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-13 at 07 10 03](https://github.com/user-attachments/assets/d5510bec-823f-4fac-ba14-e9c6954bb3dd)
