### PR TITLE
Block Bindings: Fix ESLint warnings

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -254,7 +254,7 @@ function ButtonEdit( props ) {
 					} ),
 			};
 		},
-		[ isSelected, metadata?.bindings?.url ]
+		[ context, isSelected, metadata?.bindings?.url ]
 	);
 
 	return (

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -322,7 +322,7 @@ export function ImageEdit( {
 					: __( 'Connected to dynamic data' ),
 			};
 		},
-		[ isSingleSelected, metadata?.bindings?.url ]
+		[ context, isSingleSelected, metadata?.bindings?.url ]
 	);
 	const placeholder = ( content ) => {
 		return (


### PR DESCRIPTION
## What?
PR updates the useSelect hook dependencies for the Button and Image blocks to fix the ESLint warning.

```
React Hook useSelect has a missing dependency: 'context. Either include it or remove the dependency array.
```

## Testing Instructions
The functionality has e2e test coverage. CI checks should be green.
