### PR TITLE
Build: Prepare build for more script modules

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -52,5 +52,5 @@ jobs:
             - uses: preactjs/compressed-size-action@f780fd104362cfce9e118f9198df2ee37d12946c # v2.6.0
               with:
                   repo-token: '${{ secrets.GITHUB_TOKEN }}'
-                  pattern: '{build/**/*.min.js,build/**/*.css}'
+                  pattern: '{build/**/*.min.js,build/**/*.css,build-module/**/*.min.js}'
                   clean-script: 'distclean'

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -98,6 +98,7 @@ zip -r gutenberg.zip \
 	packages/block-serialization-default-parser/*.php \
 	post-content.php \
 	$build_files \
+	build-module \
 	readme.txt \
 	changelog.txt \
 	README.md

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -16,14 +16,14 @@ function gutenberg_reregister_interactivity_script_modules() {
 
 	wp_register_script_module(
 		'@wordpress/interactivity',
-		gutenberg_url( '/build/script-modules/interactivity/' . ( SCRIPT_DEBUG ? 'debug.min.js' : 'index.min.js' ) ),
+		gutenberg_url( '/build-module/' . ( SCRIPT_DEBUG ? 'interactivity-debug.min.js' : 'interactivity.min.js' ) ),
 		array(),
 		$default_version
 	);
 
 	wp_register_script_module(
 		'@wordpress/interactivity-router',
-		gutenberg_url( '/build/script-modules/interactivity/router.min.js' ),
+		gutenberg_url( '/build-module/interactivity-router.min.js' ),
 		array( '@wordpress/interactivity' ),
 		$default_version
 	);

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -16,14 +16,14 @@ function gutenberg_reregister_interactivity_script_modules() {
 
 	wp_register_script_module(
 		'@wordpress/interactivity',
-		gutenberg_url( '/build/interactivity/' . ( SCRIPT_DEBUG ? 'debug.min.js' : 'index.min.js' ) ),
+		gutenberg_url( '/build/script-modules/interactivity/' . ( SCRIPT_DEBUG ? 'debug.min.js' : 'index.min.js' ) ),
 		array(),
 		$default_version
 	);
 
 	wp_register_script_module(
 		'@wordpress/interactivity-router',
-		gutenberg_url( '/build/interactivity/router.min.js' ),
+		gutenberg_url( '/build/script-modules/interactivity/router.min.js' ),
 		array( '@wordpress/interactivity' ),
 		$default_version
 	);

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -23,7 +23,7 @@ function gutenberg_reregister_interactivity_script_modules() {
 
 	wp_register_script_module(
 		'@wordpress/interactivity-router',
-		gutenberg_url( '/build-module/interactivity-router.min.js' ),
+		gutenberg_url( '/build-module/interactivity-router/index.min.js' ),
 		array( '@wordpress/interactivity' ),
 		$default_version
 	);

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -16,7 +16,7 @@ function gutenberg_reregister_interactivity_script_modules() {
 
 	wp_register_script_module(
 		'@wordpress/interactivity',
-		gutenberg_url( '/build-module/' . ( SCRIPT_DEBUG ? 'interactivity-debug.min.js' : 'interactivity.min.js' ) ),
+		gutenberg_url( '/build-module/' . ( SCRIPT_DEBUG ? 'interactivity/debug.min.js' : 'interactivity/index.min.js' ) ),
 		array(),
 		$default_version
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
 				"@wordpress/i18n": "file:packages/i18n",
 				"@wordpress/icons": "file:packages/icons",
 				"@wordpress/interactivity": "file:packages/interactivity",
+				"@wordpress/interactivity-router": "file:packages/interactivity-router",
 				"@wordpress/interface": "file:packages/interface",
 				"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 				"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
 		"@wordpress/i18n": "file:packages/i18n",
 		"@wordpress/icons": "file:packages/icons",
 		"@wordpress/interactivity": "file:packages/interactivity",
+		"@wordpress/interactivity-router": "file:packages/interactivity-router",
 		"@wordpress/interface": "file:packages/interface",
 		"@wordpress/is-shallow-equal": "file:packages/is-shallow-equal",
 		"@wordpress/keyboard-shortcuts": "file:packages/keyboard-shortcuts",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -30,6 +30,13 @@
 		"src/**/*.scss",
 		"{src,build,build-module}/*/init.js"
 	],
