### PR TITLE
Pattern: Don't render block controls when an entity is missing

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -29,6 +29,7 @@ import {
 	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 	BlockControls,
+	InnerBlocks,
 } from '@wordpress/block-editor';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -254,7 +255,9 @@ function ReusableBlockEdit( {
 		value: innerBlocks.length > 0 ? innerBlocks : blocks,
 		onInput: NOOP,
 		onChange: NOOP,
-		renderAppender: blocks?.length ? undefined : blocks.ButtonBlockAppender,
+		renderAppender: blocks?.length
+			? undefined
+			: InnerBlocks.ButtonBlockAppender,
 	} );
 
 	const handleEditOriginal = () => {

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -292,7 +292,7 @@ function ReusableBlockEdit( {
 
 	return (
 		<>
-			{ hasResolved && (
+			{ hasResolved && ! isMissing && (
 				<ReusableBlockControl
 					recordId={ ref }
 					canOverrideBlocks={ canOverrideBlocks }


### PR DESCRIPTION
## What?
PR updates the condition for rendering the `ReusableBlockControl` component.

## Why?
A missing entity can't be edited or reset its content to the source. This also prevents an unnecessary `OPTIONS` request.

## Testing Instructions
1. Open a post or page.
2. Insert non-existing synced pattern - `<!-- wp:block {"ref":1000000} /-->`.
3. Confirm that block controls aren't displayed.
4. Save and reload the page.
5. Confirm the `OPTIONS` request wasn't made for the `wp/v2/blocks` endpoint.

### Testing Instructions for Keyboard
Same.
