### PR TITLE
Edit Post: Fix user pattern preloading filter

### DIFF
--- a/backport-changelog/6.7/7179.md
+++ b/backport-changelog/6.7/7179.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/7179
 
 * https://github.com/WordPress/gutenberg/pull/64401
 * https://github.com/WordPress/gutenberg/pull/64459
+* https://github.com/WordPress/gutenberg/pull/64477

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -39,7 +39,7 @@ function gutenberg_block_editor_preload_paths_6_7( $paths, $context ) {
 			true
 		);
 
-		if ( false !== $parts_key ) {
+		if ( false !== $reusable_blocks_key ) {
 			unset( $paths[ $reusable_blocks_key ] );
 		}
 	}


### PR DESCRIPTION
## What?
Fix a typo we introduced in #64459.

## Why?
Just fixing a typo.

Right now we can see a warning:

```
Warning: Undefined variable $parts_key in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.7/rest-api.php on line 42

Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.7/rest-api.php:42) in /var/www/html/wp-admin/admin-header.php on line 9
```



## How?
Using the right variable name.

## Testing Instructions
* Load the post editor.
* Verify you don't see a warning.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
None
