### PR TITLE
Block Editor: Remove the Shuffle block toolbar button

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -72,13 +72,11 @@ export function PrivateBlockToolbar( {
 			getBlockParents,
 			getSelectedBlockClientIds,
 			isBlockValid,
-			getBlockRootClientId,
 			getBlockEditingMode,
 			getBlockAttributes,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
-		const blockRootClientId = getBlockRootClientId( selectedBlockClientId );
 		const parents = getBlockParents( selectedBlockClientId );
 		const firstParentClientId = parents[ parents.length - 1 ];
 		const parentBlockName = getBlockName( firstParentClientId );
@@ -103,7 +101,6 @@ export function PrivateBlockToolbar( {
 			isDefaultEditingMode: _isDefaultEditingMode,
 			blockType: selectedBlockClientId && getBlockType( _blockName ),
 			shouldShowVisualToolbar: isValid && isVisual,
-			rootClientId: blockRootClientId,
 			toolbarKey: `${ selectedBlockClientId }${ firstParentClientId }`,
 			showParentSelector:
 				parentBlockType &&

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -34,7 +34,6 @@ import { useShowHoveredOrFocusedGestures } from './utils';
 import { store as blockEditorStore } from '../../store';
 import __unstableBlockNameContext from './block-name-context';
 import NavigableToolbar from '../navigable-toolbar';
-import Shuffle from './shuffle';
 import { useHasBlockToolbar } from './use-has-block-toolbar';
 
 /**
@@ -66,7 +65,6 @@ export function PrivateBlockToolbar( {
 		shouldShowVisualToolbar,
 		showParentSelector,
 		isUsingBindings,
-		canRemove,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -77,7 +75,6 @@ export function PrivateBlockToolbar( {
 			getBlockRootClientId,
 			getBlockEditingMode,
 			getBlockAttributes,
-			canRemoveBlock,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -119,7 +116,6 @@ export function PrivateBlockToolbar( {
 				selectedBlockClientIds.length === 1 &&
 				_isDefaultEditingMode,
 			isUsingBindings: _isUsingBindings,
-			canRemove: canRemoveBlock( selectedBlockClientId ),
 		};
 	}, [] );
 
@@ -202,9 +198,6 @@ export function PrivateBlockToolbar( {
 							</ToolbarGroup>
 						</div>
 					) }
-				{ ! isMultiToolbar && canRemove && (
-					<Shuffle clientId={ blockClientId } />
-				) }
 				{ shouldShowVisualToolbar && isMultiToolbar && (
 					<BlockGroupToolbar />
 				) }


### PR DESCRIPTION
## What?
See #63900.

PR removes the Shuffle block toolbar button from the block editors' default viewing mode.

## Why?
It's a destructive action that shouldn't be this easy to get to.

## Testing Instructions
1. Open a post or page.
2. Insert a pattern from a category - "Call to Action"
3. Confirm that the "Shuffle" button isn't still available in the toolbar.
4. Switch to Zoom out view - "Desktop (50%)".
5. Confirm that the "Shuffle" button is visible.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-08-31 at 09 57 51](https://github.com/user-attachments/assets/079f9cc7-7dc2-4726-ac66-422dbbaad725)
