### PR TITLE
Try: hide rich text toolbar if no selection

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -22,8 +22,13 @@ export default function BlockToolbarPopover( {
 	isTyping,
 	__unstableContentRef,
 } ) {
-	const { capturingClientId, isInsertionPointVisible, lastClientId } =
-		useSelectedBlockToolProps( clientId );
+	const {
+		capturingClientId,
+		isInsertionPointVisible,
+		lastClientId,
+		isContentOnlyRichTextBlock,
+		hasTextSelection,
+	} = useSelectedBlockToolProps( clientId );
 
 	// Stores the active toolbar item index so the block toolbar can return focus
 	// to it when re-mounting.
@@ -56,8 +61,12 @@ export default function BlockToolbarPopover( {
 		clientId: clientIdToPositionOver,
 	} );
 
+	const showBlockToolbar =
+		( ! isTyping && ! isContentOnlyRichTextBlock ) ||
+		( isContentOnlyRichTextBlock && hasTextSelection );
+
 	return (
-		! isTyping && (
+		showBlockToolbar && (
 			<BlockPopover
 				clientId={ clientIdToPositionOver }
 				bottomClientId={ lastClientId }

--- a/packages/block-editor/src/components/block-tools/use-selected-block-tool-props.js
+++ b/packages/block-editor/src/components/block-tools/use-selected-block-tool-props.js
@@ -8,6 +8,8 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../../store';
 
+const CONTENT_ONLY_RICH_TEXT_BLOCKS = [ 'core/paragraph', 'core/heading' ];
+
 /**
  * Returns props for the selected block tools and empty block inserter.
  *
@@ -24,7 +26,11 @@ export default function useSelectedBlockToolProps( clientId ) {
 				getBlockInsertionPoint,
 				getBlockOrder,
 				hasMultiSelection,
+				getSelectionStart,
+				getSelectionEnd,
 				getLastMultiSelectedBlockClientId,
+				getBlockEditingMode,
+				getBlockName,
 			} = select( blockEditorStore );
 
 			const blockParentsClientIds = getBlockParents( clientId );
@@ -50,13 +56,24 @@ export default function useSelectedBlockToolProps( clientId ) {
 					order[ insertionPoint.index ] === clientId;
 			}
 
+			const _hasMultiSelection = hasMultiSelection();
+
 			return {
 				capturingClientId,
 				isInsertionPointVisible,
-				lastClientId: hasMultiSelection()
+				lastClientId: _hasMultiSelection
 					? getLastMultiSelectedBlockClientId()
 					: null,
 				rootClientId: getBlockRootClientId( clientId ),
+				isContentOnlyRichTextBlock:
+					getBlockEditingMode( clientId ) === 'contentOnly' &&
+					CONTENT_ONLY_RICH_TEXT_BLOCKS.includes(
+						getBlockName( clientId )
+					),
+				// Maybe rely on documentHasTextSelection instead?
+				hasTextSelection:
+					! _hasMultiSelection &&
+					getSelectionStart().offset !== getSelectionEnd().offset,
 			};
 		},
 		[ clientId ]


### PR DESCRIPTION
Limit the content only toolbar for headings and paragraphs to only show if there is a text selection.

This is a low-fidelity PR not intended to be merged. It's for design purposes to see if this is a direction we want to go as outlined in https://github.com/WordPress/gutenberg/pull/64866#issuecomment-2321369510.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
