### PR TITLE
Improve DataForm performance

### DIFF
--- a/packages/dataviews/src/dataform-controls/datetime.tsx
+++ b/packages/dataviews/src/dataform-controls/datetime.tsx
@@ -10,13 +10,12 @@ import { useCallback } from '@wordpress/element';
 import type { DataFormControlProps } from '../types';
 
 export default function DateTime< Item >( {
-	data,
+	value,
 	field,
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label } = field;
-	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
 		( newValue: string | null ) => onChange( { [ id ]: newValue } ),

--- a/packages/dataviews/src/dataform-controls/integer.tsx
+++ b/packages/dataviews/src/dataform-controls/integer.tsx
@@ -10,13 +10,12 @@ import { useCallback } from '@wordpress/element';
 import type { DataFormControlProps } from '../types';
 
 export default function Integer< Item >( {
-	data,
+	value,
 	field,
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label, description } = field;
-	const value = field.getValue( { item: data } ) ?? '';
 	const onChangeControl = useCallback(
 		( newValue: string | undefined ) =>
 			onChange( {
@@ -29,7 +28,7 @@ export default function Integer< Item >( {
 		<NumberControl
 			label={ label }
 			help={ description }
-			value={ value }
+			value={ value ?? '' }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize
 			hideLabelFromVision={ hideLabelFromVision }

--- a/packages/dataviews/src/dataform-controls/radio.tsx
+++ b/packages/dataviews/src/dataform-controls/radio.tsx
@@ -10,13 +10,12 @@ import { useCallback } from '@wordpress/element';
 import type { DataFormControlProps } from '../types';
 
 export default function Radio< Item >( {
-	data,
+	value,
 	field,
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label } = field;
-	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
 		( newValue: string ) =>

--- a/packages/dataviews/src/dataform-controls/select.tsx
+++ b/packages/dataviews/src/dataform-controls/select.tsx
@@ -11,13 +11,12 @@ import { __ } from '@wordpress/i18n';
 import type { DataFormControlProps } from '../types';
 
 export default function Select< Item >( {
-	data,
+	value,
 	field,
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label } = field;
-	const value = field.getValue( { item: data } ) ?? '';
 	const onChangeControl = useCallback(
 		( newValue: any ) =>
 			onChange( {
@@ -41,7 +40,7 @@ export default function Select< Item >( {
 	return (
 		<SelectControl
 			label={ label }
-			value={ value }
+			value={ value ?? '' }
 			options={ elements }
 			onChange={ onChangeControl }
 			__next40pxDefaultSize

--- a/packages/dataviews/src/dataform-controls/text.tsx
+++ b/packages/dataviews/src/dataform-controls/text.tsx
@@ -10,13 +10,12 @@ import { useCallback } from '@wordpress/element';
 import type { DataFormControlProps } from '../types';
 
 export default function Text< Item >( {
-	data,
+	value,
 	field,
 	onChange,
 	hideLabelFromVision,
 }: DataFormControlProps< Item > ) {
 	const { id, label, placeholder } = field;
-	const value = field.getValue( { item: data } );
 
 	const onChangeControl = useCallback(
 		( newValue: string ) =>

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -122,7 +122,7 @@ function FormField< Item >( {
 							/>
 							<field.Edit
 								key={ field.id }
-								data={ data }
+								value={ field.getValue( { item: data } ) }
 								field={ field }
 								onChange={ onChange }
 								hideLabelFromVision

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -16,9 +16,12 @@ type MemoizedFieldEditProps< Item > = {
 	onChange: Pick< DataFormProps< Item >, 'onChange' >[ 'onChange' ];
 };
 
-const MemoizedFieldEdit = memo( ( { field, value, onChange } ) => (
-	<field.Edit value={ value } field={ field } onChange={ onChange } />
-) ) as < Item >( props: MemoizedFieldEditProps< Item > ) => JSX.Element;
+const MemoizedFieldEdit = memo(
+	( { field, value, onChange } ) => (
+		<field.Edit value={ value } field={ field } onChange={ onChange } />
+	),
+	( prevProps, nextProps ) => prevProps.value === nextProps.value
+) as < Item >( props: MemoizedFieldEditProps< Item > ) => JSX.Element;
 
 export default function FormRegular< Item >( {
 	data,

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -11,7 +11,7 @@ import { normalizeFields } from '../../normalize-fields';
 import type { DataFormProps, Field, NormalizedField } from '../../types';
 
 type MemoizedFieldEditProps< Item > = {
-	value: any;
+	value: Item[ keyof Item ];
 	field: NormalizedField< Item >;
 	onChange: Pick< DataFormProps< Item >, 'onChange' >[ 'onChange' ];
 };

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -11,22 +11,14 @@ import { normalizeFields } from '../../normalize-fields';
 import type { DataFormProps, Field, NormalizedField } from '../../types';
 
 type MemoizedFieldEditProps< Item > = {
-	data: Item;
+	value: any;
 	field: NormalizedField< Item >;
 	onChange: Pick< DataFormProps< Item >, 'onChange' >[ 'onChange' ];
 };
 
-const MemoizedFieldEdit = memo(
-	( { field, data, onChange } ) => (
-		<field.Edit data={ data } field={ field } onChange={ onChange } />
-	),
-	( prevProps, nextProps ) => {
-		const prev = prevProps.field.getValue( { item: prevProps.data } );
-		const next = nextProps.field.getValue( { item: nextProps.data } );
-
-		return prev === next;
-	}
-) as < Item >( props: MemoizedFieldEditProps< Item > ) => JSX.Element;
+const MemoizedFieldEdit = memo( ( { field, value, onChange } ) => (
+	<field.Edit value={ value } field={ field } onChange={ onChange } />
+) ) as < Item >( props: MemoizedFieldEditProps< Item > ) => JSX.Element;
 
 export default function FormRegular< Item >( {
 	data,
@@ -52,7 +44,7 @@ export default function FormRegular< Item >( {
 				return (
 					<MemoizedFieldEdit
 						key={ field.id }
-						data={ data }
+						value={ field.getValue( { item: data } ) }
 						field={ field }
 						onChange={ onChange }
 					/>

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -2,13 +2,31 @@
  * WordPress dependencies
  */
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { memo, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { normalizeFields } from '../../normalize-fields';
-import type { DataFormProps, Field } from '../../types';
+import type { DataFormProps, Field, NormalizedField } from '../../types';
+
+type MemoizedFieldEditProps< Item > = {
+	data: Item;
+	field: NormalizedField< Item >;
+	onChange: Pick< DataFormProps< Item >, 'onChange' >[ 'onChange' ];
+};
+
+const MemoizedFieldEdit = memo(
+	( { field, data, onChange } ) => (
+		<field.Edit data={ data } field={ field } onChange={ onChange } />
+	),
+	( prevProps, nextProps ) => {
+		const prev = prevProps.field.getValue( { item: prevProps.data } );
+		const next = nextProps.field.getValue( { item: nextProps.data } );
+
+		return prev === next;
+	}
+) as < Item >( props: MemoizedFieldEditProps< Item > ) => JSX.Element;
 
 export default function FormRegular< Item >( {
 	data,
@@ -32,7 +50,7 @@ export default function FormRegular< Item >( {
 		<VStack spacing={ 4 }>
 			{ visibleFields.map( ( field ) => {
 				return (
-					<field.Edit
+					<MemoizedFieldEdit
 						key={ field.id }
 						data={ data }
 						field={ field }

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -2,13 +2,31 @@
  * WordPress dependencies
  */
 import { __experimentalVStack as VStack } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
+import { memo, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { normalizeFields } from '../../normalize-fields';
-import type { DataFormProps, Field } from '../../types';
+import type { DataFormProps, Field, NormalizedField } from '../../types';
+
+type MemoizedFieldEditProps< Item > = {
+	data: Item;
+	field: NormalizedField< Item >;
+	onChange: Pick< DataFormProps< Item >, 'onChange' >[ 'onChange' ];
+};
+
+const MemoizedFieldEdit = memo(
+	( { field, data, onChange } ) => (
+		<field.Edit data={ data } field={ field } onChange={ onChange } />
+	),
+	( prevProps, nextProps ) => {
+		const prev = prevProps.field.getValue( { item: prevProps.data } );
+		const next = nextProps.field.getValue( { item: nextProps.data } );
+
+		return prev === next;
+	}
+) as < Item >( props: MemoizedFieldEditProps< Item > ) => JSX.Element;
 
 export default function FormRegular< Item >( {
 	data,
@@ -32,11 +50,11 @@ export default function FormRegular< Item >( {
 		<VStack spacing={ 4 }>
 			{ visibleFields.map( ( field ) => {
 				return (
-					<field.Edit
-						key={ field.id }
-						data={ data }
+					<MemoizedFieldEdit
 						field={ field }
+						data={ data }
 						onChange={ onChange }
+						key={ field.id }
 					/>
 				);
 			} ) }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -181,8 +181,8 @@ export type Form = {
 };
 
 export type DataFormControlProps< Item > = {
-	data: Item;
 	field: NormalizedField< Item >;
+	value: any;
 	onChange: ( value: Record< string, any > ) => void;
 	hideLabelFromVision?: boolean;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

While investigating the DataView/DataForm related to [WooCommerce issue #50992](https://github.com/woocommerce/woocommerce/issues/50992), I found that the dataform component in the regular view re-renders in its entirety whenever the onChange function is triggered. To enhance performance, this PR addresses the issue by ensuring that only the specific input that has changed is re-rendered, rather than the entire component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This PR is necessary because re-rendering the entire component on every change can lead to performance bottlenecks, especially in long forms or those with slow components. For example, I simulated a slow edit component for the title field and observed significant performance improvements with this patch compared to without it.

You can verify that even the title field component is slow, this doesn't impact the speed of the other fields.


| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/b154a47f-1f9e-4500-87c9-1ec855b31c52" /> | <video src="https://github.com/user-attachments/assets/22139cfa-7a69-477a-be30-5dc1168f3d14" /> | 




## Testing Instructions

1. Checkout trunk
2. Edit the `packages/dataviews/src/dataform-controls/text.tsx` file adding this function at top of the file:

```js
function slowFunction() {
	// Simulate a CPU-intensive task
	const start = performance.now();
	while ( performance.now() - start < 1000 ) {
		// This loop runs for 1 second, simulating a slow computation
	}
	return;
}
```

In the `Text` component invoke this function:

```js
export default function Text< Item >( {
	data,
	field,
	onChange,
	hideLabelFromVision,
}: DataFormControlProps< Item > ) {
	const { id, label, placeholder } = field;
	const value = field.getValue( { item: data } );

	slowFunction();

	const onChangeControl = useCallback(
		( newValue: string ) =>
			onChange( {
				[ id ]: newValue,
			} ),
		[ id, onChange ]
	);
```

3. Run Storybook ( `npm run storybook:dev`).
4. Check the `DataForm` story.
5. Try to update the title input.
6. Ensure that the title input is slow.
7. Edit other fields.
8. Expect that other fields are slow.
9. Checkout this branch (keep the changes)
10. Check the `DataForm` story.
11. Try to update the title input.
12. Ensure that the title input is slow.
13. Edit other fields.
14. Expect that other fields aren't slow

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
