### PR TITLE
Template Part: Hide Advanced panel for non-admin users

### DIFF
--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -35,6 +35,7 @@ const htmlElementMessages = {
 export function TemplatePartAdvancedControls( {
 	tagName,
 	setAttributes,
+	isEntityAvailable,
 	templatePartId,
 	defaultWrapper,
 	hasInnerBlocks,
@@ -69,25 +70,29 @@ export function TemplatePartAdvancedControls( {
 
 	return (
 		<>
-			<TextControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Title' ) }
-				value={ title }
-				onChange={ ( value ) => {
-					setTitle( value );
-				} }
-				onFocus={ ( event ) => event.target.select() }
-			/>
-			<SelectControl
-				__next40pxDefaultSize
-				__nextHasNoMarginBottom
-				label={ __( 'Area' ) }
-				labelPosition="top"
-				options={ areaOptions }
-				value={ area }
-				onChange={ setArea }
-			/>
+			{ isEntityAvailable && (
+				<>
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Title' ) }
+						value={ title }
+						onChange={ ( value ) => {
+							setTitle( value );
+						} }
+						onFocus={ ( event ) => event.target.select() }
+					/>
+					<SelectControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Area' ) }
+						labelPosition="top"
+						options={ areaOptions }
+						value={ area }
+						onChange={ setArea }
+					/>
+				</>
+			) }
 			<SelectControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize

--- a/packages/block-library/src/template-part/edit/advanced-controls.js
+++ b/packages/block-library/src/template-part/edit/advanced-controls.js
@@ -35,7 +35,6 @@ const htmlElementMessages = {
 export function TemplatePartAdvancedControls( {
 	tagName,
 	setAttributes,
-	isEntityAvailable,
 	templatePartId,
 	defaultWrapper,
 	hasInnerBlocks,
@@ -70,30 +69,25 @@ export function TemplatePartAdvancedControls( {
 
 	return (
 		<>
-			{ isEntityAvailable && (
-				<>
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Title' ) }
-						value={ title }
-						onChange={ ( value ) => {
-							setTitle( value );
-						} }
-						onFocus={ ( event ) => event.target.select() }
-					/>
-
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Area' ) }
-						labelPosition="top"
-						options={ areaOptions }
-						value={ area }
-						onChange={ setArea }
-					/>
-				</>
-			) }
+			<TextControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Title' ) }
+				value={ title }
+				onChange={ ( value ) => {
+					setTitle( value );
+				} }
+				onFocus={ ( event ) => event.target.select() }
+			/>
+			<SelectControl
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ __( 'Area' ) }
+				labelPosition="top"
+				options={ areaOptions }
+				value={ area }
+				onChange={ setArea }
+			/>
 			<SelectControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -254,16 +254,17 @@ export default function TemplatePartEdit( {
 							</ToolbarButton>
 						</BlockControls>
 					) }
-				<InspectorControls group="advanced">
-					<TemplatePartAdvancedControls
-						tagName={ tagName }
-						setAttributes={ setAttributes }
-						isEntityAvailable={ isEntityAvailable }
-						templatePartId={ templatePartId }
-						defaultWrapper={ areaObject.tagName }
-						hasInnerBlocks={ hasInnerBlocks }
-					/>
-				</InspectorControls>
+				{ isEntityAvailable && canUserEdit && (
+					<InspectorControls group="advanced">
+						<TemplatePartAdvancedControls
+							tagName={ tagName }
+							setAttributes={ setAttributes }
+							templatePartId={ templatePartId }
+							defaultWrapper={ areaObject.tagName }
+							hasInnerBlocks={ hasInnerBlocks }
+						/>
+					</InspectorControls>
+				) }
 				{ isPlaceholder && (
 					<TagName { ...blockProps }>
 						<TemplatePartPlaceholder

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -254,11 +254,12 @@ export default function TemplatePartEdit( {
 							</ToolbarButton>
 						</BlockControls>
 					) }
-				{ isEntityAvailable && canUserEdit && (
+				{ canUserEdit && (
 					<InspectorControls group="advanced">
 						<TemplatePartAdvancedControls
 							tagName={ tagName }
 							setAttributes={ setAttributes }
+							isEntityAvailable={ isEntityAvailable }
 							templatePartId={ templatePartId }
 							defaultWrapper={ areaObject.tagName }
 							hasInnerBlocks={ hasInnerBlocks }


### PR DESCRIPTION
Related to #60447

## What?
This PR changes the Advanced panel to not show to non-admin users.

## Why?

The Advanced panel allows you to change attributes such as CSS classes, title, etc. This means updating the template that has that template part embedded in it, but non-admin users will get an error because they can't update the template:

![image](https://github.com/user-attachments/assets/d27c58aa-f86a-42cd-b103-b78ea219ece4)

## How?

Add `canUserEdit` check.

## Testing Instructions

- Log in as a user with editor capabilities.
- Open any page from the post editor.
- Access the sidebar > Template > Show template.
- Select a template part.
- The advanced panel should not be displayed.
- If you log in as an admin user, the advanced panel should be available as before.