### PR TITLE
Editor: Add extensibility to PreviewOptions v2

### DIFF
--- a/packages/e2e-tests/plugins/plugins-api.php
+++ b/packages/e2e-tests/plugins/plugins-api.php
@@ -86,6 +86,19 @@ function enqueue_plugins_api_plugin_scripts() {
 		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/document-setting.js' ),
 		true
 	);
+
+	wp_enqueue_script(
+		'gutenberg-test-plugins-api-preview-menu',
+		plugins_url( 'plugins-api/preview-menu.js', __FILE__ ),
+		array(
+			'wp-editor',
+			'wp-element',
+			'wp-i18n',
+			'wp-plugins',
+		),
+		filemtime( plugin_dir_path( __FILE__ ) . 'plugins-api/preview-menu.js' ),
+		true
+	);
 }
 
 add_action( 'init', 'enqueue_plugins_api_plugin_scripts' );

--- a/packages/e2e-tests/plugins/plugins-api/preview-menu.js
+++ b/packages/e2e-tests/plugins/plugins-api/preview-menu.js
@@ -1,0 +1,14 @@
+( function () {
+	const { __ } = wp.i18n;
+	const { registerPlugin } = wp.plugins;
+	const PluginPreviewMenuItem = wp.editor.PluginPreviewMenuItem;
+	const el = wp.element.createElement;
+
+	function CustomPreviewMenuItem() {
+		return el( PluginPreviewMenuItem, {}, __( 'Custom Preview' ) );
+	}
+
+	registerPlugin( 'custom-preview-menu-item', {
+		render: CustomPreviewMenuItem,
+	} );
+} )();

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -862,6 +862,40 @@ _Returns_
 
 -   `Component`: The component to be rendered.
 
+### PluginPreviewDropdownItem
+
+Renders a menu item in the Preview dropdown, which can be used as a button or link depending on the props provided. The text within the component appears as the menu item label.
+
+_Usage_
+
+```jsx
+import { __ } from '@wordpress/i18n';
+import { PreviewDropdownMenuItem } from './preview-dropdown-menu-item';
+import { external } from '@wordpress/icons';
+
+function onPreviewClick() {
+	// Handle preview action
+}
+
+const ExternalPreviewMenuItem = () => (
+	<PreviewDropdownMenuItem icon={ external } onClick={ onPreviewClick }>
+		{ __( 'Preview in new tab' ) }
+	</PreviewDropdownMenuItem>
+);
+```
+
+_Parameters_
+
+-   _props_ `Object`: Component properties.
+-   _props.href_ `[string]`: When `href` is provided, the menu item is rendered as an anchor instead of a button. It corresponds to the `href` attribute of the anchor.
+-   _props.icon_ `[WPBlockTypeIconRender]`: The icon to be rendered to the left of the menu item label. Can be a Dashicon slug or an SVG WP element.
+-   _props.onClick_ `[Function]`: The callback function to be executed when the user clicks the menu item.
+-   _props.other_ `[...*]`: Any additional props are passed through to the underlying MenuItem component.
+
+_Returns_
+
+-   `Component`: The rendered menu item component.
+
 ### PluginSidebar
 
 Renders a sidebar when activated. The contents within the `PluginSidebar` will appear as content within the sidebar. It also automatically renders a corresponding `PluginSidebarMenuItem` component when `isPinnable` flag is set to `true`. If you wish to display the sidebar, you can with use the `PluginSidebarMoreMenuItem` component or the `wp.data.dispatch` API:

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -862,7 +862,7 @@ _Returns_
 
 -   `Component`: The component to be rendered.
 
-### PluginPreviewDropdownItem
+### PluginPreviewMenuItem
 
 Renders a menu item in the Preview dropdown, which can be used as a button or link depending on the props provided. The text within the component appears as the menu item label.
 
@@ -870,7 +870,7 @@ _Usage_
 
 ```jsx
 import { __ } from '@wordpress/i18n';
-import { PreviewDropdownMenuItem } from './preview-dropdown-menu-item';
+import { PluginPreviewMenuItem } from '@wordpress/editor';
 import { external } from '@wordpress/icons';
 
 function onPreviewClick() {
@@ -882,6 +882,9 @@ const ExternalPreviewMenuItem = () => (
 		{ __( 'Preview in new tab' ) }
 	</PreviewDropdownMenuItem>
 );
+registerPlugin( 'external-preview-menu-item', {
+	render: ExternalPreviewMenuItem,
+} );
 ```
 
 _Parameters_

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -32,7 +32,7 @@ export { default as PluginMoreMenuItem } from './plugin-more-menu-item';
 export { default as PluginPostPublishPanel } from './plugin-post-publish-panel';
 export { default as PluginPostStatusInfo } from './plugin-post-status-info';
 export { default as PluginPrePublishPanel } from './plugin-pre-publish-panel';
