### PR TITLE
Added unit test for Tag Cloud Block render function

### DIFF
--- a/phpunit/blocks/renderBlockCoreTagCloud.php
+++ b/phpunit/blocks/renderBlockCoreTagCloud.php
@@ -6,7 +6,7 @@
  * @subpackage Blocks
  *
  * @covers ::render_block_core_tag_cloud
- * @group blocks-tag-cloud
+ * @group blocks
  */
 class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 	/**
@@ -146,7 +146,7 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 		$this->assertStringContainsString(
 			'<a',
 			$rendered,
-			'Failed to assert that $rendered contain the contain a html anchor tag.'
+			'Failed to assert that $rendered contain a html anchor tag.'
 		);
 		$this->assertStringContainsString(
 			'tag-cloud-link',
@@ -156,12 +156,38 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 		$this->assertStringContainsString(
 			get_term_link( self::$tags[0] ),
 			$rendered,
-			'Failed to assert that $rendered contain the contain the tag link.'
+			'Failed to assert that $rendered contain the tag link.'
 		);
 		$this->assertStringContainsString(
 			get_term( self::$tags[0] )->name,
 			$rendered,
-			'Failed to assert that $rendered contain the contain the tag name.'
+			'Failed to assert that $rendered contain the tag name.'
+		);
+		$this->assertStringContainsString(
+			'font-size:',
+			$rendered,
+			'Failed to assert that $rendered contain the `font-size` style for tags.'
+		);
+
+		// Test if the tag cloud is rendered with the category taxonomy.
+		wp_set_object_terms( self::$post->ID, self::$categories, 'category' );
+		self::$attributes['taxonomy'] = 'category';
+		$rendered                     = render_block_core_tag_cloud( self::$attributes );
+
+		$this->assertStringContainsString(
+			'wp-block-tag-cloud',
+			$rendered,
+			'Failed to assert that $rendered contain the `wp-block-tag-cloud` class.'
+		);
+		$this->assertStringContainsString(
+			get_term_link( self::$categories[0] ),
+			$rendered,
+			'Failed to assert that $rendered contain the category link.'
+		);
+		$this->assertStringContainsString(
+			get_term( self::$categories[0] )->name,
+			$rendered,
+			'Failed to assert that $rendered contain the category name.'
 		);
 	}
 }

--- a/phpunit/blocks/renderBlockCoreTagCloud.php
+++ b/phpunit/blocks/renderBlockCoreTagCloud.php
@@ -1,11 +1,11 @@
 <?php
 /**
- * Tests for the render_block_core_tag_cloud() function.
+ * Tests for the gutenberg_render_block_core_post_excerpt() function.
  *
  * @package WordPress
  * @subpackage Blocks
  *
- * @covers ::render_block_core_tag_cloud
+ * @covers ::gutenberg_render_block_core_post_excerpt
  * @group blocks
  */
 class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
@@ -15,13 +15,6 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 	 * @var array
 	 */
 	protected static $attributes;
-
-	/**
-	 * Block object.
-	 *
-	 * @var WP_Block
-	 */
-	protected static $block;
 
 	/**
 	 * An array of category term object.
@@ -50,14 +43,14 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
 	 */
 	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
