### PR TITLE
Add selector for getting section root clientId

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -42,7 +42,7 @@ function ZoomOutModeInserters() {
 			blockInsertionPoint: getBlockInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
-			sectionRootClientId: getSectionRootClientId(),
+			sectionRootClientId: root,
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
 			selectedBlockClientId: getSelectedBlockClientId(),

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -10,7 +10,7 @@ import { useEffect, useState } from '@wordpress/element';
 import BlockPopoverInbetween from '../block-popover/inbetween';
 import ZoomOutModeInserterButton from './zoom-out-mode-inserter-button';
 import { store as blockEditorStore } from '../../store';
-import { sectionRootClientIdKey } from '../../store/private-keys';
+import { unlock } from '../../lock-unlock';
 
 function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
@@ -32,14 +32,17 @@ function ZoomOutModeInserters() {
 			getSelectedBlockClientId,
 			getHoveredBlockClientId,
 			isBlockInsertionPointVisible,
-		} = select( blockEditorStore );
-		const { [ sectionRootClientIdKey ]: root } = getSettings();
+			getSectionRootClientId,
+		} = unlock( select( blockEditorStore ) );
+
+		const root = getSectionRootClientId();
+
 		return {
 			hasSelection: !! getSelectionStart().clientId,
 			blockInsertionPoint: getBlockInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
-			sectionRootClientId: root,
+			sectionRootClientId: getSectionRootClientId(),
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
 			selectedBlockClientId: getSelectedBlockClientId(),

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -30,7 +30,6 @@ import useBlockSync from '../provider/use-block-sync';
 import { store as blockEditorStore } from '../../store';
 import useBlockDropZone from '../use-block-drop-zone';
 import { unlock } from '../../lock-unlock';
-import { sectionRootClientIdKey } from '../../store/private-keys';
 
 const EMPTY_OBJECT = {};
 
@@ -204,7 +203,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockEditingMode,
 				getBlockSettings,
 				isDragging,
-				getSettings,
+				getSectionRootClientId,
 			} = unlock( select( blockEditorStore ) );
 			let _isDropZoneDisabled;
 
@@ -226,8 +225,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				// In zoom out mode, we want to disable the drop zone for the sections.
 				// The inner blocks belonging to the section drop zone is
 				// already disabled by the blocks themselves being disabled.
-				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
-					getSettings();
+				const sectionRootClientId = getSectionRootClientId();
 
 				_isDropZoneDisabled = clientId !== sectionRootClientId;
 			}

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -24,7 +24,6 @@ import {
 } from '../../utils/math';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { sectionRootClientIdKey } from '../../store/private-keys';
 
 const THRESHOLD_DISTANCE = 30;
 const MINIMUM_HEIGHT_FOR_THRESHOLD = 120;
@@ -314,8 +313,8 @@ export default function useBlockDropZone( {
 		getAllowedBlocks,
 		isDragging,
 		isGroupable,
-		getSettings,
 		isZoomOutMode,
+		getSectionRootClientId,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
 		showInsertionPoint,
@@ -361,8 +360,7 @@ export default function useBlockDropZone( {
 					return;
 				}
 
-				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
-					getSettings();
+				const sectionRootClientId = getSectionRootClientId();
 
 				// In Zoom Out mode, if the target is not the section root provided by settings then
 				// do not allow dropping as the drop target is not within the root (that which is
@@ -494,6 +492,8 @@ export default function useBlockDropZone( {
 				getBlockNamesByClientId,
 				getDraggedBlockClientIds,
 				getBlockType,
+				getSectionRootClientId,
+				isZoomOutMode,
 				getBlocks,
 				getBlockListSettings,
 				dropZoneElement,
@@ -506,8 +506,6 @@ export default function useBlockDropZone( {
 				isGroupable,
 				getBlockVariations,
 				getGroupingBlockName,
-				getSettings,
-				isZoomOutMode,
 			]
 		),
 		200

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -34,9 +34,6 @@ import {
 	__experimentalUpdateSettings,
 	privateRemoveBlocks,
 } from './private-actions';
-import { STORE_NAME } from './constants';
-
-import { sectionRootClientIdKey } from './private-keys';
 
 /** @typedef {import('../components/use-on-block-drop/types').WPDropOperation} WPDropOperation */
 
@@ -1671,13 +1668,12 @@ export const setNavigationMode =
  */
 export const __unstableSetEditorMode =
 	( mode ) =>
-	( { dispatch, select, registry } ) => {
+	( { dispatch, select } ) => {
 		// When switching to zoom-out mode, we need to select the parent section
 		if ( mode === 'zoom-out' ) {
 			const firstSelectedClientId = select.getBlockSelectionStart();
-			const { [ sectionRootClientIdKey ]: sectionRootClientId } = registry
-				.select( STORE_NAME )
-				.getSettings();
+
+			const sectionRootClientId = select.getSectionRootClientId();
 
 			if ( firstSelectedClientId ) {
 				let sectionClientId;

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -28,6 +28,7 @@ import { unlock } from '../lock-unlock';
 import {
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
+	sectionRootClientIdKey,
 } from './private-keys';
 
 export { getBlockSettings } from './get-block-settings';
@@ -545,6 +546,5 @@ export function isZoomOutMode( state ) {
 }
 
 export function getSectionRootClientId( state ) {
-	const sectionRootClientIdKey = 'sectionRootClientId';
 	return state.settings[ sectionRootClientIdKey ] ?? null;
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -543,3 +543,8 @@ export const getBlockStyles = createSelector(
 export function isZoomOutMode( state ) {
 	return state.editorMode === 'zoom-out';
 }
+
+export function getSectionRootClientId( state ) {
+	const sectionRootClientIdKey = 'sectionRootClientId';
+	return state.settings[ sectionRootClientIdKey ] ?? null;
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -546,5 +546,5 @@ export function isZoomOutMode( state ) {
 }
 
 export function getSectionRootClientId( state ) {
-	return state.settings[ sectionRootClientIdKey ] ?? null;
+	return state.settings?.[ sectionRootClientIdKey ];
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -37,9 +37,8 @@ import {
 	getContentLockingParent,
 	getTemporarilyEditingAsBlocks,
 	getTemporarilyEditingFocusModeToRevert,
+	getSectionRootClientId,
 } from './private-selectors';
-
-import { sectionRootClientIdKey } from './private-keys';
 
 /**
  * A block selection object.
@@ -2061,9 +2060,7 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 								let sectionRootClientId;
 								try {
 									sectionRootClientId =
-										getSettings( state )[
-											sectionRootClientIdKey
-										];
+										getSectionRootClientId( state );
 								} catch ( e ) {}
 								if (
 									sectionRootClientId &&
@@ -2841,8 +2838,7 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 
 	// In zoom-out mode, the block overlay is always active for section level blocks.
 	if ( editorMode === 'zoom-out' ) {
-		const { [ sectionRootClientIdKey ]: sectionRootClientId } =
-			getSettings( state );
+		const sectionRootClientId = getSectionRootClientId( state );
 		if ( sectionRootClientId ) {
 			const sectionClientIds = getBlockOrder(
 				state,
@@ -2935,8 +2931,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			// sections.
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'zoom-out' ) {
-				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
-					getSettings( state );
+				const sectionRootClientId = getSectionRootClientId( state );
 
 				if ( clientId === '' /* ROOT_CONTAINER_CLIENT_ID */ ) {
 					return sectionRootClientId ? 'disabled' : 'contentOnly';

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -18,9 +18,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 
-const { PrivateInserterLibrary, sectionRootClientIdKey } = unlock(
-	blockEditorPrivateApis
-);
+const { PrivateInserterLibrary } = unlock( blockEditorPrivateApis );
 
 export default function InserterSidebar() {
 	const {
@@ -40,14 +38,14 @@ export default function InserterSidebar() {
 			getBlockInsertionPoint,
 			getBlockRootClientId,
 			__unstableGetEditorMode,
-			getSettings,
-		} = select( blockEditorStore );
+			getSectionRootClientId,
+		} = unlock( select( blockEditorStore ) );
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const getBlockSectionRootClientId = () => {
 			if ( __unstableGetEditorMode() === 'zoom-out' ) {
-				const { [ sectionRootClientIdKey ]: sectionRootClientId } =
-					getSettings();
+				const sectionRootClientId = getSectionRootClientId();
+
 				if ( sectionRootClientId ) {
 					return sectionRootClientId;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Normalizes access to `sectionRootClientId` to a single private selector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Designed as a "code quality" fix. We have two options for improving the privacy of this property:

- https://github.com/WordPress/gutenberg/pull/65000
- https://github.com/WordPress/gutenberg/pull/64544

No matter which option we go with we'll want to normalize access to a single selector. This PR does that.

This PR is designed to be merged _after_ one of the above PRs has been merged.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Creates a single private selector to access the `sectionRootClientId`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


Same as https://github.com/WordPress/gutenberg/pull/65000. Basically "does Zoom Out mode still work" as per `trunk`?

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