-export { default as PluginPreviewDropdownItem } from './plugin-preview-dropdown-item';
+export { default as PluginPreviewMenuItem } from './plugin-preview-menu-item';
 export { default as PluginSidebar } from './plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './plugin-sidebar-more-menu-item';
 export { default as PostTemplatePanel } from './post-template/panel';

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -32,6 +32,7 @@ export { default as PluginMoreMenuItem } from './plugin-more-menu-item';
 export { default as PluginPostPublishPanel } from './plugin-post-publish-panel';
 export { default as PluginPostStatusInfo } from './plugin-post-status-info';
 export { default as PluginPrePublishPanel } from './plugin-pre-publish-panel';
+export { default as PluginPreviewDropdownItem } from './plugin-preview-dropdown-item';
 export { default as PluginSidebar } from './plugin-sidebar';
 export { default as PluginSidebarMoreMenuItem } from './plugin-sidebar-more-menu-item';
 export { default as PostTemplatePanel } from './post-template/panel';

--- a/packages/editor/src/components/plugin-preview-dropdown-item/index.js
+++ b/packages/editor/src/components/plugin-preview-dropdown-item/index.js
@@ -34,6 +34,9 @@ import { ActionItem } from '@wordpress/interface';
  *     { __( 'Preview in new tab' ) }
  *   </PreviewDropdownMenuItem>
  * );
+ * registerPlugin( 'external-preview-menu-item', {
+ *     render: ExternalPreviewMenuItem,
+ * } );
  * ```
  *
  * @return {Component} The rendered menu item component.

--- a/packages/editor/src/components/plugin-preview-dropdown-item/index.js
+++ b/packages/editor/src/components/plugin-preview-dropdown-item/index.js
@@ -19,7 +19,7 @@ import { ActionItem } from '@wordpress/interface';
  * @example
  * ```jsx
  * import { __ } from '@wordpress/i18n';
- * import { PreviewDropdownMenuItem } from './preview-dropdown-menu-item';
+ * import { PluginPreviewMenuItem } from '@wordpress/editor';
  * import { external } from '@wordpress/icons';
  *
  * function onPreviewClick() {

--- a/packages/editor/src/components/plugin-preview-dropdown-item/index.js
+++ b/packages/editor/src/components/plugin-preview-dropdown-item/index.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+import { MenuItem } from '@wordpress/components';
+import { withPluginContext } from '@wordpress/plugins';
+import { ActionItem } from '@wordpress/interface';
+
+/**
+ * Renders a menu item in the Preview dropdown, which can be used as a button or link depending on the props provided.
+ * The text within the component appears as the menu item label.
+ *
+ * @param {Object}                props                                 Component properties.
+ * @param {string}                [props.href]                          When `href` is provided, the menu item is rendered as an anchor instead of a button. It corresponds to the `href` attribute of the anchor.
+ * @param {WPBlockTypeIconRender} [props.icon=inherits from the plugin] The icon to be rendered to the left of the menu item label. Can be a Dashicon slug or an SVG WP element.
+ * @param {Function}              [props.onClick]                       The callback function to be executed when the user clicks the menu item.
+ * @param {...*}                  [props.other]                         Any additional props are passed through to the underlying MenuItem component.
+ *
+ * @example
+ * ```jsx
+ * import { __ } from '@wordpress/i18n';
+ * import { PreviewDropdownMenuItem } from './preview-dropdown-menu-item';
+ * import { external } from '@wordpress/icons';
+ *
+ * function onPreviewClick() {
+ *   // Handle preview action
+ * }
+ *
+ * const ExternalPreviewMenuItem = () => (
+ *   <PreviewDropdownMenuItem
+ *     icon={ external }
+ *     onClick={ onPreviewClick }
+ *   >
+ *     { __( 'Preview in new tab' ) }
+ *   </PreviewDropdownMenuItem>
+ * );
+ * ```
+ *
+ * @return {Component} The rendered menu item component.
+ */
+export default compose(
+	withPluginContext( ( context, ownProps ) => {
+		return {
+			as: ownProps.as ?? MenuItem,
+			icon: ownProps.icon || context.icon,
+			name: 'core/plugin-preview-dropdown-menu',
+		};
+	} )
+)( ActionItem );

--- a/packages/editor/src/components/plugin-preview-menu-item/index.js
+++ b/packages/editor/src/components/plugin-preview-menu-item/index.js
@@ -46,7 +46,7 @@ export default compose(
 		return {
 			as: ownProps.as ?? MenuItem,
 			icon: ownProps.icon || context.icon,
-			name: 'core/plugin-preview-dropdown-menu',
+			name: 'core/plugin-preview-menu',
 		};
 	} )
 )( ActionItem );

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -22,6 +22,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useEffect, useRef } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { ActionItem } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -206,6 +207,11 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 							/>
 						</MenuGroup>
 					) }
