### PR TITLE
Docs/DataViews - fixed tip link for block editor view

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -30,8 +30,7 @@ const Example = () => {
 };
 ```
 
-> [!TIP]
-> At https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataviews--docs there's an example implementation of the Dataviews component."
+<div class="callout callout-info">At <a href="https://wordpress.github.io/gutenberg/">WordPress Gutenberg's Storybook</a> there's and <a href="https://wordpress.github.io/gutenberg/?path=/docs/dataviews-dataviews--docs">example implementation of the Dataviews component</a></div>
 
 ## Properties
 


### PR DESCRIPTION
## What?
The tip format is not correct and the block editor is not properly processing it (see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#usage )
<img width="785" alt="Screenshot 2024-08-13 at 11 00 19" src="https://github.com/user-attachments/assets/20ab7e66-f976-4bcf-b486-6deb7dfefbd9">

## Why?
To show proper format in the docs

## How?
By using proper classes and markup as explained at https://developer.wordpress.org/block-editor/contributors/documentation/#callout-notices
