### PR TITLE
Fix Post Date Block - Reverts to the default format when the custom date/time format input field is cleared.

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -50,6 +50,14 @@ export default function DateFormatPicker( {
 	defaultFormat,
 	onChange,
 } ) {
+	const handleChecked = () => {
+		if ( null !== format && undefined !== format && format.length === 0 ) {
+			return false;
+		}
+
+		return ! format;
+	};
+
 	return (
 		<fieldset className="block-editor-date-format-picker">
 			<VisuallyHidden as="legend">{ __( 'Date format' ) }</VisuallyHidden>
@@ -60,12 +68,15 @@ export default function DateFormatPicker( {
 					defaultFormat,
 					exampleDate
 				) }` }
-				checked={ ! format }
+				checked={ handleChecked() }
 				onChange={ ( checked ) =>
 					onChange( checked ? null : defaultFormat )
 				}
 			/>
-			{ format && (
+			{ ( ( null !== format &&
+				undefined !== format &&
+				format.length === 0 ) ||
+				format ) && (
 				<NonDefaultControls format={ format } onChange={ onChange } />
 			) }
 		</fieldset>
@@ -122,8 +133,11 @@ function NonDefaultControls( { format, onChange } ) {
 
 	const [ isCustom, setIsCustom ] = useState(
 		() =>
-			!! format &&
-			! suggestedOptions.some( ( option ) => option.format === format )
+			format.length === 0 ||
+			( !! format &&
+				! suggestedOptions.some(
+					( option ) => option.format === format
+				) )
 	);
 
 	return (


### PR DESCRIPTION
## What?
- In Date Block When custom date/time format input field was cleared then "Default format" setting gets toggled on automatically.
Fixes Issue: https://github.com/WordPress/gutenberg/issues/64602

## Why?
- The input field should remain visible when its value is cleared.

## How?
- Added checks so that the input filed remains visible when it is cleared.

## Testing Instructions
- Add the Date block to any post/page/template
- Toggle the "Default format" off under Block settings.
- Choose "Custom" from "Choose a format" dropdown.
- Clear the pre-filled text from the format input field - either by selecting all and pressing delete or by deleting the characters one by one.
- When the input field is cleared, now the input filed is still visible.

## Screenshots or screencast <!-- if applicable -->
<img width="284" alt="input-field" src="https://github.com/user-attachments/assets/657776fa-02f7-4894-8cde-2dd3c93a693f">

