### PR TITLE
Writing flow: fix triple click inside text blocks

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -59,7 +59,7 @@ function extractSelectionEndNode( selection ) {
 	// may trigger multi selection even though the selection does not visually
 	// end in the next block.
 	if ( focusOffset === 0 && isSelectionForward( selection ) ) {
-		return focusNode.previousSibling;
+		return focusNode.previousSibling ?? focusNode.parentElement;
 	}
 
 	return focusNode.childNodes[ focusOffset ];

--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -4,6 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { create } from '@wordpress/rich-text';
+import { isSelectionForward } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -51,6 +52,14 @@ function extractSelectionEndNode( selection ) {
 
 	if ( focusOffset === focusNode.childNodes.length ) {
 		return focusNode;
+	}
+
+	// When the selection is forward (the selection ends with the focus node),
+	// the selection may extend into the next element with an offset of 0. This
+	// may trigger multi selection even though the selection does not visually
+	// end in the next block.
+	if ( focusOffset === 0 && isSelectionForward( selection ) ) {
+		return focusNode.previousSibling;
 	}
 
 	return focusNode.childNodes[ focusOffset ];

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -239,6 +239,22 @@ _Returns_
 
 -   `boolean`: True if rtl, false if ltr.
 
+### isSelectionForward
+
+Returns true if the given selection object is in the forward direction, or false otherwise.
+
+_Related_
+
+-   <https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition>
+
+_Parameters_
+
+-   _selection_ `Selection`: Selection object to check.
+
+_Returns_
+
+-   `boolean`: Whether the selection is forward.
+
 ### isTextContent
 
 _Parameters_

--- a/packages/dom/src/dom/index.js
+++ b/packages/dom/src/dom/index.js
@@ -24,3 +24,4 @@ export { default as isEmpty } from './is-empty';
 export { default as removeInvalidHTML } from './remove-invalid-html';
 export { default as isRTL } from './is-rtl';
 export { default as safeHTML } from './safe-html';
+export { default as isSelectionForward } from './is-selection-forward';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->


Fixes #64451.

Triple click in a paragraph currently selects the next block also. This is a small regression after #63671.

Also fixes #53128, which was a bug that existed long before #63671!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Triple should be contained in the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The problem is that the browser may select into the next element, even though this selection is not visible. 

```html
<p>test</p>
<h2>test</h2>
```

The selection may be:

anchorNode: p
anchorOffset: 0
focusNode: h2
focusOffset: 0

Even though h2 is technically selected, it is not _really_ because the offset is 0.

We can adjust this in the selection extraction: just return the previous element if the offset is 0 and the direction is forward.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Particularly in Chrome:

Have a paragraph and some block like another paragraph or heading following. Triple click in the first block. It should not select multiple blocks (check the inspector).

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
