### PR TITLE
Docs - Dataviews: Better explanation of the "elements" property and its connection to the "filterBy" property

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -124,6 +124,7 @@ Each field is an object with the following properties:
 
     -   `value`: The id of the value to filter to (for internal use)
     -   `label`: The text that will be displayed in the UI for the item.
+    -    `description`: A longer description that describes the element, to also be displayed. Optional.
 
     To enable the filter by a field we just need to set a proper value to the `elements` property of the field we'd like to filter by.
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -120,13 +120,19 @@ Each field is an object with the following properties:
 -   `label`: the field's name to be shown in the UI.
 -   `getValue`: function that returns the value of the field, defaults to `field[id]`.
 -   `render`: function that renders the field. Optional, `getValue` will be used if `render` is not defined.
--   `elements`: the set of valid values for the field's value.
+-   <code id="fields-elements">elements</code>: The list of options to pick from when using the field as a filter. It expects an array of objects with the following properties:
+
+    -   `value`: The id of the value to filter to (for internal use)
+    -   `label`: The text that will be displayed in the UI for the item.
+
+    To enable the filter by a field we just need to set a proper value to the `elements` property of the field we'd like to filter by.
+
 -   `type`: the type of the field. See "Field types".
 -   `enableSorting`: whether the data can be sorted by the given field. True by default.
 -   `enableHiding`: whether the field can be hidden. True by default.
 -   `enableGlobalSearch`: whether the field is searchable. False by default.
--   `filterBy`: configuration for the filters.
-    -   `operators`: the list of operators supported by the field.
+-   `filterBy`: configuration for the filters enabled by the `elements` property.
+    -   `operators`: the list of [operators](#operators) supported by the field.
     -   `isPrimary`: whether it is a primary filter. A primary filter is always visible and is not listed in the "Add filter" component, except for the list layout where it behaves like a secondary filter.
 
 ### `view`: `object`

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -120,7 +120,7 @@ Each field is an object with the following properties:
 -   `label`: the field's name to be shown in the UI.
 -   `getValue`: function that returns the value of the field, defaults to `field[id]`.
 -   `render`: function that renders the field. Optional, `getValue` will be used if `render` is not defined.
--   <code id="fields-elements">elements</code>: The list of options to pick from when using the field as a filter. It expects an array of objects with the following properties:
+-   <code id="fields-elements">elements</code>: The list of options to pick from when using the field as a filter or when editing (DataForm component). It expects an array of objects with the following properties:
 
     -   `value`: The id of the value to filter to (for internal use)
     -   `label`: The text that will be displayed in the UI for the item.


### PR DESCRIPTION
## What?
The connection between the `elements` and `filterBy` properties for each item passed to the `fields` prop is not clear in the docs. This PR aims to clarify this in the docs.

## Why?
To use the Dataviews component outside of WordPress, the purpose of each property needs to be crystal clear in order to make the most of this component and alleviate pain points.

## How?
This PR add to the docs the following clarifications:
- The format expected by the `elements` property
- That a filter by a field is enabled just by setting a value to the `elements` property - this is a bit confusing as one would expect to enable filters by a fields somehow through the `filterBy` property 

cc: @oandregal 