### PR TITLE
Fixes "delete" action in DataViews' storybook

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.js
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.js
@@ -144,11 +144,11 @@ export const actions = [
 		isPrimary: true,
 		icon: trash,
 		hideModalHeader: true,
-		RenderModal: ( { item, closeModal } ) => {
+		RenderModal: ( { items, closeModal } ) => {
 			return (
 				<VStack spacing="5">
 					<Text>
-						{ `Are you sure you want to delete "${ item?.title }"?` }
+						{ `Are you sure you want to delete "${ items[ 0 ].title }"?` }
 					</Text>
 					<HStack justify="right">
 						<Button


### PR DESCRIPTION
Reported at https://github.com/WordPress/gutenberg/pull/64835#discussion_r1732987476

## What?

Fixes the "Delete" action in DataView's storybook:

| Before | After |
| --- | --- |
| <img width="409" alt="Delete item modal in Dataviews story" src="https://github.com/user-attachments/assets/af963217-ca09-42bf-8fae-5b287a69bf29"> | <img width="392" alt="Captura de ecrã 2024-08-29, às 14 10 07" src="https://github.com/user-attachments/assets/e1eab85b-2a5e-483b-a103-5072841d5bbc"> |

## Why?

It's broken.

## How?

The RenderModal receives an array, not a single item.

## Testing Instructions

`npm install && npm run storybook:dev`

Open the storybook locally and verify that it works as expected.
