### PR TITLE
Add private `isZoomOutMode` selector

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -536,3 +536,14 @@ export const getBlockStyles = createSelector(
 		),
 	]
 );
+
+/**
+ * Returns whether zoom out mode is enabled.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {boolean} Is zoom out mode enabled.
+ */
+export function isZoomOutMode( state ) {
+	return state.editorMode === 'zoom-out';
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a private selector for determining if the currenting editing mode is `zoom-out`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As zoom out is developing and becoming more integral to the editor experience, the codebase is being littered with `__unstableGetEditorMode() === 'zoom-out'` calls.

This refactors to a standard selector. There is a previous precedent with the `isNavigationMode` selector.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Create a private selector which can be used to determine whether the editor is in `zoom-out` wirthout having to do a string comparison in every instance.

Currently private as zoom out is still relatively new and untested.

I haven't done any refactoring of usage because I want buy-in on the selector before I make the effort to do that.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Difficult to test as the selector is private.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
