### PR TITLE
TimePicker: use ToggleGroupControl for AM/PM toggle

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,6 @@
 ### Enhancements
 
 -   `ColorPicker`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
--   `TimePicker`: use ToggleGroupControl for AM/PM toggle ([#64800](https://github.com/WordPress/gutenberg/pull/64800)).
 -   `CustomSelectControl V2`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
 -   `DateTime`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
 -   `FormToggle`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
@@ -42,6 +41,10 @@
     -   `TimePicker` (on the inputs)
     -   `TreeSelect`
     -   `UnitControl`
+
+### Bug Fixes
+
+-   `TimePicker`: use ToggleGroupControl for AM/PM toggle ([#64800](https://github.com/WordPress/gutenberg/pull/64800)).
 
 ### Internal
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Enhancements
 
 -   `ColorPicker`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
+-   `TimePicker`: use ToggleGroupControl for AM/PM toggle ([#64800](https://github.com/WordPress/gutenberg/pull/64800)).
 -   `CustomSelectControl V2`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
 -   `DateTime`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).
 -   `FormToggle`: Adopt radius scale ([#64693](https://github.com/WordPress/gutenberg/pull/64693)).

--- a/packages/components/src/date-time/time/test/index.tsx
+++ b/packages/components/src/date-time/time/test/index.tsx
@@ -281,12 +281,9 @@ describe( 'TimePicker', () => {
 		expect(
 			( screen.getByLabelText( 'Minutes' ) as HTMLInputElement ).value
 		).toBe( '00' );
-		/**
-		 * This is not ideal, but best of we can do for now until we refactor
-		 * AM/PM into accessible elements, like radio buttons.
-		 */
-		expect( screen.getByText( 'AM' ) ).not.toHaveClass( 'is-primary' );
-		expect( screen.getByText( 'PM' ) ).toHaveClass( 'is-primary' );
+
+		expect( screen.getByRole( 'radio', { name: 'AM' } ) ).not.toBeChecked();
+		expect( screen.getByRole( 'radio', { name: 'PM' } ) ).toBeChecked();
 	} );
 
 	it( 'should have different layouts/orders for 12/24 hour formats', () => {

--- a/packages/components/src/date-time/time/time-input/index.tsx
+++ b/packages/components/src/date-time/time/time-input/index.tsx
@@ -167,7 +167,6 @@ export function TimeInput( {
 				</TimeWrapper>
 				{ is12Hour && (
 					<ToggleGroupControl
-						className="components-datetime__time-field components-datetime__time-field-am-pm" // Unused, for backwards compatibility.
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
 						isBlock
@@ -181,12 +180,10 @@ export function TimeInput( {
 						} }
 					>
 						<ToggleGroupControlOption
-							className="components-datetime__time-am-button" // Unused, for backwards compatibility.
 							value="AM"
 							label={ __( 'AM' ) }
 						/>
 						<ToggleGroupControlOption
-							className="components-datetime__time-pm-button" // Unused, for backwards compatibility.
 							value="PM"
 							label={ __( 'PM' ) }
 						/>

--- a/packages/components/src/date-time/time/time-input/index.tsx
+++ b/packages/components/src/date-time/time/time-input/index.tsx
@@ -20,8 +20,6 @@ import {
 	Fieldset,
 } from '../styles';
 import { HStack } from '../../../h-stack';
-import Button from '../../../button';
-import ButtonGroup from '../../../button-group';
 import {
 	from12hTo24h,
 	from24hTo12h,
@@ -32,6 +30,10 @@ import type { TimeInputProps } from '../../types';
 import type { InputChangeCallback } from '../../../input-control/types';
 import { useControlledValue } from '../../../utils';
 import BaseControl from '../../../base-control';
+import {
+	ToggleGroupControl,
+	ToggleGroupControlOption,
+} from '../../../toggle-group-control';
 
 export function TimeInput( {
 	value: valueProp,
@@ -164,30 +166,31 @@ export function TimeInput( {
 					/>
 				</TimeWrapper>
 				{ is12Hour && (
-					<ButtonGroup
+					<ToggleGroupControl
 						className="components-datetime__time-field components-datetime__time-field-am-pm" // Unused, for backwards compatibility.
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Select AM or PM' ) }
+						hideLabelFromVision
+						value={ dayPeriod }
+						onChange={ ( newValue ) => {
+							buildAmPmChangeCallback(
+								newValue as 'AM' | 'PM'
+							)();
+						} }
 					>
-						<Button
+						<ToggleGroupControlOption
 							className="components-datetime__time-am-button" // Unused, for backwards compatibility.
-							variant={
-								dayPeriod === 'AM' ? 'primary' : 'secondary'
-							}
-							__next40pxDefaultSize
-							onClick={ buildAmPmChangeCallback( 'AM' ) }
-						>
-							{ __( 'AM' ) }
-						</Button>
-						<Button
+							value="AM"
+							label={ __( 'AM' ) }
+						/>
+						<ToggleGroupControlOption
 							className="components-datetime__time-pm-button" // Unused, for backwards compatibility.
-							variant={
-								dayPeriod === 'PM' ? 'primary' : 'secondary'
-							}
-							__next40pxDefaultSize
-							onClick={ buildAmPmChangeCallback( 'PM' ) }
-						>
-							{ __( 'PM' ) }
-						</Button>
-					</ButtonGroup>
+							value="PM"
+							label={ __( 'PM' ) }
+						/>
+					</ToggleGroupControl>
 				) }
 			</HStack>
 		</Wrapper>

--- a/packages/components/src/date-time/time/time-input/test/index.tsx
+++ b/packages/components/src/date-time/time/time-input/test/index.tsx
@@ -80,12 +80,11 @@ describe( 'TimeInput', () => {
 		const minutesInput = screen.getByRole( 'spinbutton', {
 			name: 'Minutes',
 		} );
-		const amButton = screen.getByRole( 'button', { name: 'AM' } );
-		const pmButton = screen.getByRole( 'button', { name: 'PM' } );
+		const amButton = screen.getByRole( 'radio', { name: 'AM' } );
+		const pmButton = screen.getByRole( 'radio', { name: 'PM' } );
 
-		// TODO: Update assert these states through the accessibility tree rather than through styles, see: https://github.com/WordPress/gutenberg/issues/61163
-		expect( amButton ).toHaveClass( 'is-primary' );
-		expect( pmButton ).not.toHaveClass( 'is-primary' );
+		expect( amButton ).toBeChecked();
+		expect( pmButton ).not.toBeChecked();
 		expect( hoursInput ).not.toHaveValue( 0 );
 		expect( hoursInput ).toHaveValue( 12 );
 
@@ -94,7 +93,7 @@ describe( 'TimeInput', () => {
 		await user.keyboard( '{Tab}' );
 
 		expect( onChangeSpy ).toHaveBeenCalledWith( { hours: 0, minutes: 35 } );
-		expect( amButton ).toHaveClass( 'is-primary' );
+		expect( amButton ).toBeChecked();
 
 		await user.clear( hoursInput );
 		await user.type( hoursInput, '12' );
@@ -107,7 +106,7 @@ describe( 'TimeInput', () => {
 			hours: 12,
 			minutes: 35,
 		} );
-		expect( pmButton ).toHaveClass( 'is-primary' );
+		expect( pmButton ).toBeChecked();
 	} );
 
 	it( 'should call onChange with defined minutes steps', async () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #61163

Use `ToggleGroupControl` in `TimePicker` instead of button

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For better semantics and screen readers support (`ToggleGroupControl` implements `radio` semantics)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- swap out `ButtonGroup` and `Button` for `ToggleGroupControl` and `ToggleGroupControlOption`;
- use the `onChange` callback instead of `onClick` handlers
- update tests to reflect the new semantics

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Test component both in Storybook and in the editor (for example, by setting a future publishing date for a post)
- Make sure that the AM/PM toggle is shown (that happens if the `is12Hour` prop is `true`)
- Make sure that the datetime is updated correctly as the toggle is interacted with (including first load)
- Make sure that the new version of the toggle implements radio semantics correctly and is accessible for screen reader users

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-08-26 at 15 24 49](https://github.com/user-attachments/assets/6b57fffb-37b4-4605-b5db-fa54a7e2708c) | ![Screenshot 2024-08-26 at 15 25 04](https://github.com/user-attachments/assets/ceacd90e-a13d-48ff-a085-99a8895047b3) |


