### PR TITLE
Block Bindings: Allow only admin users to create and modify bindings by default

### DIFF
--- a/backport-changelog/6.7/7258.md
+++ b/backport-changelog/6.7/7258.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7258
+
+* https://github.com/WordPress/gutenberg/pull/64570

--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -38,3 +38,18 @@ function gutenberg_add_server_block_bindings_sources_to_editor_settings( $editor
 }
 
 add_filter( 'block_editor_settings_all', 'gutenberg_add_server_block_bindings_sources_to_editor_settings', 10 );
+
+/**
+ * Initialize `canUpdateBlockBindings` editor setting if it doesn't exist. By default, it is `true` only for admin users.
+ *
+ * @param array $settings The block editor settings from the `block_editor_settings_all` filter.
+ * @return array The editor settings including `canUpdateBlockBindings`.
+ */
+function gutenberg_add_can_update_block_bindings_editor_setting( $editor_settings ) {
+	if ( empty( $editor_settings['canUpdateBlockBindings'] ) ) {
+		$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_options' );
+	}
+	return $editor_settings;
+}
+
+add_filter( 'block_editor_settings_all', 'gutenberg_add_can_update_block_bindings_editor_setting', 10 );

--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -34,9 +34,6 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-quick-edit-dataviews', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalQuickEditDataViews = true', 'before' );
 	}
