### PR TITLE
DropdownMenuV2: use overloaded naming conventions

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -29,14 +29,7 @@ import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
 import { useBlockBindingsUtils } from '../utils/block-bindings';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	DropdownMenuItemHelpTextV2: DropdownMenuItemHelpText,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 const useToolsPanelDropdownMenuProps = () => {
 	const isMobile = useViewportMatch( 'medium', '<' );
@@ -60,7 +53,7 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 		<>
 			{ Object.entries( fieldsList ).map( ( [ name, fields ], i ) => (
 				<Fragment key={ name }>
-					<DropdownMenuGroup>
+					<DropdownMenuV2.Group>
 						{ Object.keys( fieldsList ).length > 1 && (
 							<Text
 								className="block-editor-bindings__source-label"
@@ -72,7 +65,7 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 							</Text>
 						) }
 						{ Object.entries( fields ).map( ( [ key, value ] ) => (
-							<DropdownMenuRadioItem
+							<DropdownMenuV2.RadioItem
 								key={ key }
 								onChange={ () =>
 									updateBlockBindings( {
@@ -86,17 +79,17 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 								value={ key }
 								checked={ key === currentKey }
 							>
-								<DropdownMenuItemLabel>
+								<DropdownMenuV2.ItemLabel>
 									{ key }
-								</DropdownMenuItemLabel>
-								<DropdownMenuItemHelpText>
+								</DropdownMenuV2.ItemLabel>
+								<DropdownMenuV2.ItemHelpText>
 									{ value }
-								</DropdownMenuItemHelpText>
-							</DropdownMenuRadioItem>
+								</DropdownMenuV2.ItemHelpText>
+							</DropdownMenuV2.RadioItem>
 						) ) }
-					</DropdownMenuGroup>
+					</DropdownMenuV2.Group>
 					{ i !== Object.keys( fieldsList ).length - 1 && (
-						<DropdownMenuSeparator />
+						<DropdownMenuV2.Separator />
 					) }
 				</Fragment>
 			) ) }
@@ -162,7 +155,7 @@ function EditableBlockBindingsPanelItems( {
 							} );
 						} }
 					>
-						<DropdownMenu
+						<DropdownMenuV2
 							placement={
 								isMobile ? 'bottom-start' : 'left-start'
 							}
@@ -182,7 +175,7 @@ function EditableBlockBindingsPanelItems( {
 								attribute={ attribute }
 								binding={ binding }
 							/>
-						</DropdownMenu>
+						</DropdownMenuV2>
 					</ToolsPanelItem>
 				);
 			} ) }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -82,6 +82,7 @@
 -   `Composite` v2: add focus-related props to `Composite`and`Composite.Item` subcomponents ([#64450](https://github.com/WordPress/gutenberg/pull/64450)).
 -   `Composite` v2: add `Context` subcomponent ([#64493](https://github.com/WordPress/gutenberg/pull/64493)).
 -   `DropdownMenu` v2: use themed color variables ([#64647](https://github.com/WordPress/gutenberg/pull/64647)).
+-   `DropdownMenu` v2: refactor to overloaded naming convention ([#64654](https://github.com/WordPress/gutenberg/pull/64654)).
 -   `CustomSelectControl`: Improve type inferring ([#64412](https://github.com/WordPress/gutenberg/pull/64412)).
 -   Update `ariakit` to version `0.4.10` ([#64637](https://github.com/WordPress/gutenberg/pull/64637)).
 -   Ariakit: Use `useStoreState()` instead of `store.useState()` ([#64648](https://github.com/WordPress/gutenberg/pull/64648)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Internal
 
+-   `DropdownMenu` v2: refactor to overloaded naming convention ([#64654](https://github.com/WordPress/gutenberg/pull/64654)).
 -   `Composite` V2: fix Storybook docgen ([#64682](https://github.com/WordPress/gutenberg/pull/64682)).
 
 ## 28.6.0 (2024-08-21)
@@ -82,7 +83,6 @@
 -   `Composite` v2: add focus-related props to `Composite`and`Composite.Item` subcomponents ([#64450](https://github.com/WordPress/gutenberg/pull/64450)).
 -   `Composite` v2: add `Context` subcomponent ([#64493](https://github.com/WordPress/gutenberg/pull/64493)).
 -   `DropdownMenu` v2: use themed color variables ([#64647](https://github.com/WordPress/gutenberg/pull/64647)).
--   `DropdownMenu` v2: refactor to overloaded naming convention ([#64654](https://github.com/WordPress/gutenberg/pull/64654)).
 -   `CustomSelectControl`: Improve type inferring ([#64412](https://github.com/WordPress/gutenberg/pull/64412)).
 -   Update `ariakit` to version `0.4.10` ([#64637](https://github.com/WordPress/gutenberg/pull/64637)).
 -   Ariakit: Use `useStoreState()` instead of `store.useState()` ([#64648](https://github.com/WordPress/gutenberg/pull/64648)).

--- a/packages/components/src/dropdown-menu-v2/README.md
+++ b/packages/components/src/dropdown-menu-v2/README.md
@@ -1,11 +1,10 @@
-# `DropdownMenu` (v2)
+# `DropdownMenuV2`
 
 <div class="callout callout-alert">
 This feature is still experimental. “Experimental” means this is an early implementation subject to drastic and breaking changes.
 </div>
 
-`DropdownMenu` displays a menu to the user (such as a set of actions or functions) triggered by a button.
-
+`DropdownMenuV2` displays a menu to the user (such as a set of actions or functions) triggered by a button.
 
 ## Design guidelines
 
@@ -46,7 +45,7 @@ This component is still highly experimental, and it's not normally accessible to
 
 The component exposes a set of components that are meant to be used in combination with each other in order to implement a `DropdownMenu` correctly.
 
-### `DropdownMenu`
+### `DropdownMenuV2`
 
 The root component, used to specify the menu's trigger and its contents.
 
@@ -58,62 +57,62 @@ The component accepts the following props:
 
 The trigger button
 
-- Required: yes
+-   Required: yes
 
 ##### `children`: `React.ReactNode`
 
 The contents of the dropdown
 
-- Required: yes
+-   Required: yes
 
 ##### `defaultOpen`: `boolean`
 
 The open state of the dropdown menu when it is initially rendered. Use when not wanting to control its open state.
 
-- Required: no
-- Default: `false`
+-   Required: no
+-   Default: `false`
 
 ##### `open`: `boolean`
 
 The controlled open state of the dropdown menu. Must be used in conjunction with `onOpenChange`.
 
-- Required: no
+-   Required: no
 
 ##### `onOpenChange`: `(open: boolean) => void`
 
 Event handler called when the open state of the dropdown menu changes.
 
-- Required: no
+-   Required: no
 
 ##### `modal`: `boolean`
 
 The modality of the dropdown menu. When set to true, interaction with outside elements will be disabled and only menu content will be visible to screen readers.
 
-- Required: no
-- Default: `true`
+-   Required: no
+-   Default: `true`
 
 ##### `placement`: ``'top' | 'top-start' | 'top-end' | 'right' | 'right-start' | 'right-end' | 'bottom' | 'bottom-start' | 'bottom-end' | 'left' | 'left-start' | 'left-end'`
 
 The placement of the dropdown menu popover.
 
-- Required: no
-- Default: `'bottom-start'` for root-level menus, `'right-start'` for nested menus
+-   Required: no
+-   Default: `'bottom-start'` for root-level menus, `'right-start'` for nested menus
 
 ##### `gutter`: `number`
 
 The distance in pixels from the trigger.
 
-- Required: no
-- Default: `8` for root-level menus, `16` for nested menus
+-   Required: no
+-   Default: `8` for root-level menus, `16` for nested menus
 
 ##### `shift`: `number`
 
 The skidding of the popover along the anchor element. Can be set to negative values to make the popover shift to the opposite side.
 
-- Required: no
-- Default: `0` for root-level menus, `-8` for nested menus
+-   Required: no
+-   Default: `0` for root-level menus, `-8` for nested menus
 
-### `DropdownMenuItem`
+### `DropdownMenuV2.Item`
 
 Used to render a menu item.
 
@@ -125,35 +124,35 @@ The component accepts the following props:
 
 The contents of the item
 
-- Required: yes
+-   Required: yes
 
 ##### `prefix`: `React.ReactNode`
 
 The contents of the item's prefix.
 
-- Required: no
+-   Required: no
 
 ##### `suffix`: `React.ReactNode`
 
 The contents of the item's suffix.
 
-- Required: no
+-   Required: no
 
 ##### `hideOnClick`: `boolean`
 
 Whether to hide the dropdown menu when the menu item is clicked.
 
-- Required: no
-- Default: `true`
+-   Required: no
+-   Default: `true`
 
 ##### `disabled`: `boolean`
 
 Determines if the element is disabled.
 
-- Required: no
-- Default: `false`
+-   Required: no
+-   Default: `false`
 
-### `DropdownMenuCheckboxItem`
+### `DropdownMenuV2.CheckboxItem`
 
 Used to render a checkbox item.
 
@@ -165,61 +164,61 @@ The component accepts the following props:
 
 The contents of the item
 
-- Required: yes
+-   Required: yes
 
 ##### `suffix`: `React.ReactNode`
 
 The contents of the item's suffix.
 
-- Required: no
+-   Required: no
 
 ##### `hideOnClick`: `boolean`
 
 Whether to hide the dropdown menu when the menu item is clicked.
 
-- Required: no
-- Default: `false`
+-   Required: no
+-   Default: `false`
 
 ##### `disabled`: `boolean`
 
 Determines if the element is disabled.
 
-- Required: no
-- Default: `false`
+-   Required: no
+-   Default: `false`
 
 ##### `name`: `string`
 
 The checkbox item's name.
 
-- Required: yes
+-   Required: yes
 
 ##### `value`: `string`
 
 The checkbox item's value, useful when using multiple checkbox items
- associated to the same `name`.
+associated to the same `name`.
 
-- Required: no
+-   Required: no
 
 ##### `checked`: `boolean`
 
 The checkbox item's value, useful when using multiple checkbox items
- associated to the same `name`.
+associated to the same `name`.
 
-- Required: no
+-   Required: no
 
 ##### `defaultChecked`: `boolean`
 
 The checked state of the checkbox menu item when it is initially rendered. Use when not wanting to control its checked state.
 
-- Required: no
+-   Required: no
 
 ##### `onChange`: `( event: React.ChangeEvent< HTMLInputElement > ) => void;`
 
 Event handler called when the checked state of the checkbox menu item changes.
 
-- Required: no
+-   Required: no
 
-### `DropdownMenuRadioItem`
+### `DropdownMenuV2.RadioItem`
 
 Used to render a radio item.
 
@@ -231,60 +230,60 @@ The component accepts the following props:
 
 The contents of the item
 
-- Required: yes
+-   Required: yes
 
 ##### `suffix`: `React.ReactNode`
 
 The contents of the item's suffix.
 
-- Required: no
+-   Required: no
 
 ##### `hideOnClick`: `boolean`
 
 Whether to hide the dropdown menu when the menu item is clicked.
 
-- Required: no
-- Default: `false`
+-   Required: no
+-   Default: `false`
 
 ##### `disabled`: `boolean`
 
 Determines if the element is disabled.
 
-- Required: no
-- Default: `false`
+-   Required: no
+-   Default: `false`
 
 ##### `name`: `string`
 
 The radio item's name.
 
-- Required: yes
+-   Required: yes
 
 ##### `value`: `string | number`
 
 The radio item's value.
 
-- Required: yes
+-   Required: yes
 
 ##### `checked`: `boolean`
 
 The checkbox item's value, useful when using multiple checkbox items
- associated to the same `name`.
+associated to the same `name`.
 
-- Required: no
+-   Required: no
 
 ##### `defaultChecked`: `boolean`
 
 The checked state of the radio menu item when it is initially rendered. Use when not wanting to control its checked state.
 
-- Required: no
+-   Required: no
 
 ##### `onChange`: `( event: React.ChangeEvent< HTMLInputElement > ) => void;`
 
 Event handler called when the checked radio menu item changes.
 
-- Required: no
+-   Required: no
 
-### `DropdownMenuItemLabel`
+### `DropdownMenuV2.ItemLabel`
 
 Used to render the menu item's label.
 
@@ -296,9 +295,9 @@ The component accepts the following props:
 
 The label contents.
 
-- Required: yes
+-   Required: yes
 
-### `DropdownMenuItemHelpText`
+### `DropdownMenuV2.ItemHelpText`
 
 Used to render the menu item's help text.
 
@@ -310,7 +309,7 @@ The component accepts the following props:
 
 The help text contents.
 
-- Required: yes
+-   Required: yes
 
 ### `DropdownMenuGroup`
 
@@ -324,7 +323,7 @@ The component accepts the following props:
 
 The contents of the group.
 
-- Required: yes
+-   Required: yes
 
 ### `DropdownMenuSeparatorProps`
 

--- a/packages/components/src/dropdown-menu-v2/checkbox-item.tsx
+++ b/packages/components/src/dropdown-menu-v2/checkbox-item.tsx
@@ -1,0 +1,60 @@
+/**
+ * External dependencies
+ */
+import * as Ariakit from '@ariakit/react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useContext } from '@wordpress/element';
+import { Icon, check } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import { DropdownMenuContext } from './context';
+import type { DropdownMenuCheckboxItemProps } from './types';
+import * as Styled from './styles';
+
+export const DropdownMenuCheckboxItem = forwardRef<
+	HTMLDivElement,
+	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
+>( function DropdownMenuCheckboxItem(
+	{ suffix, children, hideOnClick = false, ...props },
+	ref
+) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	return (
+		<Styled.DropdownMenuCheckboxItem
+			ref={ ref }
+			{ ...props }
+			accessibleWhenDisabled
+			hideOnClick={ hideOnClick }
+			store={ dropdownMenuContext?.store }
+		>
+			<Ariakit.MenuItemCheck
+				store={ dropdownMenuContext?.store }
+				render={ <Styled.ItemPrefixWrapper /> }
+				// Override some ariakit inline styles
+				style={ { width: 'auto', height: 'auto' } }
+			>
+				<Icon icon={ check } size={ 24 } />
+			</Ariakit.MenuItemCheck>
+
+			<Styled.DropdownMenuItemContentWrapper>
+				<Styled.DropdownMenuItemChildrenWrapper>
+					{ children }
+				</Styled.DropdownMenuItemChildrenWrapper>
+
+				{ suffix && (
+					<Styled.ItemSuffixWrapper>
+						{ suffix }
+					</Styled.ItemSuffixWrapper>
+				) }
+			</Styled.DropdownMenuItemContentWrapper>
+		</Styled.DropdownMenuCheckboxItem>
+	);
+} );
+DropdownMenuCheckboxItem.displayName = 'DropdownMenuV2.CheckboxItem';

--- a/packages/components/src/dropdown-menu-v2/context.tsx
+++ b/packages/components/src/dropdown-menu-v2/context.tsx
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import { createContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { DropdownMenuContext as DropdownMenuContextType } from './types';
+
+export const DropdownMenuContext = createContext<
+	DropdownMenuContextType | undefined
+>( undefined );
+DropdownMenuContext.displayName = 'DropdownMenuV2.Context';

--- a/packages/components/src/dropdown-menu-v2/group.tsx
+++ b/packages/components/src/dropdown-menu-v2/group.tsx
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import { DropdownMenuContext } from './context';
+import type { DropdownMenuGroupProps } from './types';
+import * as Styled from './styles';
+
+export const DropdownMenuGroup = forwardRef<
+	HTMLDivElement,
+	WordPressComponentProps< DropdownMenuGroupProps, 'div', false >
+>( function DropdownMenuGroup( props, ref ) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<Styled.DropdownMenuGroup
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+		/>
+	);
+} );
+DropdownMenuGroup.displayName = 'DropdownMenuV2.Group';

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -8,8 +8,6 @@ import { useStoreState } from '@ariakit/react';
  * WordPress dependencies
  */
 import {
-	forwardRef,
-	createContext,
 	useContext,
 	useMemo,
 	cloneElement,
@@ -17,214 +15,26 @@ import {
 	useCallback,
 } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
-import { check, chevronRightSmall } from '@wordpress/icons';
-import { SVG, Circle } from '@wordpress/primitives';
+import { chevronRightSmall } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { useContextSystem, contextConnect } from '../context';
 import type { WordPressComponentProps } from '../context';
-import Icon from '../icon';
 import type {
 	DropdownMenuContext as DropdownMenuContextType,
 	DropdownMenuProps,
-	DropdownMenuGroupProps,
-	DropdownMenuItemProps,
-	DropdownMenuCheckboxItemProps,
-	DropdownMenuRadioItemProps,
-	DropdownMenuSeparatorProps,
 } from './types';
 import * as Styled from './styles';
-
-const DropdownMenuContext = createContext<
-	DropdownMenuContextType | undefined
->( undefined );
-DropdownMenuContext.displayName = 'DropdownMenuV2.Context';
-
-const DropdownMenuItem = forwardRef<
-	HTMLDivElement,
-	WordPressComponentProps< DropdownMenuItemProps, 'div', false >
->( function DropdownMenuItem(
-	{ prefix, suffix, children, hideOnClick = true, ...props },
-	ref
-) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-
-	return (
-		<Styled.DropdownMenuItem
-			ref={ ref }
-			{ ...props }
-			accessibleWhenDisabled
-			hideOnClick={ hideOnClick }
-			store={ dropdownMenuContext?.store }
-		>
-			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
-
-			<Styled.DropdownMenuItemContentWrapper>
-				<Styled.DropdownMenuItemChildrenWrapper>
-					{ children }
-				</Styled.DropdownMenuItemChildrenWrapper>
-
-				{ suffix && (
-					<Styled.ItemSuffixWrapper>
-						{ suffix }
-					</Styled.ItemSuffixWrapper>
-				) }
-			</Styled.DropdownMenuItemContentWrapper>
-		</Styled.DropdownMenuItem>
-	);
-} );
-DropdownMenuItem.displayName = 'DropdownMenuV2.Item';
-
-const DropdownMenuCheckboxItem = forwardRef<
-	HTMLDivElement,
-	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
->( function DropdownMenuCheckboxItem(
-	{ suffix, children, hideOnClick = false, ...props },
-	ref
-) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-
-	return (
-		<Styled.DropdownMenuCheckboxItem
-			ref={ ref }
-			{ ...props }
-			accessibleWhenDisabled
-			hideOnClick={ hideOnClick }
-			store={ dropdownMenuContext?.store }
-		>
-			<Ariakit.MenuItemCheck
-				store={ dropdownMenuContext?.store }
-				render={ <Styled.ItemPrefixWrapper /> }
-				// Override some ariakit inline styles
-				style={ { width: 'auto', height: 'auto' } }
-			>
-				<Icon icon={ check } size={ 24 } />
-			</Ariakit.MenuItemCheck>
-
-			<Styled.DropdownMenuItemContentWrapper>
-				<Styled.DropdownMenuItemChildrenWrapper>
-					{ children }
-				</Styled.DropdownMenuItemChildrenWrapper>
-
-				{ suffix && (
-					<Styled.ItemSuffixWrapper>
-						{ suffix }
-					</Styled.ItemSuffixWrapper>
-				) }
-			</Styled.DropdownMenuItemContentWrapper>
-		</Styled.DropdownMenuCheckboxItem>
-	);
-} );
-DropdownMenuCheckboxItem.displayName = 'DropdownMenuV2.CheckboxItem';
-
-const radioCheck = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Circle cx={ 12 } cy={ 12 } r={ 3 }></Circle>
-	</SVG>
-);
-
-const DropdownMenuRadioItem = forwardRef<
-	HTMLDivElement,
-	WordPressComponentProps< DropdownMenuRadioItemProps, 'div', false >
->( function DropdownMenuRadioItem(
-	{ suffix, children, hideOnClick = false, ...props },
-	ref
-) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-
-	return (
-		<Styled.DropdownMenuRadioItem
-			ref={ ref }
-			{ ...props }
-			accessibleWhenDisabled
-			hideOnClick={ hideOnClick }
-			store={ dropdownMenuContext?.store }
-		>
-			<Ariakit.MenuItemCheck
-				store={ dropdownMenuContext?.store }
-				render={ <Styled.ItemPrefixWrapper /> }
-				// Override some ariakit inline styles
-				style={ { width: 'auto', height: 'auto' } }
-			>
-				<Icon icon={ radioCheck } size={ 24 } />
-			</Ariakit.MenuItemCheck>
-
-			<Styled.DropdownMenuItemContentWrapper>
-				<Styled.DropdownMenuItemChildrenWrapper>
-					{ children }
-				</Styled.DropdownMenuItemChildrenWrapper>
-
-				{ suffix && (
-					<Styled.ItemSuffixWrapper>
-						{ suffix }
-					</Styled.ItemSuffixWrapper>
-				) }
-			</Styled.DropdownMenuItemContentWrapper>
-		</Styled.DropdownMenuRadioItem>
-	);
-} );
-DropdownMenuRadioItem.displayName = 'DropdownMenuV2.RadioItem';
-
-const DropdownMenuGroup = forwardRef<
-	HTMLDivElement,
-	WordPressComponentProps< DropdownMenuGroupProps, 'div', false >
->( function DropdownMenuGroup( props, ref ) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-	return (
-		<Styled.DropdownMenuGroup
-			ref={ ref }
-			{ ...props }
-			store={ dropdownMenuContext?.store }
-		/>
-	);
-} );
-DropdownMenuGroup.displayName = 'DropdownMenuV2.Group';
-
-const DropdownMenuSeparator = forwardRef<
-	HTMLHRElement,
-	WordPressComponentProps< DropdownMenuSeparatorProps, 'hr', false >
->( function DropdownMenuSeparator( props, ref ) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-	return (
-		<Styled.DropdownMenuSeparator
-			ref={ ref }
-			{ ...props }
-			store={ dropdownMenuContext?.store }
-			variant={ dropdownMenuContext?.variant }
-		/>
-	);
-} );
-DropdownMenuSeparator.displayName = 'DropdownMenuV2.Separator';
-
-const DropdownMenuItemLabel = forwardRef<
-	HTMLSpanElement,
-	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
->( function DropdownMenuItemLabel( props, ref ) {
-	return (
-		<Styled.DropdownMenuItemLabel
-			numberOfLines={ 1 }
-			ref={ ref }
-			{ ...props }
-		/>
-	);
-} );
-DropdownMenuItemLabel.displayName = 'DropdownMenuV2.ItemLabel';
-
-const DropdownMenuItemHelpText = forwardRef<
-	HTMLSpanElement,
-	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
->( function DropdownMenuItemHelpText( props, ref ) {
-	return (
-		<Styled.DropdownMenuItemHelpText
-			numberOfLines={ 2 }
-			ref={ ref }
-			{ ...props }
-		/>
-	);
-} );
-DropdownMenuItemHelpText.displayName = 'DropdownMenuV2.ItemHelpText';
+import { DropdownMenuContext } from './context';
+import { DropdownMenuItem } from './item';
+import { DropdownMenuCheckboxItem } from './checkbox-item';
+import { DropdownMenuRadioItem } from './radio-item';
+import { DropdownMenuGroup } from './group';
+import { DropdownMenuSeparator } from './separator';
+import { DropdownMenuItemLabel } from './item-label';
+import { DropdownMenuItemHelpText } from './item-help-text';
 
 const UnconnectedDropdownMenu = (
 	props: WordPressComponentProps< DropdownMenuProps, 'div', false >,
@@ -386,10 +196,10 @@ const UnconnectedDropdownMenu = (
 		</>
 	);
 };
+
 export const DropdownMenuV2 = Object.assign(
 	contextConnect( UnconnectedDropdownMenu, 'DropdownMenu' ),
 	{
-		displayName: 'DropdownMenuV2',
 		Context: DropdownMenuContext,
 		Item: DropdownMenuItem,
 		RadioItem: DropdownMenuRadioItem,
@@ -400,3 +210,5 @@ export const DropdownMenuV2 = Object.assign(
 		ItemHelpText: DropdownMenuItemHelpText,
 	}
 );
+
+export default DropdownMenuV2;

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -37,11 +37,12 @@ import type {
 } from './types';
 import * as Styled from './styles';
 
-export const DropdownMenuContext = createContext<
+const DropdownMenuContext = createContext<
 	DropdownMenuContextType | undefined
 >( undefined );
+DropdownMenuContext.displayName = 'DropdownMenuV2.Context';
 
-export const DropdownMenuItem = forwardRef<
+const DropdownMenuItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuItemProps, 'div', false >
 >( function DropdownMenuItem(
@@ -74,8 +75,9 @@ export const DropdownMenuItem = forwardRef<
 		</Styled.DropdownMenuItem>
 	);
 } );
+DropdownMenuItem.displayName = 'DropdownMenuV2.Item';
 
-export const DropdownMenuCheckboxItem = forwardRef<
+const DropdownMenuCheckboxItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuCheckboxItemProps, 'div', false >
 >( function DropdownMenuCheckboxItem(
@@ -115,6 +117,7 @@ export const DropdownMenuCheckboxItem = forwardRef<
 		</Styled.DropdownMenuCheckboxItem>
 	);
 } );
+DropdownMenuCheckboxItem.displayName = 'DropdownMenuV2.CheckboxItem';
 
 const radioCheck = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
@@ -122,7 +125,7 @@ const radioCheck = (
 	</SVG>
 );
 
-export const DropdownMenuRadioItem = forwardRef<
+const DropdownMenuRadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuRadioItemProps, 'div', false >
 >( function DropdownMenuRadioItem(
@@ -162,8 +165,9 @@ export const DropdownMenuRadioItem = forwardRef<
 		</Styled.DropdownMenuRadioItem>
 	);
 } );
+DropdownMenuRadioItem.displayName = 'DropdownMenuV2.RadioItem';
 
-export const DropdownMenuGroup = forwardRef<
+const DropdownMenuGroup = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< DropdownMenuGroupProps, 'div', false >
 >( function DropdownMenuGroup( props, ref ) {
@@ -176,6 +180,51 @@ export const DropdownMenuGroup = forwardRef<
 		/>
 	);
 } );
+DropdownMenuGroup.displayName = 'DropdownMenuV2.Group';
+
+const DropdownMenuSeparator = forwardRef<
+	HTMLHRElement,
+	WordPressComponentProps< DropdownMenuSeparatorProps, 'hr', false >
+>( function DropdownMenuSeparator( props, ref ) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<Styled.DropdownMenuSeparator
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+			variant={ dropdownMenuContext?.variant }
+		/>
+	);
+} );
+DropdownMenuSeparator.displayName = 'DropdownMenuV2.Separator';
+
+const DropdownMenuItemLabel = forwardRef<
+	HTMLSpanElement,
+	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
+>( function DropdownMenuItemLabel( props, ref ) {
+	return (
+		<Styled.DropdownMenuItemLabel
+			numberOfLines={ 1 }
+			ref={ ref }
+			{ ...props }
+		/>
+	);
+} );
+DropdownMenuItemLabel.displayName = 'DropdownMenuV2.ItemLabel';
+
+const DropdownMenuItemHelpText = forwardRef<
+	HTMLSpanElement,
+	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
+>( function DropdownMenuItemHelpText( props, ref ) {
+	return (
+		<Styled.DropdownMenuItemHelpText
+			numberOfLines={ 2 }
+			ref={ ref }
+			{ ...props }
+		/>
+	);
+} );
+DropdownMenuItemHelpText.displayName = 'DropdownMenuV2.ItemHelpText';
 
 const UnconnectedDropdownMenu = (
 	props: WordPressComponentProps< DropdownMenuProps, 'div', false >,
@@ -337,48 +386,17 @@ const UnconnectedDropdownMenu = (
 		</>
 	);
 };
-export const DropdownMenu = contextConnect(
-	UnconnectedDropdownMenu,
-	'DropdownMenu'
+export const DropdownMenuV2 = Object.assign(
+	contextConnect( UnconnectedDropdownMenu, 'DropdownMenu' ),
+	{
+		displayName: 'DropdownMenuV2',
+		Context: DropdownMenuContext,
+		Item: DropdownMenuItem,
+		RadioItem: DropdownMenuRadioItem,
+		CheckboxItem: DropdownMenuCheckboxItem,
+		Group: DropdownMenuGroup,
+		Separator: DropdownMenuSeparator,
+		ItemLabel: DropdownMenuItemLabel,
+		ItemHelpText: DropdownMenuItemHelpText,
+	}
 );
-
-export const DropdownMenuSeparator = forwardRef<
-	HTMLHRElement,
-	WordPressComponentProps< DropdownMenuSeparatorProps, 'hr', false >
->( function DropdownMenuSeparator( props, ref ) {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
-	return (
-		<Styled.DropdownMenuSeparator
-			ref={ ref }
-			{ ...props }
-			store={ dropdownMenuContext?.store }
-			variant={ dropdownMenuContext?.variant }
-		/>
-	);
-} );
-
-export const DropdownMenuItemLabel = forwardRef<
-	HTMLSpanElement,
-	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
->( function DropdownMenuItemLabel( props, ref ) {
-	return (
-		<Styled.DropdownMenuItemLabel
-			numberOfLines={ 1 }
-			ref={ ref }
-			{ ...props }
-		/>
-	);
-} );
-
-export const DropdownMenuItemHelpText = forwardRef<
-	HTMLSpanElement,
-	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
->( function DropdownMenuItemHelpText( props, ref ) {
-	return (
-		<Styled.DropdownMenuItemHelpText
-			numberOfLines={ 2 }
-			ref={ ref }
-			{ ...props }
-		/>
-	);
-} );

--- a/packages/components/src/dropdown-menu-v2/item-help-text.tsx
+++ b/packages/components/src/dropdown-menu-v2/item-help-text.tsx
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import * as Styled from './styles';
+
+export const DropdownMenuItemHelpText = forwardRef<
+	HTMLSpanElement,
+	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
+>( function DropdownMenuItemHelpText( props, ref ) {
+	return (
+		<Styled.DropdownMenuItemHelpText
+			numberOfLines={ 2 }
+			ref={ ref }
+			{ ...props }
+		/>
+	);
+} );
+DropdownMenuItemHelpText.displayName = 'DropdownMenuV2.ItemHelpText';

--- a/packages/components/src/dropdown-menu-v2/item-label.tsx
+++ b/packages/components/src/dropdown-menu-v2/item-label.tsx
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import * as Styled from './styles';
+
+export const DropdownMenuItemLabel = forwardRef<
+	HTMLSpanElement,
+	WordPressComponentProps< { children: React.ReactNode }, 'span', true >
+>( function DropdownMenuItemLabel( props, ref ) {
+	return (
+		<Styled.DropdownMenuItemLabel
+			numberOfLines={ 1 }
+			ref={ ref }
+			{ ...props }
+		/>
+	);
+} );
+DropdownMenuItemLabel.displayName = 'DropdownMenuV2.ItemLabel';

--- a/packages/components/src/dropdown-menu-v2/item.tsx
+++ b/packages/components/src/dropdown-menu-v2/item.tsx
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import type { DropdownMenuItemProps } from './types';
+import * as Styled from './styles';
+import { DropdownMenuContext } from './context';
+
+export const DropdownMenuItem = forwardRef<
+	HTMLDivElement,
+	WordPressComponentProps< DropdownMenuItemProps, 'div', false >
+>( function DropdownMenuItem(
+	{ prefix, suffix, children, hideOnClick = true, ...props },
+	ref
+) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	return (
+		<Styled.DropdownMenuItem
+			ref={ ref }
+			{ ...props }
+			accessibleWhenDisabled
+			hideOnClick={ hideOnClick }
+			store={ dropdownMenuContext?.store }
+		>
+			<Styled.ItemPrefixWrapper>{ prefix }</Styled.ItemPrefixWrapper>
+
+			<Styled.DropdownMenuItemContentWrapper>
+				<Styled.DropdownMenuItemChildrenWrapper>
+					{ children }
+				</Styled.DropdownMenuItemChildrenWrapper>
+
+				{ suffix && (
+					<Styled.ItemSuffixWrapper>
+						{ suffix }
+					</Styled.ItemSuffixWrapper>
+				) }
+			</Styled.DropdownMenuItemContentWrapper>
+		</Styled.DropdownMenuItem>
+	);
+} );
+DropdownMenuItem.displayName = 'DropdownMenuV2.Item';

--- a/packages/components/src/dropdown-menu-v2/radio-item.tsx
+++ b/packages/components/src/dropdown-menu-v2/radio-item.tsx
@@ -1,0 +1,67 @@
+/**
+ * External dependencies
+ */
+import * as Ariakit from '@ariakit/react';
+
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useContext } from '@wordpress/element';
+import { Icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import { DropdownMenuContext } from './context';
+import type { DropdownMenuRadioItemProps } from './types';
+import * as Styled from './styles';
+import { SVG, Circle } from '@wordpress/primitives';
+
+const radioCheck = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Circle cx={ 12 } cy={ 12 } r={ 3 }></Circle>
+	</SVG>
+);
+
+export const DropdownMenuRadioItem = forwardRef<
+	HTMLDivElement,
+	WordPressComponentProps< DropdownMenuRadioItemProps, 'div', false >
+>( function DropdownMenuRadioItem(
+	{ suffix, children, hideOnClick = false, ...props },
+	ref
+) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+
+	return (
+		<Styled.DropdownMenuRadioItem
+			ref={ ref }
+			{ ...props }
+			accessibleWhenDisabled
+			hideOnClick={ hideOnClick }
+			store={ dropdownMenuContext?.store }
+		>
+			<Ariakit.MenuItemCheck
+				store={ dropdownMenuContext?.store }
+				render={ <Styled.ItemPrefixWrapper /> }
+				// Override some ariakit inline styles
+				style={ { width: 'auto', height: 'auto' } }
+			>
+				<Icon icon={ radioCheck } size={ 24 } />
+			</Ariakit.MenuItemCheck>
+
+			<Styled.DropdownMenuItemContentWrapper>
+				<Styled.DropdownMenuItemChildrenWrapper>
+					{ children }
+				</Styled.DropdownMenuItemChildrenWrapper>
+
+				{ suffix && (
+					<Styled.ItemSuffixWrapper>
+						{ suffix }
+					</Styled.ItemSuffixWrapper>
+				) }
+			</Styled.DropdownMenuItemContentWrapper>
+		</Styled.DropdownMenuRadioItem>
+	);
+} );
+DropdownMenuRadioItem.displayName = 'DropdownMenuV2.RadioItem';

--- a/packages/components/src/dropdown-menu-v2/separator.tsx
+++ b/packages/components/src/dropdown-menu-v2/separator.tsx
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { forwardRef, useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { WordPressComponentProps } from '../context';
+import { DropdownMenuContext } from './context';
+import type { DropdownMenuSeparatorProps } from './types';
+import * as Styled from './styles';
+
+export const DropdownMenuSeparator = forwardRef<
+	HTMLHRElement,
+	WordPressComponentProps< DropdownMenuSeparatorProps, 'hr', false >
+>( function DropdownMenuSeparator( props, ref ) {
+	const dropdownMenuContext = useContext( DropdownMenuContext );
+	return (
+		<Styled.DropdownMenuSeparator
+			ref={ ref }
+			{ ...props }
+			store={ dropdownMenuContext?.store }
+			variant={ dropdownMenuContext?.variant }
+		/>
+	);
+} );
+DropdownMenuSeparator.displayName = 'DropdownMenuV2.Separator';

--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -22,7 +22,7 @@ import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
 
 const meta: Meta< typeof DropdownMenuV2 > = {
-	title: 'Components (Experimental)/DropdownMenuV2 V2',
+	title: 'Components (Experimental)/DropdownMenu V2',
 	component: DropdownMenuV2,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170

--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -14,7 +14,7 @@ import { useState, useMemo, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { useCx } from '../../utils';
-import { DropdownMenuV2 } from '..';
+import DropdownMenuV2 from '..';
 import Icon from '../../icon';
 import Button from '../../button';
 import Modal from '../../modal';

--- a/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu-v2/stories/index.story.tsx
@@ -14,43 +14,33 @@ import { useState, useMemo, useContext } from '@wordpress/element';
  * Internal dependencies
  */
 import { useCx } from '../../utils';
-import {
-	DropdownMenu,
-	DropdownMenuItem,
-	DropdownMenuCheckboxItem,
-	DropdownMenuGroup,
-	DropdownMenuSeparator,
-	DropdownMenuContext,
-	DropdownMenuRadioItem,
-	DropdownMenuItemLabel,
-	DropdownMenuItemHelpText,
-} from '..';
+import { DropdownMenuV2 } from '..';
 import Icon from '../../icon';
 import Button from '../../button';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
 
-const meta: Meta< typeof DropdownMenu > = {
-	title: 'Components (Experimental)/DropdownMenu V2',
-	component: DropdownMenu,
+const meta: Meta< typeof DropdownMenuV2 > = {
+	title: 'Components (Experimental)/DropdownMenuV2 V2',
+	component: DropdownMenuV2,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuItem,
+		Item: DropdownMenuV2.Item,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuCheckboxItem,
+		CheckboxItem: DropdownMenuV2.CheckboxItem,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuGroup,
+		Group: DropdownMenuV2.Group,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuSeparator,
+		Separator: DropdownMenuV2.Separator,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuContext,
+		Context: DropdownMenuV2.Context,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuRadioItem,
+		RadioItem: DropdownMenuV2.RadioItem,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuItemLabel,
+		ItemLabel: DropdownMenuV2.ItemLabel,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
-		DropdownMenuItemHelpText,
+		ItemHelpText: DropdownMenuV2.ItemHelpText,
 	},
 	argTypes: {
 		children: { control: { type: null } },
@@ -68,51 +58,51 @@ const meta: Meta< typeof DropdownMenu > = {
 };
 export default meta;
 
-export const Default: StoryFn< typeof DropdownMenu > = ( props ) => (
-	<DropdownMenu { ...props }>
-		<DropdownMenuItem>
-			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
-		</DropdownMenuItem>
-		<DropdownMenuItem>
-			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
-			<DropdownMenuItemHelpText>Help text</DropdownMenuItemHelpText>
-		</DropdownMenuItem>
-		<DropdownMenuItem>
-			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
-			<DropdownMenuItemHelpText>
+export const Default: StoryFn< typeof DropdownMenuV2 > = ( props ) => (
+	<DropdownMenuV2 { ...props }>
+		<DropdownMenuV2.Item>
+			<DropdownMenuV2.ItemLabel>Label</DropdownMenuV2.ItemLabel>
+		</DropdownMenuV2.Item>
+		<DropdownMenuV2.Item>
+			<DropdownMenuV2.ItemLabel>Label</DropdownMenuV2.ItemLabel>
+			<DropdownMenuV2.ItemHelpText>Help text</DropdownMenuV2.ItemHelpText>
+		</DropdownMenuV2.Item>
+		<DropdownMenuV2.Item>
+			<DropdownMenuV2.ItemLabel>Label</DropdownMenuV2.ItemLabel>
+			<DropdownMenuV2.ItemHelpText>
 				The menu item help text is automatically truncated when there
 				are more than two lines of text
-			</DropdownMenuItemHelpText>
-		</DropdownMenuItem>
-		<DropdownMenuItem hideOnClick={ false }>
-			<DropdownMenuItemLabel>Label</DropdownMenuItemLabel>
-			<DropdownMenuItemHelpText>
+			</DropdownMenuV2.ItemHelpText>
+		</DropdownMenuV2.Item>
+		<DropdownMenuV2.Item hideOnClick={ false }>
+			<DropdownMenuV2.ItemLabel>Label</DropdownMenuV2.ItemLabel>
+			<DropdownMenuV2.ItemHelpText>
 				This item doesn&apos;t close the menu on click
-			</DropdownMenuItemHelpText>
-		</DropdownMenuItem>
-		<DropdownMenuItem disabled>Disabled item</DropdownMenuItem>
-		<DropdownMenuSeparator />
-		<DropdownMenuGroup>
-			<DropdownMenuItem
+			</DropdownMenuV2.ItemHelpText>
+		</DropdownMenuV2.Item>
+		<DropdownMenuV2.Item disabled>Disabled item</DropdownMenuV2.Item>
+		<DropdownMenuV2.Separator />
+		<DropdownMenuV2.Group>
+			<DropdownMenuV2.Item
 				prefix={ <Icon icon={ customLink } size={ 24 } /> }
 			>
-				<DropdownMenuItemLabel>With prefix</DropdownMenuItemLabel>
-			</DropdownMenuItem>
-			<DropdownMenuItem suffix="⌘S">With suffix</DropdownMenuItem>
-			<DropdownMenuItem
+				<DropdownMenuV2.ItemLabel>With prefix</DropdownMenuV2.ItemLabel>
+			</DropdownMenuV2.Item>
+			<DropdownMenuV2.Item suffix="⌘S">With suffix</DropdownMenuV2.Item>
+			<DropdownMenuV2.Item
 				disabled
 				prefix={ <Icon icon={ formatCapitalize } size={ 24 } /> }
 				suffix="⌥⌘T"
 			>
-				<DropdownMenuItemLabel>
+				<DropdownMenuV2.ItemLabel>
 					Disabled with prefix and suffix
-				</DropdownMenuItemLabel>
-				<DropdownMenuItemHelpText>
+				</DropdownMenuV2.ItemLabel>
+				<DropdownMenuV2.ItemHelpText>
 					And help text
-				</DropdownMenuItemHelpText>
-			</DropdownMenuItem>
-		</DropdownMenuGroup>
-	</DropdownMenu>
+				</DropdownMenuV2.ItemHelpText>
+			</DropdownMenuV2.Item>
+		</DropdownMenuV2.Group>
+	</DropdownMenuV2>
 );
 Default.args = {
 	trigger: (
@@ -122,48 +112,56 @@ Default.args = {
 	),
 };
 
-export const WithSubmenu: StoryFn< typeof DropdownMenu > = ( props ) => (
-	<DropdownMenu { ...props }>
-		<DropdownMenuItem>Level 1 item</DropdownMenuItem>
-		<DropdownMenu
+export const WithSubmenu: StoryFn< typeof DropdownMenuV2 > = ( props ) => (
+	<DropdownMenuV2 { ...props }>
+		<DropdownMenuV2.Item>Level 1 item</DropdownMenuV2.Item>
+		<DropdownMenuV2
 			trigger={
-				<DropdownMenuItem suffix="Suffix">
-					<DropdownMenuItemLabel>
+				<DropdownMenuV2.Item suffix="Suffix">
+					<DropdownMenuV2.ItemLabel>
 						Submenu trigger item with a long label
-					</DropdownMenuItemLabel>
-				</DropdownMenuItem>
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
 			}
 		>
-			<DropdownMenuItem>
-				<DropdownMenuItemLabel>Level 2 item</DropdownMenuItemLabel>
-			</DropdownMenuItem>
-			<DropdownMenuItem>
-				<DropdownMenuItemLabel>Level 2 item</DropdownMenuItemLabel>
-			</DropdownMenuItem>
-			<DropdownMenu
+			<DropdownMenuV2.Item>
+				<DropdownMenuV2.ItemLabel>
+					Level 2 item
+				</DropdownMenuV2.ItemLabel>
+			</DropdownMenuV2.Item>
+			<DropdownMenuV2.Item>
+				<DropdownMenuV2.ItemLabel>
+					Level 2 item
+				</DropdownMenuV2.ItemLabel>
+			</DropdownMenuV2.Item>
+			<DropdownMenuV2
 				trigger={
-					<DropdownMenuItem>
-						<DropdownMenuItemLabel>
+					<DropdownMenuV2.Item>
+						<DropdownMenuV2.ItemLabel>
 							Submenu trigger
-						</DropdownMenuItemLabel>
-					</DropdownMenuItem>
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.Item>
 				}
 			>
-				<DropdownMenuItem>
-					<DropdownMenuItemLabel>Level 3 item</DropdownMenuItemLabel>
-				</DropdownMenuItem>
-				<DropdownMenuItem>
-					<DropdownMenuItemLabel>Level 3 item</DropdownMenuItemLabel>
-				</DropdownMenuItem>
-			</DropdownMenu>
-		</DropdownMenu>
-	</DropdownMenu>
+				<DropdownMenuV2.Item>
+					<DropdownMenuV2.ItemLabel>
+						Level 3 item
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
+				<DropdownMenuV2.Item>
+					<DropdownMenuV2.ItemLabel>
+						Level 3 item
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
+			</DropdownMenuV2>
+		</DropdownMenuV2>
+	</DropdownMenuV2>
 );
 WithSubmenu.args = {
 	...Default.args,
 };
 
-export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
+export const WithCheckboxes: StoryFn< typeof DropdownMenuV2 > = ( props ) => {
 	const [ isAChecked, setAChecked ] = useState( false );
 	const [ isBChecked, setBChecked ] = useState( true );
 	const [ multipleCheckboxesValue, setMultipleCheckboxesValue ] = useState<
@@ -171,7 +169,7 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 	>( [ 'b' ] );
 
 	const onMultipleCheckboxesCheckedChange: React.ComponentProps<
-		typeof DropdownMenuCheckboxItem
+		typeof DropdownMenuV2.CheckboxItem
 	>[ 'onChange' ] = ( e ) => {
 		setMultipleCheckboxesValue( ( prevValues ) => {
 			if ( prevValues.includes( e.target.value ) ) {
@@ -182,176 +180,184 @@ export const WithCheckboxes: StoryFn< typeof DropdownMenu > = ( props ) => {
 	};
 
 	return (
-		<DropdownMenu { ...props }>
-			<DropdownMenuGroup>
-				<DropdownMenuCheckboxItem
+		<DropdownMenuV2 { ...props }>
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-individual-uncontrolled-a"
 					value="a"
 					suffix="⌥⌘T"
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item A
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Uncontrolled
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-individual-uncontrolled-b"
 					value="b"
 					defaultChecked
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item B
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Uncontrolled, initially checked
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-			</DropdownMenuGroup>
-			<DropdownMenuSeparator />
-			<DropdownMenuGroup>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+			</DropdownMenuV2.Group>
+			<DropdownMenuV2.Separator />
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-individual-controlled-a"
 					value="a"
 					checked={ isAChecked }
 					onChange={ ( e ) => setAChecked( e.target.checked ) }
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item A
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Controlled
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-individual-controlled-b"
 					value="b"
 					checked={ isBChecked }
 					onChange={ ( e ) => setBChecked( e.target.checked ) }
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item B
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Controlled, initially checked
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-			</DropdownMenuGroup>
-			<DropdownMenuSeparator />
-			<DropdownMenuGroup>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+			</DropdownMenuV2.Group>
+			<DropdownMenuV2.Separator />
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-multiple-uncontrolled"
 					value="a"
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item A
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Uncontrolled, multiple selection
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-multiple-uncontrolled"
 					value="b"
 					defaultChecked
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item B
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Uncontrolled, multiple selection, initially checked
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-			</DropdownMenuGroup>
-			<DropdownMenuSeparator />
-			<DropdownMenuGroup>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+			</DropdownMenuV2.Group>
+			<DropdownMenuV2.Separator />
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-multiple-controlled"
 					value="a"
 					checked={ multipleCheckboxesValue.includes( 'a' ) }
 					onChange={ onMultipleCheckboxesCheckedChange }
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item A
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Controlled, multiple selection
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-				<DropdownMenuCheckboxItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+				<DropdownMenuV2.CheckboxItem
 					name="checkbox-multiple-controlled"
 					value="b"
 					checked={ multipleCheckboxesValue.includes( 'b' ) }
 					onChange={ onMultipleCheckboxesCheckedChange }
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Checkbox item B
-					</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Controlled, multiple selection, initially checked
-					</DropdownMenuItemHelpText>
-				</DropdownMenuCheckboxItem>
-			</DropdownMenuGroup>
-		</DropdownMenu>
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.CheckboxItem>
+			</DropdownMenuV2.Group>
+		</DropdownMenuV2>
 	);
 };
 WithCheckboxes.args = {
 	...Default.args,
 };
 
-export const WithRadios: StoryFn< typeof DropdownMenu > = ( props ) => {
+export const WithRadios: StoryFn< typeof DropdownMenuV2 > = ( props ) => {
 	const [ radioValue, setRadioValue ] = useState( 'two' );
 	const onRadioChange: React.ComponentProps<
-		typeof DropdownMenuRadioItem
+		typeof DropdownMenuV2.RadioItem
 	>[ 'onChange' ] = ( e ) => setRadioValue( e.target.value );
 
 	return (
-		<DropdownMenu { ...props }>
-			<DropdownMenuGroup>
-				<DropdownMenuRadioItem name="radio-uncontrolled" value="one">
-					<DropdownMenuItemLabel>Radio item 1</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+		<DropdownMenuV2 { ...props }>
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.RadioItem name="radio-uncontrolled" value="one">
+					<DropdownMenuV2.ItemLabel>
+						Radio item 1
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Uncontrolled
-					</DropdownMenuItemHelpText>
-				</DropdownMenuRadioItem>
-				<DropdownMenuRadioItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.RadioItem>
+				<DropdownMenuV2.RadioItem
 					name="radio-uncontrolled"
 					value="two"
 					defaultChecked
 				>
-					<DropdownMenuItemLabel>Radio item 2</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					<DropdownMenuV2.ItemLabel>
+						Radio item 2
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Uncontrolled, initially checked
-					</DropdownMenuItemHelpText>
-				</DropdownMenuRadioItem>
-			</DropdownMenuGroup>
-			<DropdownMenuSeparator />
-			<DropdownMenuGroup>
-				<DropdownMenuRadioItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.RadioItem>
+			</DropdownMenuV2.Group>
+			<DropdownMenuV2.Separator />
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.RadioItem
 					name="radio-controlled"
 					value="one"
 					checked={ radioValue === 'one' }
 					onChange={ onRadioChange }
 				>
-					<DropdownMenuItemLabel>Radio item 1</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					<DropdownMenuV2.ItemLabel>
+						Radio item 1
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Controlled
-					</DropdownMenuItemHelpText>
-				</DropdownMenuRadioItem>
-				<DropdownMenuRadioItem
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.RadioItem>
+				<DropdownMenuV2.RadioItem
 					name="radio-controlled"
 					value="two"
 					checked={ radioValue === 'two' }
 					onChange={ onRadioChange }
 				>
-					<DropdownMenuItemLabel>Radio item 2</DropdownMenuItemLabel>
-					<DropdownMenuItemHelpText>
+					<DropdownMenuV2.ItemLabel>
+						Radio item 2
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
 						Controlled, initially checked
-					</DropdownMenuItemHelpText>
-				</DropdownMenuRadioItem>
-			</DropdownMenuGroup>
-		</DropdownMenu>
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.RadioItem>
+			</DropdownMenuV2.Group>
+		</DropdownMenuV2>
 	);
 };
 WithRadios.args = {
@@ -365,7 +371,7 @@ const modalOnTopOfDropdown = css`
 `;
 
 // For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
-export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
+export const WithModals: StoryFn< typeof DropdownMenuV2 > = ( props ) => {
 	const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
 	const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
 
@@ -374,23 +380,23 @@ export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 
 	return (
 		<>
-			<DropdownMenu { ...props }>
-				<DropdownMenuItem
+			<DropdownMenuV2 { ...props }>
+				<DropdownMenuV2.Item
 					onClick={ () => setOuterModalOpen( true ) }
 					hideOnClick={ false }
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Open outer modal
-					</DropdownMenuItemLabel>
-				</DropdownMenuItem>
-				<DropdownMenuItem
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
+				<DropdownMenuV2.Item
 					onClick={ () => setInnerModalOpen( true ) }
 					hideOnClick={ false }
 				>
-					<DropdownMenuItemLabel>
+					<DropdownMenuV2.ItemLabel>
 						Open inner modal
-					</DropdownMenuItemLabel>
-				</DropdownMenuItem>
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
 				{ isInnerModalOpen && (
 					<Modal
 						onRequestClose={ () => setInnerModalOpen( false ) }
@@ -402,7 +408,7 @@ export const WithModals: StoryFn< typeof DropdownMenu > = ( props ) => {
 						</button>
 					</Modal>
 				) }
-			</DropdownMenu>
+			</DropdownMenuV2>
 			{ isOuterModalOpen && (
 				<Modal
 					onRequestClose={ () => setOuterModalOpen( false ) }
@@ -424,14 +430,14 @@ WithModals.args = {
 const ExampleSlotFill = createSlotFill( 'Example' );
 
 const Slot = () => {
-	const dropdownMenuContext = useContext( DropdownMenuContext );
+	const dropdownMenuContext = useContext( DropdownMenuV2.Context );
 
 	// Forwarding the content of the slot so that it can be used by the fill
 	const fillProps = useMemo(
 		() => ( {
 			forwardedContext: [
 				[
-					DropdownMenuContext.Provider,
+					DropdownMenuV2.Context.Provider,
 					{ value: dropdownMenuContext },
 				],
 			],
@@ -472,37 +478,37 @@ const Fill = ( { children }: { children: React.ReactNode } ) => {
 	);
 };
 
-export const WithSlotFill: StoryFn< typeof DropdownMenu > = ( props ) => {
+export const WithSlotFill: StoryFn< typeof DropdownMenuV2 > = ( props ) => {
 	return (
 		<SlotFillProvider>
-			<DropdownMenu { ...props }>
-				<DropdownMenuItem>
-					<DropdownMenuItemLabel>Item</DropdownMenuItemLabel>
-				</DropdownMenuItem>
+			<DropdownMenuV2 { ...props }>
+				<DropdownMenuV2.Item>
+					<DropdownMenuV2.ItemLabel>Item</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
 				<Slot />
-			</DropdownMenu>
+			</DropdownMenuV2>
 
 			<Fill>
-				<DropdownMenuItem>
-					<DropdownMenuItemLabel>
+				<DropdownMenuV2.Item>
+					<DropdownMenuV2.ItemLabel>
 						Item from fill
-					</DropdownMenuItemLabel>
-				</DropdownMenuItem>
-				<DropdownMenu
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
+				<DropdownMenuV2
 					trigger={
-						<DropdownMenuItem>
-							<DropdownMenuItemLabel>
+						<DropdownMenuV2.Item>
+							<DropdownMenuV2.ItemLabel>
 								Submenu from fill
-							</DropdownMenuItemLabel>
-						</DropdownMenuItem>
+							</DropdownMenuV2.ItemLabel>
+						</DropdownMenuV2.Item>
 					}
 				>
-					<DropdownMenuItem>
-						<DropdownMenuItemLabel>
+					<DropdownMenuV2.Item>
+						<DropdownMenuV2.ItemLabel>
 							Submenu item from fill
-						</DropdownMenuItemLabel>
-					</DropdownMenuItem>
-				</DropdownMenu>
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			</Fill>
 		</SlotFillProvider>
 	);
@@ -512,42 +518,48 @@ WithSlotFill.args = {
 };
 
 const toolbarVariantContextValue = {
-	DropdownMenu: {
+	DropdownMenuV2: {
 		variant: 'toolbar',
 	},
 };
-export const ToolbarVariant: StoryFn< typeof DropdownMenu > = ( props ) => (
+export const ToolbarVariant: StoryFn< typeof DropdownMenuV2 > = ( props ) => (
 	// TODO: add toolbar
 	<ContextSystemProvider value={ toolbarVariantContextValue }>
-		<DropdownMenu { ...props }>
-			<DropdownMenuItem>
-				<DropdownMenuItemLabel>Level 1 item</DropdownMenuItemLabel>
-			</DropdownMenuItem>
-			<DropdownMenuItem>
-				<DropdownMenuItemLabel>Level 1 item</DropdownMenuItemLabel>
-			</DropdownMenuItem>
-			<DropdownMenuSeparator />
-			<DropdownMenu
+		<DropdownMenuV2 { ...props }>
+			<DropdownMenuV2.Item>
+				<DropdownMenuV2.ItemLabel>
+					Level 1 item
+				</DropdownMenuV2.ItemLabel>
+			</DropdownMenuV2.Item>
+			<DropdownMenuV2.Item>
+				<DropdownMenuV2.ItemLabel>
+					Level 1 item
+				</DropdownMenuV2.ItemLabel>
+			</DropdownMenuV2.Item>
+			<DropdownMenuV2.Separator />
+			<DropdownMenuV2
 				trigger={
-					<DropdownMenuItem>
-						<DropdownMenuItemLabel>
+					<DropdownMenuV2.Item>
+						<DropdownMenuV2.ItemLabel>
 							Submenu trigger
-						</DropdownMenuItemLabel>
-					</DropdownMenuItem>
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.Item>
 				}
 			>
-				<DropdownMenuItem>
-					<DropdownMenuItemLabel>Level 2 item</DropdownMenuItemLabel>
-				</DropdownMenuItem>
-			</DropdownMenu>
-		</DropdownMenu>
+				<DropdownMenuV2.Item>
+					<DropdownMenuV2.ItemLabel>
+						Level 2 item
+					</DropdownMenuV2.ItemLabel>
+				</DropdownMenuV2.Item>
+			</DropdownMenuV2>
+		</DropdownMenuV2>
 	</ContextSystemProvider>
 );
 ToolbarVariant.args = {
 	...Default.args,
 };
 
-export const InsideModal: StoryFn< typeof DropdownMenu > = ( props ) => {
+export const InsideModal: StoryFn< typeof DropdownMenuV2 > = ( props ) => {
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	return (
 		<>
@@ -560,34 +572,34 @@ export const InsideModal: StoryFn< typeof DropdownMenu > = ( props ) => {
 			</Button>
 			{ isModalOpen && (
 				<Modal onRequestClose={ () => setModalOpen( false ) }>
-					<DropdownMenu { ...props }>
-						<DropdownMenuItem>
-							<DropdownMenuItemLabel>
+					<DropdownMenuV2 { ...props }>
+						<DropdownMenuV2.Item>
+							<DropdownMenuV2.ItemLabel>
 								Level 1 item
-							</DropdownMenuItemLabel>
-						</DropdownMenuItem>
-						<DropdownMenuItem>
-							<DropdownMenuItemLabel>
+							</DropdownMenuV2.ItemLabel>
+						</DropdownMenuV2.Item>
+						<DropdownMenuV2.Item>
+							<DropdownMenuV2.ItemLabel>
 								Level 1 item
-							</DropdownMenuItemLabel>
-						</DropdownMenuItem>
-						<DropdownMenuSeparator />
-						<DropdownMenu
+							</DropdownMenuV2.ItemLabel>
+						</DropdownMenuV2.Item>
+						<DropdownMenuV2.Separator />
+						<DropdownMenuV2
 							trigger={
-								<DropdownMenuItem>
-									<DropdownMenuItemLabel>
+								<DropdownMenuV2.Item>
+									<DropdownMenuV2.ItemLabel>
 										Submenu trigger
-									</DropdownMenuItemLabel>
-								</DropdownMenuItem>
+									</DropdownMenuV2.ItemLabel>
+								</DropdownMenuV2.Item>
 							}
 						>
-							<DropdownMenuItem>
-								<DropdownMenuItemLabel>
+							<DropdownMenuV2.Item>
+								<DropdownMenuV2.ItemLabel>
 									Level 2 item
-								</DropdownMenuItemLabel>
-							</DropdownMenuItem>
-						</DropdownMenu>
-					</DropdownMenu>
+								</DropdownMenuV2.ItemLabel>
+							</DropdownMenuV2.Item>
+						</DropdownMenuV2>
+					</DropdownMenuV2>
 					<Button onClick={ () => setModalOpen( false ) }>
 						Close modal
 					</Button>

--- a/packages/components/src/dropdown-menu-v2/test/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/test/index.tsx
@@ -12,14 +12,7 @@ import { useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	DropdownMenu,
-	DropdownMenuCheckboxItem,
-	DropdownMenuItem,
-	DropdownMenuRadioItem,
-	DropdownMenuSeparator,
-	DropdownMenuGroup,
-} from '..';
+import { DropdownMenuV2 } from '..';
 
 const delay = ( delayInMs: number ) => {
 	return new Promise( ( resolve ) => setTimeout( resolve, delayInMs ) );
@@ -29,18 +22,24 @@ describe( 'DropdownMenu', () => {
 	// See https://www.w3.org/WAI/ARIA/apg/patterns/menu-button/
 	it( 'should follow the WAI-ARIA spec', async () => {
 		render(
-			<DropdownMenu trigger={ <button>Open dropdown</button> }>
-				<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-				<DropdownMenuSeparator />
-				<DropdownMenu
+			<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+				<DropdownMenuV2.Item>Dropdown menu item</DropdownMenuV2.Item>
+				<DropdownMenuV2.Separator />
+				<DropdownMenuV2
 					trigger={
-						<DropdownMenuItem>Dropdown submenu</DropdownMenuItem>
+						<DropdownMenuV2.Item>
+							Dropdown submenu
+						</DropdownMenuV2.Item>
 					}
 				>
-					<DropdownMenuItem>Dropdown submenu item 1</DropdownMenuItem>
-					<DropdownMenuItem>Dropdown submenu item 2</DropdownMenuItem>
-				</DropdownMenu>
-			</DropdownMenu>
+					<DropdownMenuV2.Item>
+						Dropdown submenu item 1
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>
+						Dropdown submenu item 2
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
+			</DropdownMenuV2>
 		);
 
 		const toggleButton = screen.getByRole( 'button', {
@@ -95,9 +94,11 @@ describe( 'DropdownMenu', () => {
 	describe( 'pointer and keyboard interactions', () => {
 		it( 'should open and focus the menu when clicking the trigger', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-				</DropdownMenu>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item>
+						Dropdown menu item
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			const toggleButton = screen.getByRole( 'button', {
@@ -116,11 +117,13 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should open and focus the first item when pressing the arrow down key on the trigger', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem disabled>First item</DropdownMenuItem>
-					<DropdownMenuItem>Second item</DropdownMenuItem>
-					<DropdownMenuItem>Third item</DropdownMenuItem>
-				</DropdownMenu>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item disabled>
+						First item
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>Second item</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>Third item</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			const toggleButton = screen.getByRole( 'button', {
@@ -146,11 +149,13 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should open and focus the first item when pressing the space key on the trigger', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem disabled>First item</DropdownMenuItem>
-					<DropdownMenuItem>Second item</DropdownMenuItem>
-					<DropdownMenuItem>Third item</DropdownMenuItem>
-				</DropdownMenu>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item disabled>
+						First item
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>Second item</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>Third item</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			const toggleButton = screen.getByRole( 'button', {
@@ -176,9 +181,11 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should close when pressing the escape key', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-				</DropdownMenu>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item>
+						Dropdown menu item
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			const trigger = screen.getByRole( 'button', {
@@ -205,12 +212,14 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should close when clicking outside of the content', async () => {
 			render(
-				<DropdownMenu
+				<DropdownMenuV2
 					defaultOpen
 					trigger={ <button>Open dropdown</button> }
 				>
-					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-				</DropdownMenu>
+					<DropdownMenuV2.Item>
+						Dropdown menu item
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
@@ -223,12 +232,14 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should close when clicking on a menu item', async () => {
 			render(
-				<DropdownMenu
+				<DropdownMenuV2
 					defaultOpen
 					trigger={ <button>Open dropdown</button> }
 				>
-					<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-				</DropdownMenu>
+					<DropdownMenuV2.Item>
+						Dropdown menu item
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
@@ -241,14 +252,14 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should not close when clicking on a menu item when the `hideOnClick` prop is set to `false`', async () => {
 			render(
-				<DropdownMenu
+				<DropdownMenuV2
 					defaultOpen
 					trigger={ <button>Open dropdown</button> }
 				>
-					<DropdownMenuItem hideOnClick={ false }>
+					<DropdownMenuV2.Item hideOnClick={ false }>
 						Dropdown menu item
-					</DropdownMenuItem>
-				</DropdownMenu>
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			expect( screen.getByRole( 'menu' ) ).toBeVisible();
@@ -261,14 +272,14 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should not close when clicking on a disabled menu item', async () => {
 			render(
-				<DropdownMenu
+				<DropdownMenuV2
 					defaultOpen
 					trigger={ <button>Open dropdown</button> }
 				>
-					<DropdownMenuItem disabled>
+					<DropdownMenuV2.Item disabled>
 						Dropdown menu item
-					</DropdownMenuItem>
-				</DropdownMenu>
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			expect( screen.getByRole( 'menu' ) ).toBeInTheDocument();
@@ -281,28 +292,34 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should reveal submenu content when hovering over the submenu trigger', async () => {
 			render(
-				<DropdownMenu
+				<DropdownMenuV2
 					defaultOpen
 					trigger={ <button>Open dropdown</button> }
 				>
-					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
-					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
-					<DropdownMenu
+					<DropdownMenuV2.Item>
+						Dropdown menu item 1
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>
+						Dropdown menu item 2
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2
 						trigger={
-							<DropdownMenuItem>
+							<DropdownMenuV2.Item>
 								Dropdown submenu
-							</DropdownMenuItem>
+							</DropdownMenuV2.Item>
 						}
 					>
-						<DropdownMenuItem>
+						<DropdownMenuV2.Item>
 							Dropdown submenu item 1
-						</DropdownMenuItem>
-						<DropdownMenuItem>
+						</DropdownMenuV2.Item>
+						<DropdownMenuV2.Item>
 							Dropdown submenu item 2
-						</DropdownMenuItem>
-					</DropdownMenu>
-					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
-				</DropdownMenu>
+						</DropdownMenuV2.Item>
+					</DropdownMenuV2>
+					<DropdownMenuV2.Item>
+						Dropdown menu item 3
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			// Before hover, submenu items are not rendered
@@ -326,28 +343,34 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should navigate menu items and subitems using the arrow, spacebar and enter keys', async () => {
 			render(
-				<DropdownMenu
+				<DropdownMenuV2
 					defaultOpen
 					trigger={ <button>Open dropdown</button> }
 				>
-					<DropdownMenuItem>Dropdown menu item 1</DropdownMenuItem>
-					<DropdownMenuItem>Dropdown menu item 2</DropdownMenuItem>
-					<DropdownMenu
+					<DropdownMenuV2.Item>
+						Dropdown menu item 1
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>
+						Dropdown menu item 2
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2
 						trigger={
-							<DropdownMenuItem>
+							<DropdownMenuV2.Item>
 								Dropdown submenu
-							</DropdownMenuItem>
+							</DropdownMenuV2.Item>
 						}
 					>
-						<DropdownMenuItem>
+						<DropdownMenuV2.Item>
 							Dropdown submenu item 1
-						</DropdownMenuItem>
-						<DropdownMenuItem>
+						</DropdownMenuV2.Item>
+						<DropdownMenuV2.Item>
 							Dropdown submenu item 2
-						</DropdownMenuItem>
-					</DropdownMenu>
-					<DropdownMenuItem>Dropdown menu item 3</DropdownMenuItem>
-				</DropdownMenu>
+						</DropdownMenuV2.Item>
+					</DropdownMenuV2>
+					<DropdownMenuV2.Item>
+						Dropdown menu item 3
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			// The menu is focused automatically when `defaultOpen` is set.
@@ -450,32 +473,32 @@ describe( 'DropdownMenu', () => {
 			const ControlledRadioGroup = () => {
 				const [ radioValue, setRadioValue ] = useState( 'two' );
 				const onRadioChange: React.ComponentProps<
-					typeof DropdownMenuRadioItem
+					typeof DropdownMenuV2.RadioItem
 				>[ 'onChange' ] = ( e ) => {
 					onRadioValueChangeSpy( e.target.value );
 					setRadioValue( e.target.value );
 				};
 				return (
-					<DropdownMenu trigger={ <button>Open dropdown</button> }>
-						<DropdownMenuGroup>
-							<DropdownMenuRadioItem
+					<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+						<DropdownMenuV2.Group>
+							<DropdownMenuV2.RadioItem
 								name="radio-test"
 								value="radio-one"
 								checked={ radioValue === 'radio-one' }
 								onChange={ onRadioChange }
 							>
 								Radio item one
-							</DropdownMenuRadioItem>
-							<DropdownMenuRadioItem
+							</DropdownMenuV2.RadioItem>
+							<DropdownMenuV2.RadioItem
 								name="radio-test"
 								value="radio-two"
 								checked={ radioValue === 'radio-two' }
 								onChange={ onRadioChange }
 							>
 								Radio item two
-							</DropdownMenuRadioItem>
-						</DropdownMenuGroup>
-					</DropdownMenu>
+							</DropdownMenuV2.RadioItem>
+						</DropdownMenuV2.Group>
+					</DropdownMenuV2>
 				);
 			};
 
@@ -533,9 +556,9 @@ describe( 'DropdownMenu', () => {
 		it( 'should check radio items and keep the menu open when clicking (uncontrolled)', async () => {
 			const onRadioValueChangeSpy = jest.fn();
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuGroup>
-						<DropdownMenuRadioItem
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Group>
+						<DropdownMenuV2.RadioItem
 							name="radio-test"
 							value="radio-one"
 							onChange={ ( e ) =>
@@ -543,8 +566,8 @@ describe( 'DropdownMenu', () => {
 							}
 						>
 							Radio item one
-						</DropdownMenuRadioItem>
-						<DropdownMenuRadioItem
+						</DropdownMenuV2.RadioItem>
+						<DropdownMenuV2.RadioItem
 							name="radio-test"
 							value="radio-two"
 							defaultChecked
@@ -553,9 +576,9 @@ describe( 'DropdownMenu', () => {
 							}
 						>
 							Radio item two
-						</DropdownMenuRadioItem>
-					</DropdownMenuGroup>
-				</DropdownMenu>
+						</DropdownMenuV2.RadioItem>
+					</DropdownMenuV2.Group>
+				</DropdownMenuV2>
 			);
 
 			// Open dropdown
@@ -617,8 +640,8 @@ describe( 'DropdownMenu', () => {
 					useState< boolean >();
 
 				return (
-					<DropdownMenu trigger={ <button>Open dropdown</button> }>
-						<DropdownMenuCheckboxItem
+					<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+						<DropdownMenuV2.CheckboxItem
 							name="item-one"
 							value="item-one-value"
 							checked={ itemOneChecked }
@@ -632,9 +655,9 @@ describe( 'DropdownMenu', () => {
 							} }
 						>
 							Checkbox item one
-						</DropdownMenuCheckboxItem>
+						</DropdownMenuV2.CheckboxItem>
 
-						<DropdownMenuCheckboxItem
+						<DropdownMenuV2.CheckboxItem
 							name="item-two"
 							value="item-two-value"
 							checked={ itemTwoChecked }
@@ -648,8 +671,8 @@ describe( 'DropdownMenu', () => {
 							} }
 						>
 							Checkbox item two
-						</DropdownMenuCheckboxItem>
-					</DropdownMenu>
+						</DropdownMenuV2.CheckboxItem>
+					</DropdownMenuV2>
 				);
 			};
 
@@ -740,8 +763,8 @@ describe( 'DropdownMenu', () => {
 			const onCheckboxValueChangeSpy = jest.fn();
 
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuCheckboxItem
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.CheckboxItem
 						name="item-one"
 						value="item-one-value"
 						onChange={ ( e ) => {
@@ -753,9 +776,9 @@ describe( 'DropdownMenu', () => {
 						} }
 					>
 						Checkbox item one
-					</DropdownMenuCheckboxItem>
+					</DropdownMenuV2.CheckboxItem>
 
-					<DropdownMenuCheckboxItem
+					<DropdownMenuV2.CheckboxItem
 						name="item-two"
 						value="item-two-value"
 						defaultChecked
@@ -768,8 +791,8 @@ describe( 'DropdownMenu', () => {
 						} }
 					>
 						Checkbox item two
-					</DropdownMenuCheckboxItem>
-				</DropdownMenu>
+					</DropdownMenuV2.CheckboxItem>
+				</DropdownMenuV2>
 			);
 
 			// Open dropdown
@@ -858,9 +881,11 @@ describe( 'DropdownMenu', () => {
 		it( 'should be modal by default', async () => {
 			render(
 				<>
-					<DropdownMenu trigger={ <button>Open dropdown</button> }>
-						<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-					</DropdownMenu>
+					<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+						<DropdownMenuV2.Item>
+							Dropdown menu item
+						</DropdownMenuV2.Item>
+					</DropdownMenuV2>
 					<button>Button outside of dropdown</button>
 				</>
 			);
@@ -885,12 +910,14 @@ describe( 'DropdownMenu', () => {
 		it( 'should not be modal when the `modal` prop is set to `false`', async () => {
 			render(
 				<>
-					<DropdownMenu
+					<DropdownMenuV2
 						trigger={ <button>Open dropdown</button> }
 						modal={ false }
 					>
-						<DropdownMenuItem>Dropdown menu item</DropdownMenuItem>
-					</DropdownMenu>
+						<DropdownMenuV2.Item>
+							Dropdown menu item
+						</DropdownMenuV2.Item>
+					</DropdownMenuV2>
 					<button>Button outside of dropdown</button>
 				</>
 			);
@@ -922,11 +949,11 @@ describe( 'DropdownMenu', () => {
 	describe( 'items prefix and suffix', () => {
 		it( 'should display a prefix on regular items', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem prefix={ <>Item prefix</> }>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item prefix={ <>Item prefix</> }>
 						Dropdown menu item
-					</DropdownMenuItem>
-				</DropdownMenu>
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			// Click to open the menu
@@ -946,11 +973,11 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should display a suffix on regular items', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem suffix={ <>Item suffix</> }>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item suffix={ <>Item suffix</> }>
 						Dropdown menu item
-					</DropdownMenuItem>
-				</DropdownMenu>
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			// Click to open the menu
@@ -970,15 +997,15 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should display a suffix on radio items', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuRadioItem
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.RadioItem
 						name="radio-test"
 						value="radio-one"
 						suffix="Radio suffix"
 					>
 						Radio item one
-					</DropdownMenuRadioItem>
-				</DropdownMenu>
+					</DropdownMenuV2.RadioItem>
+				</DropdownMenuV2>
 			);
 
 			// Click to open the menu
@@ -998,15 +1025,15 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should display a suffix on checkbox items', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuCheckboxItem
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.CheckboxItem
 						name="checkbox-test"
 						value="checkbox-one"
 						suffix="Checkbox suffix"
 					>
 						Checkbox item one
-					</DropdownMenuCheckboxItem>
-				</DropdownMenu>
+					</DropdownMenuV2.CheckboxItem>
+				</DropdownMenuV2>
 			);
 
 			// Click to open the menu
@@ -1028,10 +1055,10 @@ describe( 'DropdownMenu', () => {
 	describe( 'typeahead', () => {
 		it( 'should highlight matching item', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem>One</DropdownMenuItem>
-					<DropdownMenuItem>Two</DropdownMenuItem>
-				</DropdownMenu>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item>One</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>Two</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			// Click to open the menu
@@ -1061,10 +1088,10 @@ describe( 'DropdownMenu', () => {
 
 		it( 'should keep previous focus when no matches are found', async () => {
 			render(
-				<DropdownMenu trigger={ <button>Open dropdown</button> }>
-					<DropdownMenuItem>One</DropdownMenuItem>
-					<DropdownMenuItem>Two</DropdownMenuItem>
-				</DropdownMenu>
+				<DropdownMenuV2 trigger={ <button>Open dropdown</button> }>
+					<DropdownMenuV2.Item>One</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item>Two</DropdownMenuV2.Item>
+				</DropdownMenuV2>
 			);
 
 			// Click to open the menu

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -25,12 +25,5 @@ lock( privateApis, {
 	Tabs,
 	Theme,
 	DropdownMenuV2,
-	DropdownMenuGroupV2: DropdownMenuV2.Group,
-	DropdownMenuItemV2: DropdownMenuV2.Item,
-	DropdownMenuCheckboxItemV2: DropdownMenuV2.CheckboxItem,
-	DropdownMenuRadioItemV2: DropdownMenuV2.RadioItem,
-	DropdownMenuSeparatorV2: DropdownMenuV2.Separator,
-	DropdownMenuItemLabelV2: DropdownMenuV2.ItemLabel,
-	DropdownMenuItemHelpTextV2: DropdownMenuV2.ItemHelpText,
 	kebabCase,
 } );

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -5,16 +5,7 @@ import { Composite } from './composite';
 import { useCompositeStore } from './composite/store';
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
 import { createPrivateSlotFill } from './slot-fill';
-import {
-	DropdownMenu as DropdownMenuV2,
-	DropdownMenuGroup as DropdownMenuGroupV2,
-	DropdownMenuItem as DropdownMenuItemV2,
-	DropdownMenuCheckboxItem as DropdownMenuCheckboxItemV2,
-	DropdownMenuRadioItem as DropdownMenuRadioItemV2,
-	DropdownMenuSeparator as DropdownMenuSeparatorV2,
-	DropdownMenuItemLabel as DropdownMenuItemLabelV2,
-	DropdownMenuItemHelpText as DropdownMenuItemHelpTextV2,
-} from './dropdown-menu-v2';
+import { DropdownMenuV2 } from './dropdown-menu-v2';
 import { ComponentsContext } from './context/context-system-provider';
 import Theme from './theme';
 import Tabs from './tabs';
@@ -34,12 +25,12 @@ lock( privateApis, {
 	Tabs,
 	Theme,
 	DropdownMenuV2,
-	DropdownMenuGroupV2,
-	DropdownMenuItemV2,
-	DropdownMenuCheckboxItemV2,
-	DropdownMenuRadioItemV2,
-	DropdownMenuSeparatorV2,
-	DropdownMenuItemLabelV2,
-	DropdownMenuItemHelpTextV2,
+	DropdownMenuGroupV2: DropdownMenuV2.Group,
+	DropdownMenuItemV2: DropdownMenuV2.Item,
+	DropdownMenuCheckboxItemV2: DropdownMenuV2.CheckboxItem,
+	DropdownMenuRadioItemV2: DropdownMenuV2.RadioItem,
+	DropdownMenuSeparatorV2: DropdownMenuV2.Separator,
+	DropdownMenuItemLabelV2: DropdownMenuV2.ItemLabel,
+	DropdownMenuItemHelpTextV2: DropdownMenuV2.ItemHelpText,
 	kebabCase,
 } );

--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -18,12 +18,7 @@ import { LAYOUT_TABLE, LAYOUT_GRID } from '../../constants';
 import { unlock } from '../../lock-unlock';
 import type { Action, ActionModal } from '../../types';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 interface ActionWithModalProps< Item > {
 	action: ActionModal< Item >;
@@ -129,7 +124,7 @@ function BulkActionItem< Item >( {
 	const shouldShowModal = 'RenderModal' in action;
 
 	return (
-		<DropdownMenuItem
+		<DropdownMenuV2.Item
 			key={ action.id }
 			hideOnClick={ ! shouldShowModal }
 			onClick={ async () => {
@@ -142,7 +137,7 @@ function BulkActionItem< Item >( {
 			suffix={ eligibleItems.length }
 		>
 			{ action.label }
-		</DropdownMenuItem>
+		</DropdownMenuV2.Item>
 	);
 }
 
@@ -163,7 +158,7 @@ function ActionsMenuGroup< Item >( {
 	}
 	return (
 		<>
-			<DropdownMenuGroup>
+			<DropdownMenuV2.Group>
 				{ elligibleActions.map( ( action ) => (
 					<BulkActionItem
 						key={ action.id }
@@ -172,8 +167,8 @@ function ActionsMenuGroup< Item >( {
 						setActionWithModal={ setActionWithModal }
 					/>
 				) ) }
-			</DropdownMenuGroup>
-			<DropdownMenuSeparator />
+			</DropdownMenuV2.Group>
+			<DropdownMenuV2.Separator />
 		</>
 	);
 }
@@ -219,7 +214,7 @@ function _BulkActions() {
 	}
 	return (
 		<>
-			<DropdownMenu
+			<DropdownMenuV2
 				open={ isMenuOpen }
 				onOpenChange={ onMenuOpenChange }
 				label={ __( 'Bulk actions' ) }
@@ -250,8 +245,8 @@ function _BulkActions() {
 					setActionWithModal={ setActionWithModal }
 					selectedItems={ selectedItems }
 				/>
-				<DropdownMenuGroup>
-					<DropdownMenuItem
+				<DropdownMenuV2.Group>
+					<DropdownMenuV2.Item
 						disabled={ areAllSelected }
 						hideOnClick={ false }
 						onClick={ () => {
@@ -264,8 +259,8 @@ function _BulkActions() {
 						suffix={ numberSelectableItems }
 					>
 						{ __( 'Select all' ) }
-					</DropdownMenuItem>
-					<DropdownMenuItem
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item
 						disabled={ selection.length === 0 }
 						hideOnClick={ false }
 						onClick={ () => {
@@ -273,9 +268,9 @@ function _BulkActions() {
 						} }
 					>
 						{ __( 'Deselect' ) }
-					</DropdownMenuItem>
-				</DropdownMenuGroup>
-			</DropdownMenu>
+					</DropdownMenuV2.Item>
+				</DropdownMenuV2.Group>
+			</DropdownMenuV2>
 			{ actionWithModal && (
 				<ActionWithModal
 					action={ actionWithModal }

--- a/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
@@ -19,11 +19,7 @@ import { forwardRef } from '@wordpress/element';
 import { unlock } from '../../lock-unlock';
 import type { NormalizedFilter, View } from '../../types';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 interface AddFilterProps {
 	filters: NormalizedFilter[];
@@ -43,10 +39,10 @@ export function AddFilterDropdownMenu( {
 } ) {
 	const inactiveFilters = filters.filter( ( filter ) => ! filter.isVisible );
 	return (
-		<DropdownMenu trigger={ trigger }>
+		<DropdownMenuV2 trigger={ trigger }>
 			{ inactiveFilters.map( ( filter ) => {
 				return (
-					<DropdownMenuItem
+					<DropdownMenuV2.Item
 						key={ filter.field }
 						onClick={ () => {
 							setOpenedFilter( filter.field );
@@ -64,13 +60,13 @@ export function AddFilterDropdownMenu( {
 							} );
 						} }
 					>
-						<DropdownMenuItemLabel>
+						<DropdownMenuV2.ItemLabel>
 							{ filter.name }
-						</DropdownMenuItemLabel>
-					</DropdownMenuItem>
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.Item>
 				);
 			} ) }
-		</DropdownMenu>
+		</DropdownMenuV2>
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -23,13 +23,7 @@ import { useRegistry } from '@wordpress/data';
 import { unlock } from '../../lock-unlock';
 import type { Action, ActionModal as ActionModalType } from '../../types';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	kebabCase,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2, kebabCase } = unlock( componentsPrivateApis );
 
 export interface ActionTriggerProps< Item > {
 	action: Action< Item >;
@@ -91,12 +85,12 @@ function DropdownMenuItemTrigger< Item >( {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<DropdownMenuItem
+		<DropdownMenuV2.Item
 			onClick={ onClick }
 			hideOnClick={ ! ( 'RenderModal' in action ) }
 		>
-			<DropdownMenuItemLabel>{ label }</DropdownMenuItemLabel>
-		</DropdownMenuItem>
+			<DropdownMenuV2.ItemLabel>{ label }</DropdownMenuV2.ItemLabel>
+		</DropdownMenuV2.Item>
 	);
 }
 
@@ -158,7 +152,7 @@ export function ActionsDropdownMenuGroup< Item >( {
 }: ActionsDropdownMenuGroupProps< Item > ) {
 	const registry = useRegistry();
 	return (
-		<DropdownMenuGroup>
+		<DropdownMenuV2.Group>
 			{ actions.map( ( action ) => {
 				if ( 'RenderModal' in action ) {
 					return (
@@ -181,7 +175,7 @@ export function ActionsDropdownMenuGroup< Item >( {
 					/>
 				);
 			} ) }
-		</DropdownMenuGroup>
+		</DropdownMenuV2.Group>
 	);
 }
 
@@ -251,7 +245,7 @@ function CompactItemActions< Item >( {
 	actions,
 }: CompactItemActionsProps< Item > ) {
 	return (
-		<DropdownMenu
+		<DropdownMenuV2
 			trigger={
 				<Button
 					size="compact"
@@ -265,6 +259,6 @@ function CompactItemActions< Item >( {
 			placement="bottom-end"
 		>
 			<ActionsDropdownMenuGroup actions={ actions } item={ item } />
-		</DropdownMenu>
+		</DropdownMenuV2>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -42,11 +42,7 @@ import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
 import DensityPicker from '../../dataviews-layouts/grid/density-picker';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 interface ViewTypeMenuProps {
 	defaultLayouts?: SupportedLayouts;
@@ -62,7 +58,7 @@ function ViewTypeMenu( {
 	}
 	const activeView = VIEW_LAYOUTS.find( ( v ) => view.type === v.type );
 	return (
-		<DropdownMenu
+		<DropdownMenuV2
 			trigger={
 				<Button
 					size="compact"
@@ -77,7 +73,7 @@ function ViewTypeMenu( {
 					return null;
 				}
 				return (
-					<DropdownMenuRadioItem
+					<DropdownMenuV2.RadioItem
 						key={ layout }
 						value={ layout }
 						name="view-actions-available-view"
@@ -97,13 +93,13 @@ function ViewTypeMenu( {
 							warning( 'Invalid dataview' );
 						} }
 					>
-						<DropdownMenuItemLabel>
+						<DropdownMenuV2.ItemLabel>
 							{ config.label }
-						</DropdownMenuItemLabel>
-					</DropdownMenuRadioItem>
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.RadioItem>
 				);
 			} ) }
-		</DropdownMenu>
+		</DropdownMenuV2>
 	);
 }
 

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -27,14 +27,7 @@ import type {
 	ViewTable as ViewTableType,
 } from '../../types';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuRadioItemV2: DropdownMenuRadioItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	DropdownMenuSeparatorV2: DropdownMenuSeparator,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 interface HeaderMenuProps< Item > {
 	fieldId: string;
@@ -50,7 +43,7 @@ function WithDropDownMenuSeparators( { children }: { children: ReactNode } ) {
 		.filter( Boolean )
 		.map( ( child, i ) => (
 			<Fragment key={ i }>
-				{ i > 0 && <DropdownMenuSeparator /> }
+				{ i > 0 && <DropdownMenuV2.Separator /> }
 				{ child }
 			</Fragment>
 		) );
@@ -93,7 +86,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		! field.filterBy?.isPrimary;
 
 	return (
-		<DropdownMenu
+		<DropdownMenuV2
 			align="start"
 			trigger={
 				<Button
@@ -114,7 +107,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		>
 			<WithDropDownMenuSeparators>
 				{ isSortable && (
-					<DropdownMenuGroup>
+					<DropdownMenuV2.Group>
 						{ SORTING_DIRECTIONS.map(
 							( direction: SortDirection ) => {
 								const isChecked =
@@ -125,7 +118,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								const value = `${ field.id }-${ direction }`;
 
 								return (
-									<DropdownMenuRadioItem
+									<DropdownMenuV2.RadioItem
 										key={ value }
 										// All sorting radio items share the same name, so that
 										// selecting a sorting option automatically deselects the
@@ -145,18 +138,18 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 											} );
 										} }
 									>
-										<DropdownMenuItemLabel>
+										<DropdownMenuV2.ItemLabel>
 											{ sortLabels[ direction ] }
-										</DropdownMenuItemLabel>
-									</DropdownMenuRadioItem>
+										</DropdownMenuV2.ItemLabel>
+									</DropdownMenuV2.RadioItem>
 								);
 							}
 						) }
-					</DropdownMenuGroup>
+					</DropdownMenuV2.Group>
 				) }
 				{ canAddFilter && (
-					<DropdownMenuGroup>
-						<DropdownMenuItem
+					<DropdownMenuV2.Group>
+						<DropdownMenuV2.Item
 							prefix={ <Icon icon={ funnel } /> }
 							onClick={ () => {
 								setOpenedFilter( field.id );
@@ -174,14 +167,14 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								} );
 							} }
 						>
-							<DropdownMenuItemLabel>
+							<DropdownMenuV2.ItemLabel>
 								{ __( 'Add filter' ) }
-							</DropdownMenuItemLabel>
-						</DropdownMenuItem>
-					</DropdownMenuGroup>
+							</DropdownMenuV2.ItemLabel>
+						</DropdownMenuV2.Item>
+					</DropdownMenuV2.Group>
 				) }
-				<DropdownMenuGroup>
-					<DropdownMenuItem
+				<DropdownMenuV2.Group>
+					<DropdownMenuV2.Item
 						prefix={ <Icon icon={ arrowLeft } /> }
 						disabled={ index < 1 }
 						onClick={ () => {
@@ -200,11 +193,11 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							} );
 						} }
 					>
-						<DropdownMenuItemLabel>
+						<DropdownMenuV2.ItemLabel>
 							{ __( 'Move left' ) }
-						</DropdownMenuItemLabel>
-					</DropdownMenuItem>
-					<DropdownMenuItem
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.Item>
+					<DropdownMenuV2.Item
 						prefix={ <Icon icon={ arrowRight } /> }
 						disabled={
 							! view.fields || index >= view.fields.length - 1
@@ -227,12 +220,12 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 							} );
 						} }
 					>
-						<DropdownMenuItemLabel>
+						<DropdownMenuV2.ItemLabel>
 							{ __( 'Move right' ) }
-						</DropdownMenuItemLabel>
-					</DropdownMenuItem>
+						</DropdownMenuV2.ItemLabel>
+					</DropdownMenuV2.Item>
 					{ isHidable && (
-						<DropdownMenuItem
+						<DropdownMenuV2.Item
 							prefix={ <Icon icon={ unseen } /> }
 							onClick={ () => {
 								const viewFields =
@@ -246,14 +239,14 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								} );
 							} }
 						>
-							<DropdownMenuItemLabel>
+							<DropdownMenuV2.ItemLabel>
 								{ __( 'Hide column' ) }
-							</DropdownMenuItemLabel>
-						</DropdownMenuItem>
+							</DropdownMenuV2.ItemLabel>
+						</DropdownMenuV2.Item>
 					) }
-				</DropdownMenuGroup>
+				</DropdownMenuV2.Group>
 			</WithDropDownMenuSeparators>
-		</DropdownMenu>
+		</DropdownMenuV2>
 	);
 } );
 

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -21,17 +21,14 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-} = unlock( componentsPrivateApis );
-const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 import ScreenHeader from '../header';
 import FontSizePreview from './font-size-preview';
 import ConfirmDeleteFontSizeDialog from './confirm-delete-font-size-dialog';
 import RenameFontSizeDialog from './rename-font-size-dialog';
 import SizeControl from '../size-control';
+
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
+const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
 function FontSize() {
 	const [ isDeleteConfirmOpen, setIsDeleteConfirmOpen ] = useState( false );
@@ -160,7 +157,7 @@ function FontSize() {
 								marginBottom={ 0 }
 								paddingX={ 4 }
 							>
-								<DropdownMenu
+								<DropdownMenuV2
 									trigger={
 										<Button
 											size="small"
@@ -169,21 +166,21 @@ function FontSize() {
 										/>
 									}
 								>
-									<DropdownMenuItem
+									<DropdownMenuV2.Item
 										onClick={ toggleRenameDialog }
 									>
-										<DropdownMenuItemLabel>
+										<DropdownMenuV2.ItemLabel>
 											{ __( 'Rename' ) }
-										</DropdownMenuItemLabel>
-									</DropdownMenuItem>
-									<DropdownMenuItem
+										</DropdownMenuV2.ItemLabel>
+									</DropdownMenuV2.Item>
+									<DropdownMenuV2.Item
 										onClick={ toggleDeleteConfirm }
 									>
-										<DropdownMenuItemLabel>
+										<DropdownMenuV2.ItemLabel>
 											{ __( 'Delete' ) }
-										</DropdownMenuItemLabel>
-									</DropdownMenuItem>
-								</DropdownMenu>
+										</DropdownMenuV2.ItemLabel>
+									</DropdownMenuV2.Item>
+								</DropdownMenuV2>
 							</Spacer>
 						</FlexItem>
 					) }

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
@@ -27,11 +27,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { unlock } from '../../../lock-unlock';
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 import Subtitle from '../subtitle';
 import { NavigationButtonAsItem } from '../navigation-button';
@@ -85,7 +81,7 @@ function FontSizeGroup( {
 							/>
 						) }
 						{ !! handleResetFontSizes && (
-							<DropdownMenu
+							<DropdownMenuV2
 								trigger={
 									<Button
 										size="small"
@@ -96,14 +92,16 @@ function FontSizeGroup( {
 									/>
 								}
 							>
-								<DropdownMenuItem onClick={ toggleResetDialog }>
-									<DropdownMenuItemLabel>
+								<DropdownMenuV2.Item
+									onClick={ toggleResetDialog }
+								>
+									<DropdownMenuV2.ItemLabel>
 										{ origin === 'custom'
 											? __( 'Remove font size presets' )
 											: __( 'Reset font size presets' ) }
-									</DropdownMenuItemLabel>
-								</DropdownMenuItem>
-							</DropdownMenu>
+									</DropdownMenuV2.ItemLabel>
+								</DropdownMenuV2.Item>
+							</DropdownMenuV2>
 						) }
 					</FlexItem>
 				</HStack>

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -55,11 +55,7 @@ import {
 } from './shadow-utils';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 const customShadowMenuItems = [
 	{
@@ -151,7 +147,7 @@ export default function ShadowsEditPanel() {
 				<ScreenHeader title={ selectedShadow.name } />
 				<FlexItem>
 					<Spacer marginTop={ 2 } marginBottom={ 0 } paddingX={ 4 }>
-						<DropdownMenu
+						<DropdownMenuV2
 							trigger={
 								<Button
 									size="small"
@@ -164,7 +160,7 @@ export default function ShadowsEditPanel() {
 								? customShadowMenuItems
 								: presetShadowMenuItems
 							).map( ( item ) => (
-								<DropdownMenuItem
+								<DropdownMenuV2.Item
 									key={ item.action }
 									onClick={ () => onMenuClick( item.action ) }
 									disabled={
@@ -173,12 +169,12 @@ export default function ShadowsEditPanel() {
 											baseSelectedShadow.shadow
 									}
 								>
-									<DropdownMenuItemLabel>
+									<DropdownMenuV2.ItemLabel>
 										{ item.label }
-									</DropdownMenuItemLabel>
-								</DropdownMenuItem>
+									</DropdownMenuV2.ItemLabel>
+								</DropdownMenuV2.Item>
 							) ) }
-						</DropdownMenu>
+						</DropdownMenuV2>
 					</Spacer>
 				</FlexItem>
 			</HStack>

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -18,13 +18,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { unlock } from '../../lock-unlock';
 import { usePostActions } from './actions';
 
-const {
-	DropdownMenuV2: DropdownMenu,
-	DropdownMenuGroupV2: DropdownMenuGroup,
-	DropdownMenuItemV2: DropdownMenuItem,
-	DropdownMenuItemLabelV2: DropdownMenuItemLabel,
-	kebabCase,
-} = unlock( componentsPrivateApis );
+const { DropdownMenuV2, kebabCase } = unlock( componentsPrivateApis );
 
 export default function PostActions( { postType, postId, onActionPerformed } ) {
 	const [ isActionsMenuOpen, setIsActionsMenuOpen ] = useState( false );
@@ -60,7 +54,7 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 	}, [ allActions, itemWithPermissions ] );
 
 	return (
-		<DropdownMenu
+		<DropdownMenuV2
 			open={ isActionsMenuOpen }
 			trigger={
 				<Button
@@ -85,7 +79,7 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 					setIsActionsMenuOpen( false );
 				} }
 			/>
-		</DropdownMenu>
+		</DropdownMenuV2>
 	);
 }
 
@@ -99,12 +93,12 @@ function DropdownMenuItemTrigger( { action, onClick, items } ) {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<DropdownMenuItem
+		<DropdownMenuV2.Item
 			onClick={ onClick }
 			hideOnClick={ ! action.RenderModal }
 		>
-			<DropdownMenuItemLabel>{ label }</DropdownMenuItemLabel>
-		</DropdownMenuItem>
+			<DropdownMenuV2.ItemLabel>{ label }</DropdownMenuV2.ItemLabel>
+		</DropdownMenuV2.Item>
 	);
 }
 
@@ -151,7 +145,7 @@ function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
 // With an added onClose prop.
 function ActionsDropdownMenuGroup( { actions, item, onClose } ) {
 	return (
-		<DropdownMenuGroup>
+		<DropdownMenuV2.Group>
 			{ actions.map( ( action ) => {
 				if ( action.RenderModal ) {
 					return (
@@ -173,6 +167,6 @@ function ActionsDropdownMenuGroup( { actions, item, onClose } ) {
 					/>
 				);
 			} ) }
-		</DropdownMenuGroup>
+		</DropdownMenuV2.Group>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #50459

Apply overloaded naming conventions to `DropdownMenuV2`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To adhere to the later recommendations on [how to name compound components](https://github.com/WordPress/gutenberg/blob/236250e3fa04ad7337c305540f76ed619b0dde98/packages/components/CONTRIBUTING.md#naming-conventions)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Followed the suggested approach in [the contributing guidelines](https://github.com/WordPress/gutenberg/blob/236250e3fa04ad7337c305540f76ed619b0dde98/packages/components/CONTRIBUTING.md#naming-conventions), then updated all component usages.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- No runtime changes
- Make sure Storybook docs and examples work as expected
- Smoke test usages in the editor
