### PR TITLE
Dataviews list view: do not use Composite store

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -311,13 +311,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const baseId = useInstanceId( ViewList, 'view-list' );
 
 	const getItemDomId = useCallback(
-		( item?: Item ) => {
-			if ( ! item ) {
-				return;
-			}
-
-			return `${ baseId }-${ getItemId( item ) }`;
-		},
+		( item: Item ) => `${ baseId }-${ getItemId( item ) }`,
 		[ baseId, getItemId ]
 	);
 
@@ -332,7 +326,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		string | null | undefined
 	>(
 		// By default, the active composite item is the selected one.
-		getItemDomId( selectedItem )
+		selectedItem ? getItemDomId( selectedItem ) : undefined
 	);
 
 	const mediaField = fields.find(
@@ -452,9 +446,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 			setActiveId={ setActiveCompositeId }
 		>
 			{ data.map( ( item ) => {
-				// Since `item` is guaranteed not to be undefined, we can safely
-				// let typescript know that `id` is not undefined either.
-				const id = getItemDomId( item )!;
+				const id = getItemDomId( item );
 				return (
 					<ListItem
 						key={ id }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -314,26 +314,10 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 		selection,
 		view,
 	} = props;
-
 	const baseId = useInstanceId( ViewList, 'view-list' );
-
-	const getItemDomId = useCallback(
-		( item: Item ) => `${ baseId }-${ getItemId( item ) }`,
-		[ baseId, getItemId ]
-	);
 
 	const selectedItem = data?.findLast( ( item ) =>
 		selection.includes( getItemId( item ) )
-	);
-
-	const onSelect = ( item: Item ) =>
-		onChangeSelection( [ getItemId( item ) ] );
-
-	const [ activeCompositeId, setActiveCompositeId ] = useState<
-		string | null | undefined
-	>(
-		// By default, the active composite item is the selected one.
-		selectedItem ? getItemDomId( selectedItem ) : undefined
 	);
 
 	const mediaField = fields.find(
@@ -349,6 +333,21 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 			! [ view.layout?.primaryField, view.layout?.mediaField ].includes(
 				field.id
 			)
+	);
+
+	const onSelect = ( item: Item ) =>
+		onChangeSelection( [ getItemId( item ) ] );
+
+	const getItemDomId = useCallback(
+		( item: Item ) => `${ baseId }-${ getItemId( item ) }`,
+		[ baseId, getItemId ]
+	);
+
+	const [ activeCompositeId, setActiveCompositeId ] = useState<
+		string | null | undefined
+	>(
+		// By default, the active composite item is the selected one.
+		selectedItem ? getItemDomId( selectedItem ) : undefined
 	);
 
 	const activeItemIndex = data.findIndex( ( item ) => {

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -368,10 +368,18 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	// Controlled state for the active composite item.
 	const [ activeCompositeId, setActiveCompositeId ] = useState<
 		string | null | undefined
-	>(
-		// By default, the active composite item is the selected one.
-		selectedItem ? generateCompositeItemIdPrefix( selectedItem ) : undefined
-	);
+	>( undefined );
+
+	// Update the active composite item when the selected item changes.
+	useEffect( () => {
+		if ( selectedItem ) {
+			setActiveCompositeId(
+				generateItemWrapperCompositeId(
+					generateCompositeItemIdPrefix( selectedItem )
+				)
+			);
+		}
+	}, [ selectedItem, generateCompositeItemIdPrefix ] );
 
 	const activeItemIndex = data.findIndex( ( item ) =>
 		isActiveCompositeItem( item, activeCompositeId ?? '' )
@@ -405,17 +413,20 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	// Select a new active composite item when the current active item
 	// is removed from the list.
 	useEffect( () => {
-		if ( ! isActiveIdInList ) {
+		const wasActiveIdInList =
+			previousActiveItemIndex !== undefined &&
+			previousActiveItemIndex !== -1;
+		if ( ! isActiveIdInList && wasActiveIdInList ) {
 			// By picking `previousActiveItemIndex` as the next item index, we are
 			// basically picking the item that would have been after the deleted one.
 			// If the previously active (and removed) item was the last of the list,
 			// we will select the item before it — which is the new last item.
 			selectCompositeItem(
-				previousActiveItemIndex ?? 0,
+				previousActiveItemIndex,
 				generateItemWrapperCompositeId
 			);
 		}
-	}, [ previousActiveItemIndex, isActiveIdInList, selectCompositeItem ] );
+	}, [ isActiveIdInList, selectCompositeItem, previousActiveItemIndex ] );
 
 	// Prevent the default behavior (open dropdown menu) and instead select the
 	// dropdown menu trigger on the previous/next row.

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -380,21 +380,16 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 
 	useEffect( () => {
 		if ( ! isActiveIdInList ) {
-			// Prefer going down, except if there is no item below (last item),
-			// then go up (last item in list).
-			// By picking previousActiveItemIndex as the next item index, we are
-			// basically picking the item after the deleted one.
+			// By picking `previousActiveItemIndex` as the next item index, we are
+			// basically picking the item that would have been after the deleted one.
+			// If the previously active (and removed) item was the last of the list,
+			// we will select the item before it — which is the new last item.
 			// Clamping between 0 and data.length - 1 to avoid out of bounds.
-			const nextActiveDataItem =
-				data[
-					Math.max(
-						0,
-						Math.min(
-							previousActiveItemIndex ?? 0,
-							data.length - 1
-						)
-					)
-				];
+			const clampedPreviousActiveItemIndex = Math.max(
+				0,
+				Math.min( previousActiveItemIndex ?? 0, data.length - 1 )
+			);
+			const nextActiveDataItem = data[ clampedPreviousActiveItemIndex ];
 
 			const nextCompositeActiveId = getItemDomId( nextActiveDataItem );
 			setActiveCompositeId( nextCompositeActiveId );

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -91,7 +91,7 @@ function PrimaryActionGridCell< Item >( {
 			: primaryAction.label( [ item ] );
 
 	return 'RenderModal' in primaryAction ? (
-		<div role="gridcell">
+		<div role="gridcell" key={ primaryAction.id }>
 			<CompositeItem
 				id={ compositeItemId }
 				render={

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -59,6 +59,68 @@ function generateDropdownTriggerCompositeId( domId: string ) {
 	return `${ domId }-dropdown`;
 }
 
+function PrimaryActionGridCell< Item >( {
+	primaryAction,
+	id,
+	item,
+}: {
+	id: string;
+	primaryAction: Action< Item >;
+	item: Item;
+} ) {
+	const registry = useRegistry();
+	const [ isModalOpen, setIsModalOpen ] = useState( false );
+
+	const compositeItemId = `${ id }-${ primaryAction.id }`;
+
+	const label =
+		typeof primaryAction.label === 'string'
+			? primaryAction.label
+			: primaryAction.label( [ item ] );
+
+	return 'RenderModal' in primaryAction ? (
+		<div role="gridcell">
+			<CompositeItem
+				id={ compositeItemId }
+				render={
+					<Button
+						label={ label }
+						icon={ primaryAction.icon }
+						isDestructive={ primaryAction.isDestructive }
+						size="small"
+						onClick={ () => setIsModalOpen( true ) }
+					/>
+				}
+			>
+				{ isModalOpen && (
+					<ActionModal< Item >
+						action={ primaryAction }
+						items={ [ item ] }
+						closeModal={ () => setIsModalOpen( false ) }
+					/>
+				) }
+			</CompositeItem>
+		</div>
+	) : (
+		<div role="gridcell" key={ primaryAction.id }>
+			<CompositeItem
+				id={ compositeItemId }
+				render={
+					<Button
+						label={ label }
+						icon={ primaryAction.icon }
+						isDestructive={ primaryAction.isDestructive }
+						size="small"
+						onClick={ () => {
+							primaryAction.callback( [ item ], { registry } );
+						} }
+					/>
+				}
+			/>
+		</div>
+	);
+}
+
 function ListItem< Item >( {
 	actions,
 	id,
@@ -70,7 +132,6 @@ function ListItem< Item >( {
 	visibleFields,
 	onDropdownTriggerKeyDown,
 }: ListViewItemProps< Item > ) {
-	const registry = useRegistry();
 	const itemRef = useRef< HTMLElement >( null );
 	const labelId = `${ id }-label`;
 	const descriptionId = `${ id }-description`;
@@ -107,13 +168,6 @@ function ListItem< Item >( {
 			eligibleActions: _eligibleActions,
 		};
 	}, [ actions, item ] );
-
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
-	const primaryActionLabel =
-		primaryAction &&
-		( typeof primaryAction.label === 'string'
-			? primaryAction.label
-			: primaryAction.label( [ item ] ) );
 
 	const renderedMediaField = mediaField?.render ? (
 		<mediaField.render item={ item } />
@@ -206,60 +260,13 @@ function ListItem< Item >( {
 							width: 'auto',
 						} }
 					>
-						{ primaryAction && 'RenderModal' in primaryAction && (
-							<div role="gridcell">
-								<CompositeItem
-									id={ `${ id }-${ primaryAction.id }` }
-									render={
-										<Button
-											label={ primaryActionLabel }
-											icon={ primaryAction.icon }
-											isDestructive={
-												primaryAction.isDestructive
-											}
-											size="small"
-											onClick={ () =>
-												setIsModalOpen( true )
-											}
-										/>
-									}
-								>
-									{ isModalOpen && (
-										<ActionModal< Item >
-											action={ primaryAction }
-											items={ [ item ] }
-											closeModal={ () =>
-												setIsModalOpen( false )
-											}
-										/>
-									) }
-								</CompositeItem>
-							</div>
+						{ primaryAction && (
+							<PrimaryActionGridCell
+								id={ id }
+								primaryAction={ primaryAction }
+								item={ item }
+							/>
 						) }
-						{ primaryAction &&
-							! ( 'RenderModal' in primaryAction ) && (
-								<div role="gridcell" key={ primaryAction.id }>
-									<CompositeItem
-										id={ `${ id }-${ primaryAction.id }` }
-										render={
-											<Button
-												label={ primaryActionLabel }
-												icon={ primaryAction.icon }
-												isDestructive={
-													primaryAction.isDestructive
-												}
-												size="small"
-												onClick={ () => {
-													primaryAction.callback(
-														[ item ],
-														{ registry }
-													);
-												} }
-											/>
-										}
-									/>
-								</div>
-							) }
 						<div role="gridcell">
 							<DropdownMenu
 								trigger={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Refactor the dataviews list view component so that it doesn't use the `store` from `useCompositeStore`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By controlling the `activeId` state via props and internal logic

## Follow-ups

- Look into the styles, and see if we can use `[data-focus-visible]` instead of `:focus-visible` and `:focus-within` in order to follow ariakit's guidelines better.

## Testing Instructions (with related video captures)

**Note: this PR shouldn't change how the app behaves compared to `trunk`.**

### General navigation when loading the pages' screen

When focusing the widget for the first time, the active composite item should be the first one in the list — it should receive focus when tabbing on the composite widget.

https://github.com/user-attachments/assets/c1c62a90-0f4c-43c1-b2a3-ed5406c327cb

### The active item matches the selected page on load

When loading the screen and a page is already selected (ie via the `postId` query parameter), the initial active composite item should be the one associated to the selected page. It should receive focus when tabbing on the composite widget for the first time.

https://github.com/user-attachments/assets/1099e08d-57be-46ef-9679-ad1890fcc1fc

### Using up/down arrows correctly moves the selection

While focus in on the composite widget, left/right arrow keys should move focus of the composite items in the same row. Up/down arrow keys should focus the equivalent composite item from the previous/next row.

This should still happen even when pressing the up/down arrow keys while focussing the dropdown menu trigger buttons. In this case, the dropdown menu should _not_ open, and the composite selection should be updated instead.

https://github.com/user-attachments/assets/8aa6406f-963b-4943-a5de-7ec1e1774f0b

### Deleting a page shouldn't cause the active item to get out of sync

If the page associated with the currently active composite item gets deleted, a new active composite item should be automatically picked — if possible, the item after the one that got deleted, otherwise the one before (in case the last page in the list was deleted).

https://github.com/user-attachments/assets/6aef13b2-452d-4f5b-8e4d-c524f6268f38