-		self::$categories = self::factory()->term->create_many(
+		self::$categories = $factory->term->create_many(
 			3,
 			array(
 				'taxonomy' => 'category',
 			)
 		);
 
-		self::$tags = self::factory()->term->create_many(
+		self::$tags = $factory->term->create_many(
 			3,
 			array(
 				'taxonomy' => 'post_tag',
@@ -74,8 +67,6 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 			'smallestFontSize' => '8pt',
 			'largestFontSize'  => '22pt',
 		);
-
-		self::$block = new stdClass();
 
 		$block_args = array(
 			'blockName'    => 'core/tag-cloud',
@@ -101,6 +92,7 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 		foreach ( self::$tags as $tag ) {
 			wp_delete_term( $tag, 'post_tag' );
 		}
+		wp_delete_post( self::$post->ID, true );
 	}
 
 	/**
@@ -108,7 +100,7 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 	 */
 	public function test_should_render_empty_string_when_no_tags_available() {
 
-		$rendered = render_block_core_tag_cloud( self::$attributes );
+		$rendered = gutenberg_render_block_core_tag_cloud( self::$attributes );
 		$this->assertStringContainsString(
 			'wp-block-tag-cloud',
 			$rendered,
@@ -128,7 +120,7 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 	public function test_should_render_tag_cloud() {
 		wp_set_object_terms( self::$post->ID, self::$tags, 'post_tag' );
 
-		$rendered = render_block_core_tag_cloud( self::$attributes );
+		$rendered = gutenberg_render_block_core_tag_cloud( self::$attributes );
 		$this->assertNotEmpty(
 			$rendered,
 			'Failed to assert that $rendered is an non-empty string.'
@@ -172,7 +164,7 @@ class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
 		// Test if the tag cloud is rendered with the category taxonomy.
 		wp_set_object_terms( self::$post->ID, self::$categories, 'category' );
 		self::$attributes['taxonomy'] = 'category';
-		$rendered                     = render_block_core_tag_cloud( self::$attributes );
+		$rendered                     = gutenberg_render_block_core_tag_cloud( self::$attributes );
 
 		$this->assertStringContainsString(
 			'wp-block-tag-cloud',

--- a/phpunit/blocks/renderBlockCoreTagCloud.php
+++ b/phpunit/blocks/renderBlockCoreTagCloud.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for the render_block_core_tag_cloud() function.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ *
+ * @covers ::render_block_core_tag_cloud
+ * @group blocks-tag-cloud
+ */
+class Tests_Blocks_RenderBlockCoreTagCloud extends WP_UnitTestCase {
+	/**
+	 * Array of attributes.
+	 *
+	 * @var array
+	 */
+	protected static $attributes;
+
+	/**
+	 * Block object.
+	 *
+	 * @var WP_Block
+	 */
+	protected static $block;
+
+	/**
+	 * An array of category term object.
+	 *
+	 * @var array
+	 */
+	protected static $categories;
+
+	/**
+	 * Post object.
+	 *
+	 * @var WP_Post
+	 */
+	protected static $post;
+
+	/**
+	 * An array of tag term object.
+	 *
+	 * @var array
+	 */
+	protected static $tags;
+
+	/**
+	 * Setup method.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper that lets us create fake data.
+	 */
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$categories = self::factory()->term->create_many(
+			3,
+			array(
+				'taxonomy' => 'category',
+			)
+		);
+
+		self::$tags = self::factory()->term->create_many(
+			3,
+			array(
+				'taxonomy' => 'post_tag',
+			)
+		);
+
+		// Demo post to assign terms.
+		self::$post = $factory->post->create_and_get();
+
+		self::$attributes = array(
+			'taxonomy'         => 'post_tag',
+			'showTagCounts'    => false,
+			'numberOfTags'     => 45,
+			'smallestFontSize' => '8pt',
+			'largestFontSize'  => '22pt',
+		);
+
+		self::$block = new stdClass();
+
+		$block_args = array(
+			'blockName'    => 'core/tag-cloud',
+			'attrs'        => array(
+				'textColor' => 'red',
+			),
+			'innerBlock'   => array(),
+			'innerContent' => array(),
+			'innerHTML'    => array(),
+		);
+
+		WP_Block_Supports::init();
+		WP_Block_Supports::$block_to_render = $block_args;
+	}
+
+	/**
+	 * Tear down method.
+	 */
+	public static function wpTearDownAfterClass() {
+		foreach ( self::$categories as $category ) {
+			wp_delete_term( $category, 'category' );
+		}
+		foreach ( self::$tags as $tag ) {
+			wp_delete_term( $tag, 'post_tag' );
+		}
+	}
+
+	/**
+	 * Test if the function returns an empty string when the terms are not available.
+	 */
+	public function test_should_render_empty_string_when_no_tags_available() {
+
+		$rendered = render_block_core_tag_cloud( self::$attributes );
+		$this->assertStringContainsString(
+			'wp-block-tag-cloud',
+			$rendered,
+			'Failed to assert that $rendered contain the `wp-block-tag-cloud` class.'
+		);
+
+		$this->assertStringContainsString(
+			'There&#8217;s no content to show here yet',
+			$rendered,
+			'Failed to assert that $rendered contain message for empty tag block.'
+		);
+	}
+
+	/**
+	 * Test if the function returns tag cloud html.
+	 */
+	public function test_should_render_tag_cloud() {
+		wp_set_object_terms( self::$post->ID, self::$tags, 'post_tag' );
+
+		$rendered = render_block_core_tag_cloud( self::$attributes );
+		$this->assertNotEmpty(
+			$rendered,
+			'Failed to assert that $rendered is an non-empty string.'
+		);
+		$this->assertStringNotContainsString(
+			'There&#8217;s no content to show here yet',
+			$rendered,
+			'Failed to assert that $rendered does not contain the message for empty tag block.'
+		);
+		$this->assertStringContainsString(
+			'wp-block-tag-cloud',
+			$rendered,
+			'Failed to assert that $rendered contain the `wp-block-tag-cloud` class.'
+		);
+		$this->assertStringContainsString(
+			'<a',
+			$rendered,
+			'Failed to assert that $rendered contain the contain a html anchor tag.'
+		);
+		$this->assertStringContainsString(
+			'tag-cloud-link',
+			$rendered,
+			'Failed to assert that $rendered contain the `tag-cloud-link` class.'
+		);
+		$this->assertStringContainsString(
+			get_term_link( self::$tags[0] ),
+			$rendered,
+			'Failed to assert that $rendered contain the contain the tag link.'
+		);
+		$this->assertStringContainsString(
+			get_term( self::$tags[0] )->name,
+			$rendered,
+			'Failed to assert that $rendered contain the contain the tag name.'
+		);
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Added unit test for `Tag Cloud` block render function.
 