### PR TITLE
Block Bindings: Change placeholder when attribute is bound

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -190,7 +190,7 @@ export function RichTextWrapper(
 				? relevantBinding?.args?.key || blockBindingsSource?.label
 				: sprintf(
 						/* translators: %s: source label or key */
-						__( 'Add %s value' ),
+						__( 'Add %s' ),
 						relevantBinding?.args?.key || blockBindingsSource?.label
 				  );
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -186,8 +186,8 @@ export function RichTextWrapper(
 				} );
 
 			const _bindingsPlaceholder =
-				( relevantBinding?.args?.key || blockBindingsSource?.label ) +
-				' value is empty';
+			// Translators: %s is the bindings source or bindings key placeholder.
+			 sprintf( '%s value is empty', ( relevantBinding?.args?.key || blockBindingsSource?.label )  );
 
 			return {
 				disableBoundBlock: _disableBoundBlock,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -186,11 +186,13 @@ export function RichTextWrapper(
 					args: relevantBinding.args,
 				} );
 
-			const _bindingsPlaceholder = sprintf(
-				/* translators: %s: source label or key */
-				__( '%s value is empty' ),
-				relevantBinding?.args?.key || blockBindingsSource?.label
-			);
+			const _bindingsPlaceholder = _disableBoundBlock
+				? relevantBinding?.args?.key || blockBindingsSource?.label
+				: sprintf(
+						/* translators: %s: source label or key */
+						__( 'Add %s value' ),
+						relevantBinding?.args?.key || blockBindingsSource?.label
+				  );
 
 			return {
 				disableBoundBlock: _disableBoundBlock,

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -20,7 +20,7 @@ import {
 	removeFormat,
 } from '@wordpress/rich-text';
 import { Popover } from '@wordpress/components';
-import { getBlockType, store as blocksStore } from '@wordpress/blocks';
+import { store as blocksStore } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -163,49 +163,41 @@ export function RichTextWrapper(
 		isBlockSelected,
 	] );
 
