### PR TITLE
Background image: add uploading state and restrict drag to one image.

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -410,12 +410,7 @@ function BackgroundImageControls( {
 	return (
 		<div
 			ref={ replaceContainerRef }
-			className={ clsx(
-				'block-editor-global-styles-background-panel__image-tools-panel-item',
-				{
-					'is-uploading': isUploading,
-				}
-			) }
+			className="block-editor-global-styles-background-panel__image-tools-panel-item"
 		>
 			{ isUploading && <LoadingSpinner /> }
 			<MediaReplaceFlow

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -313,7 +313,6 @@ function BackgroundImageControls( {
 		);
 
 	const onSelectMedia = ( media ) => {
-
 		if ( ! media || ! media.url ) {
 			resetBackgroundImage();
 			setIsUploading( false );
@@ -321,7 +320,6 @@ function BackgroundImageControls( {
 		}
 
 		if ( isBlobURL( media.url ) ) {
-			// Still uploading.
 			setIsUploading( true );
 			return;
 		}
@@ -368,7 +366,14 @@ function BackgroundImageControls( {
 		setIsUploading( false );
 	};
 
+	// Drag and drop callback, restricting image to one.
 	const onFilesDrop = ( filesList ) => {
+		if ( filesList?.length > 1 ) {
+			onUploadError(
+				__( 'Only one image can be used as a background image.' )
+			);
+			return;
+		}
 		mediaUpload( {
 			allowedTypes: [ IMAGE_BACKGROUND_TYPE ],
 			filesList,
@@ -401,14 +406,19 @@ function BackgroundImageControls( {
 	const canRemove = ! hasValue && hasBackgroundImageValue( inheritedValue );
 	const imgLabel =
 		title || getFilename( url ) || __( 'Add background image' );
-// opaque when loading?
+
 	return (
 		<div
 			ref={ replaceContainerRef }
 			className="block-editor-global-styles-background-panel__image-tools-panel-item"
+			clsx={
+				( 'block-editor-global-styles-background-panel__image-tools-panel-item',
+				{
+					'is-uploading': isUploading,
+				} )
+			}
 		>
 			{ isUploading && <LoadingSpinner /> }
-			<LoadingSpinner />
 			<MediaReplaceFlow
 				mediaId={ id }
 				mediaURL={ url }
@@ -430,7 +440,7 @@ function BackgroundImageControls( {
 					/>
 				}
 				variant="secondary"
-				onError={ () => {} }
+				onError={ onUploadError }
 			>
 				{ canRemove && (
 					<MenuItem

--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -410,13 +410,12 @@ function BackgroundImageControls( {
 	return (
 		<div
 			ref={ replaceContainerRef }
-			className="block-editor-global-styles-background-panel__image-tools-panel-item"
-			clsx={
-				( 'block-editor-global-styles-background-panel__image-tools-panel-item',
+			className={ clsx(
+				'block-editor-global-styles-background-panel__image-tools-panel-item',
 				{
 					'is-uploading': isUploading,
-				} )
-			}
+				}
+			) }
 		>
 			{ isUploading && <LoadingSpinner /> }
 			<MediaReplaceFlow

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -134,6 +134,18 @@
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 	}
+
+	.block-editor-global-styles-background-panel__loading {
+		height: 100%;
+		position: absolute;
+		z-index: 1;
+		background-color: rgba($gray-900, 0.15);
+		width: 100%;
+		padding: 10px 0 0 0;
+		svg {
+			margin: 0;
+		}
+	}
 }
 
 .block-editor-global-styles-background-panel__image-preview-content,

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -135,15 +135,10 @@
 		}
 	}
 
-	&.is-uploading {
-		opacity: 0.5;
-	}
-
 	.block-editor-global-styles-background-panel__loading {
 		height: 100%;
 		position: absolute;
 		z-index: 1;
-		background-color: rgba(255, 255, 255, 0.5);
 		width: 100%;
 		padding: 10px 0 0 0;
 		svg {

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -137,6 +137,7 @@
 
 	&.is-uploading {
 		opacity: 0.5;
+		width: 100%;
 	}
 
 	.block-editor-global-styles-background-panel__loading {

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -135,11 +135,15 @@
 		}
 	}
 
+	&.is-uploading {
+		opacity: 0.5;
+	}
+
 	.block-editor-global-styles-background-panel__loading {
 		height: 100%;
 		position: absolute;
 		z-index: 1;
-		background-color: rgba($gray-900, 0.15);
+		background-color: rgba(255, 255, 255, 0.5);
 		width: 100%;
 		padding: 10px 0 0 0;
 		svg {

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -137,7 +137,6 @@
 
 	&.is-uploading {
 		opacity: 0.5;
-		width: 100%;
 	}
 
 	.block-editor-global-styles-background-panel__loading {


### PR DESCRIPTION
## What?

This PR refines the background image upload flow by:

- adds a loading spinner over the upload media control
- restricts drag and drop uploads to one image

## Why?

Because there's a potential delay when uploading an image, a loading spinner says to users on slow connections that the editor is doing something. 

Currently, it's possible to drag 1+ images onto the background control. Background images — at least for now — only support one image.

## How?

Testing for media blob, indicating a file upload, to trigger the loading spinner.

Checking the dropped files fileList length.

## Testing Instructions


### Dragging

1. Insert a Verse block, and open its block styles.
2. Select 2 or more images from your file system and drag them onto the Add background image control.
3. You shouldn't be able to.
4. Now test with 1 image.
5. You should be able to.

https://github.com/user-attachments/assets/79a24bf0-5e56-4bfe-b400-d3f70aa87083

### Loading

You can emulate slow connections in browsers by throttling the network in the console tools. 

Switch the connection to 3g or something slow and try to upload a background image.

Check that the loading spinner appears and disappears as expected.


https://github.com/user-attachments/assets/28975167-0623-47e2-a60a-0b3cbb86c5c2





