### PR TITLE
Add "Edit" button to Zoom Out mode toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { dragHandle, trash } from '@wordpress/icons';
+import { dragHandle, trash, edit } from '@wordpress/icons';
 import { Button, ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -77,7 +77,8 @@ export default function ZoomOutToolbar( { clientId, rootClientId } ) {
 		canMove,
 	} = selected;
 
-	const { removeBlock } = useDispatch( blockEditorStore );
+	const { removeBlock, __unstableSetEditorMode } =
+		useDispatch( blockEditorStore );
 
 	const classNames = clsx( 'zoom-out-toolbar', {
 		'is-block-moving-mode': !! blockMovingMode,
@@ -124,6 +125,18 @@ export default function ZoomOutToolbar( { clientId, rootClientId } ) {
 			{ canMove && canRemove && (
 				<Shuffle clientId={ clientId } as={ ToolbarButton } />
 			) }
+
+			{ ! isBlockTemplatePart && (
+				<ToolbarButton
+					className="zoom-out-toolbar-button"
+					icon={ edit }
+					label={ __( 'Edit' ) }
+					onClick={ () => {
+						__unstableSetEditorMode( 'edit' );
+					} }
+				/>
+			) }
+
 			{ canRemove && ! isBlockTemplatePart && (
 				<ToolbarButton
 					className="zoom-out-toolbar-button"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds an "Edit" button to the Zoom Out mode toolbar. When clicked will exit Zoom Out mode and allow fine grain editing.

Co-authored-by: getdave <get_dave@git.wordpress.org>

Related PR https://github.com/WordPress/gutenberg/pull/64573

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There has to be a keyboard accessible means for users to exit Zoom Out mode whilst browsing in the Zoom Out canvas. This is to allow users to choose when they'd like to be able to edit the full content of a pattern.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Add button
- Switch to "Edit" mode on click.

### Suggested improvements

- Ensure selected block is always scrolled to after existing Zoom Out. I think this needs to be handled outside of the click handler as it's a wider problem and thus should be tackled in another PR.
- Consider whether or not to close the Pattern Inserter when entering Edit mode in this fashion.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Page
- Opens Patterns inserter and select category to trigger Zoom Out mode
- Select a section on the editor canvas.
- See the toolbar
- Click "Edit"
- See that editor switches to "Edit" mode.




### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Do the same but ensure it's possible via the keyboard

## Screenshots or screencast <!-- if applicable -->
<img width="3008" alt="Screen Shot 2024-08-16 at 10 18 09" src="https://github.com/user-attachments/assets/f97a9326-e57c-4d22-9500-cf7d5c76c4f5">
