### PR TITLE
Block Editor: Add conditions when the Shuffle button can be displayed

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -65,6 +65,7 @@ export function PrivateBlockToolbar( {
 		shouldShowVisualToolbar,
 		showParentSelector,
 		isUsingBindings,
+		canRemove,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -75,6 +76,7 @@ export function PrivateBlockToolbar( {
 			getBlockRootClientId,
 			getBlockEditingMode,
 			getBlockAttributes,
+			canRemoveBlock,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -115,6 +117,7 @@ export function PrivateBlockToolbar( {
 				selectedBlockClientIds.length === 1 &&
 				_isDefaultEditingMode,
 			isUsingBindings: _isUsingBindings,
+			canRemove: canRemoveBlock( selectedBlockClientId ),
 		};
 	}, [] );
 
@@ -195,7 +198,9 @@ export function PrivateBlockToolbar( {
 							</ToolbarGroup>
 						</div>
 					) }
-				<Shuffle clientId={ blockClientId } />
+				{ ! isMultiToolbar && canRemove && (
+					<Shuffle clientId={ blockClientId } />
+				) }
 				{ shouldShowVisualToolbar && isMultiToolbar && (
 					<BlockGroupToolbar />
 				) }


### PR DESCRIPTION
## What?
PR adds conditions when the Shuffle button can be displayed in the block toolbar.

## Why?
* Don't display when multi-selecting blocks - shuffle only works for a single block.
* Don't display when block removal is locked - like transformation, shuffle "removes" the previous block. This action isn't allowed for locked blocks.

## Testing Instructions
1. Open a post or page.
2. Insert a pattern from a category - "Call to Action"
3. Confirm that the "Shuffle" button is still available in the toolbar.
4. Multi-select blocks.
5. Confirm that the shuffle button isn't visible.
6. Select a call to action pattern.
7. Lock the block removal.
8. Confirm that the shuffle button isn't visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f3ba7e2e-ee7b-4f70-aa52-73efbff80287


