### PR TITLE
Site Editor: Always use auto-cursor style for editable text

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -250,11 +250,13 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
 
-	&.is-selected {
+	&.is-selected,
+	&.is-hovered {
 		cursor: default;
 
-		&.rich-text {
-			cursor: unset;
+		&.rich-text,
+		.rich-text {
+			cursor: auto;
 		}
 	}
 


### PR DESCRIPTION
Fixes #53374

## What?

This PR applies the auto-cursor style whenever the text is editable, i.e., when it's the RichText component.

This makes it possible to tell by the cursor whether the text is editable or not.

## Why?

As of #40785, blocks that are non-editable text will now use the default cursor.

However, the block itself is not necessarily a `RichText` component, it may have a `RichText` component in it, or it may have an editable block inside it.

## How?

In addition to applying auto-cursor style when the block itself is editable, this PR also applies auto-cursor to any `RichText` components contained within.

Additionally, this PR applies the appropriate cursor style when the block is not selected and is hovered over.

## Testing Instructions

- Open the Site Editor.
- Inserts the Archive Title block (non-editable block).
- Inserts the Table block (Cells and captions are editable).
- Wrap these blocks in a Group block.
- Select the Group block.
- When you hover over a block inside, the auto-cursor style should always be applied to the editable text.
- Select a block inside the Group block. The auto-cursor style should always be applied to the editable text.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/e1d6a726-ea60-4bad-94c4-f2f85ea08f73


### After

https://github.com/user-attachments/assets/0fa35751-3035-48ab-b7b0-a3928877f200


