### PR TITLE
Block Styles: Ensure unique classname generation for variations

### DIFF
--- a/backport-changelog/6.7/7200.md
+++ b/backport-changelog/6.7/7200.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7200
+
+* https://github.com/WordPress/gutenberg/pull/64511

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -11,12 +11,15 @@
  *
  * @since 6.6.0
  *
+ * @deprecated 6.7.0
+ *
  * @param array  $block     Block object.
  * @param string $variation Slug for the block style variation.
  *
  * @return string The unique variation name.
  */
 function gutenberg_create_block_style_variation_instance_name( $block, $variation ) {
+	_deprecated_function( __FUNCTION__, '6.7.0' );
 	return $variation . '--' . md5( serialize( $block ) );
 }
 
@@ -119,7 +122,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	// theme_json data.
 	gutenberg_resolve_block_style_variation_ref_values( $variation_data, $theme_json );
 
-	$variation_instance = gutenberg_create_block_style_variation_instance_name( $parsed_block, $variation );
+	$variation_instance = wp_unique_id( $variation . '--' );
 	$class_name         = "is-style-$variation_instance";
 	$updated_class_name = $parsed_block['attrs']['className'] . " $class_name";
 
@@ -224,11 +227,9 @@ function gutenberg_render_block_style_variation_class_name( $block_content, $blo
 
 	/*
 	 * Matches a class prefixed by `is-style`, followed by the
-	 * variation slug, then `--`, and finally a hash.
-	 *
-	 * See `gutenberg_create_block_style_variation_instance_name` for class generation.
+	 * variation slug, then `--`, and finally an instance number.
 	 */
-	preg_match( '/\bis-style-(\S+?--\w+)\b/', $block['attrs']['className'], $matches );
+	preg_match( '/\bis-style-(\S+?--\d+)\b/', $block['attrs']['className'], $matches );
 
 	if ( empty( $matches ) ) {
 		return $block_content;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/64422

## What?

Simplifies block style variation class name generation to ensure unique class.

## Why?

Avoids potential for non-unique class names and conflicting styles when exact copies of a block are inserted via a repeated pattern.

### Background

Originally the block style variation block support followed the same approach as styles generated by the elements block support.  This entailed needing to generate a predictable classname in two separate filters ruling out the prior use of `wp_unique_id`.

The recent changes to these supports, such that their styles and class are generated in a single filter, mean the generated classname no longer needs to be a hash based off the block's attributes. Not only does this make the classname simpler and shorter but it also avoids the issue flagged in #64422 where exact copies of a block inserted via patterns result in the same ID and potentially conflicting styles.


## How?

Replace the hashing of block attributes in the block style variation classnames with a call to `wp_unique_id`.

## Testing Instructions

### Confirm unique classnames on frontend

1. Create a pattern
2. Add a button with the Outline block styles to the pattern
3. Save the pattern and edit a post
4. Insert the above pattern 3 times in the post
5. Save and view the post on the frontend
6. Inspect a button and search the markup for `is-style-outline-`. You should find CSS with three styles matching that pattern however they should now all be unique.

### Ensure no regressions for block style variations on the frontend

1. Add some custom block style variations to your theme. See [#57908](https://github.com/WordPress/gutenberg/pull/57908) for detailed examples or the snippet below for a quick option.
7. Add suitable content to a page, making sure there is enough that nested applications of block style variations can occur
8. In the site editor, apply the custom block style variations to various content, including in a nested fashion
9. Save and confirm the correct styling on the frontend

<details>
<summary>Example block style variation theme.json partial (place under `/styles`)</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"title": "Section A",
	"slug": "section-a",
	"blockTypes": [ "core/group" ],
	"styles": {
		"color": {
			"background": "slategrey",
			"text": "snow"
		},
		"blocks": {
			"core/group": {
				"color": {
					"background": "darkslategrey",
					"text": "whitesmoke"
				}
			}
		}
	}
}
```
</details>

## Screenshots or screencast <!-- if applicable -->

### Simple unique classnames for exact copies of blocks

<img width="532" alt="Screenshot 2024-08-14 at 9 27 11 PM" src="https://github.com/user-attachments/assets/9c0116c7-36be-4a79-b343-002bdbfc9dcc">

### Block Style Variations still working

https://github.com/user-attachments/assets/42998ead-0b03-48ab-8968-f4b0688fb661

