### PR TITLE
Drag & drop: allow direct text block drag

### DIFF
--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -18,3 +18,13 @@
 		content: none !important;
 	}
 }
+
+[draggable="true"],
+[data-fully-selected],
+img {
+	cursor: grab;
+
+	[contenteditable] {
+		cursor: text;
+	}
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -193,7 +193,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			defaultClassName
 		),
 		style: { ...wrapperProps.style, ...props.style, ...bindingsStyle },
-		draggable: true,
 	};
 }
 

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -193,6 +193,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			defaultClassName
 		),
 		style: { ...wrapperProps.style, ...props.style, ...bindingsStyle },
+		draggable: true,
 	};
 }
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { isTextField } from '@wordpress/dom';
+import { isTextField, isEntirelySelected } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
@@ -70,7 +70,20 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 * @param {DragEvent} event Drag event.
 			 */
 			function onDragStart( event ) {
-				event.preventDefault();
+				const selection = node.ownerDocument.defaultView.getSelection();
+
+				if ( selection.rangeCount && ! isEntirelySelected( node ) ) {
+					event.preventDefault();
+					return;
+				}
+
+				const data = JSON.stringify( {
+					type: 'block',
+					srcClientIds: [ clientId ],
+					srcRootClientId: getBlockRootClientId( clientId ),
+				} );
+				event.dataTransfer.clearData();
+				event.dataTransfer.setData( 'wp-blocks', data );
 			}
 
 			node.addEventListener( 'keydown', onKeyDown );

--- a/packages/block-editor/src/components/use-on-block-drop/index.js
+++ b/packages/block-editor/src/components/use-on-block-drop/index.js
@@ -79,6 +79,7 @@ export function onBlockDrop(
 	getBlock
 ) {
 	return ( event ) => {
+		event.target.ownerDocument.defaultView.getSelection().removeAllRanges();
 		const {
 			srcRootClientId: sourceRootClientId,
 			srcClientIds: sourceClientIds,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -266,6 +266,7 @@ function ButtonEdit( props ) {
 						width,
 					[ `has-custom-font-size` ]: blockProps.style.fontSize,
 				} ) }
+				draggable="true"
 			>
 				<RichText
 					ref={ mergedRef }

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -85,7 +85,7 @@ export default function ListItemEdit( {
 	const onMerge = useMerge( clientId, mergeBlocks );
 	return (
 		<>
-			<li { ...innerBlocksProps }>
+			<li { ...innerBlocksProps } draggable="true">
 				<RichText
 					ref={ useMergeRefs( [ useEnterRef, useSpaceRef ] ) }
 					identifier="content"

--- a/packages/block-library/src/quote/edit.js
+++ b/packages/block-library/src/quote/edit.js
@@ -102,7 +102,7 @@ export default function QuoteEdit( {
 					} }
 				/>
 			</BlockControls>
-			<BlockQuotation { ...innerBlocksProps }>
+			<BlockQuotation { ...innerBlocksProps } draggable="true">
 				{ innerBlocksProps.children }
 				<Caption
 					attributeKey="citation"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #63267.

Simply enables the native browser dragging, while setting data transfer to be the block.

Maybe eventually we'd want to use a different technique to have more control over what the clone is, and what content is left in place, but I think this is a great start to iterate from.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's just more intuitive to drag and drop blocks directly if possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We leverage native draggable. Text and images are draggable by default, so we don't need to do anything special. We just need to set the correct data transfer info.

Outside of that, `draggable` needs to be explicitly enabled. For example, a list item is draggable if you select all the text contents, but by also making the block itself `draggable`, the user can grab the list item by the bullet (see screenshot).

The same thing can be used for quote, button, maybe more.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try dragging text-based blocks, list items, quotes, images etc.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![drag-text](https://github.com/user-attachments/assets/4c88ec31-f4a0-4be1-8a88-dda4fab1d885)
![drag-list-item](https://github.com/user-attachments/assets/9ddd1165-7ee3-4f61-b6fb-20518b1e667d)
![drag-button](https://github.com/user-attachments/assets/b603a95e-04aa-4bfc-b48f-6325faf266ab)
![drag-image-gallery](https://github.com/user-attachments/assets/bcb804b1-8c74-4238-bb01-0f658e8cb055)
![drag-image](https://github.com/user-attachments/assets/8bef8dbb-ced9-492a-adf7-0992e526f7a5)
![drag-quote](https://github.com/user-attachments/assets/5b58f54a-a0d5-4f37-b295-7748c9bef21c)

