### PR TITLE
Remove “Columns” slider from Columns block

### DIFF
--- a/packages/block-library/src/columns/edit.native.js
+++ b/packages/block-library/src/columns/edit.native.js
@@ -9,7 +9,6 @@ import { View, Dimensions } from 'react-native';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	PanelBody,
-	RangeControl,
 	FooterMessageControl,
 	UnitControl,
 	getValueAndUnit,
@@ -36,7 +35,6 @@ import {
 } from '@wordpress/element';
 import { useResizeObserver } from '@wordpress/compose';
 import { createBlock } from '@wordpress/blocks';
-import { columns } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
@@ -214,28 +212,12 @@ function ColumnsEditContainer( {
 		} );
 	}, [ editorSidebarOpened, isSelected, innerWidths ] );
 
-	const onChangeColumnsNum = useCallback(
-		( value ) => {
-			updateColumns( columnCount, value );
-		},
-		[ columnCount ]
-	);
-
 	return (
 		<>
 			{ isSelected && (
 				<>
 					<InspectorControls>
 						<PanelBody title={ __( 'Columns Settings' ) }>
-							<RangeControl
-								label={ __( 'Number of columns' ) }
-								icon={ columns }
-								value={ columnCount }
-								onChange={ onChangeColumnsNum }
-								min={ MIN_COLUMNS_NUM }
-								max={ columnCount + 1 }
-								type="stepper"
-							/>
 							{ getColumnsSliders }
 						</PanelBody>
 						<PanelBody>

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -46,46 +46,6 @@ test.describe( 'Columns', () => {
 		await expect( inserterOptions ).toHaveText( 'Column' );
 	} );
 
-	test( 'prevent the removal of locked column block from the column count change UI', async ( {
-		page,
-		editor,
-		pageUtils,
-	} ) => {
-		// Open Columns
-		await editor.insertBlock( { name: 'core/columns' } );
-		await editor.canvas
-			.locator( '[aria-label="Three columns; equal split"]' )
-			.click();
-
-		// Lock last column block
-		await editor.selectBlocks(
-			editor.canvas.locator(
-				'role=document[name="Block: Column (3 of 3)"i]'
-			)
-		);
-		await editor.clickBlockToolbarButton( 'Options' );
-		await page.click( 'role=menuitem[name="Lock"i]' );
-		await page.locator( 'role=checkbox[name="Prevent removal"i]' ).check();
-		await page.click( 'role=button[name="Apply"i]' );
-
-		// Select columns block
-		await editor.selectBlocks(
-			editor.canvas.locator( 'role=document[name="Block: Columns"i]' )
-		);
-		await editor.openDocumentSettingsSidebar();
-
-		const columnsChangeInput = page.locator(
-			'role=spinbutton[name="Columns"i]'
-		);
-
-		// The min attribute should take into account locked columns
-		await expect( columnsChangeInput ).toHaveAttribute( 'min', '3' );
-
-		// Changing the number of columns should take into account locked columns
-		await page.fill( 'role=spinbutton[name="Columns"i]', '1' );
-		await pageUtils.pressKeys( 'Tab' );
-		await expect( columnsChangeInput ).toHaveValue( '3' );
-	} );
 	test( 'Ungroup properly', async ( { editor } ) => {
 		await editor.insertBlock( {
 			name: 'core/columns',
@@ -173,75 +133,6 @@ test.describe( 'Columns', () => {
 				attributes: { content: '2' },
 			},
 		] );
-	} );
-
-	test.describe( 'should update the column widths correctly', () => {
-		const initialColumnWidths = [ '10%', '20%', '30%', '40%' ];
-
-		const expected = [
-			{
-				newColumnCount: 2,
-				newColumnWidths: [ '33.33%', '66.67%' ],
-			},
-			{
-				newColumnCount: 3,
-				newColumnWidths: [ '16.67%', '33.33%', '50%' ],
-			},
-			{
-				newColumnCount: 5,
-				newColumnWidths: [ '8%', '16%', '24%', '32%', '20%' ],
-			},
-			{
-				newColumnCount: 6,
-				newColumnWidths: [
-					'6.67%',
-					'13.33%',
-					'20%',
-					'26.66%',
-					'16.67%',
-					'16.67%',
-				],
-			},
-		];
-
-		expected.forEach( ( { newColumnCount, newColumnWidths } ) => {
-			test( `when the column count is changed to ${ newColumnCount }`, async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/columns',
-					attributes: {
-						columns: initialColumnWidths.length,
-					},
-					innerBlocks: initialColumnWidths.map( ( width ) => ( {
-						name: 'core/column',
-						attributes: { width },
-					} ) ),
-				} );
-
-				await editor.selectBlocks(
-					editor.canvas.getByRole( 'document', {
-						name: 'Block: Columns',
-					} )
-				);
-				await editor.openDocumentSettingsSidebar();
-
-				await page
-					.getByRole( 'spinbutton', { name: 'Columns' } )
-					.fill( newColumnCount.toString() );
-
-				await expect( editor.getBlocks() ).resolves.toMatchObject( [
-					{
-						name: 'core/columns',
-						innerBlocks: newColumnWidths.map( ( width ) => ( {
-							name: 'core/column',
-							attributes: { width },
-						} ) ),
-					},
-				] );
-			} );
-		} );
 	} );
 
 	test( 'should not split in middle', async ( { editor, page } ) => {

--- a/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
+++ b/test/e2e/specs/editor/various/block-hierarchy-navigation.spec.js
@@ -66,20 +66,20 @@ test.describe( 'Navigating the block hierarchy', () => {
 
 		await expect( listView ).toBeVisible();
 		await listView
-			.getByRole( 'gridcell', { name: 'Columns', exact: true } )
+			.getByRole( 'gridcell', { name: 'Column', exact: true } )
+			.last()
 			.click();
 
-		// Tweak the columns count.
-		await page.getByRole( 'spinbutton', { name: 'Columns' } ).fill( '3' );
+		// Add another column block.
+		await pageUtils.pressKeys( 'primary+Alt+Y' );
 
 		// Wait for the new column block to appear in the list view
-		const column = listView.getByRole( 'gridcell', {
-			name: 'Column',
-			exact: true,
-		} );
-		await expect( column ).toHaveCount( 3 );
-
-		await column.last().click();
+		await expect(
+			listView.getByRole( 'gridcell', {
+				name: 'Column',
+				exact: true,
+			} )
+		).toHaveCount( 3 );
 
 		// Open the block inserter.
 		await page.keyboard.press( 'ArrowDown' );
@@ -123,18 +123,12 @@ test.describe( 'Navigating the block hierarchy', () => {
 		await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
 		await page.keyboard.press( 'Enter' );
 
-		// Move focus to the sidebar area.
-		await pageUtils.pressKeys( 'ctrl+`' );
-
-		// Navigate to the block settings sidebar and tweak the column count.
-		await pageUtils.pressKeys( 'Tab', { times: 5 } );
-		await expect(
-			page.getByRole( 'slider', { name: 'Columns' } )
-		).toBeFocused();
-		await page.keyboard.press( 'ArrowRight' );
+		// Add another column block.
+		await page.keyboard.press( 'ArrowDown' );
+		await pageUtils.pressKeys( 'primary+Alt+Y' );
 
 		// Navigate to the third column in the columns block via List View.
-		await pageUtils.pressKeys( 'ctrlShift+`', { times: 2 } );
+		await pageUtils.pressKeys( 'access+o' );
 		await pageUtils.pressKeys( 'Tab', { times: 3 } );
 		await pageUtils.pressKeys( 'ArrowDown', { times: 4 } );
 


### PR DESCRIPTION
## What?
An alternative solution to the old pitfall where the "Columns" slider deletes content within columns.

## Why?
To resolve #9009 with the least technical challenge and the upside of obviating a bunch of code.

## How?
Removes the problematic control.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/abea78e3-560a-4a29-88a9-6b1f0156e714

