### PR TITLE
Fix: Button: Replace remaining 40px default size violation [Block library 3]

### DIFF
--- a/packages/block-library/src/page-list/convert-to-links-modal.js
+++ b/packages/block-library/src/page-list/convert-to-links-modal.js
@@ -32,16 +32,14 @@ export function ConvertToLinksModal( { onClick, onClose, disabled } ) {
 			</p>
 			<div className="wp-block-page-list-modal-buttons">
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					variant="tertiary"
 					onClick={ onClose }
 				>
 					{ __( 'Cancel' ) }
 				</Button>
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					variant="primary"
 					accessibleWhenDisabled
 					disabled={ disabled }

--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -342,8 +342,7 @@ export default function PageListEdit( {
 					<PanelBody title={ __( 'Edit this menu' ) }>
 						<p>{ convertDescription }</p>
 						<Button
-							// TODO: Switch to `true` (40px size) if possible
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							variant="primary"
 							accessibleWhenDisabled
 							disabled={ ! hasResolvedPages }

--- a/packages/block-library/src/post-comments-form/form.js
+++ b/packages/block-library/src/post-comments-form/form.js
@@ -84,8 +84,7 @@ const CommentsForm = ( { postId, postType } ) => {
 		if ( 'closed' === commentStatus ) {
 			const actions = [
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					key="enableComments"
 					onClick={ () => setCommentStatus( 'open' ) }
 					variant="primary"

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -308,8 +308,7 @@ export default function PostFeaturedImageEdit( {
 				mediaLibraryButton={ ( { open } ) => {
 					return (
 						<Button
-							// TODO: Switch to `true` (40px size) if possible
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							icon={ upload }
 							variant="primary"
 							label={ label }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -627,8 +627,7 @@ export default function LogoEdit( {
 								render={ ( { open } ) => (
 									<div className="block-library-site-logo__inspector-upload-container">
 										<Button
-											// TODO: Switch to `true` (40px size) if possible
-											__next40pxDefaultSize={ false }
+											__next40pxDefaultSize
 											onClick={ open }
 											variant="secondary"
 										>
@@ -674,8 +673,7 @@ export default function LogoEdit( {
 					mediaLibraryButton={ ( { open } ) => {
 						return (
 							<Button
-								// TODO: Switch to `true` (40px size) if possible
-								__next40pxDefaultSize={ false }
+								__next40pxDefaultSize
 								icon={ upload }
 								variant="primary"
 								label={ __( 'Choose logo' ) }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -81,8 +81,7 @@ const SocialLinkURLPopover = ( {
 					/>
 				</div>
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					icon={ keyboardReturn }
 					label={ __( 'Apply' ) }
 					type="submit"

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -81,7 +81,8 @@ const SocialLinkURLPopover = ( {
 					/>
 				</div>
 				<Button
-					__next40pxDefaultSize
+					// TODO: Switch to `true` (40px size) if possible.
+					__next40pxDefaultSize={ false }
 					icon={ keyboardReturn }
 					label={ __( 'Apply' ) }
 					type="submit"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of - #65018

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - #65018, To use default to 40px for the button.
- This would fix in the blocks, `core/page-list`, `core/site-logo`, `core/post-featured-image`, `core/post-comments-form` and `core/social-link`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- To make the consistent button across Gutenberg, and we would have a lint rule added once fixed, all the button usage.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Change from `__next40pxDefaultSize={ false }` to `__next40pxDefaultSize` on component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add the blocks on the page/post and check for the buttons defined.
- Screenshot is added for individual changed files.
