### PR TITLE
Disallow dropping outside section root in Zoom Out mode

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -363,7 +363,7 @@ export default function useBlockDropZone( {
 					return;
 				}
 
-				// In Zoom Out mode, if the target is not the section root provided by settings) then do not allow dropping as
+				// In Zoom Out mode, if the target is not the section root provided by settings then do not allow dropping as
 				// the target is not within the root.
 				if (
 					isZoomOutMode &&

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -314,7 +314,7 @@ export default function useBlockDropZone( {
 		isDragging,
 		isGroupable,
 		getSettings,
-		__unstableGetEditorMode,
+		isZoomOutMode,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
 		showInsertionPoint,
@@ -322,10 +322,6 @@ export default function useBlockDropZone( {
 		startDragging,
 		stopDragging,
 	} = unlock( useDispatch( blockEditorStore ) );
-
-	const { sectionRootClientId } = unlock( getSettings() );
-
-	const isZoomOutMode = __unstableGetEditorMode() === 'zoom-out';
 
 	const onBlockDrop = useOnBlockDrop(
 		dropTarget.operation === 'before' || dropTarget.operation === 'after'
@@ -359,14 +355,18 @@ export default function useBlockDropZone( {
 					draggedBlockNames,
 					targetBlockName
 				);
+
 				if ( ! isBlockDroppingAllowed ) {
 					return;
 				}
 
-				// In Zoom Out mode, if the target is not the section root provided by settings then do not allow dropping as
-				// the target is not within the root.
+				const { sectionRootClientId } = unlock( getSettings() );
+
+				// In Zoom Out mode, if the target is not the section root provided by settings then
+				// do not allow dropping as the drop target is not within the root (that which is
+				// treated as "the content" by Zoom Out Mode).
 				if (
-					isZoomOutMode &&
+					isZoomOutMode() &&
 					sectionRootClientId !== targetRootClientId
 				) {
 					return;
@@ -492,8 +492,6 @@ export default function useBlockDropZone( {
 				getBlockNamesByClientId,
 				getDraggedBlockClientIds,
 				getBlockType,
-				isZoomOutMode,
-				sectionRootClientId,
 				getBlocks,
 				getBlockListSettings,
 				dropZoneElement,
@@ -506,6 +504,8 @@ export default function useBlockDropZone( {
 				isGroupable,
 				getBlockVariations,
 				getGroupingBlockName,
+				getSettings,
+				isZoomOutMode,
 			]
 		),
 		200

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -313,6 +313,8 @@ export default function useBlockDropZone( {
 		getAllowedBlocks,
 		isDragging,
 		isGroupable,
+		getSettings,
+		__unstableGetEditorMode,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
 		showInsertionPoint,
@@ -320,6 +322,10 @@ export default function useBlockDropZone( {
 		startDragging,
 		stopDragging,
 	} = unlock( useDispatch( blockEditorStore ) );
+
+	const { sectionRootClientId } = unlock( getSettings() );
+
+	const isZoomOutMode = __unstableGetEditorMode() === 'zoom-out';
 
 	const onBlockDrop = useOnBlockDrop(
 		dropTarget.operation === 'before' || dropTarget.operation === 'after'
@@ -343,6 +349,7 @@ export default function useBlockDropZone( {
 				const targetBlockName = getBlockNamesByClientId( [
 					targetRootClientId,
 				] )[ 0 ];
+
 				const draggedBlockNames = getBlockNamesByClientId(
 					getDraggedBlockClientIds()
 				);
@@ -353,6 +360,15 @@ export default function useBlockDropZone( {
 					targetBlockName
 				);
 				if ( ! isBlockDroppingAllowed ) {
+					return;
+				}
+
+				// In Zoom Out mode, if the target is not the section root provided by settings) then do not allow dropping as
+				// the target is not within the root.
+				if (
+					isZoomOutMode &&
+					sectionRootClientId !== targetRootClientId
+				) {
 					return;
 				}
 
@@ -470,24 +486,26 @@ export default function useBlockDropZone( {
 				} );
 			},
 			[
+				isDragging,
 				getAllowedBlocks,
 				targetRootClientId,
 				getBlockNamesByClientId,
 				getDraggedBlockClientIds,
 				getBlockType,
+				isZoomOutMode,
+				sectionRootClientId,
 				getBlocks,
 				getBlockListSettings,
 				dropZoneElement,
 				parentBlockClientId,
 				getBlockIndex,
 				registry,
-				showInsertionPoint,
-				isDragging,
 				startDragging,
+				showInsertionPoint,
 				canInsertBlockType,
+				isGroupable,
 				getBlockVariations,
 				getGroupingBlockName,
-				isGroupable,
 			]
 		),
 		200


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Disables the ability to drop patterns _outside_ of the section root when in Zoom Out mode. 

Related to https://github.com/WordPress/gutenberg/pull/63896

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes an Issue in Site Editor where it was possible to drag and drop directly on the header/footer of the template. This causes knock on effects on the appearance of / targetting of dropzones when using drag and drop in Zoom Out mode.

The issue is best illustrated when considering the site editor.

In this context the "section root" is the `<main>` tag. Elements outside of that "root" include (for example)

- header
- footer

When dragging and dropping patterns it should _not_ be possible to drop over these elements outside of the root, as the target area for the template content is the `<main>` element. 

**Note**: when using Zoom Out in the Post Editor (i.e. when creating a new Page) the section root is "empty" because the "template" is the page in question. We don't have headers or footers. The user is assembling a page and therefore should be allowed to drag patterns anywhere on that page. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionalise the `dragOver` handler with a special case for Zoom Out mode which checks whether the `rootClientId` of the dropzone (i.e. the `targetRootClientId`) matches the `sectionRootClientId` (e.g. the `<main>` element).

If they do not match then the drop zone is not within the section root and thus the operation should not be allowed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Go to Site Editor
- Open Pattern inserter and choose category to enter Zoom Out mode.
- Attempt to drag a pattern before the header of the Template. You shouldn't be able to do this.
- Check drag and drop into the main canvas works as expected.
- Go to WP Admin and create a new Page
- Open Pattern inserter and choose category to enter Zoom Out mode.
- Check you can drag and drop anywhere on the Page (as per `trunk`).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/62d144bd-ca6a-48eb-8992-e8bc7779fd28

