### PR TITLE
Fix: Link Control text/url erase issue 

### DIFF
--- a/packages/block-library/src/navigation-link/update-attributes.js
+++ b/packages/block-library/src/navigation-link/update-attributes.js
@@ -88,7 +88,7 @@ export const updateAttributes = (
 
 	setAttributes( {
 		// Passed `url` may already be encoded. To prevent double encoding, decodeURI is executed to revert to the original string.
-		...( newUrl && { url: encodeURI( safeDecodeURI( newUrl ) ) } ),
+		...{ url: newUrl ? encodeURI( safeDecodeURI( newUrl ) ) : newUrl },
 		...( label && { label } ),
 		...( undefined !== opensInNewTab && { opensInNewTab } ),
 		...( id && Number.isInteger( id ) && { id } ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes : https://github.com/WordPress/gutenberg/issues/64598

## Why?
The value of url, in link control can't remove completely. blocking to add new value

## How?
Update the short-circuit expression with ternary expression. short-circuit expression skip the url value update in case if updated state value is empty string.
