### PR TITLE
Embed Block: Replace native input element with InputControl component

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -226,7 +226,7 @@ const EmbedEdit = ( props ) => {
 					} }
 					value={ url }
 					cannotEmbed={ cannotEmbed }
-					onChange={ ( event ) => setURL( event.target.value ) }
+					onChange={ ( value ) => setURL( value ) }
 					fallback={ () => fallback( url, onReplace ) }
 					tryAgain={ () => {
 						invalidateResolution( 'getEmbedPreview', [ url ] );

--- a/packages/block-library/src/embed/editor.scss
+++ b/packages/block-library/src/embed/editor.scss
@@ -12,6 +12,10 @@
 		justify-content: center;
 	}
 
+	.wp-block-embed__placeholder-input {
+		flex: 1 1 auto;
+	}
+
 	// Stops long URLs from breaking out of the no preview available screen
 	.components-placeholder__error {
 		word-break: break-word;

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -8,6 +8,7 @@ import {
 	ExternalLink,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalInputControl as InputControl,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
 
@@ -31,15 +32,17 @@ const EmbedPlaceholder = ( {
 			) }
 		>
 			<form onSubmit={ onSubmit }>
-				<input
+				<InputControl
+					__next40pxDefaultSize
 					type="url"
 					value={ value || '' }
-					className="components-placeholder__input"
-					aria-label={ label }
+					className="wp-block-embed__placeholder-input"
+					label={ __( 'Embed URL' ) }
+					hideLabelFromVision
 					placeholder={ __( 'Enter URL to embed here…' ) }
 					onChange={ onChange }
 				/>
-				<Button variant="primary" type="submit">
+				<Button __next40pxDefaultSize variant="primary" type="submit">
 					{ _x( 'Embed', 'button label' ) }
 				</Button>
 			</form>

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -37,7 +37,7 @@ const EmbedPlaceholder = ( {
 					type="url"
 					value={ value || '' }
 					className="wp-block-embed__placeholder-input"
-					label={ __( 'Embed URL' ) }
+					label={ label }
 					hideLabelFromVision
 					placeholder={ __( 'Enter URL to embed here…' ) }
 					onChange={ onChange }


### PR DESCRIPTION
Closes #41961

## What?

This PR replaces the native input element with the `InputControl` component in the Embed block placeholder, and applies a new 40px size.

## Why?

In our current implementation, to apply the component styles we apply the `components-placeholder__input` class directly, which is not ideal. Additionally, it doesn't allow us to apply the new 40px size.

## Testing Instructions

You should be able to embed the URL as before.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8007da68-1b7f-4c6f-8416-d5b1a96af0a3) | ![image](https://github.com/user-attachments/assets/38f2a391-f9dc-4f6a-a567-53e69ad5c8fa) |
| ![image](https://github.com/user-attachments/assets/564e4e40-e522-4f02-909c-062cb0e43b99)| ![image](https://github.com/user-attachments/assets/e1ea14c4-4f59-426c-8b31-dacf861c2ed8)| 