### PR TITLE
Taxonomies: Retain flat term order

### DIFF
--- a/backport-changelog/6.8/7840.md
+++ b/backport-changelog/6.8/7840.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7840
+
+* https://github.com/WordPress/gutenberg/pull/64471

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-terms-controller-6-8.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-terms-controller-6-8.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * REST API: Gutenberg_REST_Terms_Controller_6_8 class
+ *
+ * @package    gutenberg
+ * @subpackage REST_API
+ * @since      6.8.0
+ */
+class Gutenberg_REST_Terms_Controller_6_8 extends WP_REST_Terms_Controller {
+	/**
+	 * Retrieves the query params for collections.
+	 *
+	 * @since 4.7.0
+	 * @since 6.8.0 Added 'term_order' to the list of allowed orderby parameters.
+	 *
+	 * @return array Collection parameters.
+	 */
+	public function get_collection_params() {
+		$query_params = parent::get_collection_params();
+
+		$query_params['orderby']['enum'][] = 'term_order';
+
+		return $query_params;
+	}
+}

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -26,7 +26,7 @@ add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
  *
  * @return array The updated taxonomy registration arguments.
  */
-function gutenberg_override_terms_controller_6_8( $args, $taxonomy ) {
+function gutenberg_override_terms_controller_6_8( $args ) {
 	if ( empty( $args['show_in_rest'] ) ) {
 		return $args;
 	}
@@ -38,4 +38,4 @@ function gutenberg_override_terms_controller_6_8( $args, $taxonomy ) {
 	$args['rest_controller_class'] = Gutenberg_REST_Terms_Controller_6_8::class;
 	return $args;
 }
-add_filter( 'register_taxonomy_args', 'gutenberg_override_terms_controller_6_8', 10, 2 );
+add_filter( 'register_taxonomy_args', 'gutenberg_override_terms_controller_6_8', 10 );

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -20,3 +20,22 @@ if ( ! function_exists( 'gutenberg_add_post_type_rendering_mode' ) ) {
 	}
 }
 add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
+
+/**
+ * Overrides the default 'WP_REST_Terms_Controller' class for all taxonomies upon registration.
+ *
+ * @return array The updated taxonomy registration arguments.
+ */
+function gutenberg_override_terms_controller_6_8( $args, $taxonomy ) {
+	if ( empty( $args['show_in_rest'] ) ) {
+		return $args;
+	}
+
+	if ( isset( $args['rest_controller_class'] ) && 'WP_REST_Terms_Controller' !== $args['rest_controller_class'] ) {
+		return $args;
+	}
+
+	$args['rest_controller_class'] = Gutenberg_REST_Terms_Controller_6_8::class;
+	return $args;
+}
+add_filter( 'register_taxonomy_args', 'gutenberg_override_terms_controller_6_8', 10, 2 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -50,6 +50,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/block-comments.php';
 	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php';
 	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-post-types-controller-6-8.php';
+	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-terms-controller-6-8.php';
 	require __DIR__ . '/compat/wordpress-6.8/rest-api.php';
 
 	// Plugin specific code.

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -111,6 +111,7 @@ export function FlatTermSelector( { slug, __nextHasNoMarginBottom } ) {
 			const query = {
 				...DEFAULT_QUERY,
 				include: _termIds?.join( ',' ),
+				orderby: 'include',
 				per_page: -1,
 			};
 


### PR DESCRIPTION
## What?
See https://github.com/WordPress/gutenberg/issues/65052.

## Why?
To retain the order in which "flat terms" (such as tags) are stored for a given post.

## How?
Sort the terms obtained via `getEntityRecords` by the array of term IDs that reflects the order in which they were added by the user to the current post.

## TODO

- [ ] We might want to respect the `sort` setting that's provided to [`register_taxonomy`](https://developer.wordpress.org/reference/functions/register_taxonomy/) to determine whether terms should be stored in the order they're given by the user (if `sort === true`, somewhat counter-intuitively), or if we should continue to sort them alphabetically.

> Whether terms in this taxonomy should be sorted in the order they are provided to `wp_set_object_terms()`. Default `null` which equates to `false`.

## Testing Instructions
Add the following code (e.g. to your theme's `functions.php`) and use the "Actors" panel in the block inspector to assign a number of actor names to a given post. Note that the order is kept (unlike previously, when they were re-ordered in alphabetical order). _Note however that when **saving** the post, the terms are still sorted alphabetically, and their previous order is lost. See https://github.com/WordPress/wordpress-develop/pull/7287 for a WIP fix._

```php
function register_taxonomies() {
	/**
	 * Taxonomy: Actors.
	 */

	 $labels = array(
		'name'          => __( 'Actors' ),
		'singular_name' => __( 'Actor' ),
		'add_new_item'  => __( 'Add Actor' ),
		'new_item_name' => __( 'New Actor' ),
	);

	$args = array(
		'label'                 => __( 'Cast' ),
		'labels'                => $labels,
		'public'                => true,
		'publicly_queryable'    => true,
		'hierarchical'          => false,
		'show_ui'               => true,
		'show_in_menu'          => true,
		'show_in_nav_menus'     => true,
		'query_var'             => true,
		'show_admin_column'     => false,
		'show_in_rest'          => true,
		'show_tagcloud'         => false,
		'rest_base'             => 'actors',
		'rest_controller_class' => 'WP_REST_Terms_Controller',
		'rest_namespace'        => 'wp/v2',
		'show_in_quick_edit'    => false,
		'show_in_graphql'       => false,
		'sort'                  => true, // Note this.
	);

	register_taxonomy( 'actors', array( 'post' ), $args );
}

add_action( 'init', 'register_taxonomies', 0 );
```

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|-------|-------|
| ![flat-terms-before](https://github.com/user-attachments/assets/928605a7-6240-4fff-9e87-6f387f0c7c80)| ![flat-terms-after](https://github.com/user-attachments/assets/590f891c-2409-4ffd-994c-174a46cc037f) |