### PR TITLE
Post Author Name: Add Border Support

### DIFF
--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -58,7 +58,13 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-post-author-name"

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -27,7 +27,11 @@
 		"html": false,
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
 		},
 		"color": {
 			"gradients": true,
@@ -53,6 +57,13 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
 		}
-	}
+	},
+	"style": "wp-block-post-author-name"
 }

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -27,11 +27,7 @@
 		"html": false,
 		"spacing": {
 			"margin": true,
-			"padding": true,
-			"__experimentalDefaultControls": {
-				"margin": false,
-				"padding": false
-			}
+			"padding": true
 		},
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/post-author-name/style.scss
+++ b/packages/block-library/src/post-author-name/style.scss
@@ -1,3 +1,4 @@
 .wp-block-post-author-name {
 	// This block has customizable padding, border-box makes that more predictable.
-	box-sizing: border-b
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/post-author-name/style.scss
+++ b/packages/block-library/src/post-author-name/style.scss
@@ -1,0 +1,3 @@
+.wp-block-post-author-name {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-b

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -40,6 +40,7 @@
 @import "./post-terms/style.scss";
 @import "./post-time-to-read/style.scss";
 @import "./post-title/style.scss";
+@import "./post-author-name/style.scss";
 @import "./preformatted/style.scss";
 @import "./pullquote/style.scss";
 @import "./post-template/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Post Author Name` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Author Name` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Post Author Name` block's border is Configurable via Global Styles.
- Edit template/page, Add  `Post Author Name` block and Apply the border Styles.
- Verify that `Post Author Name` block styles take precedence over global Styles.
- Verify that `Post Author Name` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->
 

https://github.com/user-attachments/assets/1bb2531c-4dd9-47e7-938d-45e177dbc10c


