### PR TITLE
Dataviews docs: Layout properties checks and link

### DIFF
--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -172,6 +172,7 @@ Properties:
 -   `perPage`: number of records to show per page.
 -   `page`: the page that is visible.
 -   `sort`:
+
     -   `field`: the field used for sorting the dataset.
     -   `direction`: the direction to use for sorting, one of `asc` or `desc`.
 
@@ -308,6 +309,8 @@ const defaultLayouts = {
 	},
 };
 ```
+
+The `defaultLayouts` property should be an object that includes properties named `table`, `grid`, or `list`. Each of these properties should contain a `layout` property, which holds the configuration for each specific layout type. Check [here](#properties-of-layout) the full list of properties available for each layout's configuration
 
 ### `onChangeSelection`: `function`
 

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -124,7 +124,7 @@ Each field is an object with the following properties:
 
     -   `value`: The id of the value to filter to (for internal use)
     -   `label`: The text that will be displayed in the UI for the item.
-    -    `description`: A longer description that describes the element, to also be displayed. Optional.
+    -   `description`: A longer description that describes the element, to also be displayed. Optional.
 
     To enable the filter by a field we just need to set a proper value to the `elements` property of the field we'd like to filter by.
 
@@ -177,14 +177,16 @@ Properties:
 -   `fields`: the `id` of the fields that are visible in the UI.
 -   `layout`: config that is specific to a particular layout type:
 
-| Properties of `layout` | Table | Grid | List |
-| --- | --- | --- | --- |
-| `primaryField`: the field's `id` to be highlighted in each layout. It's not hidable. | &check; | &check; | &check; |
-| `mediaField`: the field's `id` to be used for rendering each card's media. It's not hiddable. | | &check; | &check; |
-| `columnFields`: a list of field's `id` to render vertically stacked instead of horizontally (the default). | | &check; | |
-| `badgeFields`: a list of field's `id` to render without label and styled as badges. | | &check; | |
-| `combinedFields`: a list of "virtual" fields that are made by combining others. See "Combining fields" section. | &check; | | |
-| `styles`: additional `width`, `maxWidth`, `minWidth` styles for each field column. | &check; | | |
+#### Properties of `layout`
+
+| Properties of `layout`                                                                                          | Table | Grid | List |
+| --------------------------------------------------------------------------------------------------------------- | ----- | ---- | ---- |
+| `primaryField`: the field's `id` to be highlighted in each layout. It's not hidable.                            | ✓     | ✓    | ✓    |
+| `mediaField`: the field's `id` to be used for rendering each card's media. It's not hiddable.                   |       | ✓    | ✓    |
+| `columnFields`: a list of field's `id` to render vertically stacked instead of horizontally (the default).      |       | ✓    |      |
+| `badgeFields`: a list of field's `id` to render without label and styled as badges.                             |       | ✓    |      |
+| `combinedFields`: a list of "virtual" fields that are made by combining others. See "Combining fields" section. | ✓     |      |      |
+| `styles`: additional `width`, `maxWidth`, `minWidth` styles for each field column.                              | ✓     |      |      |
 
 ### `onChangeView`: `function`
 
@@ -330,8 +332,8 @@ Each "virtual field", has to provide an `id` and `label` (optionally a `header` 
 
 Additionally, they need to provide:
 
-- `children`: a list of field's `id` to combine
-- `direction`: how should they be stacked, `vertically` or `horizontally`
+-   `children`: a list of field's `id` to combine
+-   `direction`: how should they be stacked, `vertically` or `horizontally`
 
 For example, this is how you'd define a `site` field which is a combination of a `title` and `description` fields, which are not displayed:
 


### PR DESCRIPTION
## What?
Fixes checks in the table and add a link to the table so it can be referenced from other parts of the page

## Why?
The table at https://developer.wordpress.org/block-editor/reference-guides/packages/packages-dataviews/#view-object doesn't show properly the checks.
<img width="904" alt="Screenshot 2024-08-30 at 08 45 28" src="https://github.com/user-attachments/assets/bd7ca087-af81-4d5c-b51b-570b26873c74">
The information of this table is a great reference for other parts of the docs so a link to this part would be helpful.

