### PR TITLE
Interactivity API: Fix computeds without scope in Firefox

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix computeds without scope in Firefox ([#64825](https://github.com/WordPress/gutenberg/pull/64825)).
+
 ## 6.6.0 (2024-08-21)
 
 ### Bug Fixes

--- a/packages/interactivity/src/proxies/signals.ts
+++ b/packages/interactivity/src/proxies/signals.ts
@@ -20,7 +20,7 @@ import { withScope } from '../utils';
 /**
  * Identifier for property computeds not associated to any scope.
  */
-const NO_SCOPE = Symbol();
+const NO_SCOPE = {};
 
 /**
  * Structure that manages reactivity for a property in a state object. It uses


### PR DESCRIPTION
## What?

Replaces the internal identifier for computeds without a scope from a `Symbol` to an `Object`.

## Why?

Firefox doesn't seem to accept symbols as keys for `WeakMap` values. It fails with the following error:

```
TypeError: WeakMap key Symbol() must be an object
```

## Testing Instructions

To reproduce the issue:

1. Checkout `trunk`.
2. Add an image block on a page of your test site.
3. Enable "Expand on click".
4. Open Firefox and visit the page with the image.
5. The image can't be expanded, and the error mentioned above appears in the console.

To check the issue is fixed:

1. Checkout this PR.
2. Follow steps 2 to 4 from the list above.
3. The "Expand on click" feature should work fine. 
