### PR TITLE
Remove inconsistent dark theme focus style on block selection

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -17,7 +17,6 @@ $gray-100: #f0f0f0;		// Used for light gray backgrounds.
 $white: #fff;
 
 // Opacities & additional colors.
-$dark-theme-focus: $white;	// Focus color when the theme is dark.
 $dark-gray-placeholder: rgba($gray-900, 0.62);
 $medium-gray-placeholder: rgba($gray-900, 0.55);
 $light-gray-placeholder: rgba($white, 0.65);

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -89,11 +89,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		&::after {
 			@include selected-block-focus();
 			z-index: 1;
-
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				outline-color: $dark-theme-focus;
-			}
 		}
 	}
 
@@ -285,11 +280,6 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
 			outline-color: var(--wp-block-synced-color);
-
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				outline-color: $dark-theme-focus;
-			}
 		}
 	}
 }

--- a/packages/block-library/src/navigation-link/editor.scss
+++ b/packages/block-library/src/navigation-link/editor.scss
@@ -87,9 +87,6 @@
 		$stop2: 64%;
 
 		--wp-underline-color: var(--wp-admin-theme-color);
-		.is-dark-theme & {
-			--wp-underline-color: #{ $dark-theme-focus };
-		}
 
 		background-image:
 			linear-gradient(45deg, transparent ($stop1 - $blur), var(--wp-underline-color) $stop1, var(--wp-underline-color) ($stop1 + $width), transparent ($stop1 + $width + $blur)),

--- a/packages/block-library/src/template-part/editor.scss
+++ b/packages/block-library/src/template-part/editor.scss
@@ -35,11 +35,6 @@
 	&.block-editor-block-list__block:not([contenteditable]):focus {
 		&::after {
 			outline-color: var(--wp-block-synced-color);
-
-			// Show a light color for dark themes.
-			.is-dark-theme & {
-				outline-color: $dark-theme-focus;
-			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/64548 by removing the dark theme focus style applied on block selection. I'm leaving the class added as it's leveraged in more optimal areas, like on spacer block selection (but we likely should leverage admin color as well, as it has the same issue (when presented on a light background, but the theme is dark). 

## Why?
1. The block selection color changes from the admin color to white, if the background of a site is deemed "dark"—even if contents within that site are not dark (i.e. section/pattern styles). Changing the selection color is not a great practice, as you loose context with the one constant in the editor — what happens when you select something. 
2. The block selection color changes from the admin color to white, when distraction free mode is enabled. Inconsistent. 

This is fine, to remove the inconsistency in a timely manner, but a next step would be to explore having the dark theme applied based on the contrast of the site background color and the current admin color, if the contrast value fails, then augment the current admin color to pass — rather than go for a full white. 

And secondly, this dark theme class may need to be re-applied/checked based on the background color of blocks/parent blocks—so that you don't end up in a scenario where you have a white background with white block selection styles (not uncommon on a dark site with a white section style). 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor with Twenty Twenty Four theme active.
2. Choose one of the dark color palettes. 
3. See UI selection states retaining the admin color.
4. Turn on Distraction Free.
5. See UI selection states retaining the admin color. 


## Visuals

### Before

https://github.com/user-attachments/assets/bfa64f11-4064-4378-9b3b-79bfada69e6e

### After 

https://github.com/user-attachments/assets/37cb8474-f170-4974-abf4-c47e4104aafd


