### PR TITLE
Add new zoom out experiment

### DIFF
--- a/lib/experimental/editor-settings.php
+++ b/lib/experimental/editor-settings.php
@@ -40,6 +40,9 @@ function gutenberg_enable_experiments() {
 	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-media-processing', $gutenberg_experiments ) ) {
 		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalMediaProcessing = true', 'before' );
 	}
+	if ( $gutenberg_experiments && array_key_exists( 'gutenberg-zoom-out-experiment', $gutenberg_experiments ) ) {
+		wp_add_inline_script( 'wp-block-editor', 'window.__experimentalEnableZoomOutExperiment = true', 'before' );
+	}
 }
 
 add_action( 'admin_init', 'gutenberg_enable_experiments' );

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -199,6 +199,19 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
+	add_settings_field(
+		'gutenberg-zoom-out-experiment',
+		__( 'Zoom out experiments', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enable zoom out experiments; shows zoom out in the device preview and other zoom out experiments.', 'gutenberg' ),
+			'id'    => 'gutenberg-zoom-out-experiment',
+		)
+	);
+
+
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -210,8 +210,6 @@ function gutenberg_initialize_experiments_settings() {
 			'id'    => 'gutenberg-zoom-out-experiment',
 		)
 	);
-
-
 	register_setting(
 		'gutenberg-experiments',
 		'gutenberg-experiments'

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -112,22 +112,24 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			label: __( 'Desktop' ),
 			icon: desktop,
 		},
-		{
+	];
+	if ( window.__experimentalEnableZoomOutExperiment ) {
+		choices.push( {
 			value: 'ZoomOut',
 			label: __( 'Desktop (50%)' ),
 			icon: desktop,
-		},
-		{
-			value: 'Tablet',
-			label: __( 'Tablet' ),
-			icon: tablet,
-		},
-		{
-			value: 'Mobile',
-			label: __( 'Mobile' ),
-			icon: mobile,
-		},
-	];
+		} );
+	}
+	choices.push( {
+		value: 'Tablet',
+		label: __( 'Tablet' ),
+		icon: tablet,
+	} );
+	choices.push( {
+		value: 'Mobile',
+		label: __( 'Mobile' ),
+		icon: mobile,
+	} );
 
 	const previewValue = editorMode === 'zoom-out' ? 'ZoomOut' : deviceType;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This adds a new zoom out experiment, so that we don't expose zoom out in WordPress 6.7 before its ready.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There are still a number of questions about how we want zoom out to work which we haven't finalised. By hiding this behind an experiment we are more able to try out ideas, and also we ensure that this experience doesn't make it into WordPress 6.7 until its ready.

## How?
Add a new experiment to the experiments page, and hide the option behind that flag in the device preview.

## Testing Instructions
1. Open the site editor
2. Confirm that zoom out no longer appears under the device preview dropdown
1. Open the experiments page `wp-admin/admin.php?page=gutenberg-experiments`
3. Enable the zoom out experiment (the one at the bottom)
4. Open the site editor
5. Confirm that zoom out now appears under the device preview dropdown