-	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-block-bindings-ui', $gutenberg_experiments ) ) {
-		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalBlockBindingsUI = true', 'before' );
-	}
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-media-processing', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaProcessing = true', 'before' );
 	}

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -176,18 +176,6 @@ function gutenberg_initialize_experiments_settings() {
 	);
 
 	add_settings_field(
-		'gutenberg-block-bindings-ui',
-		__( 'UI to create block bindings', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Add UI to create and update block bindings in block inspector controls.', 'gutenberg' ),
-			'id'    => 'gutenberg-block-bindings-ui',
-		)
-	);
-
-	add_settings_field(
 		'gutenberg-media-processing',
 		__( 'Client-side media processing', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -307,6 +307,7 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 					/>
 					<InspectorControls.Slot group="styles" />
 					<PositionControls />
+					<InspectorControls.Slot group="bindings" />
 					<div>
 						<AdvancedControls />
 					</div>

--- a/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/settings-tab.js
@@ -9,6 +9,7 @@ const SettingsTab = ( { showAdvancedControls = false } ) => (
 	<>
 		<InspectorControls.Slot />
 		<PositionControls />
+		<InspectorControls.Slot group="bindings" />
 		{ showAdvancedControls && (
 			<div>
 				<AdvancedControls />

--- a/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/use-inspector-controls-tabs.js
@@ -32,6 +32,7 @@ function getShowTabs( blockName, tabSettings = {} ) {
 export default function useInspectorControlsTabs( blockName ) {
 	const tabs = [];
 	const {
+		bindings: bindingsGroup,
 		border: borderGroup,
 		color: colorGroup,
 		default: defaultGroup,
@@ -64,8 +65,10 @@ export default function useInspectorControlsTabs( blockName ) {
 	// (i.e. both list view and styles), check only the default and position
 	// InspectorControls slots. If we have multiple tabs, we'll need to check
 	// the advanced controls slot as well to ensure they are rendered.
-	const advancedFills =
-		useSlotFills( InspectorAdvancedControls.slotName ) || [];
+	const advancedFills = [
+		...( useSlotFills( InspectorAdvancedControls.slotName ) || [] ),
+		...( useSlotFills( bindingsGroup.Slot.__unstableName ) || [] ),
+	];
 
 	const settingsFills = [
 		...( useSlotFills( defaultGroup.Slot.__unstableName ) || [] ),

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -5,6 +5,7 @@ import { createSlotFill } from '@wordpress/components';
 
 const InspectorControlsDefault = createSlotFill( 'InspectorControls' );
 const InspectorControlsAdvanced = createSlotFill( 'InspectorAdvancedControls' );
+const InspectorControlsBindings = createSlotFill( 'InspectorControlsBindings' );
 const InspectorControlsBackground = createSlotFill(
 	'InspectorControlsBackground'
 );
@@ -26,6 +27,7 @@ const groups = {
 	default: InspectorControlsDefault,
 	advanced: InspectorControlsAdvanced,
 	background: InspectorControlsBackground,
+	bindings: InspectorControlsBindings,
 	border: InspectorControlsBorder,
 	color: InspectorControlsColor,
 	dimensions: InspectorControlsDimensions,

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -276,9 +276,13 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						/>
 					) }
 				</ItemGroup>
-				<Text variant="muted">
-					{ __( 'Attributes connected to various sources.' ) }
-				</Text>
+				<ItemGroup>
+					<Text variant="muted">
+						{ __(
+							'Attributes connected to custom fields or other dynamic data.'
+						) }
+					</Text>
+				</ItemGroup>
 			</ToolsPanel>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -16,7 +16,6 @@ import {
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useContext, Fragment } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -29,6 +28,7 @@ import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
 import { useBlockBindingsUtils } from '../utils/block-bindings';
+import { store as blockEditorStore } from '../store';
 
 const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
@@ -202,11 +202,10 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		}
 	} );
 
-	const { isConnectingEnabled } = useSelect( ( select ) => {
-		const { get } = select( preferencesStore );
-
+	const { canUpdateBlockBindings } = useSelect( ( select ) => {
 		return {
-			isConnectingEnabled: get( 'core', 'connectBlockAttributesUI' ),
+			canUpdateBlockBindings:
+				select( blockEditorStore ).getSettings().canUpdateBlockBindings,
 		};
 	}, [] );
 
@@ -247,7 +246,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Lock the UI when the preference to create bindings is not enabled or there are no fields to connect to.
 	const readOnly =
-		! isConnectingEnabled || ! Object.keys( fieldsList ).length;
+		! canUpdateBlockBindings || ! Object.keys( fieldsList ).length;
 
 	if ( readOnly && Object.keys( filteredBindings ).length === 0 ) {
 		return null;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -244,7 +244,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		}
 	} );
 
-	// Lock the UI when the preference to create bindings is not enabled or there are no fields to connect to.
+	// Lock the UI when the user can't update bindings or there are no fields to connect to.
 	const readOnly =
 		! canUpdateBlockBindings || ! Object.keys( fieldsList ).length;
 

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -245,7 +245,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		}
 	} );
 
-	// Lock the UI when the experiment is not enabled or there are no fields to connect to.
+	// Lock the UI when the preference to create bindings is not enabled or there are no fields to connect to.
 	const readOnly =
 		! showBlockBindingsUI || ! Object.keys( fieldsList ).length;
 

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -16,6 +16,7 @@ import {
 import { useRegistry } from '@wordpress/data';
 import { useContext, Fragment } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -201,6 +202,14 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		}
 	} );
 
+	const { showBlockBindingsUI } = useSelect( ( select ) => {
+		const { get } = select( preferencesStore );
+
+		return {
+			showBlockBindingsUI: get( 'core', 'showBlockBindingsUI' ),
+		};
+	}, [] );
+
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
 	}
@@ -238,8 +247,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Lock the UI when the experiment is not enabled or there are no fields to connect to.
 	const readOnly =
