### PR TITLE
Data views: Fix actions scrim in list layout

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -73,6 +73,7 @@
 				color: $gray-900;
 			}
 			&:hover,
+			&.is-hovered,
 			&:focus-within {
 				color: var(--wp-admin-theme-color);
 				background-color: #f8f8f8;


### PR DESCRIPTION
In data views list layout, actions are positioned absolutely and there's a subtle shadow to 'truncate' titles when the actions appear on hover/focus-within:

<img width="771" alt="Screenshot 2024-08-21 at 18 39 43" src="https://github.com/user-attachments/assets/61290386-95bd-4efd-860c-0684c41f99f8">

There is currently a bug with the implementation. When you open the ellipsis menu, the hover styles are not applied to the row, and the shadow becomes visible independently:

<img width="767" alt="Screenshot 2024-08-21 at 18 39 55" src="https://github.com/user-attachments/assets/70bee2b0-6855-45ea-86b6-9825add30fb4">

Note: You may have to increase screen brightness to see the issue.

This PR fixes this by ensuring the hover styles remain applied when the ellipsis menu is opened.

## Testing Instructions
1. Open the Pages data view
2. Open the ellipsis menu
3. Ensure the hover styles remain active on the row

<img width="863" alt="Screenshot 2024-08-21 at 18 42 24" src="https://github.com/user-attachments/assets/e12fc45e-2b1b-4902-a921-f2aa55c5d081">

