### PR TITLE
DataViews storybook: better styles for combined fields story

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -547,7 +547,15 @@ export const themeData: Theme[] = [
 export const themeFields: Field< Theme >[] = [
 	{ id: 'slug', label: 'Slug' },
 	{ id: 'name', label: 'Name' },
-	{ id: 'description', label: 'Description' },
+	{
+		id: 'description',
+		label: 'Description',
+		render: ( { item } ) => (
+			<span className="theme-field-description">
+				{ item.description }
+			</span>
+		),
+	},
 	{ id: 'requires', label: 'Requires at least' },
 	{ id: 'tested', label: 'Tested up to' },
 	{

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -19,6 +19,8 @@ import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
 import type { View } from '../../../types';
 
+import './style.css';
+
 const meta = {
 	title: 'DataViews/DataViews',
 	component: DataViews,
@@ -144,6 +146,11 @@ export const CombinedFields = () => {
 					direction: 'vertical',
 				},
 			],
+			styles: {
+				theme: {
+					maxWidth: 300,
+				},
+			},
 		},
 	} );
 	const { data: shownData, paginationInfo } = useMemo( () => {

--- a/packages/dataviews/src/components/dataviews/stories/style.css
+++ b/packages/dataviews/src/components/dataviews/stories/style.css
@@ -1,0 +1,4 @@
+.theme-field-description {
+    text-wrap: balance;
+    text-wrap: pretty;
+}


### PR DESCRIPTION
## What?

Improve styles for "combined fields" story:

| Before | After |
| --- | --- |
| <img width="1677" alt="Captura de ecrã 2024-09-05, às 08 53 52" src="https://github.com/user-attachments/assets/e3da5424-7bc2-4ac5-9cc6-f2ad7a75024c"> | <img width="1677" alt="Captura de ecrã 2024-09-05, às 08 53 18" src="https://github.com/user-attachments/assets/d0b0066c-db2b-4154-a7d4-eed93bff90a1"> |

