### PR TITLE
Button Block: Apply Stretch Styles Correctly

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -9,6 +9,9 @@ $blocks-block__margin: 0.5em;
 	text-align: center;
 	word-break: break-word; // overflow-wrap doesn't work well if a link is wrapped in the div, so use word-break here.
 	box-sizing: border-box;
+	height: 100%;
+	width: 100%;
+	align-content: center;
 
 	&.aligncenter {
 		text-align: center;


### PR DESCRIPTION
Fixes #52533

## What?

This PR ensures that buttons are stretched correctly when "Stretch to fill" or "Stretch items" are applied.

## Why?

When "Stretch to fill" or "Stretch items" is applied to the Buttons block, its child element (`.wp-block-button`) is stretched by the `align-items: stretch` style. However, the actual button is the `.wp-block-button__link` element inside it, and since this has the `display: inline-block` style, there is no visible change.

As I've researched in [this comment](https://github.com/WordPress/gutenberg/issues/52533#issuecomment-2029688551), it appears that the stretch option for the Button block never worked when it was first implemented.

## How?

Make the actual button height/width 100%. This will make the actual button the same size as the flex layout child.

However, simply changing the height or width to 100% will not center the content inside when buttons of different heights are lined up:

![image](https://github.com/user-attachments/assets/2bf70ad2-0038-4c6a-b3ab-9de9022cffec)

I first thought of applying `display: inline-flex` instead of `inline-block` to center the content, but if it contains `br` tags or inline formatting, it will cause an unintended layout:

| Actual | Expected |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bb0e35da-bd87-401f-9e38-e2f8231dd671) | ![image](https://github.com/user-attachments/assets/fc7e9309-37e5-4d3c-884e-9329b0af6710) | 

So I left it as `inline-block` and applied `align-content:center`. This CSS is now defined as available for block containers other than flex/grid layouts, and should be supported in major browsers ([W3C link](https://www.w3.org/TR/css-align-3/#align-justify-content)).

## Testing Instructions

- Insert multiple buttons.
- Vary the length of the button content and add some inline formatting to the content.
- Horizontal layout: If you select "Stretch to fill", the button height should expand to the container height and the text inside should be centered.
- Vertical layout: If you select "Stretch items", the button width should expand to the container width.

## Screenshots or screencast <!-- if applicable -->

### Horizontal Layout

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5e170d07-2d7e-4d85-96df-84aa61e7c261)| ![image](https://github.com/user-attachments/assets/4f45a75a-365c-4895-9a30-c6dd51abbd3b)| 

### Vertical Layout

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/4cbf555f-1409-40a0-b816-bcd96a3f6127) | ![image](https://github.com/user-attachments/assets/f72a2dd2-e8d8-40d8-ab12-07ba852ec91f) | 