### PR TITLE
Experiment: Try block inspector controls toggle in block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
@@ -16,7 +16,9 @@ import {
 	isReusableBlock,
 	isTemplatePart,
 } from '@wordpress/blocks';
-import { ToolbarGroup } from '@wordpress/components';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { settings as settingsIcon } from '@wordpress/icons';
+import { store as interfaceStore } from '@wordpress/interface';
 
 /**
  * Internal dependencies
@@ -125,6 +127,16 @@ export function PrivateBlockToolbar( {
 			hasParentPattern: _hasParentPattern,
 		};
 	}, [] );
+
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
+
+	const isSelected = useSelect(
+		( select ) =>
+			select( interfaceStore ).getActiveComplementaryArea( 'core' ) ===
+			'edit-post/block',
+		[]
+	);
 
 	const toolbarWrapperRef = useRef( null );
 
@@ -235,6 +247,26 @@ export function PrivateBlockToolbar( {
 					</>
 				) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />
+				<ToolbarGroup>
+					<ToolbarButton
+						icon={ settingsIcon }
+						label={ __( 'Toggle block settings' ) }
+						isPressed={ isSelected }
+						onClick={ () => {
+							if ( isSelected ) {
+								disableComplementaryArea(
+									'core',
+									'edit-post/block'
+								);
+							} else {
+								enableComplementaryArea(
+									'core',
+									'edit-post/block'
+								);
+							}
+						} }
+					/>
+				</ToolbarGroup>
 				{ isDefaultEditingMode && (
 					<BlockSettingsMenu clientIds={ blockClientIds } />
 				) }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { useRef } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import {
@@ -16,9 +16,7 @@ import {
 	isReusableBlock,
 	isTemplatePart,
 } from '@wordpress/blocks';
-import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
-import { settings as settingsIcon } from '@wordpress/icons';
-import { store as interfaceStore } from '@wordpress/interface';
+import { ToolbarGroup } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -127,16 +125,6 @@ export function PrivateBlockToolbar( {
 			hasParentPattern: _hasParentPattern,
 		};
 	}, [] );
-
-	const { enableComplementaryArea, disableComplementaryArea } =
-		useDispatch( interfaceStore );
-
-	const isSelected = useSelect(
-		( select ) =>
-			select( interfaceStore ).getActiveComplementaryArea( 'core' ) ===
-			'edit-post/block',
-		[]
-	);
 
 	const toolbarWrapperRef = useRef( null );
 
@@ -247,26 +235,6 @@ export function PrivateBlockToolbar( {
 					</>
 				) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />
-				<ToolbarGroup>
-					<ToolbarButton
-						icon={ settingsIcon }
-						label={ __( 'Toggle block settings' ) }
-						isPressed={ isSelected }
-						onClick={ () => {
-							if ( isSelected ) {
-								disableComplementaryArea(
-									'core',
-									'edit-post/block'
-								);
-							} else {
-								enableComplementaryArea(
-									'core',
-									'edit-post/block'
-								);
-							}
-						} }
-					/>
-				</ToolbarGroup>
 				{ isDefaultEditingMode && (
 					<BlockSettingsMenu clientIds={ blockClientIds } />
 				) }

--- a/packages/editor/src/hooks/block-toolbar.js
+++ b/packages/editor/src/hooks/block-toolbar.js
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { __unstableBlockToolbarLastItem as BlockToolbarLastItem } from '@wordpress/block-editor';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
+import { settings as settingsIcon } from '@wordpress/icons';
+import { store as interfaceStore } from '@wordpress/interface';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Override the default edit UI to include a new block inspector control for
+ * assigning a partial syncing controls to supported blocks in the pattern editor.
+ * Currently, only the `core/paragraph` block is supported.
+ *
+ * @param {Component} BlockEdit Original component.
+ *
+ * @return {Component} Wrapped component.
+ */
+const withBlockToolbar = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		return (
+			<>
+				<BlockEdit key="edit" { ...props } />
+				{ props.isSelected && <BlockSidebarToggle /> }
+			</>
+		);
+	},
+	'withBlockToolbar'
+);
+
+const BlockSidebarToggle = () => {
+	const { enableComplementaryArea, disableComplementaryArea } =
+		useDispatch( interfaceStore );
+
+	const isSelected = useSelect(
+		( select ) =>
+			select( interfaceStore ).getActiveComplementaryArea( 'core' ) ===
+			'edit-post/block',
+		[]
+	);
+
+	return (
+		<BlockToolbarLastItem>
+			<ToolbarGroup>
+				<ToolbarButton
+					icon={ settingsIcon }
+					label={ __( 'Toggle block settings' ) }
+					isPressed={ isSelected }
+					onClick={ () => {
+						if ( isSelected ) {
+							disableComplementaryArea(
+								'core',
+								'edit-post/block'
+							);
+						} else {
+							enableComplementaryArea(
+								'core',
+								'edit-post/block'
+							);
+						}
+					} }
+				/>
+			</ToolbarGroup>
+		</BlockToolbarLastItem>
+	);
+};
+
+addFilter(
+	'editor.BlockEdit',
+	'core/editor/with-block-toolbar',
+	withBlockToolbar
+);

--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -5,3 +5,4 @@ import './custom-sources-backwards-compatibility';
 import './default-autocompleters';
 import './media-upload';
 import './pattern-overrides';
+import './block-toolbar';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Tries adding a toggle in the block toolbar to allow quick access to full block settings in the block insepctor controls.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Users find it very hard to discover the full block controls in the inspector controls. We should make this a lot easier.

This is just one option.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Hack in (for now) a button to toggle the block inspector controls.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/57a445c0-6e7c-4353-92d0-e933c42e70e8

