### PR TITLE
Add new Media section to preferences modal

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -73,6 +73,13 @@ export function initializeEditor(
 		isPublishSidebarEnabled: true,
 	} );
 
+	if ( window.__experimentalMediaProcessing ) {
+		dispatch( preferencesStore ).setDefaults( 'core/media', {
+			requireApproval: true,
+			optimizeOnUpload: true,
+		} );
+	}
+
 	dispatch( blocksStore ).reapplyBlockTypeFilters();
 
 	// Check if the block list view should be open by default.

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -81,6 +81,13 @@ export function initializeEditor( id, settings ) {
 		showListViewByDefault: false,
 	} );
 
+	if ( window.__experimentalMediaProcessing ) {
+		dispatch( preferencesStore ).setDefaults( 'core/media', {
+			requireApproval: true,
+			optimizeOnUpload: true,
+		} );
+	}
+
 	dispatch( editSiteStore ).updateSettings( settings );
 
 	// Keep the defaultTemplateTypes in the core/editor settings too,

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -59,212 +59,254 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const sections = useMemo(
-		() => [
-			{
-				name: 'general',
-				tabLabel: __( 'General' ),
-				content: (
-					<>
-						<PreferencesModalSection title={ __( 'Interface' ) }>
-							<PreferenceToggleControl
-								scope="core"
-								featureName="showListViewByDefault"
-								help={ __(
-									'Opens the List View sidebar by default.'
-								) }
-								label={ __( 'Always open List View' ) }
-							/>
-							{ showBlockBreadcrumbsOption && (
+		() =>
+			[
+				{
+					name: 'general',
+					tabLabel: __( 'General' ),
+					content: (
+						<>
+							<PreferencesModalSection
+								title={ __( 'Interface' ) }
+							>
 								<PreferenceToggleControl
 									scope="core"
-									featureName="showBlockBreadcrumbs"
+									featureName="showListViewByDefault"
 									help={ __(
-										'Display the block hierarchy trail at the bottom of the editor.'
+										'Opens the List View sidebar by default.'
 									) }
-									label={ __( 'Show block breadcrumbs' ) }
+									label={ __( 'Always open List View' ) }
 								/>
-							) }
-							<PreferenceToggleControl
-								scope="core"
-								featureName="allowRightClickOverrides"
-								help={ __(
-									'Allows contextual List View menus via right-click, overriding browser defaults.'
-								) }
-								label={ __(
-									'Allow right-click contextual menus'
-								) }
-							/>
-						</PreferencesModalSection>
-						<PreferencesModalSection
-							title={ __( 'Document settings' ) }
-							description={ __(
-								'Select what settings are shown in the document panel.'
-							) }
-						>
-							<EnablePluginDocumentSettingPanelOption.Slot />
-							<PostTaxonomies
-								taxonomyWrapper={ ( content, taxonomy ) => (
-									<EnablePanelOption
-										label={ taxonomy.labels.menu_name }
-										panelName={ `taxonomy-panel-${ taxonomy.slug }` }
+								{ showBlockBreadcrumbsOption && (
+									<PreferenceToggleControl
+										scope="core"
+										featureName="showBlockBreadcrumbs"
+										help={ __(
+											'Display the block hierarchy trail at the bottom of the editor.'
+										) }
+										label={ __( 'Show block breadcrumbs' ) }
 									/>
 								) }
-							/>
-							<PostFeaturedImageCheck>
-								<EnablePanelOption
-									label={ __( 'Featured image' ) }
-									panelName="featured-image"
-								/>
-							</PostFeaturedImageCheck>
-							<PostExcerptCheck>
-								<EnablePanelOption
-									label={ __( 'Excerpt' ) }
-									panelName="post-excerpt"
-								/>
-							</PostExcerptCheck>
-							<PostTypeSupportCheck
-								supportKeys={ [ 'comments', 'trackbacks' ] }
-							>
-								<EnablePanelOption
-									label={ __( 'Discussion' ) }
-									panelName="discussion-panel"
-								/>
-							</PostTypeSupportCheck>
-							<PageAttributesCheck>
-								<EnablePanelOption
-									label={ __( 'Page attributes' ) }
-									panelName="page-attributes"
-								/>
-							</PageAttributesCheck>
-						</PreferencesModalSection>
-						{ isLargeViewport && (
-							<PreferencesModalSection
-								title={ __( 'Publishing' ) }
-							>
-								<EnablePublishSidebarOption
+								<PreferenceToggleControl
+									scope="core"
+									featureName="allowRightClickOverrides"
 									help={ __(
-										'Review settings, such as visibility and tags.'
+										'Allows contextual List View menus via right-click, overriding browser defaults.'
 									) }
-									label={ __( 'Enable pre-publish checks' ) }
+									label={ __(
+										'Allow right-click contextual menus'
+									) }
 								/>
 							</PreferencesModalSection>
-						) }
-						{ extraSections?.general }
-					</>
-				),
-			},
-			{
-				name: 'appearance',
-				tabLabel: __( 'Appearance' ),
-				content: (
-					<PreferencesModalSection
-						title={ __( 'Appearance' ) }
-						description={ __(
-							'Customize the editor interface to suit your needs.'
-						) }
-					>
-						<PreferenceToggleControl
-							scope="core"
-							featureName="fixedToolbar"
-							onToggle={ () =>
-								setPreference(
-									'core',
-									'distractionFree',
-									false
-								)
-							}
-							help={ __(
-								'Access all block and document tools in a single place.'
+							<PreferencesModalSection
+								title={ __( 'Document settings' ) }
+								description={ __(
+									'Select what settings are shown in the document panel.'
+								) }
+							>
+								<EnablePluginDocumentSettingPanelOption.Slot />
+								<PostTaxonomies
+									taxonomyWrapper={ ( content, taxonomy ) => (
+										<EnablePanelOption
+											label={ taxonomy.labels.menu_name }
+											panelName={ `taxonomy-panel-${ taxonomy.slug }` }
+										/>
+									) }
+								/>
+								<PostFeaturedImageCheck>
+									<EnablePanelOption
+										label={ __( 'Featured image' ) }
+										panelName="featured-image"
+									/>
+								</PostFeaturedImageCheck>
+								<PostExcerptCheck>
+									<EnablePanelOption
+										label={ __( 'Excerpt' ) }
+										panelName="post-excerpt"
+									/>
+								</PostExcerptCheck>
+								<PostTypeSupportCheck
+									supportKeys={ [ 'comments', 'trackbacks' ] }
+								>
+									<EnablePanelOption
+										label={ __( 'Discussion' ) }
+										panelName="discussion-panel"
+									/>
+								</PostTypeSupportCheck>
+								<PageAttributesCheck>
+									<EnablePanelOption
+										label={ __( 'Page attributes' ) }
+										panelName="page-attributes"
+									/>
+								</PageAttributesCheck>
+							</PreferencesModalSection>
+							{ isLargeViewport && (
+								<PreferencesModalSection
+									title={ __( 'Publishing' ) }
+								>
+									<EnablePublishSidebarOption
+										help={ __(
+											'Review settings, such as visibility and tags.'
+										) }
+										label={ __(
+											'Enable pre-publish checks'
+										) }
+									/>
+								</PreferencesModalSection>
 							) }
-							label={ __( 'Top toolbar' ) }
-						/>
-						<PreferenceToggleControl
-							scope="core"
-							featureName="distractionFree"
-							onToggle={ () => {
-								setPreference( 'core', 'fixedToolbar', true );
-								setIsInserterOpened( false );
-								setIsListViewOpened( false );
-							} }
-							help={ __(
-								'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
-							) }
-							label={ __( 'Distraction free' ) }
-						/>
-						<PreferenceToggleControl
-							scope="core"
-							featureName="focusMode"
-							help={ __(
-								'Highlights the current block and fades other content.'
-							) }
-							label={ __( 'Spotlight mode' ) }
-						/>
-						{ extraSections?.appearance }
-					</PreferencesModalSection>
-				),
-			},
-			{
-				name: 'accessibility',
-				tabLabel: __( 'Accessibility' ),
-				content: (
-					<>
+							{ extraSections?.general }
+						</>
+					),
+				},
+				{
+					name: 'appearance',
+					tabLabel: __( 'Appearance' ),
+					content: (
 						<PreferencesModalSection
-							title={ __( 'Navigation' ) }
+							title={ __( 'Appearance' ) }
 							description={ __(
-								'Optimize the editing experience for enhanced control.'
+								'Customize the editor interface to suit your needs.'
 							) }
 						>
 							<PreferenceToggleControl
 								scope="core"
-								featureName="keepCaretInsideBlock"
+								featureName="fixedToolbar"
+								onToggle={ () =>
+									setPreference(
+										'core',
+										'distractionFree',
+										false
+									)
+								}
 								help={ __(
-									'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'
+									'Access all block and document tools in a single place.'
 								) }
-								label={ __(
-									'Contain text cursor inside block'
-								) }
+								label={ __( 'Top toolbar' ) }
 							/>
-						</PreferencesModalSection>
-						<PreferencesModalSection title={ __( 'Interface' ) }>
 							<PreferenceToggleControl
 								scope="core"
-								featureName="showIconLabels"
-								label={ __( 'Show button text labels' ) }
+								featureName="distractionFree"
+								onToggle={ () => {
+									setPreference(
+										'core',
+										'fixedToolbar',
+										true
+									);
+									setIsInserterOpened( false );
+									setIsListViewOpened( false );
+								} }
 								help={ __(
-									'Show text instead of icons on buttons across the interface.'
+									'Reduce visual distractions by hiding the toolbar and other elements to focus on writing.'
 								) }
+								label={ __( 'Distraction free' ) }
 							/>
-						</PreferencesModalSection>
-					</>
-				),
-			},
-			{
-				name: 'blocks',
-				tabLabel: __( 'Blocks' ),
-				content: (
-					<>
-						<PreferencesModalSection title={ __( 'Inserter' ) }>
 							<PreferenceToggleControl
 								scope="core"
-								featureName="mostUsedBlocks"
+								featureName="focusMode"
 								help={ __(
-									'Adds a category with the most frequently used blocks in the inserter.'
+									'Highlights the current block and fades other content.'
 								) }
-								label={ __( 'Show most used blocks' ) }
+								label={ __( 'Spotlight mode' ) }
 							/>
+							{ extraSections?.appearance }
 						</PreferencesModalSection>
-						<PreferencesModalSection
-							title={ __( 'Manage block visibility' ) }
-							description={ __(
-								"Disable blocks that you don't want to appear in the inserter. They can always be toggled back on later."
-							) }
-						>
-							<BlockManager />
-						</PreferencesModalSection>
-					</>
-				),
-			},
-		],
+					),
+				},
+				{
+					name: 'accessibility',
+					tabLabel: __( 'Accessibility' ),
+					content: (
+						<>
+							<PreferencesModalSection
+								title={ __( 'Navigation' ) }
+								description={ __(
+									'Optimize the editing experience for enhanced control.'
+								) }
+							>
+								<PreferenceToggleControl
+									scope="core"
+									featureName="keepCaretInsideBlock"
+									help={ __(
+										'Keeps the text cursor within the block boundaries, aiding users with screen readers by preventing unintentional cursor movement outside the block.'
+									) }
+									label={ __(
+										'Contain text cursor inside block'
+									) }
+								/>
+							</PreferencesModalSection>
+							<PreferencesModalSection
+								title={ __( 'Interface' ) }
+							>
+								<PreferenceToggleControl
+									scope="core"
+									featureName="showIconLabels"
+									label={ __( 'Show button text labels' ) }
+									help={ __(
+										'Show text instead of icons on buttons across the interface.'
+									) }
+								/>
+							</PreferencesModalSection>
+						</>
+					),
+				},
+				{
+					name: 'blocks',
+					tabLabel: __( 'Blocks' ),
+					content: (
+						<>
+							<PreferencesModalSection title={ __( 'Inserter' ) }>
+								<PreferenceToggleControl
+									scope="core"
+									featureName="mostUsedBlocks"
+									help={ __(
+										'Adds a category with the most frequently used blocks in the inserter.'
+									) }
+									label={ __( 'Show most used blocks' ) }
+								/>
+							</PreferencesModalSection>
+							<PreferencesModalSection
+								title={ __( 'Manage block visibility' ) }
+								description={ __(
+									"Disable blocks that you don't want to appear in the inserter. They can always be toggled back on later."
+								) }
+							>
+								<BlockManager />
+							</PreferencesModalSection>
+						</>
+					),
+				},
+				window.__experimentalMediaProcessing && {
+					name: 'media',
+					tabLabel: __( 'Media' ),
+					content: (
+						<>
+							<PreferencesModalSection
+								title={ __( 'General' ) }
+								description={ __(
+									'Customize options related to the media upload flow.'
+								) }
+							>
+								<PreferenceToggleControl
+									scope="core/media"
+									featureName="optimizeOnUpload"
+									help={ __(
+										'Compress media items before uploading to the server.'
+									) }
+									label={ __( 'Pre-upload compression' ) }
+								/>
+								<PreferenceToggleControl
+									scope="core/media"
+									featureName="requireApproval"
+									help={ __(
+										'Require approval step when optimizing existing media.'
+									) }
+									label={ __( 'Approval step' ) }
+								/>
+							</PreferencesModalSection>
+						</>
+					),
+				},
+			].filter( Boolean ),
 		[
 			showBlockBreadcrumbsOption,
 			extraSections,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add new Media section to preferences modal, behind an experimental flag (`window.__experimentalMediaProcessing`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is for client-side media processing in #61447, which provides some new features such as compressing existing images in the browser. More preferences will likely added in the future as work progresses.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable client-side media processing experiment
2. See new Media section in the preferences panel in the editor

Tip: review with whitespace changes hidden, as there's a lot of formatting changes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

<img width="868" alt="Screenshot 2024-08-27 at 19 19 41" src="https://github.com/user-attachments/assets/6ae3be59-f477-48b7-871b-70c388f9f421">
