### PR TITLE
Reusable blocks: fix performance of __experimentalGetAllowedPatterns

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -20,6 +20,7 @@ import {
 	checkAllowListRecursive,
 	getAllPatternsDependants,
 	getInsertBlockTypeDependants,
+	getParsedPattern,
 } from './utils';
 import { INSERTER_PATTERN_TYPES } from '../components/inserter/block-patterns-tab/utils';
 import { STORE_NAME } from './constants';
@@ -291,16 +292,15 @@ export const getInserterMediaCategories = createSelector(
 export const hasAllowedPatterns = createRegistrySelector( ( select ) =>
 	createSelector(
 		( state, rootClientId = null ) => {
-			const { getAllPatterns, __experimentalGetParsedPattern } = unlock(
-				select( STORE_NAME )
-			);
+			const { getAllPatterns } = unlock( select( STORE_NAME ) );
 			const patterns = getAllPatterns();
 			const { allowedBlockTypes } = getSettings( state );
-			return patterns.some( ( { name, inserter = true } ) => {
+			return patterns.some( ( pattern ) => {
+				const { inserter = true } = pattern;
 				if ( ! inserter ) {
 					return false;
 				}
-				const { blocks } = __experimentalGetParsedPattern( name );
+				const { blocks } = getParsedPattern( pattern );
 				return (
 					checkAllowListRecursive( blocks, allowedBlockTypes ) &&
 					blocks.every( ( { name: blockName } ) =>

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -7,7 +7,6 @@ import {
 	getBlockVariations,
 	hasBlockSupport,
 	getPossibleBlockTransformations,
-	parse,
 	switchToBlockType,
 	store as blocksStore,
 } from '@wordpress/blocks';
@@ -27,6 +26,7 @@ import {
 	checkAllowList,
 	getAllPatternsDependants,
 	getInsertBlockTypeDependants,
+	getParsedPattern,
 } from './utils';
 import { orderBy } from '../utils/sorting';
 import { STORE_NAME } from './constants';
@@ -2348,34 +2348,6 @@ export function __experimentalGetDirectInsertBlock(
 	return getDirectInsertBlock( state, rootClientId );
 }
 
-const parsedPatternCache = new WeakMap();
-
-function parsePattern( pattern ) {
-	const blocks = parse( pattern.content, {
-		__unstableSkipMigrationLogs: true,
-	} );
-	if ( blocks.length === 1 ) {
-		blocks[ 0 ].attributes = {
-			...blocks[ 0 ].attributes,
-			metadata: {
-				...( blocks[ 0 ].attributes.metadata || {} ),
-				categories: pattern.categories,
-				patternName: pattern.name,
-				name: blocks[ 0 ].attributes.metadata?.name || pattern.title,
-			},
-		};
-	}
-	return {
-		...pattern,
-		blocks,
-	};
-}
-
-function getParsedPattern( pattern ) {
-	const parsedPattern = parsedPatternCache.has( pattern );
-	return parsedPattern ? parsedPattern : parsePattern( pattern );
-}
-
 export const __experimentalGetParsedPattern = createRegistrySelector(
 	( select ) =>
 		createSelector(
@@ -2383,10 +2355,7 @@ export const __experimentalGetParsedPattern = createRegistrySelector(
 				const pattern = unlock( select( STORE_NAME ) ).getPatternBySlug(
 					patternName
 				);
-				if ( ! pattern ) {
-					return null;
-				}
-				return getParsedPattern( pattern );
+				return pattern ? getParsedPattern( pattern ) : null;
 			},
 			( state, patternName ) => [
 				unlock( select( STORE_NAME ) ).getPatternBySlug( patternName ),

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2349,18 +2349,12 @@ export function __experimentalGetDirectInsertBlock(
 }
 
 export const __experimentalGetParsedPattern = createRegistrySelector(
-	( select ) =>
-		createSelector(
-			( state, patternName ) => {
-				const pattern = unlock( select( STORE_NAME ) ).getPatternBySlug(
-					patternName
-				);
-				return pattern ? getParsedPattern( pattern ) : null;
-			},
-			( state, patternName ) => [
-				unlock( select( STORE_NAME ) ).getPatternBySlug( patternName ),
-			]
-		)
+	( select ) => ( state, patternName ) => {
+		const pattern = unlock( select( STORE_NAME ) ).getPatternBySlug(
+			patternName
+		);
+		return pattern ? getParsedPattern( pattern ) : null;
+	}
 );
 
 const getAllowedPatternsDependants = ( select ) => ( state, rootClientId ) => [

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { parse } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import { selectBlockPatternsKey } from './private-keys';
@@ -6,6 +11,34 @@ import { unlock } from '../lock-unlock';
 import { STORE_NAME } from './constants';
 
 export const withRootClientIdOptionKey = Symbol( 'withRootClientId' );
+
+const parsedPatternCache = new WeakMap();
+
+function parsePattern( pattern ) {
+	const blocks = parse( pattern.content, {
+		__unstableSkipMigrationLogs: true,
+	} );
+	if ( blocks.length === 1 ) {
+		blocks[ 0 ].attributes = {
+			...blocks[ 0 ].attributes,
+			metadata: {
+				...( blocks[ 0 ].attributes.metadata || {} ),
+				categories: pattern.categories,
+				patternName: pattern.name,
+				name: blocks[ 0 ].attributes.metadata?.name || pattern.title,
+			},
+		};
+	}
+	return {
+		...pattern,
+		blocks,
+	};
+}
+
+export function getParsedPattern( pattern ) {
+	const parsedPattern = parsedPatternCache.has( pattern );
+	return parsedPattern ? parsedPattern : parsePattern( pattern );
+}
 
 export const checkAllowList = ( list, item, defaultResult = null ) => {
 	if ( typeof list === 'boolean' ) {

--- a/packages/block-editor/src/store/utils.js
+++ b/packages/block-editor/src/store/utils.js
@@ -36,8 +36,13 @@ function parsePattern( pattern ) {
 }
 
 export function getParsedPattern( pattern ) {
-	const parsedPattern = parsedPatternCache.has( pattern );
-	return parsedPattern ? parsedPattern : parsePattern( pattern );
+	let parsedPattern = parsedPatternCache.get( pattern );
+	if ( parsedPattern ) {
+		return parsedPattern;
+	}
+	parsedPattern = parsePattern( pattern );
+	parsedPatternCache.set( pattern, parsedPattern );
+	return parsedPattern;
 }
 
 export const checkAllowList = ( list, item, defaultResult = null ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Should fix #64219 and #64732 (which are the same issue I think).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The editor freezes when there are thousands of reusable blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The problem comes from `__experimentalGetParsedPattern`, but more specifically the invalidation function `getPatternBySlug( patternName )`, which in turn uses `getReusableBlocks()` in its invalidation function. Normally this should simply return the existing state, but maybe there's more going on in the underlying `getEntityRecords` call.

In any case, `__experimentalGetParsedPattern` is a terrible selector. It seems more appropriate to cache the parsed patterns in a weak map, which is what I did here. The performance problems seem to be resolved.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Add a huge amount of reusable blocks:
```
wp eval 'for ($i = 1; $i <= 3000; $i++) { wp_insert_post(["post_title" => "Reusable Block " . $i, "post_content" => "<!-- wp:paragraph --><p>This is block " . $i . "</p><!-- /wp:paragraph -->", "post_status" => "publish", "post_type" => "wp_block"]); }'
```

Then click around the editor. What I found particularly lagging in not selecting a block but opening the appender. What I tested was the demo content, then click on the first cover and then on the + appender.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
