### PR TITLE
Blocks: fix block variation name checking

### DIFF
--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--   Now `registerBlockVariation` won't warn `'Variation names must be unique strings.'` when registering multiple variations in an array. ([#TODO](https://github.com/WordPress/gutenberg/pull/TODO))
+-   Now `registerBlockVariation` won't warn `'Variation names must be unique strings.'` when registering multiple variations in an array. ([#64818](https://github.com/WordPress/gutenberg/pull/64818))
 
 ## 13.6.0 (2024-08-21)
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Now `registerBlockVariation` won't warn `'Variation names must be unique strings.'` when registering multiple variations in an array. ([#TODO](https://github.com/WordPress/gutenberg/pull/TODO))
+
 ## 13.6.0 (2024-08-21)
 
 ## 13.5.0 (2024-08-07)

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -726,7 +726,11 @@ export const getBlockVariations = ( blockName, scope ) => {
  * ```
  */
 export const registerBlockVariation = ( blockName, variation ) => {
-	if ( typeof variation.name !== 'string' ) {
+	if (
+		Array.isArray( variation )
+			? variation.some( ( item ) => typeof item.name !== 'string' )
+			: typeof variation.name !== 'string'
+	) {
 		warning( 'Variation names must be unique strings.' );
 	}
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1436,6 +1436,36 @@ describe( 'blocks', () => {
 				},
 			] );
 		} );
+
+		it( 'should warn when registering block variation array without a name', () => {
+			registerBlockType( 'core/variation-block', defaultBlockSettings );
+			registerBlockVariation( 'core/variation-block', [
+				{
+					title: 'Variation Title',
+					description: 'Variation description',
+				},
+				{
+					name: 'variation-name-2',
+					title: 'Variation Title 2',
+					description: 'Variation description 2',
+				},
+			] );
+
+			expect( console ).toHaveWarnedWith(
+				'Variation names must be unique strings.'
+			);
+			expect( getBlockVariations( 'core/variation-block' ) ).toEqual( [
+				{
+					title: 'Variation Title',
+					description: 'Variation description',
+				},
+				{
+					name: 'variation-name-2',
+					title: 'Variation Title 2',
+					description: 'Variation description 2',
+				},
+			] );
+		} );
 	} );
 
 	describe( 'registerBlockBindingsSource', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When registering block variations in array:

```ts
registerBlockVariation( 'core/variation-block', [
	{
		name: 'variation-name',
		title: 'Variation Title',
		description: 'Variation description',
	},
	{
		name: 'variation-name-2',
		title: 'Variation Title 2',
		description: 'Variation description 2',
	},
] );
```

There would always have a warning in console:

<img width="709" alt="image" src="https://github.com/user-attachments/assets/9deb7a2d-545e-4b82-9f7d-ab616b198617">


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fix the wrong warning

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check if the variation param is an array or not

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
