### PR TITLE
DataViews: adds two new stories for edge cases

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/index.story.js
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.js
@@ -49,6 +49,30 @@ export const Empty = ( props ) => {
 	);
 };
 
+export const FieldsNoSortableNoHidable = ( props ) => {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+
+	const _fields = fields.map( ( field ) => ( {
+		...field,
+		enableSorting: false,
+		enableHiding: false,
+	} ) );
+
+	return (
+		<DataViews
+			{ ...props }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			view={ view }
+			fields={ _fields }
+			onChangeView={ setView }
+		/>
+	);
+};
+
 Default.args = {
 	actions,
 	defaultLayouts: {

--- a/packages/dataviews/src/components/dataviews/stories/index.story.js
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.js
@@ -33,6 +33,22 @@ export const Default = ( props ) => {
 		/>
 	);
 };
+
+export const Empty = ( props ) => {
+	const [ view, setView ] = useState( DEFAULT_VIEW );
+
+	return (
+		<DataViews
+			{ ...props }
+			paginationInfo={ { totalItems: 0, totalPages: 0 } }
+			data={ [] }
+			view={ view }
+			fields={ fields }
+			onChangeView={ setView }
+		/>
+	);
+};
+
 Default.args = {
 	actions,
 	defaultLayouts: {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What?

Adds two new stories to visualize edge cases: no data, and all fields being no sortable and no hidable.

## Why?

We need to design for all states, but our testing data does not always covers them.

## Testing Instructions

`npm install && npm run storybook:dev` and verify there's two new stories: "Empty" and "Fields No Sortable No Hidable".
