### PR TITLE
Block Bindings: Fix empty strings placeholders in post meta bindings

### DIFF
--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -43,6 +43,16 @@ function gutenberg_test_block_bindings_registration() {
 	);
 	register_meta(
 		'post',
+		'empty_field',
+		array(
+			'show_in_rest' => true,
+			'type'         => 'string',
+			'single'       => true,
+			'default'      => '',
+		)
+	);
+	register_meta(
+		'post',
 		'_protected_field',
 		array(
 			'type'    => 'string',

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -22,7 +22,7 @@ export default {
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
 			// Use the key if the value is not set.
 			newValues[ attributeName ] =
-				meta?.[ source.args.key ] || source.args.key;
+				meta?.[ source.args.key ] ?? source.args.key;
 		}
 		return newValues;
 	},

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -1278,6 +1278,38 @@ test.describe( 'Block bindings', () => {
 				).toHaveText( 'fallback value' );
 			} );
 
+			test( 'should show the prompt placeholder in field with empty value', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content: 'paragraph default content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: { key: 'empty_field' },
+								},
+							},
+						},
+					},
+				} );
+
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					// Aria-label is changed for empty paragraphs.
+					name: 'Add empty_field',
+				} );
+
+				await expect( paragraphBlock ).toBeEmpty();
+
+				const placeholder = paragraphBlock.locator( 'span' );
+				await expect( placeholder ).toHaveAttribute(
+					'data-rich-text-placeholder',
+					'Add empty_field'
+				);
+			} );
+
 			test( 'should not show the value of a protected meta field', async ( {
 				editor,
 			} ) => {


### PR DESCRIPTION
## What?
As reported [here](https://github.com/WordPress/gutenberg/pull/64910#issuecomment-2330355396), the changes introduced to properly show placeholder in empty custom fields broke after that PR.

This PR addresses that and introduces an e2e test to avoid having the same issue in the future.

## Why?
It is broken.

## How?
I just changed the conditional where we change the value to consider an empty string as a valid value.

## Testing Instructions
1. Register a field with `default` empty.
```
	register_meta(
		'post',
		'empty_field',
		array(
			'show_in_rest' => true,
			'type'         => 'string',
			'single'       => true,
			'default'      => '',
		)
	);
```
3. In a new page, add a paragraph connected to that empty field.
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"empty_field"}}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
4. Check that the placeholder is shown instead of the key.