### PR TITLE
feat: Experimental editor assets REST API endpoint

### DIFF
--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -164,5 +164,34 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 				array( 'status' => rest_authorization_required_code() )
 			);
 		}
+
+		/**
+		 * Retrieves the block editor assets schema, conforming to JSON Schema.
+		 *
+		 * @return array Item schema data.
+		 */
+		public function get_item_schema() {
+			if ( $this->schema ) {
+				return $this->add_additional_fields_schema( $this->schema );
+			}
+
+			$schema = array(
+				'type'       => 'object',
+				'properties' => array(
+					'styles'  => array(
+						'description' => esc_html__( 'Style link tags for the block editor.', 'gutenberg' ),
+						'type' => 'string',
+					),
+					'scripts' => array(
+						'description' => esc_html__( 'Script tags for the block editor.', 'gutenberg' ),
+						'type' => 'string',
+					),
+				),
+			);
+
+			$this->schema = $schema;
+
+			return $this->add_additional_fields_schema( $this->schema );
+		}
 	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -44,8 +44,29 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			return array();
 		}
 
+		/**
+		 * Checks the permissions for retrieving items.
+		 *
+		 * @param WP_REST_Request $request The REST request object.
+		 *
+		 * @return bool|WP_Error True if the request has permission, WP_Error object otherwise.
+		 */
 		public function get_items_permissions_check($request) {
-			return true;
+			if ( current_user_can( 'edit_posts' ) ) {
+				return true;
+			}
+
+			foreach ( get_post_types( array( 'show_in_rest' => true ), 'objects' ) as $post_type ) {
+				if ( current_user_can( $post_type->cap->edit_posts ) ) {
+					return true;
+				}
+			}
+
+			return new WP_Error(
+				'rest_cannot_read_block_editor_assets',
+				__( 'Sorry, you are not allowed to read the block editor assets.', 'gutenberg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
 		}
 	}
 }

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 *
 		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 		 */
