### PR TITLE
Post editor: apply space below content using a pseudo-element instead of padding-bottom

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -74,7 +74,6 @@ function useEditorStyles() {
 		hasThemeStyleSupport,
 		editorSettings,
 		isZoomedOutView,
-		hasMetaBoxes,
 		renderingMode,
 		postType,
 	} = useSelect( ( select ) => {
@@ -86,7 +85,6 @@ function useEditorStyles() {
 				select( editPostStore ).isFeatureActive( 'themeStyles' ),
 			editorSettings: select( editorStore ).getEditorSettings(),
 			isZoomedOutView: __unstableGetEditorMode() === 'zoom-out',
-			hasMetaBoxes: select( editPostStore ).hasMetaBoxes(),
 			renderingMode: getRenderingMode(),
 			postType: _postType,
 		};
@@ -132,16 +130,13 @@ function useEditorStyles() {
 		// bottom, there needs to be room to scroll up.
 		if (
 			! isZoomedOutView &&
-			! hasMetaBoxes &&
 			renderingMode === 'post-only' &&
 			! DESIGN_POST_TYPES.includes( postType )
 		) {
 			return [
 				...baseStyles,
 				{
-					// Should override global styles padding, so ensure 0-1-0
-					// specificity.
-					css: ':root :where(body){padding-bottom: 40vh}',
+					css: ':root :where(.editor-styles-wrapper)::after {content: ""; display: block; height: 40vh;}',
 				},
 			];
 		}


### PR DESCRIPTION
## What?
Fixes #63882

That issue mentions that there's no space under the content with metaboxes enabled like there is when metaboxes are disabled.

This PR tries to fix by using CSS that works whether metaboxes are enabled or not.

## How?
The padding bottom solution doesn't work with metaboxes enabled, it causes a big gap under the metaboxes panel

Instead of using padding, use the `::after` pseudo element and set a height.

I've also adjusted the selector to one that works both with and without metaboxes.

Not sure if this is a workable solution, so some feedback would be appreciated.

## Testing Instructions
1. Open up a long post (e.g. the gutenberg demo post)
2. Enable metaboxes, observe there's now a gap at the end of the content
3. Try typing, ensure the typewriter effect works (scroll position stays constant)
4. Check that clicking below the content focuses the last block (though this seems a bit flakey in trunk for me)

## Screenshots or screencast <!-- if applicable -->
#### Before
![Screenshot 2024-08-20 at 5 57 21 PM](https://github.com/user-attachments/assets/8673e8f5-82c0-4959-a166-fd4f8001bceb)

#### After
![Screenshot 2024-08-20 at 5 56 41 PM](https://github.com/user-attachments/assets/3fe93372-e096-4f2b-8c01-fcf8867853e9)

