### PR TITLE
Dataviews filter: move resetValueOnSelect prop to combobox item

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -206,7 +206,6 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 	}, [ filter.elements, deferredSearchValue ] );
 	return (
 		<Ariakit.ComboboxProvider
-			resetValueOnSelect={ false }
 			selectedValue={ currentValue }
 			setSelectedValue={ ( value ) => {
 				const newFilters = currentFilter
@@ -266,6 +265,7 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 				{ matches.map( ( element ) => {
 					return (
 						<Ariakit.ComboboxItem
+							resetValueOnSelect={ false }
 							key={ element.value }
 							value={ element.value }
 							className="dataviews-filters__search-widget-listitem"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Move `resetValueOnSelect` from `Ariakit.Combobox` to `Ariakit.ComboboxItem`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `resetValueOnSelect` prop on `Ariakit.Combobox` is deprecated since [version `0.4.5`](https://ariakit.org/changelog#045).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The suggested action is to simply apply it to `Ariakit.ComboboxItem` instead, which is what this PR does.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

There shouldn't be any differences at runtime.

- Apply the following diff

<details>
<summary>Click to expand</summary>

```diff
diff --git a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
index 1b369222b8..0cc04f39d6 100644
--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -304,6 +304,5 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 }
 
 export default function SearchWidget( props: SearchWidgetProps ) {
-	const Widget = props.filter.elements.length > 10 ? ComboboxList : ListBox;
-	return <Widget { ...props } />;
+	return <ComboboxList { ...props } />;
 }

```
</details>

- Load the "pages" section in the site editor
- Add an "Author" filter
- Type "Ad", select the "Admin" item
- Make sure that the characters that were typed are still there — ie. the input field was not reset.

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-08-27 at 23 25 53](https://github.com/user-attachments/assets/11da26b5-9bea-4536-bd4a-46b7d63571ec)
