### PR TITLE
Add --silent option to wp-env run

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Add `--silent` option to `run` command to omit command tips and spinner text. This avoids needing to send that text to STDERR.
+
 ## 10.6.0 (2024-08-21)
 
 ## 10.5.0 (2024-08-07)

--- a/packages/env/lib/commands/run.js
+++ b/packages/env/lib/commands/run.js
@@ -25,6 +25,7 @@ const getHostUser = require( '../get-host-user' );
  * @param {string}   options.envCwd    The working directory for the command to be executed from.
  * @param {Object}   options.spinner   A CLI spinner which indicates progress.
  * @param {boolean}  options.debug     True if debug mode is enabled.
+ * @param {boolean}  options.silent    If present, the command tips and spinner text are omitted.
  */
 module.exports = async function run( {
 	container,
@@ -33,6 +34,7 @@ module.exports = async function run( {
 	envCwd,
 	spinner,
 	debug,
+	silent,
 } ) {
 	const config = await initConfig( { spinner, debug } );
 
@@ -44,7 +46,9 @@ module.exports = async function run( {
 
 	// Shows a contextual tip for the given command.
 	const joinedCommand = command.join( ' ' );
-	showCommandTips( joinedCommand, container, spinner );
+	if ( ! silent ) {
+		showCommandTips( joinedCommand, container, spinner );
+	}
 
 	await spawnCommandDirectly( config, container, command, envCwd, spinner );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a `--silent` option to `wp-env run` to omit the command tips and spinner text so that they do not need to be sent to STDERR.

## Why?

When running commands with `wp-env run`, the additional commands tips and spinner text can interfere when wanting to obtain the output in scripts.

For example:

```
$ npm run wp-env -- run cli -- wp option get blogname

> wp-env
> wp-env run cli -- wp option get blogname

ℹ Starting 'wp option get blogname' on the cli container. 

gutenberg
✔ Ran `wp option get blogname` in 'cli'. (in 0s 884ms)
```

The first two lines of output can be omitted by using npm's `--silent` option:

```
$ npm run --silent -- wp-env run cli -- wp option get blogname

ℹ Starting 'wp option get blogname' on the cli container. 

gutenberg
✔ Ran `wp option get blogname` in 'cli'. (in 0s 683ms)
```

But the other output currently has to be suppressed by routing to STDERR:

```
$ npm run --silent -- wp-env run cli -- wp option get blogname 2>/dev/null
gutenberg
```

It could be that commands running in the container output their own content to STDERR, which would cause that to get thrown away as well. (Nevertheless, it seems that STDOUT and STDERR are both combined into STDOUT at present, see https://github.com/WordPress/gutenberg/issues/65016.) So I suggest that `wp-env run` also take a `--silent` option to avoid needing to do this:

```
$ npm run --silent -- wp-env run --silent cli -- wp option get blogname
gutenberg
```

Note: the additional `--` arguments are required to prevent `--silent` from being picked up by `npm`. This being the case, perhaps `--quiet` would be better?