### PR TITLE
Remove unnecessary ToolbarGroup wrappers

### DIFF
--- a/packages/block-editor/src/components/block-edit-visually-button/index.js
+++ b/packages/block-editor/src/components/block-edit-visually-button/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
@@ -26,14 +26,12 @@ export default function BlockEditVisuallyButton( { clientIds } ) {
 	}
 
 	return (
-		<ToolbarGroup>
-			<ToolbarButton
-				onClick={ () => {
-					toggleBlockMode( clientId );
-				} }
-			>
-				{ __( 'Edit visually' ) }
-			</ToolbarButton>
-		</ToolbarGroup>
+		<ToolbarButton
+			onClick={ () => {
+				toggleBlockMode( clientId );
+			} }
+		>
+			{ __( 'Edit visually' ) }
+		</ToolbarButton>
 	);
 }

--- a/packages/block-editor/src/components/block-lock/toolbar.js
+++ b/packages/block-editor/src/components/block-lock/toolbar.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { useReducer, useRef, useEffect } from '@wordpress/element';
 import { lock, unlock } from '@wordpress/icons';
 
@@ -45,16 +45,14 @@ export default function BlockLockToolbar( { clientId } ) {
 
 	return (
 		<>
-			<ToolbarGroup className="block-editor-block-lock-toolbar">
-				<ToolbarButton
-					disabled={ ! canLock }
-					icon={ isLocked ? lock : unlock }
-					label={ label }
-					onClick={ toggleModal }
-					aria-expanded={ isModalOpen }
-					aria-haspopup="dialog"
-				/>
-			</ToolbarGroup>
+			<ToolbarButton
+				disabled={ ! canLock }
+				icon={ isLocked ? lock : unlock }
+				label={ label }
+				onClick={ toggleModal }
+				aria-expanded={ isModalOpen }
+				aria-haspopup="dialog"
+			/>
 			{ isModalOpen && (
 				<BlockLockModal clientId={ clientId } onClose={ toggleModal } />
 			) }

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
+import { ToolbarItem } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -10,17 +10,15 @@ import BlockSettingsDropdown from './block-settings-dropdown';
 
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
-		<ToolbarGroup>
-			<ToolbarItem>
-				{ ( toggleProps ) => (
-					<BlockSettingsDropdown
-						clientIds={ clientIds }
-						toggleProps={ toggleProps }
-						{ ...props }
-					/>
-				) }
-			</ToolbarItem>
-		</ToolbarGroup>
+		<ToolbarItem>
+			{ ( toggleProps ) => (
+				<BlockSettingsDropdown
+					clientIds={ clientIds }
+					toggleProps={ toggleProps }
+					{ ...props }
+				/>
+			) }
+		</ToolbarItem>
 	);
 }
 

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -5,7 +5,6 @@ import { __, _n, sprintf, _x } from '@wordpress/i18n';
 import {
 	DropdownMenu,
 	ToolbarButton,
-	ToolbarGroup,
 	ToolbarItem,
 	__experimentalText as Text,
 	MenuGroup,
@@ -265,20 +264,18 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 
 	if ( hideDropdown ) {
 		return (
-			<ToolbarGroup>
-				<ToolbarButton
-					disabled
-					className="block-editor-block-switcher__no-switcher-icon"
-					title={ blockSwitcherLabel }
-					icon={
-						<BlockIndicator
-							icon={ icon }
-							showTitle={ isReusable || isTemplate }
-							blockTitle={ blockTitle }
-						/>
-					}
-				/>
-			</ToolbarGroup>
+			<ToolbarButton
+				disabled
+				className="block-editor-block-switcher__no-switcher-icon"
+				title={ blockSwitcherLabel }
+				icon={
+					<BlockIndicator
+						icon={ icon }
+						showTitle={ isReusable || isTemplate }
+						blockTitle={ blockTitle }
+					/>
+				}
+			/>
 		);
 	}
 
@@ -294,42 +291,40 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 				clientIds.length
 		  );
 	return (
-		<ToolbarGroup>
-			<ToolbarItem>
-				{ ( toggleProps ) => (
-					<DropdownMenu
-						className="block-editor-block-switcher"
-						label={ blockSwitcherLabel }
-						popoverProps={ {
-							placement: 'bottom-start',
-							className: 'block-editor-block-switcher__popover',
-						} }
-						icon={
-							<BlockIndicator
-								icon={ icon }
-								showTitle={ isReusable || isTemplate }
-								blockTitle={ blockTitle }
-							/>
-						}
-						toggleProps={ {
-							description: blockSwitcherDescription,
-							...toggleProps,
-						} }
-						menuProps={ { orientation: 'both' } }
-					>
-						{ ( { onClose } ) => (
-							<BlockSwitcherDropdownMenuContents
-								onClose={ onClose }
-								clientIds={ clientIds }
-								hasBlockStyles={ hasBlockStyles }
-								canRemove={ canRemove }
-								isUsingBindings={ isUsingBindings }
-							/>
-						) }
-					</DropdownMenu>
-				) }
-			</ToolbarItem>
-		</ToolbarGroup>
+		<ToolbarItem>
+			{ ( toggleProps ) => (
+				<DropdownMenu
+					className="block-editor-block-switcher"
+					label={ blockSwitcherLabel }
+					popoverProps={ {
+						placement: 'bottom-start',
+						className: 'block-editor-block-switcher__popover',
+					} }
+					icon={
+						<BlockIndicator
+							icon={ icon }
+							showTitle={ isReusable || isTemplate }
+							blockTitle={ blockTitle }
+						/>
+					}
+					toggleProps={ {
+						description: blockSwitcherDescription,
+						...toggleProps,
+					} }
+					menuProps={ { orientation: 'both' } }
+				>
+					{ ( { onClose } ) => (
+						<BlockSwitcherDropdownMenuContents
+							onClose={ onClose }
+							clientIds={ clientIds }
+							hasBlockStyles={ hasBlockStyles }
+							canRemove={ canRemove }
+							isUsingBindings={ isUsingBindings }
+						/>
+					) }
+				</DropdownMenu>
+			) }
+		</ToolbarItem>
 	);
 };
 

