### PR TITLE
Categories Block: Add iAPI directive for client-side routing

### DIFF
--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -36,6 +36,7 @@
 			"default": true
 		}
 	},
+	"usesContext": [ "enhancedPagination" ],
 	"supports": {
 		"align": true,
 		"html": false,

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -9,12 +9,15 @@
  * Renders the `core/categories` block on server.
  *
  * @since 5.0.0
+ * @since 6.7.0 Enable client-side rendering if enhancedPagination context is true.
  *
- * @param array $attributes The block attributes.
+ * @param array    $attributes The block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
  *
  * @return string Returns the categories list/dropdown markup.
  */
-function render_block_core_categories( $attributes ) {
+function render_block_core_categories( $attributes, $content, $block ) {
 	static $block_id = 0;
 	++$block_id;
 
@@ -55,11 +58,13 @@ function render_block_core_categories( $attributes ) {
 		$items_markup   = wp_list_categories( $args );
 		$type           = 'list';
 
-		$p = new WP_HTML_Tag_Processor( $items_markup );
-		while ( $p->next_tag( 'a' ) ) {
-			$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+		if ( ! empty ( $block->context['enhancedPagination'] ) ) {
+			$p = new WP_HTML_Tag_Processor( $items_markup );
+			while ( $p->next_tag( 'a' ) ) {
+				$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+			}
+			$items_markup = $p->get_updated_html();
 		}
-		$items_markup = $p->get_updated_html();
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => "wp-block-categories-{$type}" ) );

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -58,7 +58,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 		$items_markup   = wp_list_categories( $args );
 		$type           = 'list';
 
-		if ( ! empty ( $block->context['enhancedPagination'] ) ) {
+		if ( ! empty( $block->context['enhancedPagination'] ) ) {
 			$p = new WP_HTML_Tag_Processor( $items_markup );
 			while ( $p->next_tag( 'a' ) ) {
 				$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -54,6 +54,12 @@ function render_block_core_categories( $attributes ) {
 		$wrapper_markup = '<ul %1$s>%2$s</ul>';
 		$items_markup   = wp_list_categories( $args );
 		$type           = 'list';
+
+		$p = new WP_HTML_Tag_Processor( $items_markup );
+		while ( $p->next_tag( 'a' ) ) {
+			$p->set_attribute( 'data-wp-on--click', 'core/query::actions.navigate' );
+		}
+		$items_markup = $p->get_updated_html();
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => "wp-block-categories-{$type}" ) );


### PR DESCRIPTION
## What?
Enable client-side navigation for the Categories block, when used with the Query Loop block.

## Why?
For a better user experience when using the Categories block.

## How?
By adding the Interactivity API's `data-wp-on--click` directive and setting it to the `core/query::actions.navigate` action. (The latter is provided by the Query Loop block.)

## Testing Instructions
- Create a few posts and at least two categories. Assign each category to a couple of posts.
- In an archive template (e.g. Category Archives), add the Categories block inside of the Query Loop block (if it's not already there).
- Make sure that the Query Loop block has the "Enable forced reload" toggle disabled. To that end, you might need to modify the Post Template block to only contain allowed blocks (e.g. Post Title, Excerpt, Featured Image; but not Post Content).
- View on the frontend. Verify that clicking on individual categories in the Categories block triggers a client-side navigation (rather than server-side). You can use your browser's Network tab to verify.
- Go back to the Site Editor, and enable the Query Loop block's "Force Page Reload" toggle. Save the template.
- Go back to the frontend, and reload it. Verify that clicking the category links now indeed cause a full page reload.

## Screenshots or screencast <!-- if applicable -->

![categories-block-csn](https://github.com/user-attachments/assets/70925f63-def0-4ee5-b3b3-ba85a5fee7b3)
