### PR TITLE
DataViews Extensibility: Allow unregistering the view post action

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -1,10 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { external } from '@wordpress/icons';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { __ } from '@wordpress/i18n';
 import { useMemo, useEffect } from '@wordpress/element';
 
 /**
@@ -13,30 +10,11 @@ import { useMemo, useEffect } from '@wordpress/element';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-const viewPostAction = {
-	id: 'view-post',
-	label: __( 'View' ),
-	isPrimary: true,
-	icon: external,
-	isEligible( post ) {
-		return post.status !== 'trash';
-	},
-	callback( posts, { onActionPerformed } ) {
-		const post = posts[ 0 ];
-		window.open( post.link, '_blank' );
-		if ( onActionPerformed ) {
-			onActionPerformed( posts );
-		}
-	},
-};
-
 export function usePostActions( { postType, onActionPerformed, context } ) {
-	const { defaultActions, postTypeObject } = useSelect(
+	const { defaultActions } = useSelect(
 		( select ) => {
-			const { getPostType } = select( coreStore );
 			const { getEntityActions } = unlock( select( editorStore ) );
 			return {
-				postTypeObject: getPostType( postType ),
 				defaultActions: getEntityActions( 'postType', postType ),
 			};
 		},
@@ -48,23 +26,14 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		registerPostTypeActions( postType );
 	}, [ registerPostTypeActions, postType ] );
 
-	const isLoaded = !! postTypeObject;
 	return useMemo( () => {
-		if ( ! isLoaded ) {
-			return [];
-		}
-
-		let actions = [
-			postTypeObject?.viewable && viewPostAction,
-			...defaultActions,
-		].filter( Boolean );
 		// Filter actions based on provided context. If not provided
 		// all actions are returned. We'll have a single entry for getting the actions
 		// and the consumer should provide the context to filter the actions, if needed.
 		// Actions should also provide the `context` they support, if it's specific, to
 		// compare with the provided context to get all the actions.
 		// Right now the only supported context is `list`.
-		actions = actions.filter( ( action ) => {
+		const actions = defaultActions.filter( ( action ) => {
 			if ( ! action.context ) {
 				return true;
 			}
@@ -119,11 +88,5 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		}
 
 		return actions;
-	}, [
-		defaultActions,
-		postTypeObject?.viewable,
-		onActionPerformed,
-		isLoaded,
-		context,
-	] );
+	}, [ defaultActions, onActionPerformed, context ] );
 }

--- a/packages/editor/src/dataviews/actions/view-post.tsx
+++ b/packages/editor/src/dataviews/actions/view-post.tsx
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { external } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+import type { Action } from '@wordpress/dataviews';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../types';
+
+const viewPost: Action< BasePost > = {
+	id: 'view-post',
+	label: __( 'View' ),
+	isPrimary: true,
+	icon: external,
+	isEligible( post ) {
+		return post.status !== 'trash';
+	},
+	callback( posts, { onActionPerformed } ) {
+		const post = posts[ 0 ];
+		window.open( post?.link, '_blank' );
+		if ( onActionPerformed ) {
+			onActionPerformed( posts );
+		}
+	},
+};
+
+export default viewPost;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -23,6 +23,7 @@ import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import duplicatePost from '../actions/duplicate-post';
 import viewPostRevisions from '../actions/view-post-revisions';
+import viewPost from '../actions/view-post';
 
 export function registerEntityAction< Item >(
 	kind: string,
@@ -89,6 +90,7 @@ export const registerPostTypeActions =
 			.getCurrentTheme();
 
 		const actions = [
+			postTypeConfig.viewable ? viewPost : undefined,
 			!! postTypeConfig?.supports?.revisions
 				? viewPostRevisions
 				: undefined,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -103,9 +103,10 @@ export const registerPostTypeActions =
 				  duplicatePost
 				: undefined,
 			postTypeConfig.slug === 'wp_template_part' &&
-				canCreate &&
-				currentTheme?.is_block_theme &&
-				duplicateTemplatePart,
+			canCreate &&
+			currentTheme?.is_block_theme
+				? duplicateTemplatePart
+				: undefined,
 			canCreate && postTypeConfig.slug === 'wp_block'
 				? duplicatePattern
 				: undefined,
@@ -123,7 +124,7 @@ export const registerPostTypeActions =
 
 		registry.batch( () => {
 			actions.forEach( ( action ) => {
-				if ( action === undefined ) {
+				if ( ! action ) {
 					return;
 				}
 				unlock( registry.dispatch( editorStore ) ).registerEntityAction(

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -34,6 +34,7 @@ export interface BasePost extends CommonPost {
 	featured_media?: number;
 	menu_order?: number;
 	ping_status?: 'open' | 'closed';
+	link?: string;
 }
 
 export interface Template extends CommonPost {
@@ -72,6 +73,7 @@ export type PostWithPermissions = Post & {
 
 export interface PostType {
 	slug: string;
+	viewable: boolean;
 	supports?: {
 		'page-attributes'?: boolean;
 		title?: boolean;


### PR DESCRIPTION
Related #61084 
Similar to #62647 

## What?

In #62052 an API to register and unregister dataviews actions has been implemented. But in order to allow third-party developers to be able to unregister these actions, we need to be using the same actions in Core to register the core actions. The current PR explore the possibility to use the API to register one action: "view post". 

## Testing Instructions

1- Open the pages dataviews.
2- You should be able to see the "view post" action in the actions dropdown.
3- you can try to use the action.