+	"wp-script-module-exports": {
+		"./file/view": "./build-module/file/view.js",
+		"./image/view": "./build-module/image/view.js",
+		"./navigation/view": "./build-module/navigation/view.js",
+		"./query/view": "./build-module/query/view.js",
+		"./search/view": "./build-module/search/view.js"
+	},
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
 		"@wordpress/a11y": "file:../a11y",

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -30,7 +30,7 @@
 		"src/**/*.scss",
 		"{src,build,build-module}/*/init.js"
 	],
-	"wp-script-module-exports": {
+	"wpScriptModuleExports": {
 		"./file/view": "./build-module/file/view.js",
 		"./image/view": "./build-module/image/view.js",
 		"./navigation/view": "./build-module/navigation/view.js",

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -21,7 +21,7 @@ function render_block_core_file( $attributes, $content ) {
 	if ( ! empty( $attributes['displayPreview'] ) ) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/script-modules/block-library/file.min.js' );
+			$module_url = gutenberg_url( '/build-module/block-library/file.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -21,7 +21,7 @@ function render_block_core_file( $attributes, $content ) {
 	if ( ! empty( $attributes['displayPreview'] ) ) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build-module/block-library/file.min.js' );
+			$module_url = gutenberg_url( '/build-module/block-library/file/view.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -21,7 +21,7 @@ function render_block_core_file( $attributes, $content ) {
 	if ( ! empty( $attributes['displayPreview'] ) ) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/interactivity/file.min.js' );
+			$module_url = gutenberg_url( '/build/script-modules/block-library/file.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -72,7 +72,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 	) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build-module/block-library/image.min.js' );
+			$module_url = gutenberg_url( '/build-module/block-library/image/view.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -72,7 +72,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 	) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/interactivity/image.min.js' );
+			$module_url = gutenberg_url( '/build/script-modules/block-library/image.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -72,7 +72,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 	) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/script-modules/block-library/image.min.js' );
+			$module_url = gutenberg_url( '/build-module/block-library/image.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -624,7 +624,7 @@ class WP_Navigation_Block_Renderer {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
 			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build-module/block-library/navigation.min.js' );
+				$module_url = gutenberg_url( '/build-module/block-library/navigation/view.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -624,7 +624,7 @@ class WP_Navigation_Block_Renderer {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
 			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build/interactivity/navigation.min.js' );
+				$module_url = gutenberg_url( '/build/script-modules/block-library/navigation.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -624,7 +624,7 @@ class WP_Navigation_Block_Renderer {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
 			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build/script-modules/block-library/navigation.min.js' );
+				$module_url = gutenberg_url( '/build-module/block-library/navigation.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -26,7 +26,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 	if ( $is_interactive ) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/script-modules/block-library/query.min.js' );
+			$module_url = gutenberg_url( '/build-module/block-library/query.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -26,7 +26,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 	if ( $is_interactive ) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build/interactivity/query.min.js' );
+			$module_url = gutenberg_url( '/build/script-modules/block-library/query.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -26,7 +26,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 	if ( $is_interactive ) {
 		$suffix = wp_scripts_get_suffix();
 		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build-module/block-library/query.min.js' );
+			$module_url = gutenberg_url( '/build-module/block-library/query/view.min.js' );
 		}
 
 		wp_register_script_module(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -82,7 +82,7 @@ function render_block_core_search( $attributes ) {
 		if ( $is_expandable_searchfield ) {
 			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build/script-modules/block-library/search.min.js' );
+				$module_url = gutenberg_url( '/build-module/block-library/search.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -82,7 +82,7 @@ function render_block_core_search( $attributes ) {
 		if ( $is_expandable_searchfield ) {
 			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build-module/block-library/search.min.js' );
+				$module_url = gutenberg_url( '/build-module/block-library/search/view.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -82,7 +82,7 @@ function render_block_core_search( $attributes ) {
 		if ( $is_expandable_searchfield ) {
 			$suffix = wp_scripts_get_suffix();
 			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build/interactivity/search.min.js' );
+				$module_url = gutenberg_url( '/build/script-modules/block-library/search.min.js' );
 			}
 
 			wp_register_script_module(

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -24,6 +24,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"wp-module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
 	"dependencies": {

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -24,9 +24,11 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"wp-script-module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
+	"wp-script-module-exports": {
+		".": "./build-module/index.js"
+	},
 	"dependencies": {
 		"@wordpress/interactivity": "file:../interactivity"
 	},

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -24,7 +24,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"wp-module": "build-module/index.js",
+	"wp-script-module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
 	"dependencies": {

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -26,9 +26,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
-	"wp-script-module-exports": {
-		".": "./build-module/index.js"
-	},
+	"wpScriptModuleExports": "./build-module/index.js",
 	"dependencies": {
 		"@wordpress/interactivity": "file:../interactivity"
 	},

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -26,7 +26,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
-	"wp-script-module-exports": {
+	"wpScriptModuleExports": {
 		".": "./build-module/index.js",
 		"./debug": "./build-module/debug.js"
 	},

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -24,6 +24,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
+	"wp-module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
 	"dependencies": {

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -24,9 +24,12 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"wp-script-module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
+	"wp-script-module-exports": {
+		".": "./build-module/index.js",
+		"./debug": "./build-module/debug.js"
+	},
 	"dependencies": {
 		"@preact/signals": "^1.2.2",
 		"preact": "^10.19.3"

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -24,7 +24,7 @@
 	},
 	"main": "build/index.js",
 	"module": "build-module/index.js",
-	"wp-module": "build-module/index.js",
+	"wp-script-module": "build-module/index.js",
 	"react-native": "src/index",
 	"types": "build-types",
 	"dependencies": {

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -45,7 +45,7 @@ module.exports = {
 	},
 	resolve: {
 		extensions: [ '.js', '.ts', '.tsx' ],
-		mainFields: [ 'wp-module' ],
+		mainFields: [ 'wp-script-module' ],
 	},
 	module: {
 		rules: [

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -80,7 +80,7 @@ for ( const [ packageName, versionSpecifier ] of iterableDeps ) {
 module.exports = {
 	...baseConfig,
 	name: 'script-modules',
-	entry: gutenbergScriptModules,
+	entry: Object.fromEntries( gutenbergScriptModules.entries() ),
 	experiments: {
 		outputModule: true,
 	},

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -17,16 +17,17 @@ module.exports = {
 	...baseConfig,
 	name: 'script-modules',
 	entry: {
-		interactivity: './packages/interactivity',
-		'interactivity-debug': './packages/interactivity/src/debug',
+		'interactivity/index': './packages/interactivity',
+		'interactivity/debug': './packages/interactivity/debug',
+
 		'interactivity-router': './packages/interactivity-router',
 
-		'block-library/file': './packages/block-library/src/file/view.js',
-		'block-library/image': './packages/block-library/src/image/view.js',
-		'block-library/navigation':
-			'./packages/block-library/src/navigation/view.js',
-		'block-library/query': './packages/block-library/src/query/view.js',
-		'block-library/search': './packages/block-library/src/search/view.js',
+		'block-library/file/view': './packages/block-library/file/view',
+		'block-library/image/view': './packages/block-library/image/view',
+		'block-library/navigation/view':
+			'./packages/block-library/navigation/view',
+		'block-library/query/view': './packages/block-library/query/view',
+		'block-library/search/view': './packages/block-library/search/view',
 	},
 	experiments: {
 		outputModule: true,
@@ -45,7 +46,7 @@ module.exports = {
 	},
 	resolve: {
 		extensions: [ '.js', '.ts', '.tsx' ],
-		mainFields: [ 'wp-script-module' ],
+		exportsFields: [ 'wp-script-module-exports', 'exports' ],
 	},
 	module: {
 		rules: [

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -16,7 +16,7 @@ const { baseConfig, plugins } = require( './shared' );
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const { createRequire } = require( 'node:module' );
 
-const rootPath = `${ __dirname }/../../`;
+const rootPath = new URL( '..', `file://${ __dirname }` );
 const fromRootRequire = createRequire( rootPath );
 
 /** @type {Iterable<[string, string]>} */
@@ -35,7 +35,7 @@ for ( const [ packageName, versionSpecifier ] of iterableDeps ) {
 		continue;
 	}
 	const packageRequire = createRequire(
-		`${ rootPath }/${ versionSpecifier.substring( 5 ) }/`
+		new URL( `${ versionSpecifier.substring( 5 ) }/`, rootPath )
 	);
 	const depPackageJson = packageRequire( './package.json' );
 	if ( ! Object.hasOwn( depPackageJson, 'wpScriptModuleExports' ) ) {

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -80,19 +80,7 @@ for ( const [ packageName, versionSpecifier ] of iterableDeps ) {
 module.exports = {
 	...baseConfig,
 	name: 'script-modules',
-	entry: {
-		'interactivity/index': './packages/interactivity',
-		'interactivity/debug': './packages/interactivity/debug',
-
-		'interactivity-router': './packages/interactivity-router',
-
-		'block-library/file/view': './packages/block-library/file/view',
-		'block-library/image/view': './packages/block-library/image/view',
-		'block-library/navigation/view':
-			'./packages/block-library/navigation/view',
-		'block-library/query/view': './packages/block-library/query/view',
-		'block-library/search/view': './packages/block-library/search/view',
-	},
+	entry: gutenbergScriptModules,
 	experiments: {
 		outputModule: true,
 	},

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -16,8 +16,8 @@ const { baseConfig, plugins } = require( './shared' );
 const WORDPRESS_NAMESPACE = '@wordpress/';
 const { createRequire } = require( 'node:module' );
 
-const rootPath = new URL( '..', `file://${ __dirname }` );
-const fromRootRequire = createRequire( rootPath );
+const rootURL = new URL( '..', `file://${ __dirname }` );
+const fromRootRequire = createRequire( rootURL );
 
 /** @type {Iterable<[string, string]>} */
 const iterableDeps = Object.entries(
@@ -34,9 +34,12 @@ for ( const [ packageName, versionSpecifier ] of iterableDeps ) {
 	) {
 		continue;
 	}
+
 	const packageRequire = createRequire(
-		new URL( `${ versionSpecifier.substring( 5 ) }/`, rootPath )
+		// Remove the leading "file:" specifier to build a package URL.
+		new URL( `${ versionSpecifier.substring( 5 ) }/`, rootURL )
 	);
+
 	const depPackageJson = packageRequire( './package.json' );
 	if ( ! Object.hasOwn( depPackageJson, 'wpScriptModuleExports' ) ) {
 		continue;

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -41,9 +41,11 @@ module.exports = {
 		environment: { module: true },
 		module: true,
 		chunkFormat: 'module',
+		asyncChunks: false,
 	},
 	resolve: {
 		extensions: [ '.js', '.ts', '.tsx' ],
+		mainFields: [ 'wp-module' ],
 	},
 	module: {
 		rules: [

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -17,9 +17,9 @@ module.exports = {
 	...baseConfig,
 	name: 'script-modules',
 	entry: {
-		'interactivity/index': './packages/interactivity',
-		'interactivity/debug': './packages/interactivity/src/debug',
-		'interactivity/router': './packages/interactivity-router',
+		interactivity: './packages/interactivity',
+		'interactivity-debug': './packages/interactivity/src/debug',
+		'interactivity-router': './packages/interactivity-router',
 
 		'block-library/file': './packages/block-library/src/file/view.js',
 		'block-library/image': './packages/block-library/src/image/view.js',
@@ -33,7 +33,7 @@ module.exports = {
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename: './build/script-modules/[name].min.js',
+		filename: './build-module/[name].min.js',
 		library: {
 			type: 'module',
 		},

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -15,23 +15,25 @@ const { baseConfig, plugins } = require( './shared' );
 
 module.exports = {
 	...baseConfig,
-	name: 'interactivity',
+	name: 'script-modules',
 	entry: {
-		index: './packages/interactivity',
-		debug: './packages/interactivity/src/debug',
-		router: './packages/interactivity-router',
-		navigation: './packages/block-library/src/navigation/view.js',
-		query: './packages/block-library/src/query/view.js',
-		image: './packages/block-library/src/image/view.js',
-		file: './packages/block-library/src/file/view.js',
-		search: './packages/block-library/src/search/view.js',
+		'interactivity/index': './packages/interactivity',
+		'interactivity/debug': './packages/interactivity/src/debug',
+		'interactivity/router': './packages/interactivity-router',
+
+		'block-library/file': './packages/block-library/src/file/view.js',
+		'block-library/image': './packages/block-library/src/image/view.js',
+		'block-library/navigation':
+			'./packages/block-library/src/navigation/view.js',
+		'block-library/query': './packages/block-library/src/query/view.js',
+		'block-library/search': './packages/block-library/src/search/view.js',
 	},
 	experiments: {
 		outputModule: true,
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename: './build/interactivity/[name].min.js',
+		filename: './build/script-modules/[name].min.js',
 		library: {
 			type: 'module',
 		},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,13 +3,13 @@
  */
 const blocksConfig = require( './tools/webpack/blocks' );
 const developmentConfigs = require( './tools/webpack/development' );
-const interactivity = require( './tools/webpack/interactivity' );
+const scriptModules = require( './tools/webpack/script-modules' );
 const packagesConfig = require( './tools/webpack/packages' );
 const vendorsConfig = require( './tools/webpack/vendors' );
 
 module.exports = [
 	...blocksConfig,
-	interactivity,
+	scriptModules,
 	packagesConfig,
 	...developmentConfigs,
 	...vendorsConfig,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,8 @@ const vendorsConfig = require( './tools/webpack/vendors' );
 
 module.exports = [
 	...blocksConfig,
+	scriptModules,
 	packagesConfig,
-	scriptModules, // Script modules build depends on the package build.
 	...developmentConfigs,
 	...vendorsConfig,
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,8 +9,8 @@ const vendorsConfig = require( './tools/webpack/vendors' );
 
 module.exports = [
 	...blocksConfig,
-	scriptModules,
 	packagesConfig,
+	scriptModules, // Script modules build depends on the package build.
 	...developmentConfigs,
 	...vendorsConfig,
 ];


### PR DESCRIPTION
## What?
Prepare webpack module build to handle more Script Module builds for use in WordPress.

- Rename the "interactivity" webpack build to "script modules".
- Output script-modules builds to `build-module` folder (adjacent to the `build` folder currently used for scripts).
- Add `wpScriptModulesExports` field and configure webpack to use it. This follows the same basic syntax as [package.json `exports` fields](https://nodejs.org/api/packages.html#exports). Multiple module entrypoints can be exposed per package. However, it remains a custom field, so it is clear that these entrypoints are not intended for general consumption. In the future, module-only packages (interactivity, interactivity-router) can switch to using exports directly and likely add `type: module`, but that's follow-up work 🙂 
- There are some difficulties with webpack recognizing `wpScriptModulesExports` directly, so packages are inspected programmatically in order to generated webpack script modules entrypoints.
- Adjust script module registration accordingly to find the generated script modules.

This is a first step towards building more script modules, such as `@wordpress/a11y` which may be used in https://github.com/WordPress/gutenberg/pull/62906.

https://github.com/WordPress/gutenberg/pull/65101 shows how this is used to build the `@wordpress/a11y` script module.

Related PRs:
- https://github.com/WordPress/gutenberg/pull/65101
- https://github.com/WordPress/gutenberg/pull/65123
- https://github.com/WordPress/wordpress-develop/pull/7304

## Why?

This prepares the build to produce more script modules.

## How?

See above.

## Testing Instructions

It's important to ensure that script modules are correctly registered. This should be covered by e2e tests, but testing, in particular of the affected blocks (image, query, etc.) on the frontend is appreciated.