### PR TITLE
Site Editor: Add 'OPTIONS /page' to preloaded paths

### DIFF
--- a/backport-changelog/6.7/7270.md
+++ b/backport-changelog/6.7/7270.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7270
+
+* https://github.com/WordPress/gutenberg/pull/64890

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -29,7 +29,7 @@ function gutenberg_block_editor_preload_paths_6_7( $paths, $context ) {
 		$page_options_key  = array_search( $page_options_path, $paths, true );
 		if ( false === $page_options_key ) {
 			$paths[] = $page_options_path;
-		};
+		}
 	}
 
 	if ( 'core/edit-post' === $context->name ) {

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -24,6 +24,12 @@ function gutenberg_block_editor_preload_paths_6_7( $paths, $context ) {
 		if ( false !== $parts_key ) {
 			$paths[ $parts_key ] = '/wp/v2/types/wp_template_part?context=edit';
 		}
+
+		$page_options_path = array( rest_get_route_for_post_type_items( 'page' ), 'OPTIONS' );
+		$page_options_key  = array_search( $page_options_path, $paths, true );
+		if ( false === $page_options_key ) {
+			$paths[] = $page_options_path;
+		};
 	}
 
 	if ( 'core/edit-post' === $context->name ) {


### PR DESCRIPTION
## What?
PR adds `OPTIONS /page` to the preloaded paths list for the Site Editor.

This is similar to https://github.com/WordPress/wordpress-develop/pull/2531.

## Why?
> Permissions for creating pages (`OPTIONS /wp/v2/pages`). Both requests are made in the `useBlockEditorSettings` hook, at the top of the post editor React tree.

Matches the preloaded path for the posts editor and hopefully will improve the Site Editor loading time a bit.


## Testing Instructions
1. Open the Site Editor.
2. Confirm that the `OPTIONS` request isn't made for the newly preloaded path.

### Testing Instructions for Keyboard
Same.