### PR TITLE
Improve Social Icons setup and appending

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { Button, Tooltip, VisuallyHidden } from '@wordpress/components';
-import { forwardRef } from '@wordpress/element';
+import { forwardRef, useRef } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
 import { Icon, plus } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
@@ -16,17 +16,26 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import Inserter from '../inserter';
+import { useMergeRefs } from '@wordpress/compose';
 
 function ButtonBlockAppender(
 	{ rootClientId, className, onFocus, tabIndex, onSelect },
 	ref
 ) {
+	const inserterButtonRef = useRef();
+
+	const mergedInserterButtonRef = useMergeRefs( [ inserterButtonRef, ref ] );
 	return (
 		<Inserter
 			position="bottom center"
 			rootClientId={ rootClientId }
 			__experimentalIsQuick
-			onSelectOrClose={ onSelect }
+			onSelectOrClose={ ( ...args ) => {
+				if ( onSelect && typeof onSelect === 'function' ) {
+					onSelect( ...args );
+				}
+				inserterButtonRef.current?.focus();
+			} }
 			renderToggle={ ( {
 				onToggle,
 				disabled,
@@ -53,7 +62,7 @@ function ButtonBlockAppender(
 					<Button
 						// TODO: Switch to `true` (40px size) if possible
 						__next40pxDefaultSize={ false }
-						ref={ ref }
+						ref={ mergedInserterButtonRef }
 						onFocus={ onFocus }
 						tabIndex={ tabIndex }
 						className={ clsx(

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -94,13 +94,8 @@ export function SocialLinksEdit( props ) {
 		} else {
 			setAttributes( { ...backgroundBackupRef.current } );
 		}
-	}, [
-		customIconBackgroundColor,
-		iconBackgroundColor,
-		iconBackgroundColorValue,
-		logosOnly,
-		setAttributes,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ logosOnly ] );
 
 	const SocialPlaceholder = (
 		<li className="wp-block-social-links__social-placeholder">

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -14,6 +14,7 @@ import {
 	InspectorControls,
 	ContrastChecker,
 	withColors,
+	InnerBlocks,
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 } from '@wordpress/block-editor';
@@ -75,7 +76,13 @@ export function SocialLinksEdit( props ) {
 		} else {
 			setAttributes( { ...backgroundBackupRef.current } );
 		}
-	}, [ logosOnly ] );
+	}, [
+		customIconBackgroundColor,
+		iconBackgroundColor,
+		iconBackgroundColorValue,
+		logosOnly,
+		setAttributes,
+	] );
 
 	const SocialPlaceholder = (
 		<li className="wp-block-social-links__social-placeholder">
@@ -84,12 +91,6 @@ export function SocialLinksEdit( props ) {
 				<div className="wp-social-link wp-social-link-facebook"></div>
 				<div className="wp-social-link wp-social-link-instagram"></div>
 			</div>
-		</li>
-	);
-
-	const SelectedSocialPlaceholder = (
-		<li className="wp-block-social-links__social-prompt">
-			{ __( 'Click plus to add' ) }
 		</li>
 	);
 
@@ -104,10 +105,11 @@ export function SocialLinksEdit( props ) {
 
 	const blockProps = useBlockProps( { className } );
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		placeholder: isSelected ? SelectedSocialPlaceholder : SocialPlaceholder,
+		placeholder: ! isSelected && SocialPlaceholder,
 		templateLock: false,
 		orientation: attributes.layout?.orientation ?? 'horizontal',
 		__experimentalAppenderTagName: 'li',
+		renderAppender: isSelected && InnerBlocks.ButtonBlockAppender,
 	} );
 
 	const POPOVER_PROPS = {

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -49,22 +49,6 @@ export function SocialLinksEdit( props ) {
 		setIconColor,
 	} = props;
 
-	const hasAnySelected = useSelect(
-		( select ) => {
-			const { getSelectedBlockClientId, getBlockOrder } =
-				select( blockEditorStore );
-			const selectedBlockClientId = getSelectedBlockClientId();
-			const innerBlockClientIds = getBlockOrder( clientId );
-
-			// Check if the selected block is the main block or any of its inner blocks
-			return (
-				selectedBlockClientId === clientId ||
-				innerBlockClientIds.includes( selectedBlockClientId )
-			);
-		},
-		[ clientId ]
-	);
-
 	const {
 		iconBackgroundColorValue,
 		customIconBackgroundColor,
@@ -73,6 +57,14 @@ export function SocialLinksEdit( props ) {
 		showLabels,
 		size,
 	} = attributes;
+
+	const hasSelectedChild = useSelect(
+		( select ) =>
+			select( blockEditorStore ).hasSelectedInnerBlock( clientId ),
+		[ clientId ]
+	);
+
+	const hasAnySelected = isSelected || hasSelectedChild;
 
 	const logosOnly = attributes.className?.includes( 'is-style-logos-only' );
 

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -17,6 +17,7 @@ import {
 	InnerBlocks,
 	__experimentalColorGradientSettingsDropdown as ColorGradientSettingsDropdown,
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	MenuGroup,
@@ -27,6 +28,7 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
+import { useSelect } from '@wordpress/data';
 
 const sizeOptions = [
 	{ name: __( 'Small' ), value: 'has-small-icon-size' },
@@ -46,6 +48,22 @@ export function SocialLinksEdit( props ) {
 		setIconBackgroundColor,
 		setIconColor,
 	} = props;
+
+	const hasAnySelected = useSelect(
+		( select ) => {
+			const { getSelectedBlockClientId, getBlockOrder } =
+				select( blockEditorStore );
+			const selectedBlockClientId = getSelectedBlockClientId();
+			const innerBlockClientIds = getBlockOrder( clientId );
+
+			// Check if the selected block is the main block or any of its inner blocks
+			return (
+				selectedBlockClientId === clientId ||
+				innerBlockClientIds.includes( selectedBlockClientId )
+			);
+		},
+		[ clientId ]
+	);
 
 	const {
 		iconBackgroundColorValue,
@@ -109,7 +127,7 @@ export function SocialLinksEdit( props ) {
 		templateLock: false,
 		orientation: attributes.layout?.orientation ?? 'horizontal',
 		__experimentalAppenderTagName: 'li',
-		renderAppender: isSelected && InnerBlocks.ButtonBlockAppender,
+		renderAppender: hasAnySelected && InnerBlocks.ButtonBlockAppender,
 	} );
 
 	const POPOVER_PROPS = {

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -102,18 +102,18 @@
 	position: static; // display inline.
 
 	.block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-10;
+		padding: $grid-unit-10 - 2px;
 	}
 }
 
 .wp-block-social-links {
 	&.has-small-icon-size .block-editor-button-block-appender.components-button.components-button {
-		padding: math.div($grid-unit-10, 2);
+		padding: 0;
 	}
 	&.has-large-icon-size .block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-20;
+		padding: $grid-unit-20 - 2px;
 	}
 	&.has-huge-icon-size .block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-30;
+		padding: $grid-unit-30 - 1px;
 	}
 }

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -108,7 +108,7 @@
 
 .wp-block-social-links {
 	&.has-small-icon-size .block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-10 / 2;
+		padding: math.div($grid-unit-10, 2);
 	}
 	&.has-large-icon-size .block-editor-button-block-appender.components-button.components-button {
 		padding: $grid-unit-20;

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -98,3 +98,11 @@
 .wp-social-link.wp-social-link__is-incomplete:focus {
 	opacity: 1;
 }
+
+.wp-block-social-links .block-list-appender {
+	position: static; // display inline.
+
+	.block-editor-button-block-appender.components-button.components-button {
+		padding: $grid-unit-10;
+	}
+}

--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -1,10 +1,9 @@
 // Editor specific styles for Social Links.
-.wp-block-social-links {
-	div.block-editor-url-input {
-		display: inline-block;
-		margin-left: $grid-unit-10;
-	}
+.wp-block-social-links div.block-editor-url-input {
+	display: inline-block;
+	margin-left: $grid-unit-10;
 }
+
 
 // Prevent toolbar from jumping when selecting / hovering a link.
 .wp-social-link:hover {
@@ -104,5 +103,17 @@
 
 	.block-editor-button-block-appender.components-button.components-button {
 		padding: $grid-unit-10;
+	}
+}
+
+.wp-block-social-links {
+	&.has-small-icon-size .block-editor-button-block-appender.components-button.components-button {
+		padding: $grid-unit-10 / 2;
+	}
+	&.has-large-icon-size .block-editor-button-block-appender.components-button.components-button {
+		padding: $grid-unit-20;
+	}
+	&.has-huge-icon-size .block-editor-button-block-appender.components-button.components-button {
+		padding: $grid-unit-30;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/60120
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Improves the ability to add new social icons.

This will be nicely complemented by https://github.com/WordPress/gutenberg/pull/59303.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the initial and subsequent states of the Social Icons block(s) can make it very challenging to add new social links. This PR seeks to improve that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removes the `Click + to add` instruction. It was always a stop gap and provided a poor UX.
- Utilise custom button appender similar to Nav block.
- Make appender always "inline" next to last added block.
- Show appender if either parent or any child block is selected - this allow the user to find the appender more easily.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add a Social Icons block
- Test whether it is intuitive to find a way to add new social links
- Test that empty block shows appender when selected


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Repeat steps above and ensure you can complete using only keyboard

My main concerns is how the focus move should work. I can use arrow keys to reach the appender but I'm not sure that resolves the problems in https://github.com/WordPress/gutenberg/issues/60120.

I'll do some more digging on this as I'm not confident it's good enough yet.

## Screenshots or screencast <!-- if applicable -->

#### Before
https://github.com/user-attachments/assets/bd3a783a-cc5e-42e0-85fe-cfdbe1298020


#### After
https://github.com/user-attachments/assets/d743c798-8773-46c0-837e-70d59bf10426

