### PR TITLE
Post Title: Fix pasting in Safari

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -192,7 +192,6 @@ function PostTitle( _, forwardedRef ) {
 				onFocus={ onSelect }
 				onBlur={ onUnselect }
 				onKeyDown={ onKeyDown }
-				onKeyPress={ onUnselect }
 				onPaste={ onPaste }
 			/>
 		</PostTypeSupportCheck>


### PR DESCRIPTION
## What?
Fixes #51047.

PR fixes text pasting behavior for the post title component in Safari.

## Why?
The deprecated `keypress` event, which fires before `paste`, resets the local selection state and makes it `undefined` when pasting a value. This causes unexpected behavior in browsers that still [support](https://developer.mozilla.org/en-US/docs/Web/API/Element/keypress_event#browser_compatibility) this event.

P.S. You can reproduce the same behavior on Chrome by calling `onUnselect` on `onKeyDown`.

## How?
Remove the `onKeyPress` event handler. The event has been deprecated, and as far as I can tell, there is no actual use case for this component. It was initially introduced in #1042.

## Testing Instructions
1. Open a post or page.
2. Add title
3. Try pasting a text in the title field.
4. It should paste text at the cursor position.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2875a233-36b2-4bac-a173-23d2198c639b

