### PR TITLE
Fluid typography: allow individual preset overrides

### DIFF
--- a/backport-changelog/6.7/7247.md
+++ b/backport-changelog/6.7/7247.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7247
+
+* https://github.com/WordPress/gutenberg/pull/64790

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -449,6 +449,7 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.3.0 Using layout.wideSize as max viewport width, and logarithmic scale factor to calculate minimum font scale.
  * @since 6.4.0 Added configurable min and max viewport width values to the typography.fluid theme.json schema.
  * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
+ * @since 6.7.0 Enabled individual block fluid typography settings overrides.
  *
  * @param array $preset       {
  *     Required. fontSizes preset value as seen in theme.json.
@@ -468,10 +469,11 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 	}
 
 	/*
-	 * Catches empty values and 0/'0'.
-	 * Fluid calculations cannot be performed on 0.
+	 * Catch falsy values and 0/'0'. Fluid calculations cannot be performed on `0`.
+	 * Also return early when a preset font size explicitly disables fluid typography with `false`.
 	 */
-	if ( empty( $preset['size'] ) ) {
+	$fluid_font_size_settings = $preset['fluid'] ?? null;
+	if ( false === $fluid_font_size_settings || empty( $preset['size'] ) ) {
 		return $preset['size'];
 	}
 
@@ -489,20 +491,26 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 	}
 
 	// Fallback to global settings as default.
