### PR TITLE
First pass at adding simple editing mode

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -37,6 +37,10 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoom-out-experiment', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomOutExperiment = true', 'before' );
 	}
+
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-simple-editing-mode', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalSimpleEditingMode = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -186,6 +186,19 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-zoom-out-experiment',
 		)
 	);
+
+	add_settings_field(
+		'gutenberg-simple-editing-mode',
+		__( 'Simple editing mode', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Add UI that lets you toggle between a simple and an advanced editing mode.', 'gutenberg' ),
+			'id'    => 'gutenberg-simple-editing-mode',
+		)
+	);
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -100,12 +100,23 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			getBlockName,
 			getContentLockingParent,
 			getTemplateLock,
+			getClosestSectionBlock,
+			getBlockEditingMode,
 		} = unlock( select( blockEditorStore ) );
 		const _selectedBlockClientId = getSelectedBlockClientId();
 		const _selectedBlockName =
 			_selectedBlockClientId && getBlockName( _selectedBlockClientId );
 		const _blockType =
 			_selectedBlockName && getBlockType( _selectedBlockName );
+
+		const closestSectionBlock = getClosestSectionBlock(
+			_selectedBlockClientId
+		);
+
+		const closestContentOnlySectionBlock =
+			getBlockEditingMode( closestSectionBlock ) === 'contentOnly'
+				? closestSectionBlock
+				: undefined;
 
 		return {
 			count: getSelectedBlockCount(),
@@ -117,7 +128,8 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 				( getTemplateLock( _selectedBlockClientId ) === 'contentOnly' ||
 				_selectedBlockName === 'core/block'
 					? _selectedBlockClientId
-					: undefined ),
+					: undefined ) ||
+				closestContentOnlySectionBlock,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -565,5 +565,5 @@ export function getSectionRootClientId( state ) {
  */
 export function getSectionClientIds( state ) {
 	const sectionRootClientId = getSectionRootClientId( state );
-	return getBlockOrder( sectionRootClientId );
+	return getBlockOrder( state, sectionRootClientId );
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -567,3 +567,24 @@ export function getSectionClientIds( state ) {
 	const sectionRootClientId = getSectionRootClientId( state );
 	return getBlockOrder( state, sectionRootClientId );
 }
+
+/**
+ * Retrieves the closest "section" block to the given client ID.
+ *
+ * @param {Object} state    - The current state.
+ * @param {string} clientId - The client ID to start the search from.
+ * @return {string|undefined} The client ID of the closest section block, or undefined if not found.
+ */
+export function getClosestSectionBlock( state, clientId ) {
+	let current = clientId;
+	let result;
+	const sectionClientIds = getSectionClientIds( state );
+	while ( current ) {
+		if ( sectionClientIds.includes( current ) ) {
+			result = current;
+			break;
+		}
+		current = state.blocks.parents.get( current );
+	}
+	return result;
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -545,6 +545,25 @@ export function isZoomOutMode( state ) {
 	return state.editorMode === 'zoom-out';
 }
 
+/**
+ * Retrieves the client ID for the block that is acting as the element
+ * which contains the "sections" of a template/post.
+ *
+ * @param {Object} state - The current state.
+ * @return {string|undefined} The root client ID for the section, or undefined if not set.
+ */
 export function getSectionRootClientId( state ) {
 	return state.settings?.[ sectionRootClientIdKey ];
+}
+
+/**
+ * Retrieves the client IDs for the individual "sections"
+ * within the current template/post.
+ *
+ * @param {Object} state - The current state.
+ * @return {Array} An array of client IDs for the blocks within the section.
+ */
+export function getSectionClientIds( state ) {
+	const sectionRootClientId = getSectionRootClientId( state );
+	return getBlockOrder( sectionRootClientId );
 }

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -27,6 +27,7 @@ import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 import EditorHistoryRedo from '../editor-history/redo';
 import EditorHistoryUndo from '../editor-history/undo';
+import SimpleEditingModeSelector from '../simple-editing-mode-selector';
 
 function DocumentTools( { className, disableBlockTools = false } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
@@ -139,7 +140,11 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 					<>
 						{ isLargeViewport && ! hasFixedToolbar && (
 							<ToolbarItem
-								as={ ToolSelector }
+								as={
+									window.__experimentalSimpleEditingMode
+										? SimpleEditingModeSelector
+										: ToolSelector
+								}
 								showTooltip={ ! showIconLabels }
 								variant={
 									showIconLabels ? 'tertiary' : undefined

--- a/packages/editor/src/components/provider/content-only-lock-sections.js
+++ b/packages/editor/src/components/provider/content-only-lock-sections.js
@@ -9,7 +9,7 @@ import { store as blocksStore } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Component that when rendered, makes it so that the editor allows only
@@ -26,9 +26,10 @@ export default function ContentOnlyLockSections() {
 			getBlockOrder,
 			getClientIdsOfDescendants,
 			getClientIdsWithDescendants,
-		} = select( blockEditorStore );
-		const { getEditorSettings } = select( editorStore );
-		const { sectionRootClientId } = getEditorSettings();
+			getSectionRootClientId,
+		} = unlock( select( blockEditorStore ) );
+
+		const sectionRootClientId = getSectionRootClientId();
 		const sectionClientIds = getBlockOrder( sectionRootClientId );
 		const allClientIds = sectionRootClientId
 			? getClientIdsOfDescendants( sectionRootClientId )

--- a/packages/editor/src/components/provider/content-only-lock-sections.js
+++ b/packages/editor/src/components/provider/content-only-lock-sections.js
@@ -23,14 +23,14 @@ export default function ContentOnlyLockSections() {
 
 	const selected = useSelect( ( select ) => {
 		const {
-			getBlockOrder,
 			getClientIdsOfDescendants,
 			getClientIdsWithDescendants,
 			getSectionRootClientId,
+			getSectionClientIds,
 		} = unlock( select( blockEditorStore ) );
 
 		const sectionRootClientId = getSectionRootClientId();
-		const sectionClientIds = getBlockOrder( sectionRootClientId );
+		const sectionClientIds = getSectionClientIds();
 		const allClientIds = sectionRootClientId
 			? getClientIdsOfDescendants( sectionRootClientId )
 			: getClientIdsWithDescendants();

--- a/packages/editor/src/components/provider/content-only-lock-sections.js
+++ b/packages/editor/src/components/provider/content-only-lock-sections.js
@@ -35,11 +35,12 @@ export default function ContentOnlyLockSections() {
 			? getClientIdsOfDescendants( sectionRootClientId )
 			: getClientIdsWithDescendants();
 		return {
+			sectionRootClientId,
 			sectionClientIds,
 			allClientIds,
 		};
 	}, [] );
-	const { sectionClientIds, allClientIds } = selected;
+	const { sectionClientIds, allClientIds, sectionRootClientId } = selected;
 	const { getBlockOrder, getBlockName } = useSelect( blockEditorStore );
 	const { __experimentalHasContentRoleAttribute } = useSelect( blocksStore );
 
@@ -52,12 +53,20 @@ export default function ContentOnlyLockSections() {
 		);
 
 		registry.batch( () => {
+			// 1. The section root should hide non-content controls.
+			setBlockEditingMode( sectionRootClientId, 'contentOnly' );
+
+			// 2. Each section should hide non-content controls.
 			for ( const clientId of sectionClientIds ) {
 				setBlockEditingMode( clientId, 'contentOnly' );
 			}
+
+			// 3. The children of the section should be disabled.
 			for ( const clientId of sectionChildrenClientIds ) {
 				setBlockEditingMode( clientId, 'disabled' );
 			}
+
+			// 4. ...except for the "content" blocks which should be content-only.
 			for ( const clientId of contentClientIds ) {
 				setBlockEditingMode( clientId, 'contentOnly' );
 			}
@@ -66,6 +75,7 @@ export default function ContentOnlyLockSections() {
 		return () => {
 			registry.batch( () => {
 				for ( const clientId of [
+					sectionRootClientId,
 					...sectionClientIds,
 					...sectionChildrenClientIds,
 					...contentClientIds,
@@ -80,6 +90,7 @@ export default function ContentOnlyLockSections() {
 		getBlockName,
 		getBlockOrder,
 		registry,
+		sectionRootClientId,
 		sectionClientIds,
 		setBlockEditingMode,
 		unsetBlockEditingMode,

--- a/packages/editor/src/components/provider/content-only-lock-sections.js
+++ b/packages/editor/src/components/provider/content-only-lock-sections.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
+import { store as blocksStore } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+
+/**
+ * Component that when rendered, makes it so that the editor allows only
+ * specific sections to be edited in content-only mode for templates.
+ */
+export default function ContentOnlyLockSections() {
+	const registry = useRegistry();
+
+	const { setBlockEditingMode, unsetBlockEditingMode } =
+		useDispatch( blockEditorStore );
+
+	const selected = useSelect( ( select ) => {
+		const {
+			getBlockOrder,
+			getClientIdsOfDescendants,
+			getClientIdsWithDescendants,
+		} = select( blockEditorStore );
+		const { getEditorSettings } = select( editorStore );
+		const { sectionRootClientId } = getEditorSettings();
+		const sectionClientIds = getBlockOrder( sectionRootClientId );
+		const allClientIds = sectionRootClientId
+			? getClientIdsOfDescendants( sectionRootClientId )
+			: getClientIdsWithDescendants();
+		return {
+			sectionClientIds,
+			allClientIds,
+		};
+	}, [] );
+	const { sectionClientIds, allClientIds } = selected;
+	const { getBlockOrder, getBlockName } = useSelect( blockEditorStore );
+	const { __experimentalHasContentRoleAttribute } = useSelect( blocksStore );
+
+	useEffect( () => {
+		const sectionChildrenClientIds = sectionClientIds.flatMap(
+			( clientId ) => getBlockOrder( clientId )
+		);
+		const contentClientIds = allClientIds.filter( ( clientId ) =>
+			__experimentalHasContentRoleAttribute( getBlockName( clientId ) )
+		);
+
+		registry.batch( () => {
+			for ( const clientId of sectionClientIds ) {
+				setBlockEditingMode( clientId, 'contentOnly' );
+			}
+			for ( const clientId of sectionChildrenClientIds ) {
+				setBlockEditingMode( clientId, 'disabled' );
+			}
+			for ( const clientId of contentClientIds ) {
+				setBlockEditingMode( clientId, 'contentOnly' );
+			}
+		} );
+
+		return () => {
+			registry.batch( () => {
+				for ( const clientId of [
+					...sectionClientIds,
+					...sectionChildrenClientIds,
+					...contentClientIds,
+				] ) {
+					unsetBlockEditingMode( clientId );
+				}
+			} );
+		};
+	}, [
+		__experimentalHasContentRoleAttribute,
+		allClientIds,
+		getBlockName,
+		getBlockOrder,
+		registry,
+		sectionClientIds,
+		setBlockEditingMode,
+		unsetBlockEditingMode,
+	] );
+
+	return null;
+}

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -34,6 +34,8 @@ import EditorKeyboardShortcuts from '../global-keyboard-shortcuts';
 import PatternRenameModal from '../pattern-rename-modal';
 import PatternDuplicateModal from '../pattern-duplicate-modal';
 import TemplatePartMenuItems from '../template-part-menu-items';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
+import ContentOnlyLockSections from './content-only-lock-sections';
 
 const { ExperimentalBlockEditorProvider } = unlock( blockEditorPrivateApis );
 const { PatternsMenuItems } = unlock( editPatternsPrivateApis );
@@ -302,9 +304,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 									<PatternsMenuItems />
 									<TemplatePartMenuItems />
 									<ContentOnlySettingsMenu />
-									{ mode === 'template-locked' && (
-										<DisableNonPageContentBlocks />
-									) }
+									{ mode === 'template-locked' &&
+										type === TEMPLATE_POST_TYPE && (
+											<ContentOnlyLockSections />
+										) }
+									{ mode === 'template-locked' &&
+										type !== TEMPLATE_POST_TYPE && (
+											<DisableNonPageContentBlocks />
+										) }
 									{ type === 'wp_navigation' && (
 										<NavigationBlockEditingMode />
 									) }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -25,6 +25,7 @@ import { mediaUpload } from '../../utils';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 import { useGlobalStylesContext } from '../global-styles-provider';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
 
 const EMPTY_BLOCKS_LIST = [];
 const EMPTY_OBJECT = {};
@@ -142,7 +143,10 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				: undefined;
 
 			function getSectionRootBlock() {
-				if ( renderingMode === 'template-locked' ) {
+				if (
+					renderingMode === 'template-locked' &&
+					postType !== TEMPLATE_POST_TYPE
+				) {
 					return getBlocksByName( 'core/post-content' )?.[ 0 ] ?? '';
 				}
 

--- a/packages/editor/src/components/simple-editing-mode-selector/index.js
+++ b/packages/editor/src/components/simple-editing-mode-selector/index.js
@@ -84,14 +84,14 @@ function SimpleEditingModeSelector( props, ref ) {
 						choices={ [
 							{
 								value: 'advanced',
-								label: __( 'Advanced' ),
+								label: __( 'Design' ),
 								info: __(
 									'Full control over layout and styling'
 								),
 							},
 							{
 								value: 'simple',
-								label: __( 'Simple' ),
+								label: __( 'Edit' ),
 								info: __(
 									'Focus on page structure and content'
 								),

--- a/packages/editor/src/components/simple-editing-mode-selector/index.js
+++ b/packages/editor/src/components/simple-editing-mode-selector/index.js
@@ -3,21 +3,23 @@
  */
 import { __ } from '@wordpress/i18n';
 import {
-	Dropdown,
 	Button,
-	MenuItemsChoice,
-	NavigableMenu,
 	SVG,
 	Path,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
+import { edit } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import { store as editorStore } from '../../store';
 import { TEMPLATE_POST_TYPE } from '../../store/constants';
+
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 const selectIcon = (
 	<SVG
@@ -46,61 +48,49 @@ function SimpleEditingModeSelector( props, ref ) {
 	}
 
 	return (
-		<Dropdown
-			renderToggle={ ( { isOpen, onToggle } ) => (
+		<DropdownMenuV2
+			align="start"
+			trigger={
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
 					{ ...props }
 					ref={ ref }
-					icon={ selectIcon }
-					aria-expanded={ isOpen }
-					aria-haspopup="true"
-					onClick={ onToggle }
-					/* translators: button label text should, if possible, be under 16 characters. */
+					icon={
+						renderingMode === 'template-locked' ? selectIcon : edit
+					}
 					label={ __( 'Editing mode' ) }
+					size="small"
 				/>
-			) }
-			popoverProps={ { placement: 'bottom-start' } }
-			renderContent={ () => (
-				<NavigableMenu
-					className="editor-simple-editing-mode-selector__menu"
-					role="menu"
-					aria-label={ __( 'Editing mode' ) }
+			}
+		>
+			<DropdownMenuV2.Group>
+				<DropdownMenuV2.RadioItem
+					name="editing-mode"
+					value="simple"
+					checked={ renderingMode === 'template-locked' }
+					onChange={ () => setRenderingMode( 'template-locked' ) }
 				>
-					<MenuItemsChoice
-						value={
-							renderingMode === 'template-locked'
-								? 'simple'
-								: 'advanced'
-						}
-						onSelect={ ( mode ) =>
-							setRenderingMode(
-								mode === 'simple'
-									? 'template-locked'
-									: 'post-only'
-							)
-						}
-						choices={ [
-							{
-								value: 'advanced',
-								label: __( 'Design' ),
-								info: __(
-									'Full control over layout and styling'
-								),
-							},
-							{
-								value: 'simple',
-								label: __( 'Edit' ),
-								info: __(
-									'Focus on page structure and content'
-								),
-							},
-						] }
-					/>
-				</NavigableMenu>
-			) }
-		/>
+					<DropdownMenuV2.ItemLabel>
+						{ __( 'Edit' ) }
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
+						{ __( 'Focus on content.' ) }
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.RadioItem>
+				<DropdownMenuV2.RadioItem
+					name="editing-mode"
+					value="advanced"
+					checked={ renderingMode !== 'template-locked' }
+					onChange={ () => setRenderingMode( 'post-only' ) }
+				>
+					<DropdownMenuV2.ItemLabel>
+						{ __( 'Design' ) }
+					</DropdownMenuV2.ItemLabel>
+					<DropdownMenuV2.ItemHelpText>
+						{ __( 'Full control over layout and styling.' ) }
+					</DropdownMenuV2.ItemHelpText>
+				</DropdownMenuV2.RadioItem>
+			</DropdownMenuV2.Group>
+		</DropdownMenuV2>
 	);
 }
 

--- a/packages/editor/src/components/simple-editing-mode-selector/index.js
+++ b/packages/editor/src/components/simple-editing-mode-selector/index.js
@@ -1,0 +1,107 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	Dropdown,
+	Button,
+	MenuItemsChoice,
+	NavigableMenu,
+	SVG,
+	Path,
+} from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { forwardRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { TEMPLATE_POST_TYPE } from '../../store/constants';
+
+const selectIcon = (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+	>
+		<Path d="M9.4 20.5L5.2 3.8l14.6 9-2 .3c-.2 0-.4.1-.7.1-.9.2-1.6.3-2.2.5-.8.3-1.4.5-1.8.8-.4.3-.8.8-1.3 1.5-.4.5-.8 1.2-1.2 2l-.3.6-.9 1.9zM7.6 7.1l2.4 9.3c.2-.4.5-.8.7-1.1.6-.8 1.1-1.4 1.6-1.8.5-.4 1.3-.8 2.2-1.1l1.2-.3-8.1-5z" />
+	</SVG>
+);
+
+function SimpleEditingModeSelector( props, ref ) {
+	const { postType, renderingMode } = useSelect(
+		( select ) => ( {
+			postType: select( editorStore ).getCurrentPostType(),
+			renderingMode: select( editorStore ).getRenderingMode(),
+		} ),
+		[]
+	);
+
+	const { setRenderingMode } = useDispatch( editorStore );
+
+	if ( postType !== TEMPLATE_POST_TYPE ) {
+		return null;
+	}
+
+	return (
+		<Dropdown
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					// TODO: Switch to `true` (40px size) if possible
+					__next40pxDefaultSize={ false }
+					{ ...props }
+					ref={ ref }
+					icon={ selectIcon }
+					aria-expanded={ isOpen }
+					aria-haspopup="true"
+					onClick={ onToggle }
+					/* translators: button label text should, if possible, be under 16 characters. */
+					label={ __( 'Editing mode' ) }
+				/>
+			) }
+			popoverProps={ { placement: 'bottom-start' } }
+			renderContent={ () => (
+				<NavigableMenu
+					className="editor-simple-editing-mode-selector__menu"
+					role="menu"
+					aria-label={ __( 'Editing mode' ) }
+				>
+					<MenuItemsChoice
+						value={
+							renderingMode === 'template-locked'
+								? 'simple'
+								: 'advanced'
+						}
+						onSelect={ ( mode ) =>
+							setRenderingMode(
+								mode === 'simple'
+									? 'template-locked'
+									: 'post-only'
+							)
+						}
+						choices={ [
+							{
+								value: 'advanced',
+								label: __( 'Advanced' ),
+								info: __(
+									'Full control over layout and styling'
+								),
+							},
+							{
+								value: 'simple',
+								label: __( 'Simple' ),
+								info: __(
+									'Focus on page structure and content'
+								),
+							},
+						] }
+					/>
+				</NavigableMenu>
+			) }
+		/>
+	);
+}
+
+export default forwardRef( SimpleEditingModeSelector );

--- a/packages/editor/src/components/simple-editing-mode-selector/style.scss
+++ b/packages/editor/src/components/simple-editing-mode-selector/style.scss
@@ -1,0 +1,9 @@
+.editor-simple-editing-mode-selector__menu {
+	.components-menu-item__button {
+		height: auto;
+	}
+
+	.components-menu-item__info {
+		width: max-content;
+	}
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -52,6 +52,7 @@
 @import "./components/start-page-options/style.scss";
 @import "./components/start-template-options/style.scss";
 @import "./components/sidebar/style.scss";
+@import "./components/simple-editing-mode-selector/style.scss";
 @import "./components/site-discussion/style.scss";
 @import "./components/table-of-contents/style.scss";
 @import "./components/text-editor/style.scss";


### PR DESCRIPTION
Attempting to build a more production-ready version of https://github.com/WordPress/gutenberg/pull/64866. Still pretty exploratory though. I'm opening the PR earlier than I normally would so that @getdave can have a sniff.

This PR adds a new _Simple editing mode_ experiment. When enabled, we swap the _Tool_ dropdown in the editor toolbar for a new dropdown that lets you choose between _Advanced_ and _Simple_. The design of this comes from @SaxonF's mockup in https://github.com/WordPress/gutenberg/issues/60021.

Switching to _Simple_ sets the editor's rendering mode (see [`setRenderingMode`](https://github.com/WordPress/gutenberg/blob/3a310c4dc4ad1c08c38a5cd72972f3db11ae60a8/packages/editor/src/store/actions.js#L614)) to `'template-locked'`.

We currently use `'template-locked'` when editing a page in the site editor to indicate that the template blocks should be made non-editable using `DisableNonPageContentBlocks`. It doesn't make sense to combine this existing locking affordance combined with the Simple / Advanced affordance, so I'm re-using the existing `'template-locked'` setting. When the rendering mode is `'template-locked'`, we mount `DisableNonPageContentBlocks` if you're editing a page – same as before. But if you're editing a template then we mount a new `ContentOnlyLockSections` component.

`ContentOnlyLockSections` achieves the equivalent of setting `templateLock = 'contentOnly'` on every _section_. A section is a child of the block denoted by the `sectionRootClientId` editor setting. We use `useBlockEditingMode` to achieve the locking as this is currently the only way to lock blocks without making changes to block attributes which will create undo levels and end up in `post_content`.

That brings us to the part I hate about this PR: `useBlockEditingMode` is an awful API for this use case! Ideally we'd have a way to set `templateLock` on each section without modifying any block attributes. I've ranted to @talldan before about ditching this API and possibly evolving our `lock` and `templateLock` APIs into something more general purpose. Maybe it's time.

To be continued 🙂

To test: Create a new blank template in the site editor, add some patterns using the inserter, then use the new dropdown in the toolbar to switch to _Simple_.