### PR TITLE
Add Custom Template modal: do not use Composite store

### DIFF
--- a/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-template-modal-content.js
@@ -23,11 +23,9 @@ import { useDebouncedInput } from '@wordpress/compose';
 import { unlock } from '../../lock-unlock';
 import { mapToIHasNameAndId } from './utils';
 
-const {
-	CompositeV2: Composite,
-	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
-} = unlock( componentsPrivateApis );
+const { CompositeV2: Composite, CompositeItemV2: CompositeItem } = unlock(
+	componentsPrivateApis
+);
 
 const EMPTY_ARRAY = [];
 
@@ -122,7 +120,6 @@ function useSearchSuggestions( entityForSuggestions, search ) {
 }
 
 function SuggestionList( { entityForSuggestions, onSelect } ) {
-	const composite = useCompositeStore( { orientation: 'vertical' } );
 	const [ search, setSearch, debouncedSearch ] = useDebouncedInput();
 	const suggestions = useSearchSuggestions(
 		entityForSuggestions,
@@ -146,7 +143,7 @@ function SuggestionList( { entityForSuggestions, onSelect } ) {
 			) }
 			{ !! suggestions?.length && (
 				<Composite
-					store={ composite }
+					orientation="vertical"
 					role="listbox"
 					className="edit-site-custom-template-modal__suggestions_list"
 					aria-label={ __( 'Suggestions list' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Do not use Composite's store directly in the Add Custom Template modal.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We recently made changes so that:

- the top-level `Composite` component accepts the same props as `useCompositeStore`;
- all `Composite` subcomponents already receive the correct `store` without need for the consumer to pass it explicitly


Therefore, we can migrate from

```tsx
const store = useCompositeStore( storeProps );
// ...
return (
  <Composite store={ store } {...compositeProps} >
    <Composite.Item store={ store } {...compositeItemProps }>
  </Composite>
);
```

to

```tsx
return (
  <Composite { ...storeProps } {...compositeProps} >
    <Composite.Item {...compositeItemProps }>
  </Composite>
);
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure you have at least 2 post categories in your WordPress instance
- Open the site editor and select "Templates" from the sidebar
- Click the "Add new template" button in the top right corner of the screen
- In the modal that appears, select "Category archives" and then "Category For a specific item"
- A list of existing post categories should be shown. Use the tab key to move focus to the list
- Make sure the list behaves as a composite widget like on `trunk` — ie. it is one tab stop, and using up/down arrow keys moves the focus on the other list items. Since the orientation is `vertical`, using left/right arrow keys should _not_ move focus across the list

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/d0d6e8e6-b0cb-41d3-8fd6-177c332b7578


