### PR TITLE
Block Bindings: Update label for bound paragraphs and headings

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -96,7 +96,7 @@ export function getBindableAttributes( blockName ) {
 	return BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ];
 }
 
-export const withBlockBindingSupport = createHigherOrderComponent(
+export const editWithBlockBindings = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const registry = useRegistry();
 		const blockContext = useContext( BlockContext );
@@ -296,8 +296,17 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			</>
 		);
 	},
-	'withBlockBindingSupport'
+	'editWithBlockBindings'
 );
+
+function labelWithBlockBindings( settings ) {
+	return ( attributes, { context } ) => {
+		if ( attributes?.metadata?.bindings && context === 'accessibility' ) {
+			return 'Overriding label';
+		}
+		return settings.__experimentalLabel?.( attributes, { context } );
+	};
+}
 
 /**
  * Filters a registered block's settings to enhance a block's `edit` component
@@ -314,7 +323,8 @@ function shimAttributeSource( settings, name ) {
 
 	return {
 		...settings,
-		edit: withBlockBindingSupport( settings.edit ),
+		edit: editWithBlockBindings( settings.edit ),
+		__experimentalLabel: labelWithBlockBindings( settings ),
 	};
 }
 

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -104,6 +104,10 @@ export function getBindingsValues(
 	blockContext,
 	clientId
 ) {
+	if ( ! blockBindings ) {
+		return {};
+	}
+
 	const attributes = {};
 
 	const blockBindingsBySource = new Map();

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -96,7 +96,7 @@ export function getBindableAttributes( blockName ) {
 	return BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ];
 }
 
-export const editWithBlockBindings = createHigherOrderComponent(
+export const withBlockBindingSupport = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		const registry = useRegistry();
 		const blockContext = useContext( BlockContext );
@@ -296,17 +296,8 @@ export const editWithBlockBindings = createHigherOrderComponent(
 			</>
 		);
 	},
-	'editWithBlockBindings'
+	'withBlockBindingSupport'
 );
-
-function labelWithBlockBindings( settings ) {
-	return ( attributes, { context } ) => {
-		if ( attributes?.metadata?.bindings && context === 'accessibility' ) {
-			return 'Overriding label';
-		}
-		return settings.__experimentalLabel?.( attributes, { context } );
-	};
-}
 
 /**
  * Filters a registered block's settings to enhance a block's `edit` component
@@ -323,8 +314,7 @@ function shimAttributeSource( settings, name ) {
 
 	return {
 		...settings,
-		edit: editWithBlockBindings( settings.edit ),
-		__experimentalLabel: labelWithBlockBindings( settings ),
+		edit: withBlockBindingSupport( settings.edit ),
 	};
 }
 

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -39,11 +39,7 @@ export const settings = {
 				return customName;
 			}
 
-			const { content, metadata: currentMetadata } = attributes;
-
-			if ( currentMetadata?.bindings?.content ) {
-				return __( 'Paragraph with dynamic content' );
-			}
+			const { content } = attributes;
 			return ! content || content.length === 0 ? __( 'Empty' ) : content;
 		}
 	},

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -39,7 +39,11 @@ export const settings = {
 				return customName;
 			}
 
-			const { content } = attributes;
+			const { content, metadata: currentMetadata } = attributes;
+
+			if ( currentMetadata?.bindings?.content ) {
+				return __( 'Paragraph with dynamic content' );
+			}
 			return ! content || content.length === 0 ? __( 'Empty' ) : content;
 		}
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes the label for bound paragraphs and headings, using their bindings value rather than fallback content.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/62933
The label is currently read out loud by screen readers. Unless we update the label for bound blocks, screen readers will simply announce the value in the markup, which is misleading, as the actual content will be rendered by the block bindings API.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It replicates some logic from `use-bindings-attributes.js` inside of `block-selection-button.js` in order to retrieve the bindings value, and also extracts key logic into a new `getBindingsValues` function so that it can be reused.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
<details>
<summary>1. Register post meta by adding this snippet to your theme's functions.php</summary>

```php
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_field',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'default'           => 'default text value',
		)
	);
}
```

</details>


<details>

<summary>2. Add heading and paragraph blocks bound to a custom field using the Code Editor</summary>

```
<!-- wp:heading {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<h2 class="wp-block-heading">Bound heading</h2>
<!-- /wp:heading -->
```

```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<p>Bound paragraph</p>
<!-- /wp:paragraph -->
```
</details>
 
3. Using the NVDA screen reader, navigate to the bound blocks in Navigation Mode, and see that the their modified content is announced.