### PR TITLE
ColorPalette utils: do not normalize undefined color values

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -60,6 +60,7 @@
 ### Bug Fixes
 
 -   `TimePicker`: use ToggleGroupControl for AM/PM toggle ([#64800](https://github.com/WordPress/gutenberg/pull/64800)).
+-   `ColorPalette` utils: do not normalize undefined color values ([#64969](https://github.com/WordPress/gutenberg/pull/64969)).
 
 ### Internal
 

--- a/packages/components/src/color-palette/test/utils.ts
+++ b/packages/components/src/color-palette/test/utils.ts
@@ -26,29 +26,20 @@ describe( 'ColorPalette: Utils', () => {
 	} );
 
 	describe( 'normalizeColorValue', () => {
-		test( 'should return the value as is if the color value is not a CSS variable', () => {
+		test( 'should return the value if the value argument is not a CSS variable', () => {
 			const element = document.createElement( 'div' );
 			expect( normalizeColorValue( '#ff0000', element ) ).toBe(
 				'#ff0000'
 			);
 		} );
-		test( 'should return the background color computed from a element if the color value is a CSS variable', () => {
+		test( 'should return the background color computed from an element if the value argument is a CSS variable', () => {
 			const element = document.createElement( 'div' );
 			element.style.backgroundColor = '#ff0000';
 			expect( normalizeColorValue( 'var(--red)', element ) ).toBe(
 				'#ff0000'
 			);
 		} );
-		test( 'should return the value as is if the color value undefined', () => {
-			const element = document.createElement( 'div' );
-			expect( normalizeColorValue( undefined, element ) ).toBe(
-				undefined
-			);
-		} );
-		test( 'should return the value as is if the element is null', () => {
-			expect( normalizeColorValue( '#ff0000', null ) ).toBe( '#ff0000' );
-		} );
-		test( 'should return the value as is if the value is a color mix', () => {
+		test( 'should return the background color computed from an element if the value argument is a color mix', () => {
 			const element = document.createElement( 'div' );
 			element.style.backgroundColor = '#ff0000';
 			expect(
@@ -57,6 +48,15 @@ describe( 'ColorPalette: Utils', () => {
 					element
 				)
 			).toBe( '#ff0000' );
+		} );
+		test( 'should return the value if the value argument is undefined', () => {
+			const element = document.createElement( 'div' );
+			expect( normalizeColorValue( undefined, element ) ).toBe(
+				undefined
+			);
+		} );
+		test( 'should return the value if the element argument is null', () => {
+			expect( normalizeColorValue( '#ff0000', null ) ).toBe( '#ff0000' );
 		} );
 	} );
 } );

--- a/packages/components/src/color-palette/test/utils.ts
+++ b/packages/components/src/color-palette/test/utils.ts
@@ -39,5 +39,24 @@ describe( 'ColorPalette: Utils', () => {
 				'#ff0000'
 			);
 		} );
+		test( 'should return the value as is if the color value undefined', () => {
+			const element = document.createElement( 'div' );
+			expect( normalizeColorValue( undefined, element ) ).toBe(
+				undefined
+			);
+		} );
+		test( 'should return the value as is if the element is null', () => {
+			expect( normalizeColorValue( '#ff0000', null ) ).toBe( '#ff0000' );
+		} );
+		test( 'should return the value as is if the value is a color mix', () => {
+			const element = document.createElement( 'div' );
+			element.style.backgroundColor = '#ff0000';
+			expect(
+				normalizeColorValue(
+					'color-mix(in oklab, #a71e14, white)',
+					element
+				)
+			).toBe( '#ff0000' );
+		} );
 	} );
 } );

--- a/packages/components/src/color-palette/utils.ts
+++ b/packages/components/src/color-palette/utils.ts
@@ -92,9 +92,13 @@ export const normalizeColorValue = (
 	value: string | undefined,
 	element: HTMLElement | null
 ) => {
+	if ( ! value || ! element ) {
+		return value;
+	}
+
 	const valueIsSimpleColor = value ? isSimpleCSSColor( value ) : false;
 
-	if ( valueIsSimpleColor || element === null ) {
+	if ( valueIsSimpleColor ) {
 		return value;
 	}
 

--- a/packages/components/src/color-palette/utils.ts
+++ b/packages/components/src/color-palette/utils.ts
@@ -92,13 +92,7 @@ export const normalizeColorValue = (
 	value: string | undefined,
 	element: HTMLElement | null
 ) => {
-	if ( ! value || ! element ) {
-		return value;
-	}
-
-	const valueIsSimpleColor = value ? isSimpleCSSColor( value ) : false;
-
-	if ( valueIsSimpleColor ) {
+	if ( ! value || ! element || isSimpleCSSColor( value ) ) {
 		return value;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes a regression introduced by https://github.com/WordPress/gutenberg/pull/64224

`normalizeColorValue()` was  treating empty style values as non-simple values and therefore returning `defaultView?.getComputedStyle`

Adds tests

## Why?

Empty values were being filled by an element's computed background color, which could be the site background color.

This is confusing and means that, by default, it's impossible to select a new color without adjusting the alpha value.

## How?

Detecting false values and returning the value immediately.

## Testing Instructions
1. Open the editor and insert a group block
2. Open the color picker for background or any other color style
3. Ensure that you can see your custom color preview immediately in the canvas
4. Check the test description of https://github.com/WordPress/gutenberg/pull/64224 and ensure that works


### Before

The default alpha value is `0`, which means, by default, any custom color cannot be seen in the canvas.

https://github.com/user-attachments/assets/fb482ad7-f900-41f4-ac28-9b36915f81f7


### After

The alpha is `100` so, by default, my custom color changes are visible on the canvas.


https://github.com/user-attachments/assets/3f4e9b8e-a65e-4536-a34d-664423d9abbd



### Semi-related

- https://github.com/WordPress/gutenberg/issues/64638