### PR TITLE
Inserter: Fix subtle media insertion error

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -101,12 +101,14 @@ function InserterMenu(
 			window.requestAnimationFrame( () => {
 				if (
 					! shouldFocusBlock &&
-					! blockTypesTabRef?.current.contains(
+					! blockTypesTabRef?.current?.contains(
 						ref.current.ownerDocument.activeElement
 					)
 				) {
 					// There has been a focus loss, so focus the first button in the block types tab
-					blockTypesTabRef?.current.querySelector( 'button' ).focus();
+					blockTypesTabRef?.current
+						?.querySelector( 'button' )
+						.focus();
 				}
 			} );
 		},

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -101,12 +101,12 @@ function InserterMenu(
 			window.requestAnimationFrame( () => {
 				if (
 					! shouldFocusBlock &&
-					! blockTypesTabRef?.current?.contains(
+					! blockTypesTabRef.current?.contains(
 						ref.current.ownerDocument.activeElement
 					)
 				) {
 					// There has been a focus loss, so focus the first button in the block types tab
-					blockTypesTabRef?.current
+					blockTypesTabRef.current
 						?.querySelector( 'button' )
 						.focus();
 				}

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -106,9 +106,7 @@ function InserterMenu(
 					)
 				) {
 					// There has been a focus loss, so focus the first button in the block types tab
-					blockTypesTabRef.current
-						?.querySelector( 'button' )
-						.focus();
+					blockTypesTabRef.current?.querySelector( 'button' ).focus();
 				}
 			} );
 		},


### PR DESCRIPTION
## What?
This PR fixes an error in the inserter when inserting an image (see screenshot below).

## Why?
Just resolving an error. 

Discovered while testing #65043.

## How?
We're ensuring the blocks tab exists before attempting to resolve the previously lost focus.

## Testing Instructions
* Make sure you have at least 1 image uploaded to your site.
* Start writing a new post.
* Open the inserter.
* Select "Media"
* Click "Images".
* Click the image to insert it.
* Verify the error is gone.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-09-04 at 16 45 15](https://github.com/user-attachments/assets/143cf6b1-ac08-44dd-89b0-8def5804fd54)
![Screenshot 2024-09-04 at 16 45 49](https://github.com/user-attachments/assets/31a329ca-4f69-4fc0-b6df-3d78f4aa29bc)
