### PR TITLE
Block Inserter Listbox: do not use Composite store

### DIFF
--- a/packages/block-editor/src/components/inserter-listbox/index.js
+++ b/packages/block-editor/src/components/inserter-listbox/index.js
@@ -12,17 +12,11 @@ export { default as InserterListboxGroup } from './group';
 export { default as InserterListboxRow } from './row';
 export { default as InserterListboxItem } from './item';
 
-const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
-	unlock( componentsPrivateApis );
+const { CompositeV2: Composite } = unlock( componentsPrivateApis );
 
 function InserterListbox( { children } ) {
-	const store = useCompositeStore( {
-		focusShift: true,
-		focusWrap: 'horizontal',
-	} );
-
 	return (
-		<Composite store={ store } render={ <></> }>
+		<Composite focusShift focusWrap="horizontal" render={ <></> }>
 			{ children }
 		</Composite>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Do not use Composite's store directly in the Block Inserter Listbox

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We recently made changes so that:

- the top-level `Composite` component accepts the same props as `useCompositeStore`;
- all `Composite` subcomponents already receive the correct `store` without need for the consumer to pass it explicitly


Therefore, we can migrate from

```tsx
const store = useCompositeStore( storeProps );
// ...
return (
  <Composite store={ store } {...compositeProps} >
    <Composite.Item store={ store } {...compositeItemProps }>
  </Composite>
);
```

to

```tsx
return (
  <Composite { ...storeProps } {...compositeProps} >
    <Composite.Item {...compositeItemProps }>
  </Composite>
);
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the post editor
- Open the block inserter sidebar
- Tab through the UI until the first group of blocks is focused
- Make sure that each group of blocks behaves as a two-demensional composite widget, as on `trunk`:
  - Each group is a separate tab stop
  - Moving left/right arrow keys moves the selection on the same row, but also wraps to the previous/next row as per the [`focusWrap` prop](https://ariakit.org/reference/use-composite-store#focuswrap)
  - When pressing arrow down from the last item of a row, focus is moved to the last item of the row below, even if that row doesn't have enough items to fill up the whole row (as per the [`focusShift` prop](https://ariakit.org/reference/use-composite-store#focusshift))


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/fe11bb60-1d6e-4848-8719-a4f921d82673


