### PR TITLE
Update: Rephrase "Force page reload" and move to Advanced

### DIFF
--- a/packages/block-library/src/query/edit/enhanced-pagination-modal.js
+++ b/packages/block-library/src/query/edit/enhanced-pagination-modal.js
@@ -42,7 +42,7 @@ export default function EnhancedPaginationModal( {
 	};
 
 	let notice = __(
-		'If you still want to prevent full page reloads, remove that block, then disable "Force page reload" again in the Query Block settings.'
+		'If you still want to prevent full page reloads, remove that block, then disable "Reload full page" again in the Query Block settings.'
 	);
 	if ( hasBlocksFromPlugins ) {
 		notice =
@@ -63,7 +63,7 @@ export default function EnhancedPaginationModal( {
 	return (
 		isOpen && (
 			<Modal
-				title={ __( 'Query block: Force page reload enabled' ) }
+				title={ __( 'Query block: Reload full page enabled' ) }
 				className="wp-block-query__enhanced-pagination-modal"
 				aria={ {
 					describedby: modalDescriptionId,

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -25,7 +25,7 @@ export default function EnhancedPaginationControl( {
 		);
 	} else if ( enhancedPagination ) {
 		help = __(
-			"Browsing between pages won't require a full page reload, unless non-compatible blocks are detected."
+			'Reload the full page—instead of just the posts list—when visitors navigate between pages.'
 		);
 	} else if ( hasUnsupportedBlocks ) {
 		help = __(
@@ -37,7 +37,7 @@ export default function EnhancedPaginationControl( {
 		<>
 			<ToggleControl
 				__nextHasNoMarginBottom
-				label={ __( 'Force page reload' ) }
+				label={ __( 'Reload full page' ) }
 				help={ help }
 				checked={
 					! enhancedPagination && ! fullPageClientSideNavigation

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -29,7 +29,7 @@ export default function EnhancedPaginationControl( {
 		);
 	} else if ( hasUnsupportedBlocks ) {
 		help = __(
-			"Force page reload can't be disabled because there are non-compatible blocks inside the Query block."
+			"Reload full page can't be disabled because there are non-compatible blocks inside the Query block."
 		);
 	}
 

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -29,7 +29,7 @@ export default function EnhancedPaginationControl( {
 		);
 	} else if ( hasUnsupportedBlocks ) {
 		help = __(
-			"Enhancement disabled because there are non-compatible blocks inside the Query block."
+			'Enhancement disabled because there are non-compatible blocks inside the Query block.'
 		);
 	}
 

--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -29,7 +29,7 @@ export default function EnhancedPaginationControl( {
 		);
 	} else if ( hasUnsupportedBlocks ) {
 		help = __(
-			"Reload full page can't be disabled because there are non-compatible blocks inside the Query block."
+			"Enhancement disabled because there are non-compatible blocks inside the Query block."
 		);
 	}
 

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -25,7 +25,6 @@ import AuthorControl from './author-control';
 import ParentControl from './parent-control';
 import { TaxonomyControls } from './taxonomy-controls';
 import StickyControl from './sticky-control';
-import EnhancedPaginationControl from './enhanced-pagination-control';
 import CreateNewPostLink from './create-new-post-link';
 import PerPageControl from './per-page-control';
 import OffsetControl from './offset-controls';
@@ -43,9 +42,9 @@ import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 const { BlockInfo } = unlock( blockEditorPrivateApis );
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, setDisplayLayout, setAttributes, clientId } =
+	const { attributes, setQuery, setDisplayLayout } =
 		props;
-	const { query, displayLayout, enhancedPagination } = attributes;
+	const { query, displayLayout } = attributes;
 	const {
 		order,
 		orderBy,
@@ -262,11 +261,6 @@ export default function QueryInspectorControls( props ) {
 							}
 						/>
 					) }
-					<EnhancedPaginationControl
-						enhancedPagination={ enhancedPagination }
-						setAttributes={ setAttributes }
-						clientId={ clientId }
-					/>
 				</PanelBody>
 			) }
 			{ ! inherit && showDisplayPanel && (

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -42,8 +42,7 @@ import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 const { BlockInfo } = unlock( blockEditorPrivateApis );
 
 export default function QueryInspectorControls( props ) {
-	const { attributes, setQuery, setDisplayLayout } =
-		props;
+	const { attributes, setQuery, setDisplayLayout } = props;
 	const { query, displayLayout } = attributes;
 	const {
 		order,

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -18,6 +18,7 @@ import { store as coreStore } from '@wordpress/core-data';
 /**
  * Internal dependencies
  */
+import EnhancedPaginationControl from './inspector-controls/enhanced-pagination-control';
 import QueryToolbar from './query-toolbar';
 import QueryInspectorControls from './inspector-controls';
 import EnhancedPaginationModal from './enhanced-pagination-modal';
@@ -36,6 +37,7 @@ export default function QueryContent( {
 		queryId,
 		query,
 		displayLayout,
+		enhancedPagination,
 		tagName: TagName = 'div',
 		query: { inherit } = {},
 	} = attributes;
@@ -160,6 +162,11 @@ export default function QueryContent( {
 						setAttributes( { tagName: value } )
 					}
 					help={ htmlElementMessages[ TagName ] }
+				/>
+				<EnhancedPaginationControl
+					enhancedPagination={ enhancedPagination }
+					setAttributes={ setAttributes }
+					clientId={ clientId }
 				/>
 			</InspectorControls>
 			<TagName { ...innerBlocksProps } />


### PR DESCRIPTION
## What?

Fixes #63599. Updates the phrasing of the force page reload setting, and moves it to the Advanced section. 

Before:

![before](https://github.com/user-attachments/assets/8e8c6c67-caa1-4a53-8380-ff3599125e95)

After:

![after, 1](https://github.com/user-attachments/assets/5282a8cc-8e94-4387-9cae-c01bbea3c554)

![after, 2](https://github.com/user-attachments/assets/6a1563cb-8e0c-4b65-9d83-0b3dcad61025)

## Why?

The phrasing is confusing, as is the intricate behavior of the control itself.

## Testing Instructions

Insert a query loop, and observe the control in the inspector.