### PR TITLE
Site Logo: Fix loader alignment issue

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -654,10 +654,10 @@ export default function LogoEdit( {
 			{ controls }
 			{ mediaInspectorPanel }
 			{ ( !! logoUrl || !! temporaryURL ) && logoImage }
-			{ ( !! isLoading ||
+			{ ( isLoading ||
 				( ! temporaryURL && ! logoUrl && ! canUserEdit ) ) && (
 				<Placeholder className="site-logo_placeholder" withIllustration>
-					{ !! isLoading && (
+					{ isLoading && (
 						<span className="components-placeholder__preview">
 							<Spinner />
 						</span>

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -654,8 +654,9 @@ export default function LogoEdit( {
 			{ controls }
 			{ mediaInspectorPanel }
 			{ ( !! logoUrl || !! temporaryURL ) && logoImage }
-			{ ! temporaryURL && ! logoUrl && ! canUserEdit && (
-				<Placeholder className="site-logo_placeholder">
+			{ ( !! isLoading ||
+				( ! temporaryURL && ! logoUrl && ! canUserEdit ) ) && (
+				<Placeholder className="site-logo_placeholder" withIllustration>
 					{ !! isLoading && (
 						<span className="components-placeholder__preview">
 							<Spinner />
@@ -663,7 +664,7 @@ export default function LogoEdit( {
 					) }
 				</Placeholder>
 			) }
-			{ ! temporaryURL && ! logoUrl && canUserEdit && (
+			{ ! isLoading && ! temporaryURL && ! logoUrl && canUserEdit && (
 				<MediaPlaceholder
 					onSelect={ onInitialSelectLogo }
 					accept={ ACCEPT_MEDIA_STRING }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Spinner alignment was off in `Site Logo` block when image is set and we reload the screen. 
 
## Testing Instructions
- Add `Site Logo` block
- Upload image to `Site Logo` block, and Reload the page
- Note Spinner alignment.
 
## Screenshots or screencast <!-- if applicable -->

|  In Trunk | In This PR |
| ------------- | ------------- |
| ![site-logo-spinne-before](https://github.com/user-attachments/assets/a9e7fb57-93b0-4fff-ab59-8cca9051704d) | ![site-logo-spinner-after](https://github.com/user-attachments/assets/4bdd3c4f-093d-4e0a-b96c-08a0df9521d4)
  |



