### PR TITLE
Core Data: Fix the 'query._fields' property check inside 'getEntityRecord' resolver

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -155,7 +155,7 @@ export const getEntityRecord =
 					}
 				);
 
-				if ( query !== undefined ) {
+				if ( query !== undefined && query._fields ) {
 					query = { ...query, include: [ key ] };
 
 					// The resolution cache won't consider query as reusable based on the

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -80,7 +80,6 @@ describe( 'getEntityRecord', () => {
 
 	it( 'accepts a query that overrides default api path', async () => {
 		const query = { context: 'view', _envelope: '1' };
-		const queryObj = { include: [ 'post' ], ...query };
 
 		const select = {
 			hasEntityRecords: jest.fn( () => {} ),
@@ -98,13 +97,6 @@ describe( 'getEntityRecord', () => {
 			query
 		)( { dispatch, select, registry } );
 
-		// Check resolution cache for an existing entity that fulfills the request with query.
-		expect( select.hasEntityRecords ).toHaveBeenCalledWith(
-			'root',
-			'postType',
-			queryObj
-		);
-
 		// Trigger apiFetch, test that the query is present in the url.
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/types/post?context=view&_envelope=1',
@@ -116,7 +108,7 @@ describe( 'getEntityRecord', () => {
 			'root',
 			'postType',
 			POST_TYPE,
-			queryObj
+			query
 		);
 
 		// Locks should have been acquired and released.


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/64996#issuecomment-2328406060.

PR fixes the condition for early bailout inside the `getEntityRecord` resolver. This matches check for a similar condition above:

https://github.com/WordPress/gutenberg/blob/29e344c51f6f3073bbccfbbac16cf9ac5031f1b4/packages/core-data/src/resolvers.js#L126

## Why?
The special handling is only needed when the `_fields` query property is defined and not for every selector call that passes the query.

## Testing Instructions
CI checks are passing.
