### PR TITLE
Create Block: Set minimum supported WordPress version to 6.6

### DIFF
--- a/packages/create-block-interactive-template/CHANGELOG.md
+++ b/packages/create-block-interactive-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Set the minimum supported WordPress version to 6.6 to make it work seamlessly with the latest version of `@wordpress/scripts` package ([#64920](https://github.com/WordPress/gutenberg/pull/64920)).
+
 ## 2.6.0 (2024-08-21)
 
 ## 2.5.0 (2024-08-07)

--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -8,7 +8,7 @@
  * Description:       {{description}}
 {{/description}}
  * Version:           {{version}}
- * Requires at least: 6.1
+ * Requires at least: 6.6
  * Requires PHP:      7.0
 {{#author}}
  * Author:            {{author}}

--- a/packages/create-block-interactive-template/plugin-templates/readme.txt.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/readme.txt.mustache
@@ -3,7 +3,7 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Tested up to:      6.1
+Tested up to:      6.6
 Stable tag:        {{version}}
 {{#license}}
 License:           {{license}}

--- a/packages/create-block-tutorial-template/CHANGELOG.md
+++ b/packages/create-block-tutorial-template/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Set the minimum supported WordPress version to 6.6 to make it work seamlessly with the latest version of `@wordpress/scripts` package ([#64920](https://github.com/WordPress/gutenberg/pull/64920)).
+
 ## 4.6.0 (2024-08-21)
 
 ## 4.5.0 (2024-08-07)

--- a/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
@@ -8,7 +8,7 @@
  * Description:       {{description}}
 {{/description}}
  * Version:           {{version}}
- * Requires at least: 6.2
+ * Requires at least: 6.6
  * Requires PHP:      7.0
 {{#author}}
  * Author:            {{author}}

--- a/packages/create-block-tutorial-template/plugin-templates/readme.txt.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/readme.txt.mustache
@@ -3,7 +3,7 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Tested up to:      6.4
+Tested up to:      6.6
 Stable tag:        {{version}}
 {{#license}}
 License:           {{license}}

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Unpin the `@wordpress/scripts` version and set the minimum supported WordPress version to 6.6.
+
 ## 4.49.0 (2024-08-21)
 
 ## 4.48.0 (2024-08-07)

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Enhancements
 
--   Unpin the `@wordpress/scripts` version and set the minimum supported WordPress version to 6.6.
+-   Unpin the `@wordpress/scripts` version and set the minimum supported WordPress version to 6.6 ([#64920](https://github.com/WordPress/gutenberg/pull/64920)).
 
 ## 4.49.0 (2024-08-21)
 

--- a/packages/create-block/lib/init-wp-scripts.js
+++ b/packages/create-block/lib/init-wp-scripts.js
@@ -16,7 +16,7 @@ module.exports = async ( { slug } ) => {
 	info(
 		'Installing `@wordpress/scripts` package. It might take a couple of minutes...'
 	);
-	await command( 'npm install @wordpress/scripts@27 --save-dev', {
+	await command( 'npm install @wordpress/scripts --save-dev', {
 		cwd,
 	} );
 

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -7,7 +7,7 @@
 {{#description}}
  * Description:       {{description}}
 {{/description}}
- * Requires at least: 6.1
+ * Requires at least: 6.6
  * Requires PHP:      7.0
  * Version:           {{version}}
 {{#author}}

--- a/packages/create-block/lib/templates/es5/readme.txt.mustache
+++ b/packages/create-block/lib/templates/es5/readme.txt.mustache
@@ -3,7 +3,7 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Tested up to:      6.1
+Tested up to:      6.6
 Stable tag:        {{version}}
 {{#license}}
 License:           {{license}}

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -7,7 +7,7 @@
 {{#description}}
  * Description:       {{description}}
 {{/description}}
- * Requires at least: 6.1
+ * Requires at least: 6.6
  * Requires PHP:      7.0
  * Version:           {{version}}
 {{#author}}

--- a/packages/create-block/lib/templates/plugin/readme.txt.mustache
+++ b/packages/create-block/lib/templates/plugin/readme.txt.mustache
@@ -3,7 +3,7 @@
 Contributors:      {{author}}
 {{/author}}
 Tags:              block
-Tested up to:      6.1
+Tested up to:      6.6
 Stable tag:        {{version}}
 {{#license}}
 License:           {{license}}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to https://github.com/WordPress/gutenberg/pull/62234 where the `@wordpress/scripts` version got pinned to a version supported by WordPress 6.5. Now that WordPress 6.6 is out for a couple of weeks we can finally revert this change.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

WordPress 6.6 has all the necessary code to work with the latest version of `@wordpress/scripts`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the temorary version enforcment during `@wordpress/scripts` installation and set the minimum version for WordPress as 6.6 for all templates.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Run the following locally:

```
npx wp-create-block example-block --no-wp-scripts
cd example-block
../node_modules/.bin/wp-scripts build
../node_modules/.bin/wp-scripts plugin-zip
```

Upload the zip file to the WordPress 6.6 instance, activate the plugin Example Block and ensure it works as expected.

## Screenshots or screencast <!-- if applicable -->

<img width="703" alt="Screenshot 2024-08-30 at 10 35 07" src="https://github.com/user-attachments/assets/0ca80967-9121-41dd-9a2f-9d9833527a6d">
