### PR TITLE
Grid: In RTL languages, the resize handles point in the opposite direction 

### DIFF
--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -73,8 +73,8 @@ function GridItemResizerInner( {
 	}, [ blockElement, rootBlockElement ] );
 
 	const justification = {
-		right: 'flex-start',
-		left: 'flex-end',
+		right: 'left',
+		left: 'right',
 	};
 
 	const alignment = {

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -3,7 +3,7 @@
  */
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
-import { isRTL } from '@wordpress/i18n'; // Import the isRTL utility
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -56,6 +56,7 @@ function GridItemResizerInner( {
 		left: false,
 		right: false,
 	} );
+
 	const rtl = isRTL();
 
 	useEffect( () => {

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -137,6 +137,8 @@ function GridItemResizerInner( {
 							setResizeDirection( 'right' );
 						} else if ( 'right' === direction ) {
 							setResizeDirection( 'left' );
+						} else {
+							setResizeDirection( direction );
 						}
 					} else {
 						/*

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -3,6 +3,7 @@
  */
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n'; // Import the isRTL utility
 
 /**
  * Internal dependencies
@@ -55,6 +56,7 @@ function GridItemResizerInner( {
 		left: false,
 		right: false,
 	} );
+	const rtl = isRTL();
 
 	useEffect( () => {
 		const observer = new window.ResizeObserver( () => {
@@ -129,12 +131,20 @@ function GridItemResizerInner( {
 					target.setPointerCapture( pointerId );
 				} }
 				onResizeStart={ ( event, direction ) => {
-					/*
-					 * The container justification and alignment need to be set
-					 * according to the direction the resizer is being dragged in,
-					 * so that it resizes in the right direction.
-					 */
-					setResizeDirection( direction );
+					if ( rtl ) {
+						if ( 'left' === direction ) {
+							setResizeDirection( 'right' );
+						} else if ( 'right' === direction ) {
+							setResizeDirection( 'left' );
+						}
+					} else {
+						/*
+						 * The container justification and alignment need to be set
+						 * according to the direction the resizer is being dragged in,
+						 * so that it resizes in the right direction.
+						 */
+						setResizeDirection( direction );
+					}
 				} }
 				onResizeStop={ ( event, direction, boxElement ) => {
 					const columnGap = parseFloat(

--- a/packages/block-editor/src/components/grid/grid-item-resizer.js
+++ b/packages/block-editor/src/components/grid/grid-item-resizer.js
@@ -3,7 +3,6 @@
  */
 import { ResizableBox } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
-import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -56,8 +55,6 @@ function GridItemResizerInner( {
 		left: false,
 		right: false,
 	} );
-
-	const rtl = isRTL();
 
 	useEffect( () => {
 		const observer = new window.ResizeObserver( () => {
@@ -132,22 +129,12 @@ function GridItemResizerInner( {
 					target.setPointerCapture( pointerId );
 				} }
 				onResizeStart={ ( event, direction ) => {
-					if ( rtl ) {
-						if ( 'left' === direction ) {
-							setResizeDirection( 'right' );
-						} else if ( 'right' === direction ) {
-							setResizeDirection( 'left' );
-						} else {
-							setResizeDirection( direction );
-						}
-					} else {
-						/*
-						 * The container justification and alignment need to be set
-						 * according to the direction the resizer is being dragged in,
-						 * so that it resizes in the right direction.
-						 */
-						setResizeDirection( direction );
-					}
+					/*
+					 * The container justification and alignment need to be set
+					 * according to the direction the resizer is being dragged in,
+					 * so that it resizes in the right direction.
+					 */
+					setResizeDirection( direction );
 				} }
 				onResizeStop={ ( event, direction, boxElement ) => {
 					const columnGap = parseFloat(


### PR DESCRIPTION
## What?
- Fix the resize handle direction for RTL languages.
- Fixes: https://github.com/WordPress/gutenberg/issues/64931

## Why?
- To fix horizontal resizing for RTL languages.

## How?
- Fix the direction for RTL languages.

## Testing Instructions
- Insert a Grid block.
- Switch to a RTL language.
- Resize the inner block horizontally.
