### PR TITLE
Add context to `View` string in post actions

### DIFF
--- a/packages/editor/src/dataviews/actions/view-post.tsx
+++ b/packages/editor/src/dataviews/actions/view-post.tsx
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { external } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { _x } from '@wordpress/i18n';
 import type { Action } from '@wordpress/dataviews';
 
 /**
@@ -12,7 +12,7 @@ import type { BasePost } from '../types';
 
 const viewPost: Action< BasePost > = {
 	id: 'view-post',
-	label: __( 'View' ),
+	label: _x( 'View', 'verb' ),
 	isPrimary: true,
 	icon: external,
 	isEligible( post ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds context to `View` string in post actions for translators

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed an incorrect translation because it's not clear to translators that this is actually a verb and not a noun in this context.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
