### PR TITLE
Navigator: polish Storybook examples

### DIFF
--- a/packages/components/src/navigator/index.ts
+++ b/packages/components/src/navigator/index.ts
@@ -1,6 +1,6 @@
-export { NavigatorProvider } from './navigator-provider';
-export { NavigatorScreen } from './navigator-screen';
-export { NavigatorButton } from './navigator-button';
-export { NavigatorBackButton } from './navigator-back-button';
-export { NavigatorToParentButton } from './navigator-to-parent-button';
-export { default as useNavigator } from './use-navigator';
+export { NavigatorProvider } from './navigator-provider/component';
+export { NavigatorScreen } from './navigator-screen/component';
+export { NavigatorButton } from './navigator-button/component';
+export { NavigatorBackButton } from './navigator-back-button/component';
+export { NavigatorToParentButton } from './navigator-to-parent-button/component';
+export { useNavigator } from './use-navigator';

--- a/packages/components/src/navigator/navigator-back-button/hook.ts
+++ b/packages/components/src/navigator/navigator-back-button/hook.ts
@@ -9,7 +9,7 @@ import { useCallback } from '@wordpress/element';
 import type { WordPressComponentProps } from '../../context';
 import { useContextSystem } from '../../context';
 import Button from '../../button';
-import useNavigator from '../use-navigator';
+import { useNavigator } from '../use-navigator';
 import type { NavigatorBackButtonProps } from '../types';
 
 export function useNavigatorBackButton(

--- a/packages/components/src/navigator/navigator-back-button/index.ts
+++ b/packages/components/src/navigator/navigator-back-button/index.ts
@@ -1,1 +1,0 @@
-export { default as NavigatorBackButton } from './component';

--- a/packages/components/src/navigator/navigator-button/hook.ts
+++ b/packages/components/src/navigator/navigator-button/hook.ts
@@ -10,7 +10,7 @@ import { escapeAttribute } from '@wordpress/escape-html';
 import type { WordPressComponentProps } from '../../context';
 import { useContextSystem } from '../../context';
 import Button from '../../button';
-import useNavigator from '../use-navigator';
+import { useNavigator } from '../use-navigator';
 import type { NavigatorButtonProps } from '../types';
 
 const cssSelectorForAttribute = ( attrName: string, attrValue: string ) =>

--- a/packages/components/src/navigator/navigator-button/index.ts
+++ b/packages/components/src/navigator/navigator-button/index.ts
@@ -1,1 +1,0 @@
-export { default as NavigatorButton } from './component';

--- a/packages/components/src/navigator/navigator-provider/index.ts
+++ b/packages/components/src/navigator/navigator-provider/index.ts
@@ -1,1 +1,0 @@
-export { default as NavigatorProvider } from './component';

--- a/packages/components/src/navigator/navigator-screen/index.ts
+++ b/packages/components/src/navigator/navigator-screen/index.ts
@@ -1,1 +1,0 @@
-export { default as NavigatorScreen } from './component';

--- a/packages/components/src/navigator/navigator-to-parent-button/component.tsx
+++ b/packages/components/src/navigator/navigator-to-parent-button/component.tsx
@@ -6,7 +6,7 @@ import deprecated from '@wordpress/deprecated';
 /**
  * Internal dependencies
  */
-import { NavigatorBackButton } from '../navigator-back-button';
+import { NavigatorBackButton } from '../navigator-back-button/component';
 import type { WordPressComponentProps } from '../../context';
 import { contextConnect } from '../../context';
 import type { NavigatorBackButtonProps } from '../types';

--- a/packages/components/src/navigator/navigator-to-parent-button/index.ts
+++ b/packages/components/src/navigator/navigator-to-parent-button/index.ts
@@ -1,1 +1,0 @@
-export { default as NavigatorToParentButton } from './component';

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -10,6 +10,7 @@ import Button from '../../button';
 import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { VStack } from '../../v-stack';
 import Dropdown from '../../dropdown';
+import MenuItem from '../../menu-item';
 import {
 	NavigatorProvider,
 	NavigatorScreen,
@@ -79,10 +80,6 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 									renderToggle={ ( {
 										isOpen,
 										onToggle,
-									}: {
-										// TODO: remove once `Dropdown` is refactored to TypeScript
-										isOpen: boolean;
-										onToggle: () => void;
 									} ) => (
 										<Button
 											onClick={ onToggle }
@@ -93,15 +90,15 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 										</Button>
 									) }
 									renderContent={ () => (
-										<Card>
-											<CardHeader>Go</CardHeader>
-											<CardBody>Stuff</CardBody>
-										</Card>
 									) }
 								/>
 							</VStack>
 						</CardBody>
 					</Card>
+								<>
+									<MenuItem>Item 2</MenuItem>
+									<MenuItem>Item 1</MenuItem>
+								</>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/child">

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -7,7 +7,6 @@ import type { Meta, StoryObj } from '@storybook/react';
  * Internal dependencies
  */
 import Button from '../../button';
-import { Card, CardBody, CardFooter, CardHeader } from '../../card';
 import { VStack } from '../../v-stack';
 import Dropdown from '../../dropdown';
 import MenuItem from '../../menu-item';
@@ -43,138 +42,112 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 		children: (
 			<>
 				<NavigatorScreen path="/">
-					<Card>
-						<CardBody>
-							<p>This is the home screen.</p>
+					<p>This is the home screen.</p>
 
-							<VStack alignment="left">
-								<NavigatorButton
-									variant="secondary"
-									path="/child"
+					<VStack alignment="left">
+						<NavigatorButton variant="secondary" path="/child">
+							Navigate to child screen.
+						</NavigatorButton>
+
+						<NavigatorButton
+							variant="secondary"
+							path="/overflow-child"
+						>
+							Navigate to screen with horizontal overflow.
+						</NavigatorButton>
+
+						<NavigatorButton variant="secondary" path="/stickies">
+							Navigate to screen with sticky content.
+						</NavigatorButton>
+
+						<NavigatorButton variant="secondary" path="/product/1">
+							Navigate to product screen with id 1.
+						</NavigatorButton>
+
+						<Dropdown
+							renderToggle={ ( { isOpen, onToggle } ) => (
+								<Button
+									onClick={ onToggle }
+									aria-expanded={ isOpen }
+									variant="primary"
 								>
-									Navigate to child screen.
-								</NavigatorButton>
-
-								<NavigatorButton
-									variant="secondary"
-									path="/overflow-child"
-								>
-									Navigate to screen with horizontal overflow.
-								</NavigatorButton>
-
-								<NavigatorButton
-									variant="secondary"
-									path="/stickies"
-								>
-									Navigate to screen with sticky content.
-								</NavigatorButton>
-
-								<NavigatorButton
-									variant="secondary"
-									path="/product/1"
-								>
-									Navigate to product screen with id 1.
-								</NavigatorButton>
-
-								<Dropdown
-									renderToggle={ ( {
-										isOpen,
-										onToggle,
-									} ) => (
-										<Button
-											onClick={ onToggle }
-											aria-expanded={ isOpen }
-											variant="primary"
-										>
-											Open test dialog
-										</Button>
-									) }
-									renderContent={ () => (
-									) }
-								/>
-							</VStack>
-						</CardBody>
-					</Card>
+									Open test dialog
+								</Button>
+							) }
+							renderContent={ () => (
 								<>
 									<MenuItem>Item 2</MenuItem>
 									<MenuItem>Item 1</MenuItem>
 								</>
+							) }
+						/>
+					</VStack>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/child">
-					<Card>
-						<CardBody>
-							<p>This is the child screen.</p>
-							<NavigatorBackButton variant="secondary">
-								Go back
-							</NavigatorBackButton>
-						</CardBody>
-					</Card>
+					<p>This is the child screen.</p>
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/overflow-child">
-					<Card>
-						<CardBody>
-							<NavigatorBackButton variant="secondary">
-								Go back
-							</NavigatorBackButton>
-							<div
-								style={ {
-									display: 'inline-block',
-									background: 'papayawhip',
-								} }
-							>
-								<span
-									style={ {
-										color: 'palevioletred',
-										whiteSpace: 'nowrap',
-										fontSize: '42vw',
-									} }
-								>
-									¯\_(ツ)_/¯
-								</span>
-							</div>
-						</CardBody>
-					</Card>
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
+					<div
+						style={ {
+							display: 'inline-block',
+							background: 'papayawhip',
+						} }
+					>
+						<span
+							style={ {
+								color: 'palevioletred',
+								whiteSpace: 'nowrap',
+								fontSize: '42vw',
+							} }
+						>
+							¯\_(ツ)_/¯
+						</span>
+					</div>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/stickies">
-					<Card>
-						<CardHeader style={ getStickyStyles( { zIndex: 2 } ) }>
-							<NavigatorBackButton variant="secondary">
-								Go back
-							</NavigatorBackButton>
-						</CardHeader>
-						<CardBody>
-							<div
-								style={ getStickyStyles( {
-									top: 69,
-									bgColor: 'peachpuff',
-								} ) }
-							>
-								<h2>A wild sticky element appears</h2>
-							</div>
-							<MetaphorIpsum quantity={ 3 } />
-						</CardBody>
-						<CardBody>
-							<div
-								style={ getStickyStyles( {
-									top: 69,
-									bgColor: 'paleturquoise',
-								} ) }
-							>
-								<h2>Another wild sticky element appears</h2>
-							</div>
-							<MetaphorIpsum quantity={ 3 } />
-						</CardBody>
-						<CardFooter
+					<div style={ getStickyStyles( { zIndex: 2 } ) }>
+						<NavigatorBackButton variant="secondary">
+							Go back
+						</NavigatorBackButton>
+					</div>
+					<div>
+						<div
 							style={ getStickyStyles( {
-								bgColor: 'mistyrose',
+								top: 69,
+								bgColor: 'peachpuff',
 							} ) }
 						>
-							<Button variant="primary">Primary noop</Button>
-						</CardFooter>
-					</Card>
+							<h2>A wild sticky element appears</h2>
+						</div>
+					</div>
+					<div>
+						<MetaphorIpsum quantity={ 3 } />
+						<div
+							style={ getStickyStyles( {
+								top: 69,
+								bgColor: 'paleturquoise',
+							} ) }
+						>
+							<h2>Another wild sticky element appears</h2>
+						</div>
+						<MetaphorIpsum quantity={ 3 } />
+					</div>
+					<div
+						style={ getStickyStyles( {
+							bgColor: 'mistyrose',
+						} ) }
+					>
+						<Button variant="primary">Primary noop</Button>
+					</div>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/product/:id">
@@ -223,14 +196,12 @@ function ProductDetails() {
 	const { params } = useNavigator();
 
 	return (
-		<Card>
-			<CardBody>
-				<NavigatorBackButton variant="secondary">
-					Go back
-				</NavigatorBackButton>
-				<p>This is the screen for the product with id: { params.id }</p>
-			</CardBody>
-		</Card>
+		<div>
+			<NavigatorBackButton variant="secondary">
+				Go back
+			</NavigatorBackButton>
+			<p>This is the screen for the product with id: { params.id }</p>
+		</div>
 	);
 }
 
@@ -242,52 +213,36 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 		children: (
 			<>
 				<NavigatorScreen path="/">
-					<Card>
-						<CardBody>
-							<NavigatorButton variant="secondary" path="/child1">
-								Go to first child.
-							</NavigatorButton>
-							<NavigatorButton variant="secondary" path="/child2">
-								Go to second child.
-							</NavigatorButton>
-						</CardBody>
-					</Card>
+					<NavigatorButton variant="secondary" path="/child1">
+						Go to first child.
+					</NavigatorButton>
+					<NavigatorButton variant="secondary" path="/child2">
+						Go to second child.
+					</NavigatorButton>
 				</NavigatorScreen>
 				<NavigatorScreen path="/child1">
-					<Card>
-						<CardBody>
-							This is the first child
-							<NavigatorBackButton variant="secondary">
-								Go back to parent
-							</NavigatorBackButton>
-						</CardBody>
-					</Card>
+					This is the first child
+					<NavigatorBackButton variant="secondary">
+						Go back to parent
+					</NavigatorBackButton>
 				</NavigatorScreen>
 				<NavigatorScreen path="/child2">
-					<Card>
-						<CardBody>
-							This is the second child
-							<NavigatorBackButton variant="secondary">
-								Go back to parent
-							</NavigatorBackButton>
-							<NavigatorButton
-								variant="secondary"
-								path="/child2/grandchild"
-							>
-								Go to grand child.
-							</NavigatorButton>
-						</CardBody>
-					</Card>
+					This is the second child
+					<NavigatorBackButton variant="secondary">
+						Go back to parent
+					</NavigatorBackButton>
+					<NavigatorButton
+						variant="secondary"
+						path="/child2/grandchild"
+					>
+						Go to grand child.
+					</NavigatorButton>
 				</NavigatorScreen>
 				<NavigatorScreen path="/child2/grandchild">
-					<Card>
-						<CardBody>
-							This is the grand child
-							<NavigatorBackButton variant="secondary">
-								Go back to parent
-							</NavigatorBackButton>
-						</CardBody>
-					</Card>
+					This is the grand child
+					<NavigatorBackButton variant="secondary">
+						Go back to parent
+					</NavigatorBackButton>
 				</NavigatorScreen>
 			</>
 		),

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -306,7 +306,9 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 				<div
 					style={ {
 						height: 250,
-						border: '1px solid black',
+						outline: '1px solid black',
+						outlineOffset: '-1px',
+						marginBlockEnd: '1rem',
 					} }
 				>
 					<StyledNavigatorScreen
@@ -333,11 +335,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 					</StyledNavigatorScreen>
 				</div>
 
-				<NavigatorButtonWithSkipFocus
-					variant="secondary"
-					path="/child"
-					style={ { margin: '1rem 2rem' } }
-				>
+				<NavigatorButtonWithSkipFocus variant="secondary" path="/child">
 					Go to child screen, but keep focus on this button
 				</NavigatorButtonWithSkipFocus>
 			</>

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -150,9 +150,9 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 						>
 							<h2>A wild sticky element appears</h2>
 						</div>
+						<MetaphorIpsum quantity={ 3 } />
 					</div>
 					<div style={ { padding: '1rem' } }>
-						<MetaphorIpsum quantity={ 3 } />
 						<div
 							style={ getStickyStyles( {
 								top: 68,

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -73,6 +73,10 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 							Navigate to product screen with id 1.
 						</NavigatorButton>
 
+						<NavigatorButton variant="secondary" path="/product/14">
+							Navigate to product screen with id 14.
+						</NavigatorButton>
+
 						<Dropdown
 							renderToggle={ ( { isOpen, onToggle } ) => (
 								<Button

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -47,7 +47,7 @@ const StyledNavigatorScreen = (
 export const Default: StoryObj< typeof NavigatorProvider > = {
 	args: {
 		initialPath: '/',
-		style: { height: '100vh', maxHeight: '450px' },
+		style: { height: 'calc(100vh - 2rem)' }, // take storybook's padding into account
 		children: (
 			<>
 				<StyledNavigatorScreen path="/">

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -35,13 +35,22 @@ const meta: Meta< typeof NavigatorProvider > = {
 };
 export default meta;
 
+const StyledNavigatorScreen = (
+	props: React.ComponentProps< typeof NavigatorScreen >
+) => (
+	<NavigatorScreen
+		{ ...props }
+		style={ { paddingInline: '8px', height: '100%', ...props.style } }
+	/>
+);
+
 export const Default: StoryObj< typeof NavigatorProvider > = {
 	args: {
 		initialPath: '/',
 		style: { height: '100vh', maxHeight: '450px' },
 		children: (
 			<>
-				<NavigatorScreen path="/">
+				<StyledNavigatorScreen path="/">
 					<p>This is the home screen.</p>
 
 					<VStack alignment="left">
@@ -82,16 +91,16 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 							) }
 						/>
 					</VStack>
-				</NavigatorScreen>
+				</StyledNavigatorScreen>
 
-				<NavigatorScreen path="/child">
+				<StyledNavigatorScreen path="/child">
 					<p>This is the child screen.</p>
 					<NavigatorBackButton variant="secondary">
 						Go back
 					</NavigatorBackButton>
-				</NavigatorScreen>
+				</StyledNavigatorScreen>
 
-				<NavigatorScreen path="/overflow-child">
+				<StyledNavigatorScreen path="/overflow-child">
 					<NavigatorBackButton variant="secondary">
 						Go back
 					</NavigatorBackButton>
@@ -111,9 +120,9 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 							¯\_(ツ)_/¯
 						</span>
 					</div>
-				</NavigatorScreen>
+				</StyledNavigatorScreen>
 
-				<NavigatorScreen path="/stickies">
+				<StyledNavigatorScreen path="/stickies">
 					<div
 						style={ {
 							...getStickyStyles( {
@@ -158,11 +167,11 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 					>
 						<Button variant="primary">Primary noop</Button>
 					</div>
-				</NavigatorScreen>
+				</StyledNavigatorScreen>
 
-				<NavigatorScreen path="/product/:id">
+				<StyledNavigatorScreen path="/product/:id">
 					<ProductDetails />
-				</NavigatorScreen>
+				</StyledNavigatorScreen>
 			</>
 		),
 	},
@@ -222,21 +231,21 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 		initialPath: '/child2/grandchild',
 		children: (
 			<>
-				<NavigatorScreen path="/">
+				<StyledNavigatorScreen path="/">
 					<NavigatorButton variant="secondary" path="/child1">
 						Go to first child.
 					</NavigatorButton>
 					<NavigatorButton variant="secondary" path="/child2">
 						Go to second child.
 					</NavigatorButton>
-				</NavigatorScreen>
-				<NavigatorScreen path="/child1">
+				</StyledNavigatorScreen>
+				<StyledNavigatorScreen path="/child1">
 					This is the first child
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
-				</NavigatorScreen>
-				<NavigatorScreen path="/child2">
+				</StyledNavigatorScreen>
+				<StyledNavigatorScreen path="/child2">
 					This is the second child
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
@@ -247,13 +256,13 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 					>
 						Go to grand child.
 					</NavigatorButton>
-				</NavigatorScreen>
-				<NavigatorScreen path="/child2/grandchild">
+				</StyledNavigatorScreen>
+				<StyledNavigatorScreen path="/child2/grandchild">
 					This is the grand child
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
-				</NavigatorScreen>
+				</StyledNavigatorScreen>
 			</>
 		),
 	},
@@ -288,7 +297,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 						border: '1px solid black',
 					} }
 				>
-					<NavigatorScreen
+					<StyledNavigatorScreen
 						path="/"
 						style={ {
 							height: '100%',
@@ -298,8 +307,8 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 						<NavigatorButton variant="secondary" path="/child">
 							Go to child screen.
 						</NavigatorButton>
-					</NavigatorScreen>
-					<NavigatorScreen
+					</StyledNavigatorScreen>
+					<StyledNavigatorScreen
 						path="/child"
 						style={ {
 							height: '100%',
@@ -309,7 +318,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 						<NavigatorBackButton variant="secondary">
 							Go to parent screen.
 						</NavigatorBackButton>
-					</NavigatorScreen>
+					</StyledNavigatorScreen>
 				</div>
 
 				<NavigatorButtonWithSkipFocus

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -8,8 +8,6 @@ import type { Meta, StoryObj } from '@storybook/react';
  */
 import Button from '../../button';
 import { VStack } from '../../v-stack';
-import Dropdown from '../../dropdown';
-import MenuItem from '../../menu-item';
 import {
 	NavigatorProvider,
 	NavigatorScreen,
@@ -17,6 +15,7 @@ import {
 	NavigatorBackButton,
 	useNavigator,
 } from '..';
+import { HStack } from '../../h-stack';
 
 const meta: Meta< typeof NavigatorProvider > = {
 	component: NavigatorProvider,
@@ -65,229 +64,73 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 					<h2>This is the home screen.</h2>
 
 					<VStack alignment="left">
-						<NavigatorButton variant="secondary" path="/child">
-							Navigate to child screen.
+						<NavigatorButton variant="primary" path="/child">
+							Go to child screen.
 						</NavigatorButton>
 
-						<NavigatorButton
-							variant="secondary"
-							path="/overflow-child"
-						>
-							Navigate to screen with overflowing content
+						<NavigatorButton variant="primary" path="/product/1">
+							Go to dynamic path screen with id 1.
 						</NavigatorButton>
 
-						<NavigatorButton variant="secondary" path="/stickies">
-							Navigate to screen with sticky content.
+						<NavigatorButton variant="primary" path="/product/2">
+							Go to dynamic path screen with id 2.
 						</NavigatorButton>
-
-						<NavigatorButton variant="secondary" path="/product/1">
-							Navigate to product screen with id 1.
-						</NavigatorButton>
-
-						<NavigatorButton variant="secondary" path="/product/14">
-							Navigate to product screen with id 14.
-						</NavigatorButton>
-
-						<Dropdown
-							renderToggle={ ( { isOpen, onToggle } ) => (
-								<Button
-									onClick={ onToggle }
-									aria-expanded={ isOpen }
-									variant="primary"
-								>
-									Open test dialog
-								</Button>
-							) }
-							renderContent={ () => (
-								<>
-									<MenuItem>Item 2</MenuItem>
-									<MenuItem>Item 1</MenuItem>
-								</>
-							) }
-						/>
 					</VStack>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/child">
 					<h2>This is the child screen.</h2>
-					<NavigatorBackButton variant="secondary">
-						Go back
-					</NavigatorBackButton>
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/overflow-child">
-					<h2>This is a screen with overflowing content</h2>
-
-					<NavigatorBackButton variant="secondary">
-						Go back
-					</NavigatorBackButton>
-					<div
-						style={ {
-							display: 'inline-block',
-							background: 'papayawhip',
-						} }
-					>
-						<span
-							style={ {
-								color: 'palevioletred',
-								whiteSpace: 'nowrap',
-								fontSize: '42vw',
-							} }
-						>
-							¯\_(ツ)_/¯
-						</span>
-					</div>
-				</NavigatorScreen>
-
-				<NavigatorScreen path="/stickies" data-sticky>
-					<div
-						style={ {
-							...getStickyStyles( {
-								zIndex: 2,
-							} ),
-							padding: '1rem',
-						} }
-					>
+					<HStack spacing={ 2 } alignment="left">
 						<NavigatorBackButton variant="secondary">
 							Go back
 						</NavigatorBackButton>
-					</div>
-					<div style={ { padding: '1rem' } }>
-						<div
-							style={ getStickyStyles( {
-								top: 68,
-								bgColor: 'peachpuff',
-							} ) }
+
+						<NavigatorButton
+							variant="primary"
+							path="/child/grandchild"
 						>
-							<h2>A wild sticky element appears</h2>
-						</div>
-						<MetaphorIpsum quantity={ 3 } />
-					</div>
-					<div style={ { padding: '1rem' } }>
-						<div
-							style={ getStickyStyles( {
-								top: 68,
-								bgColor: 'paleturquoise',
-							} ) }
-						>
-							<h2>Another wild sticky element appears</h2>
-						</div>
-						<MetaphorIpsum quantity={ 3 } />
-					</div>
-					<div
-						style={ {
-							...getStickyStyles( {
-								bgColor: 'mistyrose',
-							} ),
-							padding: '1rem',
-						} }
-					>
-						<Button variant="primary">Primary noop</Button>
-					</div>
+							Go to grand child screen.
+						</NavigatorButton>
+					</HStack>
+				</NavigatorScreen>
+
+				<NavigatorScreen path="/child/grandchild">
+					<h2>This is the grand child screen.</h2>
+					<NavigatorBackButton variant="secondary">
+						Go back
+					</NavigatorBackButton>
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/product/:id">
-					<ProductDetails />
+					<DynamicScreen />
 				</NavigatorScreen>
 			</>
 		),
 	},
 };
 
-function getStickyStyles( {
-	bottom = 0,
-	bgColor = 'whitesmoke',
-	top = 0,
-	zIndex = 1,
-} ): React.CSSProperties {
-	return {
-		display: 'flex',
-		position: 'sticky',
-		top,
-		bottom,
-		zIndex,
-		backgroundColor: bgColor,
-	};
-}
+function DynamicScreen() {
+	const { params } = useNavigator();
 
-function MetaphorIpsum( { quantity }: { quantity: number } ) {
-	const list = [
-		'A loopy clarinet’s year comes with it the thought that the fenny step-son is an ophthalmologist. The literature would have us believe that a glabrate country is not but a rhythm. A beech is a rub from the right perspective. In ancient times few can name an unglossed walrus that isn’t an unspilt trial.',
-		'Authors often misinterpret the afterthought as a roseless mother-in-law, when in actuality it feels more like an uncapped thunderstorm. In recent years, some posit the tarry bottle to be less than acerb. They were lost without the unkissed timbale that composed their customer. A donna is a springtime breath.',
-		'It’s an undeniable fact, really; their museum was, in this moment, a snotty beef. The swordfishes could be said to resemble prowessed lasagnas. However, the rainier authority comes from a cureless soup. Unfortunately, that is wrong; on the contrary, the cover is a powder.',
-	];
-	quantity = Math.min( list.length, quantity );
 	return (
 		<>
-			{ list.slice( 0, quantity ).map( ( text, key ) => (
-				<p style={ { maxWidth: '20em' } } key={ key }>
-					{ text }
-				</p>
-			) ) }
+			<h2>This is the dynamic screen</h2>
+			<p>
+				This screen can parse params dynamically. The current id is:{ ' ' }
+				{ params.id }
+			</p>
+			<NavigatorBackButton variant="secondary">
+				Go back
+			</NavigatorBackButton>
 		</>
 	);
 }
 
-function ProductDetails() {
-	const { params } = useNavigator();
-
-	return (
-		<div>
-			<h2>This is the product details screen</h2>
-			<p>The current product id is: { params.id }</p>
-			<NavigatorBackButton variant="secondary">
-				Go back
-			</NavigatorBackButton>
-		</div>
-	);
-}
-
-export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
+export const WithNestedInitialPath: StoryObj< typeof NavigatorProvider > = {
 	...Default,
 	args: {
 		...Default.args,
-		initialPath: '/child2/grandchild',
-		children: (
-			<>
-				<NavigatorScreen path="/">
-					<h2>Home screen</h2>
-
-					<NavigatorButton variant="secondary" path="/child1">
-						Go to first child.
-					</NavigatorButton>
-					<NavigatorButton variant="secondary" path="/child2">
-						Go to second child.
-					</NavigatorButton>
-				</NavigatorScreen>
-				<NavigatorScreen path="/child1">
-					<h2>First child screen</h2>
-
-					<NavigatorBackButton variant="secondary">
-						Go back to parent
-					</NavigatorBackButton>
-				</NavigatorScreen>
-				<NavigatorScreen path="/child2">
-					<h2>Second child screen</h2>
-
-					<NavigatorBackButton variant="secondary">
-						Go back to parent
-					</NavigatorBackButton>
-					<NavigatorButton
-						variant="secondary"
-						path="/child2/grandchild"
-					>
-						Go to grand child.
-					</NavigatorButton>
-				</NavigatorScreen>
-				<NavigatorScreen path="/child2/grandchild">
-					<h2>Grand-child screen</h2>
-
-					<NavigatorBackButton variant="secondary">
-						Go back to parent
-					</NavigatorBackButton>
-				</NavigatorScreen>
-			</>
-		),
+		initialPath: '/child/grandchild',
 	},
 };
 
@@ -328,7 +171,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 				>
 					<NavigatorScreen path="/">
 						<h2>Home screen</h2>
-						<NavigatorButton variant="secondary" path="/child">
+						<NavigatorButton variant="primary" path="/child">
 							Go to child screen.
 						</NavigatorButton>
 					</NavigatorScreen>
@@ -336,12 +179,12 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 					<NavigatorScreen path="/child">
 						<h2>Child screen</h2>
 						<NavigatorBackButton variant="secondary">
-							Go to parent screen.
+							Go back to home screen
 						</NavigatorBackButton>
 					</NavigatorScreen>
 				</div>
 
-				<NavigatorButtonWithSkipFocus variant="secondary" path="/child">
+				<NavigatorButtonWithSkipFocus path="/child">
 					Go to child screen, but keep focus on this button
 				</NavigatorButtonWithSkipFocus>
 			</>

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -41,10 +41,11 @@ const meta: Meta< typeof NavigatorProvider > = {
 						  Navigator component. Do not use outside of its source code. */
 						[data-wp-component="NavigatorProvider"] {
 							height: calc(100vh - 2rem);
+							max-height: 250px;
+
 						}
-						[data-wp-component="NavigatorScreen"] {
-							padding-inline: 8px;
-							height: 100%;
+						[data-wp-component="NavigatorScreen"]:not([data-sticky]) {
+							padding: 8px;
 						}
 					` }</style>
 					<Story />
@@ -138,7 +139,7 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 					</div>
 				</NavigatorScreen>
 
-				<NavigatorScreen path="/stickies">
+				<NavigatorScreen path="/stickies" data-sticky>
 					<div
 						style={ {
 							...getStickyStyles( {
@@ -300,6 +301,10 @@ const NavigatorButtonWithSkipFocus = ( {
 	return (
 		<Button
 			{ ...props }
+			style={ {
+				marginInline: '8px',
+				...props.style,
+			} }
 			onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
 				goTo( path, { skipFocus: true } );
 				onClick?.( e );
@@ -315,29 +320,20 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 			<>
 				<div
 					style={ {
-						height: 250,
+						height: 150,
 						outline: '1px solid black',
 						outlineOffset: '-1px',
 						marginBlockEnd: '1rem',
 					} }
 				>
-					<NavigatorScreen
-						path="/"
-						style={ {
-							height: '100%',
-						} }
-					>
+					<NavigatorScreen path="/">
 						<h2>Home screen</h2>
 						<NavigatorButton variant="secondary" path="/child">
 							Go to child screen.
 						</NavigatorButton>
 					</NavigatorScreen>
-					<NavigatorScreen
-						path="/child"
-						style={ {
-							height: '100%',
-						} }
-					>
+
+					<NavigatorScreen path="/child">
 						<h2>Child screen</h2>
 						<NavigatorBackButton variant="secondary">
 							Go to parent screen.

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -32,25 +32,35 @@ const meta: Meta< typeof NavigatorProvider > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
+	decorators: [
+		( Story ) => {
+			return (
+				<>
+					<style>{ `
+					  /* These attributes are a private implementation detail of the
+						  Navigator component. Do not use outside of its source code. */
+						[data-wp-component="NavigatorProvider"] {
+							height: calc(100vh - 2rem);
+						}
+						[data-wp-component="NavigatorScreen"] {
+							padding-inline: 8px;
+							height: 100%;
+						}
+					` }</style>
+					<Story />
+				</>
+			);
+		},
+	],
 };
 export default meta;
-
-const StyledNavigatorScreen = (
-	props: React.ComponentProps< typeof NavigatorScreen >
-) => (
-	<NavigatorScreen
-		{ ...props }
-		style={ { paddingInline: '8px', height: '100%', ...props.style } }
-	/>
-);
 
 export const Default: StoryObj< typeof NavigatorProvider > = {
 	args: {
 		initialPath: '/',
-		style: { height: 'calc(100vh - 2rem)' }, // take storybook's padding into account
 		children: (
 			<>
-				<StyledNavigatorScreen path="/">
+				<NavigatorScreen path="/">
 					<h2>This is the home screen.</h2>
 
 					<VStack alignment="left">
@@ -95,16 +105,16 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 							) }
 						/>
 					</VStack>
-				</StyledNavigatorScreen>
+				</NavigatorScreen>
 
-				<StyledNavigatorScreen path="/child">
+				<NavigatorScreen path="/child">
 					<h2>This is the child screen.</h2>
 					<NavigatorBackButton variant="secondary">
 						Go back
 					</NavigatorBackButton>
-				</StyledNavigatorScreen>
+				</NavigatorScreen>
 
-				<StyledNavigatorScreen path="/overflow-child">
+				<NavigatorScreen path="/overflow-child">
 					<h2>This is a screen with overflowing content</h2>
 
 					<NavigatorBackButton variant="secondary">
@@ -126,9 +136,9 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 							¯\_(ツ)_/¯
 						</span>
 					</div>
-				</StyledNavigatorScreen>
+				</NavigatorScreen>
 
-				<StyledNavigatorScreen path="/stickies">
+				<NavigatorScreen path="/stickies">
 					<div
 						style={ {
 							...getStickyStyles( {
@@ -173,11 +183,11 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 					>
 						<Button variant="primary">Primary noop</Button>
 					</div>
-				</StyledNavigatorScreen>
+				</NavigatorScreen>
 
-				<StyledNavigatorScreen path="/product/:id">
+				<NavigatorScreen path="/product/:id">
 					<ProductDetails />
-				</StyledNavigatorScreen>
+				</NavigatorScreen>
 			</>
 		),
 	},
@@ -238,7 +248,7 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 		initialPath: '/child2/grandchild',
 		children: (
 			<>
-				<StyledNavigatorScreen path="/">
+				<NavigatorScreen path="/">
 					<h2>Home screen</h2>
 
 					<NavigatorButton variant="secondary" path="/child1">
@@ -247,15 +257,15 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 					<NavigatorButton variant="secondary" path="/child2">
 						Go to second child.
 					</NavigatorButton>
-				</StyledNavigatorScreen>
-				<StyledNavigatorScreen path="/child1">
+				</NavigatorScreen>
+				<NavigatorScreen path="/child1">
 					<h2>First child screen</h2>
 
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
-				</StyledNavigatorScreen>
-				<StyledNavigatorScreen path="/child2">
+				</NavigatorScreen>
+				<NavigatorScreen path="/child2">
 					<h2>Second child screen</h2>
 
 					<NavigatorBackButton variant="secondary">
@@ -267,14 +277,14 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 					>
 						Go to grand child.
 					</NavigatorButton>
-				</StyledNavigatorScreen>
-				<StyledNavigatorScreen path="/child2/grandchild">
+				</NavigatorScreen>
+				<NavigatorScreen path="/child2/grandchild">
 					<h2>Grand-child screen</h2>
 
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
-				</StyledNavigatorScreen>
+				</NavigatorScreen>
 			</>
 		),
 	},
@@ -311,7 +321,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 						marginBlockEnd: '1rem',
 					} }
 				>
-					<StyledNavigatorScreen
+					<NavigatorScreen
 						path="/"
 						style={ {
 							height: '100%',
@@ -321,8 +331,8 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 						<NavigatorButton variant="secondary" path="/child">
 							Go to child screen.
 						</NavigatorButton>
-					</StyledNavigatorScreen>
-					<StyledNavigatorScreen
+					</NavigatorScreen>
+					<NavigatorScreen
 						path="/child"
 						style={ {
 							height: '100%',
@@ -332,7 +342,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 						<NavigatorBackButton variant="secondary">
 							Go to parent screen.
 						</NavigatorBackButton>
-					</StyledNavigatorScreen>
+					</NavigatorScreen>
 				</div>
 
 				<NavigatorButtonWithSkipFocus variant="secondary" path="/child">

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -114,26 +114,33 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 				</NavigatorScreen>
 
 				<NavigatorScreen path="/stickies">
-					<div style={ getStickyStyles( { zIndex: 2 } ) }>
+					<div
+						style={ {
+							...getStickyStyles( {
+								zIndex: 2,
+							} ),
+							padding: '1rem',
+						} }
+					>
 						<NavigatorBackButton variant="secondary">
 							Go back
 						</NavigatorBackButton>
 					</div>
-					<div>
+					<div style={ { padding: '1rem' } }>
 						<div
 							style={ getStickyStyles( {
-								top: 69,
+								top: 68,
 								bgColor: 'peachpuff',
 							} ) }
 						>
 							<h2>A wild sticky element appears</h2>
 						</div>
 					</div>
-					<div>
+					<div style={ { padding: '1rem' } }>
 						<MetaphorIpsum quantity={ 3 } />
 						<div
 							style={ getStickyStyles( {
-								top: 69,
+								top: 68,
 								bgColor: 'paleturquoise',
 							} ) }
 						>
@@ -142,9 +149,12 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 						<MetaphorIpsum quantity={ 3 } />
 					</div>
 					<div
-						style={ getStickyStyles( {
-							bgColor: 'mistyrose',
-						} ) }
+						style={ {
+							...getStickyStyles( {
+								bgColor: 'mistyrose',
+							} ),
+							padding: '1rem',
+						} }
 					>
 						<Button variant="primary">Primary noop</Button>
 					</div>

--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -51,7 +51,7 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 		children: (
 			<>
 				<StyledNavigatorScreen path="/">
-					<p>This is the home screen.</p>
+					<h2>This is the home screen.</h2>
 
 					<VStack alignment="left">
 						<NavigatorButton variant="secondary" path="/child">
@@ -62,7 +62,7 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 							variant="secondary"
 							path="/overflow-child"
 						>
-							Navigate to screen with horizontal overflow.
+							Navigate to screen with overflowing content
 						</NavigatorButton>
 
 						<NavigatorButton variant="secondary" path="/stickies">
@@ -94,13 +94,15 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 				</StyledNavigatorScreen>
 
 				<StyledNavigatorScreen path="/child">
-					<p>This is the child screen.</p>
+					<h2>This is the child screen.</h2>
 					<NavigatorBackButton variant="secondary">
 						Go back
 					</NavigatorBackButton>
 				</StyledNavigatorScreen>
 
 				<StyledNavigatorScreen path="/overflow-child">
+					<h2>This is a screen with overflowing content</h2>
+
 					<NavigatorBackButton variant="secondary">
 						Go back
 					</NavigatorBackButton>
@@ -216,10 +218,11 @@ function ProductDetails() {
 
 	return (
 		<div>
+			<h2>This is the product details screen</h2>
+			<p>The current product id is: { params.id }</p>
 			<NavigatorBackButton variant="secondary">
 				Go back
 			</NavigatorBackButton>
-			<p>This is the screen for the product with id: { params.id }</p>
 		</div>
 	);
 }
@@ -232,6 +235,8 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 		children: (
 			<>
 				<StyledNavigatorScreen path="/">
+					<h2>Home screen</h2>
+
 					<NavigatorButton variant="secondary" path="/child1">
 						Go to first child.
 					</NavigatorButton>
@@ -240,13 +245,15 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 					</NavigatorButton>
 				</StyledNavigatorScreen>
 				<StyledNavigatorScreen path="/child1">
-					This is the first child
+					<h2>First child screen</h2>
+
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
 				</StyledNavigatorScreen>
 				<StyledNavigatorScreen path="/child2">
-					This is the second child
+					<h2>Second child screen</h2>
+
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
@@ -258,7 +265,8 @@ export const NestedNavigator: StoryObj< typeof NavigatorProvider > = {
 					</NavigatorButton>
 				</StyledNavigatorScreen>
 				<StyledNavigatorScreen path="/child2/grandchild">
-					This is the grand child
+					<h2>Grand-child screen</h2>
+
 					<NavigatorBackButton variant="secondary">
 						Go back to parent
 					</NavigatorBackButton>
@@ -303,7 +311,7 @@ export const SkipFocus: StoryObj< typeof NavigatorProvider > = {
 							height: '100%',
 						} }
 					>
-						<h1>Home screen</h1>
+						<h2>Home screen</h2>
 						<NavigatorButton variant="secondary" path="/child">
 							Go to child screen.
 						</NavigatorButton>

--- a/packages/components/src/navigator/use-navigator.ts
+++ b/packages/components/src/navigator/use-navigator.ts
@@ -12,7 +12,7 @@ import type { Navigator } from './types';
 /**
  * Retrieves a `navigator` instance.
  */
-function useNavigator(): Navigator {
+export function useNavigator(): Navigator {
 	const { location, params, goTo, goBack, goToParent } =
 		useContext( NavigatorContext );
 
@@ -24,5 +24,3 @@ function useNavigator(): Navigator {
 		params,
 	};
 }
-
-export default useNavigator;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #59418
Extracted from #64777

While working on a few `Navigator`-related PRs, I accumulated a few small tweaks and improvements to the Storybook files.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Mostly small tweaks that don't dramatically change how the Storybook examples work and look, but iteratively improve the code quality and the examples' usefulness and sense of polish.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- better spacing, no "cutoff" overflowing styles
- removed `Card` components (they are not required to show how `Navigator` works)
- better clarity, typography, and semantics of screen titles
- cleaned up some outdated code

I also removed the intermediary `index.ts` files, since [I found out](https://github.com/WordPress/gutenberg/pull/64613#discussion_r1725316681) that the lack of `.tsx` extension can interfere with Storybook's docgen.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load Storybook
- Make sure that the examples continue to work as expected
