### PR TITLE
Note about image sizes in MediaUpload::onSelect

### DIFF
--- a/packages/block-editor/src/components/media-upload/README.md
+++ b/packages/block-editor/src/components/media-upload/README.md
@@ -105,6 +105,8 @@ Callback called when the media modal is closed after media is selected.
 
 This is called subsequent to `onClose` when media is selected. The selected media are passed as an argument.
 
+The `image.sizes.full` resolution does always exist. Other defined sizes are only available when the image is larger and thus could be scaled down.
+
 -   Type: `Function`
 -   Required: Yes
 -   Platform: Web | Mobile


### PR DESCRIPTION
## What?
Document that not all image sizes are available when an image has been selected in MediaUpload.

## Why?
It is not documented that the available image sizes depend on the original image's resolution.

## How?
README is updated


Related: #7483, #7605.