### PR TITLE
Writing flow: fix select all with full formatting

### DIFF
--- a/packages/dom/src/dom/is-entirely-selected.js
+++ b/packages/dom/src/dom/is-entirely-selected.js
@@ -93,6 +93,18 @@ function isDeepChild( query, container, propName ) {
 			return true;
 		}
 		candidate = candidate[ propName ];
+		// There may be empty text nodes between the first/last child, so ignore
+		// them.
+		while (
+			candidate &&
+			candidate.nodeType === candidate.TEXT_NODE &&
+			candidate.nodeValue === ''
+		) {
+			candidate =
+				candidate[
+					propName === 'lastChild' ? 'previousSibling' : 'nextSibling'
+				];
+		}
 	} while ( candidate );
 	return false;
 }

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -1372,6 +1372,31 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
 			.toEqual( [ 1, 2 ] );
 	} );
+
+	test( 'should select all with formatting', async ( {
+		pageUtils,
+		editor,
+		multiBlockSelectionUtils,
+	} ) => {
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '<strong>a</strong>' },
+		} );
+		await editor.insertBlock( {
+			name: 'core/paragraph',
+			attributes: { content: '<strong>b</strong>' },
+		} );
+
+		await pageUtils.pressKeys( 'primary+a' );
+		await pageUtils.pressKeys( 'primary+a' );
+
+		await expect
+			.poll( multiBlockSelectionUtils.getSelectedBlocks )
+			.toMatchObject( [
+				{ name: 'core/paragraph' },
+				{ name: 'core/paragraph' },
+			] );
+	} );
 } );
 
 class MultiBlockSelectionUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Cmd+A to select all blocks is broken when a whole paragraph is bold or formatted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #63262.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Make sure the algorithm takes into account empty text nodes when deep checking if an element is the first/last child.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See e2e test. Create a paragraph with text, bold everything. Then cmd+a twice, it will select all blocks. It won't in trunk.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