-		public function get_items($request) {
+		public function get_items( $request ) {
 			global $wp_styles, $wp_scripts;
 
 			$current_wp_styles  = $wp_styles;
@@ -58,8 +58,8 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 
 			// Register all currently registered styles and scripts. The actions that
 			// follow enqueue assets, but don't necessarily register them.
-			$wp_styles->registered  = isset($current_wp_styles->registered) ? $current_wp_styles->registered : array();
-			$wp_scripts->registered = isset($current_wp_scripts->registered) ? $current_wp_scripts->registered : array();
+			$wp_styles->registered  = isset( $current_wp_styles->registered ) ? $current_wp_styles->registered : array();
+			$wp_scripts->registered = isset( $current_wp_scripts->registered ) ? $current_wp_scripts->registered : array();
 
 			// We generally do not need reset styles for the block editor. However, if
 			// it's a classic theme, margins will be added to every block, which is
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 *
 		 * @return bool|WP_Error True if the request has permission, WP_Error object otherwise.
 		 */
-		public function get_items_permissions_check($request) {
+		public function get_items_permissions_check( $request ) {
 			if ( current_user_can( 'edit_posts' ) ) {
 				return true;
 			}
@@ -174,11 +174,11 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 				'properties' => array(
 					'styles'  => array(
 						'description' => esc_html__( 'Style link tags for the block editor.', 'gutenberg' ),
-						'type' => 'string',
+						'type'        => 'string',
 					),
 					'scripts' => array(
 						'description' => esc_html__( 'Script tags for the block editor.', 'gutenberg' ),
-						'type' => 'string',
+						'type'        => 'string',
 					),
 				),
 			);

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 * Constructor.
 		 */
 		public function __construct() {
-			$this->namespace = 'wp-block-editor/v1';
+			$this->namespace = '__experimental/wp-block-editor/v1';
 			$this->rest_base = 'editor-assets';
 		}
 

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -50,11 +50,9 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		public function get_items($request) {
 			global $wp_styles, $wp_scripts;
 
-			// Keep track of the styles and scripts instance to restore later.
 			$current_wp_styles  = $wp_styles;
 			$current_wp_scripts = $wp_scripts;
 
-			// Create new instances to collect the assets.
 			$wp_styles  = new WP_Styles();
 			$wp_scripts = new WP_Scripts();
 
@@ -63,10 +61,10 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			$wp_styles->registered  = isset($current_wp_styles->registered) ? $current_wp_styles->registered : array();
 			$wp_scripts->registered = isset($current_wp_scripts->registered) ? $current_wp_scripts->registered : array();
 
-			// We generally do not need reset styles for the iframed editor.
-			// However, if it's a classic theme, margins will be added to every block,
-			// which is reset specifically for list items, so classic themes rely on
-			// these reset styles.
+			// We generally do not need reset styles for the block editor. However, if
+			// it's a classic theme, margins will be added to every block, which is
+			// reset specifically for list items, so classic themes rely on these
+			// reset styles.
 			$wp_styles->done =
 				wp_theme_has_theme_json() ? array( 'wp-reset-editor-styles' ) : array();
 
@@ -78,14 +76,13 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 				wp_enqueue_style( 'wp-block-library-theme' );
 			}
 
-			// Enqueue frequent dependent, admin-only `dashicon` asset
+			// Enqueue frequent dependent, admin-only `dashicon` asset.
 			wp_enqueue_style( 'dashicons' );
 
-			// Enqueue frequent dependent, admin-only `postbox` asset
+			// Enqueue frequent dependent, admin-only `postbox` asset.
 			$suffix = wp_scripts_get_suffix();
 			wp_enqueue_script( 'postbox', "/wp-admin/js/postbox$suffix.js", array( 'jquery-ui-sortable', 'wp-a11y' ), false, 1 );
 
-			// Enqueue both block and block editor assets.
 			add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
 			do_action( 'enqueue_block_assets' );
 			do_action( 'enqueue_block_editor_assets' );
@@ -108,10 +105,8 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 				}
 			}
 
-			/**
-			 * Remove the deprecated `print_emoji_styles` handler.
-			 * It avoids breaking style generation with a deprecation message.
-			 */
+			// Remove the deprecated `print_emoji_styles` handler. It avoids breaking
+			// style generation with a deprecation message.
 			$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
 			if ( $has_emoji_styles ) {
 				remove_action( 'wp_print_styles', 'print_emoji_styles' );
@@ -130,7 +125,6 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			wp_print_footer_scripts();
 			$scripts = ob_get_clean();
 
-			// Restore the original instances.
 			$wp_styles  = $current_wp_styles;
 			$wp_scripts = $current_wp_scripts;
 

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 *
 		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 		 */
-		public function get_items( $request ) {
+		public function get_items() {
 			global $wp_styles, $wp_scripts;
 
 			$current_wp_styles  = $wp_styles;
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 *
 		 * @return bool|WP_Error True if the request has permission, WP_Error object otherwise.
 		 */
-		public function get_items_permissions_check( $request ) {
+		public function get_items_permissions_check() {
 			if ( current_user_can( 'edit_posts' ) ) {
 				return true;
 			}

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * REST API: WP_REST_Block_Editor_Assets_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ */
+
+if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
+
+	/**
+	 * Core class used to retrieve the block editor assets via the REST API.
+	 *
+	 * @see WP_REST_Controller
+	 */
+	class WP_REST_Block_Editor_Assets_Controller extends WP_REST_Controller {
+		/**
+		 * Constructor.
+		 */
+		public function __construct() {
+			$this->namespace = 'wp-block-editor/v1';
+			$this->rest_base = 'editor-assets';
+		}
+
+		/**
+		 * Registers the controller routes.
+		 */
+		public function register_routes() {
+			register_rest_route(
+				$this->namespace,
+				'/' . $this->rest_base,
+				array(
+					array(
+						'methods'             => WP_REST_Server::READABLE,
+						'callback'            => array( $this, 'get_items' ),
+						'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					),
+					'schema' => array( $this, 'get_public_item_schema' ),
+				)
+			);
+		}
+
+		public function get_items($request) {
+			return array();
+		}
+
+		public function get_items_permissions_check($request) {
+			return true;
+		}
+	}
+}

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 *
 		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
 		 */
-		public function get_items() {
+		public function get_items( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			global $wp_styles, $wp_scripts;
 
 			$current_wp_styles  = $wp_styles;
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 		 *
 		 * @return bool|WP_Error True if the request has permission, WP_Error object otherwise.
 		 */
-		public function get_items_permissions_check() {
+		public function get_items_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 			if ( current_user_can( 'edit_posts' ) ) {
 				return true;
 			}

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -40,8 +40,104 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			);
 		}
 
+		/**
+		 * Retrieves a collection of items.
+		 *
+		 * @param WP_REST_Request $request The request object.
+		 *
+		 * @return WP_REST_Response|WP_Error Response object on success, or WP_Error object on failure.
+		 */
 		public function get_items($request) {
-			return array();
+			global $wp_styles, $wp_scripts;
+
+			// Keep track of the styles and scripts instance to restore later.
+			$current_wp_styles  = $wp_styles;
+			$current_wp_scripts = $wp_scripts;
+
+			// Create new instances to collect the assets.
+			$wp_styles  = new WP_Styles();
+			$wp_scripts = new WP_Scripts();
+
+			// Register all currently registered styles and scripts. The actions that
+			// follow enqueue assets, but don't necessarily register them.
+			$wp_styles->registered  = isset($current_wp_styles->registered) ? $current_wp_styles->registered : array();
+			$wp_scripts->registered = isset($current_wp_scripts->registered) ? $current_wp_scripts->registered : array();
+
+			// We generally do not need reset styles for the iframed editor.
+			// However, if it's a classic theme, margins will be added to every block,
+			// which is reset specifically for list items, so classic themes rely on
+			// these reset styles.
+			$wp_styles->done =
+				wp_theme_has_theme_json() ? array( 'wp-reset-editor-styles' ) : array();
+
+			wp_enqueue_script( 'wp-polyfill' );
+			// Enqueue the `editorStyle` handles for all core block, and dependencies.
+			wp_enqueue_style( 'wp-edit-blocks' );
+
+			if ( current_theme_supports( 'wp-block-styles' ) ) {
+				wp_enqueue_style( 'wp-block-library-theme' );
+			}
+
+			// Enqueue frequent dependent, admin-only `dashicon` asset
+			wp_enqueue_style( 'dashicons' );
+
+			// Enqueue frequent dependent, admin-only `postbox` asset
+			$suffix = wp_scripts_get_suffix();
+			wp_enqueue_script( 'postbox', "/wp-admin/js/postbox$suffix.js", array( 'jquery-ui-sortable', 'wp-a11y' ), false, 1 );
+
+			// Enqueue both block and block editor assets.
+			add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
+			do_action( 'enqueue_block_assets' );
+			do_action( 'enqueue_block_editor_assets' );
+			remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
+
+			$block_registry = WP_Block_Type_Registry::get_instance();
+
+			// Additionally, do enqueue `editorStyle` and `editorScript` assets for all
+			// blocks, which contains editor-only styling for blocks (editor content).
+			foreach ( $block_registry->get_all_registered() as $block_type ) {
+				if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
+					foreach ( $block_type->editor_style_handles as $style_handle ) {
+						wp_enqueue_style( $style_handle );
+					}
+				}
+				if ( isset( $block_type->editor_script_handles ) && is_array( $block_type->editor_script_handles ) ) {
+					foreach ( $block_type->editor_script_handles as $script_handle ) {
+						wp_enqueue_script( $script_handle );
+					}
+				}
+			}
+
+			/**
+			 * Remove the deprecated `print_emoji_styles` handler.
+			 * It avoids breaking style generation with a deprecation message.
+			 */
+			$has_emoji_styles = has_action( 'wp_print_styles', 'print_emoji_styles' );
+			if ( $has_emoji_styles ) {
+				remove_action( 'wp_print_styles', 'print_emoji_styles' );
+			}
+
+			ob_start();
+			wp_print_styles();
+			$styles = ob_get_clean();
+
+			if ( $has_emoji_styles ) {
+				add_action( 'wp_print_styles', 'print_emoji_styles' );
+			}
+
+			ob_start();
+			wp_print_head_scripts();
+			wp_print_footer_scripts();
+			$scripts = ob_get_clean();
+
+			// Restore the original instances.
+			$wp_styles  = $current_wp_styles;
+			$wp_scripts = $current_wp_scripts;
+
+			return array(
+				'styles'  => $styles,
+				'scripts' => $scripts,
+			);
 		}
 
 		/**

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -56,11 +56,6 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			$wp_styles  = new WP_Styles();
 			$wp_scripts = new WP_Scripts();
 
-			// Register all currently registered styles and scripts. The actions that
-			// follow enqueue assets, but don't necessarily register them.
-			$wp_styles->registered  = isset( $current_wp_styles->registered ) ? $current_wp_styles->registered : array();
-			$wp_scripts->registered = isset( $current_wp_scripts->registered ) ? $current_wp_scripts->registered : array();
-
 			// We generally do not need reset styles for the block editor. However, if
 			// it's a classic theme, margins will be added to every block, which is
 			// reset specifically for list items, so classic themes rely on these

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -77,7 +77,7 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			// Enqueue frequent dependent, admin-only `dashicon` asset.
 			wp_enqueue_style( 'dashicons' );
 
-			// Enqueue frequent dependent, admin-only `postbox` asset.
+			// Enqueue the admin-only `postbox` asset required for the block editor.
 			$suffix = wp_scripts_get_suffix();
 			wp_enqueue_script( 'postbox', "/wp-admin/js/postbox$suffix.js", array( 'jquery-ui-sortable', 'wp-a11y' ), false, 1 );
 
@@ -85,15 +85,15 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			wp_enqueue_script( 'wp-edit-post' );
 			wp_enqueue_style( 'wp-edit-post' );
 
+			// Ensure the block editor scripts and styles are enqueued.
 			add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
 			do_action( 'enqueue_block_assets' );
 			do_action( 'enqueue_block_editor_assets' );
 			remove_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
 
-			$block_registry = WP_Block_Type_Registry::get_instance();
-
-			// Additionally, do enqueue `editorStyle` and `editorScript` assets for all
+			// Additionally, enqueue `editorStyle` and `editorScript` assets for all
 			// blocks, which contains editor-only styling for blocks (editor content).
+			$block_registry = WP_Block_Type_Registry::get_instance();
 			foreach ( $block_registry->get_all_registered() as $block_type ) {
 				if ( isset( $block_type->editor_style_handles ) && is_array( $block_type->editor_style_handles ) ) {
 					foreach ( $block_type->editor_style_handles as $style_handle ) {

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -56,6 +56,9 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			$wp_styles  = new WP_Styles();
 			$wp_scripts = new WP_Scripts();
 
+			// Trigger an action frequently used by plugins to enqueue assets.
+			do_action( 'wp_loaded' );
+
 			// We generally do not need reset styles for the block editor. However, if
 			// it's a classic theme, margins will be added to every block, which is
 			// reset specifically for list items, so classic themes rely on these

--- a/lib/experimental/class-wp-rest-block-editor-assets-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-assets-controller.php
@@ -81,6 +81,10 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Assets_Controller' ) ) {
 			$suffix = wp_scripts_get_suffix();
 			wp_enqueue_script( 'postbox', "/wp-admin/js/postbox$suffix.js", array( 'jquery-ui-sortable', 'wp-a11y' ), false, 1 );
 
+			// Enqueue foundational post editor assets.
+			wp_enqueue_script( 'wp-edit-post' );
+			wp_enqueue_style( 'wp-edit-post' );
+
 			add_filter( 'should_load_block_editor_scripts_and_styles', '__return_true' );
 			do_action( 'enqueue_block_assets' );
 			do_action( 'enqueue_block_editor_assets' );

--- a/lib/experimental/rest-api.php
+++ b/lib/experimental/rest-api.php
@@ -19,6 +19,15 @@ function gutenberg_register_block_editor_settings() {
 }
 add_action( 'rest_api_init', 'gutenberg_register_block_editor_settings' );
 
+/**
+ * Registers the block editor assets REST API route.
+ */
+function gutenberg_register_block_editor_assets() {
+	$editor_assets = new WP_REST_Block_Editor_Assets_Controller();
+	$editor_assets->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_block_editor_assets' );
+
 
 /**
  * Shim for get_sample_permalink() to add support for auto-draft status.

--- a/lib/load.php
+++ b/lib/load.php
@@ -34,6 +34,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 		require_once __DIR__ . '/experimental/class-wp-rest-block-editor-settings-controller.php';
 	}
+	require_once __DIR__ . '/experimental/class-wp-rest-block-editor-assets-controller.php';
 
 	// WordPress 6.6 compat.
 	require __DIR__ . '/compat/wordpress-6.6/class-gutenberg-rest-global-styles-revisions-controller-6-6.php';

--- a/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
@@ -89,8 +89,8 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertArrayHasKey('styles', $data, 'Editor assets should include styles.');
-		$this->assertArrayHasKey('scripts', $data, 'Editor assets should include scripts.');
+		$this->assertArrayHasKey( 'styles', $data, 'Editor assets should include styles.' );
+		$this->assertArrayHasKey( 'scripts', $data, 'Editor assets should include scripts.' );
 	}
 
 	public function test_get_item_schema() {

--- a/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
@@ -93,6 +93,17 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 		$this->assertArrayHasKey('scripts', $data, 'Editor assets should include scripts.');
 	}
 
+	public function test_get_item_schema() {
+		$request    = new WP_REST_Request( 'OPTIONS', '/wp-block-editor/v1/editor-assets' );
+		$response   = rest_get_server()->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertCount( 2, $properties, 'Schema properties array does not have exactly 2 elements' );
+		$this->assertArrayHasKey( 'styles', $properties, 'Schema properties array does not have "id" key' );
+		$this->assertArrayHasKey( 'scripts', $properties, 'Schema properties array does not have "styles" key' );
+	}
+
 	/**
 	 * @doesNotPerformAssertions
 	 */
@@ -107,11 +118,6 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 	 * @doesNotPerformAssertions
 	 */
 	public function test_get_item() {}
-
-	/**
-	 * @doesNotPerformAssertions
-	 */
-	public function test_get_item_schema() {}
 
 	/**
 	 * @doesNotPerformAssertions

--- a/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
@@ -10,8 +10,45 @@ if ( ! defined( 'REST_REQUEST' ) ) {
 }
 
 class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controller_Testcase {
+	/**
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	/**
+	 * @var int
+	 */
+	protected static $subscriber_id;
+
 	public function set_up() {
 		parent::set_up();
+	}
+
+	/**
+	 * Create fake data before test runs.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetupBeforeClass( $factory ) {
+		self::$admin_id = $factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		self::$subscriber_id = $factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Clean up fake data.
+	 */
+	public static function wpTearDownAfterClass() {
+		self::delete_user( self::$admin_id );
+		self::delete_user( self::$subscriber_id );
 	}
 
 	public function tear_down() {
@@ -27,6 +64,23 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 		);
 	}
 
+	public function test_get_items_without_user() {
+		wp_set_current_user( 0 );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/editor-assets' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_read_block_editor_assets', $response, 401 );
+	}
+
+	public function test_get_items_without_permissions() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/editor-assets' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertErrorResponse( 'rest_cannot_read_block_editor_assets', $response, 403 );
+	}
 
 	/**
 	 * @doesNotPerformAssertions

--- a/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
@@ -59,7 +59,7 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 		$routes = rest_get_server()->get_routes();
 
 		$this->assertArrayHasKey(
-			'/wp-block-editor/v1/editor-assets',
+			'/__experimental/wp-block-editor/v1/editor-assets',
 			$routes
 		);
 	}
@@ -67,7 +67,7 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 	public function test_get_items_without_user() {
 		wp_set_current_user( 0 );
 
-		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/editor-assets' );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/wp-block-editor/v1/editor-assets' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_read_block_editor_assets', $response, 401 );
@@ -76,7 +76,7 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 	public function test_get_items_without_permissions() {
 		wp_set_current_user( self::$subscriber_id );
 
-		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/editor-assets' );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/wp-block-editor/v1/editor-assets' );
 		$response = rest_get_server()->dispatch( $request );
 
 		$this->assertErrorResponse( 'rest_cannot_read_block_editor_assets', $response, 403 );
@@ -85,7 +85,7 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
 
-		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/editor-assets' );
+		$request  = new WP_REST_Request( 'GET', '/__experimental/wp-block-editor/v1/editor-assets' );
 		$response = rest_get_server()->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -94,7 +94,7 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 	}
 
 	public function test_get_item_schema() {
-		$request    = new WP_REST_Request( 'OPTIONS', '/wp-block-editor/v1/editor-assets' );
+		$request    = new WP_REST_Request( 'OPTIONS', '/__experimental/wp-block-editor/v1/editor-assets' );
 		$response   = rest_get_server()->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];

--- a/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
@@ -82,6 +82,17 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 		$this->assertErrorResponse( 'rest_cannot_read_block_editor_assets', $response, 403 );
 	}
 
+	public function test_get_items() {
+		wp_set_current_user( self::$admin_id );
+
+		$request  = new WP_REST_Request( 'GET', '/wp-block-editor/v1/editor-assets' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey('styles', $data, 'Editor assets should include styles.');
+		$this->assertArrayHasKey('scripts', $data, 'Editor assets should include scripts.');
+	}
+
 	/**
 	 * @doesNotPerformAssertions
 	 */
@@ -96,11 +107,6 @@ class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controlle
 	 * @doesNotPerformAssertions
 	 */
 	public function test_get_item() {}
-
-	/**
-	 * @doesNotPerformAssertions
-	 */
-	public function test_get_items() {}
 
 	/**
 	 * @doesNotPerformAssertions

--- a/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
+++ b/phpunit/experimental/class-wp-rest-block-editor-assets-controller-test.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Unit tests covering WP_REST_Block_Editor_Assets_Controller functionality.
+ *
+ * @package gutenberg
+ */
+
+if ( ! defined( 'REST_REQUEST' ) ) {
+	define( 'REST_REQUEST', true );
+}
+
+class WP_REST_Block_Editor_Assets_Controller_Test extends WP_Test_REST_Controller_Testcase {
+	public function set_up() {
+		parent::set_up();
+	}
+
+	public function tear_down() {
+		parent::tear_down();
+	}
+
+	public function test_register_routes() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey(
+			'/wp-block-editor/v1/editor-assets',
+			$routes
+		);
+	}
+
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_create_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_update_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_items() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_get_item_schema() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_delete_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_prepare_item() {}
+
+	/**
+	 * @doesNotPerformAssertions
+	 */
+	public function test_context_param() {}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Enable requesting all assets — styles and scripts — loaded for the block editor via the REST API. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The [WordPress mobile](https://github.com/wordpress-mobile) team is exploring a WebView-based editor where a given site's editor assets power the editing experience. If deemed successful, the experimental approach might bring a few benefits to the iOS and Android mobile apps editing experience: 

* Expanded core block support. 
* Expanded third-party block support. 
* Improved offline editing support. 
* Closer overall alignment with the web editing experience. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add an experimental block editor assets REST API endpoint. The endpoint returns a collection of relevant assets utilizing an approach similar to WordPress core's [iframe editor assets utility](https://github.com/WordPress/wordpress-develop/blob/2061a52da3d9d6d3994b0a60b2df07037d95e3d8/src/wp-includes/block-editor.php#L284-L388). 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**Without Permission**
1. Make an unauthenticated request to the new endpoint: `curl -L <site_url>/?rest_route=/__experimental/wp-block-editor/v1/editor-assets`
2. Verify a 401 error response is returned. 

**With Permission**
1. Visit you site's WP Admin and navigate to **Users** → **Edit** (the `admin` user).
2. Create and copy an [application password](https://developer.wordpress.org/rest-api/using-the-rest-api/authentication/#basic-authentication-with-application-passwords).
3. Create and copy a Base64 version of the combined username and application password: `echo -n 'admin:<application_password>' | base64 | pbcopy`
4. Make an authenticated request to the new endpoint: `curl --header "Authorization: Basic <base64_string>" -L <site_url>/?rest_route=/__experimental/wp-block-editor/v1/editor-assets`
5. Verify the response includes the expected editor style and script tags. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 