### PR TITLE
Site Logo Block: Fix non-admin users seeing zero character

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -423,7 +423,7 @@ export default function LogoEdit( {
 				context: 'view',
 			} );
 		const _isRequestingMediaItem =
-			_siteLogoId &&
+			!! _siteLogoId &&
 			! select( coreStore ).hasFinishedResolution( 'getMedia', [
 				_siteLogoId,
 				{ context: 'view' },


### PR DESCRIPTION
Follow-up #64919

## What?

This PR prevents non-admins from seeing the string "0" in the Site Logo block if no logo is set.

![image](https://github.com/user-attachments/assets/2c761a75-bd7f-4c34-8007-3a35bc2d59f3)

## Why?

This PR only contains a two-character change, but I'll explain why step by step.

Here we get the site data. If the site logo has not yet been applied and we are not an non-admin user, `siteData?.site_logo` will have `0`:

https://github.com/WordPress/gutenberg/blob/18164f0fcd09a282157f02bba7fd737012cc44fd/packages/block-library/src/site-logo/edit.js#L416-L418

Next, we check whether the media is being retrieved. `_siteLogoId` is `0`, a falsy value. Due to the rules of logical operators, a short-circuit evaluation is performed and the value on the left-hand side is returned unchanged, so `_isRequestingMediaItem` has a `0` value. Ideally, the left-hand side should be converted to a Boolean value here:

https://github.com/WordPress/gutenberg/blob/18164f0fcd09a282157f02bba7fd737012cc44fd/packages/block-library/src/site-logo/edit.js#L425-L430

As a result, `isLoading` here will have the following formula. Since the left side does not evaluate to a match, the right side, which is `0`, is returned:

```javascript
const isLoading = 0 === undefined || 0;
```

https://github.com/WordPress/gutenberg/blob/18164f0fcd09a282157f02bba7fd737012cc44fd/packages/block-library/src/site-logo/edit.js#L538

Here the spinner is rendered:

https://github.com/WordPress/gutenberg/blob/18164f0fcd09a282157f02bba7fd737012cc44fd/packages/block-library/src/site-logo/edit.js#L659-L665

Since `isLoading` is `0`, it short-circuits and expands to this:

```jsx
<Placeholder className="site-logo_placeholder" withIllustration>
	0
</Placeholder>
```

## How?

Since `_isRequestingMediaItem` is expected to be a boolean value, I explicitly converted `_siteLogoId` in the conditional expression to a boolean type. This problem was inherently there, but thankfully it was brought to light by #64919.

## Testing Instructions

- Insert a Site Logo.
- Log in as a non-admin user and open the page.
- The `0` will not be displayed.
