### PR TITLE
Core Data: Resolve entity collection user permissions

### DIFF
--- a/backport-changelog/6.7/7139.md
+++ b/backport-changelog/6.7/7139.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7139
+
+* https://github.com/WordPress/gutenberg/pull/64504

--- a/lib/compat/wordpress-6.7/class-gutenberg-rest-server.php
+++ b/lib/compat/wordpress-6.7/class-gutenberg-rest-server.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * A custom REST server for Gutenberg.
+ *
+ * @package gutenberg
+ * @since   6.7.0
+ */
+
+class Gutenberg_REST_Server extends WP_REST_Server {
+	/**
+	 * Converts a response to data to send.
+	 *
+	 * @since 4.4.0
+	 * @since 5.4.0 The `$embed` parameter can now contain a list of link relations to include.
+	 *
+	 * @param WP_REST_Response $response Response object.
+	 * @param bool|string[]    $embed    Whether to embed all links, a filtered list of link relations, or no links.
+	 * @return array {
+	 *     Data with sub-requests embedded.
+	 *
+	 *     @type array $_links    Links.
+	 *     @type array $_embedded Embedded objects.
+	 * }
+	 */
+	// @core-merge: Do not merge. The method is copied here to fix the inheritance issue.
+	public function response_to_data( $response, $embed ) {
+		$data  = $response->get_data();
+		$links = static::get_compact_response_links( $response );
+
+		if ( ! empty( $links ) ) {
+			// Convert links to part of the data.
+			$data['_links'] = $links;
+		}
+
+		if ( $embed ) {
+			$this->embed_cache = array();
+			// Determine if this is a numeric array.
+			if ( wp_is_numeric_array( $data ) ) {
+				foreach ( $data as $key => $item ) {
+					$data[ $key ] = $this->embed_links( $item, $embed );
+				}
+			} else {
+				$data = $this->embed_links( $data, $embed );
+			}
+			$this->embed_cache = array();
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Retrieves links from a response.
+	 *
+	 * Extracts the links from a response into a structured hash, suitable for
+	 * direct output.
+	 *
+	 * @since 4.4.0
+	 * @since 6.7.0 The `targetHints` property to the `self` link object was added.
+	 *
+	 * @param WP_REST_Response $response Response to extract links from.
+	 * @return array Map of link relation to list of link hashes.
+	 */
+	public static function get_response_links( $response ) {
+		$links = $response->get_links();
+
+		if ( empty( $links ) ) {
+			return array();
+		}
+
+		$server = rest_get_server();
+
+		// Convert links to part of the data.
+		$data = array();
+		foreach ( $links as $rel => $items ) {
+			$data[ $rel ] = array();
+
+			foreach ( $items as $item ) {
+				$attributes         = $item['attributes'];
+				$attributes['href'] = $item['href'];
+
+				if ( 'self' !== $rel ) {
+					$data[ $rel ][] = $attributes;
+					continue;
+				}
+
+				$request = WP_REST_Request::from_url( $item['href'] );
+				$match   = $server->match_request_to_handler( $request );
+				if ( ! is_wp_error( $match ) && $request ) {
+					$response = new WP_REST_Response();
+					$response->set_matched_route( $match[0] );
+					$response->set_matched_handler( $match[1] );
+					$headers = rest_send_allow_header( $response, $server, $request )->get_headers();
+
+					foreach ( $headers as $name => $value ) {
+						$name = WP_REST_Request::canonicalize_header_name( $name );
+
+						// Prefer targetHints that were specifically designated by the developer.
+						if ( isset( $attributes['targetHints'][ $name ] ) ) {
+							continue;
+						}
+
+						$attributes['targetHints'][ $name ] = array_map( 'trim', explode( ',', $value ) );
+					}
+				}
+
+				$data[ $rel ][] = $attributes;
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Retrieves the CURIEs (compact URIs) used for relations.
+	 *
+	 * Extracts the links from a response into a structured hash, suitable for
+	 * direct output.
+	 *
+	 * @since 4.5.0
+	 *
+	 * @param WP_REST_Response $response Response to extract links from.
+	 * @return array Map of link relation to list of link hashes.
+	 */
+	// @core-merge: Do not merge. The method is copied here to fix the inheritance issue.
+	public static function get_compact_response_links( $response ) {
+		$links = static::get_response_links( $response );
+
+		if ( empty( $links ) ) {
+			return array();
+		}
+
+		$curies      = $response->get_curies();
+		$used_curies = array();
+
+		foreach ( $links as $rel => $items ) {
+
+			// Convert $rel URIs to their compact versions if they exist.
+			foreach ( $curies as $curie ) {
+				$href_prefix = substr( $curie['href'], 0, strpos( $curie['href'], '{rel}' ) );
+				if ( ! str_starts_with( $rel, $href_prefix ) ) {
+					continue;
+				}
+
+				// Relation now changes from '$uri' to '$curie:$relation'.
+				$rel_regex = str_replace( '\{rel\}', '(.+)', preg_quote( $curie['href'], '!' ) );
+				preg_match( '!' . $rel_regex . '!', $rel, $matches );
+				if ( $matches ) {
+					$new_rel                       = $curie['name'] . ':' . $matches[1];
+					$used_curies[ $curie['name'] ] = $curie;
+					$links[ $new_rel ]             = $items;
+					unset( $links[ $rel ] );
+					break;
+				}
+			}
+		}
+
+		// Push the curies onto the start of the links array.
+		if ( $used_curies ) {
+			$links['curies'] = array_values( $used_curies );
+		}
+
+		return $links;
+	}
+}

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -107,4 +107,4 @@ add_action( 'rest_api_init', 'gutenberg_register_wp_rest_templates_controller_pl
 function gutenberg_override_default_rest_server() {
 	return 'Gutenberg_REST_Server';
 }
-add_filter( 'wp_rest_server_class', 'gutenberg_override_default_rest_server' );
+add_filter( 'wp_rest_server_class', 'gutenberg_override_default_rest_server', 1 );

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -98,3 +98,13 @@ function gutenberg_register_wp_rest_templates_controller_plugin_field() {
 	);
 }
 add_action( 'rest_api_init', 'gutenberg_register_wp_rest_templates_controller_plugin_field' );
+
+/**
+ * Overrides the default 'WP_REST_Server' class.
+ *
+ * @return string The name of the custom server class.
+ */
+function gutenberg_override_default_rest_server() {
+	return 'Gutenberg_REST_Server';
+}
+add_filter( 'wp_rest_server_class', 'gutenberg_override_default_rest_server' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -42,6 +42,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 
 	// WordPress 6.7 compat.
 	require __DIR__ . '/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php';
+	require __DIR__ . '/compat/wordpress-6.7/class-gutenberg-rest-server.php';
 	require __DIR__ . '/compat/wordpress-6.7/rest-api.php';
 
 	// Plugin specific code.

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -19,7 +19,7 @@ import {
 	forwardResolver,
 	getNormalizedCommaSeparable,
 	getUserPermissionCacheKey,
-	getUserPermissionsFromResponse,
+	getUserPermissionsFromAllowHeader,
 	ALLOWED_RESOURCE_ACTIONS,
 } from './utils';
 import { getSyncProvider } from './sync';
@@ -173,7 +173,9 @@ export const getEntityRecord =
 
 				const response = await apiFetch( { path, parse: false } );
 				const record = await response.json();
-				const permissions = getUserPermissionsFromResponse( response );
+				const permissions = getUserPermissionsFromAllowHeader(
+					response.headers?.get( 'allow' )
+				);
 
 				registry.batch( () => {
 					dispatch.receiveEntityRecords( kind, name, record, query );
@@ -440,7 +442,12 @@ export const canUser =
 			return;
 		}
 
-		const permissions = getUserPermissionsFromResponse( response );
+		// Optional chaining operator is used here because the API requests don't
+		// return the expected result in the React native version. Instead, API requests
+		// only return the result, without including response properties like the headers.
+		const permissions = getUserPermissionsFromAllowHeader(
+			response.headers?.get( 'allow' )
+		);
 		registry.batch( () => {
 			for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
 				const key = getUserPermissionCacheKey( action, resource, id );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -320,28 +320,33 @@ export const getEntityRecords =
 							),
 						} ) );
 
+					const canUserResolutionsArgs = [];
+					for ( const targetHint of targetHints ) {
+						for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
+							canUserResolutionsArgs.push( [
+								action,
+								{ kind, name, id: targetHint.id },
+							] );
+
+							dispatch.receiveUserPermission(
+								getUserPermissionCacheKey( action, {
+									kind,
+									name,
+									id: targetHint.id,
+								} ),
+								targetHint.permissions[ action ]
+							);
+						}
+					}
+
 					dispatch.finishResolutions(
 						'getEntityRecord',
 						resolutionsArgs
 					);
-
-					for ( const targetHint of targetHints ) {
-						for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
-							const permissionKey = getUserPermissionCacheKey(
-								action,
-								{ kind, name, id: targetHint.id }
-							);
-
-							dispatch.receiveUserPermission(
-								permissionKey,
-								targetHint.permissions[ action ]
-							);
-							dispatch.finishResolution( 'canUser', [
-								action,
-								{ kind, name, id: targetHint.id },
-							] );
-						}
-					}
+					dispatch.finishResolutions(
+						'canUser',
+						canUserResolutionsArgs
+					);
 				}
 
 				dispatch.__unstableReleaseStoreLock( lock );

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -219,6 +219,7 @@ describe( 'getEntityRecords', () => {
 		const finishResolutions = jest.fn();
 		const dispatch = Object.assign( jest.fn(), {
 			receiveEntityRecords: jest.fn(),
+			receiveUserPermission: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
 			finishResolutions,

--- a/packages/core-data/src/utils/index.js
+++ b/packages/core-data/src/utils/index.js
@@ -11,6 +11,6 @@ export { default as getNestedValue } from './get-nested-value';
 export { default as isNumericID } from './is-numeric-id';
 export {
 	getUserPermissionCacheKey,
-	getUserPermissionsFromResponse,
+	getUserPermissionsFromAllowHeader,
 	ALLOWED_RESOURCE_ACTIONS,
 } from './user-permissions';

--- a/packages/core-data/src/utils/user-permissions.js
+++ b/packages/core-data/src/utils/user-permissions.js
@@ -5,13 +5,11 @@ export const ALLOWED_RESOURCE_ACTIONS = [
 	'delete',
 ];
 
-export function getUserPermissionsFromResponse( response ) {
+export function getUserPermissionsFromAllowHeader( allowedMethods ) {
 	const permissions = {};
-
-	// Optional chaining operator is used here because the API requests don't
-	// return the expected result in the React native version. Instead, API requests
-	// only return the result, without including response properties like the headers.
-	const allowedMethods = response.headers?.get( 'allow' ) || '';
+	if ( ! allowedMethods ) {
+		return permissions;
+	}
 
 	const methods = {
 		create: 'POST',

--- a/phpunit/class-gutenberg-rest-server-test.php
+++ b/phpunit/class-gutenberg-rest-server-test.php
@@ -25,7 +25,7 @@ class Gutenberg_REST_Server_Test extends WP_Test_REST_TestCase {
 		$response = rest_do_request( '/wp/v2/posts' );
 		$post     = $response->get_data()[0];
 
-		$link = $post['_links'][0]['self'];
+		$link = $post['_links']['self'][0];
 		$this->assertArrayHasKey( 'targetHints', $link );
 		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
 		$this->assertSame( array( 'GET', 'PUT', 'DELETE' ), $link['targetHints']['allow'] );
@@ -35,7 +35,7 @@ class Gutenberg_REST_Server_Test extends WP_Test_REST_TestCase {
 		$response = rest_do_request( '/wp/v2/posts' );
 		$post     = $response->get_data()[0];
 
-		$link = $post['_links'][0]['self'];
+		$link = $post['_links']['self'][0];
 		$this->assertArrayHasKey( 'targetHints', $link );
 		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
 		$this->assertSame( array( 'GET' ), $link['targetHints']['allow'] );

--- a/phpunit/class-gutenberg-rest-server-test.php
+++ b/phpunit/class-gutenberg-rest-server-test.php
@@ -1,6 +1,6 @@
 <?php
 
-class Gutenberg_REST_Server_Test extends WP_Test_REST_Controller_Testcase {
+class Gutenberg_REST_Server_Test extends WP_Test_REST_TestCase {
 
 	protected static $admin_id;
 	protected static $post_id;

--- a/phpunit/class-gutenberg-rest-server-test.php
+++ b/phpunit/class-gutenberg-rest-server-test.php
@@ -20,6 +20,16 @@ class Gutenberg_REST_Server_Test extends WP_Test_REST_TestCase {
 		wp_delete_post( self::$post_id );
 	}
 
+	public function set_up() {
+		parent::set_up();
+		add_filter(
+			'wp_rest_server_class',
+			function () {
+				return 'Gutenberg_REST_Server';
+			}
+		);
+	}
+
 	public function test_populates_target_hints_for_administrator() {
 		wp_set_current_user( self::$admin_id );
 		$response = rest_do_request( '/wp/v2/posts' );
@@ -28,7 +38,7 @@ class Gutenberg_REST_Server_Test extends WP_Test_REST_TestCase {
 		$link = $post['_links']['self'][0];
 		$this->assertArrayHasKey( 'targetHints', $link );
 		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
-		$this->assertSame( array( 'GET', 'PUT', 'DELETE' ), $link['targetHints']['allow'] );
+		$this->assertSame( array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ), $link['targetHints']['allow'] );
 	}
 
 	public function test_populates_target_hints_for_logged_out_user() {

--- a/phpunit/class-gutenberg-rest-server-test.php
+++ b/phpunit/class-gutenberg-rest-server-test.php
@@ -1,0 +1,78 @@
+<?php
+
+class Gutenberg_REST_Server_Test extends WP_Test_REST_Controller_Testcase {
+
+	protected static $admin_id;
+	protected static $post_id;
+
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		self::$post_id = $factory->post->create();
+	}
+
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		wp_delete_post( self::$post_id );
+	}
+
+	public function test_populates_target_hints_for_administrator() {
+		wp_set_current_user( self::$admin_id );
+		$response = rest_do_request( '/wp/v2/posts' );
+		$post     = $response->get_data()[0];
+
+		$link = $post['_links'][0]['self'];
+		$this->assertArrayHasKey( 'targetHints', $link );
+		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
+		$this->assertSame( array( 'GET', 'PUT', 'DELETE' ), $link['targetHints']['allow'] );
+	}
+
+	public function test_populates_target_hints_for_logged_out_user() {
+		$response = rest_do_request( '/wp/v2/posts' );
+		$post     = $response->get_data()[0];
+
+		$link = $post['_links'][0]['self'];
+		$this->assertArrayHasKey( 'targetHints', $link );
+		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
+		$this->assertSame( array( 'GET' ), $link['targetHints']['allow'] );
+	}
+
+	public function test_does_not_error_on_invalid_urls() {
+		$response = new WP_REST_Response();
+		$response->add_link( 'self', 'this is not a real URL' );
+
+		$links = rest_get_server()::get_response_links( $response );
+		$this->assertArrayNotHasKey( 'targetHints', $links['self'][0] );
+	}
+
+	public function test_does_not_error_on_bad_rest_api_routes() {
+		$response = new WP_REST_Response();
+		$response->add_link( 'self', rest_url( '/this/is/not/a/real/route' ) );
+
+		$links = rest_get_server()::get_response_links( $response );
+		$this->assertArrayNotHasKey( 'targetHints', $links['self'][0] );
+	}
+
+	public function test_prefers_developer_defined_target_hints() {
+		$response = new WP_REST_Response();
+		$response->add_link(
+			'self',
+			'/wp/v2/posts/' . self::$post_id,
+			array(
+				'targetHints' => array(
+					'allow' => array( 'GET', 'PUT' ),
+				),
+			)
+		);
+
+		$links = rest_get_server()::get_response_links( $response );
+		$link  = $links['self'][0];
+		$this->assertArrayHasKey( 'targetHints', $link );
+		$this->assertArrayHasKey( 'allow', $link['targetHints'] );
+		$this->assertSame( array( 'GET', 'PUT' ), $link['targetHints']['allow'] );
+	}
+}


### PR DESCRIPTION
## What?
Track: https://core.trac.wordpress.org/ticket/61739
Based on: https://github.com/WordPress/wordpress-develop/pull/7139

PR updates `WP_REST_Sever` to add the `targetHints` property to the link description object as part of the self-link. The `targetHints` provides info about actions the user is able to perform for each item.

It also updates the `getEntityRecords` resolver to bulk update user permissions for fetched collection items. 

## Why?
Consumers who render a list of posts and CRUD actions related to each item must make a separate OPTIONS request to check if the user has permission to perform these actions.

The N+1 requests affect the performance on the client and the server.

## Testing Instructions
1. Navigate to `wp-admin/site-editor.php?postType=page&layout=table`.
2. Check the HTTP request in the Network tab.
3. Confirm that each page has no separate `OPTIONS` requests.
4. Confirm that page-related actions work as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

### Data Views > Pages

**Before**
![CleanShot 2024-08-15 at 09 11 46](https://github.com/user-attachments/assets/64e991da-dd02-4def-adf1-cf1d1e8b8086)

**After**
![CleanShot 2024-08-15 at 09 12 09](https://github.com/user-attachments/assets/5ad29912-82ac-4977-87cb-201c2fd1c905)

### Data Views > Templates

**Before**
![CleanShot 2024-08-15 at 09 17 41](https://github.com/user-attachments/assets/d863337f-4ece-4dfc-b441-d9f6224620cb)

**After**
![CleanShot 2024-08-15 at 09 18 44](https://github.com/user-attachments/assets/47522503-2ee2-42a1-886a-a8219b0df17e)
