### PR TITLE
Patterns: Pass 'blocks' as inner blocks value

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -252,7 +252,7 @@ function ReusableBlockEdit( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		templateLock: 'all',
 		layout,
-		value: innerBlocks.length > 0 ? innerBlocks : blocks,
+		value: blocks,
 		onInput: NOOP,
 		onChange: NOOP,
 		renderAppender: blocks?.length

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -248,7 +248,6 @@ function ReusableBlockEdit( {
 		),
 	} );
 
-	// Use `blocks` variable until `innerBlocks` is populated, which has the proper clientIds.
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		templateLock: 'all',
 		layout,


### PR DESCRIPTION
## What?
Fixes #63909.
Fixes #64514.

PR updates Pattern (Reusable) block to use value for inner blocks provided by the `useEntityBlockEditor` hook. It prevents infinite loops when a child blocks updates attributes inside effects on the mount.

## Why?
The attribute update will result in a new `innerBlocks` value from the store, triggering an internal block synchronization. This synchronization, in turn, re-mounts child blocks, starting the whole cycle again.

The "fresh" client IDs from inner blocks are only need to set block editing mode. See https://github.com/WordPress/gutenberg/pull/60721#issuecomment-2077765846.

## Testing Instructions
See https://github.com/WordPress/gutenberg/pull/65029#issuecomment-2328410140

### Testing Instructions for Keyboard
Same.
