### PR TITLE
Add missing styles from images when using useFirstImageFromPost

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -46,6 +46,7 @@ $navigation-icon-size: 24px;
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
 		display: block;
+		font-size: inherit;
 	}
 
 	// This rule needs extra specificity so that it inherits the correct color from its parent.

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -91,7 +91,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 			}
 
 			foreach ( $attr as $name => $value ) {
-				if ( $name !== 'style' ) {
+				if ( 'style' !== $name ) {
 					$tag_html->set_attribute( $name, $value );
 				} else {
 					$existing_styles = $tag_html->get_attribute( 'style' );

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -89,6 +89,17 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 			foreach ( $processor->get_attribute_names_with_prefix( '' ) as $name ) {
 				$tag_html->set_attribute( $name, $processor->get_attribute( $name ) );
 			}
+
+			foreach ( $attr as $name => $value ) {
+				if ( $name !== 'style' ) {
+					$tag_html->set_attribute( $name, $value );
+				} else {
+					$existing_styles = $tag_html->get_attribute( 'style' );
+					$new_styles      = empty( $existing_styles ) ? $value : $existing_styles . ';' . $value;
+					$tag_html->set_attribute( 'style', $new_styles );
+				}
+			}
+
 			$featured_image = $tag_html->get_updated_html();
 		}
 	}


### PR DESCRIPTION
## What?
- Add the missing styles for images when using useFirstImageFromPost in the Post Featured Image Block.
- Fixes: https://github.com/WordPress/gutenberg/issues/64851
- Fixes: https://github.com/WordPress/gutenberg/issues/63454

## Why?
- The styles applied should be consistent to all the image.

## How?
- Added the missing styling.

## Testing Instructions
- Open the editor.
- Add Post Featured Image Block to a post/page.
- Create 2 separate new posts, Set featured image for one post and add image in the content for the 2nd post.
- Now for the Post/Page where you have added Post Featured Image Block check the image styling.

## Screenshots or screencast <!-- if applicable -->

Styles getting applied to the image when using useFirstImageFromPost:

<img width="1431" alt="post-featured" src="https://github.com/user-attachments/assets/947f9312-7057-4ce8-b181-a196337589c2">

