### PR TITLE
Add prompt for drag and drop in Patterns tab in Zoom Out mode

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -177,7 +177,6 @@ export function PatternCategoryPreviews( {
 							<Text
 								size="12"
 								as="p"
-								variant="muted"
 								className="block-editor-inserter__help-text"
 							>
 								{ __(

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -170,32 +170,40 @@ export function PatternCategoryPreviews( {
 					</Text>
 				) }
 			</VStack>
-
-			{ currentCategoryPatterns.length > 0 && (
-				<>
-					{ isZoomOutMode && (
-						<p className="block-editor-inserter__help-text">
-							{ __(
-								'Drag and drop any pattern into the canvas.'
-							) }
-						</p>
-					) }
-					<BlockPatternsList
-						ref={ scrollContainerRef }
-						shownPatterns={ pagingProps.categoryPatternsAsyncList }
-						blockPatterns={ pagingProps.categoryPatterns }
-						onClickPattern={ onClickPattern }
-						onHover={ onHover }
-						label={ category.label }
-						orientation="vertical"
-						category={ category.name }
-						isDraggable
-						showTitlesAsTooltip={ showTitlesAsTooltip }
-						patternFilter={ patternSourceFilter }
-						pagingProps={ pagingProps }
-					/>
-				</>
-			) }
+			<VStack spacing={ 4 }>
+				{ currentCategoryPatterns.length > 0 && (
+					<>
+						{ isZoomOutMode && (
+							<Text
+								size="12"
+								as="p"
+								variant="muted"
+								className="block-editor-inserter__help-text"
+							>
+								{ __(
+									'Drag and drop patterns into the canvas.'
+								) }
+							</Text>
+						) }
+						<BlockPatternsList
+							ref={ scrollContainerRef }
+							shownPatterns={
+								pagingProps.categoryPatternsAsyncList
+							}
+							blockPatterns={ pagingProps.categoryPatterns }
+							onClickPattern={ onClickPattern }
+							onHover={ onHover }
+							label={ category.label }
+							orientation="vertical"
+							category={ category.name }
+							isDraggable
+							showTitlesAsTooltip={ showTitlesAsTooltip }
+							patternFilter={ patternSourceFilter }
+							pagingProps={ pagingProps }
+						/>
+					</>
+				) }
+			</VStack>
 		</>
 	);
 }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -16,7 +16,10 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	FlexBlock,
+	Icon,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -32,6 +35,7 @@ import {
 	myPatternsCategory,
 	INSERTER_PATTERN_TYPES,
 } from './utils';
+import { store as blockEditorStore } from '../../../store';
 
 const noop = () => {};
 
@@ -42,6 +46,11 @@ export function PatternCategoryPreviews( {
 	category,
 	showTitlesAsTooltip,
 } ) {
+	const isZoomOutMode = useSelect(
+		( select ) =>
+			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+		[]
+	);
 	const [ allPatterns, , onClickPattern ] = usePatternsState(
 		onInsert,
 		rootClientId,
@@ -165,20 +174,35 @@ export function PatternCategoryPreviews( {
 			</VStack>
 
 			{ currentCategoryPatterns.length > 0 && (
-				<BlockPatternsList
-					ref={ scrollContainerRef }
-					shownPatterns={ pagingProps.categoryPatternsAsyncList }
-					blockPatterns={ pagingProps.categoryPatterns }
-					onClickPattern={ onClickPattern }
-					onHover={ onHover }
-					label={ category.label }
-					orientation="vertical"
-					category={ category.name }
-					isDraggable
-					showTitlesAsTooltip={ showTitlesAsTooltip }
-					patternFilter={ patternSourceFilter }
-					pagingProps={ pagingProps }
-				/>
+				<>
+					{ isZoomOutMode && (
+						<HStack
+							align="top"
+							className="block-editor-inserter__help-text"
+						>
+							<Icon icon={ info } />
+							<p>
+								{ __(
+									'Drag and drop any pattern into the canvas.'
+								) }
+							</p>
+						</HStack>
+					) }
+					<BlockPatternsList
+						ref={ scrollContainerRef }
+						shownPatterns={ pagingProps.categoryPatternsAsyncList }
+						blockPatterns={ pagingProps.categoryPatterns }
+						onClickPattern={ onClickPattern }
+						onHover={ onHover }
+						label={ category.label }
+						orientation="vertical"
+						category={ category.name }
+						isDraggable
+						showTitlesAsTooltip={ showTitlesAsTooltip }
+						patternFilter={ patternSourceFilter }
+						pagingProps={ pagingProps }
+					/>
+				</>
 			) }
 		</>
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -16,10 +16,8 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	FlexBlock,
-	Icon,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
-import { info } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -176,17 +174,11 @@ export function PatternCategoryPreviews( {
 			{ currentCategoryPatterns.length > 0 && (
 				<>
 					{ isZoomOutMode && (
-						<HStack
-							align="top"
-							className="block-editor-inserter__help-text"
-						>
-							<Icon icon={ info } />
-							<p>
-								{ __(
-									'Drag and drop any pattern into the canvas.'
-								) }
-							</p>
-						</HStack>
+						<p className="block-editor-inserter__help-text">
+							{ __(
+								'Drag and drop any pattern into the canvas.'
+							) }
+						</p>
 					) }
 					<BlockPatternsList
 						ref={ scrollContainerRef }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -710,9 +710,6 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__help-text {
-	margin: 0 $grid-unit-30 1em $grid-unit-30;
-	color: $gray-900;
-	font-size: $helptext-font-size;
-	font-style: normal;
+.block-editor-tabbed-sidebar__tabpanel .block-editor-inserter__help-text {
+	padding: 0 $grid-unit-30;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -711,9 +711,8 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__help-text {
-	padding: 0 $grid-unit-30;
-
-	p:first-of-type {
-		margin-top: 0;
-	}
+	margin: 0 $grid-unit-30 1em $grid-unit-30;
+	color: $gray-900;
+	font-size: $helptext-font-size;
+	font-style: normal;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -709,3 +709,11 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 }
+
+.block-editor-inserter__help-text {
+	padding: 0 $grid-unit-30;
+
+	p:first-of-type {
+		margin-top: 0;
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a small prompt to the Patterns inserter when in Zoom Out mode to encourage users to try drag and drop.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently it's not obviously that drag and drop is enabled. This is one option to encourage that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add text.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable Zoom Out experiment.
- Site Editor
- Enable Zoom Out mode using device preview selector
- Open Patterns inserter
- Click pattern category
- See prompt text


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="2890" alt="Screen Shot 2024-09-06 at 09 45 06" src="https://github.com/user-attachments/assets/ccbc9b4c-f6e0-475e-9e4e-4e6b90fc2a43">

