### PR TITLE
Storybook: Hide deprecated `__next36pxDefaultSize` prop

### DIFF
--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -31,6 +31,7 @@ export type ComboboxControlProps = Pick<
 	 *
 	 * @default false
 	 * @deprecated
+	 * @ignore
 	 */
 	__next36pxDefaultSize?: boolean;
 	/**

--- a/packages/components/src/form-token-field/types.ts
+++ b/packages/components/src/form-token-field/types.ts
@@ -157,6 +157,7 @@ export interface FormTokenFieldProps
 	 *
 	 * @default false
 	 * @deprecated
+	 * @ignore
 	 */
 	__next36pxDefaultSize?: boolean;
 	/**

--- a/packages/components/src/input-control/types.ts
+++ b/packages/components/src/input-control/types.ts
@@ -31,6 +31,7 @@ interface BaseProps {
 	 *
 	 * @default false
 	 * @deprecated
+	 * @ignore
 	 */
 	__next36pxDefaultSize?: boolean;
 	/**


### PR DESCRIPTION
Part of #46741

## What?

Hides the deprecated `__next36pxDefaultSize` prop from the Storybook props tables.

### Affected components

- ComboboxControl
- FormTokenField
- InputControl
- NumberControl
- SelectControl
- TreeSelect
- UnitControl

## Why?

These were still shown in the docs for a transitional period, given that we weren't throwing deprecation warnings to notify the switch to the 40px size prop. It's almost been a year since that switch, so I think we can clean them up.

## How?

Hides the prop from the Storybook props tables using TSDoc `@ignore`, so TS compilation will continue to work.

## Testing Instructions

Smoke test some changed Storybook pages.
