### PR TITLE
DataViews: Remove `add filter` button if no available filters to add

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
@@ -78,10 +78,13 @@ function AddFilter(
 	{ filters, view, onChangeView, setOpenedFilter }: AddFilterProps,
 	ref: Ref< HTMLButtonElement >
 ) {
-	if ( ! filters.length || filters.every( ( { isPrimary } ) => isPrimary ) ) {
+	if (
+		! filters.length ||
+		filters.every( ( { isPrimary } ) => isPrimary ) ||
+		! filters.filter( ( filter ) => ! filter.isVisible ).length
+	) {
 		return null;
 	}
-	const inactiveFilters = filters.filter( ( filter ) => ! filter.isVisible );
 	return (
 		<AddFilterDropdownMenu
 			trigger={
@@ -90,7 +93,6 @@ function AddFilter(
 					size="compact"
 					className="dataviews-filters-button"
 					variant="tertiary"
-					disabled={ ! inactiveFilters.length }
 					ref={ ref }
 				>
 					{ __( 'Add filter' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/64689

This PR removes `add filter` button if no available filters to add. @jameskoster do you know if there is a good reason to keep it disabled as is right now?



## Testing Instructions
1. In site editor go to list that uses DataViews, like the pages
2. Add all the available filters
3. Observe that the `add filter` button is not shown

