### PR TITLE
Fix: Changing sorting direction on patterns does nothing.

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -140,7 +140,7 @@ function SortFieldControl() {
 }
 
 function SortDirectionControl() {
-	const { view, onChangeView } = useContext( DataViewsContext );
+	const { view, fields, onChangeView } = useContext( DataViewsContext );
 	return (
 		<ToggleGroupControl
 			className="dataviews-view-config__sort-direction"
@@ -149,17 +149,19 @@ function SortDirectionControl() {
 			isBlock
 			label={ __( 'Order' ) }
 			value={ view.sort?.direction || 'desc' }
-			disabled={ ! view?.sort?.field }
 			onChange={ ( newDirection ) => {
-				if ( ! view?.sort?.field ) {
-					return;
-				}
 				if ( newDirection === 'asc' || newDirection === 'desc' ) {
 					onChangeView( {
 						...view,
 						sort: {
 							direction: newDirection,
-							field: view.sort.field,
+							field:
+								view.sort?.field ||
+								// If there is no field assigned as the sorting field assign the first sortable field.
+								fields.find(
+									( field ) => field.enableSorting !== false
+								)?.id ||
+								'',
 						},
 					} );
 					return;


### PR DESCRIPTION


The sorting direction controls are not working for patterns, that happens because we don't include a default sorting field when changing the direction, this PR fixes the issue.

Now when changing the sorting direction, if no sorting field is set changing the sorting direction assigns the first sortable field as the sort-by field.

This bug was reported at https://github.com/WordPress/gutenberg/pull/64380#pullrequestreview-2238248868 by @t-hamano.


## Testing Instructions
Go to the patterns sections, open the view configuration UI and verify the sort controls work as expected.
