### PR TITLE
Try: Update block warnings.

### DIFF
--- a/packages/block-editor/src/components/block-list/block-invalid-warning.js
+++ b/packages/block-editor/src/components/block-list/block-invalid-warning.js
@@ -107,12 +107,12 @@ export default function BlockInvalidWarning( { clientId } ) {
 						onClick={ convert.toRecoveredBlock }
 						variant="primary"
 					>
-						{ __( 'Attempt Block Recovery' ) }
+						{ __( 'Attempt recovery' ) }
 					</Button>,
 				] }
 				secondaryActions={ secondaryActions }
 			>
-				{ __( 'This block contains unexpected or invalid content.' ) }
+				{ __( 'Block contains unexpected or invalid content.' ) }
 			</Warning>
 			{ compare && (
 				<Modal

--- a/packages/block-editor/src/components/warning/content.scss
+++ b/packages/block-editor/src/components/warning/content.scss
@@ -30,21 +30,14 @@
 		flex-wrap: wrap;
 		align-items: baseline;
 		width: 100%;
+		gap: $grid-unit-15;
 	}
 
 	.block-editor-warning__actions {
 		align-items: center;
 		display: flex;
-		margin-top: 1em;
+		gap: $grid-unit-10;
 	}
-
-	.block-editor-warning__action {
-		margin: 0 $grid-unit-10 0 0;
-	}
-}
-
-.block-editor-warning__secondary {
-	margin: auto 0 auto $grid-unit-10;
 }
 
 .components-popover.block-editor-warning__dropdown {

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -75,7 +75,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 		messageHTML = sprintf(
 			/* translators: %s: block name */
 			__(
-				'Your site doesn’t include support for the "%s" block. You can leave this block intact, convert its content to a Custom HTML block, or remove it entirely.'
+				'Your site doesn’t include support for the "%s" block. You can leave it as-is, convert it to custom HTML, or remove it.'
 			),
 			originalName
 		);
@@ -84,7 +84,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 		messageHTML = sprintf(
 			/* translators: %s: block name */
 			__(
-				'Your site doesn’t include support for the "%s" block. You can leave this block intact or remove it entirely.'
+				'Your site doesn’t include support for the "%s" block. You can leave it as-is or remove it.'
 			),
 			originalName
 		);

--- a/test/e2e/specs/editor/various/invalid-block.spec.js
+++ b/test/e2e/specs/editor/various/invalid-block.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Invalid blocks', () => {
 		await expect(
 			editor.canvas
 				.getByRole( 'document', { name: 'Block: Paragraph' } )
-				.getByRole( 'button', { name: 'Attempt Block Recovery' } )
+				.getByRole( 'button', { name: 'Attempt recovery' } )
 		).toBeVisible();
 
 		expect( hasAlert ).toBe( false );


### PR DESCRIPTION
## What?

Fix visual glitches in the block error boundary. Before:

![before](https://github.com/user-attachments/assets/1fec2d3f-09a0-4966-9cbc-664678c31c72)

After:

![after](https://github.com/user-attachments/assets/239d771b-90b2-49ab-b692-0052d6b5c9fa)

## Testing Instructions

Go to the code editor and insert the test code.

<details><summary>Test code</summary>

```
<!-- wp:paragraph -->
<p>Broken block:</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Broken block
<!-- /wp:paragraph -->

<!-- wp:paragraph -->
<p>Missing block:</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph2 -->
<p>Missing block</p>
<!-- /wp:paragraph2 -->
```

</details>

Now observe the result to have clearer prose, sentence case for actions, and improved margins/gaps.
