### PR TITLE
DataViews: make actions column sticky in table layout so they are visible

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -55,7 +55,8 @@
 			border-bottom: 0;
 		}
 
-		&.is-hovered {
+		&.is-hovered,
+		&.is-hovered .dataviews-view-table__actions-column {
 			background-color: #f8f8f8;
 		}
 

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -20,6 +20,9 @@
 
 		&.dataviews-view-table__actions-column {
 			text-align: right;
+			position: sticky;
+			inset-inline-end: 0;
+			background-color: $white;
 		}
 
 		&.dataviews-view-table__checkbox-column {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/63128

## What?

This makes the actions column sticky, so they are always visible.

https://github.com/user-attachments/assets/58d77ed6-9a11-4c89-a04d-165a4b16f451

## Why?

It's part of the improvements to DataViews in 6.7.

## Testing Instructions

Verify that it works in all states: resting, hovered, focused, selected.

## TODO

- Implement selected state.