### PR TITLE
File: Add border block support

### DIFF
--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -74,6 +74,18 @@
 				"link": true
 			}
 		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
+		},
 		"interactivity": true
 	},
 	"editorStyle": "wp-block-file-editor",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `File` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`File` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that `File` block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add `File`  block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend

Watch attached video for more information.

## Screenshots or screencast <!-- if applicable -->
 
 
[file-block-border-support.webm](https://github.com/user-attachments/assets/3778285d-325d-4d27-90d7-8f7409a7997a)

 