### PR TITLE
Replace instances of deprecated elevation variables

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -36,7 +36,7 @@ $block-inserter-tabs-height: 44px;
 	.components-popover__content {
 		border: none;
 		outline: none;
-		box-shadow: $shadow-popover;
+		box-shadow: $elevation-x-small;
 
 		.block-editor-inserter__quick-inserter > * {
 			border-left: $border-width solid $gray-400;

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -120,7 +120,7 @@ $input-size: 300px;
 }
 
 .block-editor-url-input__button-modal {
-	box-shadow: $shadow-popover;
+	box-shadow: $elevation-x-small;
 	border: 1px solid $gray-300;
 	background: $white;
 }

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -144,7 +144,7 @@
 	border: $border-width solid $gray-900;
 
 	&:hover {
-		box-shadow: $shadow-popover;
+		box-shadow: $elevation-x-small;
 	}
 
 	@include break-small() {

--- a/packages/dataviews/src/components/dataviews-bulk-actions-toolbar/style.scss
+++ b/packages/dataviews/src/components/dataviews-bulk-actions-toolbar/style.scss
@@ -12,7 +12,7 @@
 
 	.components-accessible-toolbar {
 		border-color: $gray-300;
-		box-shadow: $shadow-popover;
+		box-shadow: $elevation-x-small;
 
 		.components-toolbar-group {
 			border-color: $gray-200;

--- a/packages/edit-widgets/src/components/error-boundary/style.scss
+++ b/packages/edit-widgets/src/components/error-boundary/style.scss
@@ -3,5 +3,5 @@
 	max-width: 780px;
 	padding: 20px;
 	margin-top: 60px;
-	box-shadow: $shadow-modal;
+	box-shadow: $elevation-large;
 }

--- a/packages/editor/src/components/error-boundary/style.scss
+++ b/packages/editor/src/components/error-boundary/style.scss
@@ -3,5 +3,5 @@
 	max-width: 780px;
 	padding: 20px;
 	margin-top: 60px;
-	box-shadow: $shadow-modal;
+	box-shadow: $elevation-large;
 }


### PR DESCRIPTION
Following up on https://github.com/WordPress/gutenberg/pull/64108 and https://github.com/WordPress/gutenberg/pull/64655

## What?
Replace instances of the deprecated `$shadow-popover` and `$shadow-modal` variables in the editor.

## Why?
Code cleanliness. Adoption of elevation scale from the design system.

## Testing Instructions

* Observe the shadow applied to the Quick Inserter – it should match trunk
* Observe the shadow applied to the bulk actions toolbar in data views – it should match trunk
* In a non-block theme, navigate to Appearance > Widgets and observe the shadow applied to the welcome modal – it should match trunk

> [!NOTE]  
> The Gallery block was referencing `$shadow-popover` and applying it to `.block-library-gallery-item__inline-menu`, but an element with that class doesn't ever seem to render. It may be safe to remove this style entirely, but that's one to handle separately.

<img width="392" alt="Screenshot 2024-08-20 at 18 07 03" src="https://github.com/user-attachments/assets/d855cfa9-cde0-4683-9bca-2f5bdcb6d028">
<img width="409" alt="Screenshot 2024-08-20 at 18 07 17" src="https://github.com/user-attachments/assets/a143f130-d737-452b-a4a8-edc36c28f13a">
<img width="362" alt="Screenshot 2024-08-20 at 18 12 38" src="https://github.com/user-attachments/assets/ff7b137a-3053-4e8e-8cc5-81511d718c15">

