### PR TITLE
Test Core Backport Changlog GitHub Action

### DIFF
--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -15,6 +15,8 @@
  */
 class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Controller {
 
+	protected $test;
+
 	/**
 	 * Post type.
 	 *


### PR DESCRIPTION
⚠️ DO NOT MERGE

It looks like the "Verify Core Backport Changlog" GitHub Action is [not working](https://github.com/WordPress/gutenberg/actions/workflows/check-backport-changelog.yml). Even if the PR includes changes to the PHP file, it outputs the following error, and the new comment is not added.

This PR explores the cause of the problem.