### PR TITLE
Post Author: Add Border Support

### DIFF
--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -64,6 +64,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-post-author-editor",

--- a/packages/block-library/src/post-author/style.scss
+++ b/packages/block-library/src/post-author/style.scss
@@ -1,6 +1,7 @@
 .wp-block-post-author {
 	display: flex;
 	flex-wrap: wrap;
+	box-sizing: border-box;
 
 	&__byline {
 		width: 100%;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Post Author` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Author` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Post Author` block's border is Configurable via Global Styles.
- Edit Single Posts Template &  Add  `Post Author` block and Apply the border Styles.
- Verify that `Post Author` block styles take precedence over global Styles.
- Verify that `Post Author` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5ff6130d-60b6-43dd-9e2e-75a84e645a36


