### PR TITLE
Updated Several Typos in Doc files

### DIFF
--- a/docs/getting-started/fundamentals/block-in-the-editor.md
+++ b/docs/getting-started/fundamentals/block-in-the-editor.md
@@ -124,7 +124,7 @@ export default function Edit( { attributes, setAttributes } ) {
 						<legend className="blocks-base-control__label">
 							{ __( 'Background color', 'block-development-examples' ) }
 						</legend>
-						<ColorPalette // Element Tag for Gutenberg standard colour selector
+						<ColorPalette // Element Tag for Gutenberg standard color selector
 							onChange={ onChangeBGColor } // onChange event callback
 						/>
 					</fieldset>

--- a/docs/reference-guides/block-api/block-attributes.md
+++ b/docs/reference-guides/block-api/block-attributes.md
@@ -1,6 +1,6 @@
 # Attributes
 
-Block attributes provide information about the data stored by a block. For example, rich content, a list of image URLs, a background colour, or a button title.
+Block attributes provide information about the data stored by a block. For example, rich content, a list of image URLs, a background color, or a button title.
 
 A block can contain any number of attributes, and these are specified by the `attributes` field - an object where each key is the name of the attribute, and the value is the attribute definition.
 

--- a/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md
@@ -93,7 +93,7 @@ The following are the necessary steps to ensure that the directives are correctl
     </ul>
     ```
 
-That's it! Once you've set up your interctive block with `supports.interactivity`, initialized your global state or local context, and added the directives to the HTML markup, the Interactivity API will take care of the rest. There's no additional code required from the developer to process these directives on the server side.
+That's it! Once you've set up your interactive block with `supports.interactivity`, initialized your global state or local context, and added the directives to the HTML markup, the Interactivity API will take care of the rest. There's no additional code required from the developer to process these directives on the server side.
 
 Behind the scenes, WordPress uses the `wp_interactivity_process_directives` function to find and process the directives in the HTML markup of your block. This function uses the HTML API to make the necessary changes to the markup, based on the found directives and the initial global state and/or local context.
 


### PR DESCRIPTION
**Updated Several Typos in Doc files:**

1.  In docs/reference-guides/interactivity-api/core-concepts/server-side-rendering.md Line no 96  `interctive` it should be `interactive`
2. In docs/getting-started/fundamentals/block-in-the-editor.md Line no 127 and docs/reference-guides/block-api/block-attributes.md Line no 3  Updated `colour` -> `color`