### PR TITLE
Block Bindings: Fix empty custom fields not being editable in bindings

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -53,13 +53,14 @@ export default {
 		}
 
 		// Check that the custom field is not protected and available in the REST API.
-		const isFieldExposed = !! select( coreDataStore ).getEntityRecord(
+		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
+		const fieldValue = select( coreDataStore ).getEntityRecord(
 			'postType',
 			postType,
 			context?.postId
 		)?.meta?.[ args.key ];
 
-		if ( ! isFieldExposed ) {
+		if ( fieldValue === undefined ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What?
Fix an issue where empty custom fields where not editable in bindings.

## Why?
An empty string is a valid value and users should be able to edit them if needed.

## How?
Changing the conditional to check `undefined` instead of falsy values.

## Testing Instructions
1. Register a new custom field with an empty string as default value.
```
	register_meta(
		'post',
		'empty_field',
		array(
			'show_in_rest' => true,
			'single'       => true,
			'type'         => 'string',
			'default'      => '',
		)
	);
```
2. Go to a page and insert a paragraph bound to that custom field.
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"empty_field"}}}}} -->
<p></p>
<!-- /wp:paragraph -->
```
3. Save the post and refresh.
4. Check that you can edit the value of the empty custom field.
