### PR TITLE
List layout: update broken styles

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -1,3 +1,7 @@
+ul.dataviews-view-list {
+	list-style-type: none;
+}
+
 .dataviews-view-list {
 	margin: 0 0 auto;
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -153,8 +153,8 @@
 	}
 
 	.dataviews-view-list__media-placeholder {
-		min-width: $grid-unit-40;
-		height: $grid-unit-40;
+		width: $grid-unit-05 * 13;
+		height: $grid-unit-05 * 13;
 		background-color: $gray-200;
 	}
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Update list layout styles:

- update placeholder to be the same size of the wrapper
- remove browser's list type style

| Before | After |
| --- | --- |
| <img width="1048" alt="Captura de ecrã 2024-08-27, às 17 34 54" src="https://github.com/user-attachments/assets/fc20a74d-e4af-4e94-94eb-8ce344b0ac59"> | <img width="1071" alt="Captura de ecrã 2024-08-27, às 17 39 17" src="https://github.com/user-attachments/assets/d0df4327-65ce-4b88-b441-50f0287d41e2"> |

## Why?

So they don't look broken and consumers of this package have a better devexp.

## How?

- [Update media placeholder size to be identical to wrapper](https://github.com/WordPress/gutenberg/pull/64837/commits/a8aba8e3df1f15912bb498254d76053c92121727)
- [Do not show any list style](https://github.com/WordPress/gutenberg/pull/64837/commits/d2a34778a00ab8133d214cbae0c78b507664525b)

## Testing Instructions

- Open the [DataViews story](https://github.com/WordPress/gutenberg/blob/927b167b10fc3e2b1ee7aed9655bdba9f2f44d0c/packages/dataviews/src/components/dataviews/stories/index.story.js#L65) and remove the "mediaField" in the layout list.
- Open the local storybook: `npm install && npm run storybook:dev`.
- Verify the list items don't have any UL style and that the placeholder fills the wrapper.

