### PR TITLE
Pattern Transformations Menu: do not use Composite store

### DIFF
--- a/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/pattern-transformations-menu.js
@@ -21,11 +21,9 @@ import BlockPreview from '../block-preview';
 import useTransformedPatterns from './use-transformed-patterns';
 import { unlock } from '../../lock-unlock';
 
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
+const { CompositeV2: Composite, CompositeItemV2: CompositeItem } = unlock(
+	componentsPrivateApis
+);
 
 function PatternTransformationsMenu( {
 	blocks,
@@ -82,10 +80,8 @@ function PreviewPatternsPopover( { patterns, onSelect } ) {
 }
 
 function BlockPatternsList( { patterns, onSelect } ) {
-	const composite = useCompositeStore();
 	return (
 		<Composite
-			store={ composite }
 			role="listbox"
 			className="block-editor-block-switcher__preview-patterns-container"
 			aria-label={ __( 'Patterns list' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Do not use Composite's store directly in Pattern Transformations Menu

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We recently made changes so that:

- the top-level `Composite` component accepts the same props as `useCompositeStore`;
- all `Composite` subcomponents already receive the correct `store` without need for the consumer to pass it explicitly


Therefore, we can migrate from

```tsx
const store = useCompositeStore( storeProps );
// ...
return (
  <Composite store={ store } {...compositeProps} >
    <Composite.Item store={ store } {...compositeItemProps }>
  </Composite>
);
```

to

```tsx
return (
  <Composite { ...storeProps } {...compositeProps} >
    <Composite.Item {...compositeItemProps }>
  </Composite>
);
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the post editor
- Insert a query loop
- Before choosing a pattern, open the block transformation menu from the inserter toolbar
- Open the "Patterns" submenu
- Make sure the list behaves as a composite widget like on `trunk` — ie. it is one tab stop, and using arrow keys moves the focus on the other list items

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/090f22a4-8818-4544-a35d-c8f55e206ed1

