### PR TITLE
Rich text: refactor placeholder

### DIFF
--- a/packages/block-editor/src/components/rich-text/content.scss
+++ b/packages/block-editor/src/components/rich-text/content.scss
@@ -1,12 +1,6 @@
 .rich-text {
-	[data-rich-text-placeholder] {
-		pointer-events: none;
-	}
-
-	[data-rich-text-placeholder]::after {
+	&:empty::after {
 		content: attr(data-rich-text-placeholder);
-		// Use opacity to work in various editor styles.
-		// We don't specify the color here, because blocks or editor styles might provide their own.
 		opacity: 0.62;
 	}
 
@@ -28,7 +22,7 @@
 
 // Captions may have lighter (gray) text, or be shown on a range of different background luminosites.
 // To ensure legibility, we increase the default placeholder opacity to ensure contrast.
-figcaption.block-editor-rich-text__editable [data-rich-text-placeholder]::before {
+figcaption.block-editor-rich-text__editable:empty::after {
 	opacity: 0.8;
 }
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -335,7 +335,6 @@ export function RichTextWrapper(
 		selectionStart,
 		selectionEnd,
 		onSelectionChange,
-		placeholder,
 		__unstableIsSelected: isSelected,
 		__unstableDisableFormats: disableFormats,
 		preserveWhiteSpace,
@@ -461,6 +460,9 @@ export function RichTextWrapper(
 						: props.tabIndex
 				}
 				data-wp-block-attribute-key={ identifier }
+				// Ensure placeholder is not empty so the paragraph does not
+				// collapse.
+				data-rich-text-placeholder={ placeholder || '\ufeff' }
 			/>
 		</>
 	);

--- a/packages/block-library/src/button/editor.scss
+++ b/packages/block-library/src/button/editor.scss
@@ -23,7 +23,7 @@
 	}
 
 	// Increase placeholder opacity to meet contrast ratios.
-	&[data-rich-text-placeholder]::after {
+	&:empty::after {
 		opacity: 0.8;
 	}
 }

--- a/packages/block-library/src/paragraph/editor.scss
+++ b/packages/block-library/src/paragraph/editor.scss
@@ -4,17 +4,13 @@
 }
 
 // Hide multiple sequential paragraphs, but don't hide placeholders if a custom placeholder is set.
-.block-editor-block-list__block[data-empty="true"] {
-	[data-rich-text-placeholder] {
-		opacity: 1;
-	}
+.block-editor-block-list__block:empty::after {
+	// opacity: 1;
 }
 
-.block-editor-block-list__block[data-empty="true"] + .block-editor-block-list__block[data-empty="true"] {
-	&:not([data-custom-placeholder="true"]) {
-		[data-rich-text-placeholder] {
-			opacity: 0;
-		}
+.block-editor-block-list__block:empty + .block-editor-block-list__block:empty {
+	&:not([data-custom-placeholder="true"])::after {
+		opacity: 0;
 	}
 }
 

--- a/packages/rich-text/src/component/event-listeners/input-and-selection.js
+++ b/packages/rich-text/src/component/event-listeners/input-and-selection.js
@@ -21,35 +21,6 @@ const INSERTION_INPUT_TYPES_TO_IGNORE = new Set( [
 
 const EMPTY_ACTIVE_FORMATS = [];
 
-const PLACEHOLDER_ATTR_NAME = 'data-rich-text-placeholder';
-
-/**
- * If the selection is set on the placeholder element, collapse the selection to
- * the start (before the placeholder).
- *
- * @param {Window} defaultView
- */
-function fixPlaceholderSelection( defaultView ) {
-	const selection = defaultView.getSelection();
-	const { anchorNode, anchorOffset } = selection;
-
-	if ( anchorNode.nodeType !== anchorNode.ELEMENT_NODE ) {
-		return;
-	}
-
-	const targetNode = anchorNode.childNodes[ anchorOffset ];
-
-	if (
-		! targetNode ||
-		targetNode.nodeType !== targetNode.ELEMENT_NODE ||
-		! targetNode.hasAttribute( PLACEHOLDER_ATTR_NAME )
-	) {
-		return;
-	}
-
-	selection.collapseToStart();
-}
-
 export default ( props ) => ( element ) => {
 	const { ownerDocument } = element;
 	const { defaultView } = ownerDocument;
@@ -141,13 +112,6 @@ export default ( props ) => ( element ) => {
 		}
 
 		if ( start === oldRecord.start && end === oldRecord.end ) {
-			// Sometimes the browser may set the selection on the placeholder
-			// element, in which case the caret is not visible. We need to set
-			// the caret before the placeholder if that's the case.
-			if ( oldRecord.text.length === 0 && start === 0 ) {
-				fixPlaceholderSelection( defaultView );
-			}
-
 			return;
 		}
 
@@ -186,11 +150,6 @@ export default ( props ) => ( element ) => {
 			'selectionchange',
 			handleSelectionChange
 		);
-		// Remove the placeholder. Since the rich text value doesn't update
-		// during composition, the placeholder doesn't get removed. There's no
-		// need to re-add it, when the value is updated on compositionend it
-		// will be re-added when the value is empty.
-		element.querySelector( `[${ PLACEHOLDER_ATTR_NAME }]` )?.remove();
 	}
 
 	function onCompositionEnd() {

--- a/packages/rich-text/src/create.js
+++ b/packages/rich-text/src/create.js
@@ -546,7 +546,7 @@ function createFromElement( { element, range, isEditableTree } ) {
 
 		// Ignore any placeholders, but keep their content since the browser
 		// might insert text inside them when the editable element is flex.
-		if ( ! format || node.getAttribute( 'data-rich-text-placeholder' ) ) {
+		if ( ! format ) {
 			mergePair( accumulator, value );
 		} else if ( value.text.length === 0 ) {
 			if ( format.attributes ) {

--- a/packages/rich-text/src/to-tree.js
+++ b/packages/rich-text/src/to-tree.js
@@ -4,7 +4,7 @@
 
 import { getActiveFormats } from './get-active-formats';
 import { getFormatType } from './get-format-type';
-import { OBJECT_REPLACEMENT_CHARACTER, ZWNBSP } from './special-characters';
+import { OBJECT_REPLACEMENT_CHARACTER } from './special-characters';
 
 function restoreOnAttributes( attributes, isEditableTree ) {
 	if ( isEditableTree ) {
@@ -141,7 +141,6 @@ export function toTree( {
 	onStartIndex,
 	onEndIndex,
 	isEditableTree,
-	placeholder,
 } ) {
 	const { formats, replacements, text, start, end } = value;
 	const formatsLength = formats.length + 1;
@@ -150,19 +149,11 @@ export function toTree( {
 	const deepestActiveFormat = activeFormats[ activeFormats.length - 1 ];
 
 	let lastCharacterFormats;
-	let lastCharacter;
 
 	append( tree, '' );
 
 	for ( let i = 0; i < formatsLength; i++ ) {
 		const character = text.charAt( i );
-		const shouldInsertPadding =
-			isEditableTree &&
-			// Pad the line if the line is empty.
-			( ! lastCharacter ||
-				// Pad the line if the previous character is a line break, otherwise
-				// the line break won't be visible.
-				lastCharacter === '\n' );
 
 		const characterFormats = formats[ i ];
 		let pointer = getLastChild( tree );
@@ -296,24 +287,7 @@ export function toTree( {
 			onEndIndex( tree, pointer );
 		}
 
-		if ( shouldInsertPadding && i === text.length ) {
-			append( getParent( pointer ), ZWNBSP );
-
-			if ( placeholder && text.length === 0 ) {
-				append( getParent( pointer ), {
-					type: 'span',
-					attributes: {
-						'data-rich-text-placeholder': placeholder,
-						// Necessary to prevent the placeholder from catching
-						// selection and being editable.
-						style: 'pointer-events:none;user-select:none;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;',
-					},
-				} );
-			}
-		}
-
 		lastCharacterFormats = characterFormats;
-		lastCharacter = character;
 	}
 
 	return tree;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Use the :empty selector with a fallback.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's simpler. Additionally iOS does not like the current placeholder and fails to autocapitalise sentences. It's not entirely fixed with this, but it's one of the causes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
