### PR TITLE
Zoom Out: Force device type to Desktop whenever zoom out is invoked

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1276,9 +1276,15 @@ export function getRenderingMode( state ) {
  *
  * @return {string} Device type.
  */
-export function getDeviceType( state ) {
-	return state.deviceType;
-}
+export const getDeviceType = createRegistrySelector(
+	( select ) => ( state ) => {
+		const editorMode = select( blockEditorStore ).__unstableGetEditorMode();
+		if ( editorMode === 'zoom-out' ) {
+			return 'Desktop';
+		}
+		return state.deviceType;
+	}
+);
 
 /**
  * Returns true if the list view is opened.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When zoom out is engaged, always return `Desktop` as the device type. Fixes #64256.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Because when zoom out is triggered the preview becomes quite small, so it makes sense to keep the desktop view. We don't offer zoomed out and mobile as an option in the device previews.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Just return `Desktop` from the selector when the editor mode is `zoom-out`.

## Testing Instructions
1. Open the Site Editor
2. Use the device preview toggle to switch to a mobile device
3. Open Global Styles
4. Select "Browse Styles"
5. Confirm that you are zoomed out and that your device preview is set back to desktop.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f6eacd89-e6d4-41cd-8226-38e516e5ae99