### PR TITLE
Remove GB i18n domain from block-library.

### DIFF
--- a/packages/block-library/src/comment-date/index.php
+++ b/packages/block-library/src/comment-date/index.php
@@ -30,7 +30,7 @@ function render_block_core_comment_date( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => $classes ) );
 	if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
 		// translators: %s: human-readable time difference.
-		$formatted_date = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( get_comment_date( 'U', $comment ) ) );
+		$formatted_date = sprintf( __( '%s ago' ), human_time_diff( get_comment_date( 'U', $comment ) ) );
 	} else {
 		$formatted_date = get_comment_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $comment );
 	}

--- a/packages/block-library/src/form/index.php
+++ b/packages/block-library/src/form/index.php
@@ -92,7 +92,7 @@ function block_core_form_send_email() {
 	// Start building the email content.
 	$content = sprintf(
 		/* translators: %s: The request URI. */
-		__( 'Form submission from %1$s', 'gutenberg' ) . '</br>',
+		__( 'Form submission from %1$s' ) . '</br>',
 		'<a href="' . esc_url( get_site_url( null, $params['_wp_http_referer'] ) ) . '">' . get_bloginfo( 'name' ) . '</a>'
 	);
 
@@ -110,7 +110,7 @@ function block_core_form_send_email() {
 	// Send the email.
 	$result = wp_mail(
 		str_replace( 'mailto:', '', $params['formAction'] ),
-		__( 'Form submission', 'gutenberg' ),
+		__( 'Form submission' ),
 		$content
 	);
 

--- a/packages/block-library/src/post-date/index.php
+++ b/packages/block-library/src/post-date/index.php
@@ -26,10 +26,10 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		$post_timestamp = get_post_timestamp( $post_ID );
 		if ( $post_timestamp > time() ) {
 			// translators: %s: human-readable time difference.
-			$formatted_date = sprintf( __( '%s from now', 'gutenberg' ), human_time_diff( $post_timestamp ) );
+			$formatted_date = sprintf( __( '%s from now' ), human_time_diff( $post_timestamp ) );
 		} else {
 			// translators: %s: human-readable time difference.
-			$formatted_date = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( $post_timestamp ) );
+			$formatted_date = sprintf( __( '%s ago' ), human_time_diff( $post_timestamp ) );
 		}
 	} else {
 		$formatted_date = get_the_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
@@ -52,7 +52,7 @@ function render_block_core_post_date( $attributes, $content, $block ) {
 		if ( get_the_modified_date( 'Ymdhi', $post_ID ) > get_the_date( 'Ymdhi', $post_ID ) ) {
 			if ( isset( $attributes['format'] ) && 'human-diff' === $attributes['format'] ) {
 				// translators: %s: human-readable time difference.
-				$formatted_date = sprintf( __( '%s ago', 'gutenberg' ), human_time_diff( get_post_timestamp( $post_ID, 'modified' ) ) );
+				$formatted_date = sprintf( __( '%s ago' ), human_time_diff( get_post_timestamp( $post_ID, 'modified' ) ) );
 			} else {
 				$formatted_date = get_the_modified_date( empty( $attributes['format'] ) ? '' : $attributes['format'], $post_ID );
 			}


### PR DESCRIPTION
## What?

Removes the `gutenberg` i18n domain from several block library strings.

It would be good if this could be included in the 19.1 version of Gutenberg to allow the test package update in WordPress-Develop to proceed cc @artemiomorales 

## Why?

As these files are distributed to WordPress in an unaltered form, the domain needs to be removed to be added to the WordPress translations.

## How?

1. Regex search for `__\(.*, 'gutenberg'` in the packages directory
2. Strip the gutenberg domain.


## Testing Instructions

Check strings display as expected in the modified blocks:

* comment-date human readable time
* form submissions 
* post-date human readable time

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->
