### PR TITLE
Make plugin-registered templates overriden by themes to fall back to plugin-registered title and description

### DIFF
--- a/backport-changelog/6.7/7125.md
+++ b/backport-changelog/6.7/7125.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7125
 
 * https://github.com/WordPress/gutenberg/pull/61577
+* https://github.com/WordPress/gutenberg/pull/64610

--- a/lib/compat/wordpress-6.7/compat.php
+++ b/lib/compat/wordpress-6.7/compat.php
@@ -27,11 +27,15 @@ function _gutenberg_add_block_templates_from_registry( $query_result, $query, $t
 	foreach ( $query_result as $key => $value ) {
 		$registered_template = WP_Block_Templates_Registry::get_instance()->get_by_slug( $query_result[ $key ]->slug );
 		if ( $registered_template ) {
-			$query_result[ $key ]->plugin = $registered_template->plugin;
-			$query_result[ $key ]->origin =
+			$query_result[ $key ]->plugin      = $registered_template->plugin;
+			$query_result[ $key ]->origin      =
 				'theme' !== $query_result[ $key ]->origin && 'theme' !== $query_result[ $key ]->source ?
 				'plugin' :
 				$query_result[ $key ]->origin;
+			$query_result[ $key ]->title       =
+				empty( $query_result[ $key ]->title ) || $query_result[ $key ]->title === $query_result[ $key ]->slug ?
+				$registered_template->title : $query_result[ $key ]->title;
+			$query_result[ $key ]->description = empty( $query_result[ $key ]->description ) ? $registered_template->description : $query_result[ $key ]->description;
 		}
 	}
 
@@ -70,11 +74,13 @@ function _gutenberg_add_block_template_plugin_attribute( $block_template ) {
 	if ( $block_template ) {
 		$registered_template = WP_Block_Templates_Registry::get_instance()->get_by_slug( $block_template->slug );
 		if ( $registered_template ) {
-			$block_template->plugin = $registered_template->plugin;
-			$block_template->origin =
+			$block_template->plugin      = $registered_template->plugin;
+			$block_template->origin      =
 				'theme' !== $block_template->origin && 'theme' !== $block_template->source ?
 				'plugin' :
 				$block_template->origin;
+			$block_template->title       = empty( $block_template->title ) || $block_template->title === $block_template->slug ? $registered_template->title : $block_template->title;
+			$block_template->description = empty( $block_template->description ) ? $registered_template->description : $block_template->description;
 		}
 	}
 

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -160,6 +160,12 @@ test.describe( 'Block template registration', () => {
 		await expect(
 			page.getByText( 'Custom Template (overridden by the theme)' )
 		).toBeHidden();
+		// Verify the template description fall backs to the plugin registered description.
+		await expect(
+			page.getByText(
+				'A custom template registered by a plugin and overridden by a theme.'
+			)
+		).toBeVisible();
 		// Verify the theme template shows the theme name as the author.
 		await expect( page.getByText( 'AuthorEmptytheme' ) ).toBeVisible();
 	} );


### PR DESCRIPTION
## What?

As mentioned in https://github.com/WordPress/gutenberg/issues/64576, plugin-registered templates that are overridden by themes have an empty title and description if the theme doesn't provide them in `theme.json`. This PR refactors that, so the theme can still override those, but if they are missing, Gutenberg will fall back to the title and description from the template registry.

Closes https://github.com/WordPress/gutenberg/issues/64576.

## Why?

Forcing themes to provide a title and description for plugin templates adds unnecessary burden and will make it difficult for plugins to update template titles/descriptions in the future, as themes will have been forced to provide an override.

## How?

We use the hooks in `get_block_templates` and `get_block_template` to add the fallback template title and description.

## Testing Instructions

**Step 1: Register a block template**:

```php
add_action( 'init', 'devblog_register_plugin_templates' );

function devblog_register_plugin_templates() {
	wp_register_block_template( 'devblog-plugin-templates//example', [
		'title'       => __( 'Example', 'devblog-plugin-templates' ),
		'description' => __( 'An example block template from a plugin.', 'devblog-plugin-templates' ),
		'content'     => '<!-- wp:template-part {"slug":"header","area":"header","tagName":"header"} /-->
			<!-- wp:group {"tagName":"main"} -->
			<main class="wp-block-group">
				<!-- wp:group {"layout":{"type":"constrained"}} -->
				<div class="wp-block-group">
					<!-- wp:paragraph -->
					<p>This is a plugin-registered template.</p>
					<!-- /wp:paragraph -->
				</div>
				<!-- /wp:group -->
			</main>
			<!-- /wp:group -->
			<!-- wp:template-part {"slug":"footer","area":"footer","tagName":"footer"} /-->'
	] );
}
```

**Step 2: Verify title and description are correct in the UI**

Title should be should be `Example`, and description should be `An example block template from a plugin` in the Templates UI.

**Step 3: Overwrite example.html in a theme**

Create a `/templates/example.html` template in a theme with whatever block markup you want.

**Step 4: Check template title and description**

Reload the Site Editor and verify the title and description continue to be `Example` and `An example block template from a plugin` respectively.

## Screenshots or screencast

Before | After
--- | ---
![Template in the Site Editor UI showing an incorrect title and description](https://github.com/user-attachments/assets/9f150d3a-dcff-419d-ba7e-5a4ee796259f) | ![Template in the Site Editor UI showing correct title and description](https://github.com/user-attachments/assets/6d0743c0-1f6c-42b3-aa1d-07a2b66424ed)