### PR TITLE
DatePicker: restore round radius for event dot

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -64,6 +64,7 @@
 
 -   `TimePicker`: use ToggleGroupControl for AM/PM toggle ([#64800](https://github.com/WordPress/gutenberg/pull/64800)).
 -   `ColorPalette` utils: do not normalize undefined color values ([#64969](https://github.com/WordPress/gutenberg/pull/64969)).
+-   `DatePicker` restore round radius for event dot ([#65031](https://github.com/WordPress/gutenberg/pull/65031)).
 
 ### Internal
 

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -107,6 +107,7 @@ export const DayButton = styled( Button, {
 		`
 		::before {
 			background: ${ props.isSelected ? COLORS.white : COLORS.theme.accent };
+			border-radius: ${ CONFIG.radiusRound };
 			bottom: 2px;
 			content: " ";
 			height: 4px;


### PR DESCRIPTION
Related to #64693

## What?

This PR restores round-radius for event dot in the `DatePicker` component.

## Why?

This dot radius has been removed [here](https://github.com/WordPress/gutenberg/pull/64693/files#diff-31d96f3ca131e0db2cb4139278f183d847e8fc58ead209af6389d8520fffae21L110), but looking at #64693, this doesn't seem like an intentional change. This dot had a radius of 2px, but in reality it was expected to be drawn with a 50% radius, i.e. round.

## Testing Instructions

Access Storybook > DatePicker > With Events: http://localhost:50240/?path=/story/components-datepicker--with-events

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5d371a81-ac07-4989-8080-c5badefc0ab8)| ![image](https://github.com/user-attachments/assets/68e0e1c7-b9c0-4cbc-8c52-fa3896c86e5c) | 