### PR TITLE
DataViews: remove unused `.dataviews-view-table__cell-content-wrapper:empty` style rule

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -132,9 +132,6 @@
 			display: flex;
 			align-items: center;
 		}
-		.dataviews-view-table__cell-content-wrapper:empty {
-			display: none;
-		}
 
 		.components-v-stack > .dataviews-view-table__cell-content-wrapper:not(:first-child) {
 			min-height: 0;

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -132,6 +132,9 @@
 			display: flex;
 			align-items: center;
 		}
+		.dataviews-view-table__cell-content-wrapper:empty {
+			display: none;
+		}
 
 		.components-v-stack > .dataviews-view-table__cell-content-wrapper:not(:first-child) {
 			min-height: 0;
@@ -169,10 +172,6 @@
 			opacity: 1;
 		}
 	}
-}
-
-.dataviews-view-table__cell-content-wrapper:empty {
-	display: none;
 }
 
 /* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */


### PR DESCRIPTION
## What?

While working on other things, I've noticed the `.dataviews-view-table__cell-content-wrapper:empty` style rule was always discarded because the default rule had higher priority.

This removes the rule as it doesn't serve any purpose.
