### PR TITLE
Heading block: remove multi paragraph => headings transform

### DIFF
--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -13,7 +13,6 @@ const transforms = {
 	from: [
 		{
 			type: 'block',
-			isMultiBlock: true,
 			blocks: [ 'core/paragraph' ],
 			transform: ( attributes ) =>
 				attributes.map(

--- a/packages/block-library/src/heading/transforms.js
+++ b/packages/block-library/src/heading/transforms.js
@@ -14,22 +14,19 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) =>
-				attributes.map(
-					( { content, anchor, align: textAlign, metadata } ) =>
-						createBlock( 'core/heading', {
-							content,
-							anchor,
-							textAlign,
-							metadata: getTransformedMetadata(
-								metadata,
-								'core/heading',
-								( { content: contentBinding } ) => ( {
-									content: contentBinding,
-								} )
-							),
+			transform: ( { content, anchor, align: textAlign, metadata } ) =>
+				createBlock( 'core/heading', {
+					content,
+					anchor,
+					textAlign,
+					metadata: getTransformedMetadata(
+						metadata,
+						'core/heading',
+						( { content: contentBinding } ) => ( {
+							content: contentBinding,
 						} )
-				),
+					),
+				} ),
 		},
 		{
 			type: 'raw',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

To me it doesn't make much sense to convert multiple paragraphs together into headings. Please push back if you have objections.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
