### PR TITLE
Make social icon navigation one arrow keypress

### DIFF
--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -118,7 +118,6 @@ const SocialLinkEdit = ( {
 		// Manually adding this class for backwards compatibility of CSS when moving the
 		// blockProps from the li to the button: https://github.com/WordPress/gutenberg/pull/64883
 		'wp-block-social-link',
-		'wp-social-link__list-item',
 		'wp-social-link-' + service,
 		{
 			'wp-social-link__is-incomplete': ! url,

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -189,7 +189,14 @@ const SocialLinkEdit = ( {
 					backgroundColor: iconBackgroundColorValue,
 				} }
 			>
-				<button aria-haspopup="dialog" { ...blockProps }>
+				{ /*
+				 * Disable reason: The `button` ARIA role is redundant but
+				 * blockProps has a role of `document` automatically applied
+				 * which breaks the semantics of this button since it removes
+				 * the information about the popover.
+				 */
+				/* eslint-disable jsx-a11y/no-redundant-roles */ }
+				<button aria-haspopup="dialog" { ...blockProps } role="button">
 					<IconComponent />
 					<span
 						className={ clsx( 'wp-block-social-link-label', {
@@ -199,6 +206,7 @@ const SocialLinkEdit = ( {
 						{ socialLinkText }
 					</span>
 				</button>
+				{ /* eslint-enable jsx-a11y/no-redundant-roles */ }
 				{ isSelected && showURLPopover && (
 					<SocialLinkURLPopover
 						url={ url }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -182,7 +182,13 @@ const SocialLinkEdit = ( {
 					onChange={ ( value ) => setAttributes( { rel: value } ) }
 				/>
 			</InspectorControls>
+			{ /*
+			 * Because the `<ul>` element has a role=document, the `<li>` is
+			 * not semantically correct, so adding role=presentation is cleaner.
+			 * https://github.com/WordPress/gutenberg/pull/64883#issuecomment-2472874551
+			 */ }
 			<li
+				role="presentation"
 				className={ wrapperClasses }
 				style={ {
 					color: iconColorValue,

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -29,6 +29,12 @@
 		// Windows High Contrast mode will show this outline, but not the box-shadow.
 		outline: 3px solid transparent;
 	}
+
+	// Override the shared `.wp-block-social-link` class used on both the li and button
+	// due to backwards compatibility from moving the blockProps from the li to the button.
+	&:hover {
+		transform: none;
+	}
 }
 
 :root :where(.wp-block-social-links.is-style-pill-shape .wp-social-link button) {

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -21,15 +21,6 @@
 	// This rule is duplicated from the style.scss and needs to be the same as there.
 	padding: 0.25em;
 
-	// Focus styles replicate the `@wordpress/components` button component.
-	&:focus:not(:disabled) {
-		border-radius: 2px;
-		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
-
-		// Windows High Contrast mode will show this outline, but not the box-shadow.
-		outline: 3px solid transparent;
-	}
-
 	// Override the shared `.wp-block-social-link` class used on both the li and button
 	// due to backwards compatibility from moving the blockProps from the li to the button.
 	&:hover {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/64937
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Moves the `blockProps` for the social icon from the `<li>` to the `<button>`.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. Moving between each social icon was two keypresses (one to get to the `<li>` and one to the nested `<button>`.
2. The `<li>` did not have an onClick to open the popover but the `<button>` did, meaning you can only press enter to open the popover when on the `<button> but you can't tell which one you're focused on. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By moving the `blockProps` for the social icon from the `<li>` to the `<button>`, we get the appropriate behavior of being able to select and create social icons with a clean keyboard behavior. The caveat is to preserve the CSS, we needed to add the `.wp-block-social-link` to both the `li` and the `button`. This allows us the least amount of changes to the CSS, preventing a lot of potential CSS conflicts and styling issues for sites.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Check for visual regressions on both the frontend and editor

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Add a social icons block
- Using the keyboard, move focus to the social icons
- When on a social icon, moving left/right between them should only be one keypress
- Press Enter on a social icon
- Focus should be within the popover
- Submit a value
- It should be saved and focus moved to the social icon button
- Press Enter
- Focus should be within the popover
- Press Escape
- The popover should close and focus moved to the social icon button


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/63c78276-db23-4881-b0c5-861ab7b532e6


