### PR TITLE
Site Editor: add units to avoid console warning

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -66,13 +66,13 @@ const toggleHomeIconVariants = {
 
 const siteIconVariants = {
 	edit: {
-		clipPath: 'inset(0% round 0)',
+		clipPath: 'inset(0% round 0px)',
 	},
 	hover: {
 		clipPath: 'inset( 22% round 2px )',
 	},
 	tap: {
-		clipPath: 'inset(0% round 0)',
+		clipPath: 'inset(0% round 0px)',
 	},
 };
 


### PR DESCRIPTION
## What?
A fix to avoid a browser console warning that looks to have came about with #63986.

## Why?
It’s easy to avoid.

## How?
Adds units to the keyframe values.

## Testing Instructions
1. Open a post in the Site Editor
2. Open the navigation
3. Note that no logs are added to the console

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The warning as seen on trunk

https://github.com/user-attachments/assets/50feb7b0-c953-4115-a3b1-c157915d5b95

