### PR TITLE
DataViews: Update: Sort descending button may be wrongly pressed.

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -143,6 +143,10 @@ function SortFieldControl() {
 
 function SortDirectionControl() {
 	const { view, fields, onChangeView } = useContext( DataViewsContext );
+	let value = view.sort?.direction;
+	if ( ! value && view.sort?.field ) {
+		value = 'desc';
+	}
 	return (
 		<ToggleGroupControl
 			className="dataviews-view-config__sort-direction"
@@ -150,7 +154,7 @@ function SortDirectionControl() {
 			__next40pxDefaultSize
 			isBlock
 			label={ __( 'Order' ) }
-			value={ view.sort?.direction || 'desc' }
+			value={ value }
 			onChange={ ( newDirection ) => {
 				if ( newDirection === 'asc' || newDirection === 'desc' ) {
 					onChangeView( {


### PR DESCRIPTION
In the view config UI for patterns, although the sort descending button appears as pressed, the patterns are not actually sorted in descending order. This PR addresses and fixes this issue.

Before, if a sorting direction was not set, a default of descending was applied. However, if there was no sort field, sorting wouldn't occur and the default would be incorrect. This PR fixes the issue by only adding the default sorting direction of descending if a sort field is set.


## Testing Instructions
I went to the patterns page.
I opened the view config popover.
I verified that neither the ascending nor descending buttons were pressed.
I clicked these buttons and verified sorting worked as expected and the buttons become pressed.

