### PR TITLE
PostFeaturedImage: Disable the media modal while uploading an image

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -180,6 +180,8 @@ function PostFeaturedImage( {
 											: `editor-post-featured-image-${ featuredImageId }-describedby`
 									}
 									aria-haspopup="dialog"
+									disabled={ isLoading }
+									accessibleWhenDisabled
 								>
 									{ !! featuredImageId && media && (
 										<img


### PR DESCRIPTION
## What?
PR disables the ability to open the media library modal while the featured image is uploading.

## Why?
While upload is in flight, there's no need to offer other options to set a featured image.

## Testing Instructions
1. Open a post or page.
2. Throttle network using DevTools.
3. Drag media onto the feature image component.
4. Confirm you can't click the button while an upload is in progress.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8f6d9951-c142-4837-b4df-16252c8116d3