-	const disableBoundBlocks = useSelect(
+	const { disableBoundBlock, bindingsPlaceholder } = useSelect(
 		( select ) => {
-			// Disable Rich Text editing if block bindings specify that.
-			let _disableBoundBlocks = false;
-			if ( blockBindings && canBindBlock( blockName ) ) {
-				const blockTypeAttributes =
-					getBlockType( blockName ).attributes;
-				const { getBlockBindingsSource } = unlock(
-					select( blocksStore )
-				);
-				for ( const [ attribute, binding ] of Object.entries(
-					blockBindings
-				) ) {
-					if (
-						blockTypeAttributes?.[ attribute ]?.source !==
-						'rich-text'
-					) {
-						break;
-					}
-
-					// If the source is not defined, or if its value of `canUserEditValue` is `false`, disable it.
-					const blockBindingsSource = getBlockBindingsSource(
-						binding.source
-					);
-					if (
-						! blockBindingsSource?.canUserEditValue?.( {
-							select,
-							context: blockContext,
-							args: binding.args,
-						} )
-					) {
-						_disableBoundBlocks = true;
-						break;
-					}
-				}
+			if (
+				! blockBindings?.[ identifier ] ||
+				! canBindBlock( blockName )
+			) {
+				return {};
 			}
 
-			return _disableBoundBlocks;
+			const relevantBinding = blockBindings[ identifier ];
+			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
+			const blockBindingsSource = getBlockBindingsSource(
+				relevantBinding.source
+			);
+
+			const _disableBoundBlock =
+				! blockBindingsSource?.canUserEditValue?.( {
+					select,
+					context: blockContext,
+					args: relevantBinding.args,
+				} );
+
+			const _bindingsPlaceholder =
+				( relevantBinding?.args?.key || blockBindingsSource?.label ) +
+				' value is empty';
+
+			return {
+				disableBoundBlock: _disableBoundBlock,
+				bindingsPlaceholder: _bindingsPlaceholder,
+			};
 		},
-		[ blockBindings, blockName ]
+		[ blockBindings, identifier, blockName, blockContext ]
 	);
 
-	const shouldDisableEditing = readOnly || disableBoundBlocks;
+	const shouldDisableEditing = readOnly || disableBoundBlock;
 
 	const { getSelectionStart, getSelectionEnd, getBlockRootClientId } =
 		useSelect( blockEditorStore );
@@ -335,7 +327,7 @@ export function RichTextWrapper(
 		selectionStart,
 		selectionEnd,
 		onSelectionChange,
-		placeholder,
+		placeholder: bindingsPlaceholder || placeholder,
 		__unstableIsSelected: isSelected,
 		__unstableDisableFormats: disableFormats,
 		preserveWhiteSpace,
@@ -404,9 +396,11 @@ export function RichTextWrapper(
 				// Overridable props.
 				role="textbox"
 				aria-multiline={ ! disableLineBreaks }
-				aria-label={ placeholder }
 				aria-readonly={ shouldDisableEditing }
 				{ ...props }
+				aria-label={
+					bindingsPlaceholder || props[ 'aria-label' ] || placeholder
+				}
 				{ ...autocompleteProps }
 				ref={ useMergeRefs( [
 					// Rich text ref must be first because its focus listener

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -173,25 +173,25 @@ export function RichTextWrapper(
 				return {};
 			}
 
-			const relevantBinding = blockBindings[ identifier ];
+			const relatedBinding = blockBindings[ identifier ];
 			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
 			const blockBindingsSource = getBlockBindingsSource(
-				relevantBinding.source
+				relatedBinding.source
 			);
 
 			const _disableBoundBlock =
 				! blockBindingsSource?.canUserEditValue?.( {
 					select,
 					context: blockContext,
-					args: relevantBinding.args,
+					args: relatedBinding.args,
 				} );
 
 			const _bindingsPlaceholder = _disableBoundBlock
-				? relevantBinding?.args?.key || blockBindingsSource?.label
+				? relatedBinding?.args?.key || blockBindingsSource?.label
 				: sprintf(
 						/* translators: %s: source label or key */
 						__( 'Add %s' ),
-						relevantBinding?.args?.key || blockBindingsSource?.label
+						relatedBinding?.args?.key || blockBindingsSource?.label
 				  );
 
 			return {

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -191,7 +191,9 @@ export function RichTextWrapper(
 
 			return {
 				disableBoundBlock: _disableBoundBlock,
-				bindingsPlaceholder: _bindingsPlaceholder,
+				bindingsPlaceholder:
+					( ! adjustedValue || adjustedValue.length === 0 ) &&
+					_bindingsPlaceholder,
 			};
 		},
 		[ blockBindings, identifier, blockName, blockContext ]

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -199,7 +199,7 @@ export function RichTextWrapper(
 					_bindingsPlaceholder,
 			};
 		},
-		[ blockBindings, identifier, blockName, blockContext ]
+		[ blockBindings, identifier, blockName, blockContext, adjustedValue ]
 	);
 
 	const shouldDisableEditing = readOnly || disableBoundBlock;

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -22,6 +22,7 @@ import {
 import { Popover } from '@wordpress/components';
 import { store as blocksStore } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -185,9 +186,11 @@ export function RichTextWrapper(
 					args: relevantBinding.args,
 				} );
 
-			const _bindingsPlaceholder =
-			// Translators: %s is the bindings source or bindings key placeholder.
-			 sprintf( '%s value is empty', ( relevantBinding?.args?.key || blockBindingsSource?.label )  );
+			const _bindingsPlaceholder = sprintf(
+				/* translators: %s: source label or key */
+				__( '%s value is empty' ),
+				relevantBinding?.args?.key || blockBindingsSource?.label
+			);
 
 			return {
 				disableBoundBlock: _disableBoundBlock,


### PR DESCRIPTION
## What?
Adapt the placeholder and the `aria-label` attribute of the rich text component when the relevant attribute is connected to a block bindings source. The default texts don't make sense in this context.

| Before | After |
|----------|----------|
| ![Screenshot 2024-08-29 at 14 34 50](https://github.com/user-attachments/assets/747b91fd-924b-453a-ba57-bb767745d21e) | ![Screenshot 2024-08-29 at 14 33 44](https://github.com/user-attachments/assets/751f6ade-ca50-49a8-9036-32f7b183bfb5) |

Same happens with the `aria-label` text, which is also changed in this PR.

Additionally, I took the opportunity to do a small refactor on `disableBoundBlock`, which is used to lock editing when appropriate, to rely on the rich-text identifier instead of iterating through all the attributes.

## Why?
It is confusing to get a prompt to insert a block when user is actually editing the binding source value.

## How?
Return an alternative placeholder when the attribute used as identifier in the RichText is connected to any source. And use this placeholder when it exists.

## Testing Instructions
1. Register a new custom field with an empty string as default value.
```
	register_meta(
		'post',
		'empty_field',
		array(
			'show_in_rest' => true,
			'single'       => true,
			'type'         => 'string',
			'default'      => '',
		)
	);
```
2. Go to a page and insert a paragraph bound to that custom field.
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"empty_field"}}}}} -->
<p></p>
<!-- /wp:paragraph -->
```
3. Check that the placeholder shows the new text related to bindings.
4. Inspect the element and check the `aria-label` has also changed.
5. Add an empty paragraph (not bound) and check it keeps working as expected.