### PR TITLE
Featured Image Block: Reduce CSS specificity

### DIFF
--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -1,4 +1,4 @@
-.wp-block-post-featured-image {
+:where(.wp-block-post-featured-image) {
 	margin-left: 0;
 	margin-right: 0;
 	a {

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -1,4 +1,10 @@
 :where(.wp-block-post-featured-image) {
+	img {
+		vertical-align: bottom;
+		width: 100%;
+	}
+}
+.wp-block-post-featured-image {
 	margin-left: 0;
 	margin-right: 0;
 	a {
@@ -7,9 +13,7 @@
 	}
 	img {
 		max-width: 100%;
-		width: 100%;
 		height: auto;
-		vertical-align: bottom;
 		box-sizing: border-box;
 	}
 

--- a/packages/block-library/src/post-featured-image/style.scss
+++ b/packages/block-library/src/post-featured-image/style.scss
@@ -1,9 +1,3 @@
-:where(.wp-block-post-featured-image) {
-	img {
-		vertical-align: bottom;
-		width: 100%;
-	}
-}
 .wp-block-post-featured-image {
 	margin-left: 0;
 	margin-right: 0;
@@ -11,9 +5,11 @@
 		display: block;
 		height: 100%;
 	}
-	img {
+	:where(img) {
 		max-width: 100%;
+		width: 100%;
 		height: auto;
+		vertical-align: bottom;
 		box-sizing: border-box;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #64453

## What?
<!-- In a few words, what is the PR actually doing? -->

Reduces the specificity of all of the default featured-image block style rules.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The core/post-featured-image block has some styles which out specify CSS set in theme.json / the site editor. This breaks existing themes and makes overriding the styles confusing for people making new themes or using the site editor. This problem started with the CSS specificity changes introduced by WP6.6

https://github.com/WordPress/gutenberg/issues/64453

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Lower the specificity of all of the core/featured-image styles in the same way that is done elsewhere - by using a `:where` to wrap the existing selector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
 1. Add a post with a featured image
 2. Activate the [Luminance theme](https://wordpress.org/themes/luminance/) which includes some [custom css as a block style](https://github.com/Automattic/themes/blob/86579e7425456c170553814456273f305c987416/luminance/theme.json#L510)
 3. View the front-end of the site, the image will look all broken and misaligned.




To try the same thing on TT4, replace step Two above with:
 0. Ensure TT4 is the active theme
 1. In the Blog Home template, scroll down to the Post Template block
 2. Add a row block to the first column
 3. Most the Post Title block inside the row block
 4. Add a Featured Image block to the row block, after the Post Title block
 5. Set the dimensions of the Featured Image block to be something small like 20px * 20px
 6. Open the GS panel and add this css to the Featured Image block `.wp-block-post-featured-image img{vertical-align:top;width: auto;}`

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Before | After
-------|------
 ![image](https://github.com/user-attachments/assets/873af943-b6e3-4381-aab2-034e501af375)| ![image](https://github.com/user-attachments/assets/4b07c886-5071-4cc6-af5c-3e6591919101)