### PR TITLE
Navigator: remove location history, simplify internal logic

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Deprecations
+
+-   Deprecate `replace` from the options accepted by `useNavigator().goTo()` ([#64675](https://github.com/WordPress/gutenberg/pull/64675)).
+
 ### Enhancements
 
 -   `ColorPicker`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
@@ -16,6 +20,7 @@
 -   `TabPanel`: Remove radius applied to panel focus style ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
 -   `Tabs`: Remove radius applied to panel focus style ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
 -   `UnitControl`: Update unit select styles ([#64712](https://github.com/WordPress/gutenberg/pull/64712)).
+-   `Navigator`: remove location history, simplify internal logic ([#64675](https://github.com/WordPress/gutenberg/pull/64675)).
 -   Decrease horizontal padding from 16px to 12px on the following components, when in the 40px default size ([#64708](https://github.com/WordPress/gutenberg/pull/64708)).
     -   `AnglePickerControl`
     -   `ColorPicker` (on the inputs)

--- a/packages/components/src/navigator/navigator-provider/README.md
+++ b/packages/components/src/navigator/navigator-provider/README.md
@@ -72,7 +72,6 @@ The available options are:
 -   `focusTargetSelector`: `string`. An optional property used to specify the CSS selector used to restore focus on the matching element when navigating back;
 -   `isBack`: `boolean`. An optional property used to specify whether the navigation should be considered as backwards (thus enabling focus restoration when possible, and causing the animation to be backwards too);
 -   `skipFocus`: `boolean`. An optional property used to opt out of `Navigator`'s focus management, useful when the consumer of the component wants to manage focus themselves;
--   `replace`: `boolean`. An optional property used to cause the new location to replace the current location in the stack.
 
 ### `goBack`: `( path: string, options: NavigateOptions ) => void`
 
@@ -87,8 +86,8 @@ The available options are the same as for the `goTo` method, except for the `isB
 The `location` object represent the current location, and has a few properties:
 
 -   `path`: `string`. The path associated to the location.
--   `isBack`: `boolean`. A flag that is `true` when the current location was reached by navigating backwards in the location history.
--   `isInitial`: `boolean`. A flag that is `true` only for the first (root) location in the location history.
+-   `isBack`: `boolean`. A flag that is `true` when the current location was reached by navigating backwards.
+-   `isInitial`: `boolean`. A flag that is `true` only for the initial location.
 
 ### `params`: `Record< string, string | string[] >`
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -43,6 +43,14 @@ type RouterState = {
 };
 
 function addScreen( { screens }: RouterState, screen: Screen ) {
+	if ( screens.some( ( s ) => s.path === screen.path ) ) {
+		// eslint-disable-next-line no-console
+		console.warn(
+			`Navigator: a screen with path ${ screen.path } already exists.
+The screen with id ${ screen.id } will not be added.`
+		);
+		return screens;
+	}
 	return [ ...screens, screen ];
 }
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -39,7 +39,7 @@ type RouterAction =
 type RouterState = {
 	initialPath: string;
 	screens: Screen[];
-	currentLocation?: NavigatorLocation;
+	currentLocation: NavigatorLocation;
 	matchedPath: MatchedPath;
 	focusSelectors: Map< string, string >;
 };
@@ -165,6 +165,10 @@ function routerReducer(
 			break;
 	}
 
+	if ( currentLocation?.path === state.initialPath ) {
+		currentLocation = { ...currentLocation, isInitial: true };
+	}
+
 	// Return early in case there is no change
 	if (
 		screens === state.screens &&
@@ -248,19 +252,16 @@ function UnconnectedNavigatorProvider(
 		[]
 	);
 
-	const { currentLocation, matchedPath, initialPath } = routerState;
+	const { currentLocation, matchedPath } = routerState;
 
 	const navigatorContextValue: NavigatorContextType = useMemo(
 		() => ( {
-			location: {
-				...currentLocation,
-				isInitial: currentLocation?.path === initialPath,
-			},
+			location: currentLocation,
 			params: matchedPath?.params ?? {},
 			match: matchedPath?.id,
 			...methods,
 		} ),
-		[ currentLocation, matchedPath, methods, initialPath ]
+		[ currentLocation, matchedPath, methods ]
 	);
 
 	const cx = useCx();

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -37,6 +37,7 @@ type RouterAction =
 	| { type: 'gotoparent'; options?: NavigateToParentOptions };
 
 type RouterState = {
+	initialPath: string;
 	screens: Screen[];
 	currentLocation?: NavigatorLocation;
 	matchedPath: MatchedPath;
@@ -176,17 +177,22 @@ function UnconnectedNavigatorProvider(
 	props: WordPressComponentProps< NavigatorProviderProps, 'div' >,
 	forwardedRef: ForwardedRef< any >
 ) {
-	const { initialPath, children, className, ...otherProps } =
-		useContextSystem( props, 'NavigatorProvider' );
+	const {
+		initialPath: initialPathProp,
+		children,
+		className,
+		...otherProps
+	} = useContextSystem( props, 'NavigatorProvider' );
 
 	const [ routerState, dispatch ] = useReducer(
 		routerReducer,
-		initialPath,
+		initialPathProp,
 		( path ) => ( {
 			screens: [],
 			currentLocation: { path },
 			matchedPath: undefined,
 			focusSelectors: new Map(),
+			initialPath: initialPathProp,
 		} )
 	);
 
@@ -215,19 +221,19 @@ function UnconnectedNavigatorProvider(
 		[]
 	);
 
-	const { currentLocation, matchedPath } = routerState;
+	const { currentLocation, matchedPath, initialPath } = routerState;
 
 	const navigatorContextValue: NavigatorContextType = useMemo(
 		() => ( {
 			location: {
 				...currentLocation,
-				isInitial: false, // TODO: find out an alternative to this
+				isInitial: currentLocation?.path === initialPath,
 			},
 			params: matchedPath?.params ?? {},
 			match: matchedPath?.id,
 			...methods,
 		} ),
-		[ currentLocation, matchedPath, methods ]
+		[ currentLocation, matchedPath, methods, initialPath ]
 	);
 
 	const cx = useCx();

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -82,17 +82,23 @@ function goTo(
 		return { currentLocation, focusSelectors };
 	}
 
-	const focusSelectorsCopy = new Map( state.focusSelectors );
+	let focusSelectorsCopy;
 
 	// Set a focus selector that will be used when navigating
 	// back to the current location.
 	if ( focusTargetSelector && currentLocation?.path ) {
+		if ( ! focusSelectorsCopy ) {
+			focusSelectorsCopy = new Map( state.focusSelectors );
+		}
 		focusSelectorsCopy.set( currentLocation.path, focusTargetSelector );
 	}
 
 	// Get the focus selector for the new location.
 	let currentFocusSelector;
 	if ( isBack ) {
+		if ( ! focusSelectorsCopy ) {
+			focusSelectorsCopy = new Map( state.focusSelectors );
+		}
 		currentFocusSelector = focusSelectorsCopy.get( path );
 		focusSelectorsCopy.delete( path );
 	}
@@ -106,7 +112,7 @@ function goTo(
 			focusTargetSelector: currentFocusSelector,
 			skipFocus,
 		},
-		focusSelectors: focusSelectorsCopy,
+		focusSelectors: focusSelectorsCopy ?? focusSelectors,
 	};
 }
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -92,7 +92,7 @@ function goTo(
 	let currentFocusSelector;
 	if ( isBack ) {
 		currentFocusSelector = focusSelectors.get( path );
-		focusSelectors.delete( path );
+		// focusSelectors.delete( path );
 	}
 
 	return {

--- a/packages/components/src/navigator/types.ts
+++ b/packages/components/src/navigator/types.ts
@@ -28,7 +28,9 @@ export type NavigateOptions = {
 	 */
 	skipFocus?: boolean;
 	/**
-	 * Whether the navigation should replace the current location in the stack.
+	 * Note: this option is deprecated and currently doesn't have any effect.
+	 * @deprecated
+	 * @ignore
 	 */
 	replace?: boolean;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #59418
Related to #60927

Rewrite `Navigator`'s internal logic, removing the location history.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The location history is only an implementation detail after the changes in https://github.com/WordPress/gutenberg/pull/63317 deprecated the "go back in history" behaviour, in favour of always navigating to the screen's parent.

Removing the code related to the location history allows the internal logic to be simpler and easier to maintain

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Instead of storing the whole location history, `Navigator` only internally stores the current location;
- the `goBack` function inside the reducer was removed, together with some extra checks. The `goTo` function now always creates a new location object
- Focus restoration logic uses a (screen path, focus selector) map instead of the location history, and should work like before;
  - In order to make the new focus restoration logic more robust, a new constraint was added, preventing a screen from being registered if a screen with the same path already exists;
- The `isInitial` flag is now computed based on the `initialPath` prop, instead of using the location history — again, there shouldn't be any changes in behaviour.
- The `replace` option is marked as deprecated, as it doesn't make sense without a location history (I don't think it was used in the editor anyway)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Unit tests should pass
- Storybook examples should continue to work as expected
- Smoke tests 