### PR TITLE
Always show resolution dropdown option on featured image block

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -73,7 +73,7 @@ const DimensionControls = ( {
 	);
 	const imageSizeOptions = imageSizes
 		.filter( ( { slug } ) => {
-			return media?.media_details?.sizes?.[ slug ]?.source_url;
+			return media?.media_details?.sizes?.[ slug ]?.source_url || true;
 		} )
 		.map( ( { name, slug } ) => ( {
 			value: slug,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- Fixes issue [50271](https://github.com/WordPress/gutenberg/issues/50271)
- Make the "Resolution" dropdown option always available on featured image block because when it is inserted on a Single Post or Page Template, the "Resolution" option is not available.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This will allow user to select specific image resolution to featured image block while designing the Page/Post template using block editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- The "Dimensions" dropdown was available only if the Post being edited had a featured image assigned. So updated the code which allowed it to always show the "Dimensions" dropdown.

## Testing Instructions
1. Edit "Page" or "Post" template.
2. Insert Featured Image block
3. From the Featured Image block options, click 3 dots near "Dimensions" and enable "Resolution" Option as shown in screenshot below.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1785" alt="image" src="https://github.com/user-attachments/assets/e1bddc2f-e402-4809-9c9e-c18b77a2c59c">
