### PR TITLE
Core Data: Avoid loops in 'registry.batch' calls

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -177,24 +177,32 @@ export const getEntityRecord =
 					response.headers?.get( 'allow' )
 				);
 
+				const canUserResolutionsArgs = [];
+				const receiveUserPermissionArgs = {};
+				for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
+					receiveUserPermissionArgs[
+						getUserPermissionCacheKey( action, {
+							kind,
+							name,
+							id: key,
+						} )
+					] = permissions[ action ];
+
+					canUserResolutionsArgs.push( [
+						action,
+						{ kind, name, id: key },
+					] );
+				}
+
 				registry.batch( () => {
 					dispatch.receiveEntityRecords( kind, name, record, query );
-
-					for ( const action of ALLOWED_RESOURCE_ACTIONS ) {
-						const permissionKey = getUserPermissionCacheKey(
-							action,
-							{ kind, name, id: key }
-						);
-
-						dispatch.receiveUserPermission(
-							permissionKey,
-							permissions[ action ]
-						);
-						dispatch.finishResolution( 'canUser', [
-							action,
-							{ kind, name, id: key },
-						] );
-					}
+					dispatch.receiveUserPermissions(
+						receiveUserPermissionArgs
+					);
+					dispatch.finishResolutions(
+						'canUser',
+						canUserResolutionsArgs
+					);
 				} );
 			}
 		} finally {

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -36,8 +36,8 @@ describe( 'getEntityRecord', () => {
 			receiveEntityRecords: jest.fn(),
 			__unstableAcquireStoreLock: jest.fn(),
 			__unstableReleaseStoreLock: jest.fn(),
-			receiveUserPermission: jest.fn(),
-			finishResolution: jest.fn(),
+			receiveUserPermissions: jest.fn(),
+			finishResolutions: jest.fn(),
 		} );
 		triggerFetch.mockReset();
 	} );


### PR DESCRIPTION
## What?
This is similar to #64894.

PR updates `getEntityRecord` and avoids using loops inside the `registry.batch` call.

## Why?
Using actions that bulk update state should be preferred over the loops.

## Testing Instructions
1. Open a post or page.
2. Run selectors below in order using DevTools Console.
3. Running the `canUser` selector for the same entity shouldn't trigger a REST API request.

```
// 1. Fetch media details.
wp.data.select( 'core' ).getEntityRecord( 'root', 'media', 1342 );

// 2. Fetch user permission related to the media. It shouldn't trigger a REST API request.
wp.data.select( 'core' ).canUser( 'update', { kind: 'root', name: 'media', id: 1342 } );

### Testing Instructions for Keyboard
Same.
