### PR TITLE
Dataviews Filter search widget: do not use Composite store

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 ### Internal
 
+-   `DropdownMenu` v2: expose CompositeTypeaheadV2 and CompositeHoverV2 via private APIs ([#64985](https://github.com/WordPress/gutenberg/pull/64985)).
 -   `DropdownMenu` v2: fix flashing menu item styles when using keyboard ([#64873](https://github.com/WordPress/gutenberg/pull/64873), [#64942](https://github.com/WordPress/gutenberg/pull/64942)).
 -   `DropdownMenu` v2: refactor to overloaded naming convention ([#64654](https://github.com/WordPress/gutenberg/pull/64654)).
 -   `DropdownMenu` v2: add `GroupLabel` subcomponent ([#64854](https://github.com/WordPress/gutenberg/pull/64854)).

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -18,6 +18,8 @@ lock( privateApis, {
 	CompositeGroupV2: Composite.Group,
 	CompositeItemV2: Composite.Item,
 	CompositeRowV2: Composite.Row,
+	CompositeTypeaheadV2: Composite.Typeahead,
+	CompositeHoverV2: Composite.Hover,
 	useCompositeStoreV2: useCompositeStore,
 	__experimentalPopoverLegacyPositionToPlacement,
 	createPrivateSlotFill,

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -86,11 +86,11 @@ const getNewValue = (
 	return [ value ];
 };
 
-function generateCompositeItemId(
+function generateFilterElementCompositeItemId(
 	prefix: string,
-	filterElement: NormalizedFilter[ 'elements' ][ number ]
+	filterElementValue: string
 ) {
-	return `${ prefix }-${ filterElement.value }`;
+	return `${ prefix }-${ filterElementValue }`;
 }
 
 function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
@@ -130,7 +130,10 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 				// in the `useCompositeStore` hook.
 				if ( ! activeCompositeId && filter.elements.length ) {
 					setActiveCompositeId(
-						generateCompositeItemId( baseId, filter.elements[ 0 ] )
+						generateFilterElementCompositeItemId(
+							baseId,
+							filter.elements[ 0 ].value
+						)
 					);
 				}
 			} }
@@ -141,7 +144,10 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 					key={ element.value }
 					render={
 						<CompositeItem
-							id={ generateCompositeItemId( baseId, element ) }
+							id={ generateFilterElementCompositeItemId(
+								baseId,
+								element.value
+							) }
 							render={
 								<div
 									aria-label={ element.label }

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -28,6 +28,8 @@ import type { Filter, NormalizedFilter, View } from '../../types';
 const {
 	CompositeV2: Composite,
 	CompositeItemV2: CompositeItem,
+	CompositeHoverV2: CompositeHover,
+	CompositeTypeaheadV2: CompositeTypeahead,
 } = unlock( componentsPrivateApis );
 
 interface SearchWidgetProps {
@@ -130,11 +132,10 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 					);
 				}
 			} }
-			render={ <Ariakit.CompositeTypeahead store={ compositeStore } /> }
+			render={ <CompositeTypeahead /> }
 		>
 			{ filter.elements.map( ( element ) => (
-				<Ariakit.CompositeHover
-					store={ compositeStore }
+				<CompositeHover
 					key={ element.value }
 					render={
 						<CompositeItem
@@ -204,7 +205,7 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 							) }
 					</span>
 					<span>{ element.label }</span>
-				</Ariakit.CompositeHover>
+				</CompositeHover>
 			) ) }
 		</Composite>
 	);

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -99,10 +99,12 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 	const [ activeCompositeId, setActiveCompositeId ] = useState<
 		string | null | undefined
 	>(
-		// When we have no or just one operator, we can set the first item as active.
-		// We do that by setting the initial `activeId` to `undefined`.Otherwise,
-		// we set it to `null`, so the first item is not selected,
-		// since the focus is on the operators control.
+		// When there are one or less operators, the first item is set as active
+		// (by setting the initial `activeId` to `undefined`).
+		// With 2 or more operators, the focus is moved on the operators control
+		// (by setting the initial `activeId` to `null`), meaning that there won't
+		// be an active item initially. Focus is then managed via the
+		// `onFocusVisible` callback.
 		filter.operators?.length === 1 ? undefined : null
 	);
 	const currentFilter = view.filters?.find(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Refactor the dataviews filter search widget so that it doesn't use the `store` from `useCompositeStore` to function.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By controlling the `activeId` state via props, and reacting to the `onFocusVisible` callback

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

**There shouldn't be any noticeably different behaviors — make sure that the following happens both in `trunk` and in this PR:**

- Open the site editor, select "Pages" from the sidebar
- Click on the filter icon, and select "author". A dropdown menu should open
	- [ ] Make sure that, when the menu opens, no "author" option is highlighted
	- [ ] Press tab. Make sure that, as focus moves onto the list of possible "author" choices, the first item in the list gets highlighted
- Repeat the process, but for the "Status" filter
    - [ ] Make sure that, when the dropdown menu appears, the first item is automatically highlighted

## Screenshots

https://github.com/user-attachments/assets/79420d3b-630e-4c53-96c1-8086f46ec7d0

