### PR TITLE
Cover: Explicitly set isUserOverlayColor to false when media is updated

### DIFF
--- a/packages/block-library/src/cover/deprecated.js
+++ b/packages/block-library/src/cover/deprecated.js
@@ -400,8 +400,9 @@ const v12 = {
 	supports: v12BlockSupports,
 	isEligible( attributes ) {
 		return (
-			attributes.customOverlayColor !== undefined ||
-			attributes.overlayColor !== undefined
+			( attributes.customOverlayColor !== undefined ||
+				attributes.overlayColor !== undefined ) &&
+			attributes.isUserOverlayColor === undefined
 		);
 	},
 	migrate( attributes ) {

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -143,7 +143,10 @@ function CoverEdit( {
 				averageBackgroundColor
 			);
 			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { isDark: newIsDark } );
+			setAttributes( {
+				isDark: newIsDark,
+				isUserOverlayColor: isUserOverlayColor || false,
+			} );
 		} )();
 		// Disable reason: Update the block only when the featured image changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -201,6 +204,7 @@ function CoverEdit( {
 			useFeaturedImage: undefined,
 			dimRatio: newDimRatio,
 			isDark: newIsDark,
+			isUserOverlayColor: isUserOverlayColor || false,
 		} );
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #64702, fixes #64480

Update the logic in the Cover block to explicitly set `isUserOverlayColor` to `false` when the media is changed. Also, update the deprecation that sets `isUserOverlayColor` to `true` to only do so if the attribute is not already set.

Between these two changes, the issue linked issues above should be resolved. The main goal of this PR is to ensure that the Cover block's auto overlay color behaviour (where an overlay color is set when an image is added) continues to work even after a post or page reload.

Kudos: @ajlende for the suggestion of this fix in https://github.com/WordPress/gutenberg/pull/65077#issuecomment-2331949720

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Ensure that the Cover block's auto overlay color behaviour continues to work after reloading the editor, if the user has never manually set the overlay color for the Cover block.

Prior to this change, the deprecation was firing too frequently. Because the deprecation didn't check to see if `isUserOverlayColor` was already set, it would fire even when it didn't need to. Additionally, without setting `isUserOverlayColor` explicitly to `false`, the deprecation would run on Cover blocks where a user had never manually interacted with the overlay color.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* When media changes in the Cover block, explicitly set `isUserOverlayColor` to `false` if it isn't already set to `true`.
* Update the deprecation that sets `isUserOverlayColor` to only do so if the attribute has never been set to a value at all (is `undefined`).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow the reproduction steps in https://github.com/WordPress/gutenberg/issues/64702. Basically:

1. Add a Cover block to a post
2. Give it an image
3. Check that the Overlay color is set based on that image
4. Replace the image
5. Check that the Overlay color is updated
6. Save and reload the editor
7. Replace the image again
8. Check that the Overlay color is updated
9. Manually change the Overlay color to your own custom color
10. Save and reload the editor
11. Replace the image again
12. Check that the Overlay color is still the custom color you selected originally
13. Repeat all the above steps but using the Featured Image mode of the Cover block and update the post's featured image instead

Also, for extra testing, see that the sample code in #64480 works correctly with this PR applied.

## Screenshots or screencast <!-- if applicable -->

This screengrab demos the auto color overlay holding up beyond reloading the post editor. It only sticks once a user sets an overlay color deliberatly:

https://github.com/user-attachments/assets/e59ab87f-7608-4242-91f1-0dc0d38217d3
