### PR TITLE
Patterns: add opt out preference to the 'Choose a Pattern' modal when adding a page

### DIFF
--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -70,6 +70,7 @@ export function initializeEditor(
 		showBlockBreadcrumbs: true,
 		showIconLabels: false,
 		showListViewByDefault: false,
+		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
 	} );
 

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -79,6 +79,7 @@ export function initializeEditor( id, settings ) {
 		openPanels: [ 'post-status' ],
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
+		enableChoosePatternModal: true,
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -72,6 +72,7 @@ export function initializePostsDashboard( id, settings ) {
 		openPanels: [ 'post-status' ],
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
+		enableChoosePatternModal: true,
 	} );
 
 	dispatch( editSiteStore ).updateSettings( settings );

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -58,7 +58,7 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const { setIsListViewOpened, setIsInserterOpened } =
 		useDispatch( editorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const starterPatterns = useStartPatterns();
+	const hasStarterPatterns = !! useStartPatterns().length;
 
 	const sections = useMemo(
 		() =>
@@ -99,6 +99,16 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 										'Allow right-click contextual menus'
 									) }
 								/>
+								{ hasStarterPatterns && (
+									<PreferenceToggleControl
+										scope="core"
+										featureName="enableChoosePatternModal"
+										help={ __(
+											'Shows starter patterns when creating a new page.'
+										) }
+										label={ __( 'Show starter patterns' ) }
+									/>
+								) }
 							</PreferencesModalSection>
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }
@@ -247,16 +257,6 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 										'Show text instead of icons on buttons across the interface.'
 									) }
 								/>
-								{ !! starterPatterns?.length && (
-									<PreferenceToggleControl
-										scope="core"
-										featureName="enableChoosePatternModal"
-										help={ __(
-											'Shows starter patterns when creating a new page.'
-										) }
-										label={ __( 'Show starter patterns' ) }
-									/>
-								) }
 							</PreferencesModalSection>
 						</>
 					),
@@ -326,7 +326,7 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 			setIsListViewOpened,
 			setPreference,
 			isLargeViewport,
-			starterPatterns,
+			hasStarterPatterns,
 		]
 	);
 

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -26,6 +26,7 @@ import PageAttributesCheck from '../page-attributes/check';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
+import { useStartPatterns } from '../start-page-options';
 
 const {
 	PreferencesModal,
@@ -57,6 +58,7 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 	const { setIsListViewOpened, setIsInserterOpened } =
 		useDispatch( editorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
+	const starterPatterns = useStartPatterns();
 
 	const sections = useMemo(
 		() =>
@@ -208,6 +210,16 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 								) }
 								label={ __( 'Spotlight mode' ) }
 							/>
+							{ starterPatterns?.length && (
+								<PreferenceToggleControl
+									scope="core"
+									featureName="enableChoosePatternModal"
+									help={ __(
+										'Shows starter patterns when creating a new page.'
+									) }
+									label={ __( 'Show starter patterns' ) }
+								/>
+							) }
 							{ extraSections?.appearance }
 						</PreferencesModalSection>
 					),
@@ -314,6 +326,7 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 			setIsListViewOpened,
 			setPreference,
 			isLargeViewport,
+			starterPatterns,
 		]
 	);
 

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -154,17 +154,19 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 											'Enable pre-publish checks'
 										) }
 									/>
-								</PreferencesModalSection>
-							) }
-							{ starterPatterns?.length && (
-								<PreferenceToggleControl
-									scope="core"
-									featureName="enableChoosePatternModal"
-									help={ __(
-										'Shows starter patterns when creating a new page.'
+									{ starterPatterns?.length && (
+										<PreferenceToggleControl
+											scope="core"
+											featureName="enableChoosePatternModal"
+											help={ __(
+												'Shows starter patterns when creating a new page.'
+											) }
+											label={ __(
+												'Show starter patterns'
+											) }
+										/>
 									) }
-									label={ __( 'Show starter patterns' ) }
-								/>
+								</PreferencesModalSection>
 							) }
 							{ extraSections?.general }
 						</>

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -154,18 +154,6 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 											'Enable pre-publish checks'
 										) }
 									/>
-									{ starterPatterns?.length && (
-										<PreferenceToggleControl
-											scope="core"
-											featureName="enableChoosePatternModal"
-											help={ __(
-												'Shows starter patterns when creating a new page.'
-											) }
-											label={ __(
-												'Show starter patterns'
-											) }
-										/>
-									) }
 								</PreferencesModalSection>
 							) }
 							{ extraSections?.general }
