### PR TITLE
Post publish upload media dialog: handle upload errors

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -122,6 +122,9 @@ export default function PostFormatPanel() {
 							} );
 						} ).then( () => setIsAnimating( true ) )
 					)
+					.catch( () => {
+						setHadUploadError( true );
+					} )
 			)
 		).finally( () => {
 			setIsUploading( false );

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -61,6 +61,7 @@ function Image( block ) {
 export default function PostFormatPanel() {
 	const [ isUploading, setIsUploading ] = useState( false );
 	const [ isAnimating, setIsAnimating ] = useState( false );
+	const [ hadUploadError, setHadUploadError ] = useState( false );
 	const { editorBlocks, mediaUpload } = useSelect(
 		( select ) => ( {
 			editorBlocks: select( blockEditorStore ).getBlocks(),
@@ -89,6 +90,7 @@ export default function PostFormatPanel() {
 
 	function uploadImages() {
 		setIsUploading( true );
+		setHadUploadError( false );
 		Promise.all(
 			externalImages.map( ( image ) =>
 				window
@@ -114,6 +116,7 @@ export default function PostFormatPanel() {
 									resolve();
 								},
 								onError() {
+									setHadUploadError( true );
 									reject();
 								},
 							} );
@@ -154,6 +157,11 @@ export default function PostFormatPanel() {
 					</Button>
 				) }
 			</div>
+			{ hadUploadError && (
+				<p className="post-publish-panel__error">
+					{ __( 'Upload failed, try again.' ) }
+				</p>
+			) }
 		</PanelBody>
 	);
 }

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -116,7 +116,6 @@ export default function PostFormatPanel() {
 									resolve();
 								},
 								onError() {
-									setHadUploadError( true );
 									reject();
 								},
 							} );

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -157,11 +157,7 @@ export default function PostFormatPanel() {
 					</Button>
 				) }
 			</div>
-			{ hadUploadError && (
-				<p className="post-publish-panel__error">
-					{ __( 'Upload failed, try again.' ) }
-				</p>
-			) }
+			{ hadUploadError && <p>{ __( 'Upload failed, try again.' ) }</p> }
 		</PanelBody>
 	);
 }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -185,6 +185,10 @@
 	color: $alert-yellow;
 }
 
+.post-publish-panel__error {
+	color: $alert-red;
+}
+
 @media screen and (max-width: 782px) {
 	.post-publish-panel__postpublish-post-address__button-wrap {
 		// match copy button height to the address field height in smaller screens

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -185,10 +185,6 @@
 	color: $alert-yellow;
 }
 
-.post-publish-panel__error {
-	color: $alert-red;
-}
-
 @media screen and (max-width: 782px) {
 	.post-publish-panel__postpublish-post-address__button-wrap {
 		// match copy button height to the address field height in smaller screens


### PR DESCRIPTION
## What?
This PR adds minimal information to the post publish upload media dialog when an upload error takes place. Previously, it would simply show the upload button again.

This is a follow-up to #64741.

## Why?
It's important to communicate that something went wrong during the upload process.

## How?
Some simple text is displayed until the upload is tried again. Here is a video of how this looks:

https://github.com/user-attachments/assets/ef7fe7c1-5559-4df2-93ea-b2984a737f6d

## Testing Instructions
1. Create a new post
2. Add images with external links, one or more of which will generate errors (e.g. due to CORS restrictions)
3. Hit Publish
4. Hit Upload in the upload media dialog

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast <!-- if applicable -->
