### PR TITLE
Navigator: fix isInitial, refine focusSelector logic

### DIFF
--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -155,18 +155,20 @@ function routerReducer(
 			break;
 		case 'goto':
 			const goToNewState = goTo( state, action.path, action.options );
-			currentLocation = goToNewState.currentLocation;
+			currentLocation = {
+				...goToNewState.currentLocation,
+				isInitial: false,
+			};
 			focusSelectors = goToNewState.focusSelectors;
 			break;
 		case 'gotoparent':
 			const goToParentNewState = goToParent( state, action.options );
-			currentLocation = goToParentNewState.currentLocation;
+			currentLocation = {
+				...goToParentNewState.currentLocation,
+				isInitial: false,
+			};
 			focusSelectors = goToParentNewState.focusSelectors;
 			break;
-	}
-
-	if ( currentLocation?.path === state.initialPath ) {
-		currentLocation = { ...currentLocation, isInitial: true };
 	}
 
 	// Return early in case there is no change
@@ -220,7 +222,7 @@ function UnconnectedNavigatorProvider(
 		initialPathProp,
 		( path ) => ( {
 			screens: [],
-			currentLocation: { path },
+			currentLocation: { path, isInitial: true },
 			matchedPath: undefined,
 			focusSelectors: new Map(),
 			initialPath: initialPathProp,

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -79,7 +79,7 @@ function goTo(
 		...restOptions
 	} = options;
 
-	if ( currentLocation?.path === path ) {
+	if ( currentLocation.path === path ) {
 		return { currentLocation, focusSelectors };
 	}
 
@@ -92,7 +92,7 @@ function goTo(
 
 	// Set a focus selector that will be used when navigating
 	// back to the current location.
-	if ( focusTargetSelector && currentLocation?.path ) {
+	if ( focusTargetSelector && currentLocation.path ) {
 		getFocusSelectorsCopy().set(
 			currentLocation.path,
 			focusTargetSelector
@@ -130,7 +130,7 @@ function goToParent(
 ) {
 	const { screens, focusSelectors } = state;
 	const currentLocation = { ...state.currentLocation, isInitial: false };
-	const currentPath = currentLocation?.path;
+	const currentPath = currentLocation.path;
 	if ( currentPath === undefined ) {
 		return { currentLocation, focusSelectors };
 	}
@@ -186,7 +186,7 @@ function routerReducer(
 	}
 
 	// Compute the matchedPath
-	const currentPath = currentLocation?.path;
+	const currentPath = currentLocation.path;
 	matchedPath =
 		currentPath !== undefined
 			? patternMatch( currentPath, screens )

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -8,6 +8,7 @@ import type { ForwardedRef } from 'react';
  */
 import { useMemo, useReducer } from '@wordpress/element';
 import isShallowEqual from '@wordpress/is-shallow-equal';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -46,8 +47,7 @@ type RouterState = {
 
 function addScreen( { screens }: RouterState, screen: Screen ) {
 	if ( screens.some( ( s ) => s.path === screen.path ) ) {
-		// eslint-disable-next-line no-console
-		console.warn(
+		warning(
 			`Navigator: a screen with path ${ screen.path } already exists.
 The screen with id ${ screen.id } will not be added.`
 		);

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -65,7 +65,8 @@ function goTo(
 	path: string,
 	options: NavigateOptions = {}
 ) {
-	const { currentLocation, focusSelectors } = state;
+	const { focusSelectors } = state;
+	const currentLocation = { ...state.currentLocation, isInitial: false };
 
 	const {
 		// Default assignments
@@ -120,7 +121,8 @@ function goToParent(
 	state: RouterState,
 	options: NavigateToParentOptions = {}
 ) {
-	const { currentLocation, screens, focusSelectors } = state;
+	const { screens, focusSelectors } = state;
+	const currentLocation = { ...state.currentLocation, isInitial: false };
 	const currentPath = currentLocation?.path;
 	if ( currentPath === undefined ) {
 		return { currentLocation, focusSelectors };
@@ -154,20 +156,17 @@ function routerReducer(
 			screens = removeScreen( state, action.screen );
 			break;
 		case 'goto':
-			const goToNewState = goTo( state, action.path, action.options );
-			currentLocation = {
-				...goToNewState.currentLocation,
-				isInitial: false,
-			};
-			focusSelectors = goToNewState.focusSelectors;
+			( { currentLocation, focusSelectors } = goTo(
+				state,
+				action.path,
+				action.options
+			) );
 			break;
 		case 'gotoparent':
-			const goToParentNewState = goToParent( state, action.options );
-			currentLocation = {
-				...goToParentNewState.currentLocation,
-				isInitial: false,
-			};
-			focusSelectors = goToParentNewState.focusSelectors;
+			( { currentLocation, focusSelectors } = goToParent(
+				state,
+				action.options
+			) );
 			break;
 	}
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -83,25 +83,32 @@ function goTo(
 		return { currentLocation, focusSelectors };
 	}
 
-	let focusSelectorsCopy;
+	let focusSelectorsCopy: typeof focusSelectors | undefined;
+	function getFocusSelectorsCopy() {
+		focusSelectorsCopy =
+			focusSelectorsCopy ?? new Map( state.focusSelectors );
+		return focusSelectorsCopy;
+	}
 
 	// Set a focus selector that will be used when navigating
 	// back to the current location.
 	if ( focusTargetSelector && currentLocation?.path ) {
-		if ( ! focusSelectorsCopy ) {
-			focusSelectorsCopy = new Map( state.focusSelectors );
-		}
-		focusSelectorsCopy.set( currentLocation.path, focusTargetSelector );
+		getFocusSelectorsCopy().set(
+			currentLocation.path,
+			focusTargetSelector
+		);
 	}
 
 	// Get the focus selector for the new location.
 	let currentFocusSelector;
-	if ( isBack ) {
-		if ( ! focusSelectorsCopy ) {
-			focusSelectorsCopy = new Map( state.focusSelectors );
+	if ( focusSelectors.get( path ) ) {
+		if ( isBack ) {
+			// Use the found focus selector only when navigating back.
+			currentFocusSelector = focusSelectors.get( path );
 		}
-		currentFocusSelector = focusSelectorsCopy.get( path );
-		focusSelectorsCopy.delete( path );
+		// Make a copy of the focusSelectors map to remove the focus selector
+		// only if necessary (ie. a focus selector was found).
+		getFocusSelectorsCopy().delete( path );
 	}
 
 	return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #59418
Follow-up to #64675

Following the changes applied in #64675, this PR brings fixes and improvements to `Navigator`'s internal logic following [@jsnajdr 's comments](https://github.com/WordPress/gutenberg/pull/64675#pullrequestreview-2258773341)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Jarda's comments are all correct and actionable, and would improve the compoment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Fixed `isInitial` logic (as highlighted in https://github.com/WordPress/gutenberg/pull/64675#discussion_r1730038438)
- Replaced `console.warn` with `@wordpress/warning` (as suggested in https://github.com/WordPress/gutenberg/pull/64675#discussion_r1730028643)
- Improved focus selector map manipulation: optimised copy creation, more eager cleanup of stale selectors (as suggested in https://github.com/WordPress/gutenberg/pull/64675#discussion_r1730037857)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Both in Storybook and in the editor (Global Styles sidebar):

- Make sure that `isInitial` is only applied to the very first location that is assigned when `Navigator` mounts (currently, on `trunk`, it gets set to `true` any time the location's `path` is the same as the initial path — which is wrong)
- Make sure that focus restoration continues to work as before (but review the code changes to make sure that the logic is more efficient)