### PR TITLE
Experiment with block drill down in contentOnly mode

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -13,7 +13,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -21,6 +21,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 function BlockCard( { title, icon, description, blockType, className } ) {
 	if ( blockType ) {
@@ -31,29 +32,51 @@ function BlockCard( { title, icon, description, blockType, className } ) {
 		( { title, icon, description } = blockType );
 	}
 
-	const { parentNavBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-			select( blockEditorStore );
+	const { parentNavBlockClientId, contentLockedParentClientId } = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getBlockParentsByBlockName,
+				getContentLockingParent,
+			} = unlock( select( blockEditorStore ) );
 
-		const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockClientId = getSelectedBlockClientId();
 
-		return {
-			parentNavBlockClientId: getBlockParentsByBlockName(
-				_selectedBlockClientId,
-				'core/navigation',
-				true
-			)[ 0 ],
-		};
-	}, [] );
+			return {
+				parentNavBlockClientId: getBlockParentsByBlockName(
+					_selectedBlockClientId,
+					'core/navigation',
+					true
+				)[ 0 ],
+				contentLockedParentClientId: getContentLockingParent(
+					_selectedBlockClientId
+				),
+			};
+		},
+		[]
+	);
+
+	const hasContentLockedParent = contentLockedParentClientId !== undefined;
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 
 	return (
 		<div className={ clsx( 'block-editor-block-card', className ) }>
-			{ parentNavBlockClientId && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
+			{ ( parentNavBlockClientId || hasContentLockedParent ) && ( // This is only used by the Navigation block for now. It's not ideal having Navigation block specific code here.
 				<Button
-					onClick={ () => selectBlock( parentNavBlockClientId ) }
-					label={ __( 'Go to parent Navigation block' ) }
+					onClick={ () => {
+						const targetClientId =
+							parentNavBlockClientId ||
+							contentLockedParentClientId;
+						selectBlock( targetClientId );
+					} }
+					label={ sprintf(
+						// Translators: Go to the parent navigation block or the parent block.
+						__( 'Go to %s' ),
+						parentNavBlockClientId
+							? 'parent navigation block'
+							: 'parent block'
+					) }
 					style={
 						// TODO: This style override is also used in ToolsPanelHeader.
 						// It should be supported out-of-the-box by Button.

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -98,7 +98,6 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getSelectedBlockClientId,
 			getSelectedBlockCount,
 			getBlockName,
-			getContentLockingParent,
 			getTemplateLock,
 		} = unlock( select( blockEditorStore ) );
 		const _selectedBlockClientId = getSelectedBlockClientId();
@@ -113,11 +112,10 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			selectedBlockName: _selectedBlockName,
 			blockType: _blockType,
 			topLevelLockedBlock:
-				getContentLockingParent( _selectedBlockClientId ) ||
-				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly' ||
+				getTemplateLock( _selectedBlockClientId ) === 'contentOnly' ||
 				_selectedBlockName === 'core/block'
 					? _selectedBlockClientId
-					: undefined ),
+					: undefined,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -45,16 +45,15 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		clientId,
 		context: 'list-view',
 	} );
-	const { isSelected, blockHasInnerBlocks } = useSelect(
+	const { isSelected } = useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock, getBlockCount } =
+			const { isBlockSelected, hasSelectedInnerBlock } =
 				select( blockEditorStore );
 
 			return {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
-				blockHasInnerBlocks: getBlockCount( clientId ) > 0,
 			};
 		},
 		[ clientId ]
@@ -80,15 +79,12 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				<FlexBlock style={ { textAlign: 'left' } }>
 					<Truncate>{ blockTitle }</Truncate>
 				</FlexBlock>
-				{ blockHasInnerBlocks && (
-					<FlexItem>
-						<Icon
-							icon={
-								isRTL() ? chevronLeftSmall : chevronRightSmall
-							}
-						/>
-					</FlexItem>
-				) }
+
+				<FlexItem>
+					<Icon
+						icon={ isRTL() ? chevronLeftSmall : chevronRightSmall }
+					/>
+				</FlexItem>
 			</Flex>
 		</Button>
 	);

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -45,18 +45,24 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		clientId,
 		context: 'list-view',
 	} );
-	const { isSelected } = useSelect(
+
+	const isSynced = blockInformation?.isSynced;
+
+	const { isSelected, showDrillDown } = useSelect(
 		( select ) => {
 			const { isBlockSelected, hasSelectedInnerBlock } =
 				select( blockEditorStore );
+
+			const _showDrillDown = ! isSynced;
 
 			return {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
+				showDrillDown: _showDrillDown,
 			};
 		},
-		[ clientId ]
+		[ isSynced, clientId ]
 	);
 	const { selectBlock } = useDispatch( blockEditorStore );
 
@@ -80,11 +86,15 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 					<Truncate>{ blockTitle }</Truncate>
 				</FlexBlock>
 
-				<FlexItem>
-					<Icon
-						icon={ isRTL() ? chevronLeftSmall : chevronRightSmall }
-					/>
-				</FlexItem>
+				{ showDrillDown && (
+					<FlexItem>
+						<Icon
+							icon={
+								isRTL() ? chevronLeftSmall : chevronRightSmall
+							}
+						/>
+					</FlexItem>
+				) }
 			</Flex>
 		</Button>
 	);

--- a/packages/block-editor/src/components/block-quick-navigation/index.js
+++ b/packages/block-editor/src/components/block-quick-navigation/index.js
@@ -9,7 +9,10 @@ import {
 	Flex,
 	FlexBlock,
 	FlexItem,
+	Icon,
 } from '@wordpress/components';
+import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -42,15 +45,16 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 		clientId,
 		context: 'list-view',
 	} );
-	const { isSelected } = useSelect(
+	const { isSelected, blockHasInnerBlocks } = useSelect(
 		( select ) => {
-			const { isBlockSelected, hasSelectedInnerBlock } =
+			const { isBlockSelected, hasSelectedInnerBlock, getBlockCount } =
 				select( blockEditorStore );
 
 			return {
 				isSelected:
 					isBlockSelected( clientId ) ||
 					hasSelectedInnerBlock( clientId, /* deep: */ true ),
+				blockHasInnerBlocks: getBlockCount( clientId ) > 0,
 			};
 		},
 		[ clientId ]
@@ -76,6 +80,15 @@ function BlockQuickNavigationItem( { clientId, onSelect } ) {
 				<FlexBlock style={ { textAlign: 'left' } }>
 					<Truncate>{ blockTitle }</Truncate>
 				</FlexBlock>
+				{ blockHasInnerBlocks && (
+					<FlexItem>
+						<Icon
+							icon={
+								isRTL() ? chevronLeftSmall : chevronRightSmall
+							}
+						/>
+					</FlexItem>
+				) }
 			</Flex>
 		</Button>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When in contentOnly allow drilling down into sub blocks to show the full inspector panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/60021

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just a UX experiment. Effectively removing one condition to test whether it feels right.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This is an experiment only...

- Open Site Editor
- Ensure you have a template with a block structure similar to:
   - header
   - group (main) <-- we'll be targetting the top level blocks _within_ this block
   - footer
- Open Devtools console and type:

```
// Fetch the top most blocks
// Grab the "main" content.
// Grab the "sections" within it (big assumption but this is a experiment!)
// apply the template lock to them all
wp.data
  .select("core/block-editor")
  .getBlockOrder( wp.data.select("core/block-editor").getBlockOrder()[1] ).forEach( (clientId) => {
    wp.data
  .dispatch("core/block-editor").updateBlockAttributes(clientId, {
      templateLock: 'contentOnly'
    });
  });
```
- You should now find all the top level sections of your template at `templateLock: contentOnly`.
- Click around on each section and see the new drilldown under the `Content` section in the inspector controls.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="2428" alt="Screen Shot 2024-08-30 at 12 18 28" src="https://github.com/user-attachments/assets/dcbbbf59-1b30-407e-a27a-29f67ea61e12">

### Video

https://github.com/user-attachments/assets/e5bacbe2-2016-441b-926a-28c9d38ff94e

