### PR TITLE
Use four color palette colors instead of five for useStylesPreviewColors

### DIFF
--- a/packages/edit-site/src/components/global-styles/preset-colors.js
+++ b/packages/edit-site/src/components/global-styles/preset-colors.js
@@ -5,7 +5,7 @@ import { useStylesPreviewColors } from './hooks';
 
 export default function PresetColors() {
 	const { paletteColors } = useStylesPreviewColors();
-	return paletteColors.slice( 0, 5 ).map( ( { slug, color }, index ) => (
+	return paletteColors.slice( 0, 4 ).map( ( { slug, color }, index ) => (
 		<div
 			key={ `${ slug }-${ index }` }
 			style={ {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Tiny PR to make each useStylesPreviewColors less noisy by reducing the visible colors from five to four. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Site Editor.
2. Open Styles.
3. See changes.

## Screenshots or screencast <!-- if applicable -->

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-08-21 at 19 18 03](https://github.com/user-attachments/assets/1bf759c6-ba1f-4436-9e25-7e8f3f1e7109)|![CleanShot 2024-08-21 at 19 17 53](https://github.com/user-attachments/assets/568265de-a415-4f2b-b67d-72611f6311fd)|

#### With Twenty Twenty-Four
| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-08-21 at 19 18 53](https://github.com/user-attachments/assets/74a9a43b-3f31-4521-b9bf-6b2df323a705)|![CleanShot 2024-08-21 at 19 19 09](https://github.com/user-attachments/assets/13861a9f-b6a2-494a-9f6c-c35b0e2e281d)|



