### PR TITLE
Fixes the default fluid value on the UI based on the global typography fluid value.

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -44,14 +44,17 @@ function FontSize() {
 		'typography.fontSizes'
 	);
 
+	const [ globalFluid ] = useGlobalSetting( 'typography.fluid' );
+
 	// Get the font sizes from the origin, default to empty array.
 	const sizes = fontSizes[ origin ] ?? [];
 
 	// Get the font size by slug.
 	const fontSize = sizes.find( ( size ) => size.slug === slug );
 
-	// Whether fluid is true or an object, set it to true, otherwise false.
-	const isFluid = !! fontSize.fluid ?? false;
+	// Whether the font size is fluid. If not defined, use the global fluid value of the theme.
+	const isFluid =
+		fontSize.fluid !== undefined ? !! fontSize.fluid : globalFluid;
 
 	// Whether custom fluid values are used.
 	const isCustomFluid = typeof fontSize.fluid === 'object';


### PR DESCRIPTION
## What?
Fixes the default fluid value on the UI based on the global typography fluid value.

## Why?
This PR makes the UI consistent with the default behavior of the fluid typography settings. If the global fluid setting `settings.typography.fluid` is defined as `true,` all the font size presets are rendered as fluid despite not being set as `fluid` explicitly. This PR reflects that in the UI. 

Fixes: https://github.com/WordPress/gutenberg/issues/64765

## How?
Considers the global fluid typography option to render and display the control correctly.



## Testing Instructions
1. Use a theme.json like this:
```json
{
	"settings": {
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"name": "Theme font size 1",
					"size": "30px",
					"slug": "theme-1"
				}
			]
		}
	},
	"version": 3,
	"$schema": "https://schemas.wp.org/trunk/theme.json"
}
```
2. With this PR enabled, the `fluid` control should be rendered as true, and without this PR, it should render (incorrectly) as false.

## Screenshots or screencast <!-- if applicable -->
Despite the `fluid` option not being explicitly defined in the font size preset, the UI will be checked because the behavior will be true because the global option is enabled.
```json
{
	"settings": {
		"typography": {
			"fluid": true,
			"fontSizes": [
				{
					"name": "Theme font size 1",
					"size": "30px",
					"slug": "theme-1"
				}
			]
		}
	},
	"version": 3,
	"$schema": "https://schemas.wp.org/trunk/theme.json"
}
```
![image](https://github.com/user-attachments/assets/68e36240-6e7e-45a3-8044-8e18971d8c97)
