### PR TITLE
task: Remove dcalhoun code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -119,9 +119,9 @@
 /packages/plugins                               @gziolo @adamsilverstein
 
 # Rich Text
-/packages/format-library                        @ellatrix @dcalhoun
-/packages/rich-text                             @ellatrix @dcalhoun
-/packages/block-editor/src/components/rich-text @ellatrix @dcalhoun
+/packages/format-library                        @ellatrix
+/packages/rich-text                             @ellatrix
+/packages/block-editor/src/components/rich-text @ellatrix
 
 # Project Management
 /.github                                        @desrosj


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Reduce personal GitHub notifications. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
I no longer desire notification of every Rich Text-related pull request. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove my "dcalhoun" username from the `CODEOWNERS` configuration file. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes. 

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes. 