### PR TITLE
Navigation Block: Remove now-obsolete function_exists guards

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1626,15 +1626,6 @@ if (
 	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' );
 }
 
-/*
- * Previous versions of Gutenberg were attaching the block_core_navigation_update_ignore_hooked_blocks_meta
- * function to the `rest_insert_wp_navigation` _action_ (rather than the `rest_pre_insert_wp_navigation` _filter_).
- * To avoid collisions, we need to remove the filter from that action if it's present.
- */
-if ( has_filter( 'rest_insert_wp_navigation', $rest_insert_wp_navigation_core_callback ) ) {
-	remove_filter( 'rest_insert_wp_navigation', $rest_insert_wp_navigation_core_callback );
-}
-
 /**
  * Hooks into the REST API response for the core/navigation block and adds the first and last inner blocks.
  *

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -241,13 +241,11 @@ class WP_Navigation_Block_Renderer {
 			// it encounters whitespace. This code strips it.
 			$blocks = block_core_navigation_filter_out_empty_blocks( $parsed_blocks );
 
-			if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
-				// Run Block Hooks algorithm to inject hooked blocks.
-				$markup         = block_core_navigation_insert_hooked_blocks( $blocks, $navigation_post );
-				$root_nav_block = parse_blocks( $markup )[0];
+			// Run Block Hooks algorithm to inject hooked blocks.
+			$markup         = block_core_navigation_insert_hooked_blocks( $blocks, $navigation_post );
+			$root_nav_block = parse_blocks( $markup )[0];
 
-				$blocks = isset( $root_nav_block['innerBlocks'] ) ? $root_nav_block['innerBlocks'] : $blocks;
-			}
+			$blocks = isset( $root_nav_block['innerBlocks'] ) ? $root_nav_block['innerBlocks'] : $blocks;
 
 			// TODO - this uses the full navigation block attributes for the
 			// context which could be refined.
@@ -1083,15 +1081,13 @@ function block_core_navigation_get_fallback_blocks() {
 		// In this case default to the (Page List) fallback.
 		$fallback_blocks = ! empty( $maybe_fallback ) ? $maybe_fallback : $fallback_blocks;
 
-		if ( function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
-			// Run Block Hooks algorithm to inject hooked blocks.
-			// We have to run it here because we need the post ID of the Navigation block to track ignored hooked blocks.
-			$markup = block_core_navigation_insert_hooked_blocks( $fallback_blocks, $navigation_post );
-			$blocks = parse_blocks( $markup );
+		// Run Block Hooks algorithm to inject hooked blocks.
+		// We have to run it here because we need the post ID of the Navigation block to track ignored hooked blocks.
+		$markup = block_core_navigation_insert_hooked_blocks( $fallback_blocks, $navigation_post );
+		$blocks = parse_blocks( $markup );
 
-			if ( isset( $blocks[0]['innerBlocks'] ) ) {
-				$fallback_blocks = $blocks[0]['innerBlocks'];
-			}
+		if ( isset( $blocks[0]['innerBlocks'] ) ) {
+			$fallback_blocks = $blocks[0]['innerBlocks'];
 		}
 	}
 
@@ -1621,12 +1617,10 @@ $rest_insert_wp_navigation_core_callback = 'block_core_navigation_' . 'update_ig
 /*
  * Do not add the `block_core_navigation_update_ignore_hooked_blocks_meta` filter in the following cases:
  * - If Core has added the `update_ignored_hooked_blocks_postmeta` filter already (WP >= 6.6);
- * - or if the `set_ignored_hooked_blocks_metadata` function is unavailable (which is required for the filter to work. It was introduced by WP 6.5 but is not present in Gutenberg's WP 6.5 compatibility layer);
  * - or if the `$rest_insert_wp_navigation_core_callback` filter has already been added.
  */
 if (
 	! has_filter( 'rest_pre_insert_wp_navigation', 'update_ignored_hooked_blocks_postmeta' ) &&
-	function_exists( 'set_ignored_hooked_blocks_metadata' ) &&
 	! has_filter( 'rest_pre_insert_wp_navigation', $rest_insert_wp_navigation_core_callback )
 ) {
 	add_filter( 'rest_pre_insert_wp_navigation', 'block_core_navigation_update_ignore_hooked_blocks_meta' );
@@ -1678,12 +1672,10 @@ $rest_prepare_wp_navigation_core_callback = 'block_core_navigation_' . 'insert_h
 /*
  * Do not add the `block_core_navigation_insert_hooked_blocks_into_rest_response` filter in the following cases:
  * - If Core has added the `insert_hooked_blocks_into_rest_response` filter already (WP >= 6.6);
- * - or if the `set_ignored_hooked_blocks_metadata` function is unavailable (which is required for the filter to work. It was introduced by WP 6.5 but is not present in Gutenberg's WP 6.5 compatibility layer);
  * - or if the `$rest_prepare_wp_navigation_core_callback` filter has already been added.
  */
 if (
 	! has_filter( 'rest_prepare_wp_navigation', 'insert_hooked_blocks_into_rest_response' ) &&
-	function_exists( 'set_ignored_hooked_blocks_metadata' ) &&
 	! has_filter( 'rest_prepare_wp_navigation', $rest_prepare_wp_navigation_core_callback )
 ) {
 	add_filter( 'rest_prepare_wp_navigation', 'block_core_navigation_insert_hooked_blocks_into_rest_response', 10, 3 );

--- a/phpunit/blocks/block-navigation-block-hooks-test.php
+++ b/phpunit/blocks/block-navigation-block-hooks-test.php
@@ -58,10 +58,6 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_update_ignore_hooked_blocks_meta_preserves_entities() {
-		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
-			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionality.' );
-		}
-
 		register_block_type(
 			'tests/my-block',
 			array(
@@ -97,10 +93,6 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_dont_modify_no_post_id() {
-		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
-			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionality.' );
-		}
-
 		register_block_type(
 			'tests/my-block',
 			array(
@@ -127,10 +119,6 @@ class Block_Navigation_Block_Hooks_Test extends WP_UnitTestCase {
 	 * @covers ::gutenberg_block_core_navigation_update_ignore_hooked_blocks_meta
 	 */
 	public function test_block_core_navigation_retains_content_if_not_set() {
-		if ( ! function_exists( 'set_ignored_hooked_blocks_metadata' ) ) {
-			$this->markTestSkipped( 'Test skipped on WordPress versions that do not included required Block Hooks functionality.' );
-		}
-
 		register_block_type(
 			'tests/my-block',
 			array(


### PR DESCRIPTION
## What?
- Remove a number of `function_exists()` guards that checked for existence of the `set_ignored_hooked_blocks_metadata` function.
- Delete code that checked if the `block_core_navigation_update_ignore_hooked_blocks_meta` function was attached to the `rest_insert_wp_navigation` _action_ hook, and removed it if it was.

## Why?
The `set_ignored_hooked_blocks_metadata` function was [introduced in WP 6.5](https://core.trac.wordpress.org/changeset/57377/trunk/src/wp-includes/blocks/navigation.php), and Gutenberg now [requires WP 6.5 as a minimum](https://github.com/WordPress/gutenberg/blob/94091e03fed9ed5072650d5b7615efea83236663/gutenberg.php#L6).

Same for the `block_core_navigation_update_ignore_hooked_blocks_meta` action removal: This was only relevant for older GB versions and during some WP 6.5 Betas (see the [original phrasing of the comment here](https://github.com/WordPress/gutenberg/pull/59561/files#diff-90cb5b64c95087ded3c7bb160e38189c8499b0f14f61beb884c887452449fa12R1503-R1505)); it is now obsolete.

## How?
By removing them 🤷‍♂️ 

## Testing Instructions
This should be covered by unit tests (which are run both against the current and previous WP versions).
In addition, you can smoke-test Block Hooks in the Navigation block as described in other related PRs, e.g. https://github.com/WordPress/gutenberg/pull/59021.

## Follow-up

We'll be able to remove even more code once WP 6.7 is the minimum requirement for Gutenberg: https://github.com/WordPress/gutenberg/pull/64676
