### PR TITLE
Fix error and improve privacy of sectionRootClientId setting

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -10,7 +10,7 @@ import { useEffect, useState } from '@wordpress/element';
 import BlockPopoverInbetween from '../block-popover/inbetween';
 import ZoomOutModeInserterButton from './zoom-out-mode-inserter-button';
 import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
+import { sectionRootClientIdKey } from '../../store/private-keys';
 
 function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
@@ -33,7 +33,7 @@ function ZoomOutModeInserters() {
 			getHoveredBlockClientId,
 			isBlockInsertionPointVisible,
 		} = select( blockEditorStore );
-		const { sectionRootClientId: root } = unlock( getSettings() );
+		const { [ sectionRootClientIdKey ]: root } = getSettings();
 		return {
 			hasSelection: !! getSelectionStart().clientId,
 			blockInsertionPoint: getBlockInsertionPoint(),

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -30,6 +30,7 @@ import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import useBlockDropZone from '../use-block-drop-zone';
 import { unlock } from '../../lock-unlock';
+import { sectionRootClientIdKey } from '../../store/private-keys';
 
 const EMPTY_OBJECT = {};
 
@@ -225,7 +226,8 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				// In zoom out mode, we want to disable the drop zone for the sections.
 				// The inner blocks belonging to the section drop zone is
 				// already disabled by the blocks themselves being disabled.
-				const { sectionRootClientId } = unlock( getSettings() );
+				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
+					getSettings();
 
 				_isDropZoneDisabled = clientId !== sectionRootClientId;
 			}

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -24,6 +24,7 @@ import {
 } from '../../utils/math';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { sectionRootClientIdKey } from '../../store/private-keys';
 
 const THRESHOLD_DISTANCE = 30;
 const MINIMUM_HEIGHT_FOR_THRESHOLD = 120;
@@ -360,7 +361,8 @@ export default function useBlockDropZone( {
 					return;
 				}
 
-				const { sectionRootClientId } = unlock( getSettings() );
+				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
+					getSettings();
 
 				// In Zoom Out mode, if the target is not the section root provided by settings then
 				// do not allow dropping as the drop target is not within the root (that which is

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -38,6 +38,7 @@ import {
 	reusableBlocksSelectKey,
 	globalStylesDataKey,
 	globalStylesLinksDataKey,
+	sectionRootClientIdKey,
 } from './store/private-keys';
 import { requiresWrapperOnCopy } from './components/writing-flow/utils';
 import { PrivateRichText } from './components/rich-text/';
@@ -94,4 +95,5 @@ lock( privateApis, {
 	__unstableBlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
 	useBlockBindingsUtils,
+	sectionRootClientIdKey,
 } );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -35,7 +35,8 @@ import {
 	privateRemoveBlocks,
 } from './private-actions';
 import { STORE_NAME } from './constants';
-import { unlock } from '../lock-unlock';
+
+import { sectionRootClientIdKey } from './private-keys';
 
 /** @typedef {import('../components/use-on-block-drop/types').WPDropOperation} WPDropOperation */
 
@@ -1674,9 +1675,10 @@ export const __unstableSetEditorMode =
 		// When switching to zoom-out mode, we need to select the parent section
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
-			const { sectionRootClientId } = unlock(
-				registry.select( STORE_NAME ).getSettings()
-			);
+			const { [ sectionRootClientIdKey ]: sectionRootClientId } = registry
+				.select( STORE_NAME )
+				.getSettings();
+
 			if ( firstSelectedClientId ) {
 				let sectionClientId;
 

--- a/packages/block-editor/src/store/private-keys.js
+++ b/packages/block-editor/src/store/private-keys.js
@@ -2,3 +2,4 @@ export const globalStylesDataKey = Symbol( 'globalStylesDataKey' );
 export const globalStylesLinksDataKey = Symbol( 'globalStylesLinks' );
 export const selectBlockPatternsKey = Symbol( 'selectBlockPatternsKey' );
 export const reusableBlocksSelectKey = Symbol( 'reusableBlocksSelect' );
+export const sectionRootClientIdKey = Symbol( 'sectionRootClientIdKey' );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -39,6 +39,8 @@ import {
 	getTemporarilyEditingFocusModeToRevert,
 } from './private-selectors';
 
+import { sectionRootClientIdKey } from './private-keys';
+
 /**
  * A block selection object.
  *
@@ -2058,9 +2060,10 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 							if ( ! item.rootClientId ) {
 								let sectionRootClientId;
 								try {
-									sectionRootClientId = unlock(
-										getSettings( state )
-									).sectionRootClientId;
+									sectionRootClientId =
+										getSettings( state )[
+											sectionRootClientIdKey
+										];
 								} catch ( e ) {}
 								if (
 									sectionRootClientId &&
@@ -2838,7 +2841,8 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 
 	// In zoom-out mode, the block overlay is always active for section level blocks.
 	if ( editorMode === 'zoom-out' ) {
-		const { sectionRootClientId } = unlock( getSettings( state ) );
+		const { [ sectionRootClientIdKey ]: sectionRootClientId } =
+			getSettings( state );
 		if ( sectionRootClientId ) {
 			const sectionClientIds = getBlockOrder(
 				state,
@@ -2931,7 +2935,9 @@ export const getBlockEditingMode = createRegistrySelector(
 			// sections.
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'zoom-out' ) {
-				const { sectionRootClientId } = unlock( getSettings( state ) );
+				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
+					getSettings( state );
+
 				if ( clientId === '' /* ROOT_CONTAINER_CLIENT_ID */ ) {
 					return sectionRootClientId ? 'disabled' : 'contentOnly';
 				}

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -18,7 +18,9 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-const { PrivateInserterLibrary } = unlock( blockEditorPrivateApis );
+const { PrivateInserterLibrary, sectionRootClientIdKey } = unlock(
+	blockEditorPrivateApis
+);
 
 export default function InserterSidebar() {
 	const {
@@ -44,7 +46,8 @@ export default function InserterSidebar() {
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const getBlockSectionRootClientId = () => {
 			if ( __unstableGetEditorMode() === 'zoom-out' ) {
-				const { sectionRootClientId } = unlock( getSettings() );
+				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
+					getSettings();
 				if ( sectionRootClientId ) {
 					return sectionRootClientId;
 				}

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -23,7 +23,7 @@ import {
 import inserterMediaCategories from '../media-categories';
 import { mediaUpload } from '../../utils';
 import { store as editorStore } from '../../store';
-import { lock, unlock } from '../../lock-unlock';
+import { unlock } from '../../lock-unlock';
 import { useGlobalStylesContext } from '../global-styles-provider';
 
 const EMPTY_BLOCKS_LIST = [];
@@ -74,7 +74,6 @@ const BLOCK_EDITOR_SETTINGS = [
 	'postContentAttributes',
 	'postsPerPage',
 	'readOnly',
-	'sectionRootClientId',
 	'styles',
 	'titlePlaceholder',
 	'supportsLayout',
@@ -90,6 +89,7 @@ const {
 	globalStylesLinksDataKey,
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
+	sectionRootClientIdKey,
 } = unlock( privateApis );
 
 /**
@@ -325,10 +325,9 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
+			[ sectionRootClientIdKey ]: sectionRootClientId,
 		};
-		lock( blockEditorSettings, {
-			sectionRootClientId,
-		} );
+
 		return blockEditorSettings;
 	}, [
 		allowedBlockTypes,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an error caused by usage of `unlock` around `getSettings` when accessing the `sectionRootClientId` setting.

Related to https://github.com/WordPress/gutenberg/pull/65001

Resolves https://github.com/WordPress/gutenberg/pull/64141

Co-authored-by: Daniel Richards <677833+talldan@users.noreply.github.com>

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The method used to make the setting private was suboptimal and caused errors.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates to use a Symbol (hat tip @talldan) to represent the setting key. We then make the key a private API and consume it as required to access the setting.

A [separate PR will normalise all this into a single private selector](https://github.com/WordPress/gutenberg/pull/65001) to avoid having to import the private key everywhere. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow same instructions as https://github.com/WordPress/gutenberg/pull/64544

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
