### PR TITLE
Block Editor: Improve the Select/Navigation mode and keep it persistent

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -574,7 +574,6 @@ function BlockListBlockProvider( props ) {
 				hasBlockMovingClientId,
 				canInsertBlockType,
 				__unstableHasActiveBlockOverlayActive,
-				__unstableGetEditorMode,
 				getSelectedBlocksInitialCaretPosition,
 			} = unlock( select( blockEditorStore ) );
 			const blockWithoutAttributes =
@@ -678,12 +677,9 @@ function BlockListBlockProvider( props ) {
 				hasOverlay:
 					__unstableHasActiveBlockOverlayActive( clientId ) &&
 					! isDragging(),
-				initialPosition:
-					_isSelected &&
-					( __unstableGetEditorMode() === 'edit' ||
-						__unstableGetEditorMode() === 'zoom-out' ) // Don't recalculate the initialPosition when toggling in/out of zoom-out mode
-						? getSelectedBlocksInitialCaretPosition()
-						: undefined,
+				initialPosition: _isSelected
+					? getSelectedBlocksInitialCaretPosition()
+					: undefined,
 				isHighlighted: isBlockHighlighted( clientId ),
 				isMultiSelected,
 				isPartiallySelected:

--- a/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-nav-mode-exit.js
@@ -22,14 +22,12 @@ export function useNavModeExit( clientId ) {
 			function onMouseDown( event ) {
 				// Don't select a block if it's already handled by a child
 				// block.
-				if ( isNavigationMode() && ! event.defaultPrevented ) {
-					// Prevent focus from moving to the block.
-					event.preventDefault();
+				event.stopPropagation();
 
-					// When clicking on a selected block, exit navigation mode.
-					if ( isBlockSelected( clientId ) ) {
-						setNavigationMode( false );
-					} else {
+				if ( isNavigationMode() && ! event.defaultPrevented ) {
+					if ( ! isBlockSelected( clientId ) ) {
+						// Prevent focus from moving to the block.
+						event.preventDefault();
 						selectBlock( clientId );
 					}
 				}

--- a/packages/block-editor/src/components/block-tools/block-selection-button.js
+++ b/packages/block-editor/src/components/block-tools/block-selection-button.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { dragHandle } from '@wordpress/icons';
 import { Button, Flex, FlexItem } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { forwardRef, useEffect } from '@wordpress/element';
+import { forwardRef, useEffect, useRef } from '@wordpress/element';
 import {
 	BACKSPACE,
 	DELETE,
@@ -90,15 +90,20 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 		[ clientId, rootClientId ]
 	);
 	const { label, icon, blockMovingMode, editorMode, canMove } = selected;
-	const { setNavigationMode, removeBlock } = useDispatch( blockEditorStore );
+	const { removeBlock } = useDispatch( blockEditorStore );
 
 	// Focus the breadcrumb in navigation mode.
+	const labelRef = useRef( label );
+	useEffect( () => {
+		labelRef.current = label;
+	}, [ label ] );
 	useEffect( () => {
 		if ( editorMode === 'navigation' ) {
 			ref.current.focus();
-			speak( label );
+			speak( labelRef.current );
 		}
-	}, [ label, editorMode ] );
+	}, [ editorMode ] );
+
 	const blockElement = useBlockElement( clientId );
 
 	const {
@@ -279,7 +284,7 @@ function BlockSelectionButton( { clientId, rootClientId }, ref ) {
 							ref={ ref }
 							onClick={
 								editorMode === 'navigation'
-									? () => setNavigationMode( false )
+									? () => blockElement?.focus()
 									: undefined
 							}
 							onKeyDown={ onKeyDown }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1797,11 +1797,6 @@ export const blockListSettings = ( state = {}, action ) => {
  * @return {string} Updated state.
  */
 export function editorMode( state = 'edit', action ) {
-	// Let inserting block in navigation mode always trigger Edit mode.
-	if ( action.type === 'INSERT_BLOCKS' && state === 'navigation' ) {
-		return 'edit';
-	}
-
 	if ( action.type === 'SET_EDITOR_MODE' ) {
 		return action.mode;
 	}


### PR DESCRIPTION
Related to https://github.com/WordPress/gutenberg/pull/64866. 
Alternative to #65027 
Still pretty exploratory as well.

This PR takes an alternative approach to #65027. Instead of introducing a new mode that mixes multiple things (content only...), it starts from the premise that the existing "Select mode" can already be a good mode to a design tool. By making small tweaks to how it behaves we can improve the situation a lot and even consider this mode as the default in some situations later (site editor...)

So what this PR focuses on is the following:

 - Keep the drill down behavior of the select mode (which personally I find very good for a design tool)
 - Allow reaching and modifying texts and images... Basically as you reach the "leaf" notes, you can click again and type ...

Downside:

 - "Enter" doesn't exist navigation mode, I think it's ok and I'm on the camp that we should move away from "Escape/Enter" to switch between these modes. Maybe consider dedicated shortcuts.

Personally, I feel this is already an improvement over trunk for the "select" mode so I'm going to keep this PR small to try to get some feedback on this part only.

That said, if this is a direction we want to pursue, there's a lot of things we can improve here and consider as follow-ups:

 - Avoid specific toolbar for navigation mode
 - Drag and drop by clicking the blocks directly rather than the chip

**Testing instructions**

 - Try using the select mode with a page full of content.