### PR TITLE
border: 1px → $border-width

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-icon/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-icon/style.scss
@@ -3,5 +3,5 @@
 	width: $button-size * 1.5;
 	height: $button-size * 1.5;
 	vertical-align: middle;
-	border: 1px solid $gray-300;
+	border: $border-width solid $gray-300;
 }

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -231,7 +231,7 @@
 		}
 
 		.block-editor-block-parent-selector__button {
-			border: 1px solid $gray-900;
+			border: $border-width solid $gray-900;
 			padding-right: 6px;
 			padding-left: 6px;
 			background-color: $white;

--- a/packages/block-editor/src/components/block-variation-transforms/style.scss
+++ b/packages/block-editor/src/components/block-variation-transforms/style.scss
@@ -3,7 +3,7 @@
 	width: 100%;
 
 	.components-dropdown-menu__toggle {
-		border: 1px solid $gray-700;
+		border: $border-width solid $gray-700;
 		border-radius: $radius-block-ui;
 		min-height: 30px;
 		width: 100%;

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -73,7 +73,7 @@
 
 
 .block-editor-global-styles-background-panel__inspector-media-replace-container {
-	border: 1px solid $gray-300;
+	border: $border-width solid $gray-300;
 	border-radius: 2px;
 	// Full width. ToolsPanel lays out children in a grid.
 	grid-column: 1 / -1;
@@ -101,7 +101,7 @@
 }
 
 .block-editor-global-styles-background-panel__image-tools-panel-item {
-	border: 1px solid $gray-300;
+	border: $border-width solid $gray-300;
 	border-radius: 2px;
 
 	// Full width. ToolsPanel lays out children in a grid.
@@ -197,7 +197,7 @@
 	border-radius: $radius-round;
 	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
-	border: 1px solid transparent;
+	border: $border-width solid transparent;
 	box-sizing: inherit;
 }
 

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -197,7 +197,7 @@
 	border-radius: $radius-round;
 	box-shadow: inset 0 0 0 $border-width rgba(0, 0, 0, 0.2);
 	// Show a thin outline in Windows high contrast mode, otherwise the button is invisible.
-	border: $border-width solid transparent;
+	border: 1px solid transparent;
 	box-sizing: inherit;
 }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -77,7 +77,7 @@ $block-editor-link-control-number-of-actions: 1;
 	&.block-editor-url-input input[type="text"].block-editor-url-input__input {
 		@include input-control;
 		display: block;
-		border: 1px solid $gray-600;
+		border: $border-width solid $gray-600;
 		border-radius: $radius-block-ui;
 		height: $button-size-next-default-40px; // components do not properly support unstable-large yet.
 		margin: 0;

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -121,7 +121,7 @@ $input-size: 300px;
 
 .block-editor-url-input__button-modal {
 	box-shadow: $shadow-popover;
-	border: 1px solid $gray-300;
+	border: $border-width solid $gray-300;
 	background: $white;
 }
 

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -30,7 +30,7 @@
 	.components-button {
 		height: $grid-unit-70;
 		width: $grid-unit-70;
-		border: 1px solid $gray-600;
+		border: $border-width solid $gray-600;
 		border-right: 0;
 		justify-content: center;
 		border-radius: $radius-block-ui 0 0 $radius-block-ui;

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -61,6 +61,8 @@
 -   `Popover`: Replace references to deprecated styling variables ([#64655](https://github.com/WordPress/gutenberg/pull/64655)).
 -   `Snackbar`: Replace references to deprecated styling variables ([#64655](https://github.com/WordPress/gutenberg/pull/64655)).
 -   `TextareaControl`: Update styles ([#64586](https://github.com/WordPress/gutenberg/pull/64586)).
+-   `CircularOptionPicker`: Update hard-coded border-width value ([#64680](https://github.com/WordPress/gutenberg/pull/64680)).
+-   `CustomGradientPicker`: Update hard-coded border-width value ([#64680](https://github.com/WordPress/gutenberg/pull/64680)).
 
 ### Bug Fixes
 

--- a/packages/components/src/circular-option-picker/style.scss
+++ b/packages/components/src/circular-option-picker/style.scss
@@ -109,7 +109,7 @@ $color-palette-circle-spacing: 12px;
 		border-radius: $radius-round;
 		box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 		// Show a thin circular outline in Windows high contrast mode, otherwise the button is invisible.
-		border: 1px solid transparent;
+		border: $border-width solid transparent;
 		box-sizing: inherit;
 	}
 

--- a/packages/components/src/custom-gradient-picker/style.scss
+++ b/packages/components/src/custom-gradient-picker/style.scss
@@ -112,7 +112,7 @@ $components-custom-gradient-picker__padding: $grid-unit-20; // 48px container, 1
 		&.is-pressed {
 			> svg {
 				background: $white;
-				border: 1px solid $gray-600;
+				border: $border-width solid $gray-600;
 				border-radius: 2px;
 			}
 		}

--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -48,7 +48,7 @@
 
 	.dataviews-filters__summary-chip {
 		border-radius: $grid-unit-20;
-		border: 1px solid transparent;
+		border: $border-width solid transparent;
 		cursor: pointer;
 		padding: $grid-unit-05 $grid-unit-15;
 		min-height: $grid-unit-40;

--- a/packages/edit-site/src/components/add-new-template/style.scss
+++ b/packages/edit-site/src/components/add-new-template/style.scss
@@ -81,7 +81,7 @@
 }
 
 .edit-site-custom-template-modal__no-results {
-	border: 1px solid $gray-400;
+	border: $border-width solid $gray-400;
 	border-radius: $radius-block-ui;
 	padding: $grid-unit-20;
 }

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -12,7 +12,7 @@
 	box-sizing: border-box;
 	width: $sidebar-width;
 	background-color: $white;
-	border: 1px dotted $gray-300;
+	border: $border-width dotted $gray-300;
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -92,7 +92,7 @@ $footer-height: 70px;
 }
 
 .font-library-modal__font-card {
-	border: 1px solid $gray-200;
+	border: $border-width solid $gray-200;
 	width: 100%;
 	height: auto;
 	padding: $grid-unit-20;

--- a/packages/editor/src/components/block-manager/style.scss
+++ b/packages/editor/src/components/block-manager/style.scss
@@ -9,7 +9,7 @@
 }
 
 .editor-block-manager__disabled-blocks-count {
-	border: 1px solid $gray-300;
+	border: $border-width solid $gray-300;
 	border-width: 1px 0;
 	// Cover up horizontal areas off the sides of the box rectangle
 	box-shadow: -$grid-unit-40 0 0 0 $white, $grid-unit-40 0 0 0 $white;

--- a/packages/editor/src/components/block-manager/style.scss
+++ b/packages/editor/src/components/block-manager/style.scss
@@ -10,7 +10,7 @@
 
 .editor-block-manager__disabled-blocks-count {
 	border: $border-width solid $gray-300;
-	border-width: 1px 0;
+	border-width: $border-width 0;
 	// Cover up horizontal areas off the sides of the box rectangle
 	box-shadow: -$grid-unit-40 0 0 0 $white, $grid-unit-40 0 0 0 $white;
 	padding: $grid-unit-10;

--- a/packages/editor/src/components/error-boundary/style.native.scss
+++ b/packages/editor/src/components/error-boundary/style.native.scss
@@ -86,7 +86,7 @@
 }
 
 .copy-button__container--secondary {
-	border: 1px #c6c6c8;
+	border: $border-width #c6c6c8;
 	background-color: $white;
 }
 

--- a/packages/editor/src/components/save-publish-panels/style.scss
+++ b/packages/editor/src/components/save-publish-panels/style.scss
@@ -11,7 +11,7 @@
 	box-sizing: border-box;
 	width: $sidebar-width;
 	background-color: $white;
-	border: 1px dotted $gray-300;
+	border: $border-width dotted $gray-300;
 	height: auto !important; // Need to override the default sidebar positionnings
 	padding: $grid-unit-30;
 	display: flex;

--- a/packages/editor/src/components/save-publish-panels/style.scss
+++ b/packages/editor/src/components/save-publish-panels/style.scss
@@ -3,7 +3,7 @@
 .editor-layout__toggle-sidebar-panel,
 .editor-layout__toggle-entities-saved-states-panel {
 	z-index: z-index(".editor-layout__toggle-sidebar-panel");
-	position: fixed !important; // Need to override the default relative positionning
+	position: fixed !important; // Necessary to override the default relative positioning.
 	top: -9999em;
 	bottom: auto;
 	left: auto;
@@ -12,7 +12,7 @@
 	width: $sidebar-width;
 	background-color: $white;
 	border: $border-width dotted $gray-300;
-	height: auto !important; // Need to override the default sidebar positionnings
+	height: auto !important; // Necessary to override the default sidebar positioning.
 	padding: $grid-unit-30;
 	display: flex;
 	justify-content: center;

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -4,7 +4,7 @@
 	}
 	background: $white;
 	border-radius: $radius-block-ui;
-	border: 1px solid $gray-900;
+	border: $border-width solid $gray-900;
 	padding: $grid-unit-15 - 1px; // Subtract the border width.
 	max-height: calc(100vh - 2px); // Subtract the border width (both top and bottom).
 	overflow-y: scroll;
@@ -57,7 +57,7 @@
 			font-family: system-ui;
 			background-color: transparent;
 			box-sizing: border-box;
-			border: 1px solid $gray-700;
+			border: $border-width solid $gray-700;
 			border-radius: 3px;
 			box-shadow: none;
 			color: $black;
@@ -96,7 +96,7 @@
 
 	&:hover::after {
 		border-radius: $radius-block-ui;
-		border: 1px solid $gray-600;
+		border: $border-width solid $gray-600;
 		bottom: 0;
 		content: "";
 		left: 0;

--- a/packages/widgets/src/blocks/legacy-widget/editor.scss
+++ b/packages/widgets/src/blocks/legacy-widget/editor.scss
@@ -5,8 +5,8 @@
 	background: $white;
 	border-radius: $radius-block-ui;
 	border: $border-width solid $gray-900;
-	padding: $grid-unit-15 - 1px; // Subtract the border width.
-	max-height: calc(100vh - 2px); // Subtract the border width (both top and bottom).
+	padding: $grid-unit-15 - $border-width;
+	max-height: calc(100vh - #{ $border-width } - #{ $border-width });
 	overflow-y: scroll;
 
 	.wp-block-legacy-widget__edit-form-title {

--- a/packages/widgets/src/blocks/widget-group/editor.scss
+++ b/packages/widgets/src/blocks/widget-group/editor.scss
@@ -1,7 +1,7 @@
 .wp-block-widget-group {
 	&.has-child-selected::after {
 		border-radius: $radius-block-ui;
-		border: 1px solid var(--wp-admin-theme-color);
+		border: $border-width solid var(--wp-admin-theme-color);
 		bottom: 0;
 		content: "";
 		left: 0;


### PR DESCRIPTION
## What?
Replace instances of `border: 1px` with `border: $border-width`.

## Why?
Code cleanliness. Using the variable eases maintenance should it ever be decided that `$border-width` should change.

## Testing Instructions
1. Smoke test the editor
2. There should be no visual changes because `$border-width` currently equals `1px`.
