### PR TITLE
DataViews: enable all layouts for combined fields storybook

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -138,6 +138,7 @@ export const CombinedFields = () => {
 		...DEFAULT_VIEW,
 		fields: [ 'theme', 'requires', 'tested' ],
 		layout: {
+			primaryField: 'name',
 			combinedFields: [
 				{
 					id: 'theme',
@@ -165,7 +166,7 @@ export const CombinedFields = () => {
 			view={ view }
 			fields={ themeFields }
 			onChangeView={ setView }
-			defaultLayouts={ { table: {} } }
+			defaultLayouts={ { table: {}, grid: {}, list: {} } }
 		/>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -17,7 +17,7 @@ import {
 } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
-import type { View } from '../../../types';
+import type { CombinedField, View } from '../../../types';
 
 import './style.css';
 
@@ -134,25 +134,39 @@ export const FieldsNoSortableNoHidable = () => {
 };
 
 export const CombinedFields = () => {
-	const [ view, setView ] = useState< View >( {
-		...DEFAULT_VIEW,
-		fields: [ 'theme', 'requires', 'tested' ],
-		layout: {
-			primaryField: 'name',
-			combinedFields: [
-				{
-					id: 'theme',
-					label: 'Theme',
-					children: [ 'name', 'description' ],
-					direction: 'vertical',
-				},
-			],
-			styles: {
-				theme: {
-					maxWidth: 300,
+	const defaultLayoutsThemes = {
+		table: {
+			fields: [ 'theme', 'requires', 'tested' ],
+			layout: {
+				primaryField: 'name',
+				combinedFields: [
+					{
+						id: 'theme',
+						label: 'Theme',
+						children: [ 'name', 'description' ],
+						direction: 'vertical',
+					},
+				] as CombinedField[],
+				styles: {
+					theme: {
+						maxWidth: 300,
+					},
 				},
 			},
 		},
+		grid: {
+			fields: [ 'description', 'requires', 'tested' ],
+			layout: { primaryField: 'name', columnFields: [ 'description' ] },
+		},
+		list: {
+			fields: [ 'requires', 'tested' ],
+			layout: { primaryField: 'name' },
+		},
+	};
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: defaultLayoutsThemes.table.fields,
+		layout: defaultLayoutsThemes.table.layout,
 	} );
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( themeData, view, themeFields );
@@ -166,7 +180,7 @@ export const CombinedFields = () => {
 			view={ view }
 			fields={ themeFields }
 			onChangeView={ setView }
-			defaultLayouts={ { table: {}, grid: {}, list: {} } }
+			defaultLayouts={ defaultLayoutsThemes }
 		/>
 	);
 };


### PR DESCRIPTION
## What?

This enables `grid` and `list` layout for the "combined fields" story in dataviews' storybook. This is useful to see how fields can be combined for `table` while working separately for `list` and `grid`.
