### PR TITLE
Block Bindings: Add warning when block attribute is connected to an invalid source

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { store as blocksStore } from '@wordpress/blocks';
-import { Button } from '@wordpress/components';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useContext } from '@wordpress/element';
@@ -16,7 +15,6 @@ import isURLLike from '../components/link-control/is-url-like';
 import { unlock } from '../lock-unlock';
 import { Warning, useBlockProps } from '../components';
 import BlockContext from '../components/block-context';
-import { useBlockBindingsUtils } from '../utils/block-bindings';
 
 /** @typedef {import('@wordpress/compose').WPHigherOrderComponent} WPHigherOrderComponent */
 /** @typedef {import('@wordpress/blocks').WPBlockSettings} WPBlockSettings */
@@ -107,7 +105,6 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		const sources = useSelect( ( select ) =>
 			unlock( select( blocksStore ) ).getAllBlockBindingsSources()
 		);
-		const { updateBlockBindings } = useBlockBindingsUtils();
 		const { name, clientId } = props;
 		const hasParentPattern = !! props.context[ 'pattern/overrides' ];
 		const hasPatternOverridesDefaultBinding =
@@ -301,23 +298,9 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 		// Throw a warning if the block is connected to an invalid source.
 		if ( invalidBinding ) {
-			const removeInvalidBindingButton = (
-				<Button
-					__next40pxDefaultSize={ false }
-					key="remove-all-bindings"
-					onClick={ () =>
-						updateBlockBindings( {
-							[ invalidBinding.attribute ]: undefined,
-						} )
-					}
-					variant="primary"
-				>
-					{ __( 'Remove connection' ) }
-				</Button>
-			);
 			return (
 				<div { ...useBlockProps( { className: 'has-warning' } ) }>
-					<Warning actions={ [ removeInvalidBindingButton ] }>
+					<Warning>
 						{ sprintf(
 							/* translators: %1$s: block attribute, %2$s: invalid block bindings source. */
 							__(

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -14,7 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import isURLLike from '../components/link-control/is-url-like';
 import { unlock } from '../lock-unlock';
-import { Warning } from '../components';
+import { Warning, useBlockProps } from '../components';
 import BlockContext from '../components/block-context';
 import { useBlockBindingsUtils } from '../utils/block-bindings';
 
@@ -316,12 +316,12 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 				</Button>
 			);
 			return (
-				<div className="has-warning">
+				<div { ...useBlockProps( { className: 'has-warning' } ) }>
 					<Warning actions={ [ removeInvalidBindingButton ] }>
 						{ sprintf(
 							/* translators: %1$s: block attribute, %2$s: invalid block bindings source. */
 							__(
-								'Attribute "%1$s" is connected to unrecognized "%2$s" source. You can leave this block intact, modify the connection, or remove it.'
+								'Attribute "%1$s" is connected to unrecognized "%2$s" source.'
 							),
 							invalidBinding.attribute,
 							invalidBinding.source

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -301,7 +301,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 		// Throw a warning if the block is connected to an invalid source.
 		if ( invalidBinding ) {
-			const removeAllBindingsButton = (
+			const removeInvalidBindingButton = (
 				<Button
 					__next40pxDefaultSize={ false }
 					key="remove-all-bindings"
@@ -317,7 +317,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			);
 			return (
 				<div className="has-warning">
-					<Warning actions={ [ removeAllBindingsButton ] }>
+					<Warning actions={ [ removeInvalidBindingButton ] }>
 						{ sprintf(
 							/* translators: %1$s: block attribute, %2$s: invalid block bindings source. */
 							__(

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -321,7 +321,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 						{ sprintf(
 							/* translators: %1$s: block attribute, %2$s: invalid block bindings source. */
 							__(
-								'Attribute "%1$s" is connected to undefined "%2$s" block bindings source. You can leave this block intact, modify the connection, or remove it.'
+								'Attribute "%1$s" is connected to unrecognized "%2$s" source. You can leave this block intact, modify the connection, or remove it.'
 							),
 							invalidBinding.attribute,
 							invalidBinding.source

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -159,9 +159,8 @@ test.describe( 'Block bindings', () => {
 				);
 			} );
 
-			test( 'should lock the appropriate controls when source is not defined', async ( {
+			test( 'should throw a warning when source is not defined', async ( {
 				editor,
-				page,
 			} ) => {
 				await editor.insertBlock( {
 					name: 'core/paragraph',
@@ -177,32 +176,10 @@ test.describe( 'Block bindings', () => {
 						},
 					},
 				} );
-				const paragraphBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Paragraph',
-				} );
-				await paragraphBlock.click();
-
-				// Alignment controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', { name: 'Align text' } )
-				).toBeVisible();
-
-				// Format controls don't exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Bold',
-						} )
-				).toBeHidden();
-
-				// Paragraph is not editable.
-				await expect( paragraphBlock ).toHaveAttribute(
-					'contenteditable',
-					'false'
+				const warningMessage = editor.canvas.locator(
+					'.block-editor-warning__message'
 				);
+				await expect( warningMessage ).toBeVisible();
 			} );
 		} );
 
@@ -242,52 +219,6 @@ test.describe( 'Block bindings', () => {
 							bindings: {
 								content: {
 									source: 'core/post-meta',
-									args: { key: 'text_custom_field' },
-								},
-							},
-						},
-					},
-				} );
-				const headingBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Heading',
-				} );
-				await headingBlock.click();
-
-				// Alignment controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', { name: 'Align text' } )
-				).toBeVisible();
-
-				// Format controls don't exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Bold',
-						} )
-				).toBeHidden();
-
-				// Heading is not editable.
-				await expect( headingBlock ).toHaveAttribute(
-					'contenteditable',
-					'false'
-				);
-			} );
-
-			test( 'should lock the appropriate controls when source is not defined', async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/heading',
-					attributes: {
-						content: 'heading default content',
-						metadata: {
-							bindings: {
-								content: {
-									source: 'plugin/undefined-source',
 									args: { key: 'text_custom_field' },
 								},
 							},
@@ -416,68 +347,6 @@ test.describe( 'Block bindings', () => {
 				).toBeVisible();
 			} );
 
-			test( 'should lock text controls when text is bound to an undefined source', async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/buttons',
-					innerBlocks: [
-						{
-							name: 'core/button',
-							attributes: {
-								text: 'button default text',
-								url: '#default-url',
-								metadata: {
-									bindings: {
-										text: {
-											source: 'plugin/undefined-source',
-											args: { key: 'text_custom_field' },
-										},
-									},
-								},
-							},
-						},
-					],
-				} );
-				const buttonBlock = editor.canvas
-					.getByRole( 'document', {
-						name: 'Block: Button',
-						exact: true,
-					} )
-					.getByRole( 'textbox' );
-				await buttonBlock.click();
-
-				// Alignment controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', { name: 'Align text' } )
-				).toBeVisible();
-
-				// Format controls don't exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Bold',
-						} )
-				).toBeHidden();
-
-				// Button is not editable.
-				await expect( buttonBlock ).toHaveAttribute(
-					'contenteditable',
-					'false'
-				);
-
-				// Link controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', { name: 'Unlink' } )
-				).toBeVisible();
-			} );
-
 			test( 'should lock url controls when url is bound to a registered source', async ( {
 				editor,
 				page,
@@ -494,66 +363,6 @@ test.describe( 'Block bindings', () => {
 									bindings: {
 										url: {
 											source: 'core/post-meta',
-											args: { key: 'url_custom_field' },
-										},
-									},
-								},
-							},
-						},
-					],
-				} );
-				const buttonBlock = editor.canvas
-					.getByRole( 'document', {
-						name: 'Block: Button',
-						exact: true,
-					} )
-					.getByRole( 'textbox' );
-				await buttonBlock.click();
-
-				// Format controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Bold',
-						} )
-				).toBeVisible();
-
-				// Button is editable.
-				await expect( buttonBlock ).toHaveAttribute(
-					'contenteditable',
-					'true'
-				);
-
-				// Link controls don't exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', { name: 'Link' } )
-				).toBeHidden();
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', { name: 'Unlink' } )
-				).toBeHidden();
-			} );
-
-			test( 'should lock url controls when url is bound to an undefined source', async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/buttons',
-					innerBlocks: [
-						{
-							name: 'core/button',
-							attributes: {
-								text: 'button default text',
-								url: '#default-url',
-								metadata: {
-									bindings: {
-										url: {
-											source: 'plugin/undefined-source',
 											args: { key: 'url_custom_field' },
 										},
 									},
@@ -712,34 +521,6 @@ test.describe( 'Block bindings', () => {
 				).toBeHidden();
 			} );
 
-			test( 'should NOT show the upload form when url is bound to an undefined source', async ( {
-				editor,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/image',
-					attributes: {
-						url: imagePlaceholderSrc,
-						alt: 'default alt value',
-						title: 'default title value',
-						metadata: {
-							bindings: {
-								url: {
-									source: 'plugin/undefined-source',
-									args: { key: 'url_custom_field' },
-								},
-							},
-						},
-					},
-				} );
-				const imageBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Image',
-				} );
-				await imageBlock.click();
-				await expect(
-					imageBlock.getByRole( 'button', { name: 'Upload' } )
-				).toBeHidden();
-			} );
-
 			test( 'should lock url controls when url is bound to a registered source', async ( {
 				editor,
 				page,
@@ -754,75 +535,6 @@ test.describe( 'Block bindings', () => {
 							bindings: {
 								url: {
 									source: 'core/post-meta',
-									args: { key: 'url_custom_field' },
-								},
-							},
-						},
-					},
-				} );
-				const imageBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Image',
-				} );
-				await imageBlock.click();
-
-				// Replace controls don't exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Replace',
-						} )
-				).toBeHidden();
-
-				// Image placeholder doesn't show the upload button.
-				await expect(
-					imageBlock.getByRole( 'button', { name: 'Upload' } )
-				).toBeHidden();
-
-				// Alt textarea is enabled and with the original value.
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Alternative text' )
-				).toBeEnabled();
-				const altValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Alternative text' )
-					.inputValue();
-				expect( altValue ).toBe( 'default alt value' );
-
-				// Title input is enabled and with the original value.
-				await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByRole( 'button', { name: 'Advanced' } )
-					.click();
-
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Title attribute' )
-				).toBeEnabled();
-				const titleValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Title attribute' )
-					.inputValue();
-				expect( titleValue ).toBe( 'default title value' );
-			} );
-
-			test( 'should lock url controls when url is bound to an undefined source', async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/image',
-					attributes: {
-						url: imagePlaceholderSrc,
-						alt: 'default alt value',
-						title: 'default title value',
-						metadata: {
-							bindings: {
-								url: {
-									source: 'plugin/undefined-source',
 									args: { key: 'url_custom_field' },
 								},
 							},
@@ -941,69 +653,6 @@ test.describe( 'Block bindings', () => {
 				expect( titleValue ).toBe( 'default title value' );
 			} );
 
-			test( 'should disable alt textarea when alt is bound to an undefined source', async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/image',
-					attributes: {
-						url: imagePlaceholderSrc,
-						alt: 'default alt value',
-						title: 'default title value',
-						metadata: {
-							bindings: {
-								alt: {
-									source: 'plguin/undefined-source',
-									args: { key: 'text_custom_field' },
-								},
-							},
-						},
-					},
-				} );
-				const imageBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Image',
-				} );
-				await imageBlock.click();
-
-				// Replace controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Replace',
-						} )
-				).toBeVisible();
-
-				// Alt textarea is disabled and with the custom field value.
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Alternative text' )
-				).toHaveAttribute( 'readonly' );
-				const altValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Alternative text' )
-					.inputValue();
-				expect( altValue ).toBe( 'default alt value' );
-
-				// Title input is enabled and with the original value.
-				await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByRole( 'button', { name: 'Advanced' } )
-					.click();
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Title attribute' )
-				).toBeEnabled();
-				const titleValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Title attribute' )
-					.inputValue();
-				expect( titleValue ).toBe( 'default title value' );
-			} );
-
 			test( 'should disable title input when title is bound to a registered source', async ( {
 				editor,
 				page,
@@ -1065,69 +714,6 @@ test.describe( 'Block bindings', () => {
 					.getByLabel( 'Title attribute' )
 					.inputValue();
 				expect( titleValue ).toBe( 'text_custom_field' );
-			} );
-
-			test( 'should disable title input when title is bound to an undefined source', async ( {
-				editor,
-				page,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/image',
-					attributes: {
-						url: imagePlaceholderSrc,
-						alt: 'default alt value',
-						title: 'default title value',
-						metadata: {
-							bindings: {
-								title: {
-									source: 'plugin/undefined-source',
-									args: { key: 'text_custom_field' },
-								},
-							},
-						},
-					},
-				} );
-				const imageBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Image',
-				} );
-				await imageBlock.click();
-
-				// Replace controls exist.
-				await expect(
-					page
-						.getByRole( 'toolbar', { name: 'Block tools' } )
-						.getByRole( 'button', {
-							name: 'Replace',
-						} )
-				).toBeVisible();
-
-				// Alt textarea is enabled and with the original value.
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Alternative text' )
-				).toBeEnabled();
-				const altValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Alternative text' )
-					.inputValue();
-				expect( altValue ).toBe( 'default alt value' );
-
-				// Title input is disabled and with the custom field value.
-				await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByRole( 'button', { name: 'Advanced' } )
-					.click();
-				await expect(
-					page
-						.getByRole( 'tabpanel', { name: 'Settings' } )
-						.getByLabel( 'Title attribute' )
-				).toHaveAttribute( 'readonly' );
-				const titleValue = await page
-					.getByRole( 'tabpanel', { name: 'Settings' } )
-					.getByLabel( 'Title attribute' )
-					.inputValue();
-				expect( titleValue ).toBe( 'default title value' );
 			} );
 
 			test( 'Multiple bindings should lock the appropriate controls', async ( {


### PR DESCRIPTION
## What?
Now that the sources registered in the server are bootstrapped in the client after [this pull request](https://github.com/WordPress/gutenberg/pull/63470), I believe it is safe to assume that if the source doesn't exist in the editor, it is an error.

In this pull request, I'm adding a warning while checking the bindings.

## Why?
It should help notify users that the block won't possibly work as expected.

## How?
While going through the bindings, checks if the source is registered and if not, it throws a warning and provide a button to remove the connection.

## Testing Instructions
1. Go to a page and insert a paragraph connected to an undefined source.
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/undefined"}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
2. Check that the warning is shown.
![Screenshot 2024-08-29 at 10 21 59](https://github.com/user-attachments/assets/9427ef3d-12fa-4565-866c-7b9f78855fe8)

3. Click on "Remove connection" and check it shows the default content.

You can repeat the process with an image with multiple attributes:

```html
<!-- wp:image {"metadata":{"bindings":{"url":{"source":"core/undefined"},"alt":{"source":"core/undefined"},"title":{"source":"core/undefined"}}}} -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->
```
