### PR TITLE
Components: Allow `style` prop on `Popover`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -12,6 +12,8 @@
 -   `Composite`: improve Storybook examples and add interactive controls ([#64397](https://github.com/WordPress/gutenberg/pull/64397)).
 -   `TimePicker`: add `hideLabelFromVision` prop ([#64267](https://github.com/WordPress/gutenberg/pull/64267)).
 -   `DropdownMenuV2`: adopt elevation scale ([#64432](https://github.com/WordPress/gutenberg/pull/64432)).
+-   `Popover`: allow `style` prop usage ([#64489](https://github.com/WordPress/gutenberg/pull/64489)).
+
 
 ## 28.5.0 (2024-08-07)
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -113,8 +113,8 @@ const UnforwardedPopover = (
 		WordPressComponentProps< PopoverProps, 'div', false >,
 		// To avoid overlaps between the standard HTML attributes and the props
 		// expected by `framer-motion`, omit all framer motion props from popover
-		// props (except for `animate`, `children`, and `style`, which are
-		// re-defined in `PopoverProps`).
+		// props (except for `animate` and `children` which are re-defined in
+		// `PopoverProps`, and `style` which is merged safely).
 		keyof Omit< MotionProps, 'animate' | 'children' | 'style' >
 	>,
 	forwardedRef: ForwardedRef< any >

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -114,7 +114,7 @@ const UnforwardedPopover = (
 		// To avoid overlaps between the standard HTML attributes and the props
 		// expected by `framer-motion`, omit all framer motion props from popover
 		// props (except for `animate` and `children`, which are re-defined in `PopoverProps`).
-		keyof Omit< MotionProps, 'animate' | 'children' >
+		keyof Omit< MotionProps, 'animate' | 'children' | 'style' >
 	>,
 	forwardedRef: ForwardedRef< any >
 ) => {
@@ -372,13 +372,17 @@ const UnforwardedPopover = (
 				style: {
 					...motionInlineStyles,
 					...style,
+					...contentProps.style,
 				},
 				onAnimationComplete: () => setAnimationFinished( true ),
 				...otherMotionProps,
 		  }
 		: {
 				animate: false,
-				style,
+				style: {
+					...style,
+					...contentProps.style,
+				},
 		  };
 
 	// When Floating UI has finished positioning and Framer Motion has finished animating

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -139,6 +139,7 @@ const UnforwardedPopover = (
 		shift = false,
 		inline = false,
 		variant,
+		style: contentStyle,
 
 		// Deprecated props
 		__unstableForcePosition,
@@ -372,7 +373,7 @@ const UnforwardedPopover = (
 				style: {
 					...motionInlineStyles,
 					...style,
-					...contentProps.style,
+					...contentStyle,
 				},
 				onAnimationComplete: () => setAnimationFinished( true ),
 				...otherMotionProps,
@@ -381,7 +382,7 @@ const UnforwardedPopover = (
 				animate: false,
 				style: {
 					...style,
-					...contentProps.style,
+					...contentStyle,
 				},
 		  };
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -113,7 +113,8 @@ const UnforwardedPopover = (
 		WordPressComponentProps< PopoverProps, 'div', false >,
 		// To avoid overlaps between the standard HTML attributes and the props
 		// expected by `framer-motion`, omit all framer motion props from popover
-		// props (except for `animate` and `children`, which are re-defined in `PopoverProps`).
+		// props (except for `animate`, `children`, and `style`, which are
+		// re-defined in `PopoverProps`).
 		keyof Omit< MotionProps, 'animate' | 'children' | 'style' >
 	>,
 	forwardedRef: ForwardedRef< any >

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -371,9 +371,9 @@ const UnforwardedPopover = (
 	const animationProps: HTMLMotionProps< 'div' > = shouldAnimate
 		? {
 				style: {
+					...contentStyle,
 					...motionInlineStyles,
 					...style,
-					...contentStyle,
 				},
 				onAnimationComplete: () => setAnimationFinished( true ),
 				...otherMotionProps,
@@ -381,8 +381,8 @@ const UnforwardedPopover = (
 		: {
 				animate: false,
 				style: {
-					...style,
 					...contentStyle,
+					...style,
 				},
 		  };
 

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -179,6 +179,42 @@ describe( 'Popover', () => {
 			} );
 		} );
 
+		describe( 'style', () => {
+			it( 'should output inline styles added through the style prop in addition to built-in popover positioning styles', async () => {
+				render(
+					<Popover
+						style={ { zIndex: 0 } }
+						data-testid="popover-element"
+					>
+						Hello
+					</Popover>
+				);
+				const popover = screen.getByTestId( 'popover-element' );
+
+				await waitFor( () => expect( popover ).toBeVisible() );
+				expect( popover ).toHaveStyle(
+					'position: absolute; top: 0px; left: 0px; z-index: 0;'
+				);
+			} );
+
+			it( 'should not be possible to override built-in popover positioning styles via the style prop', async () => {
+				render(
+					<Popover
+						style={ { position: 'static' } }
+						data-testid="popover-element"
+					>
+						Hello
+					</Popover>
+				);
+				const popover = screen.getByTestId( 'popover-element' );
+
+				await waitFor( () => expect( popover ).toBeVisible() );
+				expect( popover ).toHaveStyle(
+					'position: absolute; top: 0px; left: 0px;'
+				);
+			} );
+		} );
+
 		describe( 'focus behavior', () => {
 			it( 'should focus the popover container when opened', async () => {
 				render(

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -209,9 +209,7 @@ describe( 'Popover', () => {
 				const popover = screen.getByTestId( 'popover-element' );
 
 				await waitFor( () => expect( popover ).toBeVisible() );
-				expect( popover ).toHaveStyle(
-					'position: absolute; top: 0px; left: 0px;'
-				);
+				expect( popover ).not.toHaveStyle( 'position: static;' );
 			} );
 		} );
 

--- a/packages/components/src/popover/test/index.tsx
+++ b/packages/components/src/popover/test/index.tsx
@@ -180,7 +180,7 @@ describe( 'Popover', () => {
 		} );
 
 		describe( 'style', () => {
-			it( 'should output inline styles added through the style prop in addition to built-in popover positioning styles', async () => {
+			it( 'outputs inline styles added through the style prop in addition to built-in popover positioning styles', async () => {
 				render(
 					<Popover
 						style={ { zIndex: 0 } }
@@ -197,7 +197,7 @@ describe( 'Popover', () => {
 				);
 			} );
 
-			it( 'should not be possible to override built-in popover positioning styles via the style prop', async () => {
+			it( 'is not possible to override built-in popover positioning styles via the style prop', async () => {
 				render(
 					<Popover
 						style={ { position: 'static' } }

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -160,6 +160,13 @@ export type PopoverProps = {
 	 * @default false
 	 */
 	inline?: boolean;
+	/**
+	 * Inline styles to apply to the popover element.
+	 *
+	 * @default undefined
+	 */
+	style?: React.CSSProperties;
+
 	// Deprecated props
 	/**
 	 * Prevent the popover from flipping and resizing when meeting the viewport

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -160,12 +160,6 @@ export type PopoverProps = {
 	 * @default false
 	 */
 	inline?: boolean;
-	/**
-	 * Inline styles to apply to the popover element.
-	 *
-	 * @default undefined
-	 */
-	style?: React.CSSProperties;
 	// Deprecated props
 	/**
 	 * Prevent the popover from flipping and resizing when meeting the viewport

--- a/packages/components/src/popover/types.ts
+++ b/packages/components/src/popover/types.ts
@@ -166,7 +166,6 @@ export type PopoverProps = {
 	 * @default undefined
 	 */
 	style?: React.CSSProperties;
-
 	// Deprecated props
 	/**
 	 * Prevent the popover from flipping and resizing when meeting the viewport


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In #64321 I have a use case for using the `style` prop on the `Popover` component (see 'Why?').

I discovered that you can use the `style` prop, but doing so clears the style properties set by floating-ui that position the popover because of the way `contentProps.style` (`contentProps` collects the 'rest' of the component's attributes) overrides `animationProps.style` when the attributes are spread onto the component:
https://github.com/WordPress/gutenberg/blob/e0760706272e4d6af3f1b0c7f90ab4ea9e305256/packages/components/src/popover/index.tsx#L401-L402

In this PR I'm making the `style` prop work correctly.

## How?
Spreads the `style` prop into the `animationProps.style` property, giving it lower precedence than other 'built-in' styles so that it isn't possible to break the popover's innate positioning.

## Why?
#64321 renders a popover inside the editor canvas iframe and requires overriding `margin` (which is added by the block layout system) and `zIndex` (one of the popover's own styles). Due to the popover being inside the iframe, regular scss styles can't be used (they're not loaded in the iframe), so inline styles seem to be the obvious option.

There are possible alternatives:
- Add a prop that removes `zIndex` from the iframe (e.g. `noZIndex`), or allows setting a custom z index. The `margin` will still be overriden, but I can solve that by wrapping the popover in a `div` that has `style={{margin:0}}` specified. I'm not sure this solution is better than the one in this PR though, it adds an extra prop that's of limited use.
- Render a style sheet within the canvas iframe. I'm reluctant when it comes to this option as it adds much more complexity compared to using an inline style, which is simple and has no specificity issues.

## Testing Instructions
A couple of unit tests have been added. I wasn't sure about adding a story for this - I thought it might be best to leave this prop undocumented just like the other html attributes that can be added via `...contentProps`.
