### PR TITLE
Shuffle: Don't call '__experimentalGetAllowedPatterns' for every block

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -34,7 +34,10 @@ export default function Shuffle( { clientId, as = Container } ) {
 			const _categories = attributes?.metadata?.categories || EMPTY_ARRAY;
 			const _patternName = attributes?.metadata?.patternName;
 			const rootBlock = getBlockRootClientId( clientId );
-			const _patterns = __experimentalGetAllowedPatterns( rootBlock );
+			const _patterns =
+				_categories.length > 0
+					? __experimentalGetAllowedPatterns( rootBlock )
+					: EMPTY_ARRAY;
 			return {
 				categories: _categories,
 				patterns: _patterns,
@@ -45,12 +48,7 @@ export default function Shuffle( { clientId, as = Container } ) {
 	);
 	const { replaceBlocks } = useDispatch( blockEditorStore );
 	const sameCategoryPatternsWithSingleWrapper = useMemo( () => {
-		if (
-			! categories ||
-			categories.length === 0 ||
-			! patterns ||
-			patterns.length === 0
-		) {
+		if ( categories.length === 0 || ! patterns || patterns.length === 0 ) {
 			return EMPTY_ARRAY;
 		}
 		return patterns.filter( ( pattern ) => {

--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -34,6 +34,10 @@ export default function Shuffle( { clientId, as = Container } ) {
 			const _categories = attributes?.metadata?.categories || EMPTY_ARRAY;
 			const _patternName = attributes?.metadata?.patternName;
 			const rootBlock = getBlockRootClientId( clientId );
+
+			// Calling `__experimentalGetAllowedPatterns` is expensive.
+			// Checking if the block can be shuffled prevents unnecessary selector calls.
+			// See: https://github.com/WordPress/gutenberg/pull/64736.
 			const _patterns =
 				_categories.length > 0
 					? __experimentalGetAllowedPatterns( rootBlock )


### PR DESCRIPTION
## What?
Related #64732.

PR avoids calling the `__experimentalGetAllowedPatterns` selector when associated categories aren't available.

## Why?
When no categories exist, the memo callback returns early, and patterns are unnecessary. Additionally, calling `__experimentalGetAllowedPatterns` is expensive - https://github.com/WordPress/gutenberg/issues/64219#issuecomment-2289429459.

## Testing Instructions
1. Open a post or page.
2. Insert a pattern from a category - "Call to Action"
3. Confirm that the "Shuffle" button is still available in the toolbar.
4. Confirm you can shuffle categories.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-23 at 13 12 22](https://github.com/user-attachments/assets/b3588cd3-0943-4b82-aed9-fdaf7f2c7cb9)
