### PR TITLE
Block Inserter Media List: do not use Composite store

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-list.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-list.js
@@ -10,8 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { MediaPreview } from './media-preview';
 import { unlock } from '../../../lock-unlock';
 
-const { CompositeV2: Composite, useCompositeStoreV2: useCompositeStore } =
-	unlock( componentsPrivateApis );
+const { CompositeV2: Composite } = unlock( componentsPrivateApis );
 
 function MediaList( {
 	mediaList,
@@ -19,10 +18,8 @@ function MediaList( {
 	onClick,
 	label = __( 'Media List' ),
 } ) {
-	const compositeStore = useCompositeStore();
 	return (
 		<Composite
-			store={ compositeStore }
 			role="listbox"
 			className="block-editor-inserter__media-list"
 			aria-label={ label }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Do not use Composite's store directly in the Block Inserter Media List

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We recently made changes so that:

- the top-level `Composite` component accepts the same props as `useCompositeStore`;
- all `Composite` subcomponents already receive the correct `store` without need for the consumer to pass it explicitly


Therefore, we can migrate from

```tsx
const store = useCompositeStore( storeProps );
// ...
return (
  <Composite store={ store } {...compositeProps} >
    <Composite.Item store={ store } {...compositeItemProps }>
  </Composite>
);
```

to

```tsx
return (
  <Composite { ...storeProps } {...compositeProps} >
    <Composite.Item {...compositeItemProps }>
  </Composite>
);
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the post editor
- Open the block inserter sidebar
- Select the "Media" tab
- Select a source of media items (eg. "Openverse")
- Tab through the UI until focus is on the list of media items
- Make sure the list behaves as a composite widget like on `trunk` — ie. it is one tab stop, and using arrow keys moves the focus on the other list items

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5e93c50d-55ee-4fd1-8c16-ed70b34b6620

