### PR TITLE
If you set a global link font size in the FSE editor and styles you can't overwrite it with blocks

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -46,6 +46,7 @@ $navigation-icon-size: 24px;
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
 		display: block;
+		font-size: inherit;
 	}
 
 	// This rule needs extra specificity so that it inherits the correct color from its parent.

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -91,7 +91,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 			}
 
 			foreach ( $attr as $name => $value ) {
-				if ( $name !== 'style' ) {
+				if ( 'style' !== $name ) {
 					$tag_html->set_attribute( $name, $value );
 				} else {
 					$existing_styles = $tag_html->get_attribute( 'style' );

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -89,6 +89,17 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 			foreach ( $processor->get_attribute_names_with_prefix( '' ) as $name ) {
 				$tag_html->set_attribute( $name, $processor->get_attribute( $name ) );
 			}
+
+			foreach ( $attr as $name => $value ) {
+				if ( $name !== 'style' ) {
+					$tag_html->set_attribute( $name, $value );
+				} else {
+					$existing_styles = $tag_html->get_attribute( 'style' );
+					$new_styles      = empty( $existing_styles ) ? $value : $existing_styles . ';' . $value;
+					$tag_html->set_attribute( 'style', $new_styles );
+				}
+			}
+
 			$featured_image = $tag_html->get_updated_html();
 		}
 	}


### PR DESCRIPTION
## What?
- Fixes overriding issue of font size of navigation links.

## Why?
- To apply font sizes correctly.

## How?
- Modified code so that the font size is inherited.