### PR TITLE
Zoom Out: Use previous device width for scale calculations

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -242,8 +242,10 @@ function Iframe( {
 	const isZoomedOut = scale !== 1;
 
 	useEffect( () => {
-		prevContainerWidth.current = containerWidth;
-	}, [ containerWidth ] );
+		if ( ! isZoomedOut ) {
+			prevContainerWidth.current = containerWidth;
+		}
+	}, [ containerWidth, isZoomedOut ] );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This restores zoom-out behaviour which was removed accidentally in https://github.com/WordPress/gutenberg/pull/63870.
Props to @stokesman who noticed this (https://github.com/WordPress/gutenberg/pull/63870/commits/44744e813ceebb64d78f58f9c9535c87e806961a)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When Zoom Out is engaged by way of the Inserter (not through the control added by this PR), the calculation needs to know about the width of the screen before zoom out is engaged, otherwise the device proportions aren't preserved.

## How?
Restore the code that was removed.

## Testing Instructions
1. Enable the zoom out experiment
2. Open the Site Editor
3. Open the inserter > patterns
4. Select a pattern category
5. Notice that when the canvas is zoomed out, the proportions are maintained

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/6a61bd84-4339-4861-83fc-9fa3d759df86





