### PR TITLE
Missing Block: Use hooks instead of HoC

### DIFF
--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -5,7 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { createBlock } from '@wordpress/blocks';
-import { withDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	Warning,
 	useBlockProps,
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/block-editor';
 import { safeHTML } from '@wordpress/dom';
 
-function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
+export default function MissingEdit( { attributes, clientId } ) {
 	const { originalName, originalUndelimitedContent } = attributes;
 	const hasContent = !! originalUndelimitedContent;
 	const { hasFreeformBlock, hasHTMLBlock } = useSelect(
@@ -34,6 +34,16 @@ function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
 		},
 		[ clientId ]
 	);
+	const { replaceBlock } = useDispatch( blockEditorStore );
+
+	function convertToHTML() {
+		replaceBlock(
+			clientId,
+			createBlock( 'core/html', {
+				content: originalUndelimitedContent,
+			} )
+		);
+	}
 
 	const actions = [];
 	let messageHTML;
@@ -81,19 +91,3 @@ function MissingBlockWarning( { attributes, convertToHTML, clientId } ) {
 		</div>
 	);
 }
-
-const MissingEdit = withDispatch( ( dispatch, { clientId, attributes } ) => {
-	const { replaceBlock } = dispatch( blockEditorStore );
-	return {
-		convertToHTML() {
-			replaceBlock(
-				clientId,
-				createBlock( 'core/html', {
-					content: attributes.originalUndelimitedContent,
-				} )
-			);
-		},
-	};
-} )( MissingBlockWarning );
-
-export default MissingEdit;


### PR DESCRIPTION
## What?
PR updates the `MissingEdit` component to use data hooks instead of HoCs.

## Why?
A micro-optimization makes the rendered component tree smaller.

Similar to #60807.

## Testing Instructions
1. Open a Post or Page.
2. Insert a Missing block. See the snippet below.
3. Confirm you can convert it to an HTML block.

### Snippet
```
<!-- wp:mamaduka/test -->
<div class="wp-block-mamaduka-text"><p>This is a <strong>missing block</strong>.</p></div>
<!-- /wp:mamaduka/test -->
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-20 at 21 16 10](https://github.com/user-attachments/assets/cf2a91fa-1380-45e8-97e9-c5e7a224ad00)
