### PR TITLE
Editor: Disable autosaving for Template Parts

### DIFF
--- a/backport-changelog/6.7/7254.md
+++ b/backport-changelog/6.7/7254.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7254
+
+* https://github.com/WordPress/gutenberg/pull/64733

--- a/lib/compat/wordpress-6.7/post.php
+++ b/lib/compat/wordpress-6.7/post.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * Overrides Core Post APIs.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Disables autosave for `wp_template` and `wp_template_part` post types.
+ *
+ * @return void
+ */
+function gutenberg_disable_templates_and_parts_autosave() {
+	remove_post_type_support( 'wp_template', 'autosave' );
+	remove_post_type_support( 'wp_template_part', 'autosave' );
+}
+add_action( 'init', 'gutenberg_disable_templates_and_parts_autosave' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -109,6 +109,7 @@ require __DIR__ . '/compat/wordpress-6.7/block-bindings.php';
 require __DIR__ . '/compat/wordpress-6.7/script-modules.php';
 require __DIR__ . '/compat/wordpress-6.7/class-wp-block-templates-registry.php';
 require __DIR__ . '/compat/wordpress-6.7/compat.php';
+require __DIR__ . '/compat/wordpress-6.7/post.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -341,7 +341,8 @@ export const autosave =
 		const post = select.getCurrentPost();
 
 		// Currently template autosaving is not supported.
-		if ( post.type === 'wp_template' ) {
+		// Remove the hardcoded check when the minimum required is WP 6.6.
+		if ( [ 'wp_template', 'wp_template_part' ].includes( post.type ) ) {
 			return;
 		}
 

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -365,7 +365,8 @@ export const getAutosaveAttribute = createRegistrySelector(
 		const postType = getCurrentPostType( state );
 
 		// Currently template autosaving is not supported.
-		if ( postType === 'wp_template' ) {
+		// Remove the hardcoded check when the minimum required is WP 6.6.
+		if ( [ 'wp_template', 'wp_template_part' ].includes( postType ) ) {
 			return false;
 		}
 
@@ -590,7 +591,8 @@ export const isEditedPostAutosaveable = createRegistrySelector(
 		const postType = getCurrentPostType( state );
 
 		// Currently template autosaving is not supported.
-		if ( postType === 'wp_template' ) {
+		// Remove the hardcoded check when the minimum required is WP 6.6.
+		if ( [ 'wp_template', 'wp_template_part' ].includes( postType ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What?

PR disables autosaving for the Template Parts entity. Hardcoding this logic shouldn't be necessary after the minimum required version is bumped to WP 6.6. See https://github.com/WordPress/gutenberg/issues/61622#issuecomment-2133035146.

## Why?
Currently, autosaving isn't supported for Templates and Template parts. Related actions cause failed requests or PHP warnings.

```
PHP Warning:  Attempt to read property "ID" on null in ~/Projects/gutenberg/wp-includes/rest-api/endpoints/class-wp-rest-autosaves-controller.php on line 167
```

## Testing Instructions
1. Using TT4
2. Open the Site Editor.
3. Edit the Header template part.
4. Confirm there are no failed requests logged in the Networks tab.
5. Confirm there are no PHP warnings logged in `debug.log`.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-23 at 08 15 00](https://github.com/user-attachments/assets/4da88b1d-f36b-412d-87ba-deef70a1cc31)
