### PR TITLE
Global Styles: Adjust spacing of background panel

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -692,16 +692,14 @@ function BackgroundToolsPanel( {
 	};
 
 	return (
-		<VStack
-			as={ ToolsPanel }
-			spacing={ 2 }
+		<ToolsPanel
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }
-		</VStack>
+		</ToolsPanel>
 	);
 }
 


### PR DESCRIPTION
## What?

This PR adjusts the spacing of the background image panel in the global styles (not the background image panel in the block sidebar).

## Why?

The panel gap should be `16px`, but it appears that `8px` is being applied because of the `VStack` component's prop `spacing={ 2 }`.

## How?

From what I've researched, it seems like it's fine to use the `ToolsPanel` component directly rather than the `VStack` component.

## Testing Instructions

- Access the Site Editor > Global Styles > Layout > Background panel.
- Check out the space between the title and the button.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/cab1e8ed-adb0-493f-bcf8-04d3e765b41b) | ![image](https://github.com/user-attachments/assets/ea2db9d9-4733-4b26-842b-28660ab6d72f) | 