### PR TITLE
PluginSidebarMoreMenuItem: Update example, screenshot and description.

### DIFF
--- a/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
@@ -1,6 +1,6 @@
 # PluginSidebarMoreMenuItem
 
-This slot is used to allow opening of a `<PluginSidebar>` panel from the Options dropdown.
+This slot is used to allow the opening of a `<PluginSidebar />` panel from the Options dropdown.
 When a `<PluginSidebar />` is registered, a `<PluginSidebarMoreMenuItem />` is automatically registered using the title prop from the `<PluginSidebar />` and so it's not required to use this slot to create the menu item.
 
 ## Example

--- a/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
@@ -53,9 +53,9 @@ const PluginSidebarMoreMenuItemTest = () => {
 						label={ __( 'Select Control' ) }
 						value={ select }
 						options={ [
-							{ value: 'a', label: 'Option A' },
-							{ value: 'b', label: 'Option B' },
-							{ value: 'c', label: 'Option C' },
+							{ value: 'a', label: __( 'Option A' ) },
+							{ value: 'b', label: __( 'Option B' ) },
+							{ value: 'c', label: __( 'Option C' ) },
 						] }
 						onChange={ ( newSelect ) => setSelect( newSelect ) }
 					/>

--- a/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
@@ -60,7 +60,7 @@ const PluginSidebarMoreMenuItemTest = () => {
 						onChange={ ( newSelect ) => setSelect( newSelect ) }
 					/>
 					<Button variant="primary">
-						{ __( 'Primary Button', 'gutenberg-slot-fill-system' ) }{ ' ' }
+						{ __( 'Primary Button' ) }{ ' ' }
 					</Button>
 				</PanelBody>
 			</PluginSidebar>

--- a/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
+++ b/docs/reference-guides/slotfills/plugin-sidebar-more-menu-item.md
@@ -1,31 +1,78 @@
 # PluginSidebarMoreMenuItem
 
-This slot allows the creation of a `<PluginSidebar>` with a menu item that when clicked will expand the sidebar to the appropriate Plugin section.
-This is done by setting the `target` on `<PluginSidebarMoreMenuItem>` to match the `name` on the `<PluginSidebar>`
+This slot is used to allow opening of a `<PluginSidebar>` panel from the Options dropdown.
+When a `<PluginSidebar />` is registered, a `<PluginSidebarMoreMenuItem />` is automatically registered using the title prop from the `<PluginSidebar />` and so it's not required to use this slot to create the menu item.
 
 ## Example
 
+This example shows how customize the text for the menu item instead of using the default text provided by the `<PluginSidebar />` title.
+
 ```js
-import { registerPlugin } from '@wordpress/plugins';
+import { __ } from '@wordpress/i18n';
 import { PluginSidebar, PluginSidebarMoreMenuItem } from '@wordpress/editor';
+import {
+	PanelBody,
+	Button,
+	TextControl,
+	SelectControl,
+} from '@wordpress/components';
+import { registerPlugin } from '@wordpress/plugins';
+import { useState } from '@wordpress/element';
 import { image } from '@wordpress/icons';
 
-const PluginSidebarMoreMenuItemTest = () => (
-	<>
-		<PluginSidebarMoreMenuItem target="sidebar-name" icon={ image }>
-			Expanded Sidebar - More item
-		</PluginSidebarMoreMenuItem>
-		<PluginSidebar name="sidebar-name" icon={ image } title="My Sidebar">
-			Content of the sidebar
-		</PluginSidebar>
-	</>
-);
+const PluginSidebarMoreMenuItemTest = () => {
+	const [ text, setText ] = useState( '' );
+	const [ select, setSelect ] = useState( 'a' );
+	return (
+		<>
+			<PluginSidebarMoreMenuItem target="sidebar-name" icon={ image }>
+				{ __( 'Custom Menu Item Text' ) }
+			</PluginSidebarMoreMenuItem>
+			<PluginSidebar
+				name="sidebar-name"
+				icon={ image }
+				title="My Sidebar"
+			>
+				<PanelBody>
+					<h2>
+						{ __(
+							'This is a heading for the PluginSidebar example.'
+						) }
+					</h2>
+					<p>
+						{ __(
+							'This is some example text for the PluginSidebar example.'
+						) }
+					</p>
+					<TextControl
+						label={ __( 'Text Control' ) }
+						value={ text }
+						onChange={ ( newText ) => setText( newText ) }
+					/>
+					<SelectControl
+						label={ __( 'Select Control' ) }
+						value={ select }
+						options={ [
+							{ value: 'a', label: 'Option A' },
+							{ value: 'b', label: 'Option B' },
+							{ value: 'c', label: 'Option C' },
+						] }
+						onChange={ ( newSelect ) => setSelect( newSelect ) }
+					/>
+					<Button variant="primary">
+						{ __( 'Primary Button', 'gutenberg-slot-fill-system' ) }{ ' ' }
+					</Button>
+				</PanelBody>
+			</PluginSidebar>
+		</>
+	);
+};
 
-registerPlugin( 'plugin-sidebar-expanded-test', {
+registerPlugin( 'plugin-sidebar-more-menu-item-example', {
 	render: PluginSidebarMoreMenuItemTest,
 } );
 ```
 
 ## Location
 
-![Interaction](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/plugin-sidebar-more-menu-item.gif?raw=true)
+![Interaction](https://developer.wordpress.org/files/2024/08/pluginsidebar-more-menu-item-1.gif)


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The PluginSidebarMoreMenuItem slot is a little redundant give that any PluginSidebar will create one automatically. This PR updates the example, description and screenshot to show how it could be used to override the default button text.

Part of: #64749
