### PR TITLE
Image block: Add reset button

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -3,6 +3,7 @@
  */
 import { isBlobURL } from '@wordpress/blob';
 import {
+	MenuItem,
 	ExternalLink,
 	ResizableBox,
 	Spinner,
@@ -597,7 +598,11 @@ export default function Image( {
 						onSelect={ onSelectImage }
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
-					/>
+					>
+						<MenuItem onClick={ () => onSelectImage( false ) }>
+							{ __( 'Reset' ) }
+						</MenuItem>
+					</MediaReplaceFlow>
 				</BlockControls>
 			) }
 			{ isSingleSelected && externalBlob && (

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -599,7 +599,7 @@ export default function Image( {
 						onSelectURL={ onSelectURL }
 						onError={ onUploadError }
 					>
-						<MenuItem onClick={ () => onSelectImage( false ) }>
+						<MenuItem onClick={ () => onSelectImage( undefined ) }>
 							{ __( 'Reset' ) }
 						</MenuItem>
 					</MediaReplaceFlow>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
There is no method to reset the image block. You can replace images but not remove them from blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR adds a 'Reset' option to the toggle control that removes the selected image from the image block. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Add image block in editor and select image
- Notice reset button in toolbar control.
 
## Screenshots or screencast <!-- if applicable -->

[image-block-add-reset-button.webm](https://github.com/user-attachments/assets/9c41cf0e-6ca4-40db-bb6e-bb4f872cead1)
 