### PR TITLE
Button Block: Set proper typography for inner elements

### DIFF
--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -38,6 +38,14 @@ $blocks-block__margin: 0.5em;
 	text-decoration: inherit;
 }
 
+.wp-block-button[style*="font-weight"] .wp-block-button__link {
+	font-weight: inherit;
+}
+
+.wp-block-button[style*="font-style"] .wp-block-button__link {
+	font-style: inherit;
+}
+
 // Increased specificity needed to override margins.
 .wp-block-buttons > .wp-block-button {
 	&.has-custom-width {


### PR DESCRIPTION
## What?
The current typography does not work correctly with the given button styles. This fix forces inner elements to inherit the styles.

## Why?
Fixes #64662 

## How?
This fix adds following CSS to the button inner elements
```css
.wp-block-button[style*="font-weight"] .wp-block-button__link {
	font-weight: inherit;
}

.wp-block-button[style*="font-style"] .wp-block-button__link {
	font-style: inherit;
}
```

## Testing Instructions
1. Set Twenty Twenty-Four theme
2. Place Button block
3. Set the Appearance to Bold, etc.

You can see that the Appearance has changed on either the editor screen or the front screen.

## Screenshots or screencast

### Before

https://github.com/user-attachments/assets/be84a97e-dc1e-491d-a0c8-9c84a897925b


### After

https://github.com/user-attachments/assets/159dd768-969b-4556-b4fa-f194c502dd6e

