### PR TITLE
If you set a global link font size in the FSE editor and styles you can't overwrite it with blocks 

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -46,6 +46,7 @@ $navigation-icon-size: 24px;
 	// but still allow them to be overridden by user-set colors.
 	.wp-block-navigation-item__content {
 		display: block;
+		font-size: inherit;
 	}
 
 	// This rule needs extra specificity so that it inherits the correct color from its parent.


### PR DESCRIPTION
## What?
- Fixes: https://github.com/WordPress/gutenberg/issues/64976

## Why?
- To apply correct font size.

## How?
- Inheriting font size.