### PR TITLE
DataViews: fix field reordering and visibility logic

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -256,7 +256,7 @@ function FieldItem( {
 	view: View;
 	onChangeView: ( view: View ) => void;
 } ) {
-	const fieldsInView = view.fields || fields.map( ( field ) => field.id );
+	const visibleFieldIds = getVisibleFieldIds( view, fields );
 
 	return (
 		<Item key={ id }>
@@ -280,13 +280,15 @@ function FieldItem( {
 									onChangeView( {
 										...view,
 										fields: [
-											...( fieldsInView.slice(
+											...( visibleFieldIds.slice(
 												0,
 												index - 1
 											) ?? [] ),
 											id,
-											fieldsInView[ index - 1 ],
-											...fieldsInView.slice( index + 1 ),
+											visibleFieldIds[ index - 1 ],
+											...visibleFieldIds.slice(
+												index + 1
+											),
 										],
 									} );
 								} }
@@ -298,20 +300,22 @@ function FieldItem( {
 								) }
 							/>
 							<Button
-								disabled={ index >= fieldsInView.length - 1 }
+								disabled={ index >= visibleFieldIds.length - 1 }
 								accessibleWhenDisabled
 								size="compact"
 								onClick={ () => {
 									onChangeView( {
 										...view,
 										fields: [
-											...( fieldsInView.slice(
+											...( visibleFieldIds.slice(
 												0,
 												index
 											) ?? [] ),
-											fieldsInView[ index + 1 ],
+											visibleFieldIds[ index + 1 ],
 											id,
-											...fieldsInView.slice( index + 2 ),
+											...visibleFieldIds.slice(
+												index + 2
+											),
 										],
 									} );
 								} }
@@ -333,10 +337,10 @@ function FieldItem( {
 							onChangeView( {
 								...view,
 								fields: isVisible
-									? fieldsInView.filter(
+									? visibleFieldIds.filter(
 											( fieldId ) => fieldId !== id
 									  )
-									: [ ...fieldsInView, id ],
+									: [ ...visibleFieldIds, id ],
 							} );
 							// Focus the visibility button to avoid focus loss.
 							// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -44,7 +44,7 @@ import {
 	getVisibleFieldIds,
 	getHiddenFieldIds,
 } from '../../dataviews-layouts';
-import type { SupportedLayouts, View } from '../../types';
+import type { SupportedLayouts, View, Field } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
 import DensityPicker from '../../dataviews-layouts/grid/density-picker';
@@ -247,13 +247,17 @@ interface FieldItemProps {
 
 function FieldItem( {
 	field: { id, label, index, isVisible, isHidable },
+	fields,
 	view,
 	onChangeView,
 }: {
 	field: FieldItemProps;
+	fields: Field< any >[];
 	view: View;
 	onChangeView: ( view: View ) => void;
 } ) {
+	const fieldsInView = view.fields || fields.map( ( field ) => field.id );
+
 	return (
 		<Item key={ id }>
 			<HStack
@@ -269,23 +273,20 @@ function FieldItem( {
 					{ view.type === LAYOUT_TABLE && isVisible && (
 						<>
 							<Button
-								disabled={ ! isVisible || index < 1 }
+								disabled={ index < 1 }
 								accessibleWhenDisabled
 								size="compact"
 								onClick={ () => {
-									if ( ! view.fields || index < 1 ) {
-										return;
-									}
 									onChangeView( {
 										...view,
 										fields: [
-											...( view.fields.slice(
+											...( fieldsInView.slice(
 												0,
 												index - 1
 											) ?? [] ),
 											id,
-											view.fields[ index - 1 ],
-											...view.fields.slice( index + 1 ),
+											fieldsInView[ index - 1 ],
+											...fieldsInView.slice( index + 1 ),
 										],
 									} );
 								} }
@@ -297,30 +298,20 @@ function FieldItem( {
 								) }
 							/>
 							<Button
-								disabled={
-									! isVisible ||
-									! view.fields ||
-									index >= view.fields.length - 1
-								}
+								disabled={ index >= fieldsInView.length - 1 }
 								accessibleWhenDisabled
 								size="compact"
 								onClick={ () => {
-									if (
-										! view.fields ||
-										index >= view.fields.length - 1
-									) {
-										return;
-									}
 									onChangeView( {
 										...view,
 										fields: [
-											...( view.fields.slice(
+											...( fieldsInView.slice(
 												0,
 												index
 											) ?? [] ),
-											view.fields[ index + 1 ],
+											fieldsInView[ index + 1 ],
 											id,
-											...view.fields.slice( index + 2 ),
+											...fieldsInView.slice( index + 2 ),
 										],
 									} );
 								} }
@@ -342,10 +333,10 @@ function FieldItem( {
 							onChangeView( {
 								...view,
 								fields: isVisible
-									? ( view.fields || [] ).filter(
+									? fieldsInView.filter(
 											( fieldId ) => fieldId !== id
 									  )
-									: [ ...( view.fields || [] ), id ],
+									: [ ...fieldsInView, id ],
 							} );
 							// Focus the visibility button to avoid focus loss.
 							// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.
@@ -446,6 +437,7 @@ function FieldControl() {
 						<FieldItem
 							key={ field.id }
 							field={ field }
+							fields={ fields }
 							view={ view }
 							onChangeView={ onChangeView }
 						/>
@@ -463,6 +455,7 @@ function FieldControl() {
 								<FieldItem
 									key={ field.id }
 									field={ field }
+									fields={ fields }
 									view={ view }
 									onChangeView={ onChangeView }
 								/>

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -420,6 +420,7 @@ function FieldControl() {
 			} );
 		} );
 	}
+	visibleFields.sort( ( a, b ) => a.index - b.index );
 
 	const hiddenFields = fields
 		.filter( ( { id } ) => hiddenFieldIds.includes( id ) )

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -417,6 +417,8 @@ function FieldControl() {
 			( { id, enableHiding } ) =>
 				! visibleFieldIds.includes( id ) &&
 				! fieldsToExclude.includes( id ) &&
+				// If a field is not visible neither hidable,
+				// it should not be listed in the properties control.
 				enableHiding
 		)
 		.map( ( { id, label }, index ) => {

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -98,6 +98,15 @@ export function getHiddenFieldIds(
 		...getVisibleFieldIds( view, fields ),
 	];
 
+	// The media field does not need to be in the view.fields to be displayed.
+	if ( view.type === LAYOUT_GRID && view.layout?.mediaField ) {
+		fieldsToExclude.push( view.layout?.mediaField );
+	}
+
+	if ( view.type === LAYOUT_LIST && view.layout?.mediaField ) {
+		fieldsToExclude.push( view.layout?.mediaField );
+	}
+
 	return fields
 		.filter(
 			( { id, enableHiding } ) =>

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -81,12 +81,23 @@ export function getVisibleFieldIds(
 ): string[] {
 	const fieldsToExclude = getCombinedFieldIds( view );
 
-	return (
-		view.fields?.filter( ( id ) => ! fieldsToExclude.includes( id ) ) ||
-		fields
+	if ( view.fields ) {
+		return view.fields.filter( ( id ) => ! fieldsToExclude.includes( id ) );
+	}
+
+	const visibleFields = [];
+	if ( view.type === LAYOUT_TABLE && view.layout?.combinedFields ) {
+		visibleFields.push(
+			...view.layout.combinedFields.map( ( { id } ) => id )
+		);
+	}
+	visibleFields.push(
+		...fields
 			.filter( ( { id } ) => ! fieldsToExclude.includes( id ) )
 			.map( ( { id } ) => id )
 	);
+
+	return visibleFields;
 }
 
 export function getHiddenFieldIds(

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -26,6 +26,7 @@ import type {
 	SortDirection,
 	ViewTable as ViewTableType,
 } from '../../types';
+import { getVisibleFieldIds } from '../index';
 
 const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
@@ -60,10 +61,12 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	}: HeaderMenuProps< Item >,
 	ref: Ref< HTMLButtonElement >
 ) {
+	const visibleFieldIds = getVisibleFieldIds( view, fields );
+	const index = visibleFieldIds?.indexOf( fieldId ) as number;
+
 	const combinedField = view.layout?.combinedFields?.find(
 		( f ) => f.id === fieldId
 	);
-	const index = view.fields?.indexOf( fieldId ) as number;
 	if ( !! combinedField ) {
 		return combinedField.header || combinedField.label;
 	}
@@ -178,17 +181,16 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						prefix={ <Icon icon={ arrowLeft } /> }
 						disabled={ index < 1 }
 						onClick={ () => {
-							if ( ! view.fields || index < 1 ) {
-								return;
-							}
 							onChangeView( {
 								...view,
 								fields: [
-									...( view.fields.slice( 0, index - 1 ) ??
-										[] ),
+									...( visibleFieldIds.slice(
+										0,
+										index - 1
+									) ?? [] ),
 									fieldId,
-									view.fields[ index - 1 ],
-									...view.fields.slice( index + 1 ),
+									visibleFieldIds[ index - 1 ],
+									...visibleFieldIds.slice( index + 1 ),
 								],
 							} );
 						} }
@@ -199,23 +201,16 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 					</DropdownMenuV2.Item>
 					<DropdownMenuV2.Item
 						prefix={ <Icon icon={ arrowRight } /> }
-						disabled={
-							! view.fields || index >= view.fields.length - 1
-						}
+						disabled={ index >= visibleFieldIds.length - 1 }
 						onClick={ () => {
-							if (
-								! view.fields ||
-								index >= view.fields.length - 1
-							) {
-								return;
-							}
 							onChangeView( {
 								...view,
 								fields: [
-									...( view.fields.slice( 0, index ) ?? [] ),
-									view.fields[ index + 1 ],
+									...( visibleFieldIds.slice( 0, index ) ??
+										[] ),
+									visibleFieldIds[ index + 1 ],
 									fieldId,
-									...view.fields.slice( index + 2 ),
+									...visibleFieldIds.slice( index + 2 ),
 								],
 							} );
 						} }
@@ -228,12 +223,10 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						<DropdownMenuV2.Item
 							prefix={ <Icon icon={ unseen } /> }
 							onClick={ () => {
-								const viewFields =
-									view.fields || fields.map( ( f ) => f.id );
 								onHide( field );
 								onChangeView( {
 									...view,
-									fields: viewFields.filter(
+									fields: visibleFieldIds.filter(
 										( id ) => id !== fieldId
 									),
 								} );

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -73,14 +73,14 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	}
 	const isHidable = field.enableHiding !== false;
 	const isSortable = field.enableSorting !== false;
-	const isSorted = view.sort?.field === field.id;
+	const isSorted = view.sort?.field === fieldId;
 	const operators = sanitizeOperators( field );
 	// Filter can be added:
 	// 1. If the field is not already part of a view's filters.
 	// 2. If the field meets the type and operator requirements.
 	// 3. If it's not primary. If it is, it should be already visible.
 	const canAddFilter =
-		! view.filters?.some( ( _filter ) => field.id === _filter.field ) &&
+		! view.filters?.some( ( _filter ) => fieldId === _filter.field ) &&
 		!! field.elements?.length &&
 		!! operators.length &&
 		! field.filterBy?.isPrimary;
@@ -115,7 +115,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 									isSorted &&
 									view.sort.direction === direction;
 
-								const value = `${ field.id }-${ direction }`;
+								const value = `${ fieldId }-${ direction }`;
 
 								return (
 									<DropdownMenuV2.RadioItem
@@ -132,7 +132,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 											onChangeView( {
 												...view,
 												sort: {
-													field: field.id,
+													field: fieldId,
 													direction,
 												},
 											} );
@@ -152,14 +152,14 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						<DropdownMenuV2.Item
 							prefix={ <Icon icon={ funnel } /> }
 							onClick={ () => {
-								setOpenedFilter( field.id );
+								setOpenedFilter( fieldId );
 								onChangeView( {
 									...view,
 									page: 1,
 									filters: [
 										...( view.filters || [] ),
 										{
-											field: field.id,
+											field: fieldId,
 											value: undefined,
 											operator: operators[ 0 ],
 										},
@@ -186,7 +186,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								fields: [
 									...( view.fields.slice( 0, index - 1 ) ??
 										[] ),
-									field.id,
+									fieldId,
 									view.fields[ index - 1 ],
 									...view.fields.slice( index + 1 ),
 								],
@@ -214,7 +214,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								fields: [
 									...( view.fields.slice( 0, index ) ?? [] ),
 									view.fields[ index + 1 ],
-									field.id,
+									fieldId,
 									...view.fields.slice( index + 2 ),
 								],
 							} );
@@ -234,7 +234,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 								onChangeView( {
 									...view,
 									fields: viewFields.filter(
-										( id ) => id !== field.id
+										( id ) => id !== fieldId
 									),
 								} );
 							} }

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -34,6 +34,7 @@ import type {
 } from '../../types';
 import type { SetSelection } from '../../private-types';
 import ColumnHeaderMenu from './column-header-menu';
+import { getVisibleFieldIds } from '../index';
 
 interface TableColumnFieldProps< Item > {
 	primaryField?: NormalizedField< Item >;
@@ -155,7 +156,7 @@ function TableRow< Item >( {
 	// `onClick` and can be used to exclude touchscreen devices from certain
 	// behaviours.
 	const isTouchDeviceRef = useRef( false );
-	const columns = view.fields || fields.map( ( f ) => f.id );
+	const columns = getVisibleFieldIds( view, fields );
 
 	return (
 		<tr
@@ -288,7 +289,7 @@ function ViewTable< Item >( {
 		setNextHeaderMenuToFocus( fallback?.node );
 	};
 
-	const columns = view.fields || fields.map( ( f ) => f.id );
+	const columns = getVisibleFieldIds( view, fields );
 	const hasData = !! data?.length;
 
 	const primaryField = fields.find(

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -61,6 +61,8 @@ export function normalizeFields< Item >(
 			sort,
 			isValid,
 			Edit,
+			enableHiding: field.enableHiding ?? true,
+			enableSorting: field.enableSorting ?? true,
 		};
 	} );
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -163,6 +163,8 @@ export type NormalizedField< Item > = Field< Item > & {
 	Edit: ComponentType< DataFormControlProps< Item > >;
 	sort: ( a: Item, b: Item, direction: SortDirection ) => number;
 	isValid: ( item: Item, context?: ValidationContext ) => boolean;
+	enableHiding: boolean;
+	enableSorting: boolean;
 };
 
 /**


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/55083

## What & Why?

This PR fixes a few issues around field reordering & visibility:

- Displays moving controls for combined fields. Combined fields could be reordered via the view config popup but lacked the same controls in the table header.
- Prevent fields that are part of a combined field from being displayed when they are listed in `view.fields`.
- Do not display hidden fields that cannot be made visible in view config.
- When `view.fields` is not provided: reordering fields should work.
- When `view.fields` is not provided: the properties panel in view config should be visible. Reordering & visibility was still available via the table header.
- When `view.fields` is not provided: display combined fields properly.

## How?

Refactored the logic that deals with visibility & reordering fields.

## Testing Instructions

### Displays moving controls for combined fields

- Go to "Site editor > Templates" and switch to table layout.
- Verify the reordering controls are visible for combined fields.

| Before | After |
| --- | --- |
| <img width="2262" alt="240903-table-header-controls-for-combined-fields-before" src="https://github.com/user-attachments/assets/7d969857-26e1-4ae6-8fb7-cf3592a244ac"> | <img width="2260" alt="240903-table-header-controls-for-combined-fields-after" src="https://github.com/user-attachments/assets/040ca3f3-7d25-4969-b27d-f9f8d1b5b677"> |

### Prevent fields that are part of a combined field from being displayed when they are listed in `view.fields`

- Add `title` in `view.fields` for the [Templates Page](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/page-templates/index.js#L40).
- Go to "Site editor > Templates" and switch to table layout.
- The expected result is that the `title` field (with `Template` label) is not visible in the table and the view config properties panel.

| Before | After |
| --- | --- |
| <img width="2262" alt="240903-combined-fields-in-view-fields-before" src="https://github.com/user-attachments/assets/192b11a1-5c37-4d6a-9677-c773823ab3dc"> | <img width="2260" alt="240903-combined-fields-in-view-after" src="https://github.com/user-attachments/assets/71b0076d-b6c7-4be6-9921-0a7a99ca9323"> |

### Do not display hidden fields that cannot be made visible in view config

- `npm install && npm run storybook:dev`.
- Go to the default story for `DataViews` in storybook and verify the `type` field is not listed in hidden fields.

| Before | After |
| --- | --- |
| <img width="1034" alt="240903-hidden-fields-not-toggeable-before" src="https://github.com/user-attachments/assets/32e57ebe-f3ad-410c-8360-93da045c4a5f"> | <img width="1034" alt="240903-hidden-fields-not-toggeable-after" src="https://github.com/user-attachments/assets/7c157829-edbf-4135-b9ea-784a972bed1b"> |

### When `view.fields` is not provided: reordering fields should work.

- Remove `view.fields` and `view.layout.combinedFields` for the [Templates Page](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/page-templates/index.js#L40).
- Go to "Site editor > Templates" and switch to table layout.
- The expected result is that reordering fields works.

Before

https://github.com/user-attachments/assets/296cfc6d-4912-41a0-8360-87d456944540

After

https://github.com/user-attachments/assets/86841338-6c32-46fa-afbe-ab485200cdea

### When `view.fields` is not provided: the properties panel in view config should be visible

- Remove `view.fields` and `view.layout.combinedFields` for the [Templates Page](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/page-templates/index.js#L40).
- Go to "Site editor > Templates" and switch to table layout.
- The expected result is that the properties panel within the view config is visible.

| Before | After |
| --- | --- |
| <img width="2262" alt="240903-view-config-with-no-view-fields-before" src="https://github.com/user-attachments/assets/0e3fda9e-8166-4236-a41e-ea85e92ecd94"> | <img width="2260" alt="240903-view-config-with-no-view-fields-after" src="https://github.com/user-attachments/assets/cea8ba32-2a2b-422c-98c1-31541e36af70"> |

### When `view.fields` is not provided: display combined fields properly

- Remove `view.fields` for the [Templates Page](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/page-templates/index.js#L40).
- Go to "Site editor > Templates" and switch to table layout.
- The expected result is that both the table & the properties panel display the proper fields (the combined `template` plus `preview` and `author` which are not part of any combination):

| Before | After |
| --- | --- |
|  <img width="2260" alt="Captura de ecrã 2024-09-03, às 12 47 43" src="https://github.com/user-attachments/assets/c930b4da-ff3e-43b7-abe2-9cbac3cf9f74"> | <img width="2260" alt="Captura de ecrã 2024-09-03, às 12 47 28" src="https://github.com/user-attachments/assets/5e41fac6-6aea-4c10-b093-d71128f486d8"> |


