### PR TITLE
Style Book: do not use Composite store

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -48,7 +48,6 @@ const { mergeBaseAndUserConfigs } = unlock( editorPrivateApis );
 const {
 	CompositeV2: Composite,
 	CompositeItemV2: CompositeItem,
-	useCompositeStoreV2: useCompositeStore,
 	Tabs,
 } = unlock( componentsPrivateApis );
 
@@ -383,11 +382,9 @@ const StyleBookBody = ( {
 
 const Examples = memo(
 	( { className, examples, category, label, isSelected, onSelect } ) => {
-		const compositeStore = useCompositeStore( { orientation: 'vertical' } );
-
 		return (
 			<Composite
-				store={ compositeStore }
+				orientation="vertical"
 				className={ className }
 				aria-label={ label }
 				role="grid"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64723

Do not use Composite's store directly in the Style Book

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/63704#issuecomment-2305291168

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We recently made changes so that:

- the top-level `Composite` component accepts the same props as `useCompositeStore`;
- all `Composite` subcomponents already receive the correct `store` without need for the consumer to pass it explicitly


Therefore, we can migrate from

```tsx
const store = useCompositeStore( storeProps );
// ...
return (
  <Composite store={ store } {...compositeProps} >
    <Composite.Item store={ store } {...compositeItemProps }>
  </Composite>
);
```

to

```tsx
return (
  <Composite { ...storeProps } {...compositeProps} >
    <Composite.Item {...compositeItemProps }>
  </Composite>
);
```


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the site editor
- Go to the "Styles" sidebar screen
- Click the "Style book" icon button (represented by an open eye icon)
- Click on the canvas to interact with the style book in the editor
- Tab through the UI until focus moves on the first block in the styles book
- Make sure the list behaves as a composite widget like on `trunk` — ie. it is one tab stop, and using up/down arrow keys moves the focus on the other list items. Since the orientation is `vertical`, using left/right arrow keys should _not_ move focus across the list

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/377b4799-ceec-44b2-89ad-5fc2441c3531


