### PR TITLE
UnitControl: Update unit select styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `UnitControl`: Update unit select styles ([#64712](https://github.com/WordPress/gutenberg/pull/64712)).
+
 ## 28.6.0 (2024-08-21)
 
 ### Deprecations

--- a/packages/components/src/unit-control/styles/unit-control-styles.ts
+++ b/packages/components/src/unit-control/styles/unit-control-styles.ts
@@ -64,6 +64,7 @@ const baseUnitLabelStyles = ( { selectSize }: SelectProps ) => {
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
+			field-sizing: content;
 
 			&:not( :disabled ) {
 				color: ${ COLORS.theme.accent };
@@ -114,7 +115,7 @@ const unitSelectSizes = ( { selectSize = 'default' }: SelectProps ) => {
 			align-items: center;
 
 			&:where( :not( :disabled ) ):hover {
-				box-shadow: inset 0 0 0
+				box-shadow: 0 0 0
 					${ CONFIG.borderWidth + ' ' + COLORS.ui.borderFocus };
 				outline: ${ CONFIG.borderWidth } solid transparent; // For High Contrast Mode
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Makes the following improvements to the UnitControl unit select styles when in the 40px size:

- Adds `field-sizing: content` so the select can hug the width of the current unit label. This will make the whitespace look more consistent across units. (Consider this a progressive enhancement, because the `field-sizing` property is [not implemented](https://caniuse.com/?search=field-sizing) in Safari and Firefox yet.)
- Fixes the hover style, which didn't properly reflect the border radius.

## Testing Instructions

See Storybook for UnitControl.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/db654c6e-6a67-42e0-8514-a2d188360d3e" alt="UnitControl, before" width="264">|<img src="https://github.com/user-attachments/assets/abe16b37-d7ba-4cda-bf3e-df3552f5828e" alt="UnitControl, after" width="264">|

