### PR TITLE
Added Global Documentation in several php file

### DIFF
--- a/lib/compat/wordpress-6.6/html-api/class-gutenberg-html-decoder-6-6.php
+++ b/lib/compat/wordpress-6.6/html-api/class-gutenberg-html-decoder-6-6.php
@@ -196,6 +196,8 @@ class Gutenberg_HTML_Decoder_6_6 {
 	 *
 	 * @since 6.6.0
 	 *
+	 * @global WP_Token_Map $html5_named_character_references
+	 *
 	 * @param string $context            `attribute` for decoding attribute values, `data` otherwise.
 	 * @param string $text               Text document containing span of text to decode.
 	 * @param int    $at                 Optional. Byte offset into text where span begins, defaults to the beginning (0).

--- a/lib/compat/wordpress-6.7/html-api/class-gutenberg-html-decoder-6-7.php
+++ b/lib/compat/wordpress-6.7/html-api/class-gutenberg-html-decoder-6-7.php
@@ -196,6 +196,8 @@ class Gutenberg_HTML_Decoder_6_7 {
 	 *
 	 * @since 6.6.0
 	 *
+	 * @global WP_Token_Map $html5_named_character_references
+	 *
 	 * @param string $context            `attribute` for decoding attribute values, `data` otherwise.
 	 * @param string $text               Text document containing span of text to decode.
 	 * @param int    $at                 Optional. Byte offset into text where span begins, defaults to the beginning (0).


### PR DESCRIPTION
Added Global Documentation in below files.

- lib/compat/wordpress-6.6/html-api/class-gutenberg-html-decoder-6-6.php
- lib/compat/wordpress-6.7/html-api/class-gutenberg-html-decoder-6-7.php
