### PR TITLE
Props Bot: update to correct event type

### DIFF
--- a/.github/workflows/props-bot.yml
+++ b/.github/workflows/props-bot.yml
@@ -18,7 +18,7 @@ on:
     # You cannot filter this event for PR comments only.
     # However, the logic below does short-circuit the workflow for issues.
     issue_comment:
-        type:
+        types:
             - created
     # This event will run everytime a new PR review is initially submitted.
     pull_request_review:


### PR DESCRIPTION
## What?

This updates the Props bot GitHub action to correct trigger on issue comments.

## Why? / How?

When wanting to filter by event type, we must use `types`, and not `type`.

Reference: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#issue_comment

## Testing Instructions

Not much to test on this PR, we will only see the results when it is merged. However, you can already compare this change with the other events we listen to in that same file.
