### PR TITLE
RadioControl: label radio group using fieldset and legend

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -242,6 +242,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				/>
 				{ displayPostContent && (
 					<RadioControl
+						className="wp-block-latest-posts__post-content-radio"
 						label={ __( 'Show:' ) }
 						selected={ displayPostContentRadio }
 						options={ [

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -18,3 +18,14 @@
 		padding-left: 0;
 	}
 }
+
+// Apply the same styles that would be applied to
+// ".block-editor-block-inspector .components-base-control"
+// (see packages/block-editor/src/components/block-inspector/style.scss)
+.wp-block-latest-posts__post-content-radio {
+	margin-bottom: #{ $grid-unit-30 };
+
+	&:last-child {
+		margin-bottom: $grid-unit-10;
+	}
+}

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -88,14 +88,3 @@
 		text-align: center;
 	}
 }
-
-// Apply the same styles that would be applied to
-// ".block-editor-block-inspector .components-base-control"
-// (see packages/block-editor/src/components/block-inspector/style.scss)
-.wp-block-latest-posts__post-content-radio {
-	margin-bottom: #{ $grid-unit-30 };
-
-	&:last-child {
-		margin-bottom: $grid-unit-10;
-	}
-}

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -88,3 +88,14 @@
 		text-align: center;
 	}
 }
