### PR TITLE
Page editor: double-click to edit template part 

### DIFF
--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -100,6 +100,12 @@ function EditableTemplatePartInnerBlocks( {
 	tagName: TagName,
 	blockProps,
 } ) {
+	const onNavigateToEntityRecord = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+		[]
+	);
+
 	const [ blocks, onInput, onChange ] = useEntityBlockEditor(
 		'postType',
 		'wp_template_part',
@@ -114,7 +120,20 @@ function EditableTemplatePartInnerBlocks( {
 		layout: useLayout( layout ),
 	} );
 
-	return <TagName { ...innerBlocksProps } />;
+	const blockEditingMode = useBlockEditingMode();
+
+	const customProps =
+		blockEditingMode === 'contentOnly' && onNavigateToEntityRecord
+			? {
+					onDoubleClick: () =>
+						onNavigateToEntityRecord( {
+							postId: id,
+							postType: 'wp_template_part',
+						} ),
+			  }
+			: {};
+
+	return <TagName { ...innerBlocksProps } { ...customProps } />;
 }
 
 export default function TemplatePartInnerBlocks( {

--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -61,7 +61,6 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			) {
 				return;
 			}
-			event.stopImmediatePropagation();
 			setIsDialogOpen( true );
 		};
 

--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -55,9 +55,13 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 				return;
 			}
 
-			if ( ! event.target.classList.contains( 'is-root-container' ) ) {
+			if (
+				! event.target.classList.contains( 'is-root-container' ) ||
+				event.target.dataset?.type === 'core/template-part'
+			) {
 				return;
 			}
+			event.stopImmediatePropagation();
 			setIsDialogOpen( true );
 		};
 


### PR DESCRIPTION

(Possibly) Resolves https://github.com/WordPress/gutenberg/issues/63305

## What? How?

> [!NOTE]
> This PR affects both the post and site editors when editing a post/page template. Should it be restricted to the site editor?

1. Adds a doubleclick handler to template part block if the content has `contentOnly` editing mode. 
2. Also tightens up the doubleclick handler that triggers the edit template modal.

## Why?

1. To make it easier to edit a template part when editing a page/post.
2. The modal should not trigger when clicking on template parts now that there's a second double click handler.  Furthermore, let's stopImmediatePropagation if the modal popups successful.


## Testing Instructions

### Site Editor

1. As admin, head to the site editor and edit a page. Double click on any of the template parts in the page. 
2. You should be taken to focussed edit view for that template part
3. Add or create another template part and try it again.
4. Back to editing the page, click outside the content area and check that the template edit modal appears.

### Post Editor

1. As admin, head to the post editor and edit a post/page. 
2. In the post settings on the right-hand side, click on the template and then click again on "Show template"
3. Double click on any of the template parts in the page. 
5. You should be taken to focussed edit view for that template part.
6. Back to editing the page, click outside the content area and check that the template edit modal appears.

For bonus points, log-in as an editor/author and ensure you can't do any of this.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

## Site editor

https://github.com/user-attachments/assets/b0ad467c-71a3-4312-83ff-8bc54c3b2ea3


### Post editor

https://github.com/user-attachments/assets/9c5aa78e-3bb5-4a98-9c30-2c12e9832807




