### PR TITLE
Refactor date picker to make components reusable for date range picker

### DIFF
--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -1,0 +1,140 @@
+/**
+ * External dependencies
+ */
+import {
+	isSameDay,
+	subMonths,
+	addMonths,
+	startOfDay,
+	isEqual,
+	addDays,
+	subWeeks,
+	addWeeks,
+	isSameMonth,
+	startOfWeek,
+	endOfWeek,
+} from 'date-fns';
+
+/**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import Day from './day';
+import { Calendar as StyledCalendar, DayOfWeek } from './styles';
+
+type CalendarProps = {
+	calendar: Date[][][];
+	isInvalidDate?: ( date: Date ) => boolean;
+	viewing: Date;
+	isSelected: ( date: Date ) => boolean;
+	onDayClick?: ( date: Date ) => void;
+	onDayKeyDown?: ( date: Date ) => void;
+	focusable: Date;
+	events: { date: Date }[];
+};
+
+export function Calendar( {
+	calendar,
+	isInvalidDate,
+	viewing,
+	isSelected,
+	onDayClick,
+	onDayKeyDown,
+	focusable,
+	events,
+}: CalendarProps ) {
+	// Allows us to only programmatically focus() a day when focus was already
+	// within the calendar. This stops us stealing focus from e.g. a TimePicker
+	// input.
+	const [ isFocusWithinCalendar, setIsFocusWithinCalendar ] =
+		useState( false );
+
+	return (
+		<StyledCalendar
+			onFocus={ () => setIsFocusWithinCalendar( true ) }
+			onBlur={ () => setIsFocusWithinCalendar( false ) }
+		>
+			{ calendar[ 0 ][ 0 ].map( ( day ) => (
+				<DayOfWeek key={ day.toString() }>
+					{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
+				</DayOfWeek>
+			) ) }
+			{ calendar[ 0 ].map( ( week ) =>
+				week.map( ( day, index ) => {
+					if ( ! isSameMonth( day, viewing ) ) {
+						return null;
+					}
+					return (
+						<Day
+							key={ day.toString() }
+							day={ day }
+							column={ index + 1 }
+							isSelected={ isSelected( day ) }
+							isFocusable={ isEqual( day, focusable ) }
+							isFocusAllowed={ isFocusWithinCalendar }
+							isToday={ isSameDay( day, new Date() ) }
+							isInvalid={
+								isInvalidDate ? isInvalidDate( day ) : false
+							}
+							numEvents={
+								events.filter( ( event ) =>
+									isSameDay( event.date, day )
+								).length
+							}
+							onClick={ () => {
+								onDayClick?.( day );
+							} }
+							onKeyDown={ ( event ) => {
+								let nextFocusable;
+								if ( event.key === 'ArrowLeft' ) {
+									nextFocusable = addDays(
+										day,
+										isRTL() ? 1 : -1
+									);
+								}
+								if ( event.key === 'ArrowRight' ) {
+									nextFocusable = addDays(
+										day,
+										isRTL() ? -1 : 1
+									);
+								}
+								if ( event.key === 'ArrowUp' ) {
+									nextFocusable = subWeeks( day, 1 );
+								}
+								if ( event.key === 'ArrowDown' ) {
+									nextFocusable = addWeeks( day, 1 );
+								}
+								if ( event.key === 'PageUp' ) {
+									nextFocusable = subMonths( day, 1 );
+								}
+								if ( event.key === 'PageDown' ) {
+									nextFocusable = addMonths( day, 1 );
+								}
+								if ( event.key === 'Home' ) {
+									nextFocusable = startOfWeek( day );
+								}
+								if ( event.key === 'End' ) {
+									nextFocusable = startOfDay(
+										endOfWeek( day )
+									);
+								}
+								if ( nextFocusable ) {
+									event.preventDefault();
+									onDayKeyDown?.( nextFocusable );
+								}
+							} }
+						/>
+					);
+				} )
+			) }
+		</StyledCalendar>
+	);
+}
+
+export default Calendar;

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -33,6 +33,7 @@ import {
 	DayOfWeek,
 	Navigator,
 	NavigatorHeading,
+	Wrapper,
 } from './styles';
 import { TIMEZONELESS_FORMAT } from '../constants';
 import Button from '../../button';
@@ -77,7 +78,11 @@ export function Calendar( {
 		useState( false );
 
 	return (
-		<>
+		<Wrapper
+			className="components-datetime__date"
+			role="application"
+			aria-label={ __( 'Calendar' ) }
+		>
 			<Navigator>
 				{ calendarIndex === 0 && (
 					<Button
@@ -204,7 +209,7 @@ export function Calendar( {
 					} )
 				) }
 			</StyledCalendar>
-		</>
+		</Wrapper>
 	);
 }
 

--- a/packages/components/src/date-time/date/calendar.tsx
+++ b/packages/components/src/date-time/date/calendar.tsx
@@ -13,12 +13,14 @@ import {
 	isSameMonth,
 	startOfWeek,
 	endOfWeek,
+	format,
 } from 'date-fns';
 
 /**
  * WordPress dependencies
  */