+					<ActionItem.Slot
+						name="core/plugin-preview-dropdown-menu"
+						as={ MenuGroup }
+						fillProps={ { onClick: onClose } }
+					/>
 				</>
 			) }
 		</DropdownMenu>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -208,7 +208,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						</MenuGroup>
 					) }
 					<ActionItem.Slot
-						name="core/plugin-preview-dropdown-menu"
+						name="core/plugin-preview-menu"
 						as={ MenuGroup }
 						fillProps={ { onClick: onClose } }
 					/>

--- a/test/e2e/specs/editor/plugins/plugins-api.spec.js
+++ b/test/e2e/specs/editor/plugins/plugins-api.spec.js
@@ -230,4 +230,25 @@ test.describe( 'Plugins API', () => {
 			).toBeVisible();
 		} );
 	} );
+
+	test.describe( 'Preview Menu Item', () => {
+		test( 'Should render and interact with PluginPreviewMenuItem', async ( {
+			page,
+		} ) => {
+			await page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.locator( '.editor-preview-dropdown__toggle' )
+				.click();
+
+			const customPreviewItem = page.getByRole( 'menuitem', {
+				name: 'Custom Preview',
+			} );
+
+			await expect( customPreviewItem ).toBeVisible();
+
+			await customPreviewItem.click();
+
+			await expect( customPreviewItem ).toBeHidden();
+		} );
+	} );
 } );


### PR DESCRIPTION
# Extend Preview Dropdown with Plugin API

Resolves https://github.com/WordPress/gutenberg/issues/25309

## What?
This PR introduces a new API to extend the Preview dropdown menu in the post/page editor. It builds upon the work done in #50605, #36119, and #31984, focusing specifically on allowing plugins to add custom menu items to the Preview dropdown.

Key features:
* Introduces `PreviewDropdownMenuItem` component for adding custom items to the Preview dropdown
* Allows plugins to add menu items with custom titles and click handlers
* Maintains the existing Preview dropdown structure while allowing for extensibility

## Why?
This extension point allows for greater flexibility in preview functionality, enabling plugin developers to integrate custom preview options seamlessly into the WordPress editor. It addresses the need for varied publishing flows and tools, such as:
* Custom format previews (e.g., AMP, social media shares)
* Previewing content with different access restrictions or user roles
* Specialized preview modes (e.g., dark mode, email format)

## How?
* Utilizes the existing `ActionItem` component from `@wordpress/interface`
* Implements a slot/fill pattern to inject custom menu items into the Preview dropdown
* Maintains the declarative nature of the API, allowing for future UI changes without breaking plugin implementations

## Testing Instructions
1. Import the `PreviewDropdownMenuItem` component in your plugin:
   ```js
   import { PreviewDropdownMenuItem } from '@wordpress/editor';
   ```
2. Implement a custom menu item:
   ```jsx
   const CustomPreviewMenuItem = () => (
     <PreviewDropdownMenuItem
       onClick={ () => {
         // Your custom preview logic
       } }
     >
       Custom Preview
     </PreviewDropdownMenuItem>
   );
   ```
3. Register your plugin with the custom menu item.
4. Open the post/page editor and check the Preview dropdown for your custom menu item.
5. Click the custom menu item and verify that your `onClick` handler is called.

### Testing Instructions for Keyboard
1. Open the post/page editor.
2. Use `Tab` to navigate to the Preview dropdown button.
3. Press `Enter` or `Space` to open the dropdown menu.
4. Use arrow keys to navigate to your custom menu item.
5. Press `Enter` to activate the custom menu item.
6. Verify that the custom action is triggered.

## Screenshots or screencast
<!-- Add screenshots or screencasts here if available -->
No icon:

<img width="360" alt="Screenshot 2024-08-20 at 1 55 05 PM" src="https://github.com/user-attachments/assets/cedac3b2-ebb5-494b-8c01-85f29294c3e7">

With icon:

<img width="359" alt="Screenshot 2024-08-20 at 2 57 14 PM" src="https://github.com/user-attachments/assets/1330a6e3-f879-4a7b-8416-4d5abf436ba6">

More than one item:

<img width="341" alt="Screenshot 2024-08-22 at 11 11 54 AM" src="https://github.com/user-attachments/assets/41de4eb1-3ddd-444f-bc7b-d228f2344ea8">

## Future Considerations
- Allow for grouping of custom preview options
- Enable custom preview canvas or sizes
- Add support for item selection within custom groups

This PR lays the groundwork for these future enhancements while providing immediate value to plugin developers wanting to extend the preview functionality.
