### PR TITLE
Revert Focus pattern inserter search when activating zoom out inserter

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -23,7 +23,6 @@ function ZoomOutModeInserters() {
 		sectionRootClientId,
 		selectedBlockClientId,
 		hoveredBlockClientId,
-		inserterSearchInputRef,
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
@@ -33,11 +32,8 @@ function ZoomOutModeInserters() {
 			getSelectedBlockClientId,
 			getHoveredBlockClientId,
 			isBlockInsertionPointVisible,
-			getInserterSearchInputRef,
-		} = unlock( select( blockEditorStore ) );
-
+		} = select( blockEditorStore );
 		const { sectionRootClientId: root } = unlock( getSettings() );
-
 		return {
 			hasSelection: !! getSelectionStart().clientId,
 			blockInsertionPoint: getBlockInsertionPoint(),
@@ -48,7 +44,6 @@ function ZoomOutModeInserters() {
 				getSettings().__experimentalSetIsInserterOpened,
 			selectedBlockClientId: getSelectedBlockClientId(),
 			hoveredBlockClientId: getHoveredBlockClientId(),
-			inserterSearchInputRef: getInserterSearchInputRef(),
 		};
 	}, [] );
 
@@ -115,7 +110,6 @@ function ZoomOutModeInserters() {
 							showInsertionPoint( sectionRootClientId, index, {
 								operation: 'insert',
 							} );
-							inserterSearchInputRef?.current?.focus();
 						} }
 					/>
 				) }

--- a/packages/block-editor/src/components/inserter/library.js
+++ b/packages/block-editor/src/components/inserter/library.js
@@ -27,7 +27,6 @@ function InserterLibrary(
 		onSelect = noop,
 		shouldFocusBlock = false,
 		onClose,
-		__experimentalSearchInputRef,
 	},
 	ref
 ) {
@@ -59,7 +58,6 @@ function InserterLibrary(
 			shouldFocusBlock={ shouldFocusBlock }
 			ref={ ref }
 			onClose={ onClose }
-			__experimentalSearchInputRef={ __experimentalSearchInputRef }
 		/>
 	);
 }

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -33,7 +33,6 @@ import useInsertionPoint from './hooks/use-insertion-point';
 import { store as blockEditorStore } from '../../store';
 import TabbedSidebar from '../tabbed-sidebar';
 import { useZoomOut } from '../../hooks/use-zoom-out';
-import { unlock } from '../../lock-unlock';
 
 const NOOP = () => {};
 function InserterMenu(
@@ -54,16 +53,11 @@ function InserterMenu(
 	},
 	ref
 ) {
-	const { isZoomOutMode, inserterSearchInputRef } = useSelect( ( select ) => {
-		const { __unstableGetEditorMode, getInserterSearchInputRef } = unlock(
-			select( blockEditorStore )
-		);
-		return {
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
-			inserterSearchInputRef: getInserterSearchInputRef(),
-		};
-	}, [] );
-
+	const isZoomOutMode = useSelect(
+		( select ) =>
+			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+		[]
+	);
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
@@ -117,7 +111,7 @@ function InserterMenu(
 				}
 			} );
 		},
-		[ onInsertBlocks, onSelect, ref, shouldFocusBlock ]
+		[ onInsertBlocks, onSelect, shouldFocusBlock ]
 	);
 
 	const onInsertPattern = useCallback(
@@ -126,7 +120,7 @@ function InserterMenu(
 			onInsertBlocks( blocks, { patternName } );
 			onSelect();
 		},
-		[ onInsertBlocks, onSelect, onToggleInsertionPoint ]
+		[ onInsertBlocks, onSelect ]
 	);
 
 	const onHover = useCallback(
@@ -177,9 +171,7 @@ function InserterMenu(
 					value={ filterValue }
 					label={ __( 'Search for blocks and patterns' ) }
 					placeholder={ __( 'Search' ) }
-					ref={ inserterSearchInputRef }
 				/>
-
 				{ !! delayedFilterValue && (
 					<InserterSearchResults
 						filterValue={ delayedFilterValue }
@@ -200,18 +192,18 @@ function InserterMenu(
 		);
 	}, [
 		selectedTab,
+		hoveredItem,
+		setHoveredItem,
+		setFilterValue,
 		filterValue,
-		inserterSearchInputRef,
 		delayedFilterValue,
 		onSelect,
 		onHover,
-		rootClientId,
-		clientId,
-		isAppender,
-		__experimentalInsertionIndex,
 		shouldFocusBlock,
-		hoveredItem,
-		setFilterValue,
+		clientId,
+		rootClientId,
+		__experimentalInsertionIndex,
+		isAppender,
 	] );
 
 	const blocksTab = useMemo( () => {

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -512,10 +512,6 @@ export function getTemporarilyEditingFocusModeToRevert( state ) {
 	return state.temporarilyEditingFocusModeRevert;
 }
 
-export function getInserterSearchInputRef( state ) {
-	return state.inserterSearchInputRef;
-}
-
 /**
  * Returns the style attributes of multiple blocks.
  *

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2087,10 +2087,6 @@ export function hoveredBlockClientId( state = false, action ) {
 	return state;
 }
 
-export function inserterSearchInputRef( state = { current: null } ) {
-	return state;
-}
-
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2124,7 +2120,6 @@ const combinedReducers = combineReducers( {
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
-	inserterSearchInputRef,
 } );
 
 function withAutomaticChangeReset( reducer ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Revert https://github.com/WordPress/gutenberg/pull/64396

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This added a React `Ref` in Redux state which is [an anti-pattern](https://redux.js.org/faq/organizing-state#can-i-put-functions-promises-or-other-non-serializable-items-in-my-store-state).

This was throwing an error like `t.toString`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Revert to remove the ref in Redux state.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the global inserter 
- Click about in the canvas
- Toggle the tabs in the Inserter
- Basically ensure that `t.toString` doesn't not happen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
