### PR TITLE
Fix: Store post meta changes are overridden when custom fields meta box is enabled

### DIFF
--- a/docs/reference-guides/data/data-core-edit-post.md
+++ b/docs/reference-guides/data/data-core-edit-post.md
@@ -438,6 +438,10 @@ _Returns_
 
 Update a metabox.
 
+_Parameters_
+
+-   _originalPost_ `Object[]`: Values of the original post without modifications.
+
 ### setAvailableMetaBoxesPerLocation
 
 Stores info about which Meta boxes are available in which location.

--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -312,6 +312,7 @@ export const requestMetaBoxUpdates =
 			post.ping_status ? [ 'ping_status', post.ping_status ] : false,
 			post.sticky ? [ 'sticky', post.sticky ] : false,
 			post.author ? [ 'post_author', post.author ] : false,
+			post.meta ? [ 'meta', post.meta ] : false,
 		].filter( Boolean );
 
 		// We gather all the metaboxes locations.


### PR DESCRIPTION
## What?
Fix https://github.com/WordPress/gutenberg/issues/64217 and https://github.com/WordPress/gutenberg/issues/23078

Right now, any changes to post meta made in the store are overridden when the custom fields meta box is enabled.

In this pull request, I'm exploring how to solve that.

## Why?
It doesn't save changes that user expect to be saved.

## How?
I must say that it is not clear to me how this can be solved. So far, it seems including `post.meta` changes in the additional params of the meta box requests solves the issue. But I am not sure about the implications.

With the initial code, the following works:
* Updating custom fields through the store and clicking save.
* Updating custom fields through the meta box and clicking update.

Here you have some demo showing that:

**Before**

https://github.com/user-attachments/assets/9d49e353-ca53-4952-8c12-ca246c0777fe


**After**

https://github.com/user-attachments/assets/69dd89e8-075e-46b5-8eb9-10e6237fc89b


**Meta box update**

https://github.com/user-attachments/assets/1c62c706-f462-48df-b532-d062b8395e0f


## Testing Instructions
Follow step-by-step reproduction instructions of the mentioned issues and check that the issues are solved.
