### PR TITLE
Corrected HTML Syntax for Closing Tags in api-reference.md file

### DIFF
--- a/docs/reference-guides/interactivity-api/api-reference.md
+++ b/docs/reference-guides/interactivity-api/api-reference.md
@@ -501,7 +501,7 @@ The `unique-id` doesn't need to be unique globally. It just needs to be differen
 
 ```html
 <div data-wp-init="callbacks.logTimeInit">
-  <p>Hi!</>
+  <p>Hi!</p>
 </div>
 ```
 


### PR DESCRIPTION
Corrected HTML Syntax for Closing Tags api-reference.md file line no 504

`<p>Hi!</>` it should be `<p>Hi!</p>`