### PR TITLE
Show block icon in contentOnly toolbar

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -181,6 +181,21 @@ function BlockSwitcherDropdownMenuContents( {
 	);
 }
 
+const BlockIndicator = ( { icon, showTitle, blockTitle } ) => (
+	<>
+		<BlockIcon
+			className="block-editor-block-switcher__toggle"
+			icon={ icon }
+			showColors
+		/>
+		{ showTitle && blockTitle && (
+			<span className="block-editor-block-switcher__toggle-text">
+				{ blockTitle }
+			</span>
+		) }
+	</>
+);
+
 export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 	const {
 		canRemove,
@@ -247,6 +262,7 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 		: __( 'Multiple blocks selected' );
 
 	const hideDropdown = disabled || ( ! hasBlockStyles && ! canRemove );
+
 	if ( hideDropdown ) {
 		return (
 			<ToolbarGroup>
@@ -255,14 +271,11 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 					className="block-editor-block-switcher__no-switcher-icon"
 					title={ blockSwitcherLabel }
 					icon={
-						<>
-							<BlockIcon icon={ icon } showColors />
-							{ ( isReusable || isTemplate ) && (
-								<span className="block-editor-block-switcher__toggle-text">
-									{ blockTitle }
-								</span>
-							) }
-						</>
+						<BlockIndicator
+							icon={ icon }
+							showTitle={ isReusable || isTemplate }
+							blockTitle={ blockTitle }
+						/>
 					}
 				/>
 			</ToolbarGroup>
@@ -292,18 +305,11 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 							className: 'block-editor-block-switcher__popover',
 						} }
 						icon={
-							<>
-								<BlockIcon
-									icon={ icon }
-									className="block-editor-block-switcher__toggle"
-									showColors
-								/>
-								{ ( isReusable || isTemplate ) && (
-									<span className="block-editor-block-switcher__toggle-text">
-										{ blockTitle }
-									</span>
-								) }
-							</>
+							<BlockIndicator
+								icon={ icon }
+								showTitle={ isReusable || isTemplate }
+								blockTitle={ blockTitle }
+							/>
 						}
 						toggleProps={ {
 							description: blockSwitcherDescription,

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -5,6 +5,7 @@ import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import {
 	DropdownMenu,
 	ToolbarButton,
+	ToolbarGroup,
 	ToolbarItem,
 	__experimentalText as Text,
 	MenuGroup,
@@ -264,18 +265,20 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 
 	if ( hideDropdown ) {
 		return (
-			<ToolbarButton
-				disabled
-				className="block-editor-block-switcher__no-switcher-icon"
-				title={ blockSwitcherLabel }
-				icon={
-					<BlockIndicator
-						icon={ icon }
-						showTitle={ isReusable || isTemplate }
-						blockTitle={ blockTitle }
-					/>
-				}
-			/>
+			<ToolbarGroup>
+				<ToolbarButton
+					disabled
+					className="block-editor-block-switcher__no-switcher-icon"
+					title={ blockSwitcherLabel }
+					icon={
+						<BlockIndicator
+							icon={ icon }
+							showTitle={ isReusable || isTemplate }
+							blockTitle={ blockTitle }
+						/>
+					}
+				/>
+			</ToolbarGroup>
 		);
 	}
 
@@ -291,40 +294,42 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 				clientIds.length
 		  );
 	return (
-		<ToolbarItem>
-			{ ( toggleProps ) => (
-				<DropdownMenu
-					className="block-editor-block-switcher"
-					label={ blockSwitcherLabel }
-					popoverProps={ {
-						placement: 'bottom-start',
-						className: 'block-editor-block-switcher__popover',
-					} }
-					icon={
-						<BlockIndicator
-							icon={ icon }
-							showTitle={ isReusable || isTemplate }
-							blockTitle={ blockTitle }
-						/>
-					}
-					toggleProps={ {
-						description: blockSwitcherDescription,
-						...toggleProps,
-					} }
-					menuProps={ { orientation: 'both' } }
-				>
-					{ ( { onClose } ) => (
-						<BlockSwitcherDropdownMenuContents
-							onClose={ onClose }
-							clientIds={ clientIds }
-							hasBlockStyles={ hasBlockStyles }
-							canRemove={ canRemove }
-							isUsingBindings={ isUsingBindings }
-						/>
-					) }
-				</DropdownMenu>
-			) }
-		</ToolbarItem>
+		<ToolbarGroup>
+			<ToolbarItem>
+				{ ( toggleProps ) => (
+					<DropdownMenu
+						className="block-editor-block-switcher"
+						label={ blockSwitcherLabel }
+						popoverProps={ {
+							placement: 'bottom-start',
+							className: 'block-editor-block-switcher__popover',
+						} }
+						icon={
+							<BlockIndicator
+								icon={ icon }
+								showTitle={ isReusable || isTemplate }
+								blockTitle={ blockTitle }
+							/>
+						}
+						toggleProps={ {
+							description: blockSwitcherDescription,
+							...toggleProps,
+						} }
+						menuProps={ { orientation: 'both' } }
+					>
+						{ ( { onClose } ) => (
+							<BlockSwitcherDropdownMenuContents
+								onClose={ onClose }
+								clientIds={ clientIds }
+								hasBlockStyles={ hasBlockStyles }
+								canRemove={ canRemove }
+								isUsingBindings={ isUsingBindings }
+							/>
+						) }
+					</DropdownMenu>
+				) }
+			</ToolbarItem>
+		</ToolbarGroup>
 	);
 };
 

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -5,7 +5,6 @@ import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import {
 	DropdownMenu,
 	ToolbarButton,
-	ToolbarGroup,
 	ToolbarItem,
 	__experimentalText as Text,
 	MenuGroup,
@@ -265,20 +264,18 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 
 	if ( hideDropdown ) {
 		return (
-			<ToolbarGroup>
-				<ToolbarButton
-					disabled
-					className="block-editor-block-switcher__no-switcher-icon"
-					title={ blockSwitcherLabel }
-					icon={
-						<BlockIndicator
-							icon={ icon }
-							showTitle={ isReusable || isTemplate }
-							blockTitle={ blockTitle }
-						/>
-					}
-				/>
-			</ToolbarGroup>
+			<ToolbarButton
+				disabled
+				className="block-editor-block-switcher__no-switcher-icon"
+				title={ blockSwitcherLabel }
+				icon={
+					<BlockIndicator
+						icon={ icon }
+						showTitle={ isReusable || isTemplate }
+						blockTitle={ blockTitle }
+					/>
+				}
+			/>
 		);
 	}
 
@@ -294,42 +291,40 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 				clientIds.length
 		  );
 	return (
-		<ToolbarGroup>
-			<ToolbarItem>
-				{ ( toggleProps ) => (
-					<DropdownMenu
-						className="block-editor-block-switcher"
-						label={ blockSwitcherLabel }
-						popoverProps={ {
-							placement: 'bottom-start',
-							className: 'block-editor-block-switcher__popover',
-						} }
-						icon={
-							<BlockIndicator
-								icon={ icon }
-								showTitle={ isReusable || isTemplate }
-								blockTitle={ blockTitle }
-							/>
-						}
-						toggleProps={ {
-							description: blockSwitcherDescription,
-							...toggleProps,
-						} }
-						menuProps={ { orientation: 'both' } }
-					>
-						{ ( { onClose } ) => (
-							<BlockSwitcherDropdownMenuContents
-								onClose={ onClose }
-								clientIds={ clientIds }
-								hasBlockStyles={ hasBlockStyles }
-								canRemove={ canRemove }
-								isUsingBindings={ isUsingBindings }
-							/>
-						) }
-					</DropdownMenu>
-				) }
-			</ToolbarItem>
-		</ToolbarGroup>
+		<ToolbarItem>
+			{ ( toggleProps ) => (
+				<DropdownMenu
+					className="block-editor-block-switcher"
+					label={ blockSwitcherLabel }
+					popoverProps={ {
+						placement: 'bottom-start',
+						className: 'block-editor-block-switcher__popover',
+					} }
+					icon={
+						<BlockIndicator
+							icon={ icon }
+							showTitle={ isReusable || isTemplate }
+							blockTitle={ blockTitle }
+						/>
+					}
+					toggleProps={ {
+						description: blockSwitcherDescription,
+						...toggleProps,
+					} }
+					menuProps={ { orientation: 'both' } }
+				>
+					{ ( { onClose } ) => (
+						<BlockSwitcherDropdownMenuContents
+							onClose={ onClose }
+							clientIds={ clientIds }
+							hasBlockStyles={ hasBlockStyles }
+							canRemove={ canRemove }
+							isUsingBindings={ isUsingBindings }
+						/>
+					) }
+				</DropdownMenu>
+			) }
+		</ToolbarItem>
 	);
 };
 

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -47,7 +47,6 @@
 
 // Even when the block switcher does not have any transformations, it still serves as a block indicator.
 .components-button.block-editor-block-switcher__no-switcher-icon[aria-disabled="true"] {
-	opacity: 1;
 	color: $gray-900;
 
 	// Since it's not clickable, though, don't show a hover state.

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -46,12 +46,12 @@
 }
 
 // Even when the block switcher does not have any transformations, it still serves as a block indicator.
-.components-button.block-editor-block-switcher__no-switcher-icon:disabled {
+.components-button.block-editor-block-switcher__no-switcher-icon[aria-disabled="true"] {
 	opacity: 1;
+	color: $gray-900;
 
 	// Since it's not clickable, though, don't show a hover state.
-	&,
-	.block-editor-block-icon.has-colors {
+	&:hover {
 		color: $gray-900;
 	}
 }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -59,6 +59,7 @@ export function PrivateBlockToolbar( {
 	const {
 		blockClientId,
 		blockClientIds,
+		isContentOnlyEditingMode,
 		isDefaultEditingMode,
 		blockType,
 		toolbarKey,
@@ -83,8 +84,8 @@ export function PrivateBlockToolbar( {
 		const firstParentClientId = parents[ parents.length - 1 ];
 		const parentBlockName = getBlockName( firstParentClientId );
 		const parentBlockType = getBlockType( parentBlockName );
-		const _isDefaultEditingMode =
-			getBlockEditingMode( selectedBlockClientId ) === 'default';
+		const editingMode = getBlockEditingMode( selectedBlockClientId );
+		const _isDefaultEditingMode = editingMode === 'default';
 		const _blockName = getBlockName( selectedBlockClientId );
 		const isValid = selectedBlockClientIds.every( ( id ) =>
 			isBlockValid( id )
@@ -99,6 +100,7 @@ export function PrivateBlockToolbar( {
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
+			isContentOnlyEditingMode: editingMode === 'contentOnly',
 			isDefaultEditingMode: _isDefaultEditingMode,
 			blockType: selectedBlockClientId && getBlockType( _blockName ),
 			shouldShowVisualToolbar: isValid && isVisual,
@@ -168,7 +170,9 @@ export function PrivateBlockToolbar( {
 					isLargeViewport &&
 					isDefaultEditingMode && <BlockParentSelector /> }
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
-					( isDefaultEditingMode || isSynced ) && (
+					( isDefaultEditingMode ||
+						isContentOnlyEditingMode ||
+						isSynced ) && (
 						<div
 							ref={ nodeRef }
 							{ ...showHoveredOrFocusedGestures }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/64663

## What?
<!-- In a few words, what is the PR actually doing? -->
The block toolbar doesn't have any context when in contentOnly mode. The block icon would be helpful.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Give a landmark to the user.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds contentOnly to the allowed modes that will show the icon.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to a contentOnly block, like the featured image on a page template
- Click on the contentOnly block
- The block icon should be in the toolbar
- Test with top toolbar and floating toolbar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="804" alt="page template with featured image block selection and grayed out featured image icon in the block toolbar" src="https://github.com/user-attachments/assets/cb50ca88-b5b9-4470-a75c-ffbe4f4f2f76">

