### PR TITLE
Global Styles: Allow non-admin users access to global styles data in post editor

### DIFF
--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -586,12 +586,11 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Controller {
 	 * @return true|WP_Error True if the request has read access for the item, WP_Error object otherwise.
 	 */
 	public function get_theme_item_permissions_check( $request ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-
 		/*
-		 * Verify if the current user has edit_theme_options capability.
-		 * This capability is required to edit/view/delete templates.
+		 * Verify if the current user has edit_posts capability.
+		 * This capability is required to view global styles.
 		 */
-		if ( ! current_user_can( 'edit_theme_options' ) ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
 			return new WP_Error(
 				'rest_cannot_manage_global_styles',
 				__( 'Sorry, you are not allowed to access the global styles on this site.', 'gutenberg' ),

--- a/lib/compat/wordpress-6.6/rest-api.php
+++ b/lib/compat/wordpress-6.6/rest-api.php
@@ -170,6 +170,7 @@ function gutenberg_block_editor_preload_paths_6_6( $paths, $context ) {
 		$paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet();
 		$paths[] = '/wp/v2/themes?context=edit&status=active';
 		$paths[] = '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id() . '?context=edit';
+		$paths[] = '/wp/v2/global-styles/' . WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 	}
 	return $paths;
 }

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -182,7 +182,7 @@ export const rootEntitiesConfig = [
 		name: 'globalStyles',
 		kind: 'root',
 		baseURL: '/wp/v2/global-styles',
-		baseURLParams: { context: 'edit' },
+		baseURLParams: {},
 		plural: 'globalStylesVariations', // Should be different from name.
 		getTitle: ( record ) => record?.title?.rendered || record?.title,
 		getRevisionsUrl: ( parentId, revisionId ) =>
@@ -190,6 +190,17 @@ export const rootEntitiesConfig = [
 				revisionId ? '/' + revisionId : ''
 			}`,
 		supportsPagination: true,
+		getPath: ( path, query, baseURL, id ) => {
+			const context =
+				query.context ||
+				( query.operation === 'read' ? 'view' : 'edit' );
+			const contextQuery = context ? `?context=${ context }` : '';
+			return `${ baseURL }${ id ? '/' + id : '' }${ contextQuery }`;
+		},
+		capabilities: {
+			read: 'edit_posts',
+			update: 'edit_theme_options',
+		},
 	},
 	{
 		label: __( 'Themes' ),

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -190,17 +190,6 @@ export const rootEntitiesConfig = [
 				revisionId ? '/' + revisionId : ''
 			}`,
 		supportsPagination: true,
-		getPath: ( path, query, baseURL, id ) => {
-			const context =
-				query.context ||
-				( query.operation === 'read' ? 'view' : 'edit' );
-			const contextQuery = context ? `?context=${ context }` : '';
-			return `${ baseURL }${ id ? '/' + id : '' }${ contextQuery }`;
-		},
-		capabilities: {
-			read: 'edit_posts',
-			update: 'edit_theme_options',
-		},
 	},
 	{
 		label: __( 'Themes' ),

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -146,13 +146,10 @@ function useGlobalStylesUserConfig() {
 
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
-		const { __experimentalGetCurrentThemeBaseGlobalStyles, canUser } =
+		const { __experimentalGetCurrentThemeBaseGlobalStyles } =
 			select( coreStore );
 
-		return (
-			canUser( 'read', { kind: 'root', name: 'theme' } ) &&
-			__experimentalGetCurrentThemeBaseGlobalStyles()
-		);
+		return __experimentalGetCurrentThemeBaseGlobalStyles();
 	}, [] );
 
 	return [ !! baseConfig, baseConfig ];

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -158,6 +158,10 @@ function useGlobalStylesBaseConfig() {
 		}
 
 		const currentTheme = getCurrentTheme();
+		if ( ! currentTheme?.stylesheet ) {
+			return;
+		}
+
 		const canUserReadBaseGlobalStyles = canUser(
 			'read',
 			`global-styles/themes/${ currentTheme.stylesheet }`

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -146,10 +146,26 @@ function useGlobalStylesUserConfig() {
 
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
-		const { __experimentalGetCurrentThemeBaseGlobalStyles } =
-			select( coreStore );
+		const {
+			__experimentalGetCurrentThemeBaseGlobalStyles,
+			getCurrentTheme,
+			canUser,
+		} = select( coreStore );
 
-		return __experimentalGetCurrentThemeBaseGlobalStyles();
+		const canReadActiveTheme = canUser( 'read', 'themes?status=active' );
+		if ( ! canReadActiveTheme ) {
+			return;
+		}
+
+		const currentTheme = getCurrentTheme();
+		const canUserReadBaseGlobalStyles = canUser(
+			'read',
+			`global-styles/themes/${ currentTheme.stylesheet }`
+		);
+
+		return canUserReadBaseGlobalStyles
+			? __experimentalGetCurrentThemeBaseGlobalStyles()
+			: undefined;
 	}, [] );
 
 	return [ !! baseConfig, baseConfig ];

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -146,30 +146,10 @@ function useGlobalStylesUserConfig() {
 
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
-		const {
-			__experimentalGetCurrentThemeBaseGlobalStyles,
-			getCurrentTheme,
-			canUser,
-		} = select( coreStore );
+		const { __experimentalGetCurrentThemeBaseGlobalStyles } =
+			select( coreStore );
 
-		const canReadActiveTheme = canUser( 'read', 'themes?status=active' );
-		if ( ! canReadActiveTheme ) {
-			return;
-		}
-
-		const currentTheme = getCurrentTheme();
-		if ( ! currentTheme?.stylesheet ) {
-			return;
-		}
-
-		const canUserReadBaseGlobalStyles = canUser(
-			'read',
-			`global-styles/themes/${ currentTheme.stylesheet }`
-		);
-
-		return canUserReadBaseGlobalStyles
-			? __experimentalGetCurrentThemeBaseGlobalStyles()
-			: undefined;
+		return __experimentalGetCurrentThemeBaseGlobalStyles();
 	}, [] );
 
 	return [ !! baseConfig, baseConfig ];


### PR DESCRIPTION
⚠️ Do not merge! ⚠️  

Related: https://github.com/WordPress/gutenberg/issues/64755

## What?

This draft PR is only intended to illustrate the sort of changes required to make global styles data available in the post editor to non-admin users (users without `edit_theme_options`).

## Why?

Global styles data is relied upon in the post editor to generate block style variation styles. It will also be needed in the current work around style inheritance and displaying inherited values in the block inspector controls.

## How?

- Allows users with `edit_posts` capabilities to read base theme global styles.
- Tries updating globalStyles entity definition to avoid enforcing edit context. (this is mostly just wild speculation and hacking due to lack of understanding)


## Testing Instructions
1. Create and log in with a non-admin user e.g. editor
2. Open the post editor, add a button, and assign it the outline block style, then save
3. Note that the styles aren't generated and applied in the editor
4. Checkout this PR and reload the editor
5. The outline style should now be applied
6. With an admin user, navigate to Appearance > Editor > Styles > Blocks > Button > Outline. Apply a custom background color for this block style variation.
7. Save the global styles changes and switch back to the non-admin user in the Post Editor
8. Reload the editor again and the customization made in global styles should be applied as well.

##### Known Issue

This approach seems to have reintroduced an issue in the post editor where there is a delay in block style variation styles being applied. This was solved previously by adding preloaded paths for global styles when in the post editor context. I'm not sure what I'm missing this time around.