@@ -259,6 +247,16 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 										'Show text instead of icons on buttons across the interface.'
 									) }
 								/>
+								{ !! starterPatterns?.length && (
+									<PreferenceToggleControl
+										scope="core"
+										featureName="enableChoosePatternModal"
+										help={ __(
+											'Shows starter patterns when creating a new page.'
+										) }
+										label={ __( 'Show starter patterns' ) }
+									/>
+								) }
 							</PreferencesModalSection>
 						</>
 					),

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -156,6 +156,16 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 									/>
 								</PreferencesModalSection>
 							) }
+							{ starterPatterns?.length && (
+								<PreferenceToggleControl
+									scope="core"
+									featureName="enableChoosePatternModal"
+									help={ __(
+										'Shows starter patterns when creating a new page.'
+									) }
+									label={ __( 'Show starter patterns' ) }
+								/>
+							) }
 							{ extraSections?.general }
 						</>
 					),
@@ -210,16 +220,6 @@ export default function EditorPreferencesModal( { extraSections = {} } ) {
 								) }
 								label={ __( 'Spotlight mode' ) }
 							/>
-							{ starterPatterns?.length && (
-								<PreferenceToggleControl
-									scope="core"
-									featureName="enableChoosePatternModal"
-									help={ __(
-										'Shows starter patterns when creating a new page.'
-									) }
-									label={ __( 'Show starter patterns' ) }
-								/>
-							) }
 							{ extraSections?.appearance }
 						</PreferencesModalSection>
 					),

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -52,8 +52,14 @@ export function useStartPatterns() {
 	);
 
 	return useMemo( () => {
-		// filter patterns without postTypes declared if the current postType is page
-		// or patterns that declare the current postType in its post type array.
+		if ( ! blockPatternsWithPostContentBlockType?.length ) {
+			return [];
+		}
+
+		/*
+		 * Filter patterns without postTypes declared if the current postType is page
+		 * or patterns that declare the current postType in its post type array.
+		 */
 		return blockPatternsWithPostContentBlockType.filter( ( pattern ) => {
 			return (
 				( postType === 'page' && ! pattern.postTypes ) ||

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -1,12 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	Button,
-	CheckboxControl,
-	Modal,
-	__experimentalHStack as HStack,
-} from '@wordpress/components';
+import { Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useMemo } from '@wordpress/element';
 import {
@@ -98,52 +93,24 @@ function PatternSelection( { blockPatterns, onChoosePattern } ) {
 }
 
 function StartPageOptionsModal( { onClose } ) {
-	const { set: setPreference } = useDispatch( preferencesStore );
-	const [ disablePreference, setDisablePreference ] = useState( false );
 	const startPatterns = useStartPatterns();
+	const hasStartPattern = startPatterns.length > 0;
 
-	if ( ! startPatterns.length ) {
-		return;
+	if ( ! hasStartPattern ) {
+		return null;
 	}
 
 	return (
 		<Modal
 			title={ __( 'Choose a pattern' ) }
 			isFullScreen
-			isDismissible={ false }
+			onRequestClose={ onClose }
 		>
 			<div className="editor-start-page-options__modal-content">
 				<PatternSelection
 					blockPatterns={ startPatterns }
 					onChoosePattern={ onClose }
 				/>
-			</div>
-			<div className="editor-start-page-options__modal-footer">
-				<HStack justify="space-between" spacing={ 8 }>
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ __( 'Do not show me this again' ) }
-						onChange={ ( newValue ) =>
-							setDisablePreference( newValue )
-						}
-					/>
-					<Button
-						__next40pxDefaultSize={ false }
-						variant="secondary"
-						onClick={ () => {
-							if ( disablePreference ) {
-								setPreference(
-									'core',
-									'enableChoosePatternModal',
-									false
-								);
-							}
-							onClose();
-						} }
-					>
-						{ __( 'Skip' ) }
-					</Button>
-				</HStack>
 			</div>
 		</Modal>
 	);

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -8,7 +8,7 @@ import {
 	__experimentalHStack as HStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useState, useMemo, useEffect } from '@wordpress/element';
+import { useState, useMemo } from '@wordpress/element';
 import {
 	store as blockEditorStore,
 	__experimentalBlockPatternsList as BlockPatternsList,
@@ -151,36 +151,23 @@ function StartPageOptionsModal( { onClose } ) {
 
 export default function StartPageOptions() {
 	const [ isClosed, setIsClosed ] = useState( false );
-	const { shouldEnableModal, postType, postId } = useSelect( ( select ) => {
-		const {
-			isEditedPostDirty,
-			isEditedPostEmpty,
-			getCurrentPostType,
-			getCurrentPostId,
-		} = select( editorStore );
-		const _postType = getCurrentPostType();
+	const shouldEnableModal = useSelect( ( select ) => {
+		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
+			select( editorStore );
 		const preferencesModalActive =
 			select( interfaceStore ).isModalActive( 'editor/preferences' );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
 			'enableChoosePatternModal'
 		);
-		return {
-			shouldEnableModal:
-				choosePatternModalEnabled &&
-				! preferencesModalActive &&
-				! isEditedPostDirty() &&
-				isEditedPostEmpty() &&
-				TEMPLATE_POST_TYPE !== _postType,
-			postType: _postType,
-			postId: getCurrentPostId(),
-		};
+		return (
+			choosePatternModalEnabled &&
+			! preferencesModalActive &&
+			! isEditedPostDirty() &&
+			isEditedPostEmpty() &&
+			TEMPLATE_POST_TYPE !== getCurrentPostType()
+		);
 	}, [] );
-
-	useEffect( () => {
-		// Should reset the modal state when navigating to a new page/post.
-		setIsClosed( false );
-	}, [ postType, postId ] );
 
 	if ( ! shouldEnableModal || isClosed ) {
 		return null;

--- a/packages/editor/src/components/start-page-options/style.scss
+++ b/packages/editor/src/components/start-page-options/style.scss
@@ -24,3 +24,25 @@
 		}
 	}
 }
+
+.editor-start-page-options__modal-content {
+	margin-bottom: 72px;
+}
+
+.editor-start-page-options__modal-footer {
+	box-sizing: border-box;
+	border-bottom: $border-width solid transparent;
+	padding: $grid-unit-10 $grid-unit-40 $grid-unit-10;
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	align-items: center;
+	height: $header-height + $grid-unit-15;
+	width: 100%;
+	z-index: z-index(".components-modal__header");
+	position: absolute;
+	bottom: 0;
+	left: 0;
+	background: $white;
+	border-top: 1px solid $gray-300;
+}

--- a/packages/editor/src/components/start-page-options/style.scss
+++ b/packages/editor/src/components/start-page-options/style.scss
@@ -24,25 +24,3 @@
 		}
 	}
 }
-
-.editor-start-page-options__modal-content {
-	margin-bottom: 72px;
-}
-
-.editor-start-page-options__modal-footer {
-	box-sizing: border-box;
-	border-bottom: $border-width solid transparent;
-	padding: $grid-unit-10 $grid-unit-40 $grid-unit-10;
-	display: flex;
-	flex-direction: row;
-	justify-content: space-between;
-	align-items: center;
-	height: $header-height + $grid-unit-15;
-	width: 100%;
-	z-index: z-index(".components-modal__header");
-	position: absolute;
-	bottom: 0;
-	left: 0;
-	background: $white;
-	border-top: 1px solid $gray-300;
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and how?

Fixes: https://github.com/WordPress/gutenberg/issues/56181

Deleting the entire modal is too easy, so this PR:

- Adds a preference to disable the loading of the "Choose a pattern" modal when adding new pages.
- Ensures the modal doesn't reappear when you edit a page's template/template parts/patterns and return to the page.


Previous attempt here: 

- https://github.com/WordPress/gutenberg/pull/56307


## Why?

When creating a new page, the "Choose a pattern" will not go away until you choose a pattern. I grow weary of it.


## Testing Instructions

> [!TIP]
> If you see the welcome modal competing for your attention, please ignore. I added an issue: https://github.com/WordPress/gutenberg/issues/65104



1. Create a new page either in the site editor or post editor
2. The patterns selector will appear. Dismiss it.
3. Now either edit the page's template, or add a new synced pattern and edit that, and then return to the page
4. The pattern selector should not display again until you revisit the page or add and save some content.
5. Now open the preferences modal and toggle off "Show starter patterns" under "Interface"
6. Return to step up and ensure the patterns selector modal does not appear again until you toggle the preference back on.

<img width="506" alt="Screenshot 2024-09-06 at 8 36 06 PM" src="https://github.com/user-attachments/assets/f7f5247f-0584-455a-af6f-014d1f6a07e8">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3500e7a4-3c0a-4a2d-ac13-6077507ca872



