### PR TITLE
Background Image: Remove unnecessary 'block-editor' store subscription

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -288,10 +288,7 @@ function BackgroundImageControls( {
 	defaultValues,
 } ) {
 	const [ isUploading, setIsUploading ] = useState( false );
-	const mediaUpload = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().mediaUpload,
-		[]
-	);
+	const { getSettings } = useSelect( blockEditorStore );
 
 	const { id, title, url } = style?.background?.backgroundImage || {
 		...inheritedValue?.background?.backgroundImage,
@@ -374,7 +371,7 @@ function BackgroundImageControls( {
 			);
 			return;
 		}
-		mediaUpload( {
+		getSettings().mediaUpload( {
 			allowedTypes: [ IMAGE_BACKGROUND_TYPE ],
 			filesList,
 			onFileChange( [ image ] ) {


### PR DESCRIPTION
## What?
This is similar to #57554.

PR removes an unnecessary 'block-editor' store subscription from the `BackgroundImageControls` component.

## Why?
The media `mediaUpload` setting is only used during the `onFilesDrop` event. We can use a static selector getter and grab the setting only when needed. 

This is a micro-optimization and has little performance impact. It's a good practice to avoid store subscriptions when unnecessary.

## Testing Instructions
1. Open a post or page.
2. Insert a Group block.
3. Select an image and drag it onto the "Add background image" control.
4. The image should be uploaded as before.

### Testing Instructions for Keyboard
Same.
