### PR TITLE
Add border to Replace item in content only image toolbar

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -559,7 +559,8 @@ export default function Image( {
 	const mediaReplaceFlow = isSingleSelected &&
 		! isEditingImage &&
 		! lockUrlControls && (
-			<BlockControls group="other">
+			// For contentOnly mode, put this button in its own area so it has borders around it.
+			<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
 				<MediaReplaceFlow
 					mediaId={ id }
 					mediaURL={ url }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/64727

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds border around Replace item in content only image

Closes https://github.com/WordPress/gutenberg/issues/64727

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
From @richtabor:
> Add a divider between "Replace" and "Alt" to better distinguish these two.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Places Replace in its own BlockControls group to have borders applied by default

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Find a contentOnly image
- Check that the replace item in the toolbar has borders around it
- Check that the replace item on a default image toolbar is in the same spot as before on trunk
- 
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="711" alt="Content only toolbar with Replace item having a border on left and right of it" src="https://github.com/user-attachments/assets/9c9fad4c-d38f-4c91-bdc0-b3046d87c5fd">
