### PR TITLE
Range control: Restore bottom margin rule.

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/style.scss
+++ b/packages/block-editor/src/components/spacing-sizes-control/style.scss
@@ -19,6 +19,7 @@
 	.spacing-sizes-control__range-control,
 	.spacing-sizes-control__custom-value-range {
 		flex: 1;
+		margin-bottom: 0; // Needed for some instances of the range control, such as the Spacer block.
 	}
 
 	.components-range-control__mark {


### PR DESCRIPTION
## What?

Followup to #64558. That PR did an amazing cleanup job, but one of the cleanups caused a regression in the Spacer block, making the range control off-center:

![before](https://github.com/user-attachments/assets/ba042ca9-3983-4f30-a73d-91b1a23c7476)

This PR restores the 0 margin that fixes this:

![after](https://github.com/user-attachments/assets/a1681838-71c5-447c-9083-298ce0fc1d97)

There may be a better fix, in that case feel free to push to this branch.

## Testing Instructions

Insert a Spacer block and observe the height range control in the inspector looking right.