### PR TITLE
fix: fix empty content sidebar panel

### DIFF
--- a/packages/editor/src/components/template-content-panel/index.js
+++ b/packages/editor/src/components/template-content-panel/index.js
@@ -59,7 +59,10 @@ export default function TemplateContentPanel() {
 
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 
-	if ( renderingMode === 'post-only' && postType !== TEMPLATE_POST_TYPE ) {
+	if (
+		( renderingMode === 'post-only' && postType !== TEMPLATE_POST_TYPE ) ||
+		clientIds.length === 0
+	) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fix hides the Content Panel when editing a template if no content is available.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes: #64472 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added a check if content is available, if not then returning `null`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate Twenty Twenty-Four.
2. Go to Appearance > Editor.
3. Open the editor, editing for example Blog Home.
4. Delete the header and footer template parts from the template.
5. Open the settings sidebar.
6. The Template Panel should be hidden

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://www.loom.com/share/a4b9f6cb7a644b8489d9669b5354ad5a?sid=2508bc29-63ea-4935-8ad5-16aa6c98665d
