### PR TITLE
Fix: Impossible to see pagination on viewports between small and medium.

### DIFF
--- a/packages/dataviews/src/components/dataviews-pagination/style.scss
+++ b/packages/dataviews/src/components/dataviews-pagination/style.scss
@@ -8,6 +8,12 @@
 	flex-shrink: 0;
 	transition: padding ease-out 0.1s;
 	@include reduce-motion("transition");
+	@include break-small() {
+		bottom: $grid-unit-70 + $border-width;
+	}
+	@include break-medium() {
+		bottom: 0;
+	}
 }
 
 .dataviews-pagination__page-select {

--- a/packages/dataviews/src/components/dataviews-pagination/style.scss
+++ b/packages/dataviews/src/components/dataviews-pagination/style.scss
@@ -8,12 +8,6 @@
 	flex-shrink: 0;
 	transition: padding ease-out 0.1s;
 	@include reduce-motion("transition");
-	@include break-small() {
-		bottom: $grid-unit-70 + $border-width;
-	}
-	@include break-medium() {
-		bottom: 0;
-	}
 }
 
 .dataviews-pagination__page-select {

--- a/packages/edit-site/src/components/page/style.scss
+++ b/packages/edit-site/src/components/page/style.scss
@@ -1,11 +1,15 @@
 .edit-site-page {
 	color: $gray-800;
 	background: $white;
-	height: 100%;
+	height: calc(100% - #{$header-height});
 	/* stylelint-disable-next-line property-no-unknown -- '@container' not globally permitted */
 	container: edit-site-page / inline-size;
 	transition: width ease-out 0.2s;
 	@include reduce-motion("transition");
+
+	@include break-medium() {
+		height: 100%;
+	}
 }
 
 .edit-site-page-header {


### PR DESCRIPTION
This fixes an already existing issue reported by @jameskoster at https://github.com/WordPress/gutenberg/pull/64268#issuecomment-2296172005. For viewports between 600 and 782, it is totally impossible to use the pagination on trunk.




## Testing Instructions
I changed the window viewport size to 650px.
On a page with more than 10 items, I configured the view to 10 items per page.
I verified the pagination UI was available (on the trunk it is not).