### PR TITLE
Edit Site Layout: remove redundant fullResizer

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -81,7 +81,6 @@ export default function Layout( { route } ) {
 	} );
 	const disableMotion = useReducedMotion();
 	const [ canvasResizer, canvasSize ] = useResizeObserver();
-	const [ fullResizer ] = useResizeObserver();
 	const isEditorLoading = useIsSiteEditorLoading();
 	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
 		useState( false );
@@ -113,7 +112,6 @@ export default function Layout( { route } ) {
 			<CommandMenu />
 			<KeyboardShortcutsRegister />
 			<KeyboardShortcutsGlobal />
-			{ fullResizer }
 			<div
 				{ ...navigateRegionsProps }
 				ref={ navigateRegionsProps.ref }


### PR DESCRIPTION
A followup to #49910 where the size reported by the `fullResizer` is no longer used, but the resize observer is still active. In this PR I'm removing it, because it has no effect: nobody is looking at the observed size. The only effect is that a resize triggers a rerender of the component, but that shouldn't be necessary.

Noticed this when working on #64820 and looking at `useResizeObserver` usages.