### PR TITLE
Pullquote: remove multi-paragraph transform

### DIFF
--- a/packages/block-library/src/pullquote/transforms.js
+++ b/packages/block-library/src/pullquote/transforms.js
@@ -2,94 +2,32 @@
  * WordPress dependencies
  */
 import { createBlock } from '@wordpress/blocks';
-import { create, join, toHTMLString } from '@wordpress/rich-text';
 
 const transforms = {
-	from: [
-		{
-			type: 'block',
-			isMultiBlock: true,
-			blocks: [ 'core/paragraph' ],
-			transform: ( attributes ) => {
-				return createBlock( 'core/pullquote', {
-					value: toHTMLString( {
-						value: join(
-							attributes.map( ( { content } ) =>
-								create( { html: content } )
-							),
-							'\n'
-						),
-					} ),
-					anchor: attributes.anchor,
-				} );
-			},
+	from: [ 'core/paragraph', 'core/heading' ].map( ( blockName ) => ( {
+		type: 'block',
+		blocks: [ blockName ],
+		transform: ( { content, anchor } ) =>
+			createBlock( 'core/pullquote', { value: content, anchor } ),
+	} ) ),
+	to: [ 'core/paragraph', 'core/heading' ].map( ( blockName ) => ( {
+		type: 'block',
+		blocks: [ blockName ],
+		transform: ( { value, citation } ) => {
+			const paragraphs = [];
+			if ( value ) {
+				paragraphs.push( createBlock( blockName, { content: value } ) );
+			}
+			if ( citation ) {
+				paragraphs.push(
+					createBlock( 'core/paragraph', { content: citation } )
+				);
+			}
+			return paragraphs.length === 0
+				? createBlock( blockName, { content: '' } )
+				: paragraphs;
 		},
-		{
-			type: 'block',
-			blocks: [ 'core/heading' ],
-			transform: ( { content, anchor } ) => {
-				return createBlock( 'core/pullquote', {
-					value: content,
-					anchor,
-				} );
-			},
-		},
-	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ 'core/paragraph' ],
-			transform: ( { value, citation } ) => {
-				const paragraphs = [];
-				if ( value ) {
-					paragraphs.push(
-						createBlock( 'core/paragraph', {
-							content: value,
-						} )
-					);
-				}
-				if ( citation ) {
-					paragraphs.push(
-						createBlock( 'core/paragraph', {
-							content: citation,
-						} )
-					);
-				}
-				if ( paragraphs.length === 0 ) {
-					return createBlock( 'core/paragraph', {
-						content: '',
-					} );
-				}
-				return paragraphs;
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/heading' ],
-			transform: ( { value, citation } ) => {
-				// If there is no pullquote content, use the citation as the
-				// content of the resulting heading. A nonexistent citation
-				// will result in an empty heading.
-				if ( ! value ) {
-					return createBlock( 'core/heading', {
-						content: citation,
-					} );
-				}
-				const headingBlock = createBlock( 'core/heading', {
-					content: value,
-				} );
-				if ( ! citation ) {
-					return headingBlock;
-				}
-				return [
-					headingBlock,
-					createBlock( 'core/heading', {
-						content: citation,
-					} ),
-				];
-			},
-		},
-	],
+	} ) ),
 };
 
 export default transforms;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It does not make much sense because the pull quote cannot contain multiple paragraphs. In order to support the transform, we have to merge the paragraphs together and separate them with line breaks. The pull quote is only really meant for a single line of text.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
