### PR TITLE
Date block HTML is different between front and editor

### DIFF
--- a/packages/block-library/src/post-date/edit.js
+++ b/packages/block-library/src/post-date/edit.js
@@ -84,26 +84,27 @@ export default function PostDateEdit( {
 	const dateLabel =
 		displayType === 'date' ? __( 'Post Date' ) : __( 'Post Modified Date' );
 
-	let postDate = date ? (
+	const formattedDate =
+		format === 'human-diff'
+			? humanTimeDiff( date )
+			: dateI18n( format || siteFormat, date );
+
+	const postDate = date ? (
 		<time dateTime={ dateI18n( 'c', date ) } ref={ setPopoverAnchor }>
-			{ format === 'human-diff'
-				? humanTimeDiff( date )
-				: dateI18n( format || siteFormat, date ) }
+			{ isLink ? (
+				<a
+					href="#post-date-pseudo-link"
+					onClick={ ( event ) => event.preventDefault() }
+				>
+					{ formattedDate }
+				</a>
+			) : (
+				formattedDate
+			) }
 		</time>
 	) : (
 		dateLabel
 	);
-
-	if ( isLink && date ) {
-		postDate = (
-			<a
-				href="#post-date-pseudo-link"
-				onClick={ ( event ) => event.preventDefault() }
-			>
-				{ postDate }
-			</a>
-		);
-	}
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Date block HTML was different between front and editor, so I fixed it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Insert a post-date block.
3. View HTML

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

###  Front
![front](https://github.com/user-attachments/assets/bed9353f-4312-4055-b2be-c80f51505ea7)


###  Editor
![editor](https://github.com/user-attachments/assets/daed18c0-34d5-4ba2-bda6-58985c1e07c9)

