### PR TITLE
Site Editor: Remove unused 'useSiteEditorSettings' hook

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
+++ b/packages/edit-site/src/components/block-editor/use-site-editor-settings.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
-import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { usePrevious } from '@wordpress/compose';
 
@@ -15,7 +14,6 @@ import { unlock } from '../../lock-unlock';
 import useNavigateToEntityRecord from './use-navigate-to-entity-record';
 import { FOCUSABLE_ENTITIES } from '../../utils/constants';
 
-const { useBlockEditorSettings } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 function useNavigateToPreviousEntityRecord() {
@@ -82,20 +80,4 @@ export function useSpecificEditorSettings() {
 	] );
 
 	return defaultEditorSettings;
-}
-
-export default function useSiteEditorSettings() {
-	const defaultEditorSettings = useSpecificEditorSettings();
-	const { postType, postId } = useSelect( ( select ) => {
-		const { getEditedPostType, getEditedPostId } = unlock(
-			select( editSiteStore )
-		);
-		const usedPostType = getEditedPostType();
-		const usedPostId = getEditedPostId();
-		return {
-			postType: usedPostType,
-			postId: usedPostId,
-		};
-	}, [] );
-	return useBlockEditorSettings( defaultEditorSettings, postType, postId );
 }

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -9,7 +9,6 @@ import * as interfaceApis from '@wordpress/interface';
 import { lock } from './lock-unlock';
 import { EntitiesSavedStatesExtensible } from './components/entities-saved-states';
 import EditorContentSlotFill from './components/editor-interface/content-slot-fill';
-import useBlockEditorSettings from './components/provider/use-block-editor-settings';
 import BackButton from './components/header/back-button';
 import CreateTemplatePartModal from './components/create-template-part-modal';
 import Editor from './components/editor';
@@ -51,7 +50,6 @@ lock( privateApis, {
 	bootstrapBlockBindingsSourcesFromServer,
 
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
-	useBlockEditorSettings,
 	interfaceStore,
 	...remainingInterfaceApis,
 } );


### PR DESCRIPTION
## What?
PR removes the unused `useSiteEditorSettings` hook from the `core/edit-site` package. I've also removed `useBlockEditorSettings` exported as private API.

## Why?
The hook hasn't been used since #62146.

## Testing Instructions
CI checks should be green.

### Testing Instructions for Keyboard
Same.
