### PR TITLE
UnitControl: Move to stricter lint rule for 40px size adherence

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -330,6 +330,7 @@ module.exports = {
 						'SelectControl',
 						'TextControl',
 						'ToggleGroupControl',
+						'UnitControl',
 					].map( ( componentName ) => ( {
 						// Falsy `__next40pxDefaultSize` without a non-default `size` prop.
 						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
@@ -345,7 +346,7 @@ module.exports = {
 							'FormFileUpload should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
 					},
 					// Temporary rules until all existing components have the `__next40pxDefaultSize` prop.
-					...[ 'Button', 'UnitControl' ].map( ( componentName ) => ( {
+					...[ 'Button' ].map( ( componentName ) => ( {
 						// Not strict. Allows pre-existing __next40pxDefaultSize={ false } usage until they are all manually updated.
 						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"])):not(:has(JSXAttribute[name.name="size"]))`,
 						message:


### PR DESCRIPTION
Follow-up to #64981
Part of #63871

## What?

Moves `UnitControl` to the stricter lint rule for adherence to the 40px default size.

## Why?

The last remaining violation was fixed in #64981.

## Testing Instructions

✅ `npm run lint:js -- --quiet` passes
