### PR TITLE
Move insertionPoint state to block-editor store/rename existing insertionPoint to insertionCue

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -262,7 +262,7 @@ _Returns_
 
 ### getBlockInsertionPoint
 
-Returns the insertion point, the index at which the new inserted block would be placed. Defaults to the last index.
+Returns the location of the insertion cue. Defaults to the last index.
 
 _Parameters_
 
@@ -982,7 +982,7 @@ _Returns_
 
 ### isBlockInsertionPointVisible
 
-Returns true if we should show the block insertion point.
+Returns true if the block insertion point is visible.
 
 _Parameters_
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1420,8 +1420,6 @@ Returns an action object used to open/close the inserter.
 _Parameters_
 
 -   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
--   _value.rootClientId_ `string`: The root client ID to insert at.
--   _value.insertionIndex_ `number`: The index to insert at.
 -   _value.filterValue_ `string`: A query to filter the inserter results.
 -   _value.onSelect_ `Function`: A callback when an item is selected.
 -   _value.tab_ `string`: The tab to open in the inserter.

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1422,6 +1422,10 @@ _Parameters_
 -   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
 -   _value.rootClientId_ `string`: The root client ID to insert at.
 -   _value.insertionIndex_ `number`: The index to insert at.
+-   _value.filterValue_ `string`: A query to filter the inserter results.
+-   _value.onSelect_ `Function`: A callback when an item is selected.
+-   _value.tab_ `string`: The tab to open in the inserter.
+-   _value.category_ `string`: The category to initialize in the inserter.
 
 _Returns_
 

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1420,6 +1420,8 @@ Returns an action object used to open/close the inserter.
 _Parameters_
 
 -   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
+-   _value.rootClientId_ `string`: Deprecated. The root client ID to insert at.
+-   _value.insertionIndex_ `number`: Deprecated. The index to insert at.
 -   _value.filterValue_ `string`: A query to filter the inserter results.
 -   _value.onSelect_ `Function`: A callback when an item is selected.
 -   _value.tab_ `string`: The tab to open in the inserter.

--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -1420,8 +1420,8 @@ Returns an action object used to open/close the inserter.
 _Parameters_
 
 -   _value_ `boolean|Object`: Whether the inserter should be opened (true) or closed (false). To specify an insertion point, use an object.
