### PR TITLE
Fix Colors not updating on click for Calender component in the Admin.

### DIFF
--- a/packages/block-library/src/calendar/edit.js
+++ b/packages/block-library/src/calendar/edit.js
@@ -96,6 +96,22 @@ export default function CalendarEdit( { attributes } ) {
 				<ServerSideRender
 					block="core/calendar"
 					attributes={ { ...attributes, ...getYearMonth( date ) } }
+					/**
+					 * The `key` prop is set to a combination of `backgroundColor` and `textColor` attributes.
+					 * This forces the <ServerSideRender> component to update.
+					 *
+					 * Reason: The <ServerSideRender> component typically fetches its content from
+					 * the server based on the provided attributes. Without forcing a re-render,
+					 * the component might not immediately reflect changes in background or text colors
+					 * selected by the user in the admin panel. By using the `key` prop in this way,
+					 * we ensure that the component re-renders and correctly displays the updated styles.
+					 *
+					 * This approach ensures that the block remains in sync with the color settings
+					 * chosen in the editor without requiring a manual refresh.
+					 */
+					key={ `${ attributes.backgroundColor || 'default' }-${
+						attributes.textColor || 'default'
+					}` }
 				/>
 			</Disabled>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: https://github.com/WordPress/gutenberg/issues/64739

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR addresses an issue where changes to the background and text colors were not immediately reflected in the Calendar block due to the server-side rendering. By adding the `key` prop and handling null values, we force a re-render when color changes are made, ensuring immediate updates in the block editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The problem was that changes to the background and text colors in the Calendar block were not reflected immediately when updated in the admin panel. The use of `<ServerSideRender>` required a forced re-render to ensure the updated attributes were reflected. By setting the `key` prop and handling null values, we ensure the block behaves as expected.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Introduced the `key` prop in the `<ServerSideRender>` component using a combination of `backgroundColor` and `textColor`.
- Handled null or undefined cases by defaulting to `'default'` when the color values are not present.
- This forces a re-render of the `<ServerSideRender>` component whenever color changes occur.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page in the block editor.
2. Insert the Calendar block.
3. Use the block settings panel to change the background and text colors.
4. Confirm that the Calendar block reflects the color changes immediately without requiring a refresh.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Use the keyboard to navigate to the block settings panel.
2. Change the background and text colors using the keyboard.
3. Verify that the color changes are reflected immediately in the Calendar block.

## Screenshots or screencast <!-- if applicable -->
<!-- Include screenshots or a screencast if they help to illustrate the change. -->

[Edit Post “Test Post for Calendar Block” ‹ gutenberg — WordPress.webm](https://github.com/user-attachments/assets/29cbba44-b078-42b8-bdb1-0f3bdadc9627)

