### PR TITLE
Block Bindings: Map `edit_block_binding` capability

### DIFF
--- a/backport-changelog/6.7/7258.md
+++ b/backport-changelog/6.7/7258.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7258
 
 * https://github.com/WordPress/gutenberg/pull/64570
+* https://github.com/WordPress/gutenberg/pull/65116

--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -58,7 +58,6 @@ function gutenberg_add_edit_block_binding_capability( $caps, $cap, $user_id, $ar
 			if ( empty( $object_subtype ) ) {
 				return array( 'do_not_allow' );
 			}
-
 			$caps = map_meta_cap( "edit_{$object_subtype}", $user_id, $object_id );
 		}
 	}
@@ -74,7 +73,7 @@ add_filter( 'map_meta_cap', 'gutenberg_add_edit_block_binding_capability', 5, 4 
  * @return array The editor settings including `canUpdateBlockBindings`.
  */
 function gutenberg_add_can_update_block_bindings_editor_setting( $editor_settings, $block_editor_context ) {
-	if ( empty( $editor_settings['canUpdateBlockBindings'] ) ) {
+	if ( ! isset( $editor_settings['canUpdateBlockBindings'] ) ) {
 		$editor_settings['canUpdateBlockBindings'] = current_user_can( 'edit_block_binding', $block_editor_context );
 	}
 	return $editor_settings;

--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -58,7 +58,8 @@ function gutenberg_add_edit_block_binding_capability( $caps, $cap, $user_id, $ar
 			if ( empty( $object_subtype ) ) {
 				return array( 'do_not_allow' );
 			}
-			$caps = map_meta_cap( "edit_{$object_subtype}", $user_id, $object_id );
+			$capability_type = get_post_type_object( $object_subtype )->capability_type;
+			$caps            = map_meta_cap( "edit_{$capability_type}", $user_id, $object_id );
 		}
 	}
 	return $caps;

--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -58,8 +58,13 @@ function gutenberg_add_edit_block_binding_capability( $caps, $cap, $user_id, $ar
 			if ( empty( $object_subtype ) ) {
 				return array( 'do_not_allow' );
 			}
-			$capability_type = get_post_type_object( $object_subtype )->capability_type;
-			$caps            = map_meta_cap( "edit_{$capability_type}", $user_id, $object_id );
+			$post_type_object = get_post_type_object( $object_subtype );
+			// Initialize empty array if it doesn't exist.
+			if ( ! isset( $post_type_object->capabilities ) ) {
+				$post_type_object->capabilities = array();
+			}
+			$post_type_capabilities = get_post_type_capabilities( $post_type_object );
+			$caps                   = map_meta_cap( $post_type_capabilities->edit_post, $user_id, $object_id );
 		}
 	}
 	return $caps;

--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -30,6 +30,21 @@ function gutenberg_bootstrap_server_block_bindings_sources() {
 add_action( 'enqueue_block_editor_assets', 'gutenberg_bootstrap_server_block_bindings_sources', 5 );
 
 /**
+ * Map the `manage_block_bindings` capability to `manage_options`.
+ */
+function gutenberg_add_manage_block_bindings_capability() {
+	global $wp_roles;
+	foreach ( $wp_roles->roles as $role_name => $role_info ) {
+		$role = get_role( $role_name );
+		// Map the capability to `manage_options`.
+		if ( $role->has_cap( 'manage_options' ) ) {
+			$role->add_cap( 'manage_block_bindings' );
+		}
+	}
+}
+add_action( 'init', 'gutenberg_add_manage_block_bindings_capability' );
+
+/**
  * Initialize `canUpdateBlockBindings` editor setting if it doesn't exist. By default, it is `true` only for admin users.
  *
  * @param array $settings The block editor settings from the `block_editor_settings_all` filter.
@@ -37,7 +52,7 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_bootstrap_server_block_bin
  */
 function gutenberg_add_can_update_block_bindings_editor_setting( $editor_settings ) {
 	if ( empty( $editor_settings['canUpdateBlockBindings'] ) ) {
-		$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_options' );
+		$editor_settings['canUpdateBlockBindings'] = current_user_can( 'manage_block_bindings' );
 	}
 	return $editor_settings;
 }


### PR DESCRIPTION
## What?
This pull requests add compatibility to create a `edit_block_binding` capability that will be mapped to what was decided [here](https://github.com/WordPress/wordpress-develop/pull/7258#discussion_r1745139982).

## Why?
The compatibility filters should work the same way as core.

## How?
Adding a new `edit_block_binding` capability through an `init` hook.

## Testing Instructions
1. Register some meta fields in your site.
```
	register_meta(
		'post',
		'my_custom_field',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'default'           => 'Default',
			'revisions_enabled' => true,
		)
	);
```
2. Go to a page as an admin and check you can connect a paragraph to the custom field.
3. Insert a filter to modify the `manage_block_bindings` capability and disable it:
```php
function restrict_edit_block_binding_cap( $caps, $cap ) {
	if ( 'edit_block_binding' === $cap ) {
		return array( 'do_not_allow' );
	}
	return $caps;
}

add_filter( 'map_meta_cap', 'restrict_edit_block_binding_cap', 10, 4 );
```
4. Go to the page and check you can't create the connections anymore.
