### PR TITLE
Fix: Ensure popover modals in block editor display above metaboxes

### DIFF
--- a/packages/editor/src/components/editor-interface/style.scss
+++ b/packages/editor/src/components/editor-interface/style.scss
@@ -9,4 +9,5 @@
 
 .editor-visual-editor {
 	flex: 1 0 auto;
+	z-index: 9; /* Added z-index to ensure popovers are displayed above other elements such as metaboxes */
 }


### PR DESCRIPTION
Problem:
When metaboxes are attached to the bottom of the screen in the WordPress block editor, popover modals (e.g., link editing popovers) within the `.editor-visual-editor` element are incorrectly rendered beneath these metaboxes. This issue makes the popovers partially or fully obscured, leading to usability problems, particularly when editing links within blocks that are located at the bottom of the screen next to possible subsequent metaboxes.

Solution:
Added a `z-index: 9;` to the `.editor-visual-editor` CSS rule. This change ensures that the `.editor-visual-editor` element and its child popovers are displayed above any metaboxes, preventing them from being obscured and maintaining their usability.

Affected Files:
- Updated the relevant SCSS file(s) to include the `z-index` property.

This commit resolves the issue where popover modals are not fully visible due to being rendered underneath subsequent containers.  https://github.com/WordPress/gutenberg/issues/64957

## Why?
#64957 

