### PR TITLE
Block bindings: Hide keys starting with underscore

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -88,10 +88,10 @@ export default {
 			return null;
 		}
 
-		// Remove footnotes from the list of fields
+		// Remove footnotes or private keys from the list of fields.
 		return Object.fromEntries(
 			Object.entries( metaFields ).filter(
-				( [ key ] ) => key !== 'footnotes'
+				( [ key ] ) => key !== 'footnotes' && key.charAt( 0 ) !== '_'
 			)
 		);
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #64575

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Keys starting with underscore should be considered as hidden following the guides:
https://developer.wordpress.org/plugins/metadata/managing-post-metadata/#hidden-custom-fields

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By filtering the values like footnotes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Register a private key. Check that exists in the DB.
- Use block bindings API and confirm is not being displayed.

I think we should wait for a definitive version of the UI to add an e2e test for this one. As reaching the list of fields to bind is not so easy (all the attributes are computed generated).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
Screenshot of the UI not showing private registered field color.
<img width="1509" alt="Screenshot 2024-08-19 at 20 04 06" src="https://github.com/user-attachments/assets/b307c6ad-a7f6-4489-9f24-5d0236cd62f7">


The field in the database.
<img width="1360" alt="Screenshot 2024-08-19 at 20 01 21" src="https://github.com/user-attachments/assets/22936333-199e-4395-9f94-9107629f7569">

Code used to add the field:
`add_post_meta( 61, '_color', 'red', true );`

