### PR TITLE
DataViews: Support defining field headers/names as React elements.

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,7 +2,13 @@
 
 ## Unreleased
 
-- The "move left/move right" controls in the table layout (popup displayed on cliking header) are always visible. ([#64646](https://github.com/WordPress/gutenberg/pull/64646)). Before this, its visibility depending on filters, enableSorting, and enableHiding.
+## New features
+
+-   Support using a component for field headers or names by providing a `header` property in the field object. The string `label` property (or `id`) is still mandatory. ([#64642](https://github.com/WordPress/gutenberg/pull/64642)).
+
+## Internal
+
+-   The "move left/move right" controls in the table layout (popup displayed on cliking header) are always visible. ([#64646](https://github.com/WordPress/gutenberg/pull/64646)). Before this, its visibility depending on filters, enableSorting, and enableHiding.
 
 ## 4.1.0 (2024-08-07)
 

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { trash } from '@wordpress/icons';
+import { trash, image, Icon, category } from '@wordpress/icons';
 import {
 	Button,
 	__experimentalText as Text,
@@ -173,6 +173,12 @@ export const fields = [
 	{
 		label: 'Image',
 		id: 'image',
+		header: (
+			<HStack justify="start">
+				<Icon icon={ image } />
+				<span>Image</span>
+			</HStack>
+		),
 		render: ( { item } ) => {
 			return (
 				<img src={ item.image } alt="" style={ { width: '100%' } } />
@@ -217,6 +223,12 @@ export const fields = [
 	{
 		label: 'Categories',
 		id: 'categories',
+		header: (
+			<HStack justify="start">
+				<Icon icon={ category } />
+				<span>Categories</span>
+			</HStack>
+		),
 		elements: [
 			{ value: 'Space', label: 'Space' },
 			{ value: 'NASA', label: 'NASA' },

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -174,7 +174,7 @@ export const fields = [
 		label: 'Image',
 		id: 'image',
 		header: (
-			<HStack justify="start">
+			<HStack spacing={ 1 } justify="start">
 				<Icon icon={ image } />
 				<span>Image</span>
 			</HStack>
@@ -224,7 +224,7 @@ export const fields = [
 		label: 'Categories',
 		id: 'categories',
 		header: (
-			<HStack justify="start">
+			<HStack spacing={ 1 } justify="start">
 				<Icon icon={ category } />
 				<span>Categories</span>
 			</HStack>

--- a/packages/dataviews/src/components/dataviews/stories/index.story.js
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.js
@@ -8,7 +8,7 @@ import { useState, useMemo } from '@wordpress/element';
  */
 import DataViews from '../index';
 import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
-import { LAYOUT_GRID, LAYOUT_TABLE } from '../../../constants';
+import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
 
 const meta = {
@@ -56,6 +56,12 @@ Default.args = {
 			},
 		},
 		[ LAYOUT_GRID ]: {
+			layout: {
+				mediaField: 'image',
+				primaryField: 'title',
+			},
+		},
+		[ LAYOUT_LIST ]: {
 			layout: {
 				mediaField: 'image',
 				primaryField: 'title',

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -145,7 +145,7 @@ function GridItem< Item >( {
 							>
 								<>
 									<FlexItem className="dataviews-view-grid__field-name">
-										{ field.label }
+										{ field.header }
 									</FlexItem>
 									<FlexItem
 										className="dataviews-view-grid__field-value"

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -72,7 +72,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	);
 	const index = view.fields?.indexOf( fieldId ) as number;
 	if ( !! combinedField ) {
-		return combinedField.label;
+		return combinedField.header || combinedField.label;
 	}
 	const field = fields.find( ( f ) => f.id === fieldId );
 	if ( ! field ) {
@@ -102,7 +102,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 					ref={ ref }
 					variant="tertiary"
 				>
-					{ field.label }
+					{ field.header }
 					{ view.sort && isSorted && (
 						<span aria-hidden="true">
 							{ sortArrows[ view.sort.direction ] }

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -55,6 +55,7 @@ export function normalizeFields< Item >(
 		return {
 			...field,
 			label: field.label || field.id,
+			header: field.header || field.label || field.id,
 			getValue,
 			render,
 			sort,

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -88,6 +88,12 @@ export type Field< Item > = {
 	label?: string;
 
 	/**
+	 * The header of the field. Defaults to the label.
+	 * It allows the usage of a React Element to render the field labels.
+	 */
+	header?: string | ReactElement;
+
+	/**
 	 * A description of the field.
 	 */
 	description?: string;
@@ -151,6 +157,7 @@ export type Field< Item > = {
 
 export type NormalizedField< Item > = Field< Item > & {
 	label: string;
+	header: string | ReactElement;
 	getValue: ( args: { item: Item } ) => any;
 	render: ComponentType< { item: Item } >;
 	Edit: ComponentType< DataFormControlProps< Item > >;
@@ -288,6 +295,8 @@ export interface CombinedField {
 	id: string;
 
 	label: string;
+
+	header?: string | ReactElement;
 
 	/**
 	 * The fields to use as columns.


### PR DESCRIPTION
Related #55083 

## What?

While trying to implement dataviews in a third-party project, we had a use-case where we wanted to add an icon and some colors to the table headers. 

I think this use-case is common enough that it deserves to be supported in the DataViews component.

## How?

In a few places (like filters), we rely on a the label being a string (for instance to render a filter summary), so I think it makes more sense to have two properties here instead of one.

## Testing Instructions

I've added an example to the storybook like shown in the image bellow.

## Screenshots or screencast 

<img width="1168" alt="Screenshot 2024-08-20 at 1 40 58 PM" src="https://github.com/user-attachments/assets/44007bfd-c119-4aad-b385-d22d1ec6f198">
