### PR TITLE
Interactivity API: Prevent calling `proxifyContext` with context proxies inside `wp-context`

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevent calling `proxifyContext` over an already-proxified context inside `wp-context` ([#65090](https://github.com/WordPress/gutenberg/pull/65090)).
+
 ## 6.7.0 (2024-09-05)
 
 ### Enhancements

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -290,11 +290,10 @@ export default () => {
 						currentValue.current,
 						deepClone( value ) as object
 					);
-					currentValue.current = proxifyContext(
+					result[ namespace ] = proxifyContext(
 						currentValue.current,
 						inheritedValue[ namespace ]
 					);
-					result[ namespace ] = currentValue.current;
 				}
 				return result;
 			}, [ defaultEntry, inheritedValue ] );


### PR DESCRIPTION
## What?

Fixes a performance regression introduced in https://github.com/WordPress/gutenberg/pull/62734, caused by `proxifyContext` being called over an already-proxified context repeatedly, thus increasing the number of proxies around the same context object every time a `wp-context` directive was rendered.
#62734

## Why?

The ever-growing number of context proxies was causing the `navigate()` action to become exponentially slower.

The following pictures show the performance recording while clicking several times on the Next and Previous links in a Query block, before and after the changes containing the regression (#62734) are applied.

1. `trunk` at https://github.com/WordPress/gutenberg/commit/c384bb6bacc574687c9e23a93e129b29e9ca46b2 (before)
![Screenshot 2024-09-05 at 11 47 22](https://github.com/user-attachments/assets/ea562546-1409-4f0e-b053-3527053f67bf)

2. `trunk` at https://github.com/WordPress/gutenberg/commit/bd9ba413cee207338de17cd7d2141debff527074 (after)
![Screenshot 2024-09-05 at 11 46 08](https://github.com/user-attachments/assets/2e702ecd-ab06-4933-8196-2c5eb72c811c)


## How?

The fix prevents assigning to `currentValue.current` the result of calling `proxifyContext( currentValue.current, ... )`. This way, `proxifyContext()` never receives an already-proxified context as an argument when the `wp-context` directive is rendered multiple times.

## Testing Instructions

1. Visit a page with a Query block. The block should have the "Force page reload" option disabled.
2. Repeatedly click on the Next and Previous links (over 20 times or more).
3. Without this PR, the clicks should become noticeably slower over time. With these PR changes, everything should be good.
