### PR TITLE
DataViews: load the filter toggle as open if there are primary filters

### DIFF
--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -71,8 +71,6 @@ export default function DataViews< Item >( {
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const [ density, setDensity ] = useState< number >( 0 );
-	const [ isShowingFilter, setIsShowingFilter ] =
-		useState< boolean >( false );
 	const isUncontrolled =
 		selectionProperty === undefined || onChangeSelection === undefined;
 	const selection = isUncontrolled ? selectionState : selectionProperty;
@@ -95,6 +93,10 @@ export default function DataViews< Item >( {
 	}, [ selection, data, getItemId ] );
 
 	const filters = useFilters( _fields, view );
+	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
+		( filters || [] ).some( ( filter ) => filter.isPrimary )
+	);
+
 	return (
 		<DataViewsContext.Provider
 			value={ {

--- a/test/e2e/specs/site-editor/patterns.spec.js
+++ b/test/e2e/specs/site-editor/patterns.spec.js
@@ -149,13 +149,6 @@ test.describe( 'Patterns', () => {
 
 		await expect( patterns.item ).toHaveCount( 3 );
 
-		await patterns.content
-			.getByRole( 'button', {
-				name: 'Toggle filter display',
-				exact: true,
-			} )
-			.click();
-
 		const searchBox = patterns.content.getByRole( 'searchbox', {
 			name: 'Search',
 		} );


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/63203#issuecomment-2296833199

## What?

If the screen has a primary filter, the "Filter toggle" loads as open.


https://github.com/user-attachments/assets/c7e1b02e-22c1-412c-a456-33d1e0620705


## Why?

Primary filters were created to give _some_ filters higher visibility. This is still useful.

## How?

When loading the component, consider whether there's any primary filter. If there is, load it opened.

## Testing Instructions

Go to the Patterns page and verify the "Sync" filter is visible and that the user can still hide all filters:

<img width="1504" alt="Captura de ecrã 2024-08-20, às 17 57 53" src="https://github.com/user-attachments/assets/84f1db91-ab0a-4be2-8d28-fa8e74441270">
