### PR TITLE
Focus selected block in editor canvas when clicking edit button on zoom out mode toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-popover.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-popover.js
@@ -42,6 +42,7 @@ export default function ZoomOutPopover( { clientId, __unstableContentRef } ) {
 			{ ...props }
 		>
 			<ZoomOutToolbar
+				__unstableContentRef={ __unstableContentRef }
 				clientId={ clientId }
 				rootClientId={ rootClientId }
 			/>

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -21,7 +21,11 @@ import BlockMover from '../block-mover';
 import Shuffle from '../block-toolbar/shuffle';
 import NavigableToolbar from '../navigable-toolbar';
 
-export default function ZoomOutToolbar( { clientId, rootClientId } ) {
+export default function ZoomOutToolbar( {
+	clientId,
+	rootClientId,
+	__unstableContentRef,
+} ) {
 	const selected = useSelect(
 		( select ) => {
 			const {
@@ -133,6 +137,7 @@ export default function ZoomOutToolbar( { clientId, rootClientId } ) {
 					label={ __( 'Edit' ) }
 					onClick={ () => {
 						__unstableSetEditorMode( 'edit' );
+						__unstableContentRef.current.focus();
 					} }
 				/>
 			) }

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -137,7 +137,7 @@ export default function ZoomOutToolbar( {
 					label={ __( 'Edit' ) }
 					onClick={ () => {
 						__unstableSetEditorMode( 'edit' );
-						__unstableContentRef.current.focus();
+						__unstableContentRef.current?.focus();
 					} }
 				/>
 			) }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes a focus loss introduced in https://github.com/WordPress/gutenberg/pull/64571

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Focus loss = bad a11y

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Send focus to the contentRef, which lets [writing flow handle sending the focus to the selected block](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-editor/src/components/writing-flow/use-tab-nav.js#L52-L56).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Enter zoom out mode via the pattern inserter
- Select a new top level group block
- Select the edit button
- Zoom out mode should exit
- The selected block should have focus. Test this by pressing Escape to enter navigation mode and see if your group block is selected 

## Screenshots or screencast <!-- if applicable -->
