### PR TITLE
De-duplicate block toolbar icons for patterns

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -65,6 +65,7 @@ export function PrivateBlockToolbar( {
 		shouldShowVisualToolbar,
 		showParentSelector,
 		isUsingBindings,
+		hasParentPattern,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -74,6 +75,7 @@ export function PrivateBlockToolbar( {
 			isBlockValid,
 			getBlockEditingMode,
 			getBlockAttributes,
+			getBlockParentsByBlockName,
 		} = select( blockEditorStore );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -94,6 +96,13 @@ export function PrivateBlockToolbar( {
 			( clientId ) =>
 				!! getBlockAttributes( clientId )?.metadata?.bindings
 		);
+
+		const _hasParentPattern = selectedBlockClientIds.every(
+			( clientId ) =>
+				getBlockParentsByBlockName( clientId, 'core/block', true )
+					.length > 0
+		);
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -113,6 +122,7 @@ export function PrivateBlockToolbar( {
 				selectedBlockClientIds.length === 1 &&
 				_isDefaultEditingMode,
 			isUsingBindings: _isUsingBindings,
+			hasParentPattern: _hasParentPattern,
 		};
 	}, [] );
 
@@ -167,7 +177,7 @@ export function PrivateBlockToolbar( {
 					isDefaultEditingMode && <BlockParentSelector /> }
 				{ ( shouldShowVisualToolbar || isMultiToolbar ) &&
 					( isDefaultEditingMode ||
-						isContentOnlyEditingMode ||
+						( isContentOnlyEditingMode && ! hasParentPattern ) ||
 						isSynced ) && (
 						<div
 							ref={ nodeRef }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the issue mentioned here - https://github.com/WordPress/gutenberg/pull/64694#issuecomment-2328455986

## How?
[There seems to be a filter for pattern blocks that adds a custom block icon in the toolbar](https://github.com/WordPress/gutenberg/blob/559edaedc00efd3cd9f47418904fb2214d970124/packages/patterns/src/components/pattern-overrides-block-controls.js#L150-L153), and it relied on there being no existing block icon for blocks in contentOnly mode. So when #64694 introduced a block icon, two icons were shown.

To solve this I've added to the already complicated check on whether to render the `BlockSwitcher`.

I think there's a better fix somewhere, probably refactoring how the custom block icon for patterns works. This fix will be quicker though, so I think would be worth merging first.

## Testing Instructions
1. Add a contentOnly group and check that the block icon for inner blocks works as it did in #64694. Here's some block markup to paste into the code editor for testing:
```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group">
<!-- wp:paragraph -->
<p>test</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->
```
2. Now insert a synced pattern that has overrides, select the overridden block and check that there's only one icon

## Screenshots or screencast <!-- if applicable -->
### Synced pattern
#### Before
![Screenshot 2024-09-04 at 12 10 58](https://github.com/user-attachments/assets/7d16f23f-a4da-4819-b35c-8f158cad9eba)

#### After
<img width="345" alt="Screenshot 2024-09-04 at 2 25 44 PM" src="https://github.com/user-attachments/assets/b50be76f-b576-40ec-ab36-ba9fd9f78a78">

### ContentOnly group (still looks the same)
<img width="222" alt="Screenshot 2024-09-04 at 2 25 51 PM" src="https://github.com/user-attachments/assets/742bbecd-c4eb-4dbe-a444-4386a60a4186">


