### PR TITLE
Data views: Update search appearance in narrow containers

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   The "move left/move right" controls in the table layout (popup displayed on cliking header) are always visible. ([#64646](https://github.com/WordPress/gutenberg/pull/64646)). Before this, its visibility depending on filters, enableSorting, and enableHiding.
 
+## Enhancements
+
+-   Adjust layout of filter / actions row, increase width of search control when the container is narrower. ([#64681](https://github.com/WordPress/gutenberg/pull/64681)).
+
 ## 4.1.0 (2024-08-07)
 
 ## Internal

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -118,11 +118,15 @@ export default function DataViews< Item >( {
 			<div className="dataviews-wrapper">
 				<HStack
 					alignment="top"
-					justify="start"
+					justify="space-between"
 					className="dataviews__view-actions"
 					spacing={ 1 }
 				>
-					<HStack justify="start" wrap>
+					<HStack
+						justify="start"
+						expanded={ false }
+						className="dataviews__search"
+					>
 						{ search && <DataViewsSearch label={ searchLabel } /> }
 						<FilterVisibilityToggle
 							filters={ filters }
@@ -133,12 +137,12 @@ export default function DataViews< Item >( {
 							isShowingFilter={ isShowingFilter }
 						/>
 					</HStack>
-					<DataViewsBulkActions />
 					<HStack
 						spacing={ 1 }
 						expanded={ false }
 						style={ { flexShrink: 0 } }
 					>
+						<DataViewsBulkActions />
 						<DataViewsViewConfig
 							defaultLayouts={ defaultLayouts }
 							density={ density }

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -18,12 +18,6 @@
 	left: 0;
 	transition: padding ease-out 0.1s;
 	@include reduce-motion("transition");
-
-	.components-search-control {
-		.components-base-control__field {
-			max-width: 240px;
-		}
-	}
 }
 
 .dataviews-view-list__primary-field,
@@ -82,12 +76,6 @@
 	.dataviews__view-actions,
 	.dataviews-filters__container {
 		padding: $grid-unit-15 $grid-unit-30;
-
-		.components-search-control {
-			.components-base-control__field {
-				max-width: 112px;
-			}
-		}
 	}
 
 	.dataviews-view-grid,


### PR DESCRIPTION
## What?
Increase the width of the search field in narrow containers.

## Why?
It's currently unnecessarily small.

## How?
Adjusts the layout of `.dataviews__view-actions` so that the search container and the actions container are the only two children, split by `justify-content: space-between`. This allows the search container to shrink / grow as needed. 

## Testing Instructions
1. Navigate to a data view with a narrow container; List layout for pages, or manually reduce the width of the viewport for any other data view
2. Observe that the search field is now larger
3. Check there are no significant changes when the container is wider

| Before | After |
| --- | --- |
| <img width="378" alt="Screenshot 2024-08-21 at 13 50 14" src="https://github.com/user-attachments/assets/21fe85ee-3965-4d58-8b59-048a8fd4c453"> <img width="403" alt="Screenshot 2024-08-21 at 13 51 11" src="https://github.com/user-attachments/assets/9275af35-99bf-417c-b99b-2beef64240e6"> | <img width="379" alt="Screenshot 2024-08-21 at 13 50 24" src="https://github.com/user-attachments/assets/05fd64ba-5e16-4161-b812-7ecd3fc4ff6e"> <img width="405" alt="Screenshot 2024-08-21 at 13 51 19" src="https://github.com/user-attachments/assets/d3ed64a9-f7c8-4061-8e11-7aca0367c5b6"> |

