### PR TITLE
Add safeguard to `mediaUploadMiddleware`

### DIFF
--- a/packages/api-fetch/src/middlewares/media-upload.js
+++ b/packages/api-fetch/src/middlewares/media-upload.js
@@ -63,6 +63,11 @@ const mediaUploadMiddleware = ( options, next ) => {
 
 	return next( { ...options, parse: false } )
 		.catch( ( response ) => {
+			// `response` could actually be an error thrown by `defaultFetchHandler`.
+			if ( ! response.headers ) {
+				return Promise.reject( response );
+			}
+
 			const attachmentId = response.headers.get(
 				'x-wp-upload-attachment-id'
 			);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add safeguard to `mediaUploadMiddleware in case `response` isn't actually a fetch response but an error.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is something I ran into when working on client-side media processing in #64278.

There I got errors about `headers` not existing on `response`, because it was actually an error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check if `response.headers` exists before using it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Unclear at this time, this didn't really happen outside that PR.

But you can probably reproduce this by doing this:

1. Throttle network
2. Upload larger file to the editor
3. Go offline so the default fetch handler triggers a `fetch_error` error
4. See `mediaUploadMiddleware` trying to use `response`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

N/A
