### PR TITLE
Block Bindings: Add styles for attribute panel read only state

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -92,14 +92,16 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 	);
 }
 
-function BlockBindingsAttribute( { attribute, binding } ) {
+function BlockBindingsAttribute( { attribute, binding, readOnly } ) {
 	const { source: sourceName, args } = binding || {};
 	const sourceProps =
 		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
 	return (
 		<VStack className="block-editor-bindings__item">
-			<Text truncate>{ attribute }</Text>
+			<Text truncate variant={ readOnly ? 'muted' : '' }>
+				{ attribute }
+			</Text>
 			{ !! binding && (
 				<Text
 					truncate
@@ -123,6 +125,7 @@ function ReadOnlyBlockBindingsPanelItems( { bindings } ) {
 					<BlockBindingsAttribute
 						attribute={ attribute }
 						binding={ binding }
+						readOnly
 					/>
 				</Item>
 			) ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Currently, only admins can create and modify bindings using the attributes panel, whereas for editors the panel is in a read only state. We do not distinguish between these two modes, so this PR adds styling to distinguish when the attributes panel is non-interactive.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/65093

We want to signal when the attributes panel is read only so users don't perceive that as a bug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It sets the attribute name to gray in the panel.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In the post editor, using an admin account, add a paragraph and create a connection. Save the post.
2. Using a non-admin user with editor privileges, access the same post.
3. See that the attribute name in the attributes panel has been set to gray.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="1023" alt="Screenshot 2024-09-05 at 5 49 04 PM" src="https://github.com/user-attachments/assets/87095fbc-40d8-4ec5-b5fe-73ccc279d246">

### After

<img width="979" alt="Screenshot 2024-09-05 at 5 47 03 PM" src="https://github.com/user-attachments/assets/e8664dac-9f97-4c40-b586-04bf519c77bd">