-	$global_settings             = gutenberg_get_global_settings();
-	$settings                    = wp_parse_args(
+	$global_settings     = gutenberg_get_global_settings();
+	$settings            = wp_parse_args(
 		$settings,
 		$global_settings
 	);
-	$typography_settings         = isset( $settings['typography'] ) ? $settings['typography'] : array();
-	$should_use_fluid_typography = ! empty( $typography_settings['fluid'] );
+	$typography_settings = $settings['typography'] ?? array();
 
-	if ( ! $should_use_fluid_typography ) {
+	/*
+	 * Return early when fluid typography is disabled in the settings, and there
+	 * are no local settings to enable it for the individual preset.
+	 *
+	 * If this condition isn't met, either the settings or individual prest settings
+	 * have enabled fluid typography.
+	 */
+	if ( empty( $typography_settings['fluid'] ) && empty( $fluid_font_size_settings ) ) {
 		return $preset['size'];
 	}
 
 	// $typography_settings['fluid'] can be a bool or an array. Normalize to array.
-	$fluid_settings  = is_array( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
+	$fluid_settings  = isset( $typography_settings['fluid'] ) ? $typography_settings['fluid'] : array();
 	$layout_settings = isset( $settings['layout'] ) ? $settings['layout'] : array();
 
 	// Defaults.
@@ -521,14 +529,6 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 	}
 	$has_min_font_size       = isset( $fluid_settings['minFontSize'] ) && ! empty( gutenberg_get_typography_value_and_unit( $fluid_settings['minFontSize'] ) );
 	$minimum_font_size_limit = $has_min_font_size ? $fluid_settings['minFontSize'] : $default_minimum_font_size_limit;
-
-	// Font sizes.
-	$fluid_font_size_settings = isset( $preset['fluid'] ) ? $preset['fluid'] : null;
-
-	// A font size has explicitly bypassed fluid calculations.
-	if ( false === $fluid_font_size_settings ) {
-		return $preset['size'];
-	}
 
 	// Try to grab explicit min and max fluid font sizes.
 	$minimum_font_size_raw = isset( $fluid_font_size_settings['min'] ) ? $fluid_font_size_settings['min'] : null;

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -502,7 +502,7 @@ function gutenberg_get_typography_font_size_value( $preset, $settings = array() 
 	 * Return early when fluid typography is disabled in the settings, and there
 	 * are no local settings to enable it for the individual preset.
 	 *
-	 * If this condition isn't met, either the settings or individual prest settings
+	 * If this condition isn't met, either the settings or individual preset settings
 	 * have enabled fluid typography.
 	 */
 	if ( empty( $typography_settings['fluid'] ) && empty( $fluid_font_size_settings ) ) {

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -28,7 +28,9 @@ describe( 'typography utils', () => {
 				preset: {
 					size: 0,
 				},
-				typographySettings: undefined,
+				typographySettings: {
+					fluid: true,
+				},
 				expected: 0,
 			},
 
@@ -37,7 +39,9 @@ describe( 'typography utils', () => {
 				preset: {
 					size: '0',
 				},
-				typographySettings: undefined,
+				typographySettings: {
+					fluid: true,
+				},
 				expected: '0',
 			},
 
@@ -46,7 +50,9 @@ describe( 'typography utils', () => {
 				preset: {
 					size: null,
 				},
-				typographySettings: null,
+				typographySettings: {
+					fluid: true,
+				},
 				expected: null,
 			},
 
@@ -153,7 +159,6 @@ describe( 'typography utils', () => {
 				message: 'should return already clamped value',
 				preset: {
 					size: 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
-					fluid: false,
 				},
 				settings: {
 					typography: {
@@ -168,7 +173,6 @@ describe( 'typography utils', () => {
 				message: 'should return value with unsupported unit',
 				preset: {
 					size: '1000%',
-					fluid: false,
 				},
 				settings: {
 					typography: {
@@ -676,6 +680,38 @@ describe( 'typography utils', () => {
 					},
 				},
 				expected: 'clamp(16px, 1rem + ((1vw - 6.4px) * 0.179), 17px)',
+			},
+
+			// Individual preset settings override global settings.
+			{
+				message:
+					'should convert individual preset size to fluid if fluid is disabled in global settings',
+				preset: {
+					size: '17px',
+					fluid: true,
+				},
+				settings: {
+					typography: {},
+				},
+				expected:
+					'clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.234), 17px)',
+			},
+			{
+				message:
+					'should use individual preset settings if fluid is disabled in global settings',
+				preset: {
+					size: '17px',
+					fluid: {
+						min: '16px',
+						max: '26px',
+					},
+				},
+				settings: {
+					typography: {
+						fluid: false,
+					},
+				},
+				expected: 'clamp(16px, 1rem + ((1vw - 3.2px) * 0.781), 26px)',
 			},
 		].forEach( ( { message, preset, settings, expected } ) => {
 			it( `${ message }`, () => {

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -40,6 +40,8 @@ import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights
  * Returns a font-size value based on a given font-size preset.
  * Takes into account fluid typography parameters and attempts to return a css formula depending on available, valid values.
  *
+ * The Core PHP equivalent is wp_get_typography_font_size_value().
+ *
  * @param {Preset}                     preset
  * @param {Object}                     settings
  * @param {boolean|TypographySettings} settings.typography.fluid  Whether fluid typography is enabled, and, optionally, fluid font size options.
@@ -50,15 +52,25 @@ import { getFontStylesAndWeights } from '../../utils/get-font-styles-and-weights
 export function getTypographyFontSizeValue( preset, settings ) {
 	const { size: defaultSize } = preset;
 
-	if ( ! isFluidTypographyEnabled( settings?.typography ) ) {
-		return defaultSize;
-	}
 	/*
-	 * Checks whether a font size has explicitly bypassed fluid calculations.
-	 * Also catches falsy values and 0/'0'.
-	 * Fluid calculations cannot be performed on `0`.
+	 * Catch falsy values and 0/'0'. Fluid calculations cannot be performed on `0`.
+	 * Also return early when a preset font size explicitly disables fluid typography with `false`.
 	 */
 	if ( ! defaultSize || '0' === defaultSize || false === preset?.fluid ) {
+		return defaultSize;
+	}
+
+	/*
+	 * Return early when fluid typography is disabled in the settings, and there
+	 * are no local settings to enable it for the individual preset.
+	 *
+	 * If this condition isn't met, either the settings or individual prest settings
+	 * have enabled fluid typography.
+	 */
+	if (
+		! isFluidTypographyEnabled( settings?.typography ) &&
+		! isFluidTypographyEnabled( preset )
+	) {
 		return defaultSize;
 	}
 

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -64,7 +64,7 @@ export function getTypographyFontSizeValue( preset, settings ) {
 	 * Return early when fluid typography is disabled in the settings, and there
 	 * are no local settings to enable it for the individual preset.
 	 *
-	 * If this condition isn't met, either the settings or individual prest settings
+	 * If this condition isn't met, either the settings or individual preset settings
 	 * have enabled fluid typography.
 	 */
 	if (

--- a/phpunit/block-supports/typography-test.php
+++ b/phpunit/block-supports/typography-test.php
@@ -351,7 +351,11 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 				'font_size'       => array(
 					'size' => null,
 				),
-				'settings'        => null,
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => true,
+					),
+				),
 				'expected_output' => null,
 			),
 
@@ -425,8 +429,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 
 			'returns already clamped value'              => array(
 				'font_size'       => array(
-					'size'  => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
-					'fluid' => false,
+					'size' => 'clamp(21px, 1.313rem + ((1vw - 7.68px) * 2.524), 42px)',
 				),
 				'settings'        => array(
 					'typography' => array(
@@ -438,8 +441,7 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 
 			'returns value with unsupported unit'        => array(
 				'font_size'       => array(
-					'size'  => '1000%',
-					'fluid' => false,
+					'size' => '1000%',
 				),
 				'settings'        => array(
 					'typography' => array(
@@ -768,6 +770,33 @@ class WP_Block_Supports_Typography_Test extends WP_UnitTestCase {
 					),
 				),
 				'expected_output' => 'clamp(100px, 6.25rem + ((1vw - 3.2px) * 7.813), 200px)',
+			),
+
+			// Individual preset settings override global settings.
+			'should convert individual preset size to fluid if fluid is disabled in global settings' => array(
+				'font_size'       => array(
+					'size'  => '17px',
+					'fluid' => true,
+				),
+				'settings'        => array(
+					'typography' => array(),
+				),
+				'expected_output' => 'clamp(14px, 0.875rem + ((1vw - 3.2px) * 0.234), 17px)',
+			),
+			'should use individual preset settings if fluid is disabled in global settings' => array(
+				'font_size'       => array(
+					'size'  => '17px',
+					'fluid' => array(
+						'min' => '16px',
+						'max' => '26px',
+					),
+				),
+				'settings'        => array(
+					'typography' => array(
+						'fluid' => false,
+					),
+				),
+				'expected_output' => 'clamp(16px, 1rem + ((1vw - 3.2px) * 0.781), 26px)',
 			),
 		);
 	}


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/64766

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR allows individual font preset overrides. 

So, if fluid typography is disabled or not active but an individual font preset does enable it, calculate the clamp value for that individual preset.

## Why?

Individual font sizes may opt out of fluid typography if it is turned on globally.

This PR does the opposite: individual font size presets can opt in to fluid typography if it is not turned on globally.

## How?

Check if fluid settings on individual font size presets are present. 

## Testing Instructions

1. In a theme's theme.json, enable fluid typography for some individual font size presets by adding `"fluid": true` to the preset object.  See the below example theme.json.
2. Make sure fluid typography is not enabled globally in the general "settings.typography" settings.
3. In the editor, apply some of your presets.
4. The presets that have fluid settings should have fluid font sizes in the editor and the frontend. 
5. The presets that have no fluid settings should behave as static font sizes.
6. Custom font sizes in the editor should not be affected. That is, they are not enabled if fluid typography is not enabled globally.


<details>

<summary>Here is some test theme.json</summary>

```json
{
	"$schema": "https://schemas.wp.org/trunk/theme.json",
	"version": 3,
	"settings": {
		"typography": {
			"fontSizes": [
				{
					"name": "Big bill",
					"size": "59px",
					"slug": "big-bill"
				},
				{
					"name": "Medium Matt",
					"size": "30px",
					"slug": "med-matt",
					"fluid": true
				},
				{
					"name": "Small Ted",
					"size": "1rem",
					"slug": "small-ted",
					"fluid": {
						"max": "60px",
						"min": "30px"
					}
				}
			]
		}
	}
}


```

</details>