### PR TITLE
Fix site editor broken when fontWeight is not defined or is an integer in theme.json or theme styles

### DIFF
--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -1327,6 +1327,25 @@ describe( 'typography utils', () => {
 					nearestFontWeight: '400',
 				},
 			},
+			{
+				message:
+					'should return nearest fontStyle and fontWeight for normal/400 when fontFamilyFaces contain undefined fontWeight value',
+				fontFamilyFaces: [
+					{
+						fontFamily: 'IBM Plex Mono',
+						fontStyle: 'normal',
+						src: [
+							'file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
+						],
+					},
+				],
+				fontStyle: 'normal',
+				fontWeight: '400',
+				expected: {
+					nearestFontStyle: 'normal',
+					nearestFontWeight: '700',
+				},
+			},
 		].forEach(
 			( {
 				message,

--- a/packages/block-editor/src/components/global-styles/test/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/test/typography-utils.js
@@ -1291,6 +1291,42 @@ describe( 'typography utils', () => {
 					nearestFontWeight: '400',
 				},
 			},
+			{
+				message:
+					'should return nearest fontStyle and fontWeight for normal/400 when fontFamilyFaces contain numerical fontWeight value',
+				fontFamilyFaces: [
+					{
+						fontFamily: 'IBM Plex Mono',
+						fontStyle: 'normal',
+						fontWeight: 400,
+						src: [
+							'file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Regular.woff2',
+						],
+					},
+					{
+						fontFamily: 'IBM Plex Mono',
+						fontStyle: 'italic',
+						fontWeight: '400',
+						src: [
+							'file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Italic.woff2',
+						],
+					},
+					{
+						fontFamily: 'IBM Plex Mono',
+						fontStyle: 'normal',
+						fontWeight: '700',
+						src: [
+							'file:./assets/fonts/ibm-plex-mono/IBMPlexMono-Bold.woff2',
+						],
+					},
+				],
+				fontStyle: 'normal',
+				fontWeight: '400',
+				expected: {
+					nearestFontStyle: 'normal',
+					nearestFontWeight: '400',
+				},
+			},
 		].forEach(
 			( {
 				message,

--- a/packages/block-editor/src/components/global-styles/typography-utils.js
+++ b/packages/block-editor/src/components/global-styles/typography-utils.js
@@ -174,6 +174,10 @@ export function findNearestFontWeight(
 	availableFontWeights,
 	newFontWeightValue
 ) {
+	newFontWeightValue =
+		'number' === typeof newFontWeightValue
+			? newFontWeightValue.toString()
+			: newFontWeightValue;
 	if ( ! newFontWeightValue || typeof newFontWeightValue !== 'string' ) {
 		return '';
 	}
@@ -260,7 +264,7 @@ export function findNearestStyleAndWeight(
 		( { value: fs } ) => fs === fontStyle
 	);
 	const hasFontWeight = fontWeights?.some(
-		( { value: fw } ) => fw === fontWeight
+		( { value: fw } ) => fw?.toString() === fontWeight?.toString()
 	);
 
 	if ( ! hasFontStyle ) {

--- a/packages/block-editor/src/utils/get-font-styles-and-weights.js
+++ b/packages/block-editor/src/utils/get-font-styles-and-weights.js
@@ -79,7 +79,10 @@ export function getFontStylesAndWeights( fontFamilyFaces ) {
 
 	fontFamilyFaces?.forEach( ( face ) => {
 		// Check for variable font by looking for a space in the font weight value. e.g. "100 900"
-		if ( /\s/.test( face.fontWeight.trim() ) ) {
+		if (
+			'string' === typeof face.fontWeight &&
+			/\s/.test( face.fontWeight.trim() )
+		) {
 			isVariableFont = true;
 
 			// Find font weight start and end values.
@@ -105,7 +108,11 @@ export function getFontStylesAndWeights( fontFamilyFaces ) {
 		}
 
 		// Format font style and weight values.
-		const fontWeight = formatFontWeight( face.fontWeight );
+		const fontWeight = formatFontWeight(
+			'number' === typeof face.fontWeight
+				? face.fontWeight.toString()
+				: face.fontWeight
+		);
 		const fontStyle = formatFontStyle( face.fontStyle );
 
 		// Create font style and font weight lists without duplicates.
@@ -118,7 +125,8 @@ export function getFontStylesAndWeights( fontFamilyFaces ) {
 				fontStyles.push( fontStyle );
 			}
 		}
-		if ( fontWeight ) {
+
+		if ( Object.keys( fontWeight ).length ) {
 			if (
 				! fontWeights.some(
 					( weight ) => weight.value === fontWeight.value

--- a/packages/block-editor/src/utils/get-font-styles-and-weights.js
+++ b/packages/block-editor/src/utils/get-font-styles-and-weights.js
@@ -116,7 +116,7 @@ export function getFontStylesAndWeights( fontFamilyFaces ) {
 		const fontStyle = formatFontStyle( face.fontStyle );
 
 		// Create font style and font weight lists without duplicates.
-		if ( fontStyle ) {
+		if ( fontStyle && Object.keys( fontStyle ).length ) {
 			if (
 				! fontStyles.some(
 					( style ) => style.value === fontStyle.value
@@ -126,7 +126,7 @@ export function getFontStylesAndWeights( fontFamilyFaces ) {
 			}
 		}
 
-		if ( Object.keys( fontWeight ).length ) {
+		if ( fontWeight && Object.keys( fontWeight ).length ) {
 			if (
 				! fontWeights.some(
 					( weight ) => weight.value === fontWeight.value

--- a/packages/block-editor/src/utils/test/get-font-styles-and-weights.js
+++ b/packages/block-editor/src/utils/test/get-font-styles-and-weights.js
@@ -346,6 +346,17 @@ describe( 'getFontStylesAndWeights', () => {
 			{
 				fontFamily: 'Piazzolla',
 				fontStyle: 'normal',
+				fontWeight: 600,
+				src: 'http://www.wordpress.org/wp-content/uploads/fonts/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JxwXL31AHfAAy5.woff2',
+			},
+			{
+				fontFamily: 'Piazzolla',
+				fontStyle: 'normal',
+				src: 'http://www.wordpress.org/wp-content/uploads/fonts/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JxwXL31AHfAAy5.woff2',
+			},
+			{
+				fontFamily: 'Piazzolla',
+				fontStyle: 'normal',
 				fontWeight: '900',
 				src: 'http://www.wordpress.org/wp-content/uploads/fonts/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7JxwXL31AHfAAy5.woff2',
 			},
@@ -379,6 +390,10 @@ describe( 'getFontStylesAndWeights', () => {
 					value: '400',
 				},
 				{
+					name: 'Semi Bold',
+					value: '600',
+				},
+				{
 					name: 'Black',
 					value: '900',
 				},
@@ -394,6 +409,14 @@ describe( 'getFontStylesAndWeights', () => {
 					style: {
 						fontStyle: 'normal',
 						fontWeight: '400',
+					},
+				},
+				{
+					key: 'normal-600',
+					name: 'Semi Bold',
+					style: {
+						fontStyle: 'normal',
+						fontWeight: '600',
 					},
 				},
 				{
@@ -418,6 +441,14 @@ describe( 'getFontStylesAndWeights', () => {
 					style: {
 						fontStyle: 'italic',
 						fontWeight: '400',
+					},
+				},
+				{
+					key: 'italic-600',
+					name: 'Semi Bold Italic',
+					style: {
+						fontStyle: 'italic',
+						fontWeight: '600',
 					},
 				},
 				{
@@ -449,6 +480,123 @@ describe( 'getFontStylesAndWeights', () => {
 				fontStyle: 'normal',
 				fontWeight: '400',
 				src: 'http://www.wordpress.org/wp-content/uploads/fonts/N0b52SlTPu5rIkWIZjVKKtYtfxYqZ4RJBFzFfYUjkSDdlqZgy7LYxnL31AHfAAy5.woff2',
+			},
+		];
+		expect( getFontStylesAndWeights( fontFamilyFaces ) ).toEqual( {
+			fontStyles: [
+				{
+					name: 'Regular',
+					value: 'normal',
+				},
+				{
+					name: 'Italic',
+					value: 'italic',
+				},
+			],
+			fontWeights: [
+				{
+					name: 'Regular',
+					value: '400',
+				},
+				{
+					name: 'Bold',
+					value: '700',
+				},
+			],
+			combinedStyleAndWeightOptions: [
+				{
+					key: 'normal-400',
+					name: 'Regular',
+					style: {
+						fontStyle: 'normal',
+						fontWeight: '400',
+					},
+				},
+				{
+					key: 'normal-700',
+					name: 'Bold',
+					style: {
+						fontStyle: 'normal',
+						fontWeight: '700',
+					},
+				},
+				{
+					key: 'italic-400',
+					name: 'Regular Italic',
+					style: {
+						fontStyle: 'italic',
+						fontWeight: '400',
+					},
+				},
+				{
+					key: 'italic-700',
+					name: 'Bold Italic',
+					style: {
+						fontStyle: 'italic',
+						fontWeight: '700',
+					},
+				},
+			],
+			isSystemFont: false,
+			isVariableFont: false,
+		} );
+	} );
+
+	it( 'should return available styles and weights for a font without fontWeight', () => {
+		const fontFamilyFaces = [
+			{
+				fontFamily: 'AR One Sans',
+				fontStyle: 'normal',
+				src: 'http://www.wordpress.org/wp-content/uploads/fonts/AROneSans-VariableFont_ARRRwght.ttf',
+			},
+		];
+		expect( getFontStylesAndWeights( fontFamilyFaces ) ).toEqual( {
+			fontStyles: [
+				{
+					name: 'Regular',
+					value: 'normal',
+				},
+				{
+					name: 'Italic',
+					value: 'italic',
+				},
+			],
+			fontWeights: [
+				{
+					name: 'Bold',
+					value: '700',
+				},
+			],
+			combinedStyleAndWeightOptions: [
+				{
+					key: 'normal-700',
+					name: 'Bold',
+					style: {
+						fontStyle: 'normal',
+						fontWeight: '700',
+					},
+				},
+				{
+					key: 'italic-700',
+					name: 'Bold Italic',
+					style: {
+						fontStyle: 'italic',
+						fontWeight: '700',
+					},
+				},
+			],
+			isSystemFont: false,
+			isVariableFont: false,
+		} );
+	} );
+
+	it( 'should return available styles and weights for a font with numeric fontWeight', () => {
+		const fontFamilyFaces = [
+			{
+				fontFamily: 'AR One Sans',
+				fontStyle: 'normal',
+				fontWeight: 400,
+				src: 'http://www.wordpress.org/wp-content/uploads/fonts/AROneSans-VariableFont_ARRRwght.ttf',
 			},
 		];
 		expect( getFontStylesAndWeights( fontFamilyFaces ) ).toEqual( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/64952

First got report in https://github.com/Automattic/wp-calypso/issues/94033

## What?
<!-- In a few words, what is the PR actually doing? -->

In some themes (for example, Pendant), when users selected a style and then tried changing the font, the site editor crashed.

Upon digging, I found that it began after this https://github.com/WordPress/gutenberg/pull/61915. The PR added a very cool feature. Previously, we showed a fixed set of font weights in the editor, which was not always correct. This PR made it dynamic. But there were three small but tricky issues, all of them caused the site editor to stop working.

**1. trim() error**

If we look at [this line](https://github.com/WordPress/gutenberg/blob/f871c01ddcf27f20448da93737ef1aaf48c720d8/packages/block-editor/src/utils/get-font-styles-and-weights.js#L82), we'll notice that here ( `/\s/.test( face.fontWeight.trim()` ) the trim function will be called on the fontWeight variable even if it's undefined or integer, in which case it will throw an error.

Now, the question is, can fontWeight be undefined or integer? According to the `theme.json` [schema](https://raw.githubusercontent.com/WordPress/gutenberg/trunk/schemas/json/theme.json), we can see that it can be both. Because it's not required, and can be either a string or an integer (may change in later versions I think).

As real example, the Pendant theme doesn't have a `fontWeight` explicitly set [here](https://github.com/Automattic/themes/blob/dd40a6ef4033ad9f1649ea4bb7d2e6147c4346b9/pendant/styles/dark-navy.json#L64-L71).

<img width="602" alt="Screenshot 2024-08-31 at 3 08 33 AM" src="https://github.com/user-attachments/assets/8aaedaa9-7dd3-475f-b657-bc5955ab08df">

**2. Empty weight option**

In [this portion](https://github.com/WordPress/gutenberg/blob/f871c01ddcf27f20448da93737ef1aaf48c720d8/packages/block-editor/src/utils/get-font-styles-and-weights.js#L121-L131) a few lines below, we check if `fontWeight` value is present, and push it in a weight list if it does. But, we get the `fontWeight` value by calling the [formatFontWeight](https://github.com/WordPress/gutenberg/blob/5a87fb03b2f7cdcd56cee8d925349bf4c443a714/packages/block-editor/src/utils/format-font-weight.js#L12-L63) which returns an empty object even when `fontWeight` doesn't exist. So this check always passes. Resulting in listing an empty weight in the option.

**3. Infinite render loop and editor crash when weight is an integer**

This was the most tricky one as there was nothing helpful found in debug console, just broke the render depth after a while and crashed.

In this [line](https://github.com/WordPress/gutenberg/blob/f871c01ddcf27f20448da93737ef1aaf48c720d8/packages/block-editor/src/components/global-styles/typography-panel.js#L271-L274), you'll notice that we're trying to fetch the nearest weight value to set to the editor, by calling the `findNearestFontWeight` function. But if we look inside the function, we'll see that it returns an empty string if the `fontWeight` value of the type `string`. But we've already seen in the screenshot above that it's possible to have an integer as a fontWeight value. Pendant theme has a [few of those as well](https://github.com/Automattic/themes/blob/dd40a6ef4033ad9f1649ea4bb7d2e6147c4346b9/pendant/styles/dark-navy.json#L86-L116). So this function will not work if the fontWeight value is an integer. So it kept trying to get a value, till it caused it to crash.
https://github.com/WordPress/gutenberg/blob/5a87fb03b2f7cdcd56cee8d925349bf4c443a714/packages/block-editor/src/components/global-styles/typography-utils.js#L177-L179

Initially I thought about changing all the values as expected on the Pendant theme. But then decided it won't probably be the right thing to do because there can be other themes like this as well. Also, it follows the `theme.json` schema.

About the `'number' === typeof` approach that I took, instead of calling `toString()` on everything is because I noticed, even though it says fontWeight can only be an integer or a string, this [line](https://github.com/WordPress/gutenberg/blob/5a87fb03b2f7cdcd56cee8d925349bf4c443a714/packages/block-editor/src/utils/format-font-weight.js#L17-L19) indicates that fontWeight can sometimes be an object too (?). So I didn't want to risk breaking any backward compatibility.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To fix the editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Having additional null checks and integer to string conversions.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Any site
2. installed Pendant theme
3. Browse to Site Editor, then Styles. 
4. Select a style
5. Drilled down into Styles to Headings.
6. Select H1.
8. Select any other font
9. Editor shouldn't crash
10. Now try with different other themes as well, to make sure nothing broke.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/5a75bb70-71f3-4cdb-b9c5-ba6596579bdd

**After**

https://github.com/user-attachments/assets/074283f0-dcad-426e-a086-81146ea64bee