### PR TITLE
DropdownMenuV2: remove flashing styles when moving focus with keyboard

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -51,6 +51,7 @@
 
 ### Internal
 
+-   `DropdownMenu` v2: fix flashing menu item styles when using keyboard ([#64873](https://github.com/WordPress/gutenberg/pull/64873)).
 -   `DropdownMenu` v2: refactor to overloaded naming convention ([#64654](https://github.com/WordPress/gutenberg/pull/64654)).
 -   `Composite` V2: fix Storybook docgen ([#64682](https://github.com/WordPress/gutenberg/pull/64682)).
 

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -171,8 +171,8 @@ const baseItem = css`
 		cursor: not-allowed;
 	}
 
-	/* Hover */
-	&[data-active-item]:not( [data-focus-visible] ):not(
+	/* Active item (including hover) */
+	&[data-active-item]:not( [data-focus-visible] ):not( :focus-visible ):not(
 			[aria-disabled='true']
 		) {
 		background-color: ${ COLORS.theme.accent };
@@ -180,7 +180,8 @@ const baseItem = css`
 	}
 
 	/* Keyboard focus (focus-visible) */
-	&[data-focus-visible] {
+	&[data-focus-visible],
+	&:focus-visible {
 		box-shadow: 0 0 0 1.5px ${ COLORS.theme.accent };
 
 		/* Only visible in Windows High Contrast mode */

--- a/packages/components/src/dropdown-menu-v2/styles.ts
+++ b/packages/components/src/dropdown-menu-v2/styles.ts
@@ -171,7 +171,10 @@ const baseItem = css`
 		cursor: not-allowed;
 	}
 
-	/* Active item (including hover) */
+	/* Active item (including hover)
+	 * Note: we should be able to remove :focus-visible once
+	 * https://github.com/ariakit/ariakit/issues/4083 is fixed and released
+	 */
 	&[data-active-item]:not( [data-focus-visible] ):not( :focus-visible ):not(
 			[aria-disabled='true']
 		) {
@@ -179,7 +182,10 @@ const baseItem = css`
 		color: ${ COLORS.white };
 	}
 
-	/* Keyboard focus (focus-visible) */
+	/* Keyboard focus (focus-visible)
+	 * Note: we should be able to remove :focus-visible once
+	 * https://github.com/ariakit/ariakit/issues/4083 is fixed and released
+	 */
 	&[data-focus-visible],
 	&:focus-visible {
 		box-shadow: 0 0 0 1.5px ${ COLORS.theme.accent };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #50459

Removing "flash of unwanted styles" when navigating `DropdownMenuV2` items using the keyboard.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While working on `DropdownMenuV2`, I noticed that menu items would sometimes flash briefly with the "active (hover)" styles, before applying the expected "focus-visible" styles — ie. it seems that the underlying ariakit implementation doesn't apply the `data-focus-visible` attribute soon enough, and therefore the focus-visible styles are applied with a delay, causing the hover (active) styles to apply for a few frames.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I removed the flash by using the native `:focus-visible` CSS selector, which matches without any delays.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In Storybook, interact with the DropdownMenuV2 examples using keyboard, moving across the menu items.

On trunk, you could sometimes see the aforementioned flash — with the changes from this PR, the flash should never happen.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/40e73caa-62d0-473e-bef0-8a301b077879" /> | <video src="https://github.com/user-attachments/assets/e2d90cad-e298-4b5a-8300-d760c575b695" /> |