+
+// Apply the same styles that would be applied to
+// ".block-editor-block-inspector .components-base-control"
+// (see packages/block-editor/src/components/block-inspector/style.scss)
+.wp-block-latest-posts__post-content-radio {
+	margin-bottom: #{ $grid-unit-30 };
+
+	&:last-child {
+		margin-bottom: $grid-unit-10;
+	}
+}

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 -   `RangeControl`: disable reset button when the current value is equal to the reset value ([#64579](https://github.com/WordPress/gutenberg/pull/64579)).
 -   `RangeControl`: tweak mark and label absolute positioning ([#64487](https://github.com/WordPress/gutenberg/pull/64487)).
+-   `RadioGroup`: use fieldset and legend to group radio inputs ([#64582](https://github.com/WordPress/gutenberg/pull/64582)).
 
 ### Internal
 

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -18,6 +18,7 @@ import type { RadioControlProps } from './types';
 import { VStack } from '../v-stack';
 import { useBaseControlProps } from '../base-control/hooks';
 import { StyledHelp } from '../base-control/styles/base-control-styles';
+import { VisuallyHidden } from '../visually-hidden';
 
 function generateOptionDescriptionId( radioGroupId: string, index: number ) {
 	return `${ radioGroupId }-${ index }-option-description`;
@@ -85,14 +86,17 @@ export function RadioControl(
 	}
 
 	return (
-		<BaseControl
-			__nextHasNoMarginBottom
-			label={ label }
-			id={ id }
-			hideLabelFromVision={ hideLabelFromVision }
-			help={ help }
-			className={ clsx( className, 'components-radio-control' ) }
-		>
+		<fieldset className="components-radio-control">
+			{ hideLabelFromVision ? (
+				<VisuallyHidden as="label" htmlFor={ id }>
+					{ label }
+				</VisuallyHidden>
+			) : (
+				<BaseControl.VisualLabel as="legend">
+					{ label }
+				</BaseControl.VisualLabel>
+			) }
+
 			<VStack
 				spacing={ 3 }
 				className={ clsx( 'components-radio-control__group-wrapper', {
@@ -142,7 +146,7 @@ export function RadioControl(
 					</div>
 				) ) }
 			</VStack>
-		</BaseControl>
+		</fieldset>
 	);
 }
 

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -90,9 +90,7 @@ export function RadioControl(
 			aria-describedby={ !! help ? generateHelpId( id ) : undefined }
 		>
 			{ hideLabelFromVision ? (
-				<VisuallyHidden as="label" htmlFor={ id }>
-					{ label }
-				</VisuallyHidden>
+				<VisuallyHidden>{ label }</VisuallyHidden>
 			) : (
 				<BaseControl.VisualLabel as="legend">
 					{ label }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -146,6 +146,15 @@ export function RadioControl(
 					</div>
 				) ) }
 			</VStack>
+			{ !! help && (
+				<StyledHelp
+					__nextHasNoMarginBottom
+					id={ id ? id + '__help' : undefined }
+					className="components-base-control__help"
+				>
+					{ help }
+				</StyledHelp>
+			) }
 		</fieldset>
 	);
 }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -86,7 +86,7 @@ export function RadioControl(
 	return (
 		<fieldset
 			id={ id }
-			className={ clsx( 'components-radio-control', className ) }
+			className={ clsx( className, 'components-radio-control' ) }
 			aria-describedby={ !! help ? generateHelpId( id ) : undefined }
 		>
 			{ hideLabelFromVision ? (

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -16,7 +16,6 @@ import BaseControl from '../base-control';
 import type { WordPressComponentProps } from '../context';
 import type { RadioControlProps } from './types';
 import { VStack } from '../v-stack';
-import { useBaseControlProps } from '../base-control/hooks';
 import { StyledHelp } from '../base-control/styles/base-control-styles';
 import { VisuallyHidden } from '../visually-hidden';
 
@@ -26,6 +25,10 @@ function generateOptionDescriptionId( radioGroupId: string, index: number ) {
 
 function generateOptionId( radioGroupId: string, index: number ) {
 	return `${ radioGroupId }-${ index }`;
+}
+
+function generateHelpId( radioGroupId: string ) {
+	return `${ radioGroupId }__help`;
 }
 
 /**
@@ -76,17 +79,15 @@ export function RadioControl(
 	const onChangeValue = ( event: ChangeEvent< HTMLInputElement > ) =>
 		onChange( event.target.value );
 
-	// Use `useBaseControlProps` to get the id of the help text.
-	const {
-		controlProps: { 'aria-describedby': helpTextId },
-	} = useBaseControlProps( { id, help } );
-
 	if ( ! options?.length ) {
 		return null;
 	}
 
 	return (
-		<fieldset className="components-radio-control">
+		<fieldset
+			className="components-radio-control"
+			aria-describedby={ !! help ? generateHelpId( id ) : undefined }
+		>
 			{ hideLabelFromVision ? (
 				<VisuallyHidden as="label" htmlFor={ id }>
 					{ label }
@@ -117,14 +118,9 @@ export function RadioControl(
 							onChange={ onChangeValue }
 							checked={ option.value === selected }
 							aria-describedby={
-								clsx( [
-									!! option.description &&
-										generateOptionDescriptionId(
-											id,
-											index
-										),
-									helpTextId,
-								] ) || undefined
+								!! option.description
+									? generateOptionDescriptionId( id, index )
+									: undefined
 							}
 							{ ...additionalProps }
 						/>
@@ -149,7 +145,7 @@ export function RadioControl(
 			{ !! help && (
 				<StyledHelp
 					__nextHasNoMarginBottom
-					id={ id ? id + '__help' : undefined }
+					id={ generateHelpId( id ) }
 					className="components-base-control__help"
 				>
 					{ help }

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -85,7 +85,8 @@ export function RadioControl(
 
 	return (
 		<fieldset
-			className="components-radio-control"
+			id={ id }
+			className={ clsx( 'components-radio-control', className ) }
 			aria-describedby={ !! help ? generateHelpId( id ) : undefined }
 		>
 			{ hideLabelFromVision ? (

--- a/packages/components/src/radio-control/index.tsx
+++ b/packages/components/src/radio-control/index.tsx
@@ -90,7 +90,7 @@ export function RadioControl(
 			aria-describedby={ !! help ? generateHelpId( id ) : undefined }
 		>
 			{ hideLabelFromVision ? (
-				<VisuallyHidden>{ label }</VisuallyHidden>
+				<VisuallyHidden as="legend">{ label }</VisuallyHidden>
 			) : (
 				<BaseControl.VisualLabel as="legend">
 					{ label }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -1,3 +1,12 @@
+.components-radio-control {
+	border: 0;
+	margin: 0;
+	padding: 0;
+
+	font-family: $default-font;
+	font-size: $default-font-size;
+}
+
 .components-radio-control__group-wrapper.has-help {
 	margin-block-end: $grid-unit-15;
 }

--- a/packages/components/src/radio-control/style.scss
+++ b/packages/components/src/radio-control/style.scss
@@ -66,5 +66,7 @@
 
 	// Override the top margin of the StyledHelp component from BaseControl.
 	// TODO: we should tweak the StyledHelp component to not have a top margin.
-	margin-top: 0;
+	&.components-radio-control__option-description {
+		margin-top: 0;
+	}
 }

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -67,6 +67,21 @@ describe.each( [
 			).toBeVisible();
 		} );
 
+		it( 'should group all radios under a fieldset with an accessible label even when the lavel is visually hidden', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultProps }
+					hideLabelFromVision
+					onChange={ onChangeSpy }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'group', { name: defaultProps.label } )
+			).toBeVisible();
+		} );
+
 		it( 'should describe the radio group with the help text', () => {
 			const onChangeSpy = jest.fn();
 			render(

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -56,6 +56,32 @@ describe.each( [
 	const [ , Component ] = modeAndComponent;
 
 	describe( 'semantics and labelling', () => {
+		it( 'should group all radios under a fieldset with an accessible label (legend)', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component { ...defaultProps } onChange={ onChangeSpy } />
+			);
+
+			expect(
+				screen.getByRole( 'group', { name: defaultProps.label } )
+			).toBeVisible();
+		} );
+
+		it( 'should describe the radio group with the help text', () => {
+			const onChangeSpy = jest.fn();
+			render(
+				<Component
+					{ ...defaultProps }
+					help="Test help text"
+					onChange={ onChangeSpy }
+				/>
+			);
+
+			expect(
+				screen.getByRole( 'group', { name: defaultProps.label } )
+			).toHaveAccessibleDescription( 'Test help text' );
+		} );
+
 		it( 'should render radio inputs with accessible labels', () => {
 			const onChangeSpy = jest.fn();
 			render(
@@ -101,46 +127,7 @@ describe.each( [
 			).toHaveAccessibleName( defaultProps.options[ 1 ].label );
 		} );
 
-		it( 'should use the group help text to describe individual options', () => {
-			const onChangeSpy = jest.fn();
-			render(
-				<Component
-					{ ...defaultProps }
-					onChange={ onChangeSpy }
-					selected={ defaultProps.options[ 1 ].value }
-					help="Select your favorite animal."
-				/>
-			);
-
-			for ( const option of defaultProps.options ) {
-				expect(
-					screen.getByRole( 'radio', { name: option.label } )
-				).toHaveAccessibleDescription( 'Select your favorite animal.' );
-			}
-		} );
-
 		it( 'should use the option description text to describe individual options', () => {
-			const onChangeSpy = jest.fn();
-			render(
-				<Component
-					{ ...defaultPropsWithDescriptions }
-					onChange={ onChangeSpy }
-					selected={ defaultProps.options[ 1 ].value }
-				/>
-			);
-
-			let index = 1;
-			for ( const option of defaultProps.options ) {
-				expect(
-					screen.getByRole( 'radio', { name: option.label } )
-				).toHaveAccessibleDescription(
-					`This is the option number ${ index }.`
-				);
-				index += 1;
-			}
-		} );
-
-		it( 'should use both the option description text and the group help text to describe individual options', () => {
 			const onChangeSpy = jest.fn();
 			render(
 				<Component
@@ -151,12 +138,13 @@ describe.each( [
 				/>
 			);
 
+			// Group help text should not be used to describe individual options.
 			let index = 1;
 			for ( const option of defaultProps.options ) {
 				expect(
 					screen.getByRole( 'radio', { name: option.label } )
 				).toHaveAccessibleDescription(
-					`This is the option number ${ index }. Select your favorite animal`
+					`This is the option number ${ index }.`
 				);
 				index += 1;
 			}

--- a/packages/components/src/radio-control/test/index.tsx
+++ b/packages/components/src/radio-control/test/index.tsx
@@ -67,7 +67,7 @@ describe.each( [
 			).toBeVisible();
 		} );
 
-		it( 'should group all radios under a fieldset with an accessible label even when the lavel is visually hidden', () => {
+		it( 'should group all radios under a fieldset with an accessible label even when the label is visually hidden', () => {
 			const onChangeSpy = jest.fn();
 			render(
 				<Component

--- a/packages/editor/src/components/post-discussion/style.scss
+++ b/packages/editor/src/components/post-discussion/style.scss
@@ -2,15 +2,6 @@
 	// sidebar width - popover padding - form margin
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;
 	margin: $grid-unit-10;
-
-	.components-radio-control__option {
-		align-items: flex-start;
-	}
-
-	.components-radio-control__label .components-text {
-		display: block;
-		margin-top: $grid-unit-05;
-	}
 }
 .editor-post-discussion__panel-toggle {
 

--- a/packages/editor/src/components/post-format/style.scss
+++ b/packages/editor/src/components/post-format/style.scss
@@ -7,9 +7,3 @@
 	min-width: $sidebar-width - $grid-unit-20 - $grid-unit-20;
 	margin: $grid-unit-10;
 }
-
-.editor-post-format__options {
-	.components-base-control__field > .components-v-stack {
-		gap: $grid-unit-15;
-	}
-}

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -18,25 +18,6 @@
 		padding: $grid-unit-20;
 	}
 
-	.editor-change-status__options {
-		.components-base-control__field > .components-v-stack {
-			gap: $grid-unit-15;
-		}
-
-		// TODO: it's not great to override component styles.. This might be resolved
-		// by the new radio control component.
-		.components-radio-control__option {
-			align-items: flex-start;
-		}
-
-		label {
-			.components-text {
-				display: block;
-				margin-top: $grid-unit-05;
-			}
-		}
-	}
-
 	.editor-change-status__password-legend {
 		padding: 0;
 		margin-bottom: $grid-unit-10;

--- a/packages/editor/src/components/site-discussion/style.scss
+++ b/packages/editor/src/components/site-discussion/style.scss
@@ -3,17 +3,3 @@
 	padding: $grid-unit-20;
 }
 
-.editor-site-discussion__options {
-	// TODO: it's not great to override component styles.. This might be resolved
-	// by the new radio control component.
-	.components-radio-control__option {
-		align-items: flex-start;
-	}
-
-	label {
-		.components-text {
-			display: block;
-			margin-top: $grid-unit-05;
-		}
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52890
Related to https://github.com/WordPress/gutenberg/pull/63751#discussion_r1686840091

Changes how radio inputs are grouped and labelled in `RadioControl`, switching to `fieldset` + `legend`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The previous approach was incorrect and inaccessible (see #52890)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Swapped `BaseControl` for a custom `fieldset`+`legend` implementation. Visual styles have been preserved thanks to using `StyledLabel` and `StyledHelp` components from `BaseControl`;
- The help text now describes the whole radio group (`fieldset`) instead of each option
- Updated unit tests
- Cleaned up some unnecessary style overrides

## Next steps

Consider replacing custom implementation in the [post visibility UI](https://github.com/WordPress/gutenberg/blob/dc27d6b034a0d112dce0b71fb7d3d5dd8e870fe6/packages/editor/src/components/post-visibility/index.js)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load the `RadioControl` examples in Storybook
  - Using screen readers and browser developer tools, make sure that the radio inputs are correctly grouped and labeled by the `fieldset` + `legend`
  - Make sure that the group help text (`help` prop) is not used to describe each option, but is instead used to describe the group itself;
  - Make sure that the design of the component hasn't changed with respect to `trunk`
- Check usages across the block editor and make sure that there are no behavioral or visual regressions (for example, the component won't be affected by any styles targeting `.components-base-control` anymore, see https://github.com/WordPress/gutenberg/pull/64526 as related PR)

## Screenshots or screencast <!-- if applicable -->

No visible changes.