### PR TITLE
Hide typeset button when there are no typesets available

### DIFF
--- a/packages/edit-site/src/components/global-styles/typeset-button.js
+++ b/packages/edit-site/src/components/global-styles/typeset-button.js
@@ -23,14 +23,20 @@ import { getFontFamilies } from './utils';
 import { NavigationButtonAsItem } from './navigation-button';
 import Subtitle from './subtitle';
 import { unlock } from '../../lock-unlock';
-import { filterObjectByProperties } from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
+import {
+	filterObjectByProperties,
+	useCurrentMergeThemeStyleVariationsWithUserConfig,
+} from '../../hooks/use-theme-style-variations/use-theme-style-variations-by-property';
 
 const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 
 function TypesetButton() {
-	const { base } = useContext( GlobalStylesContext );
-	const { user: userConfig } = useContext( GlobalStylesContext );
+	const propertiesToFilter = [ 'typography' ];
+	const typographyVariations =
+		useCurrentMergeThemeStyleVariationsWithUserConfig( propertiesToFilter );
+	const hasTypographyVariations = typographyVariations?.length > 1;
+	const { base, user: userConfig } = useContext( GlobalStylesContext );
 	const config = mergeBaseAndUserConfigs( base, userConfig );
 	const allFontFamilies = getFontFamilies( config );
 	const hasFonts =
@@ -63,6 +69,7 @@ function TypesetButton() {
 	}, [ allFontFamilies, userTypographyConfig, variations ] );
 
 	return (
+		hasTypographyVariations &&
 		hasFonts && (
 			<VStack spacing={ 2 }>
 				<HStack justify="space-between">


### PR DESCRIPTION
## What?
Hide the typesets button when there are no typesets available

## Why?
The button isn't useful, and it seems confusing when there are no typesets available in a theme.
Fixes: https://github.com/WordPress/gutenberg/issues/63940

## How?
Check if the theme has typesets available (style variations consisting only of font family presets).

## Testing Instructions
- Compare the typography panel of a theme with and without typesets available.



## Screenshots or screencast <!-- if applicable -->

| With typesets | Wtithout typesets |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/7a57bc2c-0f94-4774-ba28-955a520f1fcd) | ![Screenshot from 2024-08-14 12-10-49](https://github.com/user-attachments/assets/b57b4425-c9f1-451c-bc44-1f17dafa11ed) |


