### PR TITLE
Simplify useResizeObserver

### DIFF
--- a/packages/compose/README.md
+++ b/packages/compose/README.md
@@ -500,7 +500,7 @@ _Returns_
 
 ### useResizeObserver
 
-Hook which allows to listen the resize event of any target element when it changes sizes. \_Note: `useResizeObserver` will report `null` until after first render.
+Hook which allows to listen to the resize event of any target element when it changes size. \_Note: `useResizeObserver` will report `null` sizes until after first render.
 
 _Usage_
 

--- a/packages/compose/src/hooks/use-resize-observer/index.tsx
+++ b/packages/compose/src/hooks/use-resize-observer/index.tsx
@@ -94,8 +94,10 @@ function ResizeElement( { onResize }: ResizeElementProps ) {
 	useLayoutEffect( () => {
 		const resizeElement = resizeElementRef.current as HTMLDivElement;
 		const resizeObserver = new ResizeObserver( ( entries ) => {
-			const newSize = extractSize( entries[ 0 ] );
-			resizeCallbackRef.current( newSize );
+			for ( const entry of entries ) {
+				const newSize = extractSize( entry );
+				resizeCallbackRef.current( newSize );
+			}
 		} );
 
 		resizeObserver.observe( resizeElement );


### PR DESCRIPTION
I've been investigating a bug in WordPress.com where Gutenberg pattern previews trigger a `ResizeObserver` infinite loop:
```
ResizeObserver loop completed with undelivered notifications.
```
I started by looking at how `useResizeObserver` works, and discovered that it's unnecessarily complex. I decided to remove the unneeded features, which ended up with an almost complete rewrite.

- the only place that uses the `useResizeObserver` hook is the `useResizeAware` hook that creates a helper element with `ResizeObserver` attached to it. This usage doesn't use any `opts`, so they can be removed. Only the `contentBoxSize` entry is ever used, so we don't need to support any other. We also don't use the custom `round` function.
- the `useResolvedElement` and its special `refOrElement` option is not needed. I'm replacing that with simple logic that mounts the `ResizeElement` component, stores a local ref to the inner `div`, and then creates the observer in a layout effect.
- the `didUnmountRef` can also be removed, because React 18 no longer complains when `setState` is called after unmount.

What do you think?