### PR TITLE
Cast globalFluid value to boolean

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -54,7 +54,7 @@ function FontSize() {
 
 	// Whether the font size is fluid. If not defined, use the global fluid value of the theme.
 	const isFluid =
-		fontSize.fluid !== undefined ? !! fontSize.fluid : globalFluid;
+		fontSize.fluid !== undefined ? !! fontSize.fluid : !! globalFluid;
 
 	// Whether custom fluid values are used.
 	const isCustomFluid = typeof fontSize.fluid === 'object';


### PR DESCRIPTION
## What?
Cast globalFluid value to boolean.


## Why?
It could be an object apart from a boolean. See the theme.json schema:
https://github.com/WordPress/gutenberg/blob/561b06e6d3b577a7bf9802803f90269c7cc5c509/schemas/json/theme.json#L549-L573


## How?
casting the value to a boolean.

Props to @t-hamano[ for noticing](https://github.com/WordPress/gutenberg/pull/64803#discussion_r1732032228).