### PR TITLE
Scripts: Make React Fast Refresh work with multiple blocks

### DIFF
--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -337,7 +337,7 @@ class DependencyExtractionWebpackPlugin {
 			// `RealContentHashPlugin` after minification, but it only modifies
 			// already-produced asset filenames and the updated hash is not
 			// available to plugins.
-			const { hashFunction, hashDigest, hashDigestLength } =
+			const { hashFunction, hashDigest, hashDigestLength, uniqueName } =
 				compilation.outputOptions;
 
 			const hashBuilder = createHash( hashFunction );
@@ -385,6 +385,15 @@ class DependencyExtractionWebpackPlugin {
 
 			if ( this.useModules ) {
 				assetData.type = 'module';
+			}
+
+			if ( compilation.options?.optimization?.runtimeChunk !== false ) {
+				assetData.handle =
+					uniqueName +
+					'-' +
+					chunkJSFile
+						.replace( /\\/g, '/' )
+						.replace( jsExtensionRegExp, '' );
 			}
 
 			if ( combineAssets ) {

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -337,7 +337,7 @@ class DependencyExtractionWebpackPlugin {
 			// `RealContentHashPlugin` after minification, but it only modifies
 			// already-produced asset filenames and the updated hash is not
 			// available to plugins.
-			const { hashFunction, hashDigest, hashDigestLength, uniqueName } =
+			const { hashFunction, hashDigest, hashDigestLength } =
 				compilation.outputOptions;
 
 			const hashBuilder = createHash( hashFunction );
@@ -389,7 +389,7 @@ class DependencyExtractionWebpackPlugin {
 
 			if ( compilation.options?.optimization?.runtimeChunk !== false ) {
 				assetData.handle =
-					uniqueName +
+					compilation.name +
 					'-' +
 					chunkJSFile
 						.replace( /\\/g, '/' )

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -388,6 +388,7 @@ class DependencyExtractionWebpackPlugin {
 			}
 
 			if ( compilation.options?.optimization?.runtimeChunk !== false ) {
+				// Sets the script handle for the shared runtime file so WordPress registers it only once when using the asset file.
 				assetData.handle =
 					compilation.name +
 					'-' +

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -265,17 +265,17 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comm
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => 'ee5ac21a1f0003d732e6', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob'), 'version' => 'ee5ac21a1f0003d732e6', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-a');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '5b112b32c6db548c2997', 'type' => 'module');
+"<?php return array('dependencies' => array('@wordpress/blob', 'lodash'), 'version' => '5b112b32c6db548c2997', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-b');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => 'b1ca4106075e0bd94f9c', 'type' => 'module');
+"<?php return array('dependencies' => array(), 'version' => 'b1ca4106075e0bd94f9c', 'type' => 'module', 'handle' => 'runtime-chunk-single-modules-runtime');
 "
 `;
 
@@ -681,17 +681,17 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comm
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment-minified\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('wp-blob'), 'version' => 'd091f1cbbf7603d6e12c');
+"<?php return array('dependencies' => array('wp-blob'), 'version' => 'd091f1cbbf7603d6e12c', 'handle' => 'runtime-chunk-single-scripts-a');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'b.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '845bc6d4ffbdb9419ebd');
+"<?php return array('dependencies' => array('lodash', 'wp-blob'), 'version' => '845bc6d4ffbdb9419ebd', 'handle' => 'runtime-chunk-single-scripts-b');
 "
 `;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'runtime.asset.php' should match snapshot 1`] = `
-"<?php return array('dependencies' => array(), 'version' => '717eb779e609d175a7dd');
+"<?php return array('dependencies' => array(), 'version' => '717eb779e609d175a7dd', 'handle' => 'runtime-chunk-single-scripts-runtime');
 "
 `;
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Make React Fast Refresh in the `start` command work with multiple blocks ([64924](https://github.com/WordPress/gutenberg/pull/64924)).
+
 ## 30.6.0 (2024-11-27)
 
 ## 30.5.1 (2024-11-18)

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -7,7 +7,7 @@ const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const webpack = require( 'webpack' );
 const browserslist = require( 'browserslist' );
 const MiniCSSExtractPlugin = require( 'mini-css-extract-plugin' );
-const { basename, dirname, resolve } = require( 'path' );
+const { basename, dirname, relative, resolve, sep } = require( 'path' );
 const ReactRefreshWebpackPlugin = require( '@pmmmwh/react-refresh-webpack-plugin' );
 const RtlCssPlugin = require( 'rtlcss-webpack-plugin' );
 const TerserPlugin = require( 'terser-webpack-plugin' );
@@ -115,6 +115,7 @@ const baseConfig = {
 	optimization: {
 		// Only concatenate modules in production, when not analyzing bundles.
 		concatenateModules: isProduction && ! process.env.WP_BUNDLE_ANALYZER,
+		runtimeChunk: hasReactFastRefresh && 'single',
 		splitChunks: {
 			cacheGroups: {
 				style: {
@@ -339,6 +340,31 @@ const scriptConfig = {
 									}
 								}
 							} );
+
+							if ( hasReactFastRefresh ) {
+								const runtimePath = relative(
+									dirname( absoluteFrom ),
+									fromProjectRoot(
+										getWordPressSrcDirectory() +
+											sep +
+											'runtime.js'
+									)
+								);
+								const fields =
+									getBlockJsonScriptFields( blockJson );
+								for ( const [ fieldName ] of Object.entries(
+									fields
+								) ) {
+									blockJson[ fieldName ] = [
+										`file:${ runtimePath }`,
+										...( Array.isArray(
+											blockJson[ fieldName ]
+										)
+											? blockJson[ fieldName ]
+											: [ blockJson[ fieldName ] ] ),
+									];
+								}
+							}
 
 							return JSON.stringify( blockJson, null, 2 );
 						}

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -342,6 +342,7 @@ const scriptConfig = {
 							} );
 
 							if ( hasReactFastRefresh ) {
+								// Prepends the file reference to the shared runtime chunk to every script type defined for the block.
 								const runtimePath = relative(
 									dirname( absoluteFrom ),
 									fromProjectRoot(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/issues/25188.
Follow-up for https://github.com/WordPress/gutenberg/pull/28273.
Related comments:
- Issue raised in https://github.com/WordPress/gutenberg/issues/25188#issuecomment-1099474694 by @amjard360.
- Issue reported in https://github.com/WordPress/gutenberg/pull/28273#issuecomment-1434552486, and the workaround  shared in https://github.com/WordPress/gutenberg/pull/28273#issuecomment-1445471529 by @rafaucau.
- Follow-up https://github.com/WordPress/gutenberg/pull/28273#issuecomment-1768244883 from me.

`wp-scripts start --hot` works perfectly fine with a single entry point that contains all the logic used in the editor. It starts to break if multiple entry points get loaded in the project editor. A perfect example would be a plugin with numerous blocks where each of them loads JavaScript separately. The workaround so far was to bundle all JavaScript code for the editor together. However, it isn’t always the most efficient approach. Besides, it would be great if that worked out of the box, no matter how configured the entry points were.

Screenshot from https://github.com/WordPress/gutenberg/issues/25188#issuecomment-1104103927:

<img width="986" alt="Screenshot 2022-04-20 at 17 58 19" src="https://user-images.githubusercontent.com/699132/164273122-01ab542b-9932-4b7f-b8c2-a3fb8dea34bd.png">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Source: https://github.com/pmmmwh/react-refresh-webpack-plugin/blob/main/docs/TROUBLESHOOTING.md#component-not-updating-with-bundle-splitting-techniques

> Webpack allows various bundle splitting techniques to improve performance and cacheability. However, these techniques often result in a shuffled execution order, which will break fast refresh.
>
> Only one copy of both the HMR runtime and the plugin's runtime should be embedded for one Webpack app
> 
> This concern only applies when you have multiple entry points. You can use Webpack's optimization.runtimeChunk option to enforce this.
> 
> 
> ```js
> module.exports = {
>   optimization: {
>     runtimeChunk: 'single',
>   },
> };
> ```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the development mode when React Fast Refresh is enabled, there is a shared runtime created. This way it acts as en entry point for existing scripts that orchestrates all updates with hot-module replacement for React code.

## Known Issues

It looks like CSS support for hot-module reloading doesn't work anymore in `trunk` and with this branch. I will investigate this separately as it is unrelated to these changes. I found an issue that seems very similar https://github.com/webpack-contrib/mini-css-extract-plugin/issues/1089. My debugging session pointed me in the direction that `mini-css-extract-plugin` is unable to correctly match the url of CSS file in the `link` tags with these coming from hot reload. The reason seems to originate from the fact that the asset version appended to the url confuses the plugin.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a new test plugin with more than one block. You can do it as follows:

1. Run `npx wp-create-block my-plugin --no-wp-scripts `.
2. Refactor the plugin so it contains more than one block. Using `npx wp-create-block my-block --no-plugin` is helpful here.
3. Go to the plugins folder and run the build in the development mode with HMR/React Fast Refresh enabled:
    ```bash
    cd my-plugin
    ../node_modules/.bin/wp-scripts start --hot
    ```
4. Go to the WordPress instance and activate the test plugin.
5. Edit React components and save changes for every block in the plugin. Observe that React components get updated instantly in the browser without the need to refresh the page.