### PR TITLE
Adding a filter from the column-header-menu should open the filter panel

### DIFF
--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -93,9 +93,7 @@ export default function DataViews< Item >( {
 	}, [ selection, data, getItemId ] );
 
 	const filters = useFilters( _fields, view );
-	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
-		( filters || [] ).some( ( filter ) => filter.isPrimary )
-	);
+	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( true );
 
 	return (
 		<DataViewsContext.Provider


### PR DESCRIPTION
## What?
The fix shows the filter component when selected via column headers

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/64612

## How?
The initial state for `isShowingFilter` is set to true, so when the filter option is selected in column header the filter component renders just like when we select it using dropdown menu icon

https://github.com/WordPress/gutenberg/blob/5e779974ddda4e66d22a508bc3c79a75c4769497/packages/dataviews/src/components/dataviews/index.tsx#L96-L98

to

```js
 const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( true );
```


## Testing Instructions
1. Clone the repo
2. run `npm install` and `npm run storybook:dev`
3. go to dataview component and select `categories` column header
4. select the `Add filter` option
5. See the render filter component.

## Screenshots or screencast 

#### Before
https://github.com/user-attachments/assets/ba0086cc-1f21-4852-a1cd-0ded5bf2d0c2

#### After
https://github.com/user-attachments/assets/7ce0a401-9efc-4cf3-8593-b3c0c3984e22




