### PR TITLE
DatePicker: better hover/focus styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 -   `Modal`: Decrease close button size and remove horizontal offset ([#65131](https://github.com/WordPress/gutenberg/pull/65131)).
 
+### Bug Fixes
+
+-   `DatePicker`: better hover/focus styles ([#65117](https://github.com/WordPress/gutenberg/pull/65117)).
+
 ### Internal
 
 -   `Composite`: Remove from private APIs ([#63569](https://github.com/WordPress/gutenberg/pull/63569)).

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -38,7 +38,7 @@ export const Calendar = styled.div`
 `;
 
 export const DayOfWeek = styled.div`
-	color: ${ COLORS.gray[ 700 ] };
+	color: ${ COLORS.theme.gray[ 700 ] };
 	font-size: ${ CONFIG.fontSize };
 	line-height: ${ CONFIG.fontLineHeightBase };
 
@@ -94,7 +94,7 @@ export const DayButton = styled( Button, {
 
 				&,
 				&:hover:not(:disabled, [aria-disabled=true]) {
-					color: ${ COLORS.white };
+					color: ${ COLORS.theme.accentInverted };
 				}
 
 				&:focus:not(:disabled),
@@ -117,7 +117,7 @@ export const DayButton = styled( Button, {
 			! props.isSelected &&
 			props.isToday &&
 			`
-			background: ${ COLORS.gray[ 200 ] };
+			background: ${ COLORS.theme.gray[ 200 ] };
 			` }
 	}
 
@@ -125,7 +125,11 @@ export const DayButton = styled( Button, {
 		props.hasEvents &&
 		`
 		::before {
-			border: 2px solid ${ props.isSelected ? COLORS.white : COLORS.theme.accent };
+			border: 2px solid ${
+				props.isSelected
+					? COLORS.theme.accentInverted
+					: COLORS.theme.accent
+			};
 			border-radius: ${ CONFIG.radiusRound };
 			bottom: 2px;
 			content: " ";

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -7,13 +7,13 @@ import styled from '@emotion/styled';
  * Internal dependencies
  */
 import Button from '../../button';
-import { COLORS, CONFIG } from '../../utils';
+import { boxSizingReset, COLORS, CONFIG } from '../../utils';
 import { HStack } from '../../h-stack';
 import { Heading } from '../../heading';
 import { space } from '../../utils/space';
 
 export const Wrapper = styled.div`
-	box-sizing: border-box;
+	${ boxSizingReset }
 `;
 
 export const Navigator = styled( HStack )`
@@ -127,7 +127,6 @@ export const DayButton = styled( Button, {
 		::before {
 			border: 2px solid ${ props.isSelected ? COLORS.white : COLORS.theme.accent };
 			border-radius: ${ CONFIG.radiusRound };
-			box-sizing: border-box;
 			bottom: 2px;
 			content: " ";
 			left: 50%;

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -90,8 +90,27 @@ export const DayButton = styled( Button, {
 		${ ( props ) =>
 			props.isSelected &&
 			`
-			background: ${ COLORS.theme.accent };
-			color: ${ COLORS.white };
+				background: ${ COLORS.theme.accent };
+
+				&,
+				&:hover:not(:disabled, [aria-disabled=true]) {
+					color: ${ COLORS.white };
+				}
+
+				&:focus:not(:disabled),
+				&:focus:not(:disabled) {
+					border: ${ CONFIG.borderWidthFocus } solid currentColor;
+				}
+
+				/* Highlight the selected day for high-contrast mode */
+				&::before {
+					content: '';
+					position: absolute;
+					pointer-events: none;
+					inset: 0;
+					border-radius: inherit;
+					border: 1px solid transparent;
+				}
 			` }
 
 		${ ( props ) =>

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -125,15 +125,14 @@ export const DayButton = styled( Button, {
 		props.hasEvents &&
 		`
 		::before {
-			background: ${ props.isSelected ? COLORS.white : COLORS.theme.accent };
+			border: 2px solid ${ props.isSelected ? COLORS.white : COLORS.theme.accent };
 			border-radius: ${ CONFIG.radiusRound };
+			box-sizing: border-box;
 			bottom: 2px;
 			content: " ";
-			height: 4px;
 			left: 50%;
-			margin-left: -2px;
 			position: absolute;
-			width: 4px;
+			transform: translateX(-50%);
 		}
 		` }
 `;

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -131,11 +131,10 @@ export const DayButton = styled( Button, {
 					: COLORS.theme.accent
 			};
 			border-radius: ${ CONFIG.radiusRound };
-			bottom: 2px;
 			content: " ";
 			left: 50%;
 			position: absolute;
-			transform: translateX(-50%);
+			transform: translate(-50%, 9px);
 		}
 		` }
 `;

--- a/packages/components/src/date-time/date/styles.ts
+++ b/packages/components/src/date-time/date/styles.ts
@@ -103,7 +103,7 @@ export const DayButton = styled( Button, {
 				}
 
 				/* Highlight the selected day for high-contrast mode */
-				&::before {
+				&::after {
 					content: '';
 					position: absolute;
 					pointer-events: none;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

DatePicker: fix buggy hover styles and improve focus styles for selected day, add high-contrast mode styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fix bugs, improve accessibility and UI polish

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tweaking the day button styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the `DatePicker` in storybook
- Make sure that, when hovering over the selected day, the color of the button remains white
- Make sure that, when focusing the selected day, a more clear focus ring is shown
- Make sure that, when in high-contrast more, users can effectively understand what is the selected day
  - In chrome, this can be emulated using dev tools by setting the `forced-colors: active` media feature
 

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---| 
| <video src="https://github.com/user-attachments/assets/59f2f437-b258-4fc8-b6ef-6e9eea3fb6c6" /> | <video src="https://github.com/user-attachments/assets/850bbe1c-a521-4d55-b5b4-f76fbc77b4e3" /> |