--- a/packages/block-editor/src/components/block-toolbar/shuffle.js
+++ b/packages/block-editor/src/components/block-toolbar/shuffle.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { shuffle } from '@wordpress/icons';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { ToolbarButton } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -14,15 +14,7 @@ import { store as blockEditorStore } from '../../store';
 
 const EMPTY_ARRAY = [];
 
-function Container( props ) {
-	return (
-		<ToolbarGroup>
-			<ToolbarButton { ...props } />
-		</ToolbarGroup>
-	);
-}
-
-export default function Shuffle( { clientId, as = Container } ) {
+export default function Shuffle( { clientId } ) {
 	const { categories, patterns, patternName } = useSelect(
 		( select ) => {
 			const {
@@ -89,9 +81,8 @@ export default function Shuffle( { clientId, as = Container } ) {
 		return sameCategoryPatternsWithSingleWrapper[ nextPatternIndex ];
 	}
 
-	const ComponentToUse = as;
 	return (
-		<ComponentToUse
+		<ToolbarButton
 			label={ __( 'Shuffle' ) }
 			icon={ shuffle }
 			className="block-editor-block-toolbar-shuffle"

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -122,9 +122,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 					size="compact"
 				/>
 			) }
-			{ canMove && canRemove && (
-				<Shuffle clientId={ clientId } as={ ToolbarButton } />
-			) }
+			{ canMove && canRemove && <Shuffle clientId={ clientId } /> }
 
 			{ ! isBlockTemplatePart && (
 				<ToolbarButton


### PR DESCRIPTION
There are several toolbar items that were a singular button. I'm wondering if this was a mistake, as every button was wrapped in a group. I'm removing all the groups with only one item to see if everything works the same in order to improve semantics and reduce some unnecessary HTML.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
