### PR TITLE
Post publish upload media dialog: fix silent failure

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -14,11 +14,6 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
 
-/**
- * Internal dependencies
- */
-import { store as editorStore } from '../../store';
-
 function flattenBlocks( blocks ) {
 	const result = [];
 
@@ -67,7 +62,7 @@ export default function PostFormatPanel() {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const { editorBlocks, mediaUpload } = useSelect(
 		( select ) => ( {
-			editorBlocks: select( editorStore ).getEditorBlocks(),
+			editorBlocks: select( blockEditorStore ).getBlocks(),
 			mediaUpload: select( blockEditorStore ).getSettings().mediaUpload,
 		} ),
 		[]


### PR DESCRIPTION
## What?
Attempt to fix intermittent silent failures in the post publish upload media dialog.

## Why?
The upload process sometimes silently fails when using the upload media dialog:

https://github.com/user-attachments/assets/670efd2c-3d11-43eb-9b81-7677ac615532

The files do get uploaded, but the blocks never get their attributes updated, causing the upload suggestion to remain.

When debugging this, I noticed that the `clientId`s that are being updated don't seem to exist in the block editor store. My knowledge is extremely limited here, but I believe this may be due to a mismatch in `clientId`s between the editor store and the block editor store.

This PR may fix #63956.

## How?
This PR switches from using the editor store `getEditorBlocks()` selector to the block editor store `getBlocks()` selector. This seems like a reasonable fix, given that the `updateBlockAttributes()` action that we use to update blocks belongs to the block editor store, but again, my knowledge is extremely limited here.

## Testing Instructions
~I don't know how to reliably reproduce the failure state 😞 It sometimes happens when using patterns that include image blocks, and which point to theme images (which are considered external images).~

I figured out how to reproduce the failure state:

1. Create a new post
2. Add an image block and use an external image (e.g. `https://s.w.org/style/images/about/WordPress-logotype-simplified.png`)
3. Hit Save Draft
4. Reload the page in your browser
5. Hit Publish
6. Hit Upload on the upload media dialog

This should produce a similar failure to the one in the video above before applying this PR. The same sequence of steps should work correctly after the PR.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
