### PR TITLE
DataViews Extensibility: Allow unregistering the view post revisions action

### DIFF
--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -428,7 +428,7 @@ interface ActionBase< Item > {
 	supportsBulk?: boolean;
 
 	/**
-	 * The context is which the action is visible.
+	 * The context in which the action is visible.
 	 * This is only a "meta" information for now.
 	 */
 	context?: 'list' | 'single';

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -426,6 +426,12 @@ interface ActionBase< Item > {
 	 * Whether the action can be used as a bulk action.
 	 */
 	supportsBulk?: boolean;
+
+	/**
+	 * The context is which the action is visible.
+	 * This is only a "meta" information for now.
+	 */
+	context?: 'list' | 'single';
 }
 
 export interface RenderModalProps< Item > {

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -2,10 +2,9 @@
  * WordPress dependencies
  */
 import { external } from '@wordpress/icons';
-import { addQueryArgs } from '@wordpress/url';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { useMemo, useEffect } from '@wordpress/element';
 
 /**
@@ -31,40 +30,6 @@ const viewPostAction = {
 	},
 };
 
-const postRevisionsAction = {
-	id: 'view-post-revisions',
-	context: 'list',
-	label( items ) {
-		const revisionsCount =
-			items[ 0 ]._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
-		return sprintf(
-			/* translators: %s: number of revisions */
-			__( 'View revisions (%s)' ),
-			revisionsCount
-		);
-	},
-	isEligible: ( post ) => {
-		if ( post.status === 'trash' ) {
-			return false;
-		}
-		const lastRevisionId =
-			post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ?? null;
-		const revisionsCount =
-			post?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
-		return lastRevisionId && revisionsCount > 1;
-	},
-	callback( posts, { onActionPerformed } ) {
-		const post = posts[ 0 ];
-		const href = addQueryArgs( 'revision.php', {
-			revision: post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id,
-		} );
-		document.location.href = href;
-		if ( onActionPerformed ) {
-			onActionPerformed( posts );
-		}
-	},
-};
-
 export function usePostActions( { postType, onActionPerformed, context } ) {
 	const { defaultActions, postTypeObject } = useSelect(
 		( select ) => {
@@ -84,7 +49,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 	}, [ registerPostTypeActions, postType ] );
 
 	const isLoaded = !! postTypeObject;
-	const supportsRevisions = !! postTypeObject?.supports?.revisions;
 	return useMemo( () => {
 		if ( ! isLoaded ) {
 			return [];
@@ -92,7 +56,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 
 		let actions = [
 			postTypeObject?.viewable && viewPostAction,
-			supportsRevisions && postRevisionsAction,
 			...defaultActions,
 		].filter( Boolean );
 		// Filter actions based on provided context. If not provided
@@ -161,7 +124,6 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		postTypeObject?.viewable,
 		onActionPerformed,
 		isLoaded,
-		supportsRevisions,
 		context,
 	] );
 }

--- a/packages/editor/src/dataviews/actions/view-post-revisions.tsx
+++ b/packages/editor/src/dataviews/actions/view-post-revisions.tsx
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+import { __, sprintf } from '@wordpress/i18n';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { Post } from '../types';
+
+const viewPostRevisions: Action< Post > = {
+	id: 'view-post-revisions',
+	context: 'list',
+	label( items ) {
+		const revisionsCount =
+			items[ 0 ]._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
+		return sprintf(
+			/* translators: %s: number of revisions */
+			__( 'View revisions (%s)' ),
+			revisionsCount
+		);
+	},
+	isEligible( post ) {
+		if ( post.status === 'trash' ) {
+			return false;
+		}
+		const lastRevisionId =
+			post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ?? null;
+		const revisionsCount =
+			post?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
+		return !! lastRevisionId && revisionsCount > 1;
+	},
+	callback( posts, { onActionPerformed } ) {
+		const post = posts[ 0 ];
+		const href = addQueryArgs( 'revision.php', {
+			revision: post?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id,
+		} );
+		document.location.href = href;
+		if ( onActionPerformed ) {
+			onActionPerformed( posts );
+		}
+	},
+};
+
+export default viewPostRevisions;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -22,6 +22,7 @@ import type { PostType } from '../types';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import duplicatePost from '../actions/duplicate-post';
+import viewPostRevisions from '../actions/view-post-revisions';
 
 export function registerEntityAction< Item >(
 	kind: string,
@@ -88,6 +89,9 @@ export const registerPostTypeActions =
 			.getCurrentTheme();
 
 		const actions = [
+			!! postTypeConfig?.supports?.revisions
+				? viewPostRevisions
+				: undefined,
 			// @ts-ignore
 			globalThis.IS_GUTENBERG_PLUGIN
 				? ! [ 'wp_template', 'wp_block', 'wp_template_part' ].includes(

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -14,6 +14,13 @@ export interface CommonPost {
 	type: string;
 	id: string | number;
 	blocks?: Object[];
+	_links?: Links;
+}
+
+interface Links {
+	'predecessor-version'?: { href: string; id: number }[];
+	'version-history'?: { href: string; count: number }[];
+	[ key: string ]: { href: string }[] | undefined;
 }
 
 export interface BasePost extends CommonPost {
@@ -27,7 +34,6 @@ export interface BasePost extends CommonPost {
 	featured_media?: number;
 	menu_order?: number;
 	ping_status?: 'open' | 'closed';
-	_links?: Record< string, { href: string }[] >;
 }
 
 export interface Template extends CommonPost {
@@ -66,6 +72,7 @@ export interface PostType {
 	supports?: {
 		'page-attributes'?: boolean;
 		title?: boolean;
+		revisions?: boolean;
 	};
 }
 


### PR DESCRIPTION
Related #61084 
Similar to #62647 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions. The current PR explore the possibility to use the API to register one action: "view post revisions". 

## Testing Instructions

1- Open the pages dataviews.
2- You should be able to see the "view post revisions" action in the actions dropdown.
3- you can try to use the action.