### PR TITLE
Move sectionRootClientId to block editor state

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -32,8 +32,11 @@ function ZoomOutModeInserters() {
 			getSelectedBlockClientId,
 			getHoveredBlockClientId,
 			isBlockInsertionPointVisible,
-		} = select( blockEditorStore );
-		const { sectionRootClientId: root } = unlock( getSettings() );
+			getSectionRootClientId,
+		} = unlock( select( blockEditorStore ) );
+
+		const root = getSectionRootClientId();
+
 		return {
 			hasSelection: !! getSelectionStart().clientId,
 			blockInsertionPoint: getBlockInsertionPoint(),

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -203,7 +203,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockEditingMode,
 				getBlockSettings,
 				isDragging,
-				getSettings,
+				getSectionRootClientId,
 			} = unlock( select( blockEditorStore ) );
 			let _isDropZoneDisabled;
 
@@ -225,7 +225,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				// In zoom out mode, we want to disable the drop zone for the sections.
 				// The inner blocks belonging to the section drop zone is
 				// already disabled by the blocks themselves being disabled.
-				const { sectionRootClientId } = unlock( getSettings() );
+				const sectionRootClientId = getSectionRootClientId();
 
 				_isDropZoneDisabled = clientId !== sectionRootClientId;
 			}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -34,8 +34,6 @@ import {
 	__experimentalUpdateSettings,
 	privateRemoveBlocks,
 } from './private-actions';
-import { STORE_NAME } from './constants';
-import { unlock } from '../lock-unlock';
 
 /** @typedef {import('../components/use-on-block-drop/types').WPDropOperation} WPDropOperation */
 
@@ -1670,13 +1668,12 @@ export const setNavigationMode =
  */
 export const __unstableSetEditorMode =
 	( mode ) =>
