### PR TITLE
Fix: Button: Replace remaining 40px default size violations [Block library 1]

### DIFF
--- a/packages/block-library/src/comments/edit/comments-legacy.js
+++ b/packages/block-library/src/comments/edit/comments-legacy.js
@@ -29,8 +29,7 @@ export default function CommentsLegacy( {
 
 	const actions = [
 		<Button
-			// TODO: Switch to `true` (40px size) if possible
-			__next40pxDefaultSize={ false }
+			__next40pxDefaultSize
 			key="convert"
 			onClick={ () => void setAttributes( { legacy: false } ) }
 			variant="primary"

--- a/packages/block-library/src/embed/embed-placeholder.js
+++ b/packages/block-library/src/embed/embed-placeholder.js
@@ -66,16 +66,14 @@ const EmbedPlaceholder = ( {
 						justify="flex-start"
 					>
 						<Button
-							// TODO: Switch to `true` (40px size) if possible
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							variant="secondary"
 							onClick={ tryAgain }
 						>
 							{ _x( 'Try again', 'button label' ) }
 						</Button>{ ' ' }
 						<Button
-							// TODO: Switch to `true` (40px size) if possible
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							variant="secondary"
 							onClick={ fallback }
 						>

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -25,8 +25,7 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 
 	return (
 		<Button
-			// TODO: Switch to `true` (40px size) if possible
-			__next40pxDefaultSize={ false }
+			__next40pxDefaultSize
 			onClick={ onClick }
 			icon={ fullscreen }
 			isPressed={ isModalFullScreen }
@@ -123,8 +122,7 @@ export default function ModalEdit( props ) {
 					>
 						<FlexItem>
 							<Button
-								// TODO: Switch to `true` (40px size) if possible
-								__next40pxDefaultSize={ false }
+								__next40pxDefaultSize
 								variant="tertiary"
 								onClick={ onClose }
 							>
@@ -133,8 +131,7 @@ export default function ModalEdit( props ) {
 						</FlexItem>
 						<FlexItem>
 							<Button
-								// TODO: Switch to `true` (40px size) if possible
-								__next40pxDefaultSize={ false }
+								__next40pxDefaultSize
 								variant="primary"
 								onClick={ () => {
 									setAttributes( {

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -25,7 +25,8 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 
 	return (
 		<Button
-			__next40pxDefaultSize
+			// TODO: Switch to `true` (40px size) if possible
+			__next40pxDefaultSize={ false }
 			onClick={ onClick }
 			icon={ fullscreen }
 			isPressed={ isModalFullScreen }

--- a/packages/block-library/src/missing/edit.js
+++ b/packages/block-library/src/missing/edit.js
@@ -50,8 +50,7 @@ export default function MissingEdit( { attributes, clientId } ) {
 
 	const convertToHtmlButton = (
 		<Button
-			// TODO: Switch to `true` (40px size) if possible
-			__next40pxDefaultSize={ false }
+			__next40pxDefaultSize
 			key="convert"
 			onClick={ convertToHTML }
 			variant="primary"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of - #65018

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - #65018, To use default to 40px for the button.
- This would fix blocks like, `core/missing`, `core/freeform`, `core/comments`, `core/embed`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- To make the consistent button across Gutenberg, and we would have a lint rule added once fixed, all the button usage.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Change from `__next40pxDefaultSize={ false }` to `__next40pxDefaultSize` on component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add the blocks on the page/post and check for the buttons defined.
- Screenshot is added for individual changed files.
