### PR TITLE
Allow dropping multiple images to the image block

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/README.md
+++ b/packages/block-editor/src/components/media-placeholder/README.md
@@ -198,9 +198,9 @@ Callback called when urls can be configured. No media insertion from url will be
 
 ### handleUpload
 
-When set to false the handling of the upload is left to the calling component.
+When the value is set to `false` or returned as `false`, the handling of the upload is left to the consumer component. The function signature accepts an array containing the files to be uploaded.
 
--   Type: `Boolean`
+-   Type: `Boolean|Function`
 -   Required: No
 -   Default: `true`
 -   Platform: Web

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -172,7 +172,10 @@ export function MediaPlaceholder( {
 	};
 
 	const onFilesUpload = ( files ) => {
-		if ( ! handleUpload ) {
+		if (
+			! handleUpload ||
+			( typeof handleUpload === 'function' && ! handleUpload( files ) )
+		) {
 			return onSelect( files );
 		}
 		onFilesPreUpload( files );

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -159,46 +159,49 @@ export function ImageEdit( {
 		} );
 	}
 
-	function onSelectImage( media ) {
-		if ( Array.isArray( media ) ) {
-			const win = figureRef.current?.ownerDocument.defaultView;
+	function onSelectImagesList( images ) {
+		const win = figureRef.current?.ownerDocument.defaultView;
 
-			if ( media.every( ( file ) => file instanceof win.File ) ) {
-				const rootClientId = getBlockRootClientId( clientId );
+		if ( images.every( ( file ) => file instanceof win.File ) ) {
+			/** @type {File[]} */
+			const files = images;
+			const rootClientId = getBlockRootClientId( clientId );
 
-				if ( media.some( ( file ) => ! isValidFileType( file ) ) ) {
-					// Copied from the same notice in the gallery block.
-					createErrorNotice(
-						__(
-							'If uploading to a gallery all files need to be image formats'
-						),
-						{ id: 'gallery-upload-invalid-file', type: 'snackbar' }
-					);
-				}
-
-				const imageBlocks = media
-					.filter( ( file ) => isValidFileType( file ) )
-					.map( ( file ) =>
-						createBlock( 'core/image', {
-							blob: createBlobURL( file ),
-						} )
-					);
-
-				if ( getBlockName( rootClientId ) === 'core/gallery' ) {
-					replaceBlock( clientId, imageBlocks );
-				} else if (
-					canInsertBlockType( 'core/gallery', rootClientId )
-				) {
-					const galleryBlock = createBlock(
-						'core/gallery',
-						{},
-						imageBlocks
-					);
-
-					replaceBlock( clientId, galleryBlock );
-				}
+			if ( files.some( ( file ) => ! isValidFileType( file ) ) ) {
+				// Copied from the same notice in the gallery block.
+				createErrorNotice(
+					__(
+						'If uploading to a gallery all files need to be image formats'
+					),
+					{ id: 'gallery-upload-invalid-file', type: 'snackbar' }
+				);
 			}
 
+			const imageBlocks = files
+				.filter( ( file ) => isValidFileType( file ) )
+				.map( ( file ) =>
+					createBlock( 'core/image', {
+						blob: createBlobURL( file ),
+					} )
+				);
+
+			if ( getBlockName( rootClientId ) === 'core/gallery' ) {
+				replaceBlock( clientId, imageBlocks );
+			} else if ( canInsertBlockType( 'core/gallery', rootClientId ) ) {
+				const galleryBlock = createBlock(
+					'core/gallery',
+					{},
+					imageBlocks
+				);
+
+				replaceBlock( clientId, galleryBlock );
+			}
+		}
+	}
+
+	function onSelectImage( media ) {
+		if ( Array.isArray( media ) ) {
+			onSelectImagesList( media );
 			return;
 		}
 

--- a/packages/block-library/src/image/utils.js
+++ b/packages/block-library/src/image/utils.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { NEW_TAB_REL } from './constants';
+import { NEW_TAB_REL, ALLOWED_MEDIA_TYPES } from './constants';
 
 /**
  * Evaluates a CSS aspect-ratio property value as a number.
@@ -80,4 +80,16 @@ export function getImageSizeAttributes( image, size ) {
 	}
 
 	return {};
+}
+
+/**
+ * Checks if the file has a valid file type.
+ *
+ * @param {File} file - The file to check.
+ * @return {boolean} - Returns true if the file has a valid file type, otherwise false.
+ */
+export function isValidFileType( file ) {
+	return ALLOWED_MEDIA_TYPES.some(
+		( mediaType ) => file.type.indexOf( mediaType ) === 0
+	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Close https://github.com/WordPress/gutenberg/issues/64795.

Allow dragging and dropping multiple images to a image block (to convert to a gallery block).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

A UX improvement. See https://github.com/WordPress/gutenberg/issues/64795.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The usage of the `mediaUpload` util in `<MediaPlaceholder>` is a bit counterintuitive. It calls `onSelect` multiple times if there are multiple images. Let's say you drop two images from your local file system to the component, the `onSelect` fires four times with the different ` parameters:

1. `[{url: 'blob:...'}]`: The first image in blob format (before upload)
2. `[{url: 'blob:...'}, {url: 'blob:...'}]`: Both images in blob format (before upload)
3. `[media1, {url: 'blob:...'}]`: The first image is uploaded and replace itself with the uploaded media format (from the media library)
4. `[media1, media2]`: Both images are uploaded.

This gets significantly worse when there are more than two images. We also want to defer the upload to each individual image so that we can display some loading states too.

To avoid breaking compatibility, I adjust the `handleUpload` parameter to optionally accept a function. If the function returns `false` then it will not upload the images. We can then create the gallery block ourselves to avoid the complexity.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create an empty image block.
2. Drag and drop multiple images from your local machine to the image block.
3. Upon dropping the images, the image block should be converted to a gallery block and upload each image.
4. Bonus: Dropping images to an image block inside an existing gallery should replace and append those images inside the gallery too.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above. I'm not sure how to test dragging and dropping with keyboard though.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/fbef334b-9e49-43c2-ad00-40068754b11e