--   _value.rootClientId_ `string`: Deprecated. The root client ID to insert at.
--   _value.insertionIndex_ `number`: Deprecated. The index to insert at.
+-   _value.rootClientId_ `string`: The root client ID to insert at.
+-   _value.insertionIndex_ `number`: The index to insert at.
 -   _value.filterValue_ `string`: A query to filter the inserter results.
 -   _value.onSelect_ `Function`: A callback when an item is selected.
 -   _value.tab_ `string`: The tab to open in the inserter.

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -26,29 +26,23 @@ export function ZoomOutSeparator( {
 	position = 'top',
 } ) {
 	const [ isDraggedOver, setIsDraggedOver ] = useState( false );
-	const {
-		sectionRootClientId,
-		sectionClientIds,
-		blockInsertionPoint,
-		blockInsertionPointVisible,
-	} = useSelect( ( select ) => {
-		const {
-			getBlockInsertionPoint,
-			getBlockOrder,
-			isBlockInsertionPointVisible,
-			getSectionRootClientId,
-		} = unlock( select( blockEditorStore ) );
+	const { sectionRootClientId, sectionClientIds, inserterInsertionPoint } =
+		useSelect( ( select ) => {
+			const {
+				getInserterInsertionPoint,
+				getBlockOrder,
+				getSectionRootClientId,
+			} = unlock( select( blockEditorStore ) );
 
-		const root = getSectionRootClientId();
-		const sectionRootClientIds = getBlockOrder( root );
-		return {
-			sectionRootClientId: root,
-			sectionClientIds: sectionRootClientIds,
-			blockOrder: getBlockOrder( root ),
-			blockInsertionPoint: getBlockInsertionPoint(),
-			blockInsertionPointVisible: isBlockInsertionPointVisible(),
-		};
-	}, [] );
+			const root = getSectionRootClientId();
+			const sectionRootClientIds = getBlockOrder( root );
+			return {
+				sectionRootClientId: root,
+				sectionClientIds: sectionRootClientIds,
+				blockOrder: getBlockOrder( root ),
+				inserterInsertionPoint: getInserterInsertionPoint(),
+			};
+		}, [] );
 
 	const isReducedMotion = useReducedMotion();
 
@@ -63,21 +57,21 @@ export function ZoomOutSeparator( {
 		sectionClientIds &&
 		sectionClientIds.includes( clientId );
 
-	if ( ! isSectionBlock ) {
+	if ( ! isSectionBlock || ! inserterInsertionPoint ) {
 		return null;
 	}
 
 	if ( position === 'top' ) {
 		isVisible =
-			blockInsertionPointVisible &&
-			blockInsertionPoint.index === 0 &&
-			clientId === sectionClientIds[ blockInsertionPoint.index ];
+			inserterInsertionPoint.insertionIndex === 0 &&
+			clientId ===
+				sectionClientIds[ inserterInsertionPoint.insertionIndex ];
 	}
 
 	if ( position === 'bottom' ) {
 		isVisible =
-			blockInsertionPointVisible &&
-			clientId === sectionClientIds[ blockInsertionPoint.index - 1 ];
+			clientId ===
+			sectionClientIds[ inserterInsertionPoint.insertionIndex - 1 ];
 	}
 
 	return (

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -74,7 +74,8 @@ export function ZoomOutSeparator( {
 		inserterInsertionPoint?.insertionIndex === 0 &&
 		clientId === sectionClientIds[ inserterInsertionPoint.insertionIndex ];
 	const hasBottomInserterInsertionPoint =
-		inserterInsertionPoint?.insertionIndex &&
+		inserterInsertionPoint &&
+		inserterInsertionPoint.hasOwnProperty( 'insertionIndex' ) &&
 		clientId ===
 			sectionClientIds[ inserterInsertionPoint.insertionIndex - 1 ];
 	// We want to show the zoom out separator in either of these conditions:

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -29,12 +29,12 @@ export function ZoomOutSeparator( {
 	const {
 		sectionRootClientId,
 		sectionClientIds,
-		inserterInsertionPoint,
+		insertionPoint,
 		blockInsertionPointVisible,
 		blockInsertionPoint,
 	} = useSelect( ( select ) => {
 		const {
-			getInserterInsertionPoint,
+			getInsertionPoint,
 			getBlockOrder,
 			getSectionRootClientId,
 			isBlockInsertionPointVisible,
@@ -47,7 +47,7 @@ export function ZoomOutSeparator( {
 			sectionRootClientId: root,
 			sectionClientIds: sectionRootClientIds,
 			blockOrder: getBlockOrder( root ),
-			inserterInsertionPoint: getInserterInsertionPoint(),
+			insertionPoint: getInsertionPoint(),
 			blockInsertionPoint: getBlockInsertionPoint(),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 		};
@@ -70,20 +70,19 @@ export function ZoomOutSeparator( {
 		return null;
 	}
 
-	const hasTopInserterInsertionPoint =
-		inserterInsertionPoint?.insertionIndex === 0 &&
-		clientId === sectionClientIds[ inserterInsertionPoint.insertionIndex ];
-	const hasBottomInserterInsertionPoint =
-		inserterInsertionPoint &&
-		inserterInsertionPoint.hasOwnProperty( 'insertionIndex' ) &&
-		clientId ===
-			sectionClientIds[ inserterInsertionPoint.insertionIndex - 1 ];
+	const hasTopInsertionPoint =
+		insertionPoint?.index === 0 &&
+		clientId === sectionClientIds[ insertionPoint.index ];
+	const hasBottomInsertionPoint =
+		insertionPoint &&
+		insertionPoint.hasOwnProperty( 'index' ) &&
+		clientId === sectionClientIds[ insertionPoint.index - 1 ];
 	// We want to show the zoom out separator in either of these conditions:
 	// 1. If the inserter has an insertion index set
 	// 2. We are dragging a pattern over an insertion point
 	if ( position === 'top' ) {
 		isVisible =
-			hasTopInserterInsertionPoint ||
+			hasTopInsertionPoint ||
 			( blockInsertionPointVisible &&
 				blockInsertionPoint.index === 0 &&
 				clientId === sectionClientIds[ blockInsertionPoint.index ] );
@@ -91,7 +90,7 @@ export function ZoomOutSeparator( {
 
 	if ( position === 'bottom' ) {
 		isVisible =
-			hasBottomInserterInsertionPoint ||
+			hasBottomInsertionPoint ||
 			( blockInsertionPointVisible &&
 				clientId ===
 					sectionClientIds[ blockInsertionPoint.index - 1 ] );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -94,7 +94,7 @@ function ZoomOutModeInserters() {
 						onClick={ () => {
 							setInserterIsOpened( {
 								rootClientId: sectionRootClientId,
-								insertionIndex: index,
+								index,
 								tab: 'patterns',
 								category: 'all',
 							} );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -50,7 +50,9 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	const { showInsertionPoint } = useDispatch( blockEditorStore );
+	const { showInsertionPoint, setInserterInsertionPoint } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {
@@ -93,10 +95,12 @@ function ZoomOutModeInserters() {
 						isVisible={ isSelected || isHovered }
 						onClick={ () => {
 							setInserterIsOpened( {
-								rootClientId: sectionRootClientId,
-								insertionIndex: index,
 								tab: 'patterns',
 								category: 'all',
+							} );
+							setInserterInsertionPoint( {
+								rootClientId: sectionRootClientId,
+								insertionIndex: index,
 							} );
 							showInsertionPoint( sectionRootClientId, index, {
 								operation: 'insert',

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -18,6 +18,7 @@ function ZoomOutModeInserters() {
 		hasSelection,
 		inserterInsertionPoint,
 		blockOrder,
+		blockInsertionPointVisible,
 		setInserterIsOpened,
 		sectionRootClientId,
 		selectedBlockClientId,
@@ -31,6 +32,7 @@ function ZoomOutModeInserters() {
 			getSelectedBlockClientId,
 			getHoveredBlockClientId,
 			getSectionRootClientId,
+			isBlockInsertionPointVisible,
 		} = unlock( select( blockEditorStore ) );
 
 		const root = getSectionRootClientId();
@@ -39,6 +41,7 @@ function ZoomOutModeInserters() {
 			hasSelection: !! getSelectionStart().clientId,
 			inserterInsertionPoint: getInserterInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
+			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 			sectionRootClientId: root,
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
@@ -48,7 +51,7 @@ function ZoomOutModeInserters() {
 	}, [] );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const { setInserterInsertionPoint } = unlock(
+	const { showInsertionPoint, setInserterInsertionPoint } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -68,6 +71,7 @@ function ZoomOutModeInserters() {
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
 		const shouldRenderInsertionPoint =
+			blockInsertionPointVisible &&
 			inserterInsertionPoint?.insertionIndex === index;
 
 		const previousClientId = clientId;
@@ -88,22 +92,24 @@ function ZoomOutModeInserters() {
 				previousClientId={ previousClientId }
 				nextClientId={ nextClientId }
 			>
-				<ZoomOutModeInserterButton
-					isVisible={
-						! shouldRenderInsertionPoint &&
-						( isSelected || isHovered )
-					}
-					onClick={ () => {
-						setInserterIsOpened( {
-							tab: 'patterns',
-							category: 'all',
-						} );
-						setInserterInsertionPoint( {
-							rootClientId: sectionRootClientId,
-							insertionIndex: index,
-						} );
-					} }
-				/>
+				{ ! shouldRenderInsertionPoint && (
+					<ZoomOutModeInserterButton
+						isVisible={ isSelected || isHovered }
+						onClick={ () => {
+							setInserterIsOpened( {
+								tab: 'patterns',
+								category: 'all',
+							} );
+							setInserterInsertionPoint( {
+								rootClientId: sectionRootClientId,
+								insertionIndex: index,
+							} );
+							showInsertionPoint( sectionRootClientId, index, {
+								operation: 'insert',
+							} );
+						} }
+					/>
+				) }
 			</BlockPopoverInbetween>
 		);
 	} );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -94,7 +94,7 @@ function ZoomOutModeInserters() {
 						onClick={ () => {
 							setInserterIsOpened( {
 								rootClientId: sectionRootClientId,
-								index,
+								insertionIndex: index,
 								tab: 'patterns',
 								category: 'all',
 							} );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -16,7 +16,7 @@ function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
 	const {
 		hasSelection,
-		blockInsertionPoint,
+		inserterInsertionPoint,
 		blockOrder,
 		blockInsertionPointVisible,
 		setInserterIsOpened,
@@ -26,7 +26,7 @@ function ZoomOutModeInserters() {
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
-			getBlockInsertionPoint,
+			getInserterInsertionPoint,
 			getBlockOrder,
 			getSelectionStart,
 			getSelectedBlockClientId,
@@ -39,7 +39,7 @@ function ZoomOutModeInserters() {
 
 		return {
 			hasSelection: !! getSelectionStart().clientId,
-			blockInsertionPoint: getBlockInsertionPoint(),
+			inserterInsertionPoint: getInserterInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 			sectionRootClientId: root,
@@ -70,7 +70,8 @@ function ZoomOutModeInserters() {
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
 		const shouldRenderInsertionPoint =
-			blockInsertionPointVisible && blockInsertionPoint.index === index;
+			blockInsertionPointVisible &&
+			inserterInsertionPoint?.insertionIndex === index;
 
 		const previousClientId = clientId;
 		const nextClientId = blockOrder[ index ];

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -18,7 +18,6 @@ function ZoomOutModeInserters() {
 		hasSelection,
 		inserterInsertionPoint,
 		blockOrder,
-		blockInsertionPointVisible,
 		setInserterIsOpened,
 		sectionRootClientId,
 		selectedBlockClientId,
@@ -31,7 +30,6 @@ function ZoomOutModeInserters() {
 			getSelectionStart,
 			getSelectedBlockClientId,
 			getHoveredBlockClientId,
-			isBlockInsertionPointVisible,
 			getSectionRootClientId,
 		} = unlock( select( blockEditorStore ) );
 
@@ -41,7 +39,6 @@ function ZoomOutModeInserters() {
 			hasSelection: !! getSelectionStart().clientId,
 			inserterInsertionPoint: getInserterInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
-			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 			sectionRootClientId: root,
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
@@ -50,7 +47,8 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	const { showInsertionPoint, setInserterInsertionPoint } = unlock(
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const { setInserterInsertionPoint } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -70,7 +68,6 @@ function ZoomOutModeInserters() {
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
 		const shouldRenderInsertionPoint =
-			blockInsertionPointVisible &&
 			inserterInsertionPoint?.insertionIndex === index;
 
 		const previousClientId = clientId;
@@ -91,24 +88,22 @@ function ZoomOutModeInserters() {
 				previousClientId={ previousClientId }
 				nextClientId={ nextClientId }
 			>
-				{ ! shouldRenderInsertionPoint && (
-					<ZoomOutModeInserterButton
-						isVisible={ isSelected || isHovered }
-						onClick={ () => {
-							setInserterIsOpened( {
-								tab: 'patterns',
-								category: 'all',
-							} );
-							setInserterInsertionPoint( {
-								rootClientId: sectionRootClientId,
-								insertionIndex: index,
-							} );
-							showInsertionPoint( sectionRootClientId, index, {
-								operation: 'insert',
-							} );
-						} }
-					/>
-				) }
+				<ZoomOutModeInserterButton
+					isVisible={
+						! shouldRenderInsertionPoint &&
+						( isSelected || isHovered )
+					}
+					onClick={ () => {
+						setInserterIsOpened( {
+							tab: 'patterns',
+							category: 'all',
+						} );
+						setInserterInsertionPoint( {
+							rootClientId: sectionRootClientId,
+							insertionIndex: index,
+						} );
+					} }
+				/>
 			</BlockPopoverInbetween>
 		);
 	} );

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -16,7 +16,7 @@ function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
 	const {
 		hasSelection,
-		inserterInsertionPoint,
+		insertionPoint,
 		blockOrder,
 		blockInsertionPointVisible,
 		setInserterIsOpened,
@@ -26,7 +26,7 @@ function ZoomOutModeInserters() {
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
-			getInserterInsertionPoint,
+			getInsertionPoint,
 			getBlockOrder,
 			getSelectionStart,
 			getSelectedBlockClientId,
@@ -39,7 +39,7 @@ function ZoomOutModeInserters() {
 
 		return {
 			hasSelection: !! getSelectionStart().clientId,
-			inserterInsertionPoint: getInserterInsertionPoint(),
+			insertionPoint: getInsertionPoint(),
 			blockOrder: getBlockOrder( root ),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 			sectionRootClientId: root,
@@ -71,8 +71,7 @@ function ZoomOutModeInserters() {
 
 	return [ undefined, ...blockOrder ].map( ( clientId, index ) => {
 		const shouldRenderInsertionPoint =
-			blockInsertionPointVisible &&
-			inserterInsertionPoint?.insertionIndex === index;
+			blockInsertionPointVisible && insertionPoint?.index === index;
 
 		const previousClientId = clientId;
 		const nextClientId = blockOrder[ index ];

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -51,7 +51,7 @@ function ZoomOutModeInserters() {
 	}, [] );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const { showInsertionPoint, setInserterInsertionPoint } = unlock(
+	const { showInsertionPoint, setInsertionPoint } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -100,9 +100,9 @@ function ZoomOutModeInserters() {
 								tab: 'patterns',
 								category: 'all',
 							} );
-							setInserterInsertionPoint( {
+							setInsertionPoint( {
 								rootClientId: sectionRootClientId,
-								insertionIndex: index,
+								index,
 							} );
 							showInsertionPoint( sectionRootClientId, index, {
 								operation: 'insert',

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -94,10 +94,10 @@ function ZoomOutModeInserters() {
 						isVisible={ isSelected || isHovered }
 						onClick={ () => {
 							setInserterIsOpened( {
-								tab: 'patterns',
-								category: 'all',
 								rootClientId: sectionRootClientId,
 								insertionIndex: index,
+								tab: 'patterns',
+								category: 'all',
 							} );
 							showInsertionPoint( sectionRootClientId, index, {
 								operation: 'insert',

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -51,9 +51,7 @@ function ZoomOutModeInserters() {
 	}, [] );
 
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
-	const { showInsertionPoint, setInsertionPoint } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { showInsertionPoint } = unlock( useDispatch( blockEditorStore ) );
 
 	// Defer the initial rendering to avoid the jumps due to the animation.
 	useEffect( () => {
@@ -98,10 +96,8 @@ function ZoomOutModeInserters() {
 							setInserterIsOpened( {
 								tab: 'patterns',
 								category: 'all',
-							} );
-							setInsertionPoint( {
 								rootClientId: sectionRootClientId,
-								index,
+								insertionIndex: index,
 							} );
 							showInsertionPoint( sectionRootClientId, index, {
 								operation: 'insert',

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -93,8 +93,13 @@ function useInsertionPoint( {
 			if ( insertionIndex !== undefined ) {
 				// Insert into a specific index.
 				_destinationIndex = insertionIndex;
-			} else if ( insertionPoint?.insertionIndex ) {
-				_destinationRootClientId = insertionPoint?.rootClientId
+			} else if (
+				insertionPoint &&
+				insertionPoint.hasOwnProperty( 'insertionIndex' )
+			) {
+				_destinationRootClientId = insertionPoint.hasOwnProperty(
+					'rootClientId'
+				)
 					? insertionPoint.rootClientId
 					: rootClientId;
 				_destinationIndex = insertionPoint.insertionIndex;

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -97,9 +97,7 @@ function useInsertionPoint( {
 				insertionPoint &&
 				insertionPoint.hasOwnProperty( 'insertionIndex' )
 			) {
-				_destinationRootClientId = insertionPoint.hasOwnProperty(
-					'rootClientId'
-				)
+				_destinationRootClientId = insertionPoint?.rootClientId
 					? insertionPoint.rootClientId
 					: rootClientId;
 				_destinationIndex = insertionPoint.insertionIndex;

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -83,24 +83,24 @@ function useInsertionPoint( {
 				getBlockRootClientId,
 				getBlockIndex,
 				getBlockOrder,
-				getInserterInsertionPoint,
+				getInsertionPoint,
 			} = unlock( select( blockEditorStore ) );
 			const selectedBlockClientId = getSelectedBlockClientId();
 			let _destinationRootClientId = rootClientId;
 			let _destinationIndex;
-			const insertionPoint = getInserterInsertionPoint();
+			const insertionPoint = getInsertionPoint();
 
 			if ( insertionIndex !== undefined ) {
 				// Insert into a specific index.
 				_destinationIndex = insertionIndex;
 			} else if (
 				insertionPoint &&
-				insertionPoint.hasOwnProperty( 'insertionIndex' )
+				insertionPoint.hasOwnProperty( 'index' )
 			) {
 				_destinationRootClientId = insertionPoint?.rootClientId
 					? insertionPoint.rootClientId
 					: rootClientId;
-				_destinationIndex = insertionPoint.insertionIndex;
+				_destinationIndex = insertionPoint.index;
 			} else if ( clientId ) {
 				// Insert after a specific client ID.
 				_destinationIndex = getBlockIndex( clientId );

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -86,7 +86,6 @@ function useInsertionPoint( {
 				getInserterInsertionPoint,
 			} = unlock( select( blockEditorStore ) );
 			const selectedBlockClientId = getSelectedBlockClientId();
-
 			let _destinationRootClientId = rootClientId;
 			let _destinationIndex;
 			const insertionPoint = getInserterInsertionPoint();
@@ -94,15 +93,14 @@ function useInsertionPoint( {
 			if ( insertionIndex !== undefined ) {
 				// Insert into a specific index.
 				_destinationIndex = insertionIndex;
+			} else if ( insertionPoint?.insertionIndex ) {
+				_destinationRootClientId = insertionPoint?.rootClientId
+					? insertionPoint.rootClientId
+					: rootClientId;
+				_destinationIndex = insertionPoint.insertionIndex;
 			} else if ( clientId ) {
 				// Insert after a specific client ID.
 				_destinationIndex = getBlockIndex( clientId );
-			} else if (
-				insertionPoint?.insertionIndex &&
-				insertionPoint?.rootClientId
-			) {
-				_destinationRootClientId = insertionPoint.rootClientId;
-				_destinationIndex = insertionPoint.insertionIndex;
 			} else if ( ! isAppender && selectedBlockClientId ) {
 				_destinationRootClientId = getBlockRootClientId(
 					selectedBlockClientId

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -83,11 +83,13 @@ function useInsertionPoint( {
 				getBlockRootClientId,
 				getBlockIndex,
 				getBlockOrder,
-			} = select( blockEditorStore );
+				getInserterInsertionPoint,
+			} = unlock( select( blockEditorStore ) );
 			const selectedBlockClientId = getSelectedBlockClientId();
 
 			let _destinationRootClientId = rootClientId;
 			let _destinationIndex;
+			const insertionPoint = getInserterInsertionPoint();
 
 			if ( insertionIndex !== undefined ) {
 				// Insert into a specific index.
@@ -95,6 +97,12 @@ function useInsertionPoint( {
 			} else if ( clientId ) {
 				// Insert after a specific client ID.
 				_destinationIndex = getBlockIndex( clientId );
+			} else if (
+				insertionPoint?.insertionIndex &&
+				insertionPoint?.rootClientId
+			) {
+				_destinationRootClientId = insertionPoint.rootClientId;
+				_destinationIndex = insertionPoint.insertionIndex;
 			} else if ( ! isAppender && selectedBlockClientId ) {
 				_destinationRootClientId = getBlockRootClientId(
 					selectedBlockClientId

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, SearchControl } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -19,7 +19,6 @@ import useInsertionPoint from './hooks/use-insertion-point';
 import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
 import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
@@ -84,16 +83,15 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { setInsertionPoint } = unlock( useDispatch( blockEditorStore ) );
-
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
 		setInserterIsOpened( {
 			filterValue,
 			onSelect,
+			rootClientId,
+			insertionIndex,
 		} );
-		setInsertionPoint( { rootClientId, index: insertionIndex } );
 	};
 
 	let maxBlockPatterns = 0;

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, SearchControl } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -84,7 +84,7 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { showInsertionPoint, setInserterInsertionPoint } = unlock(
+	const { setInserterInsertionPoint } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -96,7 +96,6 @@ export default function QuickInserter( {
 			onSelect,
 		} );
 		setInserterInsertionPoint( { rootClientId, insertionIndex } );
-		showInsertionPoint( rootClientId, insertionIndex );
 	};
 
 	let maxBlockPatterns = 0;

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -19,6 +19,7 @@ import useInsertionPoint from './hooks/use-insertion-point';
 import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
@@ -83,15 +84,19 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
+	const { showInsertionPoint, setInserterInsertionPoint } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
 		setInserterIsOpened( {
-			rootClientId,
-			insertionIndex,
 			filterValue,
 			onSelect,
 		} );
+		setInserterInsertionPoint( { rootClientId, insertionIndex } );
+		showInsertionPoint( rootClientId, insertionIndex );
 	};
 
 	let maxBlockPatterns = 0;

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -84,9 +84,7 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { setInserterInsertionPoint } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { setInsertionPoint } = unlock( useDispatch( blockEditorStore ) );
 
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
@@ -95,7 +93,7 @@ export default function QuickInserter( {
 			filterValue,
 			onSelect,
 		} );
-		setInserterInsertionPoint( { rootClientId, insertionIndex } );
+		setInsertionPoint( { rootClientId, index: insertionIndex } );
 	};
 
 	let maxBlockPatterns = 0;

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -360,6 +360,20 @@ export function expandBlock( clientId ) {
 }
 
 /**
+ * @param {Object} value
+ * @param {string} value.rootClientId   The root client ID to insert at.
+ * @param {number} value.insertionIndex The index to insert at.
+ *
+ * @return {Object} Action object.
+ */
+export function setInserterInsertionPoint( value ) {
+	return {
+		type: 'SET_INSERTER_INSERTION_POINT',
+		value,
+	};
+}
+
+/**
  * Temporarily modify/unlock the content-only block for editions.
  *
  * @param {string} clientId The client id of the block.

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -361,14 +361,14 @@ export function expandBlock( clientId ) {
 
 /**
  * @param {Object} value
- * @param {string} value.rootClientId   The root client ID to insert at.
- * @param {number} value.insertionIndex The index to insert at.
+ * @param {string} value.rootClientId The root client ID to insert at.
+ * @param {number} value.index        The index to insert at.
  *
  * @return {Object} Action object.
  */
-export function setInserterInsertionPoint( value ) {
+export function setInsertionPoint( value ) {
 	return {
-		type: 'SET_INSERTER_INSERTION_POINT',
+		type: 'SET_INSERTION_POINT',
 		value,
 	};
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -700,10 +700,10 @@ export function getClosestAllowedInsertionPointForPattern(
 }
 
 /**
- * Where the inserter should insert into.
+ * Where the point where the next block will be inserted into.
  *
  * @param {Object} state
- * @return {Object} Of where the insertion point in the block editor is or null if none is set.
+ * @return {Object} where the insertion point in the block editor is or null if none is set.
  */
 export function getInsertionPoint( state ) {
 	return state.insertionPoint;

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -698,3 +698,14 @@ export function getClosestAllowedInsertionPointForPattern(
 	const names = getGrammar( pattern ).map( ( { blockName: name } ) => name );
 	return getClosestAllowedInsertionPoint( state, names, clientId );
 }
+
+/**
+ * Where the inserter should insert into.
+ *
+ * @param {Object} state
+ * @return {Object} Of where the insertion point in the block editor is or null if none is set.
+ */
+export function getInserterInsertionPoint( state ) {
+	// Potentially hook up a lot of what is happening within useInsertionPoint here.
+	return state.inserterInsertionPoint;
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -706,6 +706,5 @@ export function getClosestAllowedInsertionPointForPattern(
  * @return {Object} Of where the insertion point in the block editor is or null if none is set.
  */
 export function getInserterInsertionPoint( state ) {
-	// Potentially hook up a lot of what is happening within useInsertionPoint here.
 	return state.inserterInsertionPoint;
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -705,6 +705,6 @@ export function getClosestAllowedInsertionPointForPattern(
  * @param {Object} state
  * @return {Object} Of where the insertion point in the block editor is or null if none is set.
  */
-export function getInserterInsertionPoint( state ) {
-	return state.inserterInsertionPoint;
+export function getInsertionPoint( state ) {
+	return state.insertionPoint;
 }

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1601,7 +1601,7 @@ export function blocksMode( state = {}, action ) {
  *
  * @return {Object} Updated state.
  */
-export function insertionPoint( state = null, action ) {
+export function insertionCue( state = null, action ) {
 	switch ( action.type ) {
 		case 'SHOW_INSERTION_POINT': {
 			const {
@@ -2066,7 +2066,7 @@ export function hoveredBlockClientId( state = false, action ) {
  * @param {boolean} state  Current state.
  * @param {Object}  action Dispatched action.
  *
- * @return {boolean} Updated state.
+ * @return {number} Updated state.
  */
 export function zoomLevel( state = 100, action ) {
 	switch ( action.type ) {
@@ -2085,11 +2085,11 @@ export function zoomLevel( state = 100, action ) {
  * @param {boolean} state  Current state.
  * @param {Object}  action Dispatched action.
  *
- * @return {boolean} Updated state.
+ * @return {Object} Updated state.
  */
-export function inserterInsertionPoint( state = false, action ) {
+export function insertionPoint( state = null, action ) {
 	switch ( action.type ) {
-		case 'SET_INSERTER_INSERTION_POINT':
+		case 'SET_INSERTION_POINT':
 			return action.value;
 		case 'SELECT_BLOCK':
 			return null;
@@ -2110,8 +2110,8 @@ const combinedReducers = combineReducers( {
 	initialPosition,
 	blocksMode,
 	blockListSettings,
-	inserterInsertionPoint,
 	insertionPoint,
+	insertionCue,
 	template,
 	settings,
 	preferences,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2079,6 +2079,25 @@ export function zoomLevel( state = 100, action ) {
 	return state;
 }
 
+/**
+ * Reducer setting the insertion point
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function inserterInsertionPoint( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_INSERTER_INSERTION_POINT':
+			return action.value;
+		case 'SELECT_BLOCK':
+			return null;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2091,6 +2110,7 @@ const combinedReducers = combineReducers( {
 	initialPosition,
 	blocksMode,
 	blockListSettings,
+	inserterInsertionPoint,
 	insertionPoint,
 	template,
 	settings,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1454,8 +1454,7 @@ export function isCaretWithinFormattedText() {
 }
 
 /**
- * Returns the insertion point, the index at which the new inserted block would
- * be placed. Defaults to the last index.
+ * Returns the location of the insertion cue. Defaults to the last index.
  *
  * @param {Object} state Editor state.
  *
@@ -1493,7 +1492,7 @@ export const getBlockInsertionPoint = createSelector(
 );
 
 /**
- * Returns true if we should show the block insertion point.
+ * Returns true if the block insertion point is visible.
  *
  * @param {Object} state Global application state.
  *

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1466,11 +1466,11 @@ export const getBlockInsertionPoint = createSelector(
 		let rootClientId, index;
 
 		const {
-			insertionPoint,
+			insertionCue,
 			selection: { selectionEnd },
 		} = state;
-		if ( insertionPoint !== null ) {
-			return insertionPoint;
+		if ( insertionCue !== null ) {
+			return insertionCue;
 		}
 
 		const { clientId } = selectionEnd;
@@ -1485,7 +1485,7 @@ export const getBlockInsertionPoint = createSelector(
 		return { rootClientId, index };
 	},
 	( state ) => [
-		state.insertionPoint,
+		state.insertionCue,
 		state.selection.selectionEnd.clientId,
 		state.blocks.parents,
 		state.blocks.order,
@@ -1500,7 +1500,7 @@ export const getBlockInsertionPoint = createSelector(
  * @return {?boolean} Whether the insertion point is visible or not.
  */
 export function isBlockInsertionPointVisible( state ) {
-	return state.insertionPoint !== null;
+	return state.insertionCue !== null;
 }
 
 /**

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -6,6 +6,7 @@ import {
 	showBlockInterface,
 	expandBlock,
 	__experimentalUpdateSettings,
+	setInserterInsertionPoint,
 	setOpenedBlockSettingsMenu,
 	startDragging,
 	stopDragging,
@@ -120,6 +121,20 @@ describe( 'private actions', () => {
 			expect( expandBlock( 'block-1' ) ).toEqual( {
 				type: 'SET_BLOCK_EXPANDED_IN_LIST_VIEW',
 				clientId: 'block-1',
+			} );
+		} );
+	} );
+
+	describe( 'setInserterInsertionPoint', () => {
+		it( 'should return the SET_INSERTER_INSERTION_POINT action', () => {
+			expect(
+				setInserterInsertionPoint( {
+					rootClientId: '',
+					insertionIndex: '123',
+				} )
+			).toEqual( {
+				type: 'SET_INSERTER_INSERTION_POINT',
+				value: { rootClientId: '', insertionIndex: '123' },
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/private-actions.js
+++ b/packages/block-editor/src/store/test/private-actions.js
@@ -6,7 +6,7 @@ import {
 	showBlockInterface,
 	expandBlock,
 	__experimentalUpdateSettings,
-	setInserterInsertionPoint,
+	setInsertionPoint,
 	setOpenedBlockSettingsMenu,
 	startDragging,
 	stopDragging,
@@ -125,16 +125,16 @@ describe( 'private actions', () => {
 		} );
 	} );
 
-	describe( 'setInserterInsertionPoint', () => {
-		it( 'should return the SET_INSERTER_INSERTION_POINT action', () => {
+	describe( 'setInsertionPoint', () => {
+		it( 'should return the SET_INSERTION_POINT action', () => {
 			expect(
-				setInserterInsertionPoint( {
+				setInsertionPoint( {
 					rootClientId: '',
-					insertionIndex: '123',
+					index: '123',
 				} )
 			).toEqual( {
-				type: 'SET_INSERTER_INSERTION_POINT',
-				value: { rootClientId: '', insertionIndex: '123' },
+				type: 'SET_INSERTION_POINT',
+				value: { rootClientId: '', index: '123' },
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -29,6 +29,7 @@ import {
 	preferences,
 	blocksMode,
 	insertionPoint,
+	inserterInsertionPoint,
 	template,
 	blockListSettings,
 	lastBlockAttributesChange,
@@ -3482,6 +3483,41 @@ describe( 'state', () => {
 					clientId: 'a-different-block',
 				}
 			);
+			expect( state ).toBe( null );
+		} );
+	} );
+
+	describe( 'inserterInsertionPoint', () => {
+		it( 'should default to null', () => {
+			const state = inserterInsertionPoint( undefined, {} );
+
+			expect( state ).toBe( null );
+		} );
+
+		it( 'should set inserter insertion point', () => {
+			const state = inserterInsertionPoint( null, {
+				type: 'SET_INSERTER_INSERTION_POINT',
+				value: {
+					rootClientId: 'clientId1',
+					insertionIndex: 4,
+				},
+			} );
+
+			expect( state ).toEqual( {
+				rootClientId: 'clientId1',
+				insertionIndex: 4,
+			} );
+		} );
+
+		it( 'should clear the inserter insertion point on block selection', () => {
+			const original = deepFreeze( {
+				rootClientId: 'clientId1',
+				insertionIndex: 4,
+			} );
+			const state = inserterInsertionPoint( original, {
+				type: 'SELECT_BLOCK',
+			} );
+
 			expect( state ).toBe( null );
 		} );
 	} );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3494,7 +3494,7 @@ describe( 'state', () => {
 			expect( state ).toBe( null );
 		} );
 
-		it( 'should set inserter insertion point', () => {
+		it( 'should set insertion point', () => {
 			const state = insertionPoint( null, {
 				type: 'SET_INSERTION_POINT',
 				value: {
@@ -3509,7 +3509,7 @@ describe( 'state', () => {
 			} );
 		} );
 
-		it( 'should clear the inserter insertion point on block selection', () => {
+		it( 'should clear the insertion point on block selection', () => {
 			const original = deepFreeze( {
 				rootClientId: 'clientId1',
 				index: 4,

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3496,7 +3496,7 @@ describe( 'state', () => {
 
 		it( 'should set inserter insertion point', () => {
 			const state = inserterInsertionPoint( null, {
-				type: 'SET_INSERTER_INSERTION_POINT',
+				type: 'SET_INSERTION_POINT',
 				value: {
 					rootClientId: 'clientId1',
 					insertionIndex: 4,

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -28,8 +28,8 @@ import {
 	isMultiSelecting,
 	preferences,
 	blocksMode,
+	insertionCue,
 	insertionPoint,
-	inserterInsertionPoint,
 	template,
 	blockListSettings,
 	lastBlockAttributesChange,
@@ -2379,15 +2379,15 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'insertionPoint', () => {
+	describe( 'insertionCue', () => {
 		it( 'should default to null', () => {
-			const state = insertionPoint( undefined, {} );
+			const state = insertionCue( undefined, {} );
 
 			expect( state ).toBe( null );
 		} );
 
 		it( 'should set insertion point', () => {
-			const state = insertionPoint( null, {
+			const state = insertionCue( null, {
 				type: 'SHOW_INSERTION_POINT',
 				rootClientId: 'clientId1',
 				index: 0,
@@ -2404,7 +2404,7 @@ describe( 'state', () => {
 				rootClientId: 'clientId1',
 				index: 0,
 			} );
-			const state = insertionPoint( original, {
+			const state = insertionCue( original, {
 				type: 'HIDE_INSERTION_POINT',
 			} );
 
@@ -3487,34 +3487,34 @@ describe( 'state', () => {
 		} );
 	} );
 
-	describe( 'inserterInsertionPoint', () => {
+	describe( 'insertionPoint', () => {
 		it( 'should default to null', () => {
-			const state = inserterInsertionPoint( undefined, {} );
+			const state = insertionPoint( undefined, {} );
 
 			expect( state ).toBe( null );
 		} );
 
 		it( 'should set inserter insertion point', () => {
-			const state = inserterInsertionPoint( null, {
+			const state = insertionPoint( null, {
 				type: 'SET_INSERTION_POINT',
 				value: {
 					rootClientId: 'clientId1',
-					insertionIndex: 4,
+					index: 4,
 				},
 			} );
 
 			expect( state ).toEqual( {
 				rootClientId: 'clientId1',
-				insertionIndex: 4,
+				index: 4,
 			} );
 		} );
 
 		it( 'should clear the inserter insertion point on block selection', () => {
 			const original = deepFreeze( {
 				rootClientId: 'clientId1',
-				insertionIndex: 4,
+				index: 4,
 			} );
-			const state = inserterInsertionPoint( original, {
+			const state = insertionPoint( original, {
 				type: 'SELECT_BLOCK',
 			} );
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -2425,7 +2425,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				insertionPoint: {
+				insertionCue: {
 					rootClientId: undefined,
 					index: 0,
 				},
@@ -2466,7 +2466,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				insertionPoint: null,
+				insertionCue: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2504,7 +2504,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				insertionPoint: null,
+				insertionCue: null,
 			};
 
 			const insertionPoint1 = getBlockInsertionPoint( state );
@@ -2546,7 +2546,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				insertionPoint: null,
+				insertionCue: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2588,7 +2588,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				insertionPoint: null,
+				insertionCue: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2630,7 +2630,7 @@ describe( 'selectors', () => {
 						} )
 					),
 				},
-				insertionPoint: null,
+				insertionCue: null,
 			};
 
 			expect( getBlockInsertionPoint( state ) ).toEqual( {
@@ -2643,7 +2643,7 @@ describe( 'selectors', () => {
 	describe( 'isBlockInsertionPointVisible', () => {
 		it( 'should return false if no assigned insertion point', () => {
 			const state = {
-				insertionPoint: null,
+				insertionCue: null,
 			};
 
 			expect( isBlockInsertionPointVisible( state ) ).toBe( false );
@@ -2651,7 +2651,7 @@ describe( 'selectors', () => {
 
 		it( 'should return true if assigned insertion point', () => {
 			const state = {
-				insertionPoint: {
+				insertionCue: {
 					rootClientId: undefined,
 					index: 5,
 				},

--- a/packages/edit-post/src/store/selectors.js
+++ b/packages/edit-post/src/store/selectors.js
@@ -506,7 +506,7 @@ export const __experimentalGetInsertionPoint = createRegistrySelector(
 				version: '6.7',
 			}
 		);
-		return unlock( select( editorStore ) ).getInsertionPoint();
+		return unlock( select( editorStore ) ).getInserter();
 	}
 );
 

--- a/packages/edit-site/src/store/selectors.js
+++ b/packages/edit-site/src/store/selectors.js
@@ -213,7 +213,7 @@ export const __experimentalGetInsertionPoint = createRegistrySelector(
 				version: '6.7',
 			}
 		);
-		return unlock( select( editorStore ) ).getInsertionPoint();
+		return unlock( select( editorStore ) ).getInserter();
 	}
 );
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -88,10 +88,7 @@ export default function InserterSidebar() {
 				showMostUsedBlocks={ showMostUsedBlocks }
 				showInserterHelpPanel
 				shouldFocusBlock={ isMobileViewport }
-				rootClientId={
-					blockSectionRootClientId ?? insertionPoint.rootClientId
-				}
-				__experimentalInsertionIndex={ insertionPoint.insertionIndex }
+				rootClientId={ blockSectionRootClientId }
 				onSelect={ insertionPoint.onSelect }
 				__experimentalInitialTab={ insertionPoint.tab }
 				__experimentalInitialCategory={ insertionPoint.category }

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -24,13 +24,13 @@ export default function InserterSidebar() {
 	const {
 		blockSectionRootClientId,
 		inserterSidebarToggleRef,
-		insertionPoint,
+		inserter,
 		showMostUsedBlocks,
 		sidebarIsOpened,
 	} = useSelect( ( select ) => {
 		const {
 			getInserterSidebarToggleRef,
-			getInsertionPoint,
+			getInserter,
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
 		const {
@@ -52,7 +52,7 @@ export default function InserterSidebar() {
 		};
 		return {
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
-			insertionPoint: getInsertionPoint(),
+			inserter: getInserter(),
 			showMostUsedBlocks: get( 'core', 'mostUsedBlocks' ),
 			blockSectionRootClientId: getBlockSectionRootClientId(),
 			sidebarIsOpened: !! (
@@ -89,10 +89,10 @@ export default function InserterSidebar() {
 				showInserterHelpPanel
 				shouldFocusBlock={ isMobileViewport }
 				rootClientId={ blockSectionRootClientId }
-				onSelect={ insertionPoint.onSelect }
-				__experimentalInitialTab={ insertionPoint.tab }
-				__experimentalInitialCategory={ insertionPoint.category }
-				__experimentalFilterValue={ insertionPoint.filterValue }
+				onSelect={ inserter.onSelect }
+				__experimentalInitialTab={ inserter.tab }
+				__experimentalInitialCategory={ inserter.category }
+				__experimentalFilterValue={ inserter.filterValue }
 				onPatternCategorySelection={
 					sidebarIsOpened
 						? () => disableComplementaryArea( 'core' )

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -720,16 +720,14 @@ export function removeEditorPanel( panelName ) {
 /**
  * Returns an action object used to open/close the inserter.
  *
- * @param {boolean|Object} value                Whether the inserter should be
- *                                              opened (true) or closed (false).
- *                                              To specify an insertion point,
- *                                              use an object.
- * @param {string}         value.rootClientId   The root client ID to insert at.
- * @param {number}         value.insertionIndex The index to insert at.
- * @param {string}         value.filterValue    A query to filter the inserter results.
- * @param {Function}       value.onSelect       A callback when an item is selected.
- * @param {string}         value.tab            The tab to open in the inserter.
- * @param {string}         value.category       The category to initialize in the inserter.
+ * @param {boolean|Object} value             Whether the inserter should be
+ *                                           opened (true) or closed (false).
+ *                                           To specify an insertion point,
+ *                                           use an object.
+ * @param {string}         value.filterValue A query to filter the inserter results.
+ * @param {Function}       value.onSelect    A callback when an item is selected.
+ * @param {string}         value.tab         The tab to open in the inserter.
+ * @param {string}         value.category    The category to initialize in the inserter.
  *
  * @return {Object} Action object.
  */

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -726,6 +726,10 @@ export function removeEditorPanel( panelName ) {
  *                                              use an object.
  * @param {string}         value.rootClientId   The root client ID to insert at.
  * @param {number}         value.insertionIndex The index to insert at.
+ * @param {string}         value.filterValue    A query to filter the inserter results.
+ * @param {Function}       value.onSelect       A callback when an item is selected.
+ * @param {string}         value.tab            The tab to open in the inserter.
+ * @param {string}         value.category       The category to initialize in the inserter.
  *
  * @return {Object} Action object.
  */

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -720,23 +720,50 @@ export function removeEditorPanel( panelName ) {
 /**
  * Returns an action object used to open/close the inserter.
  *
- * @param {boolean|Object} value             Whether the inserter should be
- *                                           opened (true) or closed (false).
- *                                           To specify an insertion point,
- *                                           use an object.
- * @param {string}         value.filterValue A query to filter the inserter results.
- * @param {Function}       value.onSelect    A callback when an item is selected.
- * @param {string}         value.tab         The tab to open in the inserter.
- * @param {string}         value.category    The category to initialize in the inserter.
+ * @param {boolean|Object} value                Whether the inserter should be
+ *                                              opened (true) or closed (false).
+ *                                              To specify an insertion point,
+ *                                              use an object.
+ * @param {string}         value.rootClientId   Deprecated. The root client ID to insert at.
+ * @param {number}         value.insertionIndex Deprecated. The index to insert at.
+ * @param {string}         value.filterValue    A query to filter the inserter results.
+ * @param {Function}       value.onSelect       A callback when an item is selected.
+ * @param {string}         value.tab            The tab to open in the inserter.
+ * @param {string}         value.category       The category to initialize in the inserter.
  *
  * @return {Object} Action object.
  */
-export function setIsInserterOpened( value ) {
-	return {
-		type: 'SET_IS_INSERTER_OPENED',
-		value,
+export const setIsInserterOpened =
+	( value ) =>
+	( { dispatch, registry } ) => {
+		if (
+			typeof value === 'object' &&
+			value.hasOwnProperty( 'rootClientId' ) &&
+			value.hasOwnProperty( 'insertionIndex' )
+		) {
+			deprecated(
+				'rootClientId and insertionIndex are deprecated from the editor store state.',
+				{
+					since: '6.7',
+					version: '6.9',
+					alternative:
+						'wp.data.dispatch( "core/block-editor" ).setInserterInsertionPoint',
+				}
+			);
+
+			return registry
+				.dispatch( blockEditorStore )
+				.setInserterInsertionPoint( {
+					rootClientId: value.rootClientId,
+					insertionIndex: value.insertionIndex,
+				} );
+		}
+
+		dispatch( {
+			type: 'SET_IS_INSERTER_OPENED',
+			value,
+		} );
 	};
-}
 
 /**
  * Returns an action object used to open/close the list view.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -741,22 +741,10 @@ export const setIsInserterOpened =
 			value.hasOwnProperty( 'rootClientId' ) &&
 			value.hasOwnProperty( 'insertionIndex' )
 		) {
-			deprecated(
-				'rootClientId and insertionIndex are deprecated from the editor store state.',
-				{
-					since: '6.7',
-					version: '6.9',
-					alternative:
-						'wp.data.dispatch( "core/block-editor" ).setInserterInsertionPoint',
-				}
-			);
-
-			return registry
-				.dispatch( blockEditorStore )
-				.setInserterInsertionPoint( {
-					rootClientId: value.rootClientId,
-					insertionIndex: value.insertionIndex,
-				} );
+			return registry.dispatch( blockEditorStore ).setInsertionPoint( {
+				rootClientId: value.rootClientId,
+				index: value.insertionIndex,
+			} );
 		}
 
 		dispatch( {

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -747,7 +747,7 @@ export const setIsInserterOpened =
 			} );
 		}
 
-		return dispatch( {
+		dispatch( {
 			type: 'SET_IS_INSERTER_OPENED',
 			value,
 		} );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -26,7 +26,7 @@ import {
 	getNotificationArgumentsForSaveFail,
 	getNotificationArgumentsForTrashFail,
 } from './utils/notice-builder';
-
+import { unlock } from '../lock-unlock';
 /**
  * Returns an action generator used in signalling that editor has initialized with
  * the specified post object and editor settings.
@@ -741,7 +741,7 @@ export const setIsInserterOpened =
 			value.hasOwnProperty( 'rootClientId' ) &&
 			value.hasOwnProperty( 'insertionIndex' )
 		) {
-			return registry.dispatch( blockEditorStore ).setInsertionPoint( {
+			unlock( registry.dispatch( blockEditorStore ) ).setInsertionPoint( {
 				rootClientId: value.rootClientId,
 				index: value.insertionIndex,
 			} );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -724,8 +724,8 @@ export function removeEditorPanel( panelName ) {
  *                                              opened (true) or closed (false).
  *                                              To specify an insertion point,
  *                                              use an object.
- * @param {string}         value.rootClientId   Deprecated. The root client ID to insert at.
- * @param {number}         value.insertionIndex Deprecated. The index to insert at.
+ * @param {string}         value.rootClientId   The root client ID to insert at.
+ * @param {number}         value.insertionIndex The index to insert at.
  * @param {string}         value.filterValue    A query to filter the inserter results.
  * @param {Function}       value.onSelect       A callback when an item is selected.
  * @param {string}         value.tab            The tab to open in the inserter.

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -747,7 +747,7 @@ export const setIsInserterOpened =
 			} );
 		}
 
-		dispatch( {
+		return dispatch( {
 			type: 'SET_IS_INSERTER_OPENED',
 			value,
 		} );

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -37,13 +37,13 @@ const EMPTY_INSERTION_POINT = {
 };
 
 /**
- * Get the insertion point for the inserter.
+ * Get the inserter.
  *
  * @param {Object} state Global application state.
  *
  * @return {Object} The root client ID, index to insert at and starting filter value.
  */
-export const getInsertionPoint = createRegistrySelector( ( select ) =>
+export const getInserter = createRegistrySelector( ( select ) =>
 	createSelector(
 		( state ) => {
 			if ( typeof state.blockInserterPanel === 'object' ) {

--- a/packages/editor/src/store/test/actions.js
+++ b/packages/editor/src/store/test/actions.js
@@ -576,4 +576,80 @@ describe( 'Editor actions', () => {
 			).toBe( true );
 		} );
 	} );
+
+	describe( 'setIsInserterOpened', () => {
+		it( 'should open and close the inserter', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editorStore ).setIsInserterOpened( true );
+
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
+				true
+			);
+
+			registry.dispatch( editorStore ).setIsInserterOpened( false );
+
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
+				false
+			);
+		} );
+
+		it( 'the list view should close when the inserter is opened', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editorStore ).setIsListViewOpened( true );
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
+				true
+			);
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
+				false
+			);
+
+			registry.dispatch( editorStore ).setIsInserterOpened( true );
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
+				true
+			);
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
+				false
+			);
+		} );
+	} );
+
+	describe( 'setIsListViewOpened', () => {
+		it( 'should open and close the list view', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editorStore ).setIsListViewOpened( true );
+
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
+				true
+			);
+
+			registry.dispatch( editorStore ).setIsListViewOpened( false );
+
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
+				false
+			);
+		} );
+
+		it( 'the inserter should close when the list view is opened', () => {
+			const registry = createRegistryWithStores();
+
+			registry.dispatch( editorStore ).setIsInserterOpened( true );
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
+				true
+			);
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
+				false
+			);
+
+			registry.dispatch( editorStore ).setIsListViewOpened( true );
+			expect( registry.select( editorStore ).isListViewOpened() ).toBe(
+				true
+			);
+			expect( registry.select( editorStore ).isInserterOpened() ).toBe(
+				false
+			);
+		} );
+	} );
 } );

--- a/packages/editor/src/store/test/reducer.js
+++ b/packages/editor/src/store/test/reducer.js
@@ -18,7 +18,6 @@ import {
 	blockInserterPanel,
 	listViewPanel,
 } from '../reducer';
-import { setIsInserterOpened } from '../actions';
 
 describe( 'state', () => {
 	describe( 'hasSameKeys()', () => {
@@ -298,15 +297,6 @@ describe( 'state', () => {
 			expect( blockInserterPanel( true, {} ) ).toBe( true );
 		} );
 
-		it( 'should set the open state of the inserter panel', () => {
-			expect(
-				blockInserterPanel( false, setIsInserterOpened( true ) )
-			).toBe( true );
-			expect(
-				blockInserterPanel( true, setIsInserterOpened( false ) )
-			).toBe( false );
-		} );
-
 		it( 'should close the inserter when opening the list view panel', () => {
 			expect(
 				blockInserterPanel( true, {
@@ -348,18 +338,6 @@ describe( 'state', () => {
 					isOpen: false,
 				} )
 			).toBe( false );
-		} );
-
-		it( 'should close the list view when opening the inserter panel', () => {
-			expect( listViewPanel( true, setIsInserterOpened( true ) ) ).toBe(
-				false
-			);
-		} );
-
-		it( 'should not change the state when closing the inserter panel', () => {
-			expect( listViewPanel( true, setIsInserterOpened( false ) ) ).toBe(
-				true
-			);
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the block editor store:
- Change `insertionPoint` reducer to `insertionCue` (as it is where the blue line shows up _not_ where insertion is guaranteed to happen).
- This opens us `insertionPoint` to be used to manually pass an insertion point (such as when clicking an inline inserter button like the blue zoom out inserter buttons)
- Add `setInsertionPoint` action
- Adds private `getInsertionPoint` selector 

In the editor store:
- `setIsInserterOpened` dispatches `setInsertionPoint` to the block editor store
- Rename editor selector `getInsertionPoint` to `getInserter` to more clearly communicate this is the state of the inserter, not solely about the insertion point. 
## Why?/How
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Now that the inserter can remain open while interacting with the block canvas, it is expected that when you select a new block, the insertion will occur after the selected block. 

The insertion point is handled by the editor package via `setIsInserterOpened( value )`, which can take an object to open the inserter to a certain tab panel and also provide the place where the insertion should happen. We want to change this insertion point when selecting a new block on the canvas. Block selection is handled via the block editor package. Since the block editor should not know about the editor, and we can't rely on the `SELECTION_CHANGE` action to clear the insertion point within the editor store, I've moved the insertion point data to be within the block editor package. 

In order to clear up confusion, I've also renamed some state and selectors:
- Block editor `insertionPoint` state becomes `insertionCue`, as this more accurately names it. It was not the insertion point, but the place where we want to show the blue line on the canvas.
- This opens up `insertionPoint` to be used for manually setting an insertion point, if needed, such as when opening the inserter via one of the inline inserter buttons.
- In the editor package, `getInsertionPoint` is renamed to `getInserter`, as this was a point of confusion. It is only the insertion point if the inserter is open and becomes stale data as soon as another interaction on the canvas happens. This is about the sate of the inserter when it is opened, and if it should still be open. `getInserter` is a better name, and it could still be better. `getInserterPanel` maybe?

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Renames `state.insertionPoint` to `state.insertionCue` in the block editor store and related action/reducers.
- Adds `state.insertionPoint` to store when an insertion point is manually passed.
- Emit the private `setInsertionPoint` action in the block editor store when `setIsInserterOpen` has an root index and insertion point set.
- Clear `insertionPoint` state on `SELECT_BLOCK` 
- Renames private editor selector `getInsertionPoint` to `getInserter` to more accurately communicate that this is the state the inserter initialized to rather than the final insertion point.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### For pattern insertion points in Zoom Out
1. Open the Site Editor
2. Enter zoom out mode (this isn't necessary but it makes it much easier to test) - you can enter zoom out by selecting a pattern category in the inserter or by using the 50% desktop option in the device preview dropdown)
4. Click one on the [+] in the canvas, to set an insertion point. Notice that a wide blue line appears between the two blocks.
5. Select another block, or clear block selection. Notice that that wide blue line disappears.
6. Now select a pattern in the canvas. This pattern should be inserted after the newly selected block, not at the place where the old insertion point was.
7. Create an insertion point by clicking the [+]. Hover a pattern in the inserter. You should still see the wide blue line in the canvas.
9. Now click the pattern. It should be added to the place that the insertion point indicator was.

### Default Editing
- Use the various in-between inserters and inserters in both group and root level contexts (like a new post). 
- See if insertion always happens where you would expect it to
- If it is unexpected, check to see if it's different than trunk

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
