### PR TITLE
Writing flow: fix select all with formatting

### DIFF
--- a/packages/dom/src/dom/is-entirely-selected.js
+++ b/packages/dom/src/dom/is-entirely-selected.js
@@ -1,7 +1,6 @@
 /**
  * Internal dependencies
  */
-import { assertIsDefined } from '../utils/assert-is-defined';
 import isInputOrTextArea from './is-input-or-text-area';
 
 /**
@@ -26,59 +25,16 @@ export default function isEntirelySelected( element ) {
 
 	const { ownerDocument } = element;
 	const { defaultView } = ownerDocument;
-	assertIsDefined( defaultView, 'defaultView' );
+
+	if ( ! defaultView ) {
+		return false;
+	}
+
 	const selection = defaultView.getSelection();
-	assertIsDefined( selection, 'selection' );
-	const range = selection.rangeCount ? selection.getRangeAt( 0 ) : null;
 
-	if ( ! range ) {
-		return true;
+	if ( ! selection ) {
+		return false;
 	}
 
-	const { startContainer, endContainer, startOffset, endOffset } = range;
-
-	if (
-		startContainer === element &&
-		endContainer === element &&
-		startOffset === 0 &&
-		endOffset === element.childNodes.length
-	) {
-		return true;
-	}
-
-	const lastChild = element.lastChild;
-	assertIsDefined( lastChild, 'lastChild' );
-	const endContainerContentLength =
-		endContainer.nodeType === endContainer.TEXT_NODE
-			? /** @type {Text} */ ( endContainer ).data.length
-			: endContainer.childNodes.length;
-
-	return (
-		isDeepChild( startContainer, element, 'firstChild' ) &&
-		isDeepChild( endContainer, element, 'lastChild' ) &&
-		startOffset === 0 &&
-		endOffset === endContainerContentLength
-	);
-}
-
-/**
- * Check whether the contents of the element have been entirely selected.
- * Returns true if there is no possibility of selection.
- *
- * @param {HTMLElement|Node}         query     The element to check.
- * @param {HTMLElement}              container The container that we suspect "query" may be a first or last child of.
- * @param {"firstChild"|"lastChild"} propName  "firstChild" or "lastChild"
- *
- * @return {boolean} True if query is a deep first/last child of container, false otherwise.
- */
-function isDeepChild( query, container, propName ) {
-	/** @type {HTMLElement | ChildNode | null} */
-	let candidate = container;
-	do {
-		if ( query === candidate ) {
-			return true;
-		}
-		candidate = candidate[ propName ];
-	} while ( candidate );
-	return false;
+	return element.textContent === selection.toString();
 }

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1368,6 +1368,31 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
 			.toEqual( [ 1, 2 ] );
 	} );
+
+	test( 'should select all with formatting', async ( {
+		pageUtils,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '<strong>a</strong>' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '<strong>b</strong>' },
+		} );
+
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+a' );
+
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [
+				{ name: 'core/paragraph' },
+				{ name: 'core/paragraph' },
+			] );
+	} );
 } );
 
 class MultiBlockSelectionUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Cmd+A to select all blocks is broken when a whole paragraph is bold or formatted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #63262.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Compare the contents of the selection instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
