### PR TITLE
Post Editor: fix click space after post content to append

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -126,8 +126,8 @@ function useEditorStyles() {
 			? editorSettings.styles ?? []
 			: defaultEditorStyles;
 
-		// Add a constant padding for the typewriter effect. When typing at the
-		// bottom, there needs to be room to scroll up.
+		// Add a space for the typewriter effect. When typing in the last block,
+		// there needs to be room to scroll up.
 		if (
 			! isZoomedOutView &&
 			renderingMode === 'post-only' &&

--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -18,12 +18,12 @@ export function usePaddingAppender() {
 				const { ownerDocument } = node;
 				const { defaultView } = ownerDocument;
 
-				const paddingBottom = defaultView.parseInt(
-					defaultView.getComputedStyle( node ).paddingBottom,
+				const pseudoHeight = defaultView.parseInt(
+					defaultView.getComputedStyle( node, ':after' ).height,
 					10
 				);
 
-				if ( ! paddingBottom ) {
+				if ( ! pseudoHeight ) {
 					return;
 				}
 

--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -38,7 +38,7 @@ export function usePaddingAppender() {
 					return;
 				}
 
-				event.preventDefault();
+				event.stopPropagation();
 
 				const blockOrder = registry
 					.select( blockEditorStore )

--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -45,18 +45,13 @@ export function usePaddingAppender() {
 					.getBlockOrder( '' );
 				const lastBlockClientId = blockOrder[ blockOrder.length - 1 ];
 
-				// Do nothing when only default block appender is present.
-				if ( ! lastBlockClientId ) {
-					return;
-				}
-
 				const lastBlock = registry
 					.select( blockEditorStore )
 					.getBlock( lastBlockClientId );
 				const { selectBlock, insertDefaultBlock } =
 					registry.dispatch( blockEditorStore );
 
-				if ( isUnmodifiedDefaultBlock( lastBlock ) ) {
+				if ( lastBlock && isUnmodifiedDefaultBlock( lastBlock ) ) {
 					selectBlock( lastBlockClientId );
 				} else {
 					insertDefaultBlock();


### PR DESCRIPTION
## What?
A restoration of inserting a default block (or focusing one if already present) when the space below the post content is clicked.

## Why?
To fix #63601 

## How?
- Revises a test for padding to be a test for height of the psuedo-element per revisions in #64639.
- If there are no blocks present (new post) a default block is inserted when clicking the space below the default appender.

## Testing Instructions
1. Create a new post or page in the Post editor.
2. Add content in the empty paragraph or insert another block.
3. Click below the last block.
4. Verify a new empty paragraph is inserted and focused.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
