### PR TITLE
Block Pattern Setup: do not use Composite store

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -22,11 +22,9 @@ import usePatternsSetup from './use-patterns-setup';
 import { VIEWMODES } from './constants';
 import { unlock } from '../../lock-unlock';
 
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
+const { CompositeV2: Composite, CompositeItemV2: CompositeItem } = unlock(
+	componentsPrivateApis
+);
 
 const SetupContent = ( {
 	viewMode,
@@ -35,7 +33,6 @@ const SetupContent = ( {
 	onBlockPatternSelect,
 	showTitles,
 } ) => {
-	const compositeStore = useCompositeStore();
 	const containerClass = 'block-editor-block-pattern-setup__container';
 
 	if ( viewMode === VIEWMODES.carousel ) {
@@ -65,7 +62,6 @@ const SetupContent = ( {
 	return (
 		<div className="block-editor-block-pattern-setup__grid">
 			<Composite
-				store={ compositeStore }
 				role="listbox"
 				className={ containerClass }
 				aria-label={ __( 'Patterns list' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Do not use Composite's store directly in Block Pattern Setup

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We recently made changes so that:

- the top-level `Composite` component accepts the same props as `useCompositeStore`;
- all `Composite` subcomponents already receive the correct `store` without need for the consumer to pass it explicitly


Therefore, we can migrate from

```tsx
const store = useCompositeStore( storeProps );
// ...
return (
  <Composite store={ store } {...compositeProps} >
    <Composite.Item store={ store } {...compositeItemProps }>
  </Composite>
);
```

to

```tsx
return (
  <Composite { ...storeProps } {...compositeProps} >
    <Composite.Item {...compositeItemProps }>
  </Composite>
);
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This component is not used in the editor anymore, but you can follow testing instructions from https://github.com/WordPress/gutenberg/pull/55425 on how to test it with an external plugin.