### PR TITLE
DropdownMenuV2: update animation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -67,6 +67,7 @@
 -   `DropdownMenu` v2: fix flashing menu item styles when using keyboard ([#64873](https://github.com/WordPress/gutenberg/pull/64873)).
 -   `DropdownMenu` v2: refactor to overloaded naming convention ([#64654](https://github.com/WordPress/gutenberg/pull/64654)).
 -   `DropdownMenu` v2: add `GroupLabel` subcomponent ([#64854](https://github.com/WordPress/gutenberg/pull/64854)).
+-   `DropdownMenuV2`: update animation ([#64868](https://github.com/WordPress/gutenberg/pull/64868)).
 -   `Composite` V2: fix Storybook docgen ([#64682](https://github.com/WordPress/gutenberg/pull/64682)).
 -   `Composite` V2: accept store props on top-level component ([#64832](https://github.com/WordPress/gutenberg/pull/64832)).
 

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -109,9 +109,11 @@ const UnconnectedDropdownMenu = (
 	);
 
 	// Extract the side from the applied placement — useful for animations.
+	// Using `currentPlacement` instead of `placement` to make sure that we
+	// use the final computed placement (including "flips" etc).
 	const appliedPlacementSide = useStoreState(
 		dropdownMenuStore,
-		'placement'
+		'currentPlacement'
 	).split( '-' )[ 0 ];
 
 	if (

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -173,7 +173,7 @@ const UnconnectedDropdownMenu = (
 			/>
 
 			{ /* Menu popover */ }
-			<Styled.DropdownMenu
+			<Ariakit.Menu
 				{ ...otherProps }
 				modal={ modal }
 				store={ dropdownMenuStore }
@@ -185,15 +185,23 @@ const UnconnectedDropdownMenu = (
 				shift={ shift ?? ( dropdownMenuStore.parent ? -4 : 0 ) }
 				hideOnHoverOutside={ false }
 				data-side={ appliedPlacementSide }
-				variant={ variant }
 				wrapperProps={ wrapperProps }
 				hideOnEscape={ hideOnEscape }
 				unmountOnHide
+				render={ ( renderProps ) => (
+					// Two wrappers are needed for the entry animation, where the menu
+					// container scales with a different factor than its contents.
+					// The {...renderProps} are passed to the inner wrapper, so that the
+					// menu element is the direct parent of the menu item elements.
+					<Styled.MenuPopoverOuterWrapper variant={ variant }>
+						<Styled.MenuPopoverInnerWrapper { ...renderProps } />
+					</Styled.MenuPopoverOuterWrapper>
+				) }
 			>
 				<DropdownMenuContext.Provider value={ contextValue }>
-					<Styled.ContentWrapper>{ children }</Styled.ContentWrapper>
+					{ children }
 				</DropdownMenuContext.Provider>
-			</Styled.DropdownMenu>
+			</Ariakit.Menu>
 		</>
 	);
 };

--- a/packages/components/src/dropdown-menu-v2/index.tsx
+++ b/packages/components/src/dropdown-menu-v2/index.tsx
@@ -191,7 +191,7 @@ const UnconnectedDropdownMenu = (
 				unmountOnHide
 			>
 				<DropdownMenuContext.Provider value={ contextValue }>
-					{ children }
+					<Styled.ContentWrapper>{ children }</Styled.ContentWrapper>
 				</DropdownMenuContext.Provider>
 			</Styled.DropdownMenu>
 		</>

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -60,7 +60,7 @@ const fadeIn = keyframes( {
 	},
 } );
 
-export const DropdownMenu = styled( Ariakit.Menu )<
+export const MenuPopoverOuterWrapper = styled.div<
 	Pick< DropdownMenuContext, 'variant' >
 >`
 	position: relative;
@@ -76,35 +76,32 @@ export const DropdownMenu = styled( Ariakit.Menu )<
 			: DEFAULT_BOX_SHADOW };
 	` }
 
-	/* Only visible in Windows High Contrast mode */
-	outline: 2px solid transparent !important;
-
 	overflow: hidden;
 
 	/* Animation */
 	@media not ( prefers-reduced-motion ) {
-		&[data-open] {
+		&:has( [data-open] ) {
 			animation-duration: ${ ANIMATION_PARAMS.DURATION };
 			animation-timing-function: ${ ANIMATION_PARAMS.EASING };
 			will-change: transform, opacity;
+		}
 
-			&[data-side='bottom'] {
-				transform-origin: top;
-				animation-name: ${ fadeIn }, ${ scaleYOuter };
-			}
-			&[data-side='top'] {
-				transform-origin: bottom;
-				animation-name: ${ fadeIn }, ${ scaleYOuter };
-			}
-			&[data-side='left'],
-			&[data-side='right'] {
-				animation-name: ${ fadeIn };
-			}
+		&:has( [data-open][data-side='bottom'] ) {
+			transform-origin: top;
+			animation-name: ${ fadeIn }, ${ scaleYOuter };
+		}
+		&:has( [data-open][data-side='top'] ) {
+			transform-origin: bottom;
+			animation-name: ${ fadeIn }, ${ scaleYOuter };
+		}
+		&:has( [data-open][data-side='left'] ),
+		&:has( [data-open][data-side='right'] ) {
+			animation-name: ${ fadeIn };
 		}
 	}
 `;
 
-export const ContentWrapper = styled.div`
+export const MenuPopoverInnerWrapper = styled.div`
 	position: relative;
 
 	display: grid;
@@ -121,18 +118,21 @@ export const ContentWrapper = styled.div`
 	overscroll-behavior: contain;
 	overflow: auto;
 
+	/* Only visible in Windows High Contrast mode */
+	outline: 2px solid transparent !important;
+
 	/* Animation */
 	@media not ( prefers-reduced-motion ) {
-		[data-open] & {
+		&[data-open] {
 			animation-duration: inherit;
 			animation-timing-function: inherit;
 			will-change: transform, opacity;
 			transform-origin: inherit;
 		}
-		[data-open][data-side='bottom'] & {
+		&[data-open][data-side='bottom'] {
 			animation-name: ${ fadeIn }, ${ scaleYContent };
 		}
-		[data-open][data-side='top'] & {
+		&[data-open][data-side='top'] {
 			animation-name: ${ fadeIn }, ${ scaleYContent };
 		}
 	}
@@ -216,7 +216,7 @@ const baseItem = css`
 	}
 
 	/* When the item is the trigger of an open submenu */
-	${ DropdownMenu }:not(:focus) &:not(:focus)[aria-expanded="true"] {
+	${ MenuPopoverInnerWrapper }:not(:focus) &:not(:focus)[aria-expanded="true"] {
 		background-color: ${ LIGHT_BACKGROUND_COLOR };
 		color: ${ COLORS.theme.foreground };
 	}
@@ -314,9 +314,9 @@ export const ItemSuffixWrapper = styled.span`
 	 * When the parent menu item is active, except when it's a non-focused/hovered
 	 * submenu trigger (in that case, color should not be inherited)
 	 */
-	[data-active-item]:not( [data-focus-visible] ) *:not(${ DropdownMenu }) &,
+	[data-active-item]:not( [data-focus-visible] ) *:not(${ MenuPopoverInnerWrapper }) &,
 	/* When the parent menu item is disabled */
-	[aria-disabled='true'] *:not(${ DropdownMenu }) & {
+	[aria-disabled='true'] *:not(${ MenuPopoverInnerWrapper }) & {
 		color: inherit;
 	}
 `;
@@ -379,8 +379,10 @@ export const DropdownMenuItemHelpText = styled( Truncate )`
 	color: ${ LIGHTER_TEXT_COLOR };
 	word-break: break-all;
 
-	[data-active-item]:not( [data-focus-visible] ) *:not( ${ DropdownMenu } ) &,
-	[aria-disabled='true'] *:not( ${ DropdownMenu } ) & {
+	[data-active-item]:not( [data-focus-visible] )
+		*:not( ${ MenuPopoverInnerWrapper } )
+		&,
+	[aria-disabled='true'] *:not( ${ MenuPopoverInnerWrapper } ) & {
 		color: inherit;
 	}
 `;

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -85,12 +85,16 @@ export const MenuPopoverOuterWrapper = styled.div<
 
 		&:has( [data-open][data-side='bottom'] ) {
 			transform-origin: top;
-			animation-name: ${ fadeIn }, ${ scaleYOuter };
 		}
 		&:has( [data-open][data-side='top'] ) {
 			transform-origin: bottom;
+		}
+
+		&:has( [data-open][data-side='bottom'] ),
+		&:has( [data-open][data-side='top'] ) {
 			animation-name: ${ fadeIn }, ${ scaleYOuter };
 		}
+
 		&:has( [data-open][data-side='left'] ),
 		&:has( [data-open][data-side='right'] ) {
 			animation-name: ${ fadeIn };
@@ -129,9 +133,7 @@ export const MenuPopoverInnerWrapper = styled.div`
 			will-change: transform, opacity;
 			transform-origin: inherit;
 		}
-		&[data-open][data-side='bottom'] {
-			animation-name: ${ fadeIn }, ${ scaleYContent };
-		}
+		&[data-open][data-side='bottom'],
 		&[data-open][data-side='top'] {
 			animation-name: ${ fadeIn }, ${ scaleYContent };
 		}

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -130,7 +130,6 @@ export const MenuPopoverInnerWrapper = styled.div`
 		&[data-open] {
 			animation-duration: inherit;
 			animation-timing-function: inherit;
-			will-change: transform, opacity;
 			transform-origin: inherit;
 		}
 		&[data-open][data-side='bottom'],

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import * as Ariakit from '@ariakit/react';
-import { css, keyframes } from '@emotion/react';
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 /**

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -119,8 +119,8 @@ export const MenuPopoverInnerWrapper = styled.div`
 		/*
 		 * For menus opening on top and bottom side, animate the scale Y too.
 		 * The content scales at a different rate than the outer container:
-	   * - first, counter the outer scale factor by doing "1 / scaleAmountOuter"
-	   * - then, apply the content scale factor.
+		 * - first, counter the outer scale factor by doing "1 / scaleAmountOuter"
+		 * - then, apply the content scale factor.
 		 */
 		&[data-side='bottom'],
 		&[data-side='top'] {

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -64,9 +64,6 @@ export const MenuPopoverOuterWrapper = styled.div<
 	Pick< DropdownMenuContext, 'variant' >
 >`
 	position: relative;
-	/* Same as popover component */
-	/* TODO: is there a way to read the sass variable? */
-	z-index: 1000000;
 
 	background-color: ${ COLORS.ui.background };
 	border-radius: ${ CONFIG.radiusMedium };
@@ -103,6 +100,9 @@ export const MenuPopoverOuterWrapper = styled.div<
 
 export const MenuPopoverInnerWrapper = styled.div`
 	position: relative;
+	/* Same as popover component */
+	/* TODO: is there a way to read the sass variable? */
+	z-index: 1000000;
 
 	display: grid;
 	grid-template-columns: ${ GRID_TEMPLATE_COLS };

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -15,7 +15,7 @@ import { Truncate } from '../truncate';
 import type { DropdownMenuContext } from './types';
 
 const ANIMATION_PARAMS = {
-	SCALE_AMOUNT_OUTER: 0.8,
+	SCALE_AMOUNT_OUTER: 0.82,
 	SCALE_AMOUNT_CONTENT: 0.9,
 	DURATION: '400ms',
 	EASING: 'cubic-bezier(0.33, 0, 0, 1)',

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -39,27 +39,6 @@ const TOOLBAR_VARIANT_BOX_SHADOW = `0 0 0 ${ CONFIG.borderWidth } ${ TOOLBAR_VAR
 
 const GRID_TEMPLATE_COLS = 'minmax( 0, max-content ) 1fr';
 
-const scaleYOuter = keyframes( {
-	from: {
-		transform: `scaleY(${ ANIMATION_PARAMS.SCALE_AMOUNT_OUTER })`,
-	},
-} );
-
-const scaleYContent = keyframes( {
-	// Cause the content to scale at a different rate than the outer container:
-	// - counter the outer scale factor by doing "1 / scaleAmountOuter"
-	// - then apply the content scale factor
-	from: {
-		transform: `scaleY(calc(1 / ${ ANIMATION_PARAMS.SCALE_AMOUNT_OUTER } * ${ ANIMATION_PARAMS.SCALE_AMOUNT_CONTENT }))`,
-	},
-} );
-
-const fadeIn = keyframes( {
-	from: {
-		opacity: 0,
-	},
-} );
-
 export const MenuPopoverOuterWrapper = styled.div<
 	Pick< DropdownMenuContext, 'variant' >
 >`
@@ -75,29 +54,36 @@ export const MenuPopoverOuterWrapper = styled.div<
 
 	overflow: hidden;
 
-	/* Animation */
+	/* Open/close animation (outer wrapper) */
 	@media not ( prefers-reduced-motion ) {
-		&:has( [data-open] ) {
-			animation-duration: ${ ANIMATION_PARAMS.DURATION };
-			animation-timing-function: ${ ANIMATION_PARAMS.EASING };
-			will-change: transform, opacity;
+		transition-property: transform, opacity;
+		transition-timing-function: ${ ANIMATION_PARAMS.EASING };
+		transition-duration: ${ ANIMATION_PARAMS.DURATION };
+		will-change: transform, opacity;
+
+		/* Regardless of the side, fade in and out. */
+		opacity: 0;
+		&:has( [data-enter] ) {
+			opacity: 1;
 		}
 
-		&:has( [data-open][data-side='bottom'] ) {
+		/* For menus opening on top and bottom side, animate the scale Y too. */
+		&:has( [data-side='bottom'] ),
+		&:has( [data-side='top'] ) {
+			transform: scaleY( ${ ANIMATION_PARAMS.SCALE_AMOUNT_OUTER } );
+		}
+		&:has( [data-side='bottom'] ) {
 			transform-origin: top;
 		}
-		&:has( [data-open][data-side='top'] ) {
+		&:has( [data-side='top'] ) {
 			transform-origin: bottom;
 		}
-
-		&:has( [data-open][data-side='bottom'] ),
-		&:has( [data-open][data-side='top'] ) {
-			animation-name: ${ fadeIn }, ${ scaleYOuter };
-		}
-
-		&:has( [data-open][data-side='left'] ),
-		&:has( [data-open][data-side='right'] ) {
-			animation-name: ${ fadeIn };
+		&:has( [data-enter][data-side='bottom'] ),
+		&:has( [data-enter][data-side='top'] ),
+		/* Do not animate the scaleY when closing the menu */
+		&:has( [data-leave][data-side='bottom'] ),
+		&:has( [data-leave][data-side='top'] ) {
+			transform: scaleY( 1 );
 		}
 	}
 `;
@@ -125,16 +111,32 @@ export const MenuPopoverInnerWrapper = styled.div`
 	/* Only visible in Windows High Contrast mode */
 	outline: 2px solid transparent !important;
 
-	/* Animation */
+	/* Open/close animation (inner content wrapper) */
 	@media not ( prefers-reduced-motion ) {
-		&[data-open] {
-			animation-duration: inherit;
-			animation-timing-function: inherit;
-			transform-origin: inherit;
+		transition: inherit;
+		transform-origin: inherit;
+
+		/*
+		 * For menus opening on top and bottom side, animate the scale Y too.
+		 * The content scales at a different rate than the outer container:
+	   * - first, counter the outer scale factor by doing "1 / scaleAmountOuter"
+	   * - then, apply the content scale factor.
+		 */
+		&[data-side='bottom'],
+		&[data-side='top'] {
+			transform: scaleY(
+				calc(
+					1 / ${ ANIMATION_PARAMS.SCALE_AMOUNT_OUTER } *
+						${ ANIMATION_PARAMS.SCALE_AMOUNT_CONTENT }
+				)
+			);
 		}
-		&[data-open][data-side='bottom'],
-		&[data-open][data-side='top'] {
-			animation-name: ${ fadeIn }, ${ scaleYContent };
+		&[data-enter][data-side='bottom'],
+		&[data-enter][data-side='top'],
+		/* Do not animate the scaleY when closing the menu */
+		&[data-leave][data-side='bottom'],
+		&[data-leave][data-side='top'] {
+			transform: scaleY( 1 );
 		}
 	}
 `;

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -17,7 +17,10 @@ import type { DropdownMenuContext } from './types';
 const ANIMATION_PARAMS = {
 	SCALE_AMOUNT_OUTER: 0.82,
 	SCALE_AMOUNT_CONTENT: 0.9,
-	DURATION: '400ms',
+	DURATION: {
+		IN: '400ms',
+		OUT: '200ms',
+	},
 	EASING: 'cubic-bezier(0.33, 0, 0, 1)',
 };
 
@@ -58,13 +61,17 @@ export const MenuPopoverOuterWrapper = styled.div<
 	@media not ( prefers-reduced-motion ) {
 		transition-property: transform, opacity;
 		transition-timing-function: ${ ANIMATION_PARAMS.EASING };
-		transition-duration: ${ ANIMATION_PARAMS.DURATION };
+		transition-duration: ${ ANIMATION_PARAMS.DURATION.IN };
 		will-change: transform, opacity;
 
 		/* Regardless of the side, fade in and out. */
 		opacity: 0;
 		&:has( [data-enter] ) {
 			opacity: 1;
+		}
+
+		&:has( [data-leave] ) {
+			transition-duration: ${ ANIMATION_PARAMS.DURATION.OUT };
 		}
 
 		/* For menus opening on top and bottom side, animate the scale Y too. */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #50459

Updates `DropdownMenuV2` animation following the latest specs (shared by @nick-a8c)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For a better sense of polish, and alignment with the rest of the animations in Gutenberg.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The new animation specs require the popover wrapper and the popover contents to scale at different rates. That required a small refactor to include an extra wrapper element, to account for the two separate animations (proof of concept: https://codepen.io/ciampo/pen/mdZjPWg)

The scale animation does not happen when the popover opens to the side of its trigger — in that case, the popover only fades in.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check `DropdownMenuV2` examples in Storybook and its usages across the editor, make sure the animation looks good and follows the specs, without impactive the usability and the semantics of the component.-->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/33a8d47d-a8f8-402a-a1b6-6b0c21098add

