### PR TITLE
Feat : double-click to open/close block in List View

### DIFF
--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -535,6 +535,7 @@ function ListViewBlock( {
 			data-block={ clientId }
 			data-expanded={ canEdit ? isExpanded : undefined }
 			ref={ rowRef }
+			onDoubleClick={ toggleExpanded }
 		>
 			<TreeGridCell
 				className="block-editor-list-view-block__contents-cell"


### PR DESCRIPTION
## What?
resolve #64625 

## Why?
To enhance accessibility

## How?
Registering the doubleClick event listener to `ListViewBlock` component