### PR TITLE
Fix: Moving a page to the trash on the site editor does not goes back to the pages list

### DIFF
--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -17,22 +17,6 @@ export function getPostEditURL( postId ) {
 	return addQueryArgs( 'post.php', { post: postId, action: 'edit' } );
 }
 
-/**
- * Returns the Post's Trashed URL.
- *
- * @param {number} postId   Post ID.
- * @param {string} postType Post Type.
- *
- * @return {string} Post trashed URL.
- */
-export function getPostTrashedURL( postId, postType ) {
-	return addQueryArgs( 'edit.php', {
-		trashed: 1,
-		post_type: postType,
-		ids: postId,
-	} );
-}
-
 export class BrowserURL extends Component {
 	constructor() {
 		super( ...arguments );
@@ -43,16 +27,8 @@ export class BrowserURL extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { postId, postStatus, postType, isSavingPost, hasHistory } =
-			this.props;
+		const { postId, postStatus, hasHistory } = this.props;
 		const { historyId } = this.state;
-
-		// Posts are still dirty while saving so wait for saving to finish
-		// to avoid the unsaved changes warning when trashing posts.
-		if ( postStatus === 'trash' && ! isSavingPost ) {
-			this.setTrashURL( postId, postType );
-			return;
-		}
 
 		if (
 			( postId !== prevProps.postId || postId !== historyId ) &&
@@ -62,16 +38,6 @@ export class BrowserURL extends Component {
 		) {
 			this.setBrowserURL( postId );
 		}
-	}
-
-	/**
-	 * Navigates the browser to the post trashed URL to show a notice about the trashed post.
-	 *
-	 * @param {number} postId   Post ID.
-	 * @param {string} postType Post Type.
-	 */
-	setTrashURL( postId, postType ) {
-		window.location.href = getPostTrashedURL( postId, postType );
 	}
 
 	/**
@@ -101,7 +67,7 @@ export class BrowserURL extends Component {
 }
 
 export default withSelect( ( select ) => {
-	const { getCurrentPost, isSavingPost } = select( editorStore );
+	const { getCurrentPost } = select( editorStore );
 	const post = getCurrentPost();
 	let { id, status, type } = post;
 	const isTemplate = [ 'wp_template', 'wp_template_part' ].includes( type );
@@ -112,7 +78,5 @@ export default withSelect( ( select ) => {
 	return {
 		postId: id,
 		postStatus: status,
-		postType: type,
-		isSavingPost: isSavingPost(),
 	};
 } )( BrowserURL );

--- a/packages/edit-post/src/components/browser-url/test/index.js
+++ b/packages/edit-post/src/components/browser-url/test/index.js
@@ -6,7 +6,7 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { getPostEditURL, getPostTrashedURL, BrowserURL } from '../';
+import { getPostEditURL, BrowserURL } from '../';
 
 describe( 'getPostEditURL', () => {
 	it( 'should generate relative path with post and action arguments', () => {

--- a/packages/edit-post/src/components/browser-url/test/index.js
+++ b/packages/edit-post/src/components/browser-url/test/index.js
@@ -16,14 +16,6 @@ describe( 'getPostEditURL', () => {
 	} );
 } );
 
-describe( 'getPostTrashedURL', () => {
-	it( 'should generate relative path with post and action arguments', () => {
-		const url = getPostTrashedURL( 1, 'page' );
-
-		expect( url ).toBe( 'edit.php?trashed=1&post_type=page&ids=1' );
-	} );
-} );
-
 describe( 'BrowserURL', () => {
 	let replaceStateSpy;
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1471,6 +1471,10 @@ Undocumented declaration.
 
 Displays the Post Trash Button and Confirm Dialog in the Editor.
 
+_Parameters_
+
+-   _An_ `?{onActionPerformed: Object}`: object containing the onActionPerformed function.
+
 _Returns_
 
 -   `JSX.Element|null`: The rendered PostTrash component.

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -88,7 +88,9 @@ export default function PostSummary( { onActionPerformed } ) {
 										<SiteDiscussion />
 										<PostFormatPanel />
 									</VStack>
-									<PostTrash />
+									<PostTrash
+										onActionPerformed={ onActionPerformed }
+									/>
 									{ fills }
 								</VStack>
 							) }


### PR DESCRIPTION
On https://github.com/WordPress/gutenberg/pull/65087 we restored the move to trash button. But with the sidebar unification between the edit post and edit site that means the move to trash button is now also available on the edit site.

On the edit site, we have an issue where if we move a page to the trash the page is moved to trash but for the user, it seems like nothing happened as the editor keeps open on that page. And the move to trash button is still available, which is confusing.

This PR fixes the issue by calling onActionPerformed with the move-to-trash action after the post is moved to the trash, this ensures the expected behavior after a post is trashed happens no matter if the user is on the site editor or the post editor.

cc: @youknowriad, @Mamaduka as code reviewers of the related pull request.

## Testing Instructions
Opened the site editor, and went to the pages section.
Opened a page in the editor, moved the page to the trash, and verified the UI was moved to the pages list (on the trunk it keeps the page opened as if nothing happened).
