### PR TITLE
Fix flaky block template registration e2e test

### DIFF
--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -243,8 +243,13 @@ test.describe( 'Block template registration', () => {
 
 	test( 'WP default templates can be overridden by plugins', async ( {
 		page,
+		requestUtils,
 	} ) => {
-		await page.goto( '?page_id=2' );
+		const { id } = await requestUtils.createPage( {
+			title: 'Plugin override page',
+			status: 'publish',
+		} );
+		await page.goto( `?page_id=${ id }` );
 		await expect(
 			page.getByText( 'This is a plugin-registered page template.' )
 		).toBeVisible();


### PR DESCRIPTION
## What?
PR fixes flaky `WP default templates can be overridden by plugins` e2e test.

## Why?
The page with ID = 2 isn't guaranteed to be available for test runs.

## How?
Create a test page and use its ID.

## Testing Instructions
```
npm run test:e2e -- test/e2e/specs/site-editor/template-registration.spec.js --ui
```
