### PR TITLE
Fix editor error in Safari due to availability of checkVisibility method

### DIFF
--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -96,7 +96,7 @@ function isElementVisible( element ) {
 		return false;
 	}
 
-	// Older browsers, e.g. Safari may not have `checkVisibility` method.
+	// Older browsers, e.g. Safari < 17.4 may not support the `checkVisibility` method.
 	if ( element.checkVisibility ) {
 		return element.checkVisibility?.( {
 			opacityProperty: true,

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -96,11 +96,26 @@ function isElementVisible( element ) {
 		return false;
 	}
 
-	return element.checkVisibility?.( {
-		opacityProperty: true,
-		contentVisibilityAuto: true,
-		visibilityProperty: true,
-	} );
+	// Older browsers, e.g. Safari may not have `checkVisibility` method.
+	if ( element.checkVisibility ) {
+		return element.checkVisibility?.( {
+			opacityProperty: true,
+			contentVisibilityAuto: true,
+			visibilityProperty: true,
+		} );
+	}
+
+	const style = viewport.getComputedStyle( element );
+
+	if (
+		style.display === 'none' ||
+		style.visibility === 'hidden' ||
+		style.opacity === '0'
+	) {
+		return false;
+	}
+
+	return true;
 }
 
 /**

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -96,7 +96,7 @@ function isElementVisible( element ) {
 		return false;
 	}
 
-	return element.checkVisibility( {
+	return element.checkVisibility?.( {
 		opacityProperty: true,
 		contentVisibilityAuto: true,
 		visibilityProperty: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an editor error caused by #62711 in older versions of Safari that do not have support for `element.checkVisibility`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Raised in https://github.com/WordPress/gutenberg/pull/62711/files#r1743668601, in older Safari versions the editor will error out when selecting a block as `checkVisibility` is not available.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check that `element.checkVisibility` is available before calling it. If it's not available, then manually check the computed style's display, visibility, and opacity as in an earlier commit in #62711.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In an older version of Safari (e.g. 16.4.1 on MacOS Monterey) open up the post editor and select a block
2. In `trunk` the editor will error out. With this PR applied it shouldn't.
3. Test the changes in #62711 in latest Chrome, FF, or other browsers and make sure nothing else is affected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/47755fab-9b8c-476f-a4fb-5ba4972faf56)

### After

![image](https://github.com/user-attachments/assets/d6888ee1-9729-475a-b492-ea67c80607db)
