### PR TITLE
Update the import for PluginBlockSettingsMenuItem

### DIFF
--- a/docs/reference-guides/slotfills/plugin-block-settings-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-block-settings-menu-item.md
@@ -7,7 +7,7 @@ This will either appear in the controls for each block or at the Top Toolbar dep
 
 ```js
 import { registerPlugin } from '@wordpress/plugins';
-import { PluginBlockSettingsMenuItem } from '@wordpress/edit-post';
+import { PluginBlockSettingsMenuItem } from '@wordpress/editor';
 
 const PluginBlockSettingsMenuGroupTest = () => (
 	<PluginBlockSettingsMenuItem


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updating the import to the correct package.

Part of: #64749
