### PR TITLE
Site Title, Post Title: Fix typography for blocks with `a` children

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -80,5 +80,8 @@
 			}
 		}
 	},
-	"style": "wp-block-post-title"
+	"style": "wp-block-post-title",
+	"selectors": {
+		"typography": ".wp-block-post-title, .wp-block-post-title > a"
+	}
 }

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -3,6 +3,29 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
+	&[style*="font-weight"] :where(a) {
+		font-weight: inherit;
+	}
+	&[style*="font-family"] :where(a) {
+		font-family: inherit;
+	}
+	&[class*="-font-size"] :where(a),
+	&[style*="font-size"] :where(a) {
+		font-size: inherit;
+	}
+	&[style*="line-height"] :where(a) {
+		line-height: inherit;
+	}
+	&[style*="font-style"] :where(a) {
+		font-style: inherit;
+	}
+	&[style*="letter-spacing"] :where(a) {
+		letter-spacing: inherit;
+	}
+	&[style*="text-decoration"] :where(a) {
+		text-decoration: inherit;
+	}
+
 	a {
 		display: inline-block;
 	}

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -6,6 +6,7 @@
 	&[style*="font-weight"] :where(a) {
 		font-weight: inherit;
 	}
+	&[class*="-font-family"] :where(a),
 	&[style*="font-family"] :where(a) {
 		font-family: inherit;
 	}

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -75,5 +75,8 @@
 		}
 	},
 	"editorStyle": "wp-block-site-title-editor",
-	"style": "wp-block-site-title"
+	"style": "wp-block-site-title",
+	"selectors": {
+		"typography": ".wp-block-site-title > span, .wp-block-site-title > a"
+	}
 }

--- a/packages/block-library/src/site-title/style.scss
+++ b/packages/block-library/src/site-title/style.scss
@@ -2,6 +2,29 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
+	&[style*="font-weight"] :where(a) {
+		font-weight: inherit;
+	}
+	&[style*="font-family"] :where(a) {
+		font-family: inherit;
+	}
+	&[class*="-font-size"] :where(a),
+	&[style*="font-size"] :where(a) {
+		font-size: inherit;
+	}
+	&[style*="line-height"] :where(a) {
+		line-height: inherit;
+	}
+	&[style*="font-style"] :where(a) {
+		font-style: inherit;
+	}
+	&[style*="letter-spacing"] :where(a) {
+		letter-spacing: inherit;
+	}
+	&[style*="text-decoration"] :where(a) {
+		text-decoration: inherit;
+	}
+
 	:where(a) {
 		color: inherit;
 	}

--- a/packages/block-library/src/site-title/style.scss
+++ b/packages/block-library/src/site-title/style.scss
@@ -5,6 +5,7 @@
 	&[style*="font-weight"] :where(a) {
 		font-weight: inherit;
 	}
+	&[class*="-font-family"] :where(a),
 	&[style*="font-family"] :where(a) {
 		font-family: inherit;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Related to:
- #42404
- #41725
- #46180
- https://github.com/Automattic/wp-calypso/issues/92525

## What?
This PR fixes the typography properties for Site Title and Post Title blocks, enabling their specific styles to be respected/take precedence over more generic styles.
<!-- In a few words, what is the PR actually doing? -->

## Why?
Individual typography styles for the block are not respected if it acts as a link (if the "Make title a link" setting is enabled). Styles-defined settings are being used for these blocks. The text decoration, font family, and a few other attributes (described below) can't be set individually for these blocks, then.

## How?
- The `selectors` setting for the `typography` within the `block.json` of the blocks needs to be updated - as in the PR - to ensure any `theme.json` style change also affects the inner `a` element;
- There are also CSS rules to pass through editor-defined styles from the parent element to the `a` children, if present; otherwise, use whatever gets defined in Styles/`theme.json`.

## Testing Instructions
- To test block-specific styles:
  - Go to Appearance > Editor;
  - Select "Styles" and edit link-specific styles - set a different font family for them;
  - Then, in any template, add the "Site Title" block;
  - Try to change the font to one different than previously selected, and ensure it works properly.
- To test `theme.json` styles:
  - Activate `emptytheme`;
  - Define specific styles for the `core/site-title` element:
  - ```json
    "styles": {
        "blocks": {
            "core/site-title": {
                "typography": {
                    "fontFamily": "Comic Sans MS, sans-serif"
                }
            }
        }
    }
    ```
   - Go to Appearance > Editor;
   - Add the "Site Title" block in any template and ensure the font used in `theme.json` is being correctly displayed;
   - Change the font family for the block and ensure it gets correctly updated.

Any other typography property can also be used (font was just used as an example):
- Font;
- Size
- Appearance;
- Line height;
- Letter spacing;
- Decoration;
- Letter case.

## Screenshots or screencast <!-- if applicable -->
### Before
https://github.com/user-attachments/assets/937b6620-1a90-4b16-a7c0-4db7f4a81e80

### After
https://github.com/user-attachments/assets/e908141b-d770-41de-aeb2-7f081690855c