### PR TITLE
Block Patterns List: do not use Composite store

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -27,11 +27,9 @@ import InserterDraggableBlocks from '../inserter-draggable-blocks';
 import BlockPatternsPaging from '../block-patterns-paging';
 import { INSERTER_PATTERN_TYPES } from '../inserter/block-patterns-tab/utils';
 
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
+const { CompositeV2: Composite, CompositeItemV2: CompositeItem } = unlock(
+	componentsPrivateApis
+);
 
 const WithToolTip = ( { showTooltip, title, children } ) => {
 	if ( showTooltip ) {
@@ -206,19 +204,23 @@ function BlockPatternsList(
 	},
 	ref
 ) {
-	const compositeStore = useCompositeStore( { orientation } );
-	const { setActiveId } = compositeStore;
+	const [ activeCompositeId, setActiveCompositeId ] = useState( undefined );
 
 	useEffect( () => {
-		// We reset the active composite item whenever the
-		// available patterns change, to make sure that
-		// focus is put back to the start.
-		setActiveId( undefined );
-	}, [ setActiveId, shownPatterns, blockPatterns ] );
+		// Reset the active composite item whenever the available patterns change,
+		// to make sure that Composite widget can receive focus correctly when its
+		// composite items change. The first composite item will receive focus.
+		const firstCompositeItemId = blockPatterns.find( ( pattern ) =>
+			shownPatterns.includes( pattern )
+		)?.name;
+		setActiveCompositeId( firstCompositeItemId );
+	}, [ shownPatterns, blockPatterns ] );
 
 	return (
 		<Composite
-			store={ compositeStore }
+			orientation={ orientation }
+			activeId={ activeCompositeId }
+			setActiveId={ setActiveCompositeId }
 			role="listbox"
 			className="block-editor-block-patterns-list"
 			aria-label={ label }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Refactor the block patterns list widget so that it doesn't use the `store` from `useCompositeStore` to function.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By controlling the `activeId` state via props.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**There shouldn't be any noticeably different behaviors — make sure that the following happens both in `trunk` and in this PR:**

- Open the post editor
- Open the block inserter sidebar, and select the "Patterns" tab
- Click on the "Explore all patterns" button, the pattern inserter modal should open
- Tab through the list of pattern categories, until the focus moves to the pattern list.
- Make sure that the first pattern is highlighted
- Make sure that using arrow keys moves the selection to a different patterns
- Press shift+tab to move focus back to the category list
- Press tab to move focus back to the pattern composite widget
  - [ ] **make sure that focus is restored on the pattern that was last selected in the previous interaction**
- Select a new category from the list, notice how the matching patterns change
  - [ ] **Using the tab key, move focus until it's back on the patterns composite widget. Make sure that the first pattern gets focus (ie. becomes the active composite item)**
- Type in the search input field in the top-left corner of the modal, notice how the matching patterns change
  - [ ] **Using the tab key, move focus until it's back on the patterns composite widget. Make sure that the first pattern gets focus (ie. becomes the active composite item)**

## Screenshots


https://github.com/user-attachments/assets/efc8125f-b050-4ed6-98ea-03d26d32a748

