### PR TITLE
Inserter: fix loading indicator for reusable blocks

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -421,9 +421,11 @@ const EMPTY_ARRAY = [];
 export const getReusableBlocks = createRegistrySelector(
 	( select ) => ( state ) => {
 		const reusableBlocksSelect = state.settings[ reusableBlocksSelectKey ];
-		return reusableBlocksSelect
-			? reusableBlocksSelect( select )
-			: state.settings.__experimentalReusableBlocks ?? EMPTY_ARRAY;
+		return (
+			( reusableBlocksSelect
+				? reusableBlocksSelect( select )
+				: state.settings.__experimentalReusableBlocks ) ?? EMPTY_ARRAY
+		);
 	}
 );
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -26,15 +26,20 @@ import { store as editorStore } from '../../store';
 import { lock, unlock } from '../../lock-unlock';
 import { useGlobalStylesContext } from '../global-styles-provider';
 
-const EMPTY_BLOCKS_LIST = [];
 const EMPTY_OBJECT = {};
 
 function __experimentalReusableBlocksSelect( select ) {
-	return (
-		select( coreStore ).getEntityRecords( 'postType', 'wp_block', {
-			per_page: -1,
-		} ) ?? EMPTY_BLOCKS_LIST
-	);
+	const { getEntityRecords, hasFinishedResolution } = select( coreStore );
+	const reusableBlocks = getEntityRecords( 'postType', 'wp_block', {
+		per_page: -1,
+	} );
+	return hasFinishedResolution( 'getEntityRecords', [
+		'postType',
+		'wp_block',
+		{ per_page: -1 },
+	] )
+		? reusableBlocks
+		: undefined;
 }
 
 const BLOCK_EDITOR_SETTINGS = [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #64274.

Loading state was introduced in #61513, but was not properly added to the reusable blocks selector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

If there's only reusable blocks to be fetched, it causes the loading indicator to not appear, instead it will show "no results".

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the same technique as in #61513 for the reusable blocks selector.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Add some reusable blocks.
* Add the following code to disable the other patterns (from #64274)

```php
/**
 * Restricts block editor patterns in the editor by removing support for all patterns from:
 *   - Dotcom and plugins like Jetpack
 *   - Dotorg pattern directory except for theme patterns
 */
function remove_non_user_created_patterns( $dispatch_result, $request, $route ) {
    if ( strpos( $route, '/wp/v2/block-patterns/patterns' ) === 0 ) {
        $patterns = WP_Block_Patterns_Registry::get_instance()->get_all_registered();


        if ( ! empty( $patterns ) ) {
            // Remove theme support for all patterns from Dotcom, and plugins. See https://developer.wordpress.org/themes/features/block-patterns/#unregistering-block-patterns
            foreach ( $patterns as $pattern ) {
                unregister_block_pattern( $pattern['name'] );
            }

            // Remove theme support for core patterns from the Dotorg pattern directory. See https://developer.wordpress.org/themes/features/block-patterns/#removing-core-patterns
            remove_theme_support( 'core-block-patterns' );
        }
    }


    return $dispatch_result;
}

 
 
// Remove and unregister patterns from core, Dotcom, and plugins. See https://github.com/Automattic/jetpack/blob/d032fbb807e9cd69891e4fcbc0904a05508a1c67/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php#L107
add_filter( 'rest_dispatch_request', 'remove_non_user_created_patterns', 12, 3 );
 
 
// Disable the remote patterns coming from the Dotorg pattern directory. See https://developer.wordpress.org/themes/features/block-patterns/#disabling-remote-patterns
add_filter( 'should_load_remote_block_patterns', '__return_false' );
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
