### PR TITLE
Comment Author Name: Add Border Support

### DIFF
--- a/packages/block-library/src/comment-author-name/block.json
+++ b/packages/block-library/src/comment-author-name/block.json
@@ -51,6 +51,19 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
-	}
+	},
+	"style": "wp-block-comment-author-name"
 }

--- a/packages/block-library/src/comment-author-name/style.scss
+++ b/packages/block-library/src/comment-author-name/style.scss
@@ -1,0 +1,4 @@
+.wp-block-comment-author-name {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -12,6 +12,7 @@
 @import "./comment-template/style.scss";
 @import "./comment-date/style.scss";
 @import "./comment-content/style.scss";
+@import "./comment-author-name/style.scss";
 @import "./cover/style.scss";
 @import "./details/style.scss";
 @import "./embed/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add Border support in the `Comment Author Name` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Comment Author Name` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Comment Author Name` block's border is Configurable via Global Styles.
- Edit Template/Page Template & Add `Comment Author Name` Block and Apply the border Styles.
- Verify that `Comment Author Name` block styles take precedence over global Styles.
- Verify that `Comment Author Name` block borders is showing correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->


https://github.com/user-attachments/assets/59429578-9fb3-4afe-9f6e-ed6f3757410c