-	( { dispatch, select, registry } ) => {
+	( { dispatch, select } ) => {
 		// When switching to zoom-out mode, we need to select the parent section
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
-			const { sectionRootClientId } = unlock(
-				registry.select( STORE_NAME ).getSettings()
-			);
+			const sectionRootClientId = select.getSectionRootClientId();
+
 			if ( firstSelectedClientId ) {
 				let sectionClientId;
 

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -383,3 +383,15 @@ export const modifyContentLockBlock =
 			focusModeToRevert
 		);
 	};
+
+/**
+ * Sets the sectionRootClientId of the block editor.
+ *
+ * @param {string} clientId The client id of the block.
+ */
+export function setSectionRootClientId( clientId ) {
+	return {
+		type: 'SET_SECTION_ROOT_CLIENT_ID',
+		clientId,
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -543,3 +543,17 @@ export const getBlockStyles = createSelector(
 export function isZoomOutMode( state ) {
 	return state.editorMode === 'zoom-out';
 }
+
+/**
+ * Returns the clientID of the element that is
+ * considered to be the root for inserting new
+ * "sections" into the editor. This can be thought
+ * of as the "content" of the current editor.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string} The client ID of the section root.
+ */
+export function getSectionRootClientId( state = '' ) {
+	return state.sectionRootClientId;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2087,6 +2087,13 @@ export function hoveredBlockClientId( state = false, action ) {
 	return state;
 }
 
+export function sectionRootClientId( state = null, action ) {
+	if ( action.type === 'SET_SECTION_ROOT_CLIENT_ID' ) {
+		return action.clientId;
+	}
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2120,6 +2127,7 @@ const combinedReducers = combineReducers( {
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
+	sectionRootClientId,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2059,7 +2059,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 								let sectionRootClientId;
 								try {
 									sectionRootClientId =
-										getSectionRootClientId();
+										getSectionRootClientId( state );
 								} catch ( e ) {}
 								if (
 									sectionRootClientId &&
@@ -2827,7 +2827,8 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 
 	// In zoom-out mode, the block overlay is always active for section level blocks.
 	if ( editorMode === 'zoom-out' ) {
-		const sectionRootClientId = getSectionRootClientId();
+		const sectionRootClientId = getSectionRootClientId( state );
+
 		if ( sectionRootClientId ) {
 			const sectionClientIds = getBlockOrder(
 				state,
@@ -2920,7 +2921,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			// sections.
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'zoom-out' ) {
-				const sectionRootClientId = getSectionRootClientId();
+				const sectionRootClientId = getSectionRootClientId( state );
 				if ( clientId === '' /* ROOT_CONTAINER_CLIENT_ID */ ) {
 					return sectionRootClientId ? 'disabled' : 'contentOnly';
 				}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -36,6 +36,7 @@ import {
 	getContentLockingParent,
 	getTemporarilyEditingAsBlocks,
 	getTemporarilyEditingFocusModeToRevert,
+	getSectionRootClientId,
 } from './private-selectors';
 
 /**
@@ -2057,9 +2058,8 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							if ( ! item.rootClientId ) {
 								let sectionRootClientId;
 								try {
-									sectionRootClientId = unlock(
-										getSettings( state )
-									).sectionRootClientId;
+									sectionRootClientId =
+										getSectionRootClientId();
 								} catch ( e ) {}
 								if (
 									sectionRootClientId &&
@@ -2827,7 +2827,7 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 
 	// In zoom-out mode, the block overlay is always active for section level blocks.
 	if ( editorMode === 'zoom-out' ) {
-		const { sectionRootClientId } = unlock( getSettings( state ) );
+		const sectionRootClientId = getSectionRootClientId();
 		if ( sectionRootClientId ) {
 			const sectionClientIds = getBlockOrder(
 				state,
@@ -2920,7 +2920,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			// sections.
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'zoom-out' ) {
-				const { sectionRootClientId } = unlock( getSettings( state ) );
+				const sectionRootClientId = getSectionRootClientId();
 				if ( clientId === '' /* ROOT_CONTAINER_CLIENT_ID */ ) {
 					return sectionRootClientId ? 'disabled' : 'contentOnly';
 				}

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -38,13 +38,15 @@ export default function InserterSidebar() {
 			getBlockInsertionPoint,
 			getBlockRootClientId,
 			__unstableGetEditorMode,
-			getSettings,
-		} = select( blockEditorStore );
+			getSectionRootClientId,
+		} = unlock( select( blockEditorStore ) );
+
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const getBlockSectionRootClientId = () => {
 			if ( __unstableGetEditorMode() === 'zoom-out' ) {
-				const { sectionRootClientId } = unlock( getSettings() );
+				const sectionRootClientId = getSectionRootClientId();
+
 				if ( sectionRootClientId ) {
 					return sectionRootClientId;
 				}

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -9,6 +9,7 @@ import {
 	BlockEditorProvider,
 	BlockContextProvider,
 	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
@@ -222,6 +223,26 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setEditedPost,
 			setRenderingMode,
 		} = unlock( useDispatch( editorStore ) );
+
+		const { computedSectionRootClientId } = useSelect( ( select ) => {
+			const { getBlockAttributes, getBlocksByName } =
+				select( blockEditorStore );
+
+			const _sectionRootClientId =
+				getBlocksByName( 'core/group' ).find(
+					( clientId ) =>
+						getBlockAttributes( clientId )?.tagName === 'main'
+				) ?? '';
+
+			return {
+				computedSectionRootClientId: _sectionRootClientId,
+			};
+		}, [] );
+
+		const { setSectionRootClientId } = unlock(
+			useDispatch( blockEditorStore )
+		);
+
 		const { createWarningNotice } = useDispatch( noticesStore );
 
 		// Ideally this should be synced on each change and not just something you do once.
@@ -270,6 +291,13 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		useEffect( () => {
 			setRenderingMode( settings.defaultRenderingMode ?? 'post-only' );
 		}, [ settings.defaultRenderingMode, setRenderingMode ] );
+
+		// Sets the section root client id once it is computed.
+		useEffect( () => {
+			if ( computedSectionRootClientId ) {
+				setSectionRootClientId( computedSectionRootClientId );
+			}
+		}, [ computedSectionRootClientId, setSectionRootClientId ] );
 
 		useHideBlocksFromInserter( post.type, mode );
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -224,20 +224,31 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			setRenderingMode,
 		} = unlock( useDispatch( editorStore ) );
 
-		const { computedSectionRootClientId } = useSelect( ( select ) => {
-			const { getBlockAttributes, getBlocksByName } =
-				select( blockEditorStore );
+		const { computedSectionRootClientId } = useSelect(
+			( select ) => {
+				const { getBlockAttributes, getBlocksByName } =
+					select( blockEditorStore );
 
-			const _sectionRootClientId =
-				getBlocksByName( 'core/group' ).find(
-					( clientId ) =>
-						getBlockAttributes( clientId )?.tagName === 'main'
-				) ?? '';
+				let _sectionRootClientId;
 
-			return {
-				computedSectionRootClientId: _sectionRootClientId,
-			};
-		}, [] );
+				if ( mode === 'template-locked' ) {
+					_sectionRootClientId =
+						getBlocksByName( 'core/post-content' )?.[ 0 ] ?? '';
+				} else {
+					_sectionRootClientId =
+						getBlocksByName( 'core/group' ).find(
+							( clientId ) =>
+								getBlockAttributes( clientId )?.tagName ===
+								'main'
+						) ?? '';
+				}
+
+				return {
+					computedSectionRootClientId: _sectionRootClientId,
+				};
+			},
+			[ mode ]
+		);
 
 		const { setSectionRootClientId } = unlock(
 			useDispatch( blockEditorStore )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Moves the source of truth for `sectionRootClientId` to the block-editor store.

<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/pull/65001

Resolves https://github.com/WordPress/gutenberg/pull/64141

Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: talldan <talldanwp@git.wordpress.org>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently on `trunk` the `sectionRootClientId` is provided to the block editor via block editor settings. This is necessary because the algorithm which determines the block to be designated as the "section root" must consider blocks that may not be present in every editor (e.g. `core/post-content`). Therefore to make this setting "editor agnostic" it must be passed to the block editor.

However, at this stage it's important this feature is kept private as we are not yet confident in it as a public API. Therefore efforts were made to "lock" the setting. However, this seems to be non-standard and is causing errors as described in https://github.com/WordPress/gutenberg/pull/64141.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


This PR seeks to explore an alternative method of providing the "section root" by moving it to block editor state with private selectors / actions to set/set the state.

Then the consuming editor instance (in WP this is the `@wordpress/editor` package) implements it's own algorithm to determine the "section root" and dispatches an action with the `clientId` of that block element it wants to use as the root.

This has two advantages:

1. avoids the complexity of passing state via the block editor settings.
2. uses a standardised pattern for privacy.

**Note**: I am not fully invested in this method and would be keen to understand from others whether this method is actually preferable to passing the data via block editor settings.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

The aim is to verify that when in Zoom Out mode the behaviour is the same as that currently on `trunk`.

- Enable Zoom Out mode experiment
- Open Site Editor
- Open Pattern inserter and select category to go into Zoom Out mode.
- Check that you can only select the top level patterns/blocks within the `<main>` tag. 
- Check you cannot select the header/footer.
- Check you cannot drag/drop inside of the patterns or the header/footer. You should only be able to drop _within_ the main tag element.
- Repeat for Page editor but verify you can drop patterns anywhere (other than within existing patterns).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
