### PR TITLE
Placeholders: Update radius temporarily.

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### Enhancements
 
+-   `Placeholder`: Temporarily rewind radius scale ([#64672](https://github.com/WordPress/gutenberg/pull/64672)).
 -   `Composite`: improve Storybook examples and add interactive controls ([#64397](https://github.com/WordPress/gutenberg/pull/64397)).
 -   `Composite`: use internal context to forward the composite store to sub-components ([#64493](https://github.com/WordPress/gutenberg/pull/64493)).
 -   `QueryControls`: Default to new 40px size ([#64457](https://github.com/WordPress/gutenberg/pull/64457)).

--- a/packages/components/src/placeholder/style.scss
+++ b/packages/components/src/placeholder/style.scss
@@ -19,7 +19,7 @@
 
 
 	// Block UI appearance.
-	border-radius: $radius-medium;
+	border-radius: $radius-small;	// Match the block toolbar material radius.
 	background-color: $white;
 	box-shadow: inset 0 0 0 $border-width $gray-900;
 	outline: 1px solid transparent; // Shown for Windows 10 High Contrast mode.
@@ -143,6 +143,9 @@
 	color: inherit;
 	display: flex;
 	box-shadow: none;
+
+	// In the unselected state, radius should match Global Styles > Image > Radius.
+	border-radius: 0;
 
 	// Blur the background so layered dashed placeholders are still visually separate.
 	// Make the background transparent to not interfere with the background overlay in placeholder-style() pseudo element


### PR DESCRIPTION
## What?

Followup to #64368. Temporarily reverts the placeholder radius change, and also removes it from the unselected image block state.

## Why?

In trunk, the radius differes between site logo, image, and other placeholders like Group or Column:

![placeholders before](https://github.com/user-attachments/assets/8b54e54e-033a-430c-aff1-19893eb64ca8)

Some of them have 0, some have 2px some have 4px, it's a little random.

Part of the effort is to sync this up and apply a system to it. We should still do that. But we should change the block toolbar and placeholders together, and probably do that at a later stage in the process. Pending that, this PR makes a few changes back again:

![placeholders after](https://github.com/user-attachments/assets/fdfc168a-dcc8-4b97-a374-7929756e030d)

* 2px across all placeholders
* 0px on unselected placeholders that use the gray material

The latter change is to lean into the literal placeholder aspect, it's meant to represent a block. This state can even be styled with border and radius properties, so it makes sense that its default state has whatever radius is set by Global Styles or the inspector, and 0 to match if nothing is set there:

![Screenshot 2024-08-21 at 10 42 53](https://github.com/user-attachments/assets/9823641e-67ff-4831-b27f-7eaf74fdf176)

## Testing Instructions

Observe the placeholder state radius for image, site logo, group, columns, selected and unselected, focused and unfocused states.