### PR TITLE
Block Bindings: Rely on `Text` component instead of `Truncate` in bindings panel

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -9,7 +9,6 @@ import {
 	__experimentalText as Text,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
-	__experimentalTruncate as Truncate,
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
@@ -98,19 +97,17 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
 	return (
-		<VStack>
-			<Truncate>{ attribute }</Truncate>
+		<VStack className="block-editor-bindings__item">
+			<Text truncate>{ attribute }</Text>
 			{ !! binding && (
 				<Text
+					truncate
 					variant={ ! isSourceInvalid && 'muted' }
-					className="block-editor-bindings__item-explanation"
 					isDestructive={ isSourceInvalid }
 				>
-					<Truncate>
-						{ isSourceInvalid
-							? __( 'Invalid source' )
-							: args?.key || sourceProps?.label || sourceName }
-					</Truncate>
+					{ isSourceInvalid
+						? __( 'Invalid source' )
+						: args?.key || sourceProps?.label || sourceName }
 				</Text>
 			) }
 		</VStack>

--- a/packages/block-editor/src/hooks/block-bindings.scss
+++ b/packages/block-editor/src/hooks/block-bindings.scss
@@ -1,6 +1,6 @@
 div.block-editor-bindings__panel {
 	grid-template-columns: repeat(auto-fit, minmax(100%, 1fr));
-	button:hover .block-editor-bindings__item-explanation {
+	button:hover .block-editor-bindings__item span {
 		color: inherit;
 	}
 }


### PR DESCRIPTION
## What?
Remove usage of `Truncate` component and rely on `Text` component with `truncate` prop in the bindings panel.

## Why?
It seems `Truncate` is not needed, and it will help with style consistency. It should palliate the issue mentioned [here](https://github.com/WordPress/gutenberg/pull/65002#issuecomment-2326448376). And if `Text` styles change in the future, it will just work as expected.

Additionally, it removes an extra `span` from the HTML.

## How?
Using the `truncate` prop of the `Text` component.

## Testing Instructions
1. Go to a page and insert a paragraph connected to post meta with a long key.
```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong"}}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
2. Check that the text is truncated.
3. Inspect the elements and check that the attribute line height is the same as the key line height.