### PR TITLE
feat: Add parameter to display featured image caption

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -643,7 +643,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, displayCaption, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -55,6 +55,10 @@
 		"useFirstImageFromPost": {
 			"type": "boolean",
 			"default": false
+		},
+		"displayCaption": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "postId", "postType", "queryId" ],

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -38,13 +38,17 @@ import { store as noticesStore } from '@wordpress/notices';
 import DimensionControls from './dimension-controls';
 import OverlayControls from './overlay-controls';
 import Overlay from './overlay';
+import { Caption } from '../utils/caption';
 
 const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 function getMediaSourceUrlBySizeSlug( media, slug ) {
-	return (
-		media?.media_details?.sizes?.[ slug ]?.source_url || media?.source_url
-	);
+	return {
+		mediaUrl:
+			media?.media_details?.sizes?.[ slug ]?.source_url ||
+			media?.source_url,
+		mediaCaption: media?.caption?.rendered,
+	};
 }
 
 const disabledClickProps = {
@@ -69,7 +73,9 @@ export default function PostFeaturedImageEdit( {
 		rel,
 		linkTarget,
 		useFirstImageFromPost,
+		displayCaption,
 	} = attributes;
+
 	const [ temporaryURL, setTemporaryURL ] = useState();
 
 	const [ storedFeaturedImage, setFeaturedImage ] = useEntityProp(
@@ -128,7 +134,10 @@ export default function PostFeaturedImageEdit( {
 		[ featuredImage, postTypeSlug, postId ]
 	);
 
-	const mediaUrl = getMediaSourceUrlBySizeSlug( media, sizeSlug );
+	const { mediaUrl, mediaCaption } = getMediaSourceUrlBySizeSlug(
+		media,
+		sizeSlug
+	);
 
 	const blockProps = useBlockProps( {
 		style: { width, height, aspectRatio },
@@ -239,6 +248,14 @@ export default function PostFeaturedImageEdit( {
 							/>
 						</>
 					) }
+					<ToggleControl
+						__nextHasNoMarginBottom
+						label={ __( 'Display Caption' ) }
+						onChange={ ( value ) =>
+							setAttributes( { displayCaption: value } )
+						}
+						checked={ displayCaption }
+					/>
 				</PanelBody>
 			</InspectorControls>
 		</>
@@ -383,6 +400,14 @@ export default function PostFeaturedImageEdit( {
 					</a>
 				) : (
 					image
+				) }
+				{ !! displayCaption && (
+					<Caption
+						attributes={ { caption: mediaCaption } }
+						setAttributes={ setAttributes }
+						label={ __( 'Image caption text' ) }
+						readOnly="true"
+					/>
 				) }
 				<Overlay
 					attributes={ attributes }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -21,11 +21,11 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	}
 	$post_ID = $block->context['postId'];
 
-	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];
-	$display_caption       = isset( $attributes['displayCaption'] ) && $attributes['displayCaption'];
-	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
-	$attr           = get_block_core_post_featured_image_border_attributes( $attributes );
-	$overlay_markup = get_block_core_post_featured_image_overlay_element_markup( $attributes );
+	$is_link         = isset( $attributes['isLink'] ) && $attributes['isLink'];
+	$display_caption = isset( $attributes['displayCaption'] ) && $attributes['displayCaption'];
+	$size_slug       = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
+	$attr            = get_block_core_post_featured_image_border_attributes( $attributes );
+	$overlay_markup  = get_block_core_post_featured_image_overlay_element_markup( $attributes );
 
 	if ( $is_link ) {
 		if ( get_the_title( $post_ID ) ) {
@@ -114,9 +114,9 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	} else {
 		$featured_image = $featured_image . $overlay_markup;
 	}
-	
-	if ($display_caption) {
-		$caption = get_the_post_thumbnail_caption( $post_ID );
+
+	if ( $display_caption ) {
+		$caption         = get_the_post_thumbnail_caption( $post_ID );
 		$featured_image .= sprintf(
 			'<figcaption class="wp-element-caption">%1$s</figcaption>',
 			$caption

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -22,6 +22,7 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$post_ID = $block->context['postId'];
 
 	$is_link        = isset( $attributes['isLink'] ) && $attributes['isLink'];
+	$display_caption       = isset( $attributes['displayCaption'] ) && $attributes['displayCaption'];
 	$size_slug      = isset( $attributes['sizeSlug'] ) ? $attributes['sizeSlug'] : 'post-thumbnail';
 	$attr           = get_block_core_post_featured_image_border_attributes( $attributes );
 	$overlay_markup = get_block_core_post_featured_image_overlay_element_markup( $attributes );
@@ -112,6 +113,14 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 		);
 	} else {
 		$featured_image = $featured_image . $overlay_markup;
+	}
+	
+	if ($display_caption) {
+		$caption = get_the_post_thumbnail_caption( $post_ID );
+		$featured_image .= sprintf(
+			'<figcaption class="wp-element-caption">%1$s</figcaption>',
+			$caption
+		);
 	}
 
 	$aspect_ratio = ! empty( $attributes['aspectRatio'] )

--- a/test/integration/fixtures/blocks/core__post-featured-image.json
+++ b/test/integration/fixtures/blocks/core__post-featured-image.json
@@ -8,7 +8,8 @@
 			"rel": "",
 			"linkTarget": "_self",
 			"dimRatio": 0,
-			"useFirstImageFromPost": false
+			"useFirstImageFromPost": false,
+			"displayCaption": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add an option to display caption on featured image block

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Closes #40946 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added a new toggle control to display featured image caption

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Upload an image
2. Add a caption to the image
3. Open a post or page
4. Set the featured image to the image you've just uploaded
5. Enable "Display caption"

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![displaycaption](https://github.com/user-attachments/assets/1929f044-cdcd-4d64-adaf-6291d4b41cc7)

