### PR TITLE
Dataviews: Filter icon is displayed even when no filter capabilities are given to any field 

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -95,6 +95,9 @@ export function FilterVisibilityToggle( {
 	const visibleFilters = filters.filter( ( filter ) => filter.isVisible );
 
 	const hasVisibleFilters = !! visibleFilters.length;
+	if ( filters.length === 0 ) {
+		return null;
+	}
 	if ( ! hasVisibleFilters ) {
 		return (
 			<AddFilterDropdownMenu


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This fix hides the dropdown button when there are no filter option available to choose from


## Why?
Fixes https://github.com/WordPress/gutenberg/issues/64631

## How?
Added a check if filters are available, if not then return null


## Testing Instructions
1. Clone the repo
2. Edit `packages/dataviews/src/components/dataviews/stories/fixtures.js` and comment on any elements or filterBy properties passed in the items passed to the fields props
```js
{
		label: 'Type',
		id: 'type',
		enableHiding: false,
		// elements: [
		// 	{ value: 'Not a planet', label: 'Not a planet' },
		// 	{ value: 'Ice giant', label: 'Ice giant' },
		// 	{ value: 'Terrestrial', label: 'Terrestrial' },
		// 	{ value: 'Gas giant', label: 'Gas giant' },
		// ],
},
```

```js
{
		label: 'Categories',
		id: 'categories',
		// elements: [
		// 	{ value: 'Space', label: 'Space' },
		// 	{ value: 'NASA', label: 'NASA' },
		// 	{ value: 'Planet', label: 'Planet' },
		// 	{ value: 'Solar system', label: 'Solar system' },
		// 	{ value: 'Ice giant', label: 'Ice giant' },
		// ],
		// filterBy: {
		// 	operators: [ 'isAny', 'isNone', 'isAll', 'isNotAll' ],
		// },
		getValue: ( { item } ) => {
			return item.categories;
		},
		render: ( { item } ) => {
			return item.categories.join( ',' );
		},
		enableSorting: false,
},
```
3. Run `npm run storybook:dev`
4. Go to `/?path=/story/dataviews-dataviews--default` and check how the filter icon no longer appears

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<img width="1480" alt="Screenshot 2024-08-20 at 3 31 48 PM" src="https://github.com/user-attachments/assets/a9c1a24f-f615-46ba-b54a-20128360554d">
The dropdown button is no longer visible when there are no filter options 