### PR TITLE
Base Styles: Restore deprecated `$dark-theme-focus` variable

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -25,3 +25,6 @@ $light-gray-placeholder: rgba($white, 0.65);
 $alert-yellow: #f0b849;
 $alert-red: #cc1818;
 $alert-green: #4ab866;
+
+// Deprecated, please avoid using these.
+$dark-theme-focus: $white;	// Focus color when the theme is dark.


### PR DESCRIPTION
Follow-up #64549

## What?

From what I understand, SCSS variables that are no longer used in the Gutenberg project need to be maintained. Otherwise, they could cause build errors in other projects that import the `@wordpress/base-styles` package and depend on them.

For example, the following variables are maintained:

https://github.com/WordPress/gutenberg/blob/8457cb8eff5bcdf37c6f3518aac9fc15f2a61278/packages/base-styles/_variables.scss#L115-L119

https://github.com/WordPress/gutenberg/blob/8457cb8eff5bcdf37c6f3518aac9fc15f2a61278/packages/base-styles/_colors.native.scss#L115-L120

## Testing Instructions

All CIs should be ✅.