-		! window.__experimentalBlockBindingsUI ||
-		! Object.keys( fieldsList ).length;
+		! showBlockBindingsUI || ! Object.keys( fieldsList ).length;
 
 	if ( readOnly && Object.keys( filteredBindings ).length === 0 ) {
 		return null;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -13,7 +13,7 @@ import {
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
-import { useRegistry } from '@wordpress/data';
+import { useRegistry, useSelect } from '@wordpress/data';
 import { useContext, Fragment } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { store as preferencesStore } from '@wordpress/preferences';

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -254,7 +254,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	}
 
 	return (
-		<InspectorControls>
+		<InspectorControls group="bindings">
 			<ToolsPanel
 				label={ __( 'Attributes' ) }
 				resetAll={ () => {

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -202,11 +202,11 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		}
 	} );
 
-	const { showBlockBindingsUI } = useSelect( ( select ) => {
+	const { isConnectingEnabled } = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 
 		return {
-			showBlockBindingsUI: get( 'core', 'showBlockBindingsUI' ),
+			isConnectingEnabled: get( 'core', 'connectBlockAttributesUI' ),
 		};
 	}, [] );
 
@@ -247,7 +247,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 
 	// Lock the UI when the preference to create bindings is not enabled or there are no fields to connect to.
 	const readOnly =
-		! showBlockBindingsUI || ! Object.keys( fieldsList ).length;
+		! isConnectingEnabled || ! Object.keys( fieldsList ).length;
 
 	if ( readOnly && Object.keys( filteredBindings ).length === 0 ) {
 		return null;

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -4,6 +4,7 @@
 
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
+import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import {
@@ -36,7 +37,12 @@ const {
 
 export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { isActive, showBlockBreadcrumbsOption, isTemplate } = useSelect(
+	const {
+		isActive,
+		showBlockBreadcrumbsOption,
+		isTemplate,
+		canUpdateSettings,
+	} = useSelect(
 		( select ) => {
 			const { getEditorSettings, getEditedPostAttribute } =
 				select( editorStore );
@@ -44,6 +50,7 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 			const { isModalActive } = select( interfaceStore );
 			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
 			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );
+			const { canUser } = select( coreStore );
 			return {
 				showBlockBreadcrumbsOption:
 					! isDistractionFreeEnabled &&
@@ -51,6 +58,10 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 					isRichEditingEnabled,
 				isActive: isModalActive( 'editor/preferences' ),
 				isTemplate: getEditedPostAttribute( 'type' ) === 'wp_template',
+				canUpdateSettings: canUser( 'update', {
+					kind: 'root',
+					name: 'site',
+				} ),
 			};
 		},
 		[ isLargeViewport ]
@@ -256,17 +267,17 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 							/>
 						</PreferencesModalSection>
 						{ /* Don't show preference in templates until connecting attributes there is supported */ }
-						{ ! isTemplate && (
-							<PreferencesModalSection
-								title={ __( 'Block settings' ) }
-								description={ __(
-									'Select what settings are shown in the block panel.'
-								) }
-							>
+						{ ! isTemplate && canUpdateSettings && (
+							<PreferencesModalSection title={ __( 'Advanced' ) }>
 								<PreferenceToggleControl
 									scope="core"
-									featureName="showBlockBindingsUI"
-									label={ __( 'Block bindings UI' ) }
+									featureName="connectBlockAttributesUI"
+									label={ __(
+										'Enable connecting block attributes'
+									) }
+									help={ __(
+										'Allows connecting block attributes to custom fields or other dynamic data.'
+									) }
 								/>
 							</PreferencesModalSection>
 						) }

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -254,6 +254,18 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 							/>
 						</PreferencesModalSection>
 						<PreferencesModalSection
+							title={ __( 'Block settings' ) }
+							description={ __(
+								'Select what settings are shown in the block panel.'
+							) }
+						>
+							<PreferenceToggleControl
+								scope="core"
+								featureName="showBlockBindingsUI"
+								label={ __( 'Block bindings UI' ) }
+							/>
+						</PreferencesModalSection>
+						<PreferencesModalSection
 							title={ __( 'Manage block visibility' ) }
 							description={ __(
 								"Disable blocks that you don't want to appear in the inserter. They can always be toggled back on later."

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -36,9 +36,10 @@ const {
 
 export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const { isActive, showBlockBreadcrumbsOption } = useSelect(
+	const { isActive, showBlockBreadcrumbsOption, isTemplate } = useSelect(
 		( select ) => {
-			const { getEditorSettings } = select( editorStore );
+			const { getEditorSettings, getEditedPostAttribute } =
+				select( editorStore );
 			const { get } = select( preferencesStore );
 			const { isModalActive } = select( interfaceStore );
 			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
@@ -49,6 +50,7 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 					isLargeViewport &&
 					isRichEditingEnabled,
 				isActive: isModalActive( 'editor/preferences' ),
+				isTemplate: getEditedPostAttribute( 'type' ) === 'wp_template',
 			};
 		},
 		[ isLargeViewport ]
@@ -253,18 +255,21 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 								label={ __( 'Show most used blocks' ) }
 							/>
 						</PreferencesModalSection>
-						<PreferencesModalSection
-							title={ __( 'Block settings' ) }
-							description={ __(
-								'Select what settings are shown in the block panel.'
-							) }
-						>
-							<PreferenceToggleControl
-								scope="core"
-								featureName="showBlockBindingsUI"
-								label={ __( 'Block bindings UI' ) }
-							/>
-						</PreferencesModalSection>
+						{ /* Don't show preference in templates until connecting attributes there is supported */ }
+						{ ! isTemplate && (
+							<PreferencesModalSection
+								title={ __( 'Block settings' ) }
+								description={ __(
+									'Select what settings are shown in the block panel.'
+								) }
+							>
+								<PreferenceToggleControl
+									scope="core"
+									featureName="showBlockBindingsUI"
+									label={ __( 'Block bindings UI' ) }
+								/>
+							</PreferencesModalSection>
+						) }
 						<PreferencesModalSection
 							title={ __( 'Manage block visibility' ) }
 							description={ __(

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -4,7 +4,6 @@
 
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { store as coreStore } from '@wordpress/core-data';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import {
@@ -37,31 +36,19 @@ const {
 
 export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const isLargeViewport = useViewportMatch( 'medium' );
-	const {
-		isActive,
-		showBlockBreadcrumbsOption,
-		isTemplate,
-		canUpdateSettings,
-	} = useSelect(
+	const { isActive, showBlockBreadcrumbsOption } = useSelect(
 		( select ) => {
-			const { getEditorSettings, getEditedPostAttribute } =
-				select( editorStore );
+			const { getEditorSettings } = select( editorStore );
 			const { get } = select( preferencesStore );
 			const { isModalActive } = select( interfaceStore );
 			const isRichEditingEnabled = getEditorSettings().richEditingEnabled;
 			const isDistractionFreeEnabled = get( 'core', 'distractionFree' );
-			const { canUser } = select( coreStore );
 			return {
 				showBlockBreadcrumbsOption:
 					! isDistractionFreeEnabled &&
 					isLargeViewport &&
 					isRichEditingEnabled,
 				isActive: isModalActive( 'editor/preferences' ),
-				isTemplate: getEditedPostAttribute( 'type' ) === 'wp_template',
-				canUpdateSettings: canUser( 'update', {
-					kind: 'root',
-					name: 'site',
-				} ),
 			};
 		},
 		[ isLargeViewport ]
@@ -266,21 +253,6 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 								label={ __( 'Show most used blocks' ) }
 							/>
 						</PreferencesModalSection>
-						{ /* Don't show preference in templates until connecting attributes there is supported */ }
-						{ ! isTemplate && canUpdateSettings && (
-							<PreferencesModalSection title={ __( 'Advanced' ) }>
-								<PreferenceToggleControl
-									scope="core"
-									featureName="connectBlockAttributesUI"
-									label={ __(
-										'Enable connecting block attributes'
-									) }
-									help={ __(
-										'Allows connecting block attributes to custom fields or other dynamic data.'
-									) }
-								/>
-							</PreferencesModalSection>
-						) }
 						<PreferencesModalSection
 							title={ __( 'Manage block visibility' ) }
 							description={ __(

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -47,6 +47,7 @@ const BLOCK_EDITOR_SETTINGS = [
 	'allowedMimeTypes',
 	'bodyPlaceholder',
 	'canLockBlocks',
+	'canUpdateBlockBindings',
 	'capabilities',
 	'clearBlockSelection',
 	'codeEditingEnabled',

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1394,11 +1394,6 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI preference.
-				await editor.setPreferences( 'core', {
-					connectBlockAttributesUI: true,
-				} );
-
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 				} );
@@ -1412,11 +1407,6 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI preference.
-				await editor.setPreferences( 'core', {
-					connectBlockAttributesUI: true,
-				} );
-
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 					attributes: {
@@ -1529,11 +1519,6 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI preference.
-				await editor.setPreferences( 'core', {
-					connectBlockAttributesUI: true,
-				} );
-
 				await editor.insertBlock( {
 					name: 'core/heading',
 				} );
@@ -1724,11 +1709,6 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI preference.
-				await editor.setPreferences( 'core', {
-					connectBlockAttributesUI: true,
-				} );
-
 				await editor.insertBlock( {
 					name: 'core/buttons',
 					innerBlocks: [
@@ -2059,11 +2039,6 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI preference.
-				await editor.setPreferences( 'core', {
-					connectBlockAttributesUI: true,
-				} );
-
 				await editor.insertBlock( {
 					name: 'core/image',
 				} );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1394,9 +1394,9 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI experiment.
-				await page.evaluate( () => {
-					window.__experimentalBlockBindingsUI = true;
+				// Activate the block bindings UI preference.
+				await editor.setPreferences( 'core', {
+					showBlockBindingsUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -1417,9 +1417,9 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI experiment.
-				await page.evaluate( () => {
-					window.__experimentalBlockBindingsUI = true;
+				// Activate the block bindings UI preference.
+				await editor.setPreferences( 'core', {
+					showBlockBindingsUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -1539,9 +1539,9 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI experiment.
-				await page.evaluate( () => {
-					window.__experimentalBlockBindingsUI = true;
+				// Activate the block bindings UI preference.
+				await editor.setPreferences( 'core', {
+					showBlockBindingsUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -1739,9 +1739,9 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI experiment.
-				await page.evaluate( () => {
-					window.__experimentalBlockBindingsUI = true;
+				// Activate the block bindings UI preference.
+				await editor.setPreferences( 'core', {
+					showBlockBindingsUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -2074,9 +2074,9 @@ test.describe( 'Block bindings', () => {
 				editor,
 				page,
 			} ) => {
-				// Activate the block bindings UI experiment.
-				await page.evaluate( () => {
-					window.__experimentalBlockBindingsUI = true;
+				// Activate the block bindings UI preference.
+				await editor.setPreferences( 'core', {
+					showBlockBindingsUI: true,
 				} );
 
 				await editor.insertBlock( {

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1402,12 +1402,7 @@ test.describe( 'Block bindings', () => {
 				await editor.insertBlock( {
 					name: 'core/paragraph',
 				} );
-				await page
-					.getByRole( 'tabpanel', {
-						name: 'Settings',
-					} )
-					.getByLabel( 'Attributes options' )
-					.click();
+				await page.getByLabel( 'Attributes options' ).click();
 				const contentAttribute = page.getByRole( 'menuitemcheckbox', {
 					name: 'Show content',
 				} );
@@ -1436,12 +1431,7 @@ test.describe( 'Block bindings', () => {
 						},
 					},
 				} );
-				await page
-					.getByRole( 'tabpanel', {
-						name: 'Settings',
-					} )
-					.getByRole( 'button', { name: 'content' } )
-					.click();
+				await page.getByRole( 'button', { name: 'content' } ).click();
 
 				await page
 					.getByRole( 'menuitemradio' )
@@ -1547,12 +1537,7 @@ test.describe( 'Block bindings', () => {
 				await editor.insertBlock( {
 					name: 'core/heading',
 				} );
-				await page
-					.getByRole( 'tabpanel', {
-						name: 'Settings',
-					} )
-					.getByLabel( 'Attributes options' )
-					.click();
+				await page.getByLabel( 'Attributes options' ).click();
 				const contentAttribute = page.getByRole( 'menuitemcheckbox', {
 					name: 'Show content',
 				} );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -2352,11 +2352,9 @@ test.describe( 'Block bindings', () => {
 				},
 			} );
 
-			const bindingsPanel = page
-				.getByRole( 'tabpanel', {
-					name: 'Settings',
-				} )
-				.locator( '.block-editor-bindings__panel' );
+			const bindingsPanel = page.locator(
+				'.block-editor-bindings__panel'
+			);
 			await expect( bindingsPanel ).toContainText( 'Server Source' );
 		} );
 	} );

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1396,7 +1396,7 @@ test.describe( 'Block bindings', () => {
 			} ) => {
 				// Activate the block bindings UI preference.
 				await editor.setPreferences( 'core', {
-					showBlockBindingsUI: true,
+					connectBlockAttributesUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -1414,7 +1414,7 @@ test.describe( 'Block bindings', () => {
 			} ) => {
 				// Activate the block bindings UI preference.
 				await editor.setPreferences( 'core', {
-					showBlockBindingsUI: true,
+					connectBlockAttributesUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -1531,7 +1531,7 @@ test.describe( 'Block bindings', () => {
 			} ) => {
 				// Activate the block bindings UI preference.
 				await editor.setPreferences( 'core', {
-					showBlockBindingsUI: true,
+					connectBlockAttributesUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -1726,7 +1726,7 @@ test.describe( 'Block bindings', () => {
 			} ) => {
 				// Activate the block bindings UI preference.
 				await editor.setPreferences( 'core', {
-					showBlockBindingsUI: true,
+					connectBlockAttributesUI: true,
 				} );
 
 				await editor.insertBlock( {
@@ -2061,7 +2061,7 @@ test.describe( 'Block bindings', () => {
 			} ) => {
 				// Activate the block bindings UI preference.
 				await editor.setPreferences( 'core', {
-					showBlockBindingsUI: true,
+					connectBlockAttributesUI: true,
 				} );
 
 				await editor.insertBlock( {


### PR DESCRIPTION
## What?
This pull request removes the experimental flag to enable the block bindings UI to create connections and tries an approach where only admin users can create and modify bindings by default.

As part of it, it includes a new `canUpdateBlockBindings` editor setting to let developers override this behavior.

It creates a "bindings" group in the inspector controls that follows the same "workflows" as the Advanced panel. This means that in the blocks where there are no "Settings", it shows in the initial list. This solves the issue where every empty paragraph was adding the panel and changing the workflow.

Additionally, it address some improvements to the UX, like not showing the help text when there are no attributes connected.

| Image with URL connected | Empty paragraph |
|----------|----------|
| ![Screenshot 2024-09-03 at 16 11 44](https://github.com/user-attachments/assets/c11696f7-9764-49f2-9435-6b5a64564971) | ![Screenshot 2024-09-03 at 16 11 55](https://github.com/user-attachments/assets/0a041ed5-8d9d-4c44-9e91-34cdc77da96b) |

## Why?
It can remove the experiment while keeping it safe only for admin users and provides a method to change this behavior. And it solves the issue with empty paragraphs.

## How?
I added a new `canUpdateBlockBindings` editor setting that it is true for admin users by default. This setting is read from the block bindings component to decide if it should show as "read-only" or it should allow the user to create and modify connections.

Apart from that, I created a new "bindings" group to put the panel just above the Advanced section in the different scenarios.

## Testing Instructions
**Logged as an admin**
1. Go to a page and insert a paragraph.
2. Check that the bindings UI to connect attributes appear on top of the Advanced section, without creating a new "Settings" tab.
3. Check that you can create bindings.

**Logged as an editor**
1. Go to a page and insert a paragraph.
2. Check that the bindings UI to connect attributes is not present.