### PR TITLE
Core Data: Derive collection totals for unbound queries

### DIFF
--- a/packages/core-data/src/hooks/test/use-entity-records.js
+++ b/packages/core-data/src/hooks/test/use-entity-records.js
@@ -69,8 +69,8 @@ describe( 'useEntityRecords', () => {
 			hasStarted: true,
 			isResolving: false,
 			status: 'SUCCESS',
-			totalItems: null,
-			totalPages: null,
+			totalItems: 3,
+			totalPages: 1,
 		} );
 	} );
 } );

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -273,6 +273,10 @@ export const getEntityRecords =
 				};
 			} else {
 				records = Object.values( await apiFetch( { path } ) );
+				meta = {
+					totalItems: records.length,
+					totalPages: 1,
+				};
 			}
 
 			// If we request fields but the result doesn't contain the fields,

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -181,7 +181,7 @@ describe( 'getEntityRecords', () => {
 			{},
 			false,
 			undefined,
-			undefined
+			{ totalItems: 2, totalPages: 1 }
 		);
 	} );
 


### PR DESCRIPTION
## What?
PR updates the `getEntityRecords` resolver and derives collection totals from returned records. This ensures the total items/page selectors are consistent for all queries.

## Why?
Unbound queries can't use response header information due to how to fetch all middleware works. It requires the `parse` argument to be `true`. 

## Testing Instructions
1. Open a post or page.
2. Query the all patterns - `wp.data.select( 'core' ).getEntityRecords( 'postType', 'wp_block', { per_page: -1 } );`
3. Query total items for patterns - `wp.data.select( 'core' ).getEntityRecordsTotalItems( 'postType', 'wp_block', { per_page: -1 } );`
4. Confirm it returns a correct number of records.

### Testing Instructions for Keyboard
Same.