### PR TITLE
DataViews: Fix pattern title direction in RTL languages

### DIFF
--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -126,7 +126,7 @@ function TitleField( { item } ) {
 			<Flex
 				as="div"
 				gap={ 0 }
-				justify="left"
+				justify="flex-start"
 				className="edit-site-patterns__pattern-title"
 			>
 				{ item.type === PATTERN_TYPES.theme ? (


### PR DESCRIPTION
## What?

This PR adjusts the direction of patterns data view titles in the table layout in RTL languages.

## Why?

The `justify-content: left` physically positions flex items to the left regardless of the logical direction of the flex container. I think we should use `flex-start` here and take the logical direction of the flex container into account.

## Testing Instructions

- Switch to some RTL language.
- Go to `http://localhost:8888/wp-admin/site-editor.php?postType=wp_block` and switch to the table layout.
- Check the title alignment.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5664d412-07b6-4d85-b71c-9ab40ba791d6) | ![image](https://github.com/user-attachments/assets/24305eca-1ed4-46a6-8b23-dfafc175cfc9)| 
