### PR TITLE
Media & Text: fix content loss from transform + add text transform

### DIFF
--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -3,6 +3,25 @@
  */
 import { createBlock } from '@wordpress/blocks';
 
+function transform(
+	{ mediaType, mediaPosition, mediaAlt, mediaId, mediaUrl, anchor },
+	innerBlocks
+) {
+	const output = [ ...innerBlocks ];
+	if ( mediaType ) {
+		const action = mediaPosition === 'right' ? 'push' : 'unshift';
+		output[ action ](
+			createBlock( `core/${ mediaType }`, {
+				alt: mediaAlt,
+				id: mediaId,
+				url: mediaUrl,
+				anchor,
+			} )
+		);
+	}
+	return output;
+}
+
 const transforms = {
 	from: [
 		{
@@ -102,26 +121,19 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/image' ],
 			isMatch: ( { mediaType } ) => mediaType === 'image',
-			transform: ( { mediaAlt, mediaId, mediaUrl, anchor } ) => {
-				return createBlock( 'core/image', {
-					alt: mediaAlt,
-					id: mediaId,
-					url: mediaUrl,
-					anchor,
-				} );
-			},
+			transform,
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
 			isMatch: ( { mediaType } ) => mediaType === 'video',
-			transform: ( { mediaId, mediaUrl, anchor } ) => {
-				return createBlock( 'core/video', {
-					id: mediaId,
-					src: mediaUrl,
-					anchor,
-				} );
-			},
+			transform,
+		},
+		{
+			type: 'block',
+			// To do: ideally this should be '*', and quote should also use '*'.
+			blocks: [ 'core/paragraph' ],
+			transform,
 		},
 		{
 			type: 'block',

--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -101,9 +101,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/image' ],
-			isMatch: ( { mediaType, mediaUrl } ) => {
-				return ! mediaUrl || mediaType === 'image';
-			},
+			isMatch: ( { mediaType } ) => mediaType === 'image',
 			transform: ( { mediaAlt, mediaId, mediaUrl, anchor } ) => {
 				return createBlock( 'core/image', {
 					alt: mediaAlt,
@@ -116,9 +114,7 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
-			isMatch: ( { mediaType, mediaUrl } ) => {
-				return ! mediaUrl || mediaType === 'video';
-			},
+			isMatch: ( { mediaType } ) => mediaType === 'video',
 			transform: ( { mediaId, mediaUrl, anchor } ) => {
 				return createBlock( 'core/video', {
 					id: mediaId,

--- a/packages/block-library/src/media-text/transforms.js
+++ b/packages/block-library/src/media-text/transforms.js
@@ -3,7 +3,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 
-function transform(
+function unwrap(
 	{ mediaType, mediaPosition, mediaAlt, mediaId, mediaUrl, anchor },
 	innerBlocks
 ) {
@@ -121,19 +121,19 @@ const transforms = {
 			type: 'block',
 			blocks: [ 'core/image' ],
 			isMatch: ( { mediaType } ) => mediaType === 'image',
-			transform,
+			transform: unwrap,
 		},
 		{
 			type: 'block',
 			blocks: [ 'core/video' ],
 			isMatch: ( { mediaType } ) => mediaType === 'video',
-			transform,
+			transform: unwrap,
 		},
 		{
 			type: 'block',
 			// To do: ideally this should be '*', and quote should also use '*'.
 			blocks: [ 'core/paragraph' ],
-			transform,
+			transform: unwrap,
 		},
 		{
 			type: 'block',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See #63635.

Currently the image and video transforms dump all the text you have next to the media.

The image, video and the newly introduced paragraph transform are all the same transform. They just transform the block into the base blocks.

It might be better to have a single well-labeled transform, I'm not sure. But currently this is not possible. The quote block is actually a bit similar: the "paragraph" transform actually converts it to the inner blocks, so it's also mislabelled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

You shouldn't lose your content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
