### PR TITLE
UX Experiment - "Simple" mode for content editing

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -179,18 +179,18 @@ export function PrivateBlockToolbar( {
 									disabled={ ! isDefaultEditingMode }
 									isUsingBindings={ isUsingBindings }
 								/>
-								{ isDefaultEditingMode && (
-									<>
-										{ ! isMultiToolbar && (
-											<BlockLockToolbar
-												clientId={ blockClientId }
-											/>
-										) }
-										<BlockMover
-											clientIds={ blockClientIds }
-											hideDragHandle={ hideDragHandle }
-										/>
-									</>
+								{ isDefaultEditingMode && ! isMultiToolbar && (
+									<BlockLockToolbar
+										clientId={ blockClientId }
+									/>
+								) }
+
+								{ ( isDefaultEditingMode ||
+									isContentOnlyEditingMode ) && (
+									<BlockMover
+										clientIds={ blockClientIds }
+										hideDragHandle={ hideDragHandle }
+									/>
 								) }
 							</ToolbarGroup>
 						</div>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -31,7 +31,6 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const [ isSimpleMode, setIsSimpleMode ] = useState( false );
 	const [ originalTemplateLocks, setOriginalTemplateLocks ] = useState( {} );
 	const { mode, blocksWithinMainBlockClientIds, getBlockAttributes } =
 		useSelect( ( select ) => {
@@ -75,7 +74,7 @@ function ToolSelector( props, ref ) {
 				<>
 					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>
 						<MenuItemsChoice
-							value={ isSimpleMode ? 'simple' : mode }
+							value={ mode }
 							onSelect={ ( newMode ) => {
 								if ( newMode === 'simple' ) {
 									const originalLocks = {};
@@ -94,8 +93,6 @@ function ToolSelector( props, ref ) {
 											templateLock: 'contentOnly',
 										}
 									);
-									__unstableSetEditorMode( 'edit' );
-									setIsSimpleMode( true );
 								} else {
 									// Restore the original templateLock attributes
 									blocksWithinMainBlockClientIds.forEach(
@@ -108,9 +105,8 @@ function ToolSelector( props, ref ) {
 											} );
 										}
 									);
-									__unstableSetEditorMode( newMode );
-									setIsSimpleMode( false );
 								}
+								__unstableSetEditorMode( newMode );
 							} }
 							choices={ [
 								{

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -11,8 +11,9 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useEffect } from '@wordpress/element';
 import { Icon, edit as editIcon, brush as brushIcon } from '@wordpress/icons';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -50,6 +51,18 @@ function ToolSelector( props, ref ) {
 
 	// Usage
 	const modeIcon = modeIcons[ mode ] || modeIcons.default;
+
+	const { get: getPreference } = useSelect( ( select ) =>
+		select( preferencesStore )
+	);
+
+	// Todo - avoid effect.
+	useEffect( () => {
+		const editorMode = getPreference( 'core', '__experimentalEditorMode' );
+		if ( editorMode === 'simple' ) {
+			__unstableSetEditorMode( editorMode );
+		}
+	}, [ __unstableSetEditorMode, getPreference ] );
 
 	return (
 		<Dropdown

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -11,14 +11,13 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { forwardRef, useState } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { Icon, edit as editIcon, brush as brushIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { sectionRootClientIdKey } from '../../store/private-keys';
 
 const selectIcon = (
 	<SVG
@@ -32,34 +31,15 @@ const selectIcon = (
 );
 
 function ToolSelector( props, ref ) {
-	const [ originalTemplateLocks, setOriginalTemplateLocks ] = useState( {} );
-	const { mode, sectionBlocksClientIds, getBlockAttributes } = useSelect(
-		( select ) => {
-			const {
-				__unstableGetEditorMode,
-				getBlockOrder,
-				getBlockAttributes: _getBlockAttributes,
-				getSettings,
-			} = select( blockEditorStore );
+	const { mode } = useSelect( ( select ) => {
+		const { __unstableGetEditorMode } = select( blockEditorStore );
 
-			const { [ sectionRootClientIdKey ]: sectionRootClientId } =
-				getSettings();
+		return {
+			mode: __unstableGetEditorMode(),
+		};
+	}, [] );
 
-			return {
-				mode: __unstableGetEditorMode(),
-				sectionBlocksClientIds: getBlockOrder( sectionRootClientId ),
-				getBlockAttributes: _getBlockAttributes,
-			};
-		},
-		[]
-	);
-
-	const {
-		__unstableSetEditorMode,
-		updateBlockAttributes,
-		setBlockEditingMode,
-		unsetBlockEditingMode,
-	} = useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	const modeIcons = {
 		edit: editIcon,
@@ -94,42 +74,6 @@ function ToolSelector( props, ref ) {
 						<MenuItemsChoice
 							value={ mode }
 							onSelect={ ( newMode ) => {
-								if ( newMode === 'simple' ) {
-									const originalLocks = {};
-									sectionBlocksClientIds.forEach(
-										( clientId ) => {
-											const attributes =
-												getBlockAttributes( clientId );
-											originalLocks[ clientId ] =
-												attributes.templateLock;
-
-											setBlockEditingMode(
-												clientId,
-												'contentOnly'
-											);
-										}
-									);
-									setOriginalTemplateLocks( originalLocks );
-									updateBlockAttributes(
-										sectionBlocksClientIds,
-										{
-											templateLock: 'contentOnly',
-										}
-									);
-								} else {
-									// Restore the original templateLock attributes
-									sectionBlocksClientIds.forEach(
-										( clientId ) => {
-											updateBlockAttributes( clientId, {
-												templateLock:
-													originalTemplateLocks[
-														clientId
-													],
-											} );
-											unsetBlockEditingMode( clientId );
-										}
-									);
-								}
 								__unstableSetEditorMode( newMode );
 							} }
 							choices={ [

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -54,8 +54,12 @@ function ToolSelector( props, ref ) {
 		[]
 	);
 
-	const { __unstableSetEditorMode, updateBlockAttributes } =
-		useDispatch( blockEditorStore );
+	const {
+		__unstableSetEditorMode,
+		updateBlockAttributes,
+		setBlockEditingMode,
+		unsetBlockEditingMode,
+	} = useDispatch( blockEditorStore );
 
 	return (
 		<Dropdown
@@ -88,6 +92,11 @@ function ToolSelector( props, ref ) {
 												getBlockAttributes( clientId );
 											originalLocks[ clientId ] =
 												attributes.templateLock;
+
+											setBlockEditingMode(
+												clientId,
+												'contentOnly'
+											);
 										}
 									);
 									setOriginalTemplateLocks( originalLocks );
@@ -107,10 +116,11 @@ function ToolSelector( props, ref ) {
 														clientId
 													],
 											} );
+											unsetBlockEditingMode( clientId );
 										}
 									);
 								}
-								__unstableSetEditorMode( newMode );
+								__unstableSetEditorMode( mode );
 							} }
 							choices={ [
 								{

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -61,6 +61,16 @@ function ToolSelector( props, ref ) {
 		unsetBlockEditingMode,
 	} = useDispatch( blockEditorStore );
 
+	const modeIcons = {
+		edit: editIcon,
+		navigation: selectIcon,
+		simple: brushIcon,
+		default: editIcon, // Fallback icon if mode is not recognized
+	};
+
+	// Usage
+	const modeIcon = modeIcons[ mode ] || modeIcons.default;
+
 	return (
 		<Dropdown
 			renderToggle={ ( { isOpen, onToggle } ) => (
@@ -69,7 +79,7 @@ function ToolSelector( props, ref ) {
 					__next40pxDefaultSize={ false }
 					{ ...props }
 					ref={ ref }
-					icon={ mode === 'navigation' ? selectIcon : editIcon }
+					icon={ modeIcon }
 					aria-expanded={ isOpen }
 					aria-haspopup="true"
 					onClick={ onToggle }
@@ -120,7 +130,7 @@ function ToolSelector( props, ref ) {
 										}
 									);
 								}
-								__unstableSetEditorMode( mode );
+								__unstableSetEditorMode( newMode );
 							} }
 							choices={ [
 								{

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -133,30 +133,30 @@ function ToolSelector( props, ref ) {
 								__unstableSetEditorMode( newMode );
 							} }
 							choices={ [
-								{
-									value: 'edit',
-									label: (
-										<>
-											<Icon icon={ editIcon } />
-											{ __( 'Edit' ) }
-										</>
-									),
-								},
-								{
-									value: 'navigation',
-									label: (
-										<>
-											{ selectIcon }
-											{ __( 'Select' ) }
-										</>
-									),
-								},
+								// {
+								// 	value: 'navigation',
+								// 	label: (
+								// 		<>
+								// 			{ selectIcon }
+								// 			{ __( 'Select' ) }
+								// 		</>
+								// 	),
+								// },
 								{
 									value: 'simple',
 									label: (
 										<>
 											<Icon icon={ brushIcon } />
 											{ __( 'Simple' ) }
+										</>
+									),
+								},
+								{
+									value: 'edit',
+									label: (
+										<>
+											<Icon icon={ editIcon } />
+											{ __( 'Advanced Mode' ) }
 										</>
 									),
 								},

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -18,6 +18,7 @@ import { Icon, edit as editIcon, brush as brushIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { sectionRootClientIdKey } from '../../store/private-keys';
 
 const selectIcon = (
 	<SVG
@@ -32,23 +33,26 @@ const selectIcon = (
 
 function ToolSelector( props, ref ) {
 	const [ originalTemplateLocks, setOriginalTemplateLocks ] = useState( {} );
-	const { mode, blocksWithinMainBlockClientIds, getBlockAttributes } =
-		useSelect( ( select ) => {
+	const { mode, sectionBlocksClientIds, getBlockAttributes } = useSelect(
+		( select ) => {
 			const {
 				__unstableGetEditorMode,
 				getBlockOrder,
 				getBlockAttributes: _getBlockAttributes,
+				getSettings,
 			} = select( blockEditorStore );
 
-			const mainBlockClientId = getBlockOrder()[ 1 ];
+			const { [ sectionRootClientIdKey ]: sectionRootClientId } =
+				getSettings();
 
 			return {
 				mode: __unstableGetEditorMode(),
-				blocksWithinMainBlockClientIds:
-					getBlockOrder( mainBlockClientId ),
+				sectionBlocksClientIds: getBlockOrder( sectionRootClientId ),
 				getBlockAttributes: _getBlockAttributes,
 			};
-		}, [] );
+		},
+		[]
+	);
 
 	const { __unstableSetEditorMode, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
@@ -78,7 +82,7 @@ function ToolSelector( props, ref ) {
 							onSelect={ ( newMode ) => {
 								if ( newMode === 'simple' ) {
 									const originalLocks = {};
-									blocksWithinMainBlockClientIds.forEach(
+									sectionBlocksClientIds.forEach(
 										( clientId ) => {
 											const attributes =
 												getBlockAttributes( clientId );
@@ -88,14 +92,14 @@ function ToolSelector( props, ref ) {
 									);
 									setOriginalTemplateLocks( originalLocks );
 									updateBlockAttributes(
-										blocksWithinMainBlockClientIds,
+										sectionBlocksClientIds,
 										{
 											templateLock: 'contentOnly',
 										}
 									);
 								} else {
 									// Restore the original templateLock attributes
-									blocksWithinMainBlockClientIds.forEach(
+									sectionBlocksClientIds.forEach(
 										( clientId ) => {
 											updateBlockAttributes( clientId, {
 												templateLock:

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1672,20 +1672,20 @@ export const setNavigationMode =
 export const __unstableSetEditorMode =
 	( mode ) =>
 	( { dispatch, select, registry } ) => {
+		const { [ sectionRootClientIdKey ]: sectionRootClientId } = registry
+			.select( STORE_NAME )
+			.getSettings();
+
+		const sectionClientIds = select.getBlockOrder( sectionRootClientId );
+
 		// When switching to zoom-out mode, we need to select the parent section
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
-			const { [ sectionRootClientIdKey ]: sectionRootClientId } = registry
-				.select( STORE_NAME )
-				.getSettings();
 
 			if ( firstSelectedClientId ) {
 				let sectionClientId;
 
 				if ( sectionRootClientId ) {
-					const sectionClientIds =
-						select.getBlockOrder( sectionRootClientId );
-
 					// If the selected block is a section block, use it.
 					if ( sectionClientIds?.includes( firstSelectedClientId ) ) {
 						sectionClientId = firstSelectedClientId;
@@ -1710,6 +1710,25 @@ export const __unstableSetEditorMode =
 					dispatch.clearSelectedBlock();
 				}
 			}
+		}
+
+		// Insert the provided logic here
+		if ( mode === 'simple' ) {
+			dispatch.updateBlockAttributes( sectionClientIds, {
+				templateLock: 'contentOnly',
+			} );
+
+			sectionClientIds.forEach( ( clientId ) => {
+				dispatch.setBlockEditingMode( clientId, 'contentOnly' );
+			} );
+		} else {
+			dispatch.updateBlockAttributes( sectionClientIds, {
+				templateLock: null,
+			} );
+
+			sectionClientIds.forEach( ( clientId ) => {
+				dispatch.unsetBlockEditingMode( clientId );
+			} );
 		}
 
 		dispatch( { type: 'SET_EDITOR_MODE', mode } );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1714,20 +1714,30 @@ export const __unstableSetEditorMode =
 
 		dispatch( { type: 'SET_EDITOR_MODE', mode } );
 
-		if ( mode === 'navigation' ) {
-			speak(
-				__(
-					'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press Enter.'
-				)
-			);
-		} else if ( mode === 'edit' ) {
-			speak(
-				__(
-					'You are currently in edit mode. To return to the navigation mode, press Escape.'
-				)
-			);
-		} else if ( mode === 'zoom-out' ) {
-			speak( __( 'You are currently in zoom-out mode.' ) );
+		switch ( mode ) {
+			case 'navigation':
+				speak(
+					__(
+						'You are currently in navigation mode. Navigate blocks using the Tab key and Arrow keys. Use Left and Right Arrow keys to move between nesting levels. To exit navigation mode and edit the selected block, press Enter.'
+					)
+				);
+				break;
+			case 'edit':
+				speak(
+					__(
+						'You are currently in edit mode. To return to the navigation mode, press Escape.'
+					)
+				);
+				break;
+			case 'zoom-out':
+				speak( __( 'You are currently in zoom-out mode.' ) );
+				break;
+			case 'simple':
+				speak( __( 'You are currently in simple editing mode.' ) );
+				break;
+			default:
+				// Optional: handle other cases or do nothing
+				break;
 		}
 	};
 

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -21,6 +21,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { create, insert, remove, toHTMLString } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -1672,6 +1673,8 @@ export const setNavigationMode =
 export const __unstableSetEditorMode =
 	( mode ) =>
 	( { dispatch, select, registry } ) => {
+		const { set: setPreference } = registry.dispatch( preferencesStore );
+
 		const { [ sectionRootClientIdKey ]: sectionRootClientId } = registry
 			.select( STORE_NAME )
 			.getSettings();
@@ -1721,6 +1724,9 @@ export const __unstableSetEditorMode =
 			sectionClientIds.forEach( ( clientId ) => {
 				dispatch.setBlockEditingMode( clientId, 'contentOnly' );
 			} );
+
+			// Set the preference
+			setPreference( 'core', '__experimentalEditorMode', 'simple' );
 		} else {
 			dispatch.updateBlockAttributes( sectionClientIds, {
 				templateLock: null,
@@ -1729,6 +1735,9 @@ export const __unstableSetEditorMode =
 			sectionClientIds.forEach( ( clientId ) => {
 				dispatch.unsetBlockEditingMode( clientId );
 			} );
+
+			// Remove the preference
+			setPreference( 'core', '__experimentalEditorMode', null );
 		}
 
 		dispatch( { type: 'SET_EDITOR_MODE', mode } );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1770,6 +1770,11 @@ export function canMoveBlock( state, clientId ) {
 	if ( getTemplateLock( state, rootClientId ) === 'all' ) {
 		return false;
 	}
+
+	if ( getBlockEditingMode( state, clientId ) === 'contentOnly' ) {
+		return true;
+	}
+
 	return getBlockEditingMode( state, rootClientId ) !== 'disabled';
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tries creating a `Simple` mode for the Editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is just an experiment to see how it feels if we make all the blocks within the top level sections content only. This makes the editor feel a lot more simple.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

To make this easy to test, i've shoehorned in a `Simple` mode into the mode selector at the top of the editor. This is only for testing purposes!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/53474810-5b2c-492c-a9e9-d41b142ebc5b

