### PR TITLE
Layout content and wide width controls: remove confusing icon and clarify labels

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -474,8 +474,7 @@ export default function DimensionsPanel( {
 				>
 					<HStack alignment="flex-end" justify="flex-start">
 						<UnitControl
-							// TODO: Switch to `true` (40px size) if possible (https://github.com/WordPress/gutenberg/pull/64520#discussion_r1717314262)
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							label={ __( 'Content' ) }
 							labelPosition="top"
 							value={ contentSizeValue || '' }
@@ -500,8 +499,7 @@ export default function DimensionsPanel( {
 				>
 					<HStack alignment="flex-end" justify="flex-start">
 						<UnitControl
-							// TODO: Switch to `true` (40px size) if possible
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							label={ __( 'Wide' ) }
 							labelPosition="top"
 							value={ wideSizeValue || '' }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -11,7 +11,6 @@ import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalBoxControl as BoxControl,
-	__experimentalHStack as HStack,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
 } from '@wordpress/components';
@@ -250,7 +249,7 @@ export default function DimensionsPanel( {
 	const minimumMargin = -Infinity;
 	const [ minMarginValue, setMinMarginValue ] = useState( minimumMargin );
 
-	// Content Size
+	// Content Width
 	const showContentSizeControl =
 		useHasContentSize( settings ) && includeLayoutControls;
 	const contentSizeValue = decodeValue( inheritedValue?.layout?.contentSize );
@@ -266,7 +265,7 @@ export default function DimensionsPanel( {
 	const hasUserSetContentSizeValue = () => !! value?.layout?.contentSize;
 	const resetContentSizeValue = () => setContentSizeValue( undefined );
 
-	// Wide Size
+	// Wide Width
 	const showWideSizeControl =
 		useHasWideSize( settings ) && includeLayoutControls;
 	const wideSizeValue = decodeValue( inheritedValue?.layout?.wideSize );
@@ -462,8 +461,7 @@ export default function DimensionsPanel( {
 			) }
 			{ showContentSizeControl && (
 				<ToolsPanelItem
-					className="single-column"
-					label={ __( 'Content size' ) }
+					label={ __( 'Content width' ) }
 					hasValue={ hasUserSetContentSizeValue }
 					onDeselect={ resetContentSizeValue }
 					isShownByDefault={
@@ -472,24 +470,22 @@ export default function DimensionsPanel( {
 					}
 					panelId={ panelId }
 				>
-					<HStack alignment="flex-end" justify="flex-start">
-						<UnitControl
-							__next40pxDefaultSize
-							label={ __( 'Content' ) }
-							labelPosition="top"
-							value={ contentSizeValue || '' }
-							onChange={ ( nextContentSize ) => {
-								setContentSizeValue( nextContentSize );
-							} }
-							units={ units }
-						/>
-					</HStack>
+					<UnitControl
+						__next40pxDefaultSize
+						label={ __( 'Content width' ) }
+						labelPosition="top"
+						__unstableInputWidth="112px"
+						value={ contentSizeValue || '' }
+						onChange={ ( nextContentSize ) => {
+							setContentSizeValue( nextContentSize );
+						} }
+						units={ units }
+					/>
 				</ToolsPanelItem>
 			) }
 			{ showWideSizeControl && (
 				<ToolsPanelItem
-					className="single-column"
-					label={ __( 'Wide size' ) }
+					label={ __( 'Wide width' ) }
 					hasValue={ hasUserSetWideSizeValue }
 					onDeselect={ resetWideSizeValue }
 					isShownByDefault={
@@ -497,18 +493,17 @@ export default function DimensionsPanel( {
 					}
 					panelId={ panelId }
 				>
-					<HStack alignment="flex-end" justify="flex-start">
-						<UnitControl
-							__next40pxDefaultSize
-							label={ __( 'Wide' ) }
-							labelPosition="top"
-							value={ wideSizeValue || '' }
-							onChange={ ( nextWideSize ) => {
-								setWideSizeValue( nextWideSize );
-							} }
-							units={ units }
-						/>
-					</HStack>
+					<UnitControl
+						__next40pxDefaultSize
+						label={ __( 'Wide width' ) }
+						labelPosition="top"
+						__unstableInputWidth="112px"
+						value={ wideSizeValue || '' }
+						onChange={ ( nextWideSize ) => {
+							setWideSizeValue( nextWideSize );
+						} }
+						units={ units }
+					/>
 				</ToolsPanelItem>
 			) }
 			{ showPaddingControl && (

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -14,9 +14,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalView as View,
 } from '@wordpress/components';
-import { Icon, positionCenter, stretchWide } from '@wordpress/icons';
 import { useCallback, useState, Platform } from '@wordpress/element';
 
 /**
@@ -480,16 +478,12 @@ export default function DimensionsPanel( {
 							__next40pxDefaultSize={ false }
 							label={ __( 'Content' ) }
 							labelPosition="top"
-							__unstableInputWidth="80px"
 							value={ contentSizeValue || '' }
 							onChange={ ( nextContentSize ) => {
 								setContentSizeValue( nextContentSize );
 							} }
 							units={ units }
 						/>
-						<View>
-							<Icon icon={ positionCenter } />
-						</View>
 					</HStack>
 				</ToolsPanelItem>
 			) }
@@ -510,16 +504,12 @@ export default function DimensionsPanel( {
 							__next40pxDefaultSize={ false }
 							label={ __( 'Wide' ) }
 							labelPosition="top"
-							__unstableInputWidth="80px"
 							value={ wideSizeValue || '' }
 							onChange={ ( nextWideSize ) => {
 								setWideSizeValue( nextWideSize );
 							} }
 							units={ units }
 						/>
-						<View>
-							<Icon icon={ stretchWide } />
-						</View>
 					</HStack>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -13,7 +13,9 @@ import {
 	__experimentalBoxControl as BoxControl,
 	__experimentalUnitControl as UnitControl,
 	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
+import { Icon, alignNone, stretchWide } from '@wordpress/icons';
 import { useCallback, useState, Platform } from '@wordpress/element';
 
 /**
@@ -474,12 +476,16 @@ export default function DimensionsPanel( {
 						__next40pxDefaultSize
 						label={ __( 'Content width' ) }
 						labelPosition="top"
-						__unstableInputWidth="112px"
 						value={ contentSizeValue || '' }
 						onChange={ ( nextContentSize ) => {
 							setContentSizeValue( nextContentSize );
 						} }
 						units={ units }
+						prefix={
+							<InputControlPrefixWrapper variant="icon">
+								<Icon icon={ alignNone } />
+							</InputControlPrefixWrapper>
+						}
 					/>
 				</ToolsPanelItem>
 			) }
@@ -497,12 +503,16 @@ export default function DimensionsPanel( {
 						__next40pxDefaultSize
 						label={ __( 'Wide width' ) }
 						labelPosition="top"
-						__unstableInputWidth="112px"
 						value={ wideSizeValue || '' }
 						onChange={ ( nextWideSize ) => {
 							setWideSizeValue( nextWideSize );
 						} }
 						units={ units }
+						prefix={
+							<InputControlPrefixWrapper variant="icon">
+								<Icon icon={ stretchWide } />
+							</InputControlPrefixWrapper>
+						}
 					/>
 				</ToolsPanelItem>
 			) }

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -1,3 +1,9 @@
+.block-editor-hooks__layout-controls-units {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20;
+}
+
 .block-editor-block-inspector .block-editor-hooks__layout-controls-unit-input {
 	margin-bottom: 0;
 }

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -1,17 +1,3 @@
-.block-editor-hooks__layout-controls {
-	display: flex;
-	margin-bottom: $grid-unit-10;
-
-	.block-editor-hooks__layout-controls-unit {
-		display: flex;
-		margin-right: $grid-unit-30;
-
-		svg {
-			margin: auto 0 $grid-unit-05 $grid-unit-10;
-		}
-	}
-}
-
 .block-editor-block-inspector .block-editor-hooks__layout-controls-unit-input {
 	margin-bottom: 0;
 }

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -6,9 +6,17 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
+	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
+import {
+	Icon,
+	alignNone,
+	stretchWide,
+	justifyLeft,
+	justifyCenter,
+	justifyRight,
+} from '@wordpress/icons';
 import { getCSSRules } from '@wordpress/style-engine';
 
 /**
@@ -71,7 +79,6 @@ export default {
 								className="block-editor-hooks__layout-controls-unit-input"
 								label={ __( 'Content width' ) }
 								labelPosition="top"
-								__unstableInputWidth="112px"
 								value={ contentSize || wideSize || '' }
 								onChange={ ( nextWidth ) => {
 									nextWidth =
@@ -84,6 +91,11 @@ export default {
 									} );
 								} }
 								units={ units }
+								prefix={
+									<InputControlPrefixWrapper variant="icon">
+										<Icon icon={ alignNone } />
+									</InputControlPrefixWrapper>
+								}
 							/>
 						</div>
 						<div className="block-editor-hooks__layout-controls-unit">
@@ -92,7 +104,6 @@ export default {
 								className="block-editor-hooks__layout-controls-unit-input"
 								label={ __( 'Wide width' ) }
 								labelPosition="top"
-								__unstableInputWidth="112px"
 								value={ wideSize || contentSize || '' }
 								onChange={ ( nextWidth ) => {
 									nextWidth =
@@ -105,6 +116,11 @@ export default {
 									} );
 								} }
 								units={ units }
+								prefix={
+									<InputControlPrefixWrapper variant="icon">
+										<Icon icon={ stretchWide } />
+									</InputControlPrefixWrapper>
+								}
 							/>
 						</div>
 						<p className="block-editor-hooks__layout-controls-helptext">

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -8,14 +8,7 @@ import {
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import {
-	Icon,
-	positionCenter,
-	stretchWide,
-	justifyLeft,
-	justifyCenter,
-	justifyRight,
-} from '@wordpress/icons';
+import { justifyLeft, justifyCenter, justifyRight } from '@wordpress/icons';
 import { getCSSRules } from '@wordpress/style-engine';
 
 /**
@@ -72,53 +65,47 @@ export default {
 			<>
 				{ allowCustomContentAndWideSize && (
 					<>
-						<div className="block-editor-hooks__layout-controls">
-							<div className="block-editor-hooks__layout-controls-unit">
-								<UnitControl
-									// TODO: Switch to `true` (40px size) if possible (https://github.com/WordPress/gutenberg/pull/64520#discussion_r1717314262)
-									__next40pxDefaultSize={ false }
-									className="block-editor-hooks__layout-controls-unit-input"
-									label={ __( 'Content' ) }
-									labelPosition="top"
-									__unstableInputWidth="80px"
-									value={ contentSize || wideSize || '' }
-									onChange={ ( nextWidth ) => {
-										nextWidth =
-											0 > parseFloat( nextWidth )
-												? '0'
-												: nextWidth;
-										onChange( {
-											...layout,
-											contentSize: nextWidth,
-										} );
-									} }
-									units={ units }
-								/>
-								<Icon icon={ positionCenter } />
-							</div>
-							<div className="block-editor-hooks__layout-controls-unit">
-								<UnitControl
-									// TODO: Switch to `true` (40px size) if possible
-									__next40pxDefaultSize={ false }
-									className="block-editor-hooks__layout-controls-unit-input"
-									label={ __( 'Wide' ) }
-									labelPosition="top"
-									__unstableInputWidth="80px"
-									value={ wideSize || contentSize || '' }
-									onChange={ ( nextWidth ) => {
-										nextWidth =
-											0 > parseFloat( nextWidth )
-												? '0'
-												: nextWidth;
-										onChange( {
-											...layout,
-											wideSize: nextWidth,
-										} );
-									} }
-									units={ units }
-								/>
-								<Icon icon={ stretchWide } />
-							</div>
+						<div className="block-editor-hooks__layout-controls-unit">
+							<UnitControl
+								__next40pxDefaultSize
+								className="block-editor-hooks__layout-controls-unit-input"
+								label={ __( 'Content width' ) }
+								labelPosition="top"
+								__unstableInputWidth="112px"
+								value={ contentSize || wideSize || '' }
+								onChange={ ( nextWidth ) => {
+									nextWidth =
+										0 > parseFloat( nextWidth )
+											? '0'
+											: nextWidth;
+									onChange( {
+										...layout,
+										contentSize: nextWidth,
+									} );
+								} }
+								units={ units }
+							/>
+						</div>
+						<div className="block-editor-hooks__layout-controls-unit">
+							<UnitControl
+								__next40pxDefaultSize
+								className="block-editor-hooks__layout-controls-unit-input"
+								label={ __( 'Wide width' ) }
+								labelPosition="top"
+								__unstableInputWidth="112px"
+								value={ wideSize || contentSize || '' }
+								onChange={ ( nextWidth ) => {
+									nextWidth =
+										0 > parseFloat( nextWidth )
+											? '0'
+											: nextWidth;
+									onChange( {
+										...layout,
+										wideSize: nextWidth,
+									} );
+								} }
+								units={ units }
+							/>
 						</div>
 						<p className="block-editor-hooks__layout-controls-helptext">
 							{ __(

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -72,63 +72,59 @@ export default {
 		return (
 			<>
 				{ allowCustomContentAndWideSize && (
-					<>
-						<div className="block-editor-hooks__layout-controls-unit">
-							<UnitControl
-								__next40pxDefaultSize
-								className="block-editor-hooks__layout-controls-unit-input"
-								label={ __( 'Content width' ) }
-								labelPosition="top"
-								value={ contentSize || wideSize || '' }
-								onChange={ ( nextWidth ) => {
-									nextWidth =
-										0 > parseFloat( nextWidth )
-											? '0'
-											: nextWidth;
-									onChange( {
-										...layout,
-										contentSize: nextWidth,
-									} );
-								} }
-								units={ units }
-								prefix={
-									<InputControlPrefixWrapper variant="icon">
-										<Icon icon={ alignNone } />
-									</InputControlPrefixWrapper>
-								}
-							/>
-						</div>
-						<div className="block-editor-hooks__layout-controls-unit">
-							<UnitControl
-								__next40pxDefaultSize
-								className="block-editor-hooks__layout-controls-unit-input"
-								label={ __( 'Wide width' ) }
-								labelPosition="top"
-								value={ wideSize || contentSize || '' }
-								onChange={ ( nextWidth ) => {
-									nextWidth =
-										0 > parseFloat( nextWidth )
-											? '0'
-											: nextWidth;
-									onChange( {
-										...layout,
-										wideSize: nextWidth,
-									} );
-								} }
-								units={ units }
-								prefix={
-									<InputControlPrefixWrapper variant="icon">
-										<Icon icon={ stretchWide } />
-									</InputControlPrefixWrapper>
-								}
-							/>
-						</div>
+					<div className="block-editor-hooks__layout-controls-units">
+						<UnitControl
+							__next40pxDefaultSize
+							className="block-editor-hooks__layout-controls-unit-input"
+							label={ __( 'Content width' ) }
+							labelPosition="top"
+							value={ contentSize || wideSize || '' }
+							onChange={ ( nextWidth ) => {
+								nextWidth =
+									0 > parseFloat( nextWidth )
+										? '0'
+										: nextWidth;
+								onChange( {
+									...layout,
+									contentSize: nextWidth,
+								} );
+							} }
+							units={ units }
+							prefix={
+								<InputControlPrefixWrapper variant="icon">
+									<Icon icon={ alignNone } />
+								</InputControlPrefixWrapper>
+							}
+						/>
+						<UnitControl
+							__next40pxDefaultSize
+							className="block-editor-hooks__layout-controls-unit-input"
+							label={ __( 'Wide width' ) }
+							labelPosition="top"
+							value={ wideSize || contentSize || '' }
+							onChange={ ( nextWidth ) => {
+								nextWidth =
+									0 > parseFloat( nextWidth )
+										? '0'
+										: nextWidth;
+								onChange( {
+									...layout,
+									wideSize: nextWidth,
+								} );
+							} }
+							units={ units }
+							prefix={
+								<InputControlPrefixWrapper variant="icon">
+									<Icon icon={ stretchWide } />
+								</InputControlPrefixWrapper>
+							}
+						/>
 						<p className="block-editor-hooks__layout-controls-helptext">
 							{ __(
 								'Customize the width for all elements that are assigned to the center or wide columns.'
 							) }
 						</p>
-					</>
+					</div>
 				) }
 				{ allowJustification && (
 					<ToggleGroupControl


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/64842
See https://github.com/WordPress/gutenberg/issues/64862
See https://github.com/WordPress/gutenberg/issues/43468

## What?
<!-- In a few words, what is the PR actually doing? -->
The layout Content width and Wide width controls have icons on the right that are confusing and unnecessary, as they look like clickable buttons but they aren't buttons, thus breaking an establisehed design pattern in the editor. They also prevent these inputs from using the new 40 pixels size.
Tha labeling of these inputs is shortened to 'Content' and 'Wide' only because the design wants a two-columns layout. However, the labels are unclear and confusing for users as these settings refer to _widths_. Additionanlly, the panel to reset these settings incorrectly uses the term 'size' e.g. 'Wide size' while in the block toolbar this is called 'Wide width'.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Non-clickable icons on the right of controls have the only effect to confuse users because the editor uses clickable _icon buttons_ in many other cases in the same spot. Design patterns should be consistent and predictable. 
- Labels should be consistend to clearly identify settings and features across the editor.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Remove the icons.
- Use the 40 pixels input size. This also makes the unit control consistent with other inputs.
- Clarifies the input labels:
  - Content → Content width
  - Wide → Wide width
- The new labels are longer and may be even longer in other languages so the two columns layout is removed in favor of vertically stacking the inputs.

A note on labels:
I see a trend from the design team to shorten or truncate control labels only to make the controls 'fit' in specific design e.g. a two columns layout. This has the only effect to make the controls unclear for users. Features and settings must have clear, meaningful, understandable names. Please do not ever shorten labels only for visuals reasons.
Labeling a control by an adjective e.g. 'Wide' seems to me far from ideal and not the best UI.

Regarding translations, the new labels may be way longer in other languages. For example, in Italian they woul dbe:
```
Default width > Larghezza predefinita
Wide width    > Larghezza ampia
```

As such, the two columns layout nheeds to be removed in favor ov vertically stacking the inputs.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to Site editor > Styles > Layout > Dimensions
- Observe the two controls labels are now 'Content width' and 'Wide width'.
- Observe the two controls don't use decorative icons any longer.
- Observe the two controls are vertically stacked.
- Observe the two controls use the 40 pixels size.
- Open the Dimensions option panel.
- Observe the settings name is consistent: 'Content width' and 'Wide width'.

Screenshot before and after:

![styles layout width before and after](https://github.com/user-attachments/assets/f27d9d63-a6aa-49a7-988d-dc2ab5511b76)


- Go to the post editor.
- Select a Group block.
- In the setttings panel, enable 'Inner blocks use content width'.
- Observe the two controls labels are now 'Content width' and 'Wide width'.
- Observe the two controls don't use decorative icons any longer.
- Observe the two controls are vertically stacked.
- Observe the two controls use the 40 pixels size.

Screenshot before and after:

![block settings before ](https://github.com/user-attachments/assets/a6b44d54-7a36-4430-9f68-4b7d4166be95)

Worth reminding the names 'Content width' and 'Wide width' are consistent with the pattern of the settings name used in the block toolbar > Align setting, see the 'Wide width' menu item in the screenshot below:


![block toolbar align](https://github.com/user-attachments/assets/361b64e0-e920-45d0-b510-9b73cf49d452)

I will creeate a separate issue to consider to rename the 'None' setting, as it is actually the 'content width'.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
