### PR TITLE
Restore: Move to trash button in Document settings

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -104,7 +104,7 @@ function DropdownMenuItemTrigger( { action, onClick, items } ) {
 
 // Copied as is from packages/dataviews/src/item-actions.js
 // With an added onClose prop.
-export function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
+function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
@@ -132,9 +132,7 @@ export function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
 						items={ [ item ] }
 						closeModal={ () => {
 							setIsModalOpen( false );
-							if ( onClose ) {
-								onClose();
-							}
+							onClose();
 						} }
 					/>
 				</Modal>

--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -104,7 +104,7 @@ function DropdownMenuItemTrigger( { action, onClick, items } ) {
 
 // Copied as is from packages/dataviews/src/item-actions.js
 // With an added onClose prop.
-function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
+export function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const actionTriggerProps = {
 		action,
@@ -132,7 +132,9 @@ function ActionWithModal( { action, item, ActionTrigger, onClose } ) {
 						items={ [ item ] }
 						closeModal={ () => {
 							setIsModalOpen( false );
-							onClose();
+							if ( onClose ) {
+								onClose();
+							}
 						} }
 					/>
 				</Modal>

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -34,10 +34,14 @@ export default function PostTrashCheck( { children } ) {
 			: false;
 
 		return {
-			canTrashPost: ( ! isNew || postId ) && canUserDelete,
+			canTrashPost:
+				( ! isNew || postId ) &&
+				canUserDelete &&
+				postType !== 'wp_template' &&
+				postType !== 'wp_block' &&
+				postType !== 'wp_template_part',
 		};
 	}, [] );
-
 	if ( ! canTrashPost ) {
 		return null;
 	}

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -8,6 +8,7 @@ import { store as coreStore } from '@wordpress/core-data';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { GLOBAL_POST_TYPES } from '../../store/constants';
 
 /**
  * Wrapper component that renders its children only if the post can trashed.
@@ -37,9 +38,7 @@ export default function PostTrashCheck( { children } ) {
 			canTrashPost:
 				( ! isNew || postId ) &&
 				canUserDelete &&
-				postType !== 'wp_template' &&
-				postType !== 'wp_block' &&
-				postType !== 'wp_template_part',
+				! GLOBAL_POST_TYPES.includes( postType ),
 		};
 	}, [] );
 	if ( ! canTrashPost ) {

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -1,86 +1,75 @@
 /**
  * WordPress dependencies
  */
-import { Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	__experimentalConfirmDialog as ConfirmDialog,
+} from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { usePostActions } from '../post-actions/actions';
 import PostTrashCheck from './check';
-import { ActionWithModal } from '../post-actions';
-
-function TrashActionTriggerButton( { action, onClick, items } ) {
-	const { isDeleting } = useSelect( ( select ) => {
-		const store = select( editorStore );
-		return {
-			isDeleting: store.isDeletingPost(),
-		};
-	}, [] );
-	const label =
-		typeof action.label === 'string' ? action.label : action.label( items );
-	return (
-		<Button
-			__next40pxDefaultSize
-			className="editor-post-trash"
-			isDestructive
-			variant="secondary"
-			isBusy={ isDeleting }
-			aria-disabled={ isDeleting }
-			onClick={ onClick }
-		>
-			{ label }
-		</Button>
-	);
-}
 
 /**
  * Displays the Post Trash Button and Confirm Dialog in the Editor.
  *
- * @param {{onActionPerformed: Object}} Object containing the onActionPerformed actions to execute.
  * @return {JSX.Element|null} The rendered PostTrash component.
  */
-function PostTrashButton( { onActionPerformed } ) {
-	const { postType, item } = useSelect( ( select ) => {
+export default function PostTrash() {
+	const { isNew, isDeleting, postId, title } = useSelect( ( select ) => {
 		const store = select( editorStore );
-		const { getEditedEntityRecord } = select( coreStore );
-		const postId = store.getCurrentPostId();
-		const _postType = store.getCurrentPostType();
 		return {
-			postType: _postType,
-			item: getEditedEntityRecord( 'postType', _postType, postId ),
+			isNew: store.isEditedPostNew(),
+			isDeleting: store.isDeletingPost(),
+			postId: store.getCurrentPostId(),
+			title: store.getCurrentPostAttribute( 'title' ),
 		};
 	}, [] );
-	const actions = usePostActions( { postType, onActionPerformed } );
-	const trashPostAction = actions.find(
-		( action ) => action.id === 'move-to-trash'
-	);
-	if ( ! trashPostAction ) {
+	const { trashPost } = useDispatch( editorStore );
+	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
+
+	if ( isNew || ! postId ) {
 		return null;
 	}
-	return (
-		<ActionWithModal
-			action={ trashPostAction }
-			item={ item }
-			ActionTrigger={ TrashActionTriggerButton }
-		/>
-	);
-}
 
-/**
- * Displays the Post Trash Button and Confirm Dialog in the Editor,
- * checking for the eligibility of the action.
- *
- * @param {{onActionPerformed: Object}} Object containing the onActionPerformed actions to execute.
- * @return {JSX.Element|null} The rendered PostTrash component.
- */
-export default function PostTrash( { onActionPerformed } ) {
+	const handleConfirm = () => {
+		setShowConfirmDialog( false );
+		trashPost();
+	};
+
 	return (
 		<PostTrashCheck>
-			<PostTrashButton onActionPerformed={ onActionPerformed } />
+			<Button
+				__next40pxDefaultSize
+				className="editor-post-trash"
+				isDestructive
+				variant="secondary"
+				isBusy={ isDeleting }
+				aria-disabled={ isDeleting }
+				onClick={
+					isDeleting ? undefined : () => setShowConfirmDialog( true )
+				}
+			>
+				{ __( 'Move to trash' ) }
+			</Button>
+			<ConfirmDialog
+				isOpen={ showConfirmDialog }
+				onConfirm={ handleConfirm }
+				onCancel={ () => setShowConfirmDialog( false ) }
+				confirmButtonText={ __( 'Move to trash' ) }
+				size="small"
+			>
+				{ sprintf(
+					// translators: %s: The item's title.
+					__( 'Are you sure you want to move "%s" to the trash?' ),
+					title
+				) }
+			</ConfirmDialog>
 		</PostTrashCheck>
 	);
 }

--- a/packages/editor/src/components/post-trash/index.js
+++ b/packages/editor/src/components/post-trash/index.js
@@ -1,71 +1,86 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
-import {
-	Button,
-	__experimentalConfirmDialog as ConfirmDialog,
-} from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { Button } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { usePostActions } from '../post-actions/actions';
+import PostTrashCheck from './check';
+import { ActionWithModal } from '../post-actions';
+
+function TrashActionTriggerButton( { action, onClick, items } ) {
+	const { isDeleting } = useSelect( ( select ) => {
+		const store = select( editorStore );
+		return {
+			isDeleting: store.isDeletingPost(),
+		};
+	}, [] );
+	const label =
+		typeof action.label === 'string' ? action.label : action.label( items );
+	return (
+		<Button
+			__next40pxDefaultSize
+			className="editor-post-trash"
+			isDestructive
+			variant="secondary"
+			isBusy={ isDeleting }
+			aria-disabled={ isDeleting }
+			onClick={ onClick }
+		>
+			{ label }
+		</Button>
+	);
+}
 
 /**
  * Displays the Post Trash Button and Confirm Dialog in the Editor.
  *
+ * @param {{onActionPerformed: Object}} Object containing the onActionPerformed actions to execute.
  * @return {JSX.Element|null} The rendered PostTrash component.
  */
-export default function PostTrash() {
-	const { isNew, isDeleting, postId } = useSelect( ( select ) => {
+function PostTrashButton( { onActionPerformed } ) {
+	const { postType, item } = useSelect( ( select ) => {
 		const store = select( editorStore );
+		const { getEditedEntityRecord } = select( coreStore );
+		const postId = store.getCurrentPostId();
+		const _postType = store.getCurrentPostType();
 		return {
-			isNew: store.isEditedPostNew(),
-			isDeleting: store.isDeletingPost(),
-			postId: store.getCurrentPostId(),
+			postType: _postType,
+			item: getEditedEntityRecord( 'postType', _postType, postId ),
 		};
 	}, [] );
-	const { trashPost } = useDispatch( editorStore );
-	const [ showConfirmDialog, setShowConfirmDialog ] = useState( false );
-
-	if ( isNew || ! postId ) {
+	const actions = usePostActions( { postType, onActionPerformed } );
+	const trashPostAction = actions.find(
+		( action ) => action.id === 'move-to-trash'
+	);
+	if ( ! trashPostAction ) {
 		return null;
 	}
-
-	const handleConfirm = () => {
-		setShowConfirmDialog( false );
-		trashPost();
-	};
-
 	return (
-		<>
-			<Button
-				__next40pxDefaultSize
-				className="editor-post-trash"
-				isDestructive
-				variant="secondary"
-				isBusy={ isDeleting }
-				aria-disabled={ isDeleting }
-				onClick={
-					isDeleting ? undefined : () => setShowConfirmDialog( true )
-				}
-			>
-				{ __( 'Move to trash' ) }
-			</Button>
-			<ConfirmDialog
-				isOpen={ showConfirmDialog }
-				onConfirm={ handleConfirm }
-				onCancel={ () => setShowConfirmDialog( false ) }
-				confirmButtonText={ __( 'Move to trash' ) }
-				size="medium"
-			>
-				{ __(
-					'Are you sure you want to move this post to the trash?'
-				) }
-			</ConfirmDialog>
-		</>
+		<ActionWithModal
+			action={ trashPostAction }
+			item={ item }
+			ActionTrigger={ TrashActionTriggerButton }
+		/>
+	);
+}
+
+/**
+ * Displays the Post Trash Button and Confirm Dialog in the Editor,
+ * checking for the eligibility of the action.
+ *
+ * @param {{onActionPerformed: Object}} Object containing the onActionPerformed actions to execute.
+ * @return {JSX.Element|null} The rendered PostTrash component.
+ */
+export default function PostTrash( { onActionPerformed } ) {
+	return (
+		<PostTrashCheck>
+			<PostTrashButton onActionPerformed={ onActionPerformed } />
+		</PostTrashCheck>
 	);
 }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -88,9 +88,7 @@ export default function PostSummary( { onActionPerformed } ) {
 										<SiteDiscussion />
 										<PostFormatPanel />
 									</VStack>
-									<PostTrash
-										onActionPerformed={ onActionPerformed }
-									/>
+									<PostTrash />
 									{ fills }
 								</VStack>
 							) }

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -28,6 +28,7 @@ import PostsPerPage from '../posts-per-page';
 import SiteDiscussion from '../site-discussion';
 import { store as editorStore } from '../../store';
 import { PrivatePostLastRevision } from '../post-last-revision';
+import PostTrash from '../post-trash';
 
 /**
  * Module Constants
@@ -87,6 +88,9 @@ export default function PostSummary( { onActionPerformed } ) {
 										<SiteDiscussion />
 										<PostFormatPanel />
 									</VStack>
+									<PostTrash
+										onActionPerformed={ onActionPerformed }
+									/>
 									{ fills }
 								</VStack>
 							) }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/65023

This PR readds a big "Move to trash" button that was available on older releases and was meanwhile removed.

In progress:

Needs to call the action that already has a modal instead of implementing its own confirmation modal.
Should use eligibility checks of the action.
Should not appear when editing the template of a post on the post editor.


## Screenshots or screencast <!-- if applicable -->
<img width="350" alt="Screenshot 2024-09-05 at 11 51 55" src="https://github.com/user-attachments/assets/6dff25d4-475f-4fbb-9a94-c9679e52ac8a">
