### PR TITLE
Fix data views style inheritance

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -18,10 +18,18 @@
 }
 
 .dataviews-filters__summary-popover {
+	font-size: $default-font-size;
+	line-height: $default-line-height;
+
 	.components-popover__content {
 		width: 230px;
-		padding: 0;
 		border-radius: $grid-unit-05;
+	}
+
+	&.components-dropdown__content {
+		.components-popover__content {
+			padding: 0;
+		}
 	}
 }
 
@@ -57,6 +65,7 @@
 		position: relative;
 		display: flex;
 		align-items: center;
+		box-sizing: border-box;
 
 		&.has-reset {
 			padding-inline-end: $button-size-small + $grid-unit-05;
@@ -275,6 +284,7 @@
 	font-size: 11px;
 	outline: var(--wp-admin-border-width-focus) solid $white;
 	color: $white;
+	box-sizing: border-box;
 }
 
 .dataviews-search {

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -3,6 +3,8 @@
 	/* stylelint-disable-next-line property-no-unknown -- the linter needs to be updated to accepted the container-type property */
 	container-type: inline-size;
 	padding: $grid-unit-20;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
 }
 .dataviews-view-config__sort-direction .components-toggle-group-control-option-base {
 	text-transform: uppercase;

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -7,6 +7,8 @@
 	container: dataviews-wrapper / inline-size;
 	display: flex;
 	flex-direction: column;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
 }
 
 .dataviews__view-actions,


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/64925, https://github.com/WordPress/gutenberg/issues/64927.

In the site editor a number of styles applied to data views are inherited from wp-admin stylesheets. When the data view component is consumed in different environments those styles are not present leading to inconsistent appearance. This can be observed by comparing the Data View component [in Storybook](http://localhost:50240/?path=/docs/dataviews-dataviews--docs) with the Site editor.

This PR adds the necessary local styles to close the gap between the site editor and Storybook.

## Before

<img width="649" alt="Screenshot 2024-08-30 at 15 46 21" src="https://github.com/user-attachments/assets/5f751fd3-acd7-4a4c-9be7-a179ff4fd2c7">
<img width="388" alt="Screenshot 2024-08-30 at 15 46 30" src="https://github.com/user-attachments/assets/338e65bb-ff42-47fe-8cdb-5b923c79ff46">

* Font size of several elements is too large
* Filter chips are too large
* Filter count is elongated
* Filter configuration popover has incorrect padding

## After
<img width="441" alt="Screenshot 2024-08-30 at 15 55 33" src="https://github.com/user-attachments/assets/fb80a09a-541d-47af-9240-ef7e2a8bf50f">
<img width="338" alt="Screenshot 2024-08-30 at 15 55 44" src="https://github.com/user-attachments/assets/ee4956de-8df6-4e30-a949-7713ab226c2f">

## Testing Instructions
* Open the Site Editor in one tab and navigate to a data view,
* `npm run storybook:dev` and navigate to the data view component (http://localhost:50240/?path=/docs/dataviews-dataviews--docs),
* Ensure alignment between Storybook and the site editor;
  * Font sizes should match,
  * Filter chips should match,
  * Filter count should match,
  * Filter configuration popover should match.

