### PR TITLE
Remove ability to crop image if content only mode

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -357,7 +357,11 @@ export default function Image( {
 	}, [ isSingleSelected ] );
 
 	const canEditImage = id && naturalWidth && naturalHeight && imageEditing;
-	const allowCrop = isSingleSelected && canEditImage && ! isEditingImage;
+	const allowCrop =
+		isSingleSelected &&
+		canEditImage &&
+		! isEditingImage &&
+		! isContentOnlyMode;
 
 	function switchToCover() {
 		replaceBlocks(


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/64727
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the crop from the image toolbar if contentOnly mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
From @richtabor:
> Remove the cropping mechanism. Perhaps if it gets better in the future we can reintroduce, but for now it's clunky and does not work well in the contentOnly implementation where you can't really resize the image after cropping.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check `! isContentOnlyMode` in `allowCrop`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Find a contentOnly image
- Check that the crop tool is gone from the toolbar
- Check that the crop is available on a default image toolbar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
