### PR TITLE
Writing Flow: avoid range removal in multi selection and select all

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-multi-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-multi-selection.js
@@ -76,10 +76,10 @@ export default function useMultiSelection() {
 			node.contentEditable = true;
 
 			// For some browsers, like Safari, it is important that focus
-			// happens BEFORE selection removal.
+			// happens BEFORE updating the selection.
 			node.focus();
 
-			defaultView.getSelection().removeAllRanges();
+			defaultView.getSelection().setPosition( node );
 		},
 		[
 			hasMultiSelection,

--- a/packages/block-editor/src/components/writing-flow/use-select-all.js
+++ b/packages/block-editor/src/components/writing-flow/use-select-all.js
@@ -44,7 +44,7 @@ export default function useSelectAll() {
 				if ( rootClientId ) {
 					node.ownerDocument.defaultView
 						.getSelection()
-						.removeAllRanges();
+						.setPosition( node );
 					selectBlock( rootClientId );
 				}
 				return;


### PR DESCRIPTION
## What?
A naive attempt to fix #64617

## Why?
To resolve an issue where a selected container block can become unselected as the window regains focus. This probably hardly ever bothers a human but I have another PR that mysteriously surfaces the issue in E2E tests and that’s what made me aware of it and is the actual motive.

## How?
Avoids removing the selection and instead collapses it to the active node.

It seems the reason this works is it avoids a `selectionchange` event being fired when the window regains focus and thereby avoids the `useSelectionObserver` hook moving focus here:
https://github.com/WordPress/gutenberg/blob/b1324c55d67d24d924f7c073b9c482e5d5699453/packages/block-editor/src/components/writing-flow/use-selection-observer.js#L125-L144

## Testing Instructions
1. Using the following markup
```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>one</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>two</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
2. Select one of the Paragraph blocks
3. Use the "Select all" shortcut repeatedly until the Group block is selected
4. Switch to a different browser tab or separate window and then switch back
5. Note the Group block is still selected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
