### PR TITLE
REST API: Fix hacky block editor settings filter

### DIFF
--- a/lib/experimental/block-editor-settings-mobile.php
+++ b/lib/experimental/block-editor-settings-mobile.php
@@ -16,24 +16,15 @@
  * @return array New block editor settings.
  */
 function gutenberg_get_block_editor_settings_mobile( $settings ) {
-	if (
-		defined( 'REST_REQUEST' ) &&
-		REST_REQUEST &&
-		isset( $_GET['context'] ) &&
-		'mobile' === $_GET['context']
-	) {
-		if ( wp_theme_has_theme_json() ) {
-			$settings['__experimentalStyles'] = gutenberg_get_global_styles();
-		}
-
-		// To tell mobile that the site uses quote v2 (inner blocks).
-		// See https://github.com/WordPress/gutenberg/pull/25892.
-		$settings['__experimentalEnableQuoteBlockV2'] = true;
-		// To tell mobile that the site uses list v2 (inner blocks).
-		$settings['__experimentalEnableListBlockV2'] = true;
+	if ( wp_theme_has_theme_json() ) {
+		$settings['__experimentalStyles'] = gutenberg_get_global_styles();
 	}
+
+	// To tell mobile that the site uses quote v2 (inner blocks).
+	// See https://github.com/WordPress/gutenberg/pull/25892.
+	$settings['__experimentalEnableQuoteBlockV2'] = true;
+	// To tell mobile that the site uses list v2 (inner blocks).
+	$settings['__experimentalEnableListBlockV2'] = true;
 
 	return $settings;
 }
-
-add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );

--- a/lib/experimental/class-wp-rest-block-editor-settings-controller.php
+++ b/lib/experimental/class-wp-rest-block-editor-settings-controller.php
@@ -93,8 +93,12 @@ if ( ! class_exists( 'WP_REST_Block_Editor_Settings_Controller' ) ) {
 					break;
 			}
 
+			add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );
+
 			$editor_context = new WP_Block_Editor_Context( array( 'name' => $editor_context_name ) );
 			$settings       = get_block_editor_settings( array(), $editor_context );
+
+			remove_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings_mobile', PHP_INT_MAX );
 
 			return rest_ensure_response( $settings );
 		}

--- a/phpunit/experimental/block-editor-settings-mobile-test.php
+++ b/phpunit/experimental/block-editor-settings-mobile-test.php
@@ -10,11 +10,6 @@
  *
  * @covers WP_REST_Block_Editor_Settings_Controller
  */
-
-if ( ! defined( 'REST_REQUEST' ) ) {
-	define( 'REST_REQUEST', true );
-}
-
 class Gutenberg_REST_Block_Editor_Settings_Controller_Test extends WP_Test_REST_Controller_Testcase {
 	/**
 	 * @var int
@@ -56,10 +51,9 @@ class Gutenberg_REST_Block_Editor_Settings_Controller_Test extends WP_Test_REST_
 	public function test_get_items() {
 		wp_set_current_user( self::$admin_id );
 		$request = new WP_REST_Request( 'GET', '/wp-block-editor/v1/settings' );
-		// Set context for mobile settings.
-		$_GET['context'] = 'mobile';
-		$response        = rest_get_server()->dispatch( $request );
-		$data            = $response->get_data();
+		$request->set_param( 'context', 'mobile' );
+		$response = rest_get_server()->dispatch( $request );
+		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( '__experimentalStyles', $data, '__experimentalStyles should be in the returned data' );
 		$this->assertArrayHasKey( '__experimentalFeatures', $data, '__experimentalFeatures should be in the returned data' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix `gutenberg_get_block_editor_settings_mobile` and `WP_REST_Block_Editor_Settings_Controller` to not rely on constants and superglobals.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I wanted to work on some PHP stuff in another PR and realized that this hacky code breaks a lot of things because of side effects like defining `REST_REQUEST` in a test file (not even within the class and in a separate process!)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor these two places to not rely on `$_GET['context']` or `defined( 'REST_REQUEST' )` and do things the proper way.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Block editor settings for mobile should still work the same.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A