### PR TITLE
Tabs: Fix indicator misalignment when the browser width changes in RTL languages

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -60,6 +60,7 @@
 ### Bug Fixes
 
 -   `TimePicker`: use ToggleGroupControl for AM/PM toggle ([#64800](https://github.com/WordPress/gutenberg/pull/64800)).
+-   `Tabs`: Fix indicator misalignment when the browser width changes in RTL languages ([#64965](https://github.com/WordPress/gutenberg/pull/64965)).
 
 ### Internal
 

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -24,7 +24,7 @@ export const TabListWrapper = styled.div`
 
 	@media not ( prefers-reduced-motion: reduce ) {
 		&.is-animation-enabled::after {
-			transition-property: left, top, width, height;
+			transition-property: inset-inline-start, top, width, height;
 			transition-duration: 0.2s;
 			transition-timing-function: ease-out;
 		}
@@ -40,7 +40,7 @@ export const TabListWrapper = styled.div`
 	}
 	&:not( [aria-orientation='vertical'] )::after {
 		bottom: 0;
-		left: var( --indicator-left );
+		inset-inline-start: var( --indicator-inset-inline-start );
 		width: var( --indicator-width );
 		height: 0;
 		border-bottom: var( --wp-admin-border-width-focus ) solid

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -9,6 +9,7 @@ import { useStoreState } from '@ariakit/react';
  */
 import warning from '@wordpress/warning';
 import { forwardRef, useState } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -78,7 +79,9 @@ export const TabList = forwardRef<
 			onBlur={ onBlur }
 			{ ...otherProps }
 			style={ {
-				'--indicator-left': `${ indicatorPosition.left }px`,
+				'--indicator-inset-inline-start': `${
+					isRTL() ? indicatorPosition.right : indicatorPosition.left
+				}px`,
 				'--indicator-top': `${ indicatorPosition.top }px`,
 				'--indicator-width': `${ indicatorPosition.width }px`,
 				'--indicator-height': `${ indicatorPosition.height }px`,


### PR DESCRIPTION
Part of #64963

## What?

This PR fixes the tab indicator misalignment when the browser width changes in RTL languages.

## Why?

The horizontal position of the indicator is determined by the CSS `left`. However, in RTL languages, the tab buttons are located on the right side.

When we change the browser width, the left offset position of the button relative to the parent element will change, but the indicator position is fixed by the CSS `left`, so there is a misalignment between the button and the indicator.

## How?

I think in RTL languages ​​we should determine the offset position via `right` instead of `left`.

First, to calculate the right offset position, I used the following logic:

- Get the parent element's width, including decimal points.
- Subtract the button element's width from its parent element. Round this value and convert it to an integer pixel value.
- Subtract the element's `offsetLeft` from this value. This is the basic right value for the indicator.
- Similar to the approach taken in [#61979](https://github.com/WordPress/gutenberg/pull/61979), subtract `1` to prevent unintended overflow. If the right value is negative, convert it to `0`.

Next, apply the calculated value as CSS.

We can also use the CSS `right` instead of `left` in RTL languages. However, in this PR, I replaced the CSS `left` with [inset-inline-start](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start). Unlike the CSS `left`, this CSS applies a physical offset according to the document direction. This CSS is also supported by all browsers.

## Testing Instructions

### Storybook

- Start the storybook
- Access http://localhost:50240/?path=/story/components-experimental-tabs--default
- Change to an RTL language
- Make sure the indicator stays aligned with the tab buttons when the browser is resized

### Before

https://github.com/user-attachments/assets/a1b7a776-5e1b-4b58-94df-463e70717a37


### After

https://github.com/user-attachments/assets/803e41b9-4350-4632-935e-c15f7ff19f00

### Site Editor

The easiest way to confirm is to look at the Font Library modal.

- Access the Site Editor > Global Styles > Typography > Manage Fonts button
- Make sure the indicator stays aligned with the tab buttons when the browser is resized

### Before

https://github.com/user-attachments/assets/a071bf90-b076-41ad-95ae-7b7de3177521

### After

https://github.com/user-attachments/assets/98c2dc7d-d768-4965-91ef-f5b21d1724bb


