### PR TITLE
Global Styles: Allow referenced zero value and simplify getValueFromObjectPath calls

### DIFF
--- a/packages/block-editor/src/components/global-styles/test/utils.js
+++ b/packages/block-editor/src/components/global-styles/test/utils.js
@@ -73,6 +73,11 @@ describe( 'editor utils', () => {
 					dimensions: {
 						minHeight: '100px',
 					},
+					spacing: {
+						padding: {
+							top: 0,
+						},
+					},
 				},
 			},
 		},
@@ -442,6 +447,11 @@ describe( 'editor utils', () => {
 			[
 				{ ref: 'styles.background.backgroundImage' },
 				{ url: 'file:./assets/image.jpg' },
+				themeJson,
+			],
+			[
+				{ ref: 'styles.blocks.core/group.spacing.padding.top' },
+				0,
 				themeJson,
 			],
 			[

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -579,7 +579,7 @@ export function getResolvedRefValue( ruleValue, tree ) {
 			return undefined;
 		}
 
-		if ( ! resolvedRuleValue ) {
+		if ( resolvedRuleValue === undefined ) {
 			return ruleValue;
 		}
 

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -306,9 +306,8 @@ function getValueFromCustomVariable( features, blockName, variable, path ) {
  */
 export function getValueFromVariable( features, blockName, variable ) {
 	if ( ! variable || typeof variable !== 'string' ) {
-		if ( variable?.ref && typeof variable?.ref === 'string' ) {
-			const refPath = variable.ref.split( '.' );
-			variable = getValueFromObjectPath( features, refPath );
+		if ( typeof variable?.ref === 'string' ) {
+			variable = getValueFromObjectPath( features, variable.ref );
 			// Presence of another ref indicates a reference to another dynamic value.
 			// Pointing to another dynamic value is not supported.
 			if ( ! variable || !! variable?.ref ) {
@@ -568,9 +567,8 @@ export function getResolvedRefValue( ruleValue, tree ) {
 	 * For example: { "ref": "style.color.background" } => "#fff".
 	 */
 	if ( typeof ruleValue !== 'string' && ruleValue?.ref ) {
-		const refPath = ruleValue.ref.split( '.' );
 		const resolvedRuleValue = getCSSValueFromRawStyle(
-			getValueFromObjectPath( tree, refPath )
+			getValueFromObjectPath( tree, ruleValue.ref )
 		);
 
 		/*


### PR DESCRIPTION

## What?

A few minor code quality tweaks for global styles util functions.

## Why?

Bottle pickup during an exploration into style inheritance.

## How?

- `getValueFromObjectPath` can accept a string or array for the object path. Let the function do its thing to make the consumer code a touch more concise.
- Tighten up the check for retrieved `ref` values by explicitly checking for `undefined`. This allows referenced integer zero values.

The existing unit tests already have coverage related to the calls to `getValueFromObjectPath` in the affected utils. A new test case was added for `getResolvedRefValue` to ensure referenced zero integer values were successfully returned.

## Testing Instructions

1. Ensure the e2es pass.
2. Bonus points: 
    i. Add a zero integer value for a block type's padding in theme.json
    ii. Define a style for a second block type or padding side that references the zero integer value
    iii. Load up global styles and ensure that the reference zero value displays

## Screenshots or screencast <!-- if applicable -->

<img width="1198" alt="Screenshot 2024-08-27 at 10 03 21 PM" src="https://github.com/user-attachments/assets/7f56072c-7cc2-4f20-b34f-ab24fa5623dd">

<img width="1394" alt="Screenshot 2024-08-27 at 10 03 09 PM" src="https://github.com/user-attachments/assets/bbe5a4f9-84cf-4674-b830-86a54716fa62">
