### PR TITLE
Fix: Adjust Site URL Styles to Prevent Overflow in Pre-Publish Component

### DIFF
--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -54,6 +54,7 @@
 	display: block;
 	color: $gray-700;
 	font-size: $helptext-font-size;
+	word-break: break-word;
 }
 
 .editor-post-publish-panel__header-publish-button,

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -39,6 +39,7 @@
 	border: none;
 	border-radius: $radius-block-ui;
 	margin-right: $grid-unit-15;
+	flex-shrink: 0;
 
 	// Same size as in the Site menu.
 	height: 36px;


### PR DESCRIPTION
## What?
This fix stops the URL from overflowing in the panel body in the Pre Publish Panel. URL now wraps around the container.

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/64730

## How?
adding the following styles
`word-break: break-word;` to `.components-site-home`

## Testing Instructions
1. Checkout the PR in the local WordPress installation 
2. Create a New Post
3. Click Publish; the Pre Publish screen should be shown.
4. Notice how the URL is broken into multiple lines if the site URL cannot fit properly.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/f2c401fb-6e72-48ee-8c3c-d443e474f07f

### After
https://github.com/user-attachments/assets/2c3791e4-a5d8-414e-ba24-a307f6e01d05



