### PR TITLE
Categories List block: Add variations for taxonomies

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -5,7 +5,6 @@
 	"title": "Terms List",
 	"category": "widgets",
 	"description": "Display a list of all terms of a given taxonomy.",
-	"keywords": [ "categories" ],
 	"textdomain": "default",
 	"attributes": {
 		"taxonomy": {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import {
 	PanelBody,
 	Placeholder,
-	SelectControl,
 	Spinner,
 	ToggleControl,
 	VisuallyHidden,
@@ -23,7 +22,7 @@ import {
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
-import { useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -41,17 +40,14 @@ export default function CategoriesEdit( {
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 
-	const { records: allTaxonomies, isResolvingTaxonomies } = useEntityRecords(
+	const { record: taxonomy, isResolvingTaxonomy } = useEntityRecord(
 		'root',
-		'taxonomy'
+		'taxonomy',
+		taxonomySlug
 	);
 
-	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );
-
-	const taxonomy = taxonomies?.find( ( t ) => t.slug === taxonomySlug );
-
 	const isHierarchicalTaxonomy =
-		! isResolvingTaxonomies && taxonomy?.hierarchical;
+		! isResolvingTaxonomy && taxonomy?.hierarchical;
 
 	const query = { per_page: -1, hide_empty: ! showEmpty, context: 'view' };
 	if ( isHierarchicalTaxonomy && showOnlyTopLevel ) {
@@ -185,21 +181,6 @@ export default function CategoriesEdit( {
 		<TagName { ...blockProps }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					{ Array.isArray( taxonomies ) && (
-						<SelectControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Taxonomy' ) }
-							options={ taxonomies.map( ( t ) => ( {
-								label: t.name,
-								value: t.slug,
-							} ) ) }
-							value={ taxonomySlug }
-							onChange={ ( selectedTaxonomy ) =>
-								setAttributes( { taxonomy: selectedTaxonomy } )
-							}
-						/>
-					) }
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Display as dropdown' ) }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -116,15 +116,73 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 }
 
 /**
+ * Returns the available variations for the `core/categories` block.
+ *
+ * @since 6.7.0
+ *
+ * @return array The available variations for the block.
+ */
+function block_core_categories_build_variations() {
+	$taxonomies = get_taxonomies(
+		array(
+			'publicly_queryable' => true,
+			'show_in_rest'       => true,
+		),
+		'objects'
+	);
+
+	// Split the available taxonomies to `built_in` and custom ones,
+	// in order to prioritize the `built_in` taxonomies at the
+	// search results.
+	$built_ins         = array();
+	$custom_variations = array();
+
+	// Create and register the eligible taxonomies variations.
+	foreach ( $taxonomies as $taxonomy ) {
+		$variation = array(
+			'name'        => $taxonomy->name,
+			'title'       => sprintf(
+				/* translators: %s: taxonomy's label */
+				__( '%s List' ),
+				$taxonomy->label
+			),
+			'description' => sprintf(
+				/* translators: %s: taxonomy's label */
+				__( 'Display a list of all terms for the taxonomy: %s' ),
+				$taxonomy->label
+			),
+			'attributes'  => array(
+				'taxonomy' => $taxonomy->name,
+			),
+			'isActive'    => array( 'taxonomy' ),
+			'scope'       => array( 'inserter', 'transform' ),
+		);
+		// Set the category variation as the default one.
+		if ( 'category' === $taxonomy->name ) {
+			$variation['isDefault'] = true;
+		}
+		if ( $taxonomy->_builtin ) {
+			$built_ins[] = $variation;
+		} else {
+			$custom_variations[] = $variation;
+		}
+	}
+
+	return array_merge( $built_ins, $custom_variations );
+}
+
+/**
  * Registers the `core/categories` block on server.
  *
  * @since 5.0.0
+ * @since 6.7.0 Added the `variation_callback` argument.
  */
 function register_block_core_categories() {
 	register_block_type_from_metadata(
 		__DIR__ . '/categories',
 		array(
-			'render_callback' => 'render_block_core_categories',
+			'render_callback'    => 'render_block_core_categories',
+			'variation_callback' => 'block_core_categories_build_variations',
 		)
 	);
 }


### PR DESCRIPTION
## What?
Create block variations of the Categories List block, one for each existing taxonomy.

<img width="279" alt="image" src="https://github.com/user-attachments/assets/d36b5165-69c0-474f-a0f9-0d7e448e7254">

## Why?
There's been some demand for a "Terms List" block that would render a list of existing taxonomy terms for a given taxonomy -- much like the Categories List block has so far done for categories.

Fixes https://github.com/WordPress/gutenberg/issues/51388.

## How?
By adding a `taxonomy` attribute to the Categories List block, and registering a block variation for each publicly visible taxonomy.

The principal choice here was to either use block variations -- or not. In the latter case, we would have needed to add some sort of control (probably a dropdown) to the block inspector. There is already at least one open PR that do just that: #26555.

However, for consistency with the Post Terms block, I decided to go with block variations instead. (In fact, the code that generates the block variations for this block is largely copied from the Post Terms block.) Note that this still gives us a comfortable UI to easily switch between variations (and thus, taxonomies).

## What is this _not_?
A full-fledged "Terms Query" block, as requested by #49094.

However, there's been a few issues and PRs floating around for a while for _just_ a "simple" Terms _List_ block (e.g. https://github.com/WordPress/gutenberg/pull/58033, https://github.com/WordPress/gutenberg/pull/26555), and I recently found myself working on a project where I could've used a "Terms List" block myself. I concluded that it might make sense to add such a block after all; this doesn't preclude us from adding a more powerful (and complex) Terms _Query_ block later.

## Testing Instructions
Add the following code (e.g. to your theme's `functions.php`) and use the "Project Types" panel in the block inspector to create a number of "Project Type" terms and assign them to a given post. 

<details>
<summary>
Code
</summary>

```php
function register_taxonomies() {
	/**
	 * Taxonomy: Project Types.
	 */

	 $labels = array(
		'name'          => __( 'Project Types' ),
		'singular_name' => __( 'Project Type' ),
		'add_new_item'  => __( 'Add Project Type' ),
		'new_item_name' => __( 'New Project Type' ),
	);

	$args = array(
		'label'                 => __( 'Project Types' ),
		'labels'                => $labels,
		'public'                => true,
		'publicly_queryable'    => true,
		'hierarchical'          => false,
		'show_ui'               => true,
		'show_in_menu'          => true,
		'show_in_nav_menus'     => true,
		'query_var'             => true,
		'show_admin_column'     => false,
		'show_in_rest'          => true,
		'show_tagcloud'         => false,
		'rest_base'             => 'project_types',
		'rest_controller_class' => 'WP_REST_Terms_Controller',
		'rest_namespace'        => 'wp/v2',
		'show_in_quick_edit'    => false,
		'show_in_graphql'       => false,
		/*
		 * Set the `sort` and `args` properties so that the order of terms as
		 * assigned by the user is retained (rather than sorted alphabetically).
		 * See https://developer.wordpress.org/reference/functions/register_taxonomy/#comment-2687.
		 */
		'sort'                  => true,
		'args'                  => array( 'orderby' => 'term_order' ),
	);

	register_taxonomy( 'project_types', array( 'post' ), $args );
}

add_action( 'init', 'register_taxonomies', 0 );
```
</details>

Then, navigate to the Site Editor and insert the "Project Types List" block into a template of your choosing. Save the template, and verify on the frontend that the block does indeed render a list of project type terms.

Furthermore, make sure to test with built-in taxonomies, both hierarchical (Categories) and flat (Tags). Verify that creating those blocks works both if done from scratch, and if done by transforming an existing instance of the block that was created for a different taxonomy.

Finally, test the toggles in the block inspector. Specifically, change the block's appearance to a dropdown, and verify that it's rendered correctly both in the editor, and on the frontend. Also verify that selecting individual items from the dropdown on the frontend causes WordPress to navigate to the corresponding taxonomy term's archive page.

## Screenshots or screencast <!-- if applicable -->

![terms-list](https://github.com/user-attachments/assets/8694ea3b-ebab-42cb-b3a3-64e01214dcbc)

## TODO

- [x] ~Fix `Uncaught TypeError: t.toString is not a function` (`at ae.stringifyFunction (page.bundle.js:1:1448)`).~
  - That seems to have been a problem in Redux DevTools, not with this code 😌 