### PR TITLE
Zoom Out: Move the device type to the block editor store

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -500,6 +500,18 @@ _Returns_
 
 -   `Array`: ids of top-level and descendant blocks.
 
+### getDeviceType
+
+Returns the current editing canvas device type.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `string`: Device type.
+
 ### getDirectInsertBlock
 
 Returns the block to be directly inserted by the block appender.
@@ -1674,6 +1686,18 @@ Action that sets whether given blocks are visible on the canvas.
 _Parameters_
 
 -   _updates_ `Record<string,boolean>`: For each block's clientId, its new visibility setting.
+
+### setDeviceType
+
+Action that changes the width of the editing canvas.
+
+_Parameters_
+
+-   _deviceType_ `string`:
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### setHasControlledInnerBlocks
 

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -15,7 +15,8 @@ import { store as blockEditorStore } from '../store';
  * @param {boolean} zoomOut If we should enter into zoomOut mode or not
  */
 export function useZoomOut( zoomOut = true ) {
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode, setDeviceType } =
+		useDispatch( blockEditorStore );
 	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 
 	const originalEditingMode = useRef( null );
@@ -42,6 +43,7 @@ export function useZoomOut( zoomOut = true ) {
 	useEffect( () => {
 		if ( zoomOut && mode !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
+			setDeviceType( 'Desktop' );
 		} else if (
 			! zoomOut &&
 			__unstableGetEditorMode() === 'zoom-out' &&

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2191,3 +2191,17 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+/**
+ * Action that changes the width of the editing canvas.
+ *
+ * @param {string} deviceType
+ *
+ * @return {Object} Action object.
+ */
+export function setDeviceType( deviceType ) {
+	return {
+		type: 'SET_DEVICE_TYPE',
+		deviceType,
+	};
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2091,6 +2091,23 @@ export function inserterSearchInputRef( state = { current: null } ) {
 	return state;
 }
 
+/**
+ * Reducer returning the editing canvas device type.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function deviceType( state = 'Desktop', action ) {
+	switch ( action.type ) {
+		case 'SET_DEVICE_TYPE':
+			return action.deviceType;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2125,6 +2142,7 @@ const combinedReducers = combineReducers( {
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
 	inserterSearchInputRef,
+	deviceType,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3113,3 +3113,14 @@ export function __unstableGetTemporarilyEditingFocusModeToRevert( state ) {
 	);
 	return getTemporarilyEditingFocusModeToRevert( state );
 }
+
+/**
+ * Returns the current editing canvas device type.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {string} Device type.
+ */
+export function getDeviceType( state ) {
+	return state.deviceType;
+}

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -9,6 +9,7 @@ import {
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
 import deprecated from '@wordpress/deprecated';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -468,7 +469,7 @@ export const __experimentalGetPreviewDeviceType = createRegistrySelector(
 				alternative: `select( 'core/editor' ).getDeviceType`,
 			}
 		);
-		return select( editorStore ).getDeviceType();
+		return select( blockEditorStore ).getDeviceType();
 	}
 );
 

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -62,7 +62,7 @@ export const __experimentalGetPreviewDeviceType = createRegistrySelector(
 				alternative: `select( 'core/editor' ).getDeviceType`,
 			}
 		);
-		return select( editorStore ).getDeviceType();
+		return select( blockEditorStore ).getDeviceType();
 	}
 );
 

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -38,10 +38,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		isViewable,
 		showIconLabels,
 	} = useSelect( ( select ) => {
-		const { getDeviceType, getCurrentPostType } = select( editorStore );
+		const { getCurrentPostType } = select( editorStore );
 		const { getUnstableBase, getPostType } = select( coreStore );
 		const { get } = select( preferencesStore );
-		const { __unstableGetEditorMode } = select( blockEditorStore );
+		const { __unstableGetEditorMode, getDeviceType } =
+			select( blockEditorStore );
 		const _currentPostType = getCurrentPostType();
 		return {
 			deviceType: getDeviceType(),
@@ -52,8 +53,8 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			showIconLabels: get( 'core', 'showIconLabels' ),
 		};
 	}, [] );
-	const { setDeviceType } = useDispatch( editorStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode, setDeviceType } =
+		useDispatch( blockEditorStore );
 
 	/**
 	 * Save the original editing mode in a ref to restore it when we exit zoom out.

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -114,7 +114,6 @@ function VisualEditor( {
 		editedPostTemplate = {},
 		wrapperBlockName,
 		wrapperUniqueId,
-		deviceType,
 		isFocusedEntity,
 		isDesignPostType,
 		postType,
@@ -126,7 +125,6 @@ function VisualEditor( {
 			getCurrentTemplateId,
 			getEditorSettings,
 			getRenderingMode,
-			getDeviceType,
 		} = select( editorStore );
 		const { getPostType, canUser, getEditedEntityRecord } =
 			select( coreStore );
@@ -170,7 +168,6 @@ function VisualEditor( {
 					: undefined,
 			wrapperBlockName: _wrapperBlockName,
 			wrapperUniqueId: getCurrentPostId(),
-			deviceType: getDeviceType(),
 			isFocusedEntity: !! editorSettings.onNavigateToPreviousEntityRecord,
 			postType: postTypeSlug,
 			isPreview: editorSettings.__unstableIsPreviewMode,
@@ -178,15 +175,17 @@ function VisualEditor( {
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
 	const {
+		deviceType,
 		hasRootPaddingAwareAlignments,
 		themeHasDisabledLayoutStyles,
 		themeSupportsLayout,
 		isZoomOutMode,
 	} = useSelect( ( select ) => {
-		const { getSettings, __unstableGetEditorMode } =
+		const { getSettings, __unstableGetEditorMode, getDeviceType } =
 			select( blockEditorStore );
 		const _settings = getSettings();
 		return {
+			deviceType: getDeviceType(),
 			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
 			themeSupportsLayout: _settings.supportsLayout,
 			hasRootPaddingAwareAlignments:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Moves the deviceType store setting from the editor store to the block editor store.
Fixes #64256.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We need to change the device preview type in the zoom out hook, which means it needs to be in the block editor store, not the editor store.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Moving the code around. I've not done the cleanup in case this is a bad idea.

## Testing Instructions
1. Open the Site Editor
2. Use the device preview toggle to switch to a mobile device
3. Open Global Styles
4. Select "Browse Styles"
5. Confirm that you are zoomed out and that your device preview is set back to desktop.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f6eacd89-e6d4-41cd-8226-38e516e5ae99


