### PR TITLE
Updated small typo in modularity.md

### DIFF
--- a/docs/explanations/architecture/modularity.md
+++ b/docs/explanations/architecture/modularity.md
@@ -42,7 +42,7 @@ function MyApp() {
 
 ```php
 // myplugin.php
-// Example of script registration dependending on the "components" and "element packages.
+// Example of script registration depending on the "components" and "element packages.
 wp_register_script( 'myscript', 'pathtomyscript.js', array ('wp-components', "react" ) );
 ```
 


### PR DESCRIPTION
Corrected small typo in docs/explanations/architecture/modularity.md Line no 45 `dependending` it should be `depending`

