### PR TITLE
Block Bindings: Fix long keys overflow in bindings panel

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.scss
+++ b/packages/block-editor/src/hooks/block-bindings.scss
@@ -1,5 +1,5 @@
 div.block-editor-bindings__panel {
-	grid-template-columns: auto;
+	grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
 	button:hover .block-editor-bindings__item-explanation {
 		color: inherit;
 	}


### PR DESCRIPTION
## What?
It fixes an issue where an overflow is created when a long key is used while connecting a block to bindings.

## Why?
It breaks the user experience.

## How?
I changed the ToolsPanel custom CSS to ensure width is not extended by children.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|----------|----------|
| <img width="284" alt="Screenshot 2024-08-13 at 10 57 47" src="https://github.com/user-attachments/assets/e08aedc8-af03-4ac3-9496-1a10495480fc"> | <img width="285" alt="Screenshot 2024-08-13 at 10 57 21" src="https://github.com/user-attachments/assets/330dd0db-7cc9-4a2b-9743-650d947b0362"> |