### PR TITLE
`RangeControl`: tweak mark and label absolute positioning

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,10 @@
 -   `FocalPointPicker`: Default to new 40px size ([#64456](https://github.com/WordPress/gutenberg/pull/64456)).
 -   `DropdownMenuV2`: adopt elevation scale ([#64432](https://github.com/WordPress/gutenberg/pull/64432)).
 
+### Bug Fixes
+
+-   `RangeControl`: tweak mark and label absolute positioning ([#64487](https://github.com/WordPress/gutenberg/pull/64487)).
+
 ### Internal
 
 -   `Composite` v2: add `Hover` and `Typeahead` subcomponents ([#64399](https://github.com/WordPress/gutenberg/pull/64399)).

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -154,7 +154,7 @@ export const Mark = styled.span`
 	height: ${ thumbSize }px;
 	left: 0;
 	position: absolute;
-	top: -4px;
+	top: 9px;
 	width: 1px;
 
 	${ markFill };
@@ -170,7 +170,7 @@ export const MarkLabel = styled.span`
 	color: ${ COLORS.gray[ 300 ] };
 	font-size: 11px;
 	position: absolute;
-	top: 12px;
+	top: 22px;
 	white-space: nowrap;
 
 	${ rtl( { left: 0 } ) };


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Resolves: https://github.com/WordPress/gutenberg/issues/64481

This commit tweaks the position of the range control marks and labels to fit the [original 2020 design](https://github.com/WordPress/gutenberg/pull/19916).

## Why?

I can't find the regression, but there seems to be one.

## How?
Tweaky tweaky.

## Testing Instructions


The easiest way to test is to run story book locally — `npm run storybook:dev` — and head to http://localhost:50240/?path=/story/components-rangecontrol--with-integer-step-and-marks

Check that that the marks and labels sit neat behind, and under the range control bar.

Compare with trunk: https://wordpress.github.io/gutenberg/?path=/story/components-rangecontrol--with-integer-step-and-marks

I also added some marks to existing block editor controls to check for side-effects.

Here's the Cover block opacity range control:


https://github.com/user-attachments/assets/c96f712d-3b40-414a-9128-1520984420fd


<details>

<summary>Diff for the above cover block test</summary>

```diff
diff --git a/packages/block-library/src/cover/edit/inspector-controls.js b/packages/block-library/src/cover/edit/inspector-controls.js
index 5f93df58ad..54e1a7489a 100644
--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -291,8 +291,34 @@ export default function CoverInspectorControls( {
 							}
 							min={ 0 }
 							max={ 100 }
-							step={ 10 }
+							step={ 20 }
 							required
+							marks={ [
+								{
+									value: 0,
+									label: '0',
+								},
+								{
+									value: 20,
+									label: '20',
+								},
+								{
+									value: 40,
+									label: '40',
+								},
+								{
+									value: 60,
+									label: '60',
+								},
+								{
+									value: 80,
+									label: '80',
+								},
+								{
+									value: 100,
+									label: '100',
+								},
+							] }
 							__next40pxDefaultSize
 						/>
 					</ToolsPanelItem>
```

</details>



## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| <img width="300" alt="Screenshot 2024-08-14 at 12 23 30 PM" src="https://github.com/user-attachments/assets/ef5ba518-618d-4d8a-8713-ac18d91cc99d"> | <img width="300" alt="Screenshot 2024-08-14 at 12 00 09 PM" src="https://github.com/user-attachments/assets/1a5d5ca4-48f4-4072-aa4c-3b6a02d8ac38"> | 








