### PR TITLE
Fix: Buttons block: block spacing value does not apply to both vertical and horizontal alignment

### DIFF
--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -21,7 +21,7 @@
 			}
 		},
 		"spacing": {
-			"blockGap": true,
+			"blockGap": [ "horizontal", "vertical" ],
 			"padding": true,
 			"margin": [ "top", "bottom" ],
 			"__experimentalDefaultControls": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - https://github.com/WordPress/gutenberg/issues/64948

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- PR solves - https://github.com/WordPress/gutenberg/issues/64948

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR adds the supports for `horizontal` and `vertical` block gap options.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Checkout this branch.
2. Open any page/post.
3. Add the buttons block.
4. Check for the spacing option, you can see option to set horizontal and vertical spacing.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/9abd077b-ebc2-47d0-9791-62f37b9a4526

