### PR TITLE
TextDecorationControl, TextTransformControl: Remove size prop in Storybook

### DIFF
--- a/packages/block-editor/src/components/text-decoration-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-decoration-control/stories/index.story.js
@@ -13,10 +13,6 @@ export default {
 	component: TextDecorationControl,
 	argTypes: {
 		onChange: { action: 'onChange' },
-		size: {
-			options: [ 'default', '__unstable-large' ],
-			control: { type: 'radio' },
-		},
 	},
 };
 

--- a/packages/block-editor/src/components/text-transform-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-transform-control/stories/index.story.js
@@ -13,10 +13,6 @@ export default {
 	component: TextTransformControl,
 	argTypes: {
 		onChange: { action: 'onChange' },
-		size: {
-			options: [ 'default', '__unstable-large' ],
-			control: { type: 'radio' },
-		},
 	},
 };
 


### PR DESCRIPTION
Noticed in #64529

## What?

Removes the outdated `size` prop controls from the Storybook for TextDecorationControl and TextTransformControl.

## Why?

This prop was introduced in #43328 (Aug 26, 2022) and regressed in #44067 (Sep 16, 2022). There was technically a Gutenberg plugin release in between, but there's not much we can do about it at this point 😅 They have been defaulting to the 40px size for a while now.

## Testing Instructions

See Storybook for the two components.