### PR TITLE
Performance: Fetch permissions for visible patterns only

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -23,7 +23,7 @@ import {
 } from '../../utils/constants';
 import usePatternSettings from './use-pattern-settings';
 import { unlock } from '../../lock-unlock';
-import usePatterns from './use-patterns';
+import usePatterns, { useAugmentPatternsWithPermissions } from './use-patterns';
 import PatternsHeader from './header';
 import { useEditPostAction } from '../dataviews-actions';
 import {
@@ -136,6 +136,8 @@ export default function DataviewsPatterns() {
 		return filterSortAndPaginate( patterns, viewWithoutFilters, fields );
 	}, [ patterns, view, fields, type ] );
 
+	const dataWithPermissions = useAugmentPatternsWithPermissions( data );
+
 	const templatePartActions = usePostActions( {
 		postType: TEMPLATE_PART_POST_TYPE,
 		context: 'list',
@@ -175,7 +177,7 @@ export default function DataviewsPatterns() {
 					paginationInfo={ paginationInfo }
 					fields={ fields }
 					actions={ actions }
-					data={ data || EMPTY_ARRAY }
+					data={ dataWithPermissions || EMPTY_ARRAY }
 					getItemId={ ( item ) => item.name ?? item.id }
 					isLoading={ isResolving }
 					view={ view }


### PR DESCRIPTION
## What?

When rendering patterns, we need the user permissions. Unfortunately right now, the only way to fetch the permissions is to do a request per pattern. There's some ongoing work to improve that but in the mean time, this PR restores the previous behavior where we fetch the permissions for visible patterns only.

## Testing Instructions

Please check #64219 for detailed steps.
