### PR TITLE
Query Title: Add Border Support

### DIFF
--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -58,6 +58,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-query-title"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add Border support in the `Query Title` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Query Title` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Query Title` block's border is Configurable via Global Styles.
- Edit Archive Template & Add `Query Title` Block and Apply the border Styles.
- Verify that `Query Title` block styles take precedence over global Styles.
- Verify that `Query Title` block borders is showing correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ed28594b-2f05-41a1-bf1c-7da6cafdcc76


