### PR TITLE
DataViews: Add missing styles and remove opinionated ones for generic usage

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -29,6 +29,10 @@
 	}
 }
 
+.dataviews-settings-section:has(.dataviews-settings-section__content:empty) {
+	display: none;
+}
+
 /* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
 @container (max-width: 500px) {
 	.dataviews-settings-section.dataviews-settings-section {

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -191,6 +191,9 @@ export const fields = [
 		id: 'title',
 		enableHiding: false,
 		enableGlobalSearch: true,
+		render: ( { item } ) => {
+			return <a href="#nothing">{ item.title }</a>;
+		},
 	},
 	{
 		id: 'date',

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -100,6 +100,7 @@
 	}
 
 	.dataviews-view-list__item {
+		box-sizing: border-box;
 		padding: $grid-unit-20 $grid-unit-30;
 		width: 100%;
 		scroll-margin: $grid-unit-10 0;

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -7,11 +7,6 @@
 	color: $gray-700;
 	margin-bottom: auto;
 
-	a {
-		text-decoration: none;
-		color: $gray-900;
-		font-weight: 500;
-	}
 	th {
 		text-align: left;
 		color: $gray-900;


### PR DESCRIPTION
Related #55083 

## What?

As I was using the DataViews component in a third-party project, I noticed that the styles make some assumptions that don't hold true everywhere. This PR updates the styles to make it easier to integrate in different contexts.

## Testing Instructions

1- Open the DataViews in the site editor
2- Ensure there are no style regressions.