### PR TITLE
Fix Footnotes not saved if the Custom Fields panel is open

### DIFF
--- a/packages/block-library/src/footnotes/edit.js
+++ b/packages/block-library/src/footnotes/edit.js
@@ -75,19 +75,31 @@ export default function FootnotesEdit( { context: { postType, postId } } ) {
 							}
 						} }
 						onChange={ ( nextFootnote ) => {
+							const newValue = JSON.stringify(
+								footnotes.map( ( footnote ) => {
+									return footnote.id === id
+										? {
+												content: nextFootnote,
+												id,
+										  }
+										: footnote;
+								} )
+							);
 							updateMeta( {
 								...meta,
-								footnotes: JSON.stringify(
-									footnotes.map( ( footnote ) => {
-										return footnote.id === id
-											? {
-													content: nextFootnote,
-													id,
-											  }
-											: footnote;
-									} )
-								),
+								footnotes: newValue,
 							} );
+							const metaKeyInput = document.querySelector(
+								'input[value="footnotes"]'
+							);
+							const metaId = metaKeyInput
+								? metaKeyInput.id
+								: null;
+							if ( metaId ) {
+								document.querySelector(
+									`#${ metaId.replace( '-key', '-value' ) }`
+								).innerHTML = newValue;
+							}
 						} }
 					/>{ ' ' }
 					<a href={ `#${ id }-link` }>↩︎</a>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
fix #54653

Fix Footnotes not saved if the Custom Fields panel is open

I used this note as reference.
https://github.com/mburridge/gutenberg/blob/5e2df720ae89962df5ca8ce548846c1e1a6785ae/docs/how-to-guides/plugin-sidebar-0.md#note

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page. 
2. Open Custom Fields panel
3. setting footnotes and block.
4. You can confirm that it works as expected on both the management screen and the front screen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- 

https://github.com/user-attachments/assets/0edbae45-8a3d-48f8-a540-00cf29e9f27c

if applicable -->


