### PR TITLE
RangeControl: disable reset button consistently

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ### Bug Fixes
 
+-   `RangeControl`: disable reset button when the current value is equal to the reset value ([#64579](https://github.com/WordPress/gutenberg/pull/64579)).
 -   `RangeControl`: tweak mark and label absolute positioning ([#64487](https://github.com/WordPress/gutenberg/pull/64487)).
 
 ### Internal

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -41,6 +41,21 @@ import { space } from '../utils/space';
 
 const noop = () => {};
 
+function computeResetValue( {
+	resetFallbackValue,
+	initialPosition,
+}: Pick< RangeControlProps, 'resetFallbackValue' | 'initialPosition' > ) {
+	if ( resetFallbackValue !== undefined ) {
+		return ! Number.isNaN( resetFallbackValue ) ? resetFallbackValue : null;
+	}
+
+	if ( initialPosition !== undefined ) {
+		return ! Number.isNaN( initialPosition ) ? initialPosition : null;
+	}
+
+	return null;
+}
+
 function UnforwardedRangeControl(
 	props: WordPressComponentProps< RangeControlProps, 'input', false >,
 	forwardedRef: ForwardedRef< HTMLInputElement >
@@ -166,13 +181,16 @@ function UnforwardedRangeControl(
 	};
 
 	const handleOnReset = () => {
-		let resetValue: number | null = parseFloat( `${ resetFallbackValue }` );
-		let onChangeResetValue: number | undefined = resetValue;
+		// Reset to `resetFallbackValue` if defined, otherwise set internal value
+		// to `null`.
+		const resetValue = Number.isNaN( resetFallbackValue )
+			? null
+			: resetFallbackValue ?? null;
 
-		if ( isNaN( resetValue ) ) {
-			resetValue = null;
-			onChangeResetValue = undefined;
-		}
+		// const resetValue = computeResetValue( {
+		// 	resetFallbackValue,
+		// 	initialPosition,
+		// } );
 
 		setValue( resetValue );
 
@@ -189,7 +207,7 @@ function UnforwardedRangeControl(
 		 * preserve the undefined callback argument, except when a
 		 * resetFallbackValue is defined.
 		 */
-		onChange( onChangeResetValue );
+		onChange( resetValue ?? undefined );
 	};
 
 	const handleShowTooltip = () => setShowTooltip( true );
@@ -210,6 +228,7 @@ function UnforwardedRangeControl(
 	const offsetStyle = {
 		[ isRTL() ? 'right' : 'left' ]: fillValueOffset,
 	};
+
 	return (
 		<BaseControl
 			__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
@@ -329,7 +348,17 @@ function UnforwardedRangeControl(
 							className="components-range-control__reset"
 							// If the RangeControl itself is disabled, the reset button shouldn't be in the tab sequence.
 							accessibleWhenDisabled={ ! disabled }
-							disabled={ disabled || value === undefined }
+							// The reset button should be disabled if RangeControl itself is disabled,
+							// or if the current `value` is equal to the value that would be currently
+							// assigned when clicking the button.
+							disabled={
+								disabled ||
+								value ===
+									computeResetValue( {
+										resetFallbackValue,
+										initialPosition,
+									} )
+							}
 							variant="secondary"
 							size="small"
 							onClick={ handleOnReset }

--- a/packages/components/src/range-control/index.tsx
+++ b/packages/components/src/range-control/index.tsx
@@ -41,6 +41,10 @@ import { space } from '../utils/space';
 
 const noop = () => {};
 
+/**
+ * Computes the value that `RangeControl` should reset to when pressing
+ * the reset button.
+ */
 function computeResetValue( {
 	resetFallbackValue,
 	initialPosition,
@@ -182,15 +186,11 @@ function UnforwardedRangeControl(
 
 	const handleOnReset = () => {
 		// Reset to `resetFallbackValue` if defined, otherwise set internal value
-		// to `null`.
+		// to `null` — which, if propagated to the `value` prop, will cause
+		// the value to be reset to the `initialPosition` prop if defined.
 		const resetValue = Number.isNaN( resetFallbackValue )
 			? null
 			: resetFallbackValue ?? null;
-
-		// const resetValue = computeResetValue( {
-		// 	resetFallbackValue,
-		// 	initialPosition,
-		// } );
 
 		setValue( resetValue );
 

--- a/packages/components/src/range-control/stories/index.story.tsx
+++ b/packages/components/src/range-control/stories/index.story.tsx
@@ -72,7 +72,7 @@ export const Default: StoryFn< typeof RangeControl > = Template.bind( {} );
 Default.args = {
 	__nextHasNoMarginBottom: true,
 	help: 'Please select how transparent you would like this.',
-	// initialPosition: 50,
+	initialPosition: 50,
 	label: 'Opacity',
 	max: 100,
 	min: 0,

--- a/packages/components/src/range-control/stories/index.story.tsx
+++ b/packages/components/src/range-control/stories/index.story.tsx
@@ -72,7 +72,7 @@ export const Default: StoryFn< typeof RangeControl > = Template.bind( {} );
 Default.args = {
 	__nextHasNoMarginBottom: true,
 	help: 'Please select how transparent you would like this.',
-	initialPosition: 50,
+	// initialPosition: 50,
 	label: 'Opacity',
 	max: 100,
 	min: 0,

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -298,20 +298,13 @@ describe( 'RangeControl', () => {
 	} );
 
 	describe.only( 'reset', () => {
-		// TODO: behaviour to be tested:
-		// - when resetFallbackValue is provided:
-		//    - value resets to resetFallbackValue;
-		//    - onChange() is called with resetFallbackValue;
-		// - when initialPosition is provided:
-		//    - value is assigned to `null`;
-		//    - onChange() is called with `undefined`;
-		//    - value is usually assigned to initialPosition because the component
-		//      is used in controlled mode and initialPosition is used as a fallback;
-		// - when neither resetFallbackValue nor initialPosition are provided:
-		//    - value is assigned to `null`;
-		//    - onChange() is called with `undefined`;
-		//    - value remains `null` (empty) because there is no `initialPosition`
-		//      to fallback to;
+		// TODO: behaviour to be tested, in controlled mode:
+		// - when `resetFallbackValue` is provided, the value is ultimately set to
+		//   `resetFallbackValue`; `onChange()` is called with `resetFallbackValue`.
+		// - when `initialPosition` is provided, the value is ultimately set to
+		//   `initialPosition`; `onChange()` is called with `undefined`.
+		// - when neither `resetFallbackValue` nor `initialPosition` are provided,
+		//   the input values is cleared; `onChange()` is called with `undefined`.
 		// - in any case, when the current value is the same as the reset value
 		//   (ie. the value that would be assigned when clicking the reset button),
 		//   the reset button should be disabled;

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -297,7 +297,25 @@ describe( 'RangeControl', () => {
 		} );
 	} );
 
-	describe( 'reset', () => {
+	describe.only( 'reset', () => {
+		// TODO: behaviour to be tested:
+		// - when resetFallbackValue is provided:
+		//    - value resets to resetFallbackValue;
+		//    - onChange() is called with resetFallbackValue;
+		// - when initialPosition is provided:
+		//    - value is assigned to `null`;
+		//    - onChange() is called with `undefined`;
+		//    - value is usually assigned to initialPosition because the component
+		//      is used in controlled mode and initialPosition is used as a fallback;
+		// - when neither resetFallbackValue nor initialPosition are provided:
+		//    - value is assigned to `null`;
+		//    - onChange() is called with `undefined`;
+		//    - value remains `null` (empty) because there is no `initialPosition`
+		//      to fallback to;
+		// - in any case, when the current value is the same as the reset value
+		//   (ie. the value that would be assigned when clicking the reset button),
+		//   the reset button should be disabled;
+
 		it( 'should reset to a custom fallback value, defined by a parent component', () => {
 			const spy = jest.fn();
 			render(
@@ -318,6 +336,8 @@ describe( 'RangeControl', () => {
 			expect( rangeInput.value ).toBe( '33' );
 			expect( numberInput.value ).toBe( '33' );
 			expect( spy ).toHaveBeenCalledWith( 33 );
+
+			expect( resetButton ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 
 		it( 'should reset to a 50% of min/max value, of no initialPosition or value is defined', () => {

--- a/packages/components/src/range-control/test/index.tsx
+++ b/packages/components/src/range-control/test/index.tsx
@@ -297,19 +297,61 @@ describe( 'RangeControl', () => {
 		} );
 	} );
 
-	describe.only( 'reset', () => {
-		// TODO: behaviour to be tested, in controlled mode:
-		// - when `resetFallbackValue` is provided, the value is ultimately set to
-		//   `resetFallbackValue`; `onChange()` is called with `resetFallbackValue`.
-		// - when `initialPosition` is provided, the value is ultimately set to
-		//   `initialPosition`; `onChange()` is called with `undefined`.
-		// - when neither `resetFallbackValue` nor `initialPosition` are provided,
-		//   the input values is cleared; `onChange()` is called with `undefined`.
-		// - in any case, when the current value is the same as the reset value
-		//   (ie. the value that would be assigned when clicking the reset button),
-		//   the reset button should be disabled;
+	describe( 'reset', () => {
+		it( 'should clear the input value when clicking the reset button', () => {
+			const spy = jest.fn();
+			render( <RangeControl allowReset onChange={ spy } /> );
 
-		it( 'should reset to a custom fallback value, defined by a parent component', () => {
+			const resetButton = getResetButton();
+			const rangeInput = getRangeInput();
+			const numberInput = getNumberInput();
+
+			fireChangeEvent( numberInput, '14' );
+
+			expect( rangeInput.value ).toBe( '14' );
+			expect( numberInput.value ).toBe( '14' );
+			expect( spy ).toHaveBeenCalledWith( 14 );
+
+			fireEvent.click( resetButton );
+
+			// range input resets to min + (max-min)/2
+			expect( rangeInput.value ).toBe( '50' );
+			expect( numberInput.value ).toBe( '' );
+			expect( spy ).toHaveBeenCalledWith( undefined );
+
+			expect( resetButton ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'should reset to the `initialPosition` value when clicking the reset button', () => {
+			const spy = jest.fn();
+			render(
+				<RangeControl
+					allowReset
+					initialPosition={ 23 }
+					onChange={ spy }
+				/>
+			);
+
+			const resetButton = getResetButton();
+			const rangeInput = getRangeInput();
+			const numberInput = getNumberInput();
+
+			fireChangeEvent( numberInput, '14' );
+
+			expect( rangeInput.value ).toBe( '14' );
+			expect( numberInput.value ).toBe( '14' );
+			expect( spy ).toHaveBeenCalledWith( 14 );
+
+			fireEvent.click( resetButton );
+
+			expect( rangeInput.value ).toBe( '23' );
+			expect( numberInput.value ).toBe( '23' );
+			expect( spy ).toHaveBeenCalledWith( undefined );
+
+			expect( resetButton ).toHaveAttribute( 'aria-disabled', 'true' );
+		} );
+
+		it( 'should reset to the `resetFallbackValue` value when clicking the reset button', () => {
 			const spy = jest.fn();
 			render(
 				<RangeControl
@@ -331,27 +373,6 @@ describe( 'RangeControl', () => {
 			expect( spy ).toHaveBeenCalledWith( 33 );
 
 			expect( resetButton ).toHaveAttribute( 'aria-disabled', 'true' );
-		} );
-
-		it( 'should reset to a 50% of min/max value, of no initialPosition or value is defined', () => {
-			render(
-				<RangeControl
-					initialPosition={ undefined }
-					min={ 0 }
-					max={ 100 }
-					allowReset
-					resetFallbackValue={ undefined }
-				/>
-			);
-
-			const resetButton = getResetButton();
-			const rangeInput = getRangeInput();
-			const numberInput = getNumberInput();
-
-			fireEvent.click( resetButton );
-
-			expect( rangeInput.value ).toBe( '50' );
-			expect( numberInput.value ).toBe( '' );
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #63061

Disable the reset button in `RangeControl` when the current value of the component is already equal to the "reset value".

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Leaving the reset button enabled in this scenario can cause confusion in the end user and make the UX worse.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By tweaking the `disabled` logic for the reset button, making sure that `value` is compared to the correct "reset" value in every scenario.

I also updated unit tests in the process.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In Storybook, set `allowReset` to `true` and play around the `RangeControl` component and the `initialPosition` and `resetFallbackValue` props. Make sure that:

- if `resetFallbackValue` is provided, the value resets to `resetFallbackValue`;
- otherwise, if `initialPosition` is provided, the value resets to `initilaPosition`;
- otherwise, the slider resets to the value half way between min and max, and the number input clears up.

In any case, the reset button should become disabled when resetting the `RangeControl` component.