### PR TITLE
Block Bindings: Remove `getPlaceholder` API and rely on `key` argument or source label

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -10,6 +10,7 @@ import { addFilter } from '@wordpress/hooks';
 /**
  * Internal dependencies
  */
+import isURLLike from '../components/link-control/is-url-like';
 import { unlock } from '../lock-unlock';
 import BlockContext from '../components/block-context';
 
@@ -176,14 +177,12 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					for ( const [ attributeName, value ] of Object.entries(
 						values
 					) ) {
-						if ( attributeName === 'url' ) {
+						if (
+							attributeName === 'url' &&
+							( ! value || ! isURLLike( value ) )
+						) {
 							// Return null if value is not a valid URL.
-							try {
-								new URL( value );
-								attributes[ attributeName ] = value;
-							} catch ( error ) {
-								attributes[ attributeName ] = null;
-							}
+							attributes[ attributeName ] = null;
 						} else {
 							attributes[ attributeName ] = value;
 						}

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -160,9 +160,10 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					// Get values in batch if the source supports it.
 					let values = {};
 					if ( ! source.getValues ) {
-						// Set `undefined` if `getValues` doesn't exist.
 						Object.keys( bindings ).forEach( ( attr ) => {
-							values[ attr ] = undefined;
+							// Default to the `key` or the source label when `getValues` doesn't exist
+							values[ attr ] =
+								bindings[ attr ].args?.key || source.label;
 						} );
 					} else {
 						values = source.getValues( {
@@ -175,16 +176,13 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					for ( const [ attributeName, value ] of Object.entries(
 						values
 					) ) {
-						// Use placeholder when value is undefined.
-						if ( value === undefined ) {
-							if ( attributeName === 'url' ) {
+						if ( attributeName === 'url' ) {
+							// Return null if value is not a valid URL.
+							try {
+								new URL( value );
+								attributes[ attributeName ] = value;
+							} catch ( error ) {
 								attributes[ attributeName ] = null;
-							} else {
-								// Use the key of the source as a placeholder for the attribute.
-								// If it doesn't have a key, use the source label.
-								attributes[ attributeName ] =
-									bindings[ attributeName ].args?.key ||
-									source.label;
 							}
 						} else {
 							attributes[ attributeName ] = value;

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -134,10 +134,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			) ) {
 				const { source: sourceName, args: sourceArgs } = binding;
 				const source = sources[ sourceName ];
-				if (
-					! source?.getValues ||
-					! canBindAttribute( name, attributeName )
-				) {
+				if ( ! canBindAttribute( name, attributeName ) ) {
 					continue;
 				}
 
@@ -161,12 +158,20 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					}
 
 					// Get values in batch if the source supports it.
-					const values = source.getValues( {
-						registry,
-						context,
-						clientId,
-						bindings,
-					} );
+					let values = {};
+					if ( ! source.getValues ) {
+						// Set `undefined` if `getValues` doesn't exist.
+						Object.keys( bindings ).forEach( ( attr ) => {
+							values[ attr ] = undefined;
+						} );
+					} else {
+						values = source.getValues( {
+							registry,
+							context,
+							clientId,
+							bindings,
+						} );
+					}
 					for ( const [ attributeName, value ] of Object.entries(
 						values
 					) ) {
@@ -175,14 +180,11 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 							if ( attributeName === 'url' ) {
 								attributes[ attributeName ] = null;
 							} else {
+								// Use the key of the source as a placeholder for the attribute.
+								// If it doesn't have a key, use the source label.
 								attributes[ attributeName ] =
-									source.getPlaceholder?.( {
-										registry,
-										context,
-										clientId,
-										attributeName,
-										args: bindings[ attributeName ].args,
-									} );
+									bindings[ attributeName ].args?.key ||
+									source.label;
 							}
 						} else {
 							attributes[ attributeName ] = value;

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -134,7 +134,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			) ) {
 				const { source: sourceName, args: sourceArgs } = binding;
 				const source = sources[ sourceName ];
-				if ( ! canBindAttribute( name, attributeName ) ) {
+				if ( ! source || ! canBindAttribute( name, attributeName ) ) {
 					continue;
 				}
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -773,7 +773,6 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  * @param {Array}    [source.usesContext]      Array of context needed by the source only in the editor.
  * @param {Function} [source.getValues]        Function to get the values from the source.
  * @param {Function} [source.setValues]        Function to update multiple values connected to the source.
- * @param {Function} [source.getPlaceholder]   Function to get the placeholder when the value is undefined.
  * @param {Function} [source.canUserEditValue] Function to determine if the user can edit the value.
  * @param {Function} [source.getFieldsList]    Function to get the lists of fields to expose in the connections panel.
  *
@@ -787,7 +786,6 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  *     label: _x( 'My Custom Source', 'block bindings source' ),
  *     getValues: () => getSourceValues(),
  *     setValues: () => updateMyCustomValuesInBatch(),
- *     getPlaceholder: () => 'Placeholder text when the value is undefined',
  *     canUserEditValue: () => true,
  * } );
  * ```
@@ -799,7 +797,6 @@ export const registerBlockBindingsSource = ( source ) => {
 		usesContext,
 		getValues,
 		setValues,
-		getPlaceholder,
 		canUserEditValue,
 		getFieldsList,
 	} = source;
@@ -889,13 +886,7 @@ export const registerBlockBindingsSource = ( source ) => {
 		return;
 	}
 
-	// Check the `getPlaceholder` property is correct.
-	if ( getPlaceholder && typeof getPlaceholder !== 'function' ) {
-		warning( 'Block bindings source getPlaceholder must be a function.' );
-		return;
-	}
-
-	// Check the `getPlaceholder` property is correct.
+	// Check the `canUserEditValue` property is correct.
 	if ( canUserEditValue && typeof canUserEditValue !== 'function' ) {
 		warning( 'Block bindings source canUserEditValue must be a function.' );
 		return;

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1630,19 +1630,6 @@ describe( 'blocks', () => {
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
 
-		// Check the `getPlaceholder` callback is correct.
-		it( 'should reject invalid getPlaceholder callback', () => {
-			registerBlockBindingsSource( {
-				name: 'core/testing',
-				label: 'testing',
-				getPlaceholder: 'should be a function',
-			} );
-			expect( console ).toHaveWarnedWith(
-				'Block bindings source getPlaceholder must be a function.'
-			);
-			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
-		} );
-
 		// Check the `canUserEditValue` callback is correct.
 		it( 'should reject invalid canUserEditValue callback', () => {
 			registerBlockBindingsSource( {
@@ -1676,7 +1663,6 @@ describe( 'blocks', () => {
 				usesContext: [ 'postId' ],
 				getValues: () => 'value',
 				setValues: () => 'new values',
-				getPlaceholder: () => 'placeholder',
 				canUserEditValue: () => true,
 				getFieldsList: () => {
 					return { field: 'value' };
@@ -1701,7 +1687,6 @@ describe( 'blocks', () => {
 			expect( source.usesContext ).toBeUndefined();
 			expect( source.getValues ).toBeUndefined();
 			expect( source.setValues ).toBeUndefined();
-			expect( source.getPlaceholder ).toBeUndefined();
 			expect( source.canUserEditValue ).toBeUndefined();
 			expect( source.getFieldsList ).toBeUndefined();
 			unregisterBlockBindingsSource( 'core/valid-source' );
@@ -1726,7 +1711,6 @@ describe( 'blocks', () => {
 			const clientOnlyProperties = {
 				getValues: () => 'values',
 				setValues: () => 'new values',
-				getPlaceholder: () => 'placeholder',
 				canUserEditValue: () => true,
 			};
 			registerBlockBindingsSource( {

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -54,7 +54,6 @@ export function addBlockBindingsSource( source ) {
 		usesContext: source.usesContext,
 		getValues: source.getValues,
 		setValues: source.setValues,
-		getPlaceholder: source.getPlaceholder,
 		canUserEditValue: source.canUserEditValue,
 		getFieldsList: source.getFieldsList,
 	};

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -404,7 +404,6 @@ export function blockBindingsSources( state = {}, action ) {
 					),
 					getValues: action.getValues,
 					setValues: action.setValues,
-					getPlaceholder: action.getPlaceholder,
 					canUserEditValue: action.canUserEditValue,
 					getFieldsList: action.getFieldsList,
 				},

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -10,9 +10,6 @@ import { store as editorStore } from '../store';
 
 export default {
 	name: 'core/post-meta',
-	getPlaceholder( { args } ) {
-		return args.key;
-	},
 	getValues( { registry, context, bindings } ) {
 		const meta = registry
 			.select( coreDataStore )

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -20,7 +20,9 @@ export default {
 			)?.meta;
 		const newValues = {};
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
-			newValues[ attributeName ] = meta?.[ source.args.key ];
+			// Use the key if the value is not set.
+			newValues[ attributeName ] =
+				meta?.[ source.args.key ] || source.args.key;
 		}
 		return newValues;
 	},

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -41,7 +41,7 @@ test.describe( 'Block bindings', () => {
 		} );
 
 		test.describe( 'Paragraph', () => {
-			test( 'should show the value of the custom field', async ( {
+			test( 'should show the key of the custom field in post meta', async ( {
 				editor,
 			} ) => {
 				await editor.insertBlock( {
@@ -64,6 +64,53 @@ test.describe( 'Block bindings', () => {
 				await expect( paragraphBlock ).toHaveText(
 					'text_custom_field'
 				);
+			} );
+
+			test( 'should show the key of the custom field in server sources with key', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content: 'paragraph default content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/server-source',
+									args: { key: 'text_custom_field' },
+								},
+							},
+						},
+					},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				await expect( paragraphBlock ).toHaveText(
+					'text_custom_field'
+				);
+			} );
+
+			test( 'should show the source label in server sources without key', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content: 'paragraph default content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/server-source',
+								},
+							},
+						},
+					},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+				await expect( paragraphBlock ).toHaveText( 'Server Source' );
 			} );
 
 			test( 'should lock the appropriate controls with a registered source', async ( {


### PR DESCRIPTION
## What?
Remove the current `getPlaceholder` API and rely instead on the `key` argument if it exists or in the source label if it doesn't.

Some examples where placeholders are needed could be if we are in a template or if we are consuming a source that is registered only in the server.

Additionally, I added some logic to use the same placeholder (key or label), in sources without `getValues` defined (sources defined only in the server, for example). Previously, they were showing the original attribute value, which could be confusing.

| Before | After |
|----------|----------|
| ![Screenshot 2024-08-29 at 17 45 04](https://github.com/user-attachments/assets/9649583c-f669-4c69-b14f-0176e5b34810) | ![Screenshot 2024-08-29 at 17 44 07](https://github.com/user-attachments/assets/4cd93ab0-5748-4cf3-8f50-021994b234c1) |

## Why?
It isn't clear if an API for the placeholders is needed or how it should look like. So far, it seems to be enough relying on the `key` or the source label.

## How?
I'm removing the `getPlaceholder` API. Sources now decide what to show directly in the `getValues` functions. If the value is `undefined`, it is up to them to decide if they want to pass `undefined` or other value like the `key`. For those sources without `getValues` defined, we default to the `key` or the source label if it exists.

## Testing Instructions
1. Register a source only in the server:
```php
	register_block_bindings_source(
		'core/custom',
		array(
			'label'              => 'Custom Source',
			'get_value_callback' => function(){},
			'uses_context'       => array( 'postId', 'postType' ),
		)
	);
```

2. Go to a template and add three blocks: one connected to post meta, other connected to custom source using a key, and another connected to custom source without key.

```html
<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Post meta field</h3>
<!-- /wp:heading -->

<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"my_custom_field"}}}}} -->
<p>Page Text Custom Field</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Server source with key</h3>
<!-- /wp:heading -->

<!-- wp:paragraph {"placeholder":"Page Text Custom Field","metadata":{"bindings":{"content":{"source":"core/custom","args":{"key":"custom_key"}}}}} -->
<p>Original content</p>
<!-- /wp:paragraph -->

<!-- wp:heading {"level":3} -->
<h3 class="wp-block-heading">Server source without key</h3>
<!-- /wp:heading -->

<!-- wp:paragraph {"placeholder":"Page Text Custom Field","metadata":{"bindings":{"content":{"source":"core/custom"}}}} -->
<p>Original content</p>
<!-- /wp:paragraph -->
```

3. Check that the first two blocks show the `key` and the third one shows the source label.