### PR TITLE
Fix visibility of the template Welcome Guide in the Site Editor

### DIFF
--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -6,11 +6,13 @@ import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
+import { useState } from '@wordpress/element';
+import { useDebounce } from '@wordpress/compose';
 
 export default function WelcomeGuideTemplate() {
 	const { toggle } = useDispatch( preferencesStore );
 
-	const isVisible = useSelect( ( select ) => {
+	const visibility = useSelect( ( select ) => {
 		const isTemplateActive = !! select( preferencesStore ).get(
 			'core/edit-site',
 			'welcomeGuideTemplate'
@@ -29,6 +31,13 @@ export default function WelcomeGuideTemplate() {
 			hasBackNavigation
 		);
 	}, [] );
+
+	// The visibility conditions change in such a way that it’s tricky to avoid
+	// an unexpected flash of the component. Using state and debouncing writes
+	// to it works around the issue.
+	const [ isVisible, setIsVisible ] = useState();
+	const debouncedSetIsVisible = useDebounce( setIsVisible, 32 );
+	debouncedSetIsVisible( visibility );
 
 	if ( ! isVisible ) {
 		return null;

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -15,8 +15,8 @@ import useEditedEntityRecord from '../use-edited-entity-record';
 export default function WelcomeGuideTemplate() {
 	const { toggle } = useDispatch( preferencesStore );
 
-	const edited = useEditedEntityRecord();
-	const isPostTypeTemplate = edited.record.type === 'wp_template';
+	const { isLoaded, record } = useEditedEntityRecord();
+	const isPostTypeTemplate = isLoaded && record.type === 'wp_template';
 	const { isActive, hasPreviousEntity } = useSelect( ( select ) => {
 		const { getEditorSettings } = select( editorStore );
 		const { get } = select( preferencesStore );

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -7,11 +7,6 @@ import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
 
-/**
- * Internal dependencies
- */
-import { store as editSiteStore } from '../../store';
-
 export default function WelcomeGuideTemplate() {
 	const { toggle } = useDispatch( preferencesStore );
 
@@ -24,13 +19,14 @@ export default function WelcomeGuideTemplate() {
 			'core/edit-site',
 			'welcomeGuide'
 		);
-		const { isPage } = select( editSiteStore );
-		const { getCurrentPostType } = select( editorStore );
+		const { getCurrentPostType, getEditorSettings } = select( editorStore );
+		const hasBackNavigation =
+			!! getEditorSettings().onNavigateToPreviousEntityRecord;
 		return (
 			isTemplateActive &&
 			! isEditorActive &&
-			isPage() &&
-			getCurrentPostType() === 'wp_template'
+			getCurrentPostType() === 'wp_template' &&
+			hasBackNavigation
 		);
 	}, [] );
 

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -6,36 +6,27 @@ import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
-import { usePrevious } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import useEditedEntityRecord from '../use-edited-entity-record';
+
 export default function WelcomeGuideTemplate() {
 	const { toggle } = useDispatch( preferencesStore );
 
-	const {
-		postId,
-		isEditorActive,
-		isTemplateActive,
-		isPostTypeTemplate,
-		hasBackNavigation,
-	} = useSelect( ( select ) => {
-		const { getCurrentPostId, getCurrentPostType, getEditorSettings } =
-			select( editorStore );
+	const edited = useEditedEntityRecord();
+	const isPostTypeTemplate = edited.record.type === 'wp_template';
+	const { isActive, hasPreviousEntity } = useSelect( ( select ) => {
+		const { getEditorSettings } = select( editorStore );
 		const { get } = select( preferencesStore );
 		return {
-			postId: getCurrentPostId(),
-			isEditorActive: get( 'core/edit-site', 'welcomeGuide' ),
-			isTemplateActive: get( 'core/edit-site', 'welcomeGuideTemplate' ),
-			isPostTypeTemplate: getCurrentPostType() === 'wp_template',
-			hasBackNavigation:
+			isActive: get( 'core/edit-site', 'welcomeGuideTemplate' ),
+			hasPreviousEntity:
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
 		};
 	}, [] );
-	const priorPostId = usePrevious( postId );
-	const isVisible =
-		postId !== priorPostId &&
-		isTemplateActive &&
-		! isEditorActive &&
-		isPostTypeTemplate &&
-		hasBackNavigation;
+	const isVisible = isActive && isPostTypeTemplate && hasPreviousEntity;
 
 	if ( ! isVisible ) {
 		return null;

--- a/packages/editor/src/components/post-template/block-theme.js
+++ b/packages/editor/src/components/post-template/block-theme.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import { check } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -43,6 +44,8 @@ export default function BlockThemeControl( { id } ) {
 		};
 	}, [] );
 
+	const { get: getPreference } = useSelect( preferencesStore );
+
 	const { editedRecord: template, hasResolved } = useEntityRecord(
 		'postType',
 		'wp_template',
@@ -75,6 +78,17 @@ export default function BlockThemeControl( { id } ) {
 				},
 		  ]
 		: undefined;
+
+	const mayShowTemplateEditNotice = () => {
+		if ( ! getPreference( 'core/edit-site', 'welcomeGuideTemplate' ) ) {
+			createSuccessNotice(
+				__(
+					'Editing template. Changes made here affect all posts and pages that use the template.'
+				),
+				{ type: 'snackbar', actions: notificationAction }
+			);
+		}
+	};
 	return (
 		<DropdownMenu
 			popoverProps={ POPOVER_PROPS }
@@ -99,15 +113,7 @@ export default function BlockThemeControl( { id } ) {
 										postType: 'wp_template',
 									} );
 									onClose();
-									createSuccessNotice(
-										__(
-											'Editing template. Changes made here affect all posts and pages that use the template.'
-										),
-										{
-											type: 'snackbar',
-											actions: notificationAction,
-										}
-									);
+									mayShowTemplateEditNotice();
 								} }
 							>
 								{ __( 'Edit template' ) }


### PR DESCRIPTION
## What?
Makes the Welcome guide for page templates actually show up when editing a page template.

## Why?
To fix that the Welcome guide for a page template does not show up when expected as it was originally implemented in #52014. Also, to fix #62525, that describes how the Welcome guide flashes briefly at an unexpected moment.

## How?
- Adds a condition that the editor has a previous entity in its history in order to show the Welcome Guide
- Prevents showing the snackbar notice for template editing if the Welcome Guide is active

## Testing Instructions
1. Start from the WP admin Dashboard
2. Visit the site editor
3. Ensure the preference to show the template Welcome Guide is set by running the following snippet in the console:
```js
if ( ! wp.data.select('core/preferences').get('core/edit-site', 'welcomeGuideTemplate' ) ) {
	wp.data.dispatch('core/preferences').toggle('core/edit-site', 'welcomeGuideTemplate')
}
```
4. Go to "Pages" view
5. Use the "Edit" button (pencil icon) to edit the page directly (without first having selected the page)
6. Watch intently for the flash of the Welcome Guide and verify it does not
7. Open the Page settings sidebar
8. Choose "Edit template" from the "Template Options" dropdown menu
9. Verify that the Welcome Guide shows up and that the snackbar notice is not shown
10. Go back one step in browser history
11. Choose "Edit template" from the "Template Options" dropdown menu
12. Verify that the snackbar notice for template editing is shown and the Welcome Guide is not.

### Testing Instructions for Keyboard

## Screenshots or screencast <!-- if applicable -->
