### PR TITLE
Video Block: fix layout issue

### DIFF
--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -85,7 +85,6 @@
 
 .block-library-video-tracks-editor > .components-popover__content {
 	width: 360px;
-	padding: 0;
 }
 
 .block-library-video-tracks-editor__track-list,
@@ -94,10 +93,3 @@
 		padding: 0;
 	}
 }
-
-.block-library-video-tracks-editor__single-track-editor,
-.block-library-video-tracks-editor__track-list,
-.block-library-video-tracks-editor__add-tracks-container {
-	padding: $grid-unit-15;
-}
-


### PR DESCRIPTION
## What?

This PR fixes an overflow that was occurring in the Video Block track editor.

## Why?

As of #59723, the CSS selector has been changed to the following so that the dropdown can support menu groups:

```css
// From
.components-dropdown-menu__menu .components-menu-group,
.components-dropdown-menu__menu .components-menu-group + .components-menu-group {
}

// To
.components-dropdown__content .components-menu-group,
.components-dropdown__content .components-menu-group + .components-menu-group {
}
```

This CSS overrides the styles defined by the track editor:

![image](https://github.com/user-attachments/assets/afb10b15-deb4-4609-9f1b-9b48e5677e2d)


## How?

I think the root issue is that the track editor is overriding component styles. It's overriding a whole lot of component styles, but this PR only fixes the overflow and padding issues.

The track editor uses the `NavigableMenu` component, but I'm wondering if the current implementation is correct. The component has `role="menu"` but may not contain any elements with the appropriate role:

```html
<div class="block-library-video-tracks-editor__track-list components-menu-group">
  <div class="components-menu-group__label" aria-hidden="true">Text tracks</div>
  <div role="group" >
    <p class="block-library-video-tracks-editor__tracks-informative-message">Tracks can be subtitles, captions, chapters, or descriptions. They help make your content more accessible to a wider range of users.</p>
  </div>
</div>
```

The [README](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/navigable-container/README.md#navigablemenu) for this component states:

> The `NavigableMenu` by default has a `menu` role and therefore, in order to function as expected, the component expects its children elements to have one of the following roles: `'menuitem' | 'menuitemradio' | 'menuitemcheckbox'`.

If the current implementation is not correct, a total refactoring would be necessary, so I would like to address this in a follow-up PR.

## Testing Instructions

- Add a Video block.
- Click `Text tracks` from the block toolbar.
- Check the layout.
- Add some tracks.

For media and text tracks, please use the samples below.

[Desktop.zip](https://github.com/user-attachments/files/16763563/Desktop.zip)


## Screenshots or screencast <!-- if applicable -->

### No Text Tracks

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b05db2fe-54ee-4269-958e-4edc85262ccd)| ![image](https://github.com/user-attachments/assets/0bb4aca7-8d43-47dd-9280-2d3d9141a255) |

### Has Text Tracks

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/570aa6c8-6689-41b0-9572-5738dab7fbcf) | ![image](https://github.com/user-attachments/assets/c5f19079-a88e-49c5-937e-cc31411da2ea) |