### PR TITLE
Create greater visual distinction between filter chips and adjacent buttons

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -48,11 +48,11 @@
 
 	.dataviews-filters__summary-chip {
 		border-radius: $grid-unit-20;
-		border: $border-width solid transparent;
 		cursor: pointer;
 		padding: $grid-unit-05 $grid-unit-15;
 		min-height: $grid-unit-40;
 		background: $gray-100;
+		border: 1px solid $gray-200;
 		color: $gray-800;
 		position: relative;
 		display: flex;
@@ -72,6 +72,7 @@
 		&.has-values {
 			color: var(--wp-admin-theme-color);
 			background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
+			border: 1px solid rgba(var(--wp-admin-theme-color--rgb), 0.12);
 
 			&:hover,
 			&[aria-expanded="true"] {


### PR DESCRIPTION
## What?
Adds a border to filter chips.

## Why?
There is arguably too much visual overlap between filter chips and their adjacent ('Add filter', 'Reset') buttons, particularly when hovered.

### Before

<img width="301" alt="Screenshot 2024-08-30 at 16 14 17" src="https://github.com/user-attachments/assets/5fbec031-65e7-4143-aa36-f52831ec7bb1">


### After

This PR attempts to create distinction by applying a subtle border to the chips. This gives them greater prominence compared with the buttons which feels appropriate in this context.


<img width="588" alt="Screenshot 2024-08-30 at 16 21 49" src="https://github.com/user-attachments/assets/a16d978d-c853-4bc1-b53b-be060604d2b5">


What do y'all think?

## Testing Instructions
1. Open a data view in the site editor
2. Add filters
3. Observe updated chip appearance

