### PR TITLE
Updated @since order in Inline document in client-assets.php file

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -487,9 +487,9 @@ add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
  * This hook also exists, and should be backported to Core in future versions.
  * However, it is envisaged that Gutenberg will continue to use the Style Engine's `gutenberg_*` functions and `_Gutenberg` classes to aid continuous development.
  *
- * See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
- *
  * @since 6.1
+ *
+ * @see https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
  *
  * @param array $options {
  *     Optional. An array of options to pass to gutenberg_style_engine_get_stylesheet_from_context(). Default empty array.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -489,14 +489,14 @@ add_action( 'wp_default_styles', 'gutenberg_register_packages_styles' );
  *
  * See: https://developer.wordpress.org/block-editor/reference-guides/packages/packages-style-engine/
  *
+ * @since 6.1
+ *
  * @param array $options {
  *     Optional. An array of options to pass to gutenberg_style_engine_get_stylesheet_from_context(). Default empty array.
  *
  *     @type bool $optimize Whether to optimize the CSS output, e.g., combine rules. Default is `false`.
  *     @type bool $prettify Whether to add new lines and indents to output. Default is the test of whether the global constant `SCRIPT_DEBUG` is defined.
  * }
- *
- * @since 6.1
  *
  * @return void
  */


### PR DESCRIPTION
- Added `@since` before `@param` and `@return` according to [PHP Doc Standards](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/)