### PR TITLE
Table Block: Hide caption toolbar button on multiple selection

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -95,7 +95,7 @@ function TableEdit( {
 	attributes,
 	setAttributes,
 	insertBlocksAfter,
-	isSelected,
+	isSelected: isSingleSelected,
 } ) {
 	const { hasFixedLayout, head, foot } = attributes;
 	const [ initialRowCount, setInitialRowCount ] = useState( 2 );
@@ -340,10 +340,10 @@ function TableEdit( {
 	}
 
 	useEffect( () => {
-		if ( ! isSelected ) {
+		if ( ! isSingleSelected ) {
 			setSelectedCell();
 		}
-	}, [ isSelected ] );
+	}, [ isSingleSelected ] );
 
 	useEffect( () => {
 		if ( hasTableCreated ) {
@@ -565,9 +565,10 @@ function TableEdit( {
 				<Caption
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					isSelected={ isSelected }
+					isSelected={ isSingleSelected }
 					insertBlocksAfter={ insertBlocksAfter }
 					label={ __( 'Table caption text' ) }
+					showToolbarButton={ isSingleSelected }
 				/>
 			) }
 		</figure>


### PR DESCRIPTION
Similar to #57449, #57375 and #57376

## What?

This PR updates the Table block to hide the "Caption" toolbar control when blocks are multi-selected.

## Why?

When blocks are multi-selected, pressing the Caption toolbar button does nothing.

## How?

## Testing Instructions

The caption toolbar button is not displayed when multiple blocks are selected.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/f617cdcd-a85d-4c32-9917-c8624029cd1c)

### After

![image](https://github.com/user-attachments/assets/9ec9fb96-1c29-43bd-9027-2baff18fac22)