-import { isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
+import { arrowLeft, arrowRight } from '@wordpress/icons';
 import { dateI18n } from '@wordpress/date';
 import { useState } from '@wordpress/element';
 
@@ -26,7 +28,14 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import Day from './day';
-import { Calendar as StyledCalendar, DayOfWeek } from './styles';
+import {
+	Calendar as StyledCalendar,
+	DayOfWeek,
+	Navigator,
+	NavigatorHeading,
+} from './styles';
+import { TIMEZONELESS_FORMAT } from '../constants';
+import Button from '../../button';
 
 type CalendarProps = {
 	calendar: Date[][][];
@@ -37,6 +46,12 @@ type CalendarProps = {
 	onDayKeyDown?: ( date: Date ) => void;
 	focusable: Date;
 	events: { date: Date }[];
+	viewPreviousMonth: () => void;
+	viewNextMonth: () => void;
+	setFocusable: React.Dispatch< React.SetStateAction< Date > >;
+	onMonthPreviewed?: ( date: string ) => void;
+	calendarIndex?: number;
+	numberOfMonths?: number;
 };
 
 export function Calendar( {
@@ -48,6 +63,12 @@ export function Calendar( {
 	onDayKeyDown,
 	focusable,
 	events,
+	viewPreviousMonth,
+	viewNextMonth,
+	setFocusable,
+	onMonthPreviewed,
+	calendarIndex = 0,
+	numberOfMonths = 1,
 }: CalendarProps ) {
 	// Allows us to only programmatically focus() a day when focus was already
 	// within the calendar. This stops us stealing focus from e.g. a TimePicker
@@ -56,84 +77,134 @@ export function Calendar( {
 		useState( false );
 
 	return (
-		<StyledCalendar
-			onFocus={ () => setIsFocusWithinCalendar( true ) }
-			onBlur={ () => setIsFocusWithinCalendar( false ) }
-		>
-			{ calendar[ 0 ][ 0 ].map( ( day ) => (
-				<DayOfWeek key={ day.toString() }>
-					{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
-				</DayOfWeek>
-			) ) }
-			{ calendar[ 0 ].map( ( week ) =>
-				week.map( ( day, index ) => {
-					if ( ! isSameMonth( day, viewing ) ) {
-						return null;
-					}
-					return (
-						<Day
-							key={ day.toString() }
-							day={ day }
-							column={ index + 1 }
-							isSelected={ isSelected( day ) }
-							isFocusable={ isEqual( day, focusable ) }
-							isFocusAllowed={ isFocusWithinCalendar }
-							isToday={ isSameDay( day, new Date() ) }
-							isInvalid={
-								isInvalidDate ? isInvalidDate( day ) : false
-							}
-							numEvents={
-								events.filter( ( event ) =>
-									isSameDay( event.date, day )
-								).length
-							}
-							onClick={ () => {
-								onDayClick?.( day );
-							} }
-							onKeyDown={ ( event ) => {
-								let nextFocusable;
-								if ( event.key === 'ArrowLeft' ) {
-									nextFocusable = addDays(
-										day,
-										isRTL() ? 1 : -1
-									);
+		<>
+			<Navigator>
+				{ calendarIndex === 0 && (
+					<Button
+						icon={ isRTL() ? arrowRight : arrowLeft }
+						variant="tertiary"
+						aria-label={ __( 'View previous month' ) }
+						onClick={ () => {
+							viewPreviousMonth();
+							setFocusable( subMonths( focusable, 1 ) );
+							onMonthPreviewed?.(
+								format(
+									subMonths( viewing, 1 ),
+									TIMEZONELESS_FORMAT
+								)
+							);
+						} }
+					/>
+				) }
+				<NavigatorHeading level={ 3 }>
+					<strong>
+						{ dateI18n(
+							'F',
+							viewing,
+							-viewing.getTimezoneOffset()
+						) }
+					</strong>{ ' ' }
+					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
+				</NavigatorHeading>
+				{ calendarIndex === numberOfMonths - 1 && (
+					<Button
+						icon={ isRTL() ? arrowLeft : arrowRight }
+						variant="tertiary"
+						aria-label={ __( 'View next month' ) }
+						onClick={ () => {
+							viewNextMonth();
+							setFocusable( addMonths( focusable, 1 ) );
+							onMonthPreviewed?.(
+								format(
+									addMonths( viewing, 1 ),
+									TIMEZONELESS_FORMAT
+								)
+							);
+						} }
+					/>
+				) }
+			</Navigator>
+			<StyledCalendar
+				onFocus={ () => setIsFocusWithinCalendar( true ) }
+				onBlur={ () => setIsFocusWithinCalendar( false ) }
+			>
+				{ calendar[ 0 ][ 0 ].map( ( day ) => (
+					<DayOfWeek key={ day.toString() }>
+						{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
+					</DayOfWeek>
+				) ) }
+				{ calendar[ 0 ].map( ( week ) =>
+					week.map( ( day, index ) => {
+						if ( ! isSameMonth( day, viewing ) ) {
+							return null;
+						}
+						return (
+							<Day
+								key={ day.toString() }
+								day={ day }
+								column={ index + 1 }
+								isSelected={ isSelected( day ) }
+								isFocusable={ isEqual( day, focusable ) }
+								isFocusAllowed={ isFocusWithinCalendar }
+								isToday={ isSameDay( day, new Date() ) }
+								isInvalid={
+									isInvalidDate ? isInvalidDate( day ) : false
 								}
-								if ( event.key === 'ArrowRight' ) {
-									nextFocusable = addDays(
-										day,
-										isRTL() ? -1 : 1
-									);
+								numEvents={
+									events.filter( ( event ) =>
+										isSameDay( event.date, day )
+									).length
 								}
-								if ( event.key === 'ArrowUp' ) {
-									nextFocusable = subWeeks( day, 1 );
-								}
-								if ( event.key === 'ArrowDown' ) {
-									nextFocusable = addWeeks( day, 1 );
-								}
-								if ( event.key === 'PageUp' ) {
-									nextFocusable = subMonths( day, 1 );
-								}
-								if ( event.key === 'PageDown' ) {
-									nextFocusable = addMonths( day, 1 );
-								}
-								if ( event.key === 'Home' ) {
-									nextFocusable = startOfWeek( day );
-								}
-								if ( event.key === 'End' ) {
-									nextFocusable = startOfDay(
-										endOfWeek( day )
-									);
-								}
-								if ( nextFocusable ) {
-									event.preventDefault();
-									onDayKeyDown?.( nextFocusable );
-								}
-							} }
-						/>
-					);
-				} )
-			) }
-		</StyledCalendar>
+								onClick={ () => {
+									setFocusable?.( day );
+									onDayClick?.( day );
+								} }
+								onKeyDown={ ( event ) => {
+									let nextFocusable;
+									if ( event.key === 'ArrowLeft' ) {
+										nextFocusable = addDays(
+											day,
+											isRTL() ? 1 : -1
+										);
+									}
+									if ( event.key === 'ArrowRight' ) {
+										nextFocusable = addDays(
+											day,
+											isRTL() ? -1 : 1
+										);
+									}
+									if ( event.key === 'ArrowUp' ) {
+										nextFocusable = subWeeks( day, 1 );
+									}
+									if ( event.key === 'ArrowDown' ) {
+										nextFocusable = addWeeks( day, 1 );
+									}
+									if ( event.key === 'PageUp' ) {
+										nextFocusable = subMonths( day, 1 );
+									}
+									if ( event.key === 'PageDown' ) {
+										nextFocusable = addMonths( day, 1 );
+									}
+									if ( event.key === 'Home' ) {
+										nextFocusable = startOfWeek( day );
+									}
+									if ( event.key === 'End' ) {
+										nextFocusable = startOfDay(
+											endOfWeek( day )
+										);
+									}
+									if ( nextFocusable ) {
+										event.preventDefault();
+										setFocusable( nextFocusable );
+										onDayKeyDown?.( nextFocusable );
+									}
+								} }
+							/>
+						);
+					} )
+				) }
+			</StyledCalendar>
+		</>
 	);
 }
 

--- a/packages/components/src/date-time/date/day.tsx
+++ b/packages/components/src/date-time/date/day.tsx
@@ -1,0 +1,115 @@
+/**
+ * External dependencies
+ */
+import type { KeyboardEventHandler } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { dateI18n, getSettings } from '@wordpress/date';
+import { useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { DayButton } from './styles';
+
+type DayProps = {
+	day: Date;
+	column: number;
+	isSelected: boolean;
+	isFocusable: boolean;
+	isFocusAllowed: boolean;
+	isToday: boolean;
+	numEvents: number;
+	isInvalid: boolean;
+	onClick: () => void;
+	onKeyDown: KeyboardEventHandler;
+};
+
+function Day( {
+	day,
+	column,
+	isSelected,
+	isFocusable,
+	isFocusAllowed,
+	isToday,
+	isInvalid,
+	numEvents,
+	onClick,
+	onKeyDown,
+}: DayProps ) {
+	const ref = useRef< HTMLButtonElement >();
+
+	// Focus the day when it becomes focusable, e.g. because an arrow key is
+	// pressed. Only do this if focus is allowed - this stops us stealing focus
+	// from e.g. a TimePicker input.
+	useEffect( () => {
+		if ( ref.current && isFocusable && isFocusAllowed ) {
+			ref.current.focus();
+		}
+		// isFocusAllowed is not a dep as there is no point calling focus() on
+		// an already focused element.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isFocusable ] );
+
+	return (
+		<DayButton
+			ref={ ref }
+			className="components-datetime__date__day" // Unused, for backwards compatibility.
+			disabled={ isInvalid }
+			tabIndex={ isFocusable ? 0 : -1 }
+			aria-label={ getDayLabel( day, isSelected, numEvents ) }
+			column={ column }
+			isSelected={ isSelected }
+			isToday={ isToday }
+			hasEvents={ numEvents > 0 }
+			onClick={ onClick }
+			onKeyDown={ onKeyDown }
+		>
+			{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
+		</DayButton>
+	);
+}
+
+function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
+	const { formats } = getSettings();
+	const localizedDate = dateI18n(
+		formats.date,
+		date,
+		-date.getTimezoneOffset()
+	);
+	if ( isSelected && numEvents > 0 ) {
+		return sprintf(
+			// translators: 1: The calendar date. 2: Number of events on the calendar date.
+			_n(
+				'%1$s. Selected. There is %2$d event',
+				'%1$s. Selected. There are %2$d events',
+				numEvents
+			),
+			localizedDate,
+			numEvents
+		);
+	} else if ( isSelected ) {
+		return sprintf(
+			// translators: %s: The calendar date.
+			__( '%1$s. Selected' ),
+			localizedDate
+		);
+	} else if ( numEvents > 0 ) {
+		return sprintf(
+			// translators: 1: The calendar date. 2: Number of events on the calendar date.
+			_n(
+				'%1$s. There is %2$d event',
+				'%1$s. There are %2$d events',
+				numEvents
+			),
+			localizedDate,
+			numEvents
+		);
+	}
+	return localizedDate;
+}
+
+export default Day;

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -7,7 +7,6 @@ import { format, startOfDay, isSameMonth } from 'date-fns';
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
@@ -15,7 +14,6 @@ import { useState } from '@wordpress/element';
  */
 import Calendar from './calendar';
 import type { DatePickerProps } from '../types';
-import { Wrapper } from './styles';
 import { inputToDate } from '../utils';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
@@ -76,50 +74,44 @@ export function DatePicker( {
 	}
 
 	return (
-		<Wrapper
-			className="components-datetime__date"
-			role="application"
-			aria-label={ __( 'Calendar' ) }
-		>
-			<Calendar
-				calendar={ calendar }
-				events={ events }
-				isInvalidDate={ isInvalidDate }
-				isSelected={ isSelected }
-				onMonthPreviewed={ onMonthPreviewed }
-				setFocusable={ setFocusable }
-				viewing={ viewing }
-				viewPreviousMonth={ viewPreviousMonth }
-				viewNextMonth={ viewNextMonth }
-				onDayClick={ ( day ) => {
-					setSelected( [ day ] );
-					onChange?.(
-						format(
-							// Don't change the selected date's time fields.
-							new Date(
-								day.getFullYear(),
-								day.getMonth(),
-								day.getDate(),
-								date.getHours(),
-								date.getMinutes(),
-								date.getSeconds(),
-								date.getMilliseconds()
-							),
-							TIMEZONELESS_FORMAT
-						)
+		<Calendar
+			calendar={ calendar }
+			events={ events }
+			isInvalidDate={ isInvalidDate }
+			isSelected={ isSelected }
+			onMonthPreviewed={ onMonthPreviewed }
+			setFocusable={ setFocusable }
+			viewing={ viewing }
+			viewPreviousMonth={ viewPreviousMonth }
+			viewNextMonth={ viewNextMonth }
+			onDayClick={ ( day ) => {
+				setSelected( [ day ] );
+				onChange?.(
+					format(
+						// Don't change the selected date's time fields.
+						new Date(
+							day.getFullYear(),
+							day.getMonth(),
+							day.getDate(),
+							date.getHours(),
+							date.getMinutes(),
+							date.getSeconds(),
+							date.getMilliseconds()
+						),
+						TIMEZONELESS_FORMAT
+					)
+				);
+			} }
+			onDayKeyDown={ ( nextFocusable ) => {
+				if ( ! isSameMonth( nextFocusable, viewing ) ) {
+					setViewing( nextFocusable );
+					onMonthPreviewed?.(
+						format( nextFocusable, TIMEZONELESS_FORMAT )
 					);
-				} }
-				onDayKeyDown={ ( nextFocusable ) => {
-					if ( ! isSameMonth( nextFocusable, viewing ) ) {
-						setViewing( nextFocusable );
-						onMonthPreviewed?.(
-							format( nextFocusable, TIMEZONELESS_FORMAT )
-						);
-					}
-				} }
-				focusable={ focusable }
-			/>
-		</Wrapper>
+				}
+			} }
+			focusable={ focusable }
+		/>
 	);
 }
 

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -2,20 +2,12 @@
  * External dependencies
  */
 import { useLilius } from 'use-lilius';
-import {
-	format,
-	subMonths,
-	addMonths,
-	startOfDay,
-	isSameMonth,
-} from 'date-fns';
+import { format, startOfDay, isSameMonth } from 'date-fns';
 
 /**
  * WordPress dependencies
  */
-import { __, isRTL } from '@wordpress/i18n';
-import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { dateI18n } from '@wordpress/date';
+import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
@@ -23,9 +15,8 @@ import { useState } from '@wordpress/element';
  */
 import Calendar from './calendar';
 import type { DatePickerProps } from '../types';
-import { Wrapper, Navigator, NavigatorHeading } from './styles';
+import { Wrapper } from './styles';
 import { inputToDate } from '../utils';
-import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
 
 /**
@@ -90,57 +81,18 @@ export function DatePicker( {
 			role="application"
 			aria-label={ __( 'Calendar' ) }
 		>
-			<Navigator>
-				<Button
-					icon={ isRTL() ? arrowRight : arrowLeft }
-					variant="tertiary"
-					aria-label={ __( 'View previous month' ) }
-					onClick={ () => {
-						viewPreviousMonth();
-						setFocusable( subMonths( focusable, 1 ) );
-						onMonthPreviewed?.(
-							format(
-								subMonths( viewing, 1 ),
-								TIMEZONELESS_FORMAT
-							)
-						);
-					} }
-				/>
-				<NavigatorHeading level={ 3 }>
-					<strong>
-						{ dateI18n(
-							'F',
-							viewing,
-							-viewing.getTimezoneOffset()
-						) }
-					</strong>{ ' ' }
-					{ dateI18n( 'Y', viewing, -viewing.getTimezoneOffset() ) }
-				</NavigatorHeading>
-				<Button
-					icon={ isRTL() ? arrowLeft : arrowRight }
-					variant="tertiary"
-					aria-label={ __( 'View next month' ) }
-					onClick={ () => {
-						viewNextMonth();
-						setFocusable( addMonths( focusable, 1 ) );
-						onMonthPreviewed?.(
-							format(
-								addMonths( viewing, 1 ),
-								TIMEZONELESS_FORMAT
-							)
-						);
-					} }
-				/>
-			</Navigator>
 			<Calendar
 				calendar={ calendar }
-				isInvalidDate={ isInvalidDate }
-				viewing={ viewing }
-				isSelected={ isSelected }
 				events={ events }
+				isInvalidDate={ isInvalidDate }
+				isSelected={ isSelected }
+				onMonthPreviewed={ onMonthPreviewed }
+				setFocusable={ setFocusable }
+				viewing={ viewing }
+				viewPreviousMonth={ viewPreviousMonth }
+				viewNextMonth={ viewNextMonth }
 				onDayClick={ ( day ) => {
 					setSelected( [ day ] );
-					setFocusable( day );
 					onChange?.(
 						format(
 							// Don't change the selected date's time fields.
@@ -158,7 +110,6 @@ export function DatePicker( {
 					);
 				} }
 				onDayKeyDown={ ( nextFocusable ) => {
-					setFocusable( nextFocusable );
 					if ( ! isSameMonth( nextFocusable, viewing ) ) {
 						setViewing( nextFocusable );
 						onMonthPreviewed?.(

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -4,40 +4,26 @@
 import { useLilius } from 'use-lilius';
 import {
 	format,
-	isSameDay,
 	subMonths,
 	addMonths,
 	startOfDay,
-	isEqual,
-	addDays,
-	subWeeks,
-	addWeeks,
 	isSameMonth,
-	startOfWeek,
-	endOfWeek,
 } from 'date-fns';
-import type { KeyboardEventHandler } from 'react';
 
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf, isRTL } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
-import { dateI18n, getSettings } from '@wordpress/date';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { dateI18n } from '@wordpress/date';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
+import Calendar from './calendar';
 import type { DatePickerProps } from '../types';
-import {
-	Wrapper,
-	Navigator,
-	NavigatorHeading,
-	Calendar,
-	DayOfWeek,
-	DayButton,
-} from './styles';
+import { Wrapper, Navigator, NavigatorHeading } from './styles';
 import { inputToDate } from '../utils';
 import Button from '../../button';
 import { TIMEZONELESS_FORMAT } from '../constants';
@@ -88,12 +74,6 @@ export function DatePicker( {
 	// Used to implement a roving tab index. Tracks the day that receives focus
 	// when the user tabs into the calendar.
 	const [ focusable, setFocusable ] = useState( startOfDay( date ) );
-
-	// Allows us to only programmatically focus() a day when focus was already
-	// within the calendar. This stops us stealing focus from e.g. a TimePicker
-	// input.
-	const [ isFocusWithinCalendar, setIsFocusWithinCalendar ] =
-		useState( false );
 
 	// Update internal state when currentDate prop changes.
 	const [ prevCurrentDate, setPrevCurrentDate ] = useState( currentDate );
@@ -153,212 +133,43 @@ export function DatePicker( {
 				/>
 			</Navigator>
 			<Calendar
-				onFocus={ () => setIsFocusWithinCalendar( true ) }
-				onBlur={ () => setIsFocusWithinCalendar( false ) }
-			>
-				{ calendar[ 0 ][ 0 ].map( ( day ) => (
-					<DayOfWeek key={ day.toString() }>
-						{ dateI18n( 'D', day, -day.getTimezoneOffset() ) }
-					</DayOfWeek>
-				) ) }
-				{ calendar[ 0 ].map( ( week ) =>
-					week.map( ( day, index ) => {
-						if ( ! isSameMonth( day, viewing ) ) {
-							return null;
-						}
-						return (
-							<Day
-								key={ day.toString() }
-								day={ day }
-								column={ index + 1 }
-								isSelected={ isSelected( day ) }
-								isFocusable={ isEqual( day, focusable ) }
-								isFocusAllowed={ isFocusWithinCalendar }
-								isToday={ isSameDay( day, new Date() ) }
-								isInvalid={
-									isInvalidDate ? isInvalidDate( day ) : false
-								}
-								numEvents={
-									events.filter( ( event ) =>
-										isSameDay( event.date, day )
-									).length
-								}
-								onClick={ () => {
-									setSelected( [ day ] );
-									setFocusable( day );
-									onChange?.(
-										format(
-											// Don't change the selected date's time fields.
-											new Date(
-												day.getFullYear(),
-												day.getMonth(),
-												day.getDate(),
-												date.getHours(),
-												date.getMinutes(),
-												date.getSeconds(),
-												date.getMilliseconds()
-											),
-											TIMEZONELESS_FORMAT
-										)
-									);
-								} }
-								onKeyDown={ ( event ) => {
-									let nextFocusable;
-									if ( event.key === 'ArrowLeft' ) {
-										nextFocusable = addDays(
-											day,
-											isRTL() ? 1 : -1
-										);
-									}
-									if ( event.key === 'ArrowRight' ) {
-										nextFocusable = addDays(
-											day,
-											isRTL() ? -1 : 1
-										);
-									}
-									if ( event.key === 'ArrowUp' ) {
-										nextFocusable = subWeeks( day, 1 );
-									}
-									if ( event.key === 'ArrowDown' ) {
-										nextFocusable = addWeeks( day, 1 );
-									}
-									if ( event.key === 'PageUp' ) {
-										nextFocusable = subMonths( day, 1 );
-									}
-									if ( event.key === 'PageDown' ) {
-										nextFocusable = addMonths( day, 1 );
-									}
-									if ( event.key === 'Home' ) {
-										nextFocusable = startOfWeek( day );
-									}
-									if ( event.key === 'End' ) {
-										nextFocusable = startOfDay(
-											endOfWeek( day )
-										);
-									}
-									if ( nextFocusable ) {
-										event.preventDefault();
-										setFocusable( nextFocusable );
-										if (
-											! isSameMonth(
-												nextFocusable,
-												viewing
-											)
-										) {
-											setViewing( nextFocusable );
-											onMonthPreviewed?.(
-												format(
-													nextFocusable,
-													TIMEZONELESS_FORMAT
-												)
-											);
-										}
-									}
-								} }
-							/>
+				calendar={ calendar }
+				isInvalidDate={ isInvalidDate }
+				viewing={ viewing }
+				isSelected={ isSelected }
+				events={ events }
+				onDayClick={ ( day ) => {
+					setSelected( [ day ] );
+					setFocusable( day );
+					onChange?.(
+						format(
+							// Don't change the selected date's time fields.
+							new Date(
+								day.getFullYear(),
+								day.getMonth(),
+								day.getDate(),
+								date.getHours(),
+								date.getMinutes(),
+								date.getSeconds(),
+								date.getMilliseconds()
+							),
+							TIMEZONELESS_FORMAT
+						)
+					);
+				} }
+				onDayKeyDown={ ( nextFocusable ) => {
+					setFocusable( nextFocusable );
+					if ( ! isSameMonth( nextFocusable, viewing ) ) {
+						setViewing( nextFocusable );
+						onMonthPreviewed?.(
+							format( nextFocusable, TIMEZONELESS_FORMAT )
 						);
-					} )
-				) }
-			</Calendar>
+					}
+				} }
+				focusable={ focusable }
+			/>
 		</Wrapper>
 	);
-}
-
-type DayProps = {
-	day: Date;
-	column: number;
-	isSelected: boolean;
-	isFocusable: boolean;
-	isFocusAllowed: boolean;
-	isToday: boolean;
-	numEvents: number;
-	isInvalid: boolean;
-	onClick: () => void;
-	onKeyDown: KeyboardEventHandler;
-};
-
-function Day( {
-	day,
-	column,
-	isSelected,
-	isFocusable,
-	isFocusAllowed,
-	isToday,
-	isInvalid,
-	numEvents,
-	onClick,
-	onKeyDown,
-}: DayProps ) {
-	const ref = useRef< HTMLButtonElement >();
-
-	// Focus the day when it becomes focusable, e.g. because an arrow key is
-	// pressed. Only do this if focus is allowed - this stops us stealing focus
-	// from e.g. a TimePicker input.
-	useEffect( () => {
-		if ( ref.current && isFocusable && isFocusAllowed ) {
-			ref.current.focus();
-		}
-		// isFocusAllowed is not a dep as there is no point calling focus() on
-		// an already focused element.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isFocusable ] );
-
-	return (
-		<DayButton
-			ref={ ref }
-			className="components-datetime__date__day" // Unused, for backwards compatibility.
-			disabled={ isInvalid }
-			tabIndex={ isFocusable ? 0 : -1 }
-			aria-label={ getDayLabel( day, isSelected, numEvents ) }
-			column={ column }
-			isSelected={ isSelected }
-			isToday={ isToday }
-			hasEvents={ numEvents > 0 }
-			onClick={ onClick }
-			onKeyDown={ onKeyDown }
-		>
-			{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
-		</DayButton>
-	);
-}
-
-function getDayLabel( date: Date, isSelected: boolean, numEvents: number ) {
-	const { formats } = getSettings();
-	const localizedDate = dateI18n(
-		formats.date,
-		date,
-		-date.getTimezoneOffset()
-	);
-	if ( isSelected && numEvents > 0 ) {
-		return sprintf(
-			// translators: 1: The calendar date. 2: Number of events on the calendar date.
-			_n(
-				'%1$s. Selected. There is %2$d event',
-				'%1$s. Selected. There are %2$d events',
-				numEvents
-			),
-			localizedDate,
-			numEvents
-		);
-	} else if ( isSelected ) {
-		return sprintf(
-			// translators: %s: The calendar date.
-			__( '%1$s. Selected' ),
-			localizedDate
-		);
-	} else if ( numEvents > 0 ) {
-		return sprintf(
-			// translators: 1: The calendar date. 2: Number of events on the calendar date.
-			_n(
-				'%1$s. There is %2$d event',
-				'%1$s. There are %2$d events',
-				numEvents
-			),
-			localizedDate,
-			numEvents
-		);
-	}
-	return localizedDate;
 }
 
 export default DatePicker;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

The PR refactors Calendar and Day to separate components, so that they could be used in the to-be-created Date Range picker. The prototype could be found [here](https://github.com/kangzj/gutenberg/pull/1).

## Why?

Create a Date Range picker as a Core component.

## How?

Extracted Day and Calendar to separate component, and re-arranged event handlers.


## Testing Instructions

- Ensure all tests pass
- Open storybook and find DatePicker
- Ensure all the examples still work okay
- Ensure the code looks okay

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
