### PR TITLE
Paste: fix image paste from Google Forms

### DIFF
--- a/packages/blocks/src/api/raw-handling/figure-content-reducer.js
+++ b/packages/blocks/src/api/raw-handling/figure-content-reducer.js
@@ -95,7 +95,7 @@ export default function figureContentReducer( node, doc, schema ) {
 		) {
 			wrapFigureContent( nodeToInsert, wrapper );
 		}
-	} else if ( nodeToInsert.parentNode.nodeName === 'BODY' ) {
+	} else {
 		wrapFigureContent( nodeToInsert );
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Builds on the fix from #64479. When pasting from Google Forms, the image in pasted inline. This is happening because the raw HTML is an image wrapped an a `b` tag, and the image wasn't wrapped in a figure.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/issues/60811.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Let's try to skip the body check and see if we get past integration failures. I don't see why we can't wrap any image that occurs outside of a p or div, in a figure element.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a Google form that generates a chart in the responses tab and copy that into GB.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
