### PR TITLE
ContentOnly: Add support for block styles on top-level contentOnly locked blocks

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -32,19 +32,37 @@ import { useBorderPanelLabel } from '../../hooks/border';
 
 import { unlock } from '../../lock-unlock';
 
+function BlockStylesPanel( { clientId } ) {
+	return (
+		<div>
+			<PanelBody title={ __( 'Styles' ) }>
+				<BlockStyles clientId={ clientId } />
+			</PanelBody>
+		</div>
+	);
+}
+
 function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
-	const contentClientIds = useSelect(
+	const { contentClientIds, hasBlockStyles } = useSelect(
 		( select ) => {
 			const {
 				getClientIdsOfDescendants,
 				getBlockName,
 				getBlockEditingMode,
 			} = select( blockEditorStore );
-			return getClientIdsOfDescendants( topLevelLockedBlock ).filter(
-				( clientId ) =>
-					getBlockName( clientId ) !== 'core/list-item' &&
-					getBlockEditingMode( clientId ) === 'contentOnly'
-			);
+			const { getBlockStyles } = select( blocksStore );
+			return {
+				contentClientIds: getClientIdsOfDescendants(
+					topLevelLockedBlock
+				).filter(
+					( clientId ) =>
+						getBlockName( clientId ) !== 'core/list-item' &&
+						getBlockEditingMode( clientId ) === 'contentOnly'
+				),
+				hasBlockStyles: !! getBlockStyles(
+					getBlockName( topLevelLockedBlock )
+				)?.length,
+			};
 		},
 		[ topLevelLockedBlock ]
 	);
@@ -57,6 +75,9 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 			/>
 			<BlockVariationTransforms blockClientId={ topLevelLockedBlock } />
 			<BlockInfo.Slot />
+			{ hasBlockStyles && (
+				<BlockStylesPanel clientId={ topLevelLockedBlock } />
+			) }
 			{ contentClientIds.length > 0 && (
 				<PanelBody title={ __( 'Content' ) }>
 					<BlockQuickNavigation clientIds={ contentClientIds } />
@@ -81,7 +102,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getContentLockingParent,
 			getTemplateLock,
 		} = unlock( select( blockEditorStore ) );
-
 		const _selectedBlockClientId = getSelectedBlockClientId();
 		const _selectedBlockName =
 			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
@@ -276,11 +296,7 @@ const BlockInspectorSingleBlock = ( { clientId, blockName } ) => {
 			{ ! showTabs && (
 				<>
 					{ hasBlockStyles && (
-						<div>
-							<PanelBody title={ __( 'Styles' ) }>
-								<BlockStyles clientId={ clientId } />
-							</PanelBody>
-						</div>
+						<BlockStylesPanel clientId={ clientId } />
 					) }
 					<InspectorControls.Slot />
 					<InspectorControls.Slot group="list" />

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -9,7 +9,6 @@ import {
 } from '@wordpress/blocks';
 import { PanelBody, __unstableMotion as motion } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -42,29 +41,29 @@ function BlockStylesPanel( { clientId } ) {
 }
 
 function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
-	const { getBlockName, getBlockEditingMode } = useSelect( blockEditorStore );
-	const { contentClientIds, hasBlockStyles } = useSelect(
+	const contentClientIds = useSelect(
 		( select ) => {
-			const { getClientIdsOfDescendants } = select( blockEditorStore );
-			const { getBlockStyles } = select( blocksStore );
-			return {
-				contentClientIds:
-					getClientIdsOfDescendants( topLevelLockedBlock ),
-				hasBlockStyles: !! getBlockStyles(
-					getBlockName( topLevelLockedBlock )
-				)?.length,
-			};
-		},
-		[ topLevelLockedBlock, getBlockName ]
-	);
-	const eligibleContentClientIds = useMemo(
-		() =>
-			contentClientIds.filter(
+			const {
+				getClientIdsOfDescendants,
+				getBlockName,
+				getBlockEditingMode,
+			} = select( blockEditorStore );
+			return getClientIdsOfDescendants( topLevelLockedBlock ).filter(
 				( clientId ) =>
 					getBlockName( clientId ) !== 'core/list-item' &&
 					getBlockEditingMode( clientId ) === 'contentOnly'
-			),
-		[ contentClientIds, getBlockName, getBlockEditingMode ]
+			);
+		},
+		[ topLevelLockedBlock ]
+	);
+	const hasBlockStyles = useSelect(
+		( select ) => {
+			const { getBlockName } = select( blockEditorStore );
+			const { getBlockStyles } = select( blocksStore );
+			return !! getBlockStyles( getBlockName( topLevelLockedBlock ) )
+				?.length;
+		},
+		[ topLevelLockedBlock ]
 	);
 	const blockInformation = useBlockDisplayInformation( topLevelLockedBlock );
 	return (
@@ -78,11 +77,9 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 			{ hasBlockStyles && (
 				<BlockStylesPanel clientId={ topLevelLockedBlock } />
 			) }
-			{ eligibleContentClientIds.length > 0 && (
+			{ contentClientIds.length > 0 && (
 				<PanelBody title={ __( 'Content' ) }>
-					<BlockQuickNavigation
-						clientIds={ eligibleContentClientIds }
-					/>
+					<BlockQuickNavigation clientIds={ contentClientIds } />
 				</PanelBody>
 			) }
 		</div>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/64660


This PR adds support for surfacing a parent block's style variations on [contentOnly locked groups](https://rich.blog/content-only/). This way styles can still be applied cohesively across the group of blocks.
<!-- In a few words, what is the PR actually doing? -->

Before            |  After
:-------------------------:|:-------------------------:
<img width="899" alt="Screenshot 2024-08-28 at 5 11 47 PM" src="https://github.com/user-attachments/assets/7472fe0b-bfa0-492e-bd93-0991c7fbbac2"> | <img width="899" alt="Screenshot 2024-08-28 at 5 11 10 PM" src="https://github.com/user-attachments/assets/88ef8f11-fc24-4f93-861e-89f5f4d7a5ec">


## Testing Instructions
1. In post editor create a Group block and make it `contentOnly` in code editor by adding `"templateLock": "contentOnly"` attribute at the top-level that block.
2. Add some test style variations. You could add the below in `Group` block.json file:
```
"styles": [
	{
		"name": "default",
		"label": "Default",
		"isDefault": true
	},
	{ "name": "rounded", "label": "Rounded" },
	{ "name": "demo", "label": "Demo" }
]
```
3. Verify that block styles for the contentOnly locked block are shown in the inspector controls
4. Ensure that there is no regression if the block has no block styles and that block styles for rest of cases (blocks not locked) are working as before.