### PR TITLE
Block Patterns List: Fix visual title and tooltip inconsistencies

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/README.md
+++ b/packages/block-editor/src/components/block-patterns-list/README.md
@@ -61,6 +61,14 @@ The aria label for the block patterns list.
 -   Required: No
 -   Default: `Block Patterns`
 
+#### showTitlesAsTooltip
+
+Whether to show the block pattern title as a tooltip. User-defined patterns always show their visual title regardless of this prop.
+
+-   Type: `boolean`
+-   Required: No
+-   Default: `false`
+
 ## Related components
 
 Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [`BlockEditorProvider`](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/block-patterns-list/README.md
+++ b/packages/block-editor/src/components/block-patterns-list/README.md
@@ -63,7 +63,7 @@ The aria label for the block patterns list.
 
 #### showTitlesAsTooltip
 
-Whether to show the block pattern title as a tooltip. User-defined patterns always show their visual title regardless of this prop.
+Whether to render the title of each pattern as a tooltip. User-defined patterns always show their visual title regardless of this prop.
 
 -   Type: `boolean`
 -   Required: No

--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -39,14 +39,14 @@ function BlockPattern( {
 	pattern,
 	onClick,
 	onHover,
-	showTitle = true,
-	showTooltip,
+	showTitlesAsTooltip,
 	category,
 } ) {
 	const [ isDragging, setIsDragging ] = useState( false );
 	const { blocks, viewportWidth } = pattern;
 	const instanceId = useInstanceId( BlockPattern );
 	const descriptionId = `block-editor-block-patterns-list__item-description-${ instanceId }`;
+	const isUserPattern = pattern.type === INSERTER_PATTERN_TYPES.user;
 
 	// When we have a selected category and the pattern is draggable, we need to update the
 	// pattern's categories in metadata to only contain the selected category, and pass this to
@@ -94,10 +94,7 @@ function BlockPattern( {
 					} }
 				>
 					<WithToolTip
-						showTooltip={
-							showTooltip &&
-							! pattern.type !== INSERTER_PATTERN_TYPES.user
-						}
+						showTooltip={ showTitlesAsTooltip && ! isUserPattern }
 						title={ pattern.title }
 					>
 						<Composite.Item
@@ -142,29 +139,22 @@ function BlockPattern( {
 									viewportWidth={ viewportWidth }
 								/>
 							</BlockPreview.Async>
-
-							{ showTitle && (
+							{ ( ! showTitlesAsTooltip || isUserPattern ) && (
 								<HStack
 									className="block-editor-patterns__pattern-details"
 									spacing={ 2 }
 								>
-									{ pattern.type ===
-										INSERTER_PATTERN_TYPES.user &&
-										! pattern.syncStatus && (
-											<div className="block-editor-patterns__pattern-icon-wrapper">
-												<Icon
-													className="block-editor-patterns__pattern-icon"
-													icon={ symbol }
-												/>
-											</div>
-										) }
-									{ ( ! showTooltip ||
-										pattern.type ===
-											INSERTER_PATTERN_TYPES.user ) && (
-										<div className="block-editor-block-patterns-list__item-title">
-											{ pattern.title }
+									{ isUserPattern && ! pattern.syncStatus && (
+										<div className="block-editor-patterns__pattern-icon-wrapper">
+											<Icon
+												className="block-editor-patterns__pattern-icon"
+												icon={ symbol }
+											/>
 										</div>
 									) }
+									<div className="block-editor-block-patterns-list__item-title">
+										{ pattern.title }
+									</div>
 								</HStack>
 							) }
 
@@ -196,7 +186,6 @@ function BlockPatternsList(
 		orientation,
 		label = __( 'Block patterns' ),
 		category,
-		showTitle = true,
 		showTitlesAsTooltip,
 		pagingProps,
 	},
@@ -230,8 +219,7 @@ function BlockPatternsList(
 					onClick={ onClickPattern }
 					onHover={ onHover }
 					isDraggable={ isDraggable }
-					showTitle={ showTitle }
-					showTooltip={ showTitlesAsTooltip }
+					showTitlesAsTooltip={ showTitlesAsTooltip }
 					category={ category }
 				/>
 			) ) }

--- a/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
+++ b/packages/block-editor/src/components/block-patterns-list/stories/index.story.js
@@ -31,7 +31,6 @@ export const Default = {
 		blockPatterns: patterns,
 		isDraggable: false,
 		label: 'Block patterns story',
-		showTitle: true,
 		showTitlesAsTooltip: false,
 	},
 	argTypes: {
@@ -40,18 +39,11 @@ export const Default = {
 			description:
 				'Usually this component is used with `useAsyncList` for performance reasons and you should provide the returned list from that hook. Alternatively it should have the same value with `blockPatterns`.',
 		},
-		showTitle: {
-			description: 'Whether to render the title of each pattern.',
-			table: {
-				defaultValue: { summary: true },
-				type: { summary: 'boolean' },
-			},
-		},
 		onClickPattern: { type: 'function' },
 		onHover: { type: 'function' },
 		showTitlesAsTooltip: {
 			description:
-				'Whether to render the title of each pattern as a tooltip. If enabled, it takes precedence over `showTitle` prop.',
+				'Whether to render the title of each pattern as a tooltip. If enabled',
 		},
 		orientation: {
 			description: 'Orientation for the underlying composite widget.',

--- a/packages/block-editor/src/components/block-toolbar/change-design.js
+++ b/packages/block-editor/src/components/block-toolbar/change-design.js
@@ -118,7 +118,7 @@ export default function ChangeDesign( { clientId } ) {
 					<BlockPatternsList
 						blockPatterns={ sameCategoryPatternsWithSingleWrapper }
 						onClickPattern={ onClickPattern }
-						showTitle={ false }
+						showTitlesAsTooltip
 					/>
 				</DropdownContentWrapper>
 			) }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -79,7 +79,6 @@ function BlockPatternsTab( {
 								onInsert={ onInsert }
 								rootClientId={ rootClientId }
 								category={ category }
-								showTitlesAsTooltip={ false }
 							/>
 						</div>
 					) }

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -95,7 +95,7 @@ function TemplatesList( { area, clientId, isEntityAvailable, onSelect } ) {
 				label={ __( 'Templates' ) }
 				blockPatterns={ blockPatterns }
 				onClickPattern={ onSelect }
-				showTitle={ false }
+				showTitlesAsTooltip
 			/>
 		</PanelBody>
 	);


### PR DESCRIPTION
Fixes #64632
Related to #64166, #60160

## What?

This PR resolves inconsistencies and introduces clearer rules for the title and tooltip in the `BlockPatternList` component.

## Why?

I think there are three problems with this component currently:

1. Even though the pattern has a visual title and an aria-label applied, a tooltip is rendered.

![image](https://github.com/user-attachments/assets/041255ad-2534-4eb0-84c0-79c3cc4a66d4)

2. In the Design panel for replacing template content, there is no visible title. Additionally, there is no tooltip displayed when we focus on a pattern, so to find out what the pattern's name is, we'll need to use a screen reader or go into the source code and look for aria-label.

![image](https://github.com/user-attachments/assets/0e6ce3ed-9614-4ec6-a6ae-cb6abcdc56b0)

3. An empty div may be rendered even though no visual title is present.

![empty-div](https://github.com/user-attachments/assets/b701a86e-7869-4ea4-a48f-2d64e81caa1b)

## How?

In this PR, I apply the following rules wherever the `BlockPatternsList` component is used to resolve these inconsistencies:

- In inserters and sidebars, Don't show the visual title. However, user-defined patterns always show the visual title.
- In modals, always show the visual title.
- If the pattern has a visual title, don't show a tooltip. If not, show a tooltip.

To achieve this, I removed the ~~showTitlesAsTooltip~~ `showTitle` prop from the `BlockPatternsList` component. Whether or not to show a tooltip is determined solely by whether or not to show the visual title, i.e. the ~~showTitle~~ `showTitleAsTooltip` prop.

I am also aware that in some places the visual title is intentionally hidden. One example is #60160. Respecting this approach, the visual titles remain unchanged in this PR, with one exception.

The only visual change in this PR is the modal after creating a custom template:

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/0b4fa776-0325-4d87-9531-725bd32dcff2)| ![image](https://github.com/user-attachments/assets/9bcb82ec-674e-4c00-b77d-fcf61cdfa248)| 

This is the result based on the rule "In modals, always show the visual title", but we can change the title "Fallback content" or make an exception and not display a visual title.

## Testing Instructions

Check where the `BlockPatternsList` component is used and make sure there are no visual changes.
Make sure that visual titles and tooltips are displayed based on the following rules:

> - In inserters and sidebars, Don't show the visual title. However, user-defined patterns always show the visual title.
> - In modals, always show the visual title.
> - If the pattern has a visual title, don't show a tooltip. If not, show a tooltip.

<details><summary>Pattern inserter</summary>

![image](https://github.com/user-attachments/assets/3a80a557-37fe-4357-b0cd-f916d86fd99e)

</details> 

<details><summary>Pattern inserter (mobile)</summary>

![image](https://github.com/user-attachments/assets/f17650ac-f9b4-4d74-bb05-8f1e2d8b4250)

</details> 

<details><summary>Template Parts Design panel</summary>

![image](https://github.com/user-attachments/assets/69d0efc8-80df-44ce-8bb8-c1154e3003b0)

</details> 

<details><summary>Explore all patterns modal</summary>

![image](https://github.com/user-attachments/assets/f6006425-5f2e-48d0-bd9b-3e50ec99b2b3)

</details> 

<details><summary>Template Parts replace modal</summary>

![image](https://github.com/user-attachments/assets/dda45ef4-34f6-4ac0-884d-315f3d291d58)

</details> 

<details><summary>Main inserter > Search pattern</summary>

![image](https://github.com/user-attachments/assets/4d27b01f-53c9-4c68-81cb-2059410734e6)

</details> 

<details><summary>Query Loop block > Choose a pattern modal</summary>

![image](https://github.com/user-attachments/assets/23c500e5-3d0b-4ee6-ac4e-7aa807b0586f)

</details> 

<details><summary>Swap Template modal</summary>

![image](https://github.com/user-attachments/assets/a936f4c9-9b46-4cb1-8aba-2a86f4fefe48)

</details> 

<details><summary>After creating a custom template</summary>

![image](https://github.com/user-attachments/assets/2b2ea0f2-903d-4969-870b-678f69ff0b69)

</details> 

<details><summary>After creating a new page</summary>

![image](https://github.com/user-attachments/assets/863e6125-a29c-490a-86e0-6da1628ab558)

</details> 

<details><summary>Transform a Query Loop block to a pattern</summary>

![image](https://github.com/user-attachments/assets/6cfd4128-e2a4-4a01-b0a5-7855fcefb5fd)

</details> 