### PR TITLE
Block Bindings: Add warning in attributes connected to invalid sources

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -102,12 +102,12 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 			<Truncate>{ attribute }</Truncate>
 			{ !! binding && (
 				<Text
-					variant={ ! isUndefined && 'muted' }
+					variant={ ! isSourceInvalid && 'muted' }
 					className="block-editor-bindings__item-explanation"
-					isDestructive={ isUndefined }
+					isDestructive={ isSourceInvalid }
 				>
 					<Truncate>
-						{ ! sourceProps
+						{ isSourceInvalid
 							? __( 'Invalid source' )
 							: args?.key || sourceProps?.label || sourceName }
 					</Truncate>

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -96,7 +96,7 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 	const { source: sourceName, args } = binding || {};
 	const sourceProps =
 		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
-	const isUndefined = ! sourceProps;
+	const isSourceInvalid = ! sourceProps;
 	return (
 		<VStack>
 			<Truncate>{ attribute }</Truncate>

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -96,16 +96,20 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 	const { source: sourceName, args } = binding || {};
 	const sourceProps =
 		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
+	const isUndefined = ! sourceProps;
 	return (
 		<VStack>
 			<Truncate>{ attribute }</Truncate>
 			{ !! binding && (
 				<Text
-					variant="muted"
+					variant={ ! isUndefined && 'muted' }
 					className="block-editor-bindings__item-explanation"
+					isDestructive={ isUndefined }
 				>
 					<Truncate>
-						{ args?.key || sourceProps?.label || sourceName }
+						{ ! sourceProps
+							? __( 'Invalid source' )
+							: args?.key || sourceProps?.label || sourceName }
 					</Truncate>
 				</Text>
 			) }


### PR DESCRIPTION
## What?
Alternative to https://github.com/WordPress/gutenberg/pull/64893

Instead of stopping the rendering of the block, just shows the default content and add a warning message in the connections panel.

## Why?
It is less invasive, especially for use cases where the invalid attribute wouldn't break the block.

## How?
I'm just checking if the source exists and, if not, change the message and add the `isDestructive` property of the `Text` component.

## Testing Instructions
1. Go to a page and insert a paragraph connected to an undefined source.
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/undefined"}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
2. Check that the warning is shown.
![Screenshot 2024-09-03 at 14 16 00](https://github.com/user-attachments/assets/8c7c2801-35ac-407e-9a5e-a24c7f423606)

3. Check the paragraph still shows the default content.

You can repeat the process with an image with multiple attributes:

```html
<!-- wp:image {"metadata":{"bindings":{"url":{"source":"core/undefined"},"alt":{"source":"core/undefined"},"title":{"source":"core/undefined"}}}} -->
<figure class="wp-block-image"><img alt=""/></figure>
<!-- /wp:image -->
```


