### PR TITLE
Page list: Use `fields` param for `get_pages()`

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -263,12 +263,11 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$parent_page_id = $attributes['parentPageID'];
 	$is_nested      = $attributes['isNested'];
 
-	$all_pages = get_posts(
+	$all_pages = get_pages(
 		array(
-			'post_type'   => 'page',
 			'sort_column' => 'menu_order,post_title',
 			'order'       => 'asc',
-			'fields'      => 'ID, post_author, post_date, post_date_gmt, post_title, post_name, post_status, post_type, post_author, post_parent'
+			'fields'      => 'ID, post_author, post_date, post_date_gmt, post_title, post_name, post_status, post_type, post_author, post_parent',
 		)
 	);
 

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -263,10 +263,12 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$parent_page_id = $attributes['parentPageID'];
 	$is_nested      = $attributes['isNested'];
 
-	$all_pages = get_pages(
+	$all_pages = get_posts(
 		array(
+			'post_type'   => 'page',
 			'sort_column' => 'menu_order,post_title',
 			'order'       => 'asc',
+			'fields'      => 'ID, post_author, post_date, post_date_gmt, post_title, post_name, post_status, post_type, post_author, post_parent'
 		)
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Specify the fields used in the query so the page list component doesn't break for pages with a very large content.

## Why?
`get_pages()` always selects all fields (`*`) - and some data isn't used when rendering the block. This breaks sites that have pages with extensive content.
We could use a direct query, but caching wouldn't be implemented. By specifying the `fields` param, we can specify the list of fields used in the component, andcaching gets deferred to `WP_Query`.
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
For a site with very large content on its pages, try to load/use/add the navigation block and ensure it loads correctly. It's somewhat difficult to reproduce because sometimes - in a local environment - you can meet other limits (OOM, request failing because OOM, etc), so it's more like an optimization to be able to render the block/cache the results properly so it can be used.