### PR TITLE
Post Author Biography: Add Border Support

### DIFF
--- a/packages/block-library/src/post-author-biography/block.json
+++ b/packages/block-library/src/post-author-biography/block.json
@@ -43,6 +43,19 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
-	}
+	},
+	"style": "wp-block-post-author-biography"
 }

--- a/packages/block-library/src/post-author-biography/style.scss
+++ b/packages/block-library/src/post-author-biography/style.scss
@@ -1,0 +1,4 @@
+.wp-block-post-author-biography {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -32,6 +32,7 @@
 @import "./page-list/style.scss";
 @import "./paragraph/style.scss";
 @import "./post-author/style.scss";
+@import "./post-author-biography/style.scss";
 @import "./post-comments-form/style.scss";
 @import "./post-content/style.scss";
 @import "./post-date/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the `Post Author Biography` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Author Biography` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border block support in block.json.

## Testing Instructions

- Go to Global Styles Settings ( Under Appearance > Editor > Styles > Edit styles > Blocks ).
- Make sure that `Post Author Biography` block's border is Configurable via Global Styles.
- Edit Template/Page  &  Add  `Post Author Biography` block and Apply the border Styles.
- Verify that `Post Author Biography` block styles take precedence over global Styles.
- Verify that `Post Author Biography` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->


https://github.com/user-attachments/assets/cc754f1b-faeb-4524-9dbb-a8726e7bf775


