### PR TITLE
Remove invisible overlay over metaboxes while saving

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
+++ b/packages/edit-post/src/components/meta-boxes/meta-boxes-area/style.scss
@@ -61,17 +61,6 @@
 		width: 44px;
 	}
 
-	&.is-loading::before {
-		position: absolute;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		content: "";
-		background: transparent;
-		z-index: z-index(".edit-post-meta-boxes-area.is-loading::before");
-	}
-
 	.components-spinner {
 		position: absolute;
 		top: 10px;


### PR DESCRIPTION
## What?
This PR removes the use of an invisible element to prevent clicks inside metaboxes during a save.

## Why?
While the existing approach might make sense in theory, in reality, it results in flaky playwright tests which rely on access to elements in that element. 

It's also inconsistently used, as blocks themselves do not do this same thing. 

This approach is not a reliable way of doing this anyway, as you can still use the tab key to navigate into that area and make changes, for example.

## How?
This PR simply removes the CSS which puts the empty element on top of the metabox.

## Testing Instructions
1. On `trunk` load a post in the UI and enable Custom Fields in the Post Editor's Preferences
2. During a save of a post, notice that the custom fields are unclickable, with an `is-loading` class applied to the `edit-post-meta-boxes-area` elements.
3. On `try/remove-is-loading-invisible-overlay`, notice that div is no longer there.

### Testing Instructions for Keyboard
Notice you can tab into the metaboxes on either branch, highlighting that this is not needed or reliable, and can be removed.

## Screenshots or screencast <!-- if applicable -->

<img width="1724" alt="Screenshot 2024-08-19 at 3 16 51 PM" src="https://github.com/user-attachments/assets/00c52bda-7e3f-4e45-80f6-ec79a079a0ff">
