### PR TITLE
Locked Templates: blocks with contentOnly locking should not be transformable

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -72,7 +72,6 @@ function BlockInspectorLockedBlocks( { topLevelLockedBlock } ) {
 				{ ...blockInformation }
 				className={ blockInformation.isSynced && 'is-synced' }
 			/>
-			<BlockVariationTransforms blockClientId={ topLevelLockedBlock } />
 			<BlockInfo.Slot />
 			{ hasBlockStyles && (
 				<BlockStylesPanel clientId={ topLevelLockedBlock } />

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -107,9 +107,10 @@ function BlockSwitcherDropdownMenuContents( {
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
-	const hasBlockOrBlockVariationTransforms =
+	/*	const hasBlockOrBlockVariationTransforms =
 		hasPossibleBlockTransformations ||
-		hasPossibleBlockVariationTransformations;
+		hasPossibleBlockVariationTransformations;*/
+	const hasBlockOrBlockVariationTransforms = false;
 	const hasContents =
 		hasBlockStyles ||
 		hasBlockOrBlockVariationTransforms ||
@@ -198,6 +199,7 @@ const BlockIndicator = ( { icon, showTitle, blockTitle } ) => (
 
 export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 	const {
+		selectedHasTemplateLock,
 		canRemove,
 		hasBlockStyles,
 		icon,
@@ -206,8 +208,12 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 		isTemplate,
 	} = useSelect(
 		( select ) => {
-			const { getBlocksByClientId, getBlockAttributes, canRemoveBlocks } =
-				select( blockEditorStore );
+			const {
+				getTemplateLock,
+				getBlocksByClientId,
+				getBlockAttributes,
+				canRemoveBlocks,
+			} = select( blockEditorStore );
 			const { getBlockStyles, getBlockType, getActiveBlockVariation } =
 				select( blocksStore );
 			const _blocks = getBlocksByClientId( clientIds );
@@ -219,6 +225,7 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 			const blockType = getBlockType( firstBlockName );
 
 			let _icon;
+			let _hasTemplateLock;
 			if ( _isSingleBlockSelected ) {
 				const match = getActiveBlockVariation(
 					firstBlockName,
@@ -226,6 +233,8 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 				);
 				// Take into account active block variations.
 				_icon = match?.icon || blockType.icon;
+				_hasTemplateLock =
+					getTemplateLock( clientIds[ 0 ] ) === 'contentOnly';
 			} else {
 				const isSelectionOfSameType =
 					new Set( _blocks.map( ( { name } ) => name ) ).size === 1;
@@ -244,6 +253,7 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 					_isSingleBlockSelected && isReusableBlock( _blocks[ 0 ] ),
 				isTemplate:
 					_isSingleBlockSelected && isTemplatePart( _blocks[ 0 ] ),
+				selectedHasTemplateLock: _hasTemplateLock,
 			};
 		},
 		[ clientIds ]
@@ -252,7 +262,8 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 		clientId: clientIds?.[ 0 ],
 		maximumLength: 35,
 	} );
-	if ( invalidBlocks ) {
+
+	if ( invalidBlocks || selectedHasTemplateLock ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -237,6 +237,9 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 			} else {
 				const isSelectionOfSameType =
 					new Set( _blocks.map( ( { name } ) => name ) ).size === 1;
+				_hasTemplateLock = clientIds.some(
+					( id ) => getTemplateLock( id ) === 'contentOnly'
+				);
 				// When selection consists of blocks of multiple types, display an
 				// appropriate icon to communicate the non-uniformity.
 				_icon = isSelectionOfSameType ? blockType.icon : copy;

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -198,7 +198,7 @@ const BlockIndicator = ( { icon, showTitle, blockTitle } ) => (
 
 export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 	const {
-		selectedHasTemplateLock,
+		hasContentOnlyLocking,
 		canRemove,
 		hasBlockStyles,
 		icon,
@@ -255,7 +255,7 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 					_isSingleBlockSelected && isReusableBlock( _blocks[ 0 ] ),
 				isTemplate:
 					_isSingleBlockSelected && isTemplatePart( _blocks[ 0 ] ),
-				selectedHasTemplateLock: _hasTemplateLock,
+				hasContentOnlyLocking: _hasTemplateLock,
 			};
 		},
 		[ clientIds ]
@@ -265,7 +265,7 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 		maximumLength: 35,
 	} );
 
-	if ( invalidBlocks || selectedHasTemplateLock ) {
+	if ( invalidBlocks ) {
 		return null;
 	}
 
@@ -274,7 +274,10 @@ export const BlockSwitcher = ( { clientIds, disabled, isUsingBindings } ) => {
 		? blockTitle
 		: __( 'Multiple blocks selected' );
 
-	const hideDropdown = disabled || ( ! hasBlockStyles && ! canRemove );
+	const hideDropdown =
+		disabled ||
+		( ! hasBlockStyles && ! canRemove ) ||
+		hasContentOnlyLocking;
 
 	if ( hideDropdown ) {
 		return (

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -107,10 +107,9 @@ function BlockSwitcherDropdownMenuContents( {
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;
-	/*	const hasBlockOrBlockVariationTransforms =
+	const hasBlockOrBlockVariationTransforms =
 		hasPossibleBlockTransformations ||
-		hasPossibleBlockVariationTransformations;*/
-	const hasBlockOrBlockVariationTransforms = false;
+		hasPossibleBlockVariationTransformations;
 	const hasContents =
 		hasBlockStyles ||
 		hasBlockOrBlockVariationTransforms ||

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -66,6 +66,7 @@ export function PrivateBlockToolbar( {
 		showParentSelector,
 		isUsingBindings,
 		hasParentPattern,
+		selectedHasTemplateLock,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -76,6 +77,7 @@ export function PrivateBlockToolbar( {
 			getBlockEditingMode,
 			getBlockAttributes,
 			getBlockParentsByBlockName,
+			getTemplateLock,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -103,6 +105,10 @@ export function PrivateBlockToolbar( {
 					.length > 0
 		);
 
+		// If one or more selected blocks re locked, do not show the BlockGroupToolbar.
+		const _hasTemplateLock = selectedBlockClientIds.some(
+			( id ) => getTemplateLock( id ) === 'contentOnly'
+		);
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -123,6 +129,7 @@ export function PrivateBlockToolbar( {
 				_isDefaultEditingMode,
 			isUsingBindings: _isUsingBindings,
 			hasParentPattern: _hasParentPattern,
+			selectedHasTemplateLock: _hasTemplateLock,
 		};
 	}, [] );
 
@@ -205,9 +212,9 @@ export function PrivateBlockToolbar( {
 							</ToolbarGroup>
 						</div>
 					) }
-				{ shouldShowVisualToolbar && isMultiToolbar && (
-					<BlockGroupToolbar />
-				) }
+				{ ! selectedHasTemplateLock &&
+					shouldShowVisualToolbar &&
+					isMultiToolbar && <BlockGroupToolbar /> }
 				{ shouldShowVisualToolbar && (
 					<>
 						<BlockControls.Slot

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -105,7 +105,7 @@ export function PrivateBlockToolbar( {
 					.length > 0
 		);
 
-		// If one or more selected blocks re locked, do not show the BlockGroupToolbar.
+		// If one or more selected blocks are locked, do not show the BlockGroupToolbar.
 		const _hasTemplateLock = selectedBlockClientIds.some(
 			( id ) => getTemplateLock( id ) === 'contentOnly'
 		);

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -66,7 +66,7 @@ export function PrivateBlockToolbar( {
 		showParentSelector,
 		isUsingBindings,
 		hasParentPattern,
-		selectedHasTemplateLock,
+		hasContentOnlyLocking,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -129,7 +129,7 @@ export function PrivateBlockToolbar( {
 				_isDefaultEditingMode,
 			isUsingBindings: _isUsingBindings,
 			hasParentPattern: _hasParentPattern,
-			selectedHasTemplateLock: _hasTemplateLock,
+			hasContentOnlyLocking: _hasTemplateLock,
 		};
 	}, [] );
 
@@ -212,7 +212,7 @@ export function PrivateBlockToolbar( {
 							</ToolbarGroup>
 						</div>
 					) }
-				{ ! selectedHasTemplateLock &&
+				{ ! hasContentOnlyLocking &&
 					shouldShowVisualToolbar &&
 					isMultiToolbar && <BlockGroupToolbar /> }
 				{ shouldShowVisualToolbar && (


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/64661

## What?

Where a block has content locking, do not show the block transformation/variations picker in the block tools popover or the block tools inspector.

## Why?

Switching variations or to other block variations transforms the block and, therefore, potentially the content inside.

Blocks that a locked with `contentOnly` should theoretically only allow editing of content (text, images etc).


## How?
Checking for `contentOnly` status and not rendering the variation tools.

## Testing Instructions

<details>

<summary>Example HTML</summary>

```html
<!-- wp:group {"templateLock":"contentOnly", "layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"backgroundColor":"currentcolor-50"} -->
<p class="has-currentcolor-50-background-color has-background">This is a group block</p>
<!-- /wp:paragraph -->

<!-- wp:group {"style":{"color":{"background":"#ec3a3acf"}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group has-background" style="background-color:#ec3a3acf"><!-- wp:paragraph -->
<p>This is another group block</p>
<!-- /wp:paragraph -->

<!-- wp:cover {"customOverlayColor":"#6c19cc","isUserOverlayColor":true,"layout":{"type":"constrained"}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#6c19cc"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Cover</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->

```

</details>

Click on a locked group. Check that the transformation/variation options in the toolbar and inspector are not available.

Unlock the block group by right clicking and selecting "Modify" - you should see the regular transformation/variation options in the toolbar and inspector. 

Select several locked blocks. The toolbar/inspector should not display any block transform options.

| A locked block is selected | No locked blocks selected |
|--------|--------|
| <img width="500" alt="Screenshot 2024-09-03 at 12 58 15 PM" src="https://github.com/user-attachments/assets/846f6bf9-3319-49b0-a0b8-aa0c1ec32b2e"> | <img width="500" alt="Screenshot 2024-09-03 at 12 58 28 PM" src="https://github.com/user-attachments/assets/3e60e89d-12df-4e43-8b37-3df68d1bcdd8"> | 



## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/18e6d6bf-95b0-4644-bb07-57a0176dc7db


