### PR TITLE
Try: Hyphenate long block names in the inserter

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -120,4 +120,5 @@
 .block-editor-block-types-list__item-title {
 	padding: 4px 2px 8px;
 	font-size: 12px;
+	hyphens: auto;
 }


### PR DESCRIPTION
Fixes #8047

## What?
This PR attempts to hyphenate long block names in the block inserter.

P.S. I'm not a native English speaker, so I would appreciate it if you could let me know if hyphenating the text would improve readability.

## Why?
 
At the time #8047 was submitted, it seems that `hyphens` did not work on Windows/Chrome.

However, it now works on Windows/Chrome, and `hyphens` is supported by major browsers ([Can I use link](https://caniuse.com/css-hyphens)).

Whether `hyphens` is supported varies depending on the locale and browser ([MDN link](https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens#browser_compatibility)), but for locales and browsers that support it, it can be considered an enhancement.

Additionally, it seems to be used widely in core: https://github.com/search?q=repo%3AWordPress%2Fwordpress-develop%20hyphens%3A%20auto&type=code

## Testing Instructions

The only core block affected by this PR is the experimental Request Form block. To test for intentionally long block names, run the following code in your browser console. If you want to try a different block name, reload the browser, change the value of the `title` field, and run it again from the browser console.

```javascript
wp.blocks.registerBlockType(
	'test/one',
	{
		title: 'Supercalifragilisticexpialidocious',
		category: 'text',
		edit: () =>  wp.element.createElement( 'div', {}, 'Hello World' ),
	}
);

wp.blocks.registerBlockType(
	'test/two',
	{
		title: 'Hippopotomonstrosesquipedaliophobia',
		category: 'text',
		edit: () =>  wp.element.createElement( 'div', {}, 'Hello World' ),
	}
);
```

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cb0d8cbf-39b7-4eba-bf59-bc6148f30e2e) | ![image](https://github.com/user-attachments/assets/aef9418e-1d3d-4ab4-a2cd-4a5e290656b4) |

