### PR TITLE
Add: Typography styling support to the navigation submenu block.

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -493,7 +493,7 @@ Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/navigation-submenu
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** interactivity (clientNavigation), ~~html~~, ~~reusable~~
+-	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -59,6 +59,19 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/49319

Currently, the navigation submenu block does not support typography styles, while the navigation link block supports them.
This has several issues:

1. The user is not able to configure the typography of submenu links as they can on normal links.
2. When a normal link is converted to a submenu its styles are lost which is a buggy behavior.

This PR adds the same typography styles supported in the navigation link to the navigation submenu block.

cc: @cuemarie, @annezazu

## Testing Instructions
I added a navigation submenu and verified I could change its typography. The styles are applied on both the frontend and the editor.

I added a navigation link with some typography styles. I transformed that link into a submenu and verified the styles were kept (on the trunk they are discarded).
