### PR TITLE
Fix: Pagination arrows are pointing in the wrong direction in RTL languages

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/setup-toolbar.js
+++ b/packages/block-editor/src/components/block-pattern-setup/setup-toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import {
 	chevronRight,
@@ -38,7 +38,7 @@ const CarouselNavigation = ( {
 		<Button
 			// TODO: Switch to `true` (40px size) if possible
 			__next40pxDefaultSize={ false }
-			icon={ chevronLeft }
+			icon={ isRTL() ? chevronRight : chevronLeft }
 			label={ __( 'Previous pattern' ) }
 			onClick={ handlePrevious }
 			disabled={ activeSlide === 0 }
@@ -47,7 +47,7 @@ const CarouselNavigation = ( {
 		<Button
 			// TODO: Switch to `true` (40px size) if possible
 			__next40pxDefaultSize={ false }
-			icon={ chevronRight }
+			icon={ isRTL() ? chevronLeft : chevronRight }
 			label={ __( 'Next pattern' ) }
 			onClick={ handleNext }
 			disabled={ activeSlide === totalSlides - 1 }

--- a/packages/block-editor/src/components/grid/grid-item-movers.js
+++ b/packages/block-editor/src/components/grid/grid-item-movers.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import {
 	VisuallyHidden,
 	ToolbarButton,
@@ -57,7 +57,7 @@ export function GridItemMovers( {
 			<ToolbarGroup className="block-editor-grid-item-mover__move-button-container">
 				<div className="block-editor-grid-item-mover__move-horizontal-button-container is-left">
 					<GridItemMover
-						icon={ chevronLeft }
+						icon={ isRTL() ? chevronRight : chevronLeft }
 						label={ __( 'Move left' ) }
 						description={ __( 'Move left' ) }
 						isDisabled={ columnStart <= 1 }
@@ -126,7 +126,7 @@ export function GridItemMovers( {
 				</div>
 				<div className="block-editor-grid-item-mover__move-horizontal-button-container is-right">
 					<GridItemMover
-						icon={ chevronRight }
+						icon={ isRTL() ? chevronLeft : chevronRight }
 						label={ __( 'Move right' ) }
 						description={ __( 'Move right' ) }
 						isDisabled={ columnCount && columnEnd >= columnCount }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -8,7 +8,7 @@ import {
 	VisuallyHidden,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	__experimentalLinkControl as LinkControl,
 	store as blockEditorStore,
@@ -28,7 +28,7 @@ import {
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { chevronLeftSmall, plus } from '@wordpress/icons';
+import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 
 /**
@@ -123,7 +123,7 @@ function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
 
 			<Button
 				className="link-ui-block-inserter__back"
-				icon={ chevronLeftSmall }
+				icon={ isRTL() ? chevronRightSmall : chevronLeftSmall }
 				onClick={ ( e ) => {
 					e.preventDefault();
 					onBack();

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -7,7 +7,7 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { createInterpolateElement, memo, useContext } from '@wordpress/element';
-import { sprintf, __, _x } from '@wordpress/i18n';
+import { sprintf, __, _x, isRTL } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
 
 /**
@@ -103,7 +103,7 @@ function DataViewsPagination() {
 						disabled={ currentPage === 1 }
 						accessibleWhenDisabled
 						label={ __( 'Previous page' ) }
-						icon={ previous }
+						icon={ isRTL() ? next : previous }
 						showTooltip
 						size="compact"
 						tooltipPosition="top"
@@ -115,7 +115,7 @@ function DataViewsPagination() {
 						disabled={ currentPage >= totalPages }
 						accessibleWhenDisabled
 						label={ __( 'Next page' ) }
-						icon={ next }
+						icon={ isRTL() ? previous : next }
 						showTooltip
 						size="compact"
 						tooltipPosition="top"

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-card.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-card.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _n, sprintf } from '@wordpress/i18n';
+import { _n, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	__experimentalUseNavigator as useNavigator,
 	__experimentalText as Text,
@@ -15,7 +15,7 @@ import {
  * Internal dependencies
  */
 import FontDemo from './font-demo';
-import { chevronRight } from '@wordpress/icons';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 
 function FontCard( { font, onClick, variantsText, navigatorPath } ) {
 	const variantsCount = font.fontFace?.length || 1;
@@ -57,7 +57,7 @@ function FontCard( { font, onClick, variantsText, navigatorPath } ) {
 						</Text>
 					</FlexItem>
 					<FlexItem>
-						<Icon icon={ chevronRight } />
+						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 					</FlexItem>
 				</Flex>
 			</Flex>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/font-collection.js
@@ -28,7 +28,7 @@ import {
 	CheckboxControl,
 } from '@wordpress/components';
 import { debounce } from '@wordpress/compose';
-import { sprintf, __, _x } from '@wordpress/i18n';
+import { sprintf, __, _x, isRTL } from '@wordpress/i18n';
 import { moreVertical, chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
@@ -383,7 +383,9 @@ function FontCollection( { slug } ) {
 						<NavigatorScreen path="/fontFamily">
 							<Flex justify="flex-start">
 								<NavigatorBackButton
-									icon={ chevronLeft }
+									icon={
+										isRTL() ? chevronRight : chevronLeft
+									}
 									size="small"
 									onClick={ () => {
 										setSelectedFont( null );
@@ -484,7 +486,7 @@ function FontCollection( { slug } ) {
 								disabled={ page === 1 }
 								showTooltip
 								accessibleWhenDisabled
-								icon={ chevronLeft }
+								icon={ isRTL() ? chevronRight : chevronLeft }
 								tooltipPosition="top"
 							/>
 							<HStack
@@ -535,7 +537,7 @@ function FontCollection( { slug } ) {
 								onClick={ () => setPage( page + 1 ) }
 								disabled={ page === totalPages }
 								accessibleWhenDisabled
-								icon={ chevronRight }
+								icon={ isRTL() ? chevronLeft : chevronRight }
 								tooltipPosition="top"
 							/>
 						</HStack>

--- a/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/installed-fonts.js
@@ -21,8 +21,8 @@ import {
 import { useEntityRecord, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useContext, useEffect, useState } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
-import { chevronLeft } from '@wordpress/icons';
+import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
 /**
@@ -354,7 +354,9 @@ function InstalledFonts() {
 
 							<Flex justify="flex-start">
 								<NavigatorBackButton
-									icon={ chevronLeft }
+									icon={
+										isRTL() ? chevronRight : chevronLeft
+									}
 									size="small"
 									onClick={ () => {
 										handleSetLibraryFontSelected( null );

--- a/packages/edit-site/src/components/pagination/index.js
+++ b/packages/edit-site/src/components/pagination/index.js
@@ -11,7 +11,7 @@ import {
 	__experimentalText as Text,
 	Button,
 } from '@wordpress/components';
-import { __, _x, _n, sprintf } from '@wordpress/i18n';
+import { __, _x, _n, sprintf, isRTL } from '@wordpress/i18n';
 import { previous, chevronLeft, chevronRight, next } from '@wordpress/icons';
 
 export default function Pagination( {
@@ -50,7 +50,7 @@ export default function Pagination( {
 					accessibleWhenDisabled
 					disabled={ disabled || currentPage === 1 }
 					label={ __( 'First page' ) }
-					icon={ previous }
+					icon={ isRTL() ? next : previous }
 					size="compact"
 				/>
 				<Button
@@ -59,7 +59,7 @@ export default function Pagination( {
 					accessibleWhenDisabled
 					disabled={ disabled || currentPage === 1 }
 					label={ __( 'Previous page' ) }
-					icon={ chevronLeft }
+					icon={ isRTL() ? chevronRight : chevronLeft }
 					size="compact"
 				/>
 			</HStack>
@@ -78,7 +78,7 @@ export default function Pagination( {
 					accessibleWhenDisabled
 					disabled={ disabled || currentPage === numPages }
 					label={ __( 'Next page' ) }
-					icon={ chevronRight }
+					icon={ isRTL() ? chevronLeft : chevronRight }
 					size="compact"
 				/>
 				<Button
@@ -87,7 +87,7 @@ export default function Pagination( {
 					accessibleWhenDisabled
 					disabled={ disabled || currentPage === numPages }
 					label={ __( 'Last page' ) }
-					icon={ next }
+					icon={ isRTL() ? previous : next }
 					size="compact"
 				/>
 			</HStack>


### PR DESCRIPTION
Fixes #64929

## What?

This PR fixes the incorrect chevron icon direction in RTL languages.

## Why?

In RTL languages, the horizontal document flow is reversed, so the chevron icon must also be displayed in reverse.

## How?

- Search the whole project for the keyword `chevronLeft` and `chevronRight`. This keyword will find the following icons: `chevronLeft`, `chevronLeftSmall`, `chevronRight`, `chevrontRightSmall`.
- In an RTL language, evaluate whether the direction of the icon is appropriate. If not, use the `isRTL()` function to reverse the direction.

## Testing Instructions

- Enable RTL languages.
- Verify that the chevron icon direction is correct in the following locations.

## Screenshots or screencast <!-- if applicable -->

### Grid Block Mover

- First, enable the Grid interactivity experiment setting.
- Insert a block using the HTML below.

<details><summary>Details</summary>

```html
<!-- wp:group {"layout":{"type":"grid","columnCount":3,"rowCount":3,"isManualPlacement":true,"minimumColumnWidth":null}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":1}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 1</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":2,"rowStart":1}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 2</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":3,"rowStart":1}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 3</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":2}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 4</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":2,"rowStart":2}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 5</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":3,"rowStart":2}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 6</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":3}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 7</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":1,"rowStart":3}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 7</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":2,"rowStart":3,"columnSpan":1}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 8</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"layout":{"columnStart":3,"rowStart":3,"columnSpan":1}},"backgroundColor":"accent-4"} -->
<p class="has-accent-4-background-color has-background">Paragraph 9</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```

</details> 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/b8943d93-9394-45c0-8fa7-d46aae80dcda)| ![image](https://github.com/user-attachments/assets/01a1c078-4389-4339-a19b-d45148124e6d)| 

### Navigation Block

- Access the Site Editor > select any template
- Select a Navigation block
- Click the quick inserter
- Click the Add Block button
- Check the back button icon direction

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2e87709c-42ac-4428-9c6d-fe13fa6eaba9)| ![image](https://github.com/user-attachments/assets/2168ce70-65c3-45b0-9a52-4d499df1fe1c)| 

### DataViews Pagination

- Check the direction of the previous button and next button icons

Note: You can also see that the text "PAGE 1 OF N" is not displayed correctly in RTL languages, but I'm not sure if this is an implementation issue or if it's not yet translated.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/221524ae-80ef-40a7-a5d5-b070d48f5a0d)| ![image](https://github.com/user-attachments/assets/c3a7c490-518e-433e-bce0-ea529663f533)| 

### Font Library Modal

- Access the Site Editor > Select any template
- Access the global styles > typography > Manage Fonts button
- Install Fonts Tab:
  - Check the direction of the icon displayed to the left of the font item
  - Click on any font
  - Check the back button icon direction
- Library Tab:
  - Check the direction of the icon displayed to the left of the font item
  - Click on any font
  - Check the back button icon direction

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7ced3b1e-dcf4-41b1-b4f9-555d32dd78d5)| ![image](https://github.com/user-attachments/assets/1ca14551-31b0-4848-a646-c2bf610f5a7c)|
| ![image](https://github.com/user-attachments/assets/95113404-133c-4a29-a395-d43e1e36387d)| ![image](https://github.com/user-attachments/assets/04201900-96b7-486b-b57b-4552979d1e0a)| 
| ![image](https://github.com/user-attachments/assets/4b0cd7df-47aa-4c84-a923-d45cf9a648ff)| ![image](https://github.com/user-attachments/assets/ac883316-f8b3-42fe-8042-d68307db9004) |
| ![image](https://github.com/user-attachments/assets/abafadeb-4e05-4126-97a0-46063d4522c7)| ![image](https://github.com/user-attachments/assets/362660ee-56cb-4ae2-8d25-ea2ebfe0153f)| 

### Edit Site Pagination Component (Revisions Pagination)

- Access the Site Editor > Select any template
- Continue modifying and saving the template to create sufficient revisions
- Access the global styles > revisions
- Check the direction of the Last page, Next page, Previous page, and First page button icons
 
Note: You can also see that the text "1 OF N" is not displayed correctly in RTL languages, but I'm not sure if this is an implementation issue or if it's not yet translated.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/77c6bea1-bf28-41e2-a247-ca6a094091d0)| ![image](https://github.com/user-attachments/assets/85b7e6a8-a7f9-400c-afac-f322766b2bb5) | 