### PR TITLE
Post publish upload media dialog: handle more block types

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -207,7 +207,7 @@ export default function MaybeUploadMediaPanel() {
 		);
 
 		// Wait for all blocks to be updated with library media.
-		Promise.all(
+		Promise.allSettled(
 			blocksWithExternalMedia.map( ( block ) => {
 				const { url } = getMediaInfo( block );
 

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -30,10 +30,16 @@ function flattenBlocks( blocks ) {
 	return result;
 }
 
-// Determine whether a block has external media.
-// Different blocks use different attribute names (and potentially
-// different logic as well) in determining whether the media is
-// present, and whether it's external.
+/**
+ * Determine whether a block has external media.
+ *
+ * Different blocks use different attribute names (and potentially
+ * different logic as well) in determining whether the media is
+ * present, and whether it's external.
+ *
+ * @param {{name: string, attributes: Object}} block The block.
+ * @return {boolean?} Whether the block has external media
+ */
 function hasExternalMedia( block ) {
 	if ( block.name === 'core/image' || block.name === 'core/cover' ) {
 		return block.attributes.url && ! block.attributes.id;
@@ -42,11 +48,19 @@ function hasExternalMedia( block ) {
 	if ( block.name === 'core/media-text' ) {
 		return block.attributes.mediaUrl && ! block.attributes.mediaId;
 	}
+
+	return undefined;
 }
 
-// Retrieve media info from a block.
-// Different blocks use different attribute names, so we need this
-// function to normalize things into a consistent naming scheme.
+/**
+ * Retrieve media info from a block.
+ *
+ * Different blocks use different attribute names, so we need this
+ * function to normalize things into a consistent naming scheme.
+ *
+ * @param {{name: string, attributes: Object}} block The block.
+ * @return {{url: ?string, alt: ?string, id: ?string}} The media info for the block.
+ */
 function getMediaInfo( block ) {
 	if ( block.name === 'core/image' || block.name === 'core/cover' ) {
 		const { url, alt, id } = block.attributes;
@@ -57,6 +71,8 @@ function getMediaInfo( block ) {
 		const { mediaUrl: url, mediaAlt: alt, mediaId: id } = block.attributes;
 		return { url, alt, id };
 	}
+
+	return {};
 }
 
 // Image component to represent a single image in the upload dialog.
@@ -122,19 +138,25 @@ export default function MaybeUploadMediaPanel() {
 		</span>,
 	];
 
-	// Update an individual block to point to newly-added library media.
-	// Different blocks use different attribute names, so we need this
-	// function to ensure we modify the correct attributes for each type.
+	/**
+	 * Update an individual block to point to newly-added library media.
+	 *
+	 * Different blocks use different attribute names, so we need this
+	 * function to ensure we modify the correct attributes for each type.
+	 *
+	 * @param {{name: string, attributes: Object}} block The block.
+	 * @param {{id: string, url: string}}          media Media library file info.
+	 */
 	function updateBlockWithUploadedMedia( block, media ) {
 		if ( block.name === 'core/image' || block.name === 'core/cover' ) {
-			return updateBlockAttributes( block.clientId, {
+			updateBlockAttributes( block.clientId, {
 				id: media.id,
 				url: media.url,
 			} );
 		}
 
 		if ( block.name === 'core/media-text' ) {
-			return updateBlockAttributes( block.clientId, {
+			updateBlockAttributes( block.clientId, {
 				mediaId: media.id,
 				mediaUrl: media.url,
 			} );

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -158,28 +158,30 @@ export default function MaybeUploadMediaPanel() {
 		// Create an upload promise for each URL, that we can wait for in all
 		// blocks that make use of that media.
 		const uploadPromises = Object.fromEntries(
-			fetchMedia( [ ...mediaUrls ] ).map( ( { url, filePromise } ) => {
-				const uploadPromise = filePromise.then(
-					( blob ) =>
-						new Promise( ( resolve, reject ) => {
-							mediaUpload( {
-								filesList: [ blob ],
-								onFileChange: ( [ media ] ) => {
-									if ( isBlobURL( media.url ) ) {
-										return;
-									}
+			Object.entries( fetchMedia( [ ...mediaUrls ] ) ).map(
+				( [ url, filePromise ] ) => {
+					const uploadPromise = filePromise.then(
+						( blob ) =>
+							new Promise( ( resolve, reject ) => {
+								mediaUpload( {
+									filesList: [ blob ],
+									onFileChange: ( [ media ] ) => {
+										if ( isBlobURL( media.url ) ) {
+											return;
+										}
 
-									resolve( media );
-								},
-								onError() {
-									reject();
-								},
-							} );
-						} )
-				);
+										resolve( media );
+									},
+									onError() {
+										reject();
+									},
+								} );
+							} )
+					);
 
-				return [ url, uploadPromise ];
-			} )
+					return [ url, uploadPromise ];
+				}
+			)
 		);
 
 		// Wait for all blocks to be updated with library media.

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -158,8 +158,8 @@ export default function MaybeUploadMediaPanel() {
 		// Create an upload promise for each URL, that we can wait for in all
 		// blocks that make use of that media.
 		const uploadPromises = Object.fromEntries(
-			fetchMedia( [ ...mediaUrls ] ).map( ( { url, blobPromise } ) => {
-				const uploadPromise = blobPromise.then(
+			fetchMedia( [ ...mediaUrls ] ).map( ( { url, filePromise } ) => {
+				const uploadPromise = filePromise.then(
 					( blob ) =>
 						new Promise( ( resolve, reject ) => {
 							mediaUpload( {

--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -59,7 +59,7 @@ function hasExternalMedia( block ) {
  * function to normalize things into a consistent naming scheme.
  *
  * @param {{name: string, attributes: Object}} block The block.
- * @return {{url: ?string, alt: ?string, id: ?string}} The media info for the block.
+ * @return {{url: ?string, alt: ?string, id: ?number}} The media info for the block.
  */
 function getMediaInfo( block ) {
 	if ( block.name === 'core/image' || block.name === 'core/cover' ) {
@@ -145,7 +145,7 @@ export default function MaybeUploadMediaPanel() {
 	 * function to ensure we modify the correct attributes for each type.
 	 *
 	 * @param {{name: string, attributes: Object}} block The block.
-	 * @param {{id: string, url: string}}          media Media library file info.
+	 * @param {{id: number, url: string}}          media Media library file info.
 	 */
 	function updateBlockWithUploadedMedia( block, media ) {
 		if ( block.name === 'core/image' || block.name === 'core/cover' ) {

--- a/packages/editor/src/components/post-publish-panel/media-util.js
+++ b/packages/editor/src/components/post-publish-panel/media-util.js
@@ -96,12 +96,12 @@ export function getExtensionFromMimeType( mime ) {
 	return extension || '';
 }
 
-// Returns an array of { url, blobPromise } objects, where the promise
-// points to a fetched blob. Blobs will have unique filenames.
+// Returns an array of { url, filePromise } objects, where the promise
+// points to a file built from a fetched blob. Filenames should be unique.
 export function fetchMedia( urls ) {
 	return generateUniqueFilenames( urls ).map(
 		( { url, basename, extension } ) => {
-			const blobPromise = window
+			const filePromise = window
 				.fetch( url.includes( '?' ) ? url : url + '?' )
 				.then( ( response ) => response.blob() )
 				.then( ( blob ) => {
@@ -110,11 +110,12 @@ export function fetchMedia( urls ) {
 					if ( ! extension ) {
 						extension = getExtensionFromMimeType( blob.type );
 					}
-					blob.name = `${ basename }.${ extension }`;
-					return blob;
+					return new File( [ blob ], `${ basename }.${ extension }`, {
+						type: blob.type,
+					} );
 				} );
 
-			return { url, blobPromise };
+			return { url, filePromise };
 		}
 	);
 }

--- a/packages/editor/src/components/post-publish-panel/media-util.js
+++ b/packages/editor/src/components/post-publish-panel/media-util.js
@@ -1,0 +1,120 @@
+/**
+ * External dependencies
+ */
+import { v4 as uuid } from 'uuid';
+
+/**
+ * WordPress dependencies
+ */
+import { getFilename } from '@wordpress/url';
+
+// Generate a list of unique filenames given a list of URLs.
+// We want all basenames to be unique, since sometimes the extension
+// doesn't reflect the mime type, and may end up getting changed by
+// the server, on upload.
+export function generateUniqueFilenames( urls ) {
+	const basenames = new Set();
+
+	return urls.map( ( url ) => {
+		// We prefer to match the remote filename, if possible.
+		const filename = getFilename( url );
+		let basename = '';
+		let extension = '';
+
+		if ( filename ) {
+			const parts = filename.split( '.' );
+			if ( parts.length > 1 ) {
+				// Assume the last part is the extension.
+				extension = parts.pop();
+			}
+			basename = parts.join( '.' );
+		}
+
+		if ( ! basename ) {
+			// It looks like we don't have a basename, so let's use a UUID.
+			basename = uuid();
+		}
+
+		if ( basenames.has( basename ) ) {
+			// Append a UUID to deduplicate the basename.
+			// The server will try to deduplicate on its own if we don't do this,
+			// but it may run into a race condition
+			// (see https://github.com/WordPress/gutenberg/issues/64899).
+			// Deduplicating the filenames before uploading is safer.
+			basename = `${ basename }-${ uuid() }`;
+		}
+
+		basenames.add( basename );
+
+		return { url, basename, extension };
+	} );
+}
+
+const mimeTypeToExtension = {
+	'image/apng': 'apng',
+	'image/avif': 'avif',
+	'image/bmp': 'bmp',
+	'image/gif': 'gif',
+	'image/vnd.microsoft.icon': 'ico',
+	'image/jpeg': 'jpg',
+	'image/jxl': 'jxl',
+	'image/png': 'png',
+	'image/svg+xml': 'svg',
+	'image/tiff': 'tiff',
+	'image/webp': 'webp',
+	'video/x-msvideo': 'avi',
+	'video/mp4': 'mp4',
+	'video/mpeg': 'mpeg',
+	'video/ogg': 'ogg',
+	'video/mp2t': 'ts',
+	'video/webm': 'webm',
+	'video/3gpp': '3gp',
+	'video/3gpp2': '3g2',
+};
+
+// Get the file extension to use for a given mime type.
+export function getExtensionFromMimeType( mime ) {
+	mime = ( mime ?? '' ).toLowerCase();
+
+	let extension = mimeTypeToExtension[ mime ];
+
+	if ( ! extension ) {
+		// We don't know which extension to use, so we need to fall back to
+		// something safe. The server should replace it with an appropriate
+		// extension for the mime type.
+		if ( mime.startsWith( 'image/' ) ) {
+			extension = 'png';
+		}
+		if ( mime.startsWith( 'video/' ) ) {
+			extension = 'mp4';
+		}
+	}
+
+	// If all else fails, try an empty extension.
+	// The server will probably reject the upload, but there isn't much
+	// else we can do.
+	return extension || '';
+}
+
+// Returns an array of { url, blobPromise } objects, where the promise
+// points to a fetched blob. Blobs will have unique filenames.
+export function fetchMedia( urls ) {
+	return generateUniqueFilenames( urls ).map(
+		( { url, basename, extension } ) => {
+			const blobPromise = window
+				.fetch( url.includes( '?' ) ? url : url + '?' )
+				.then( ( response ) => response.blob() )
+				.then( ( blob ) => {
+					// Not all remote filenames have an extension, but we need to
+					// provide one, or the server is likely to reject the upload.
+					if ( ! extension ) {
+						extension = getExtensionFromMimeType( blob.type );
+					}
+					blob.name = `${ basename }.${ extension }`;
+					return blob;
+				} );
+
+			return { url, blobPromise };
+		}
+	);
+}

--- a/packages/editor/src/components/post-publish-panel/media-util.js
+++ b/packages/editor/src/components/post-publish-panel/media-util.js
@@ -8,114 +8,80 @@ import { v4 as uuid } from 'uuid';
  */
 import { getFilename } from '@wordpress/url';
 
-// Generate a list of unique filenames given a list of URLs.
-// We want all basenames to be unique, since sometimes the extension
-// doesn't reflect the mime type, and may end up getting changed by
-// the server, on upload.
-export function generateUniqueFilenames( urls ) {
+/**
+ * Generate a list of unique basenames given a list of URLs.
+ *
+ * We want all basenames to be unique, since sometimes the extension
+ * doesn't reflect the mime type, and may end up getting changed by
+ * the server, on upload.
+ *
+ * @param {string[]} urls The list of URLs
+ * @return {Record< string, string >} A URL => basename record.
+ */
+export function generateUniqueBasenames( urls ) {
 	const basenames = new Set();
 
-	return urls.map( ( url ) => {
-		// We prefer to match the remote filename, if possible.
-		const filename = getFilename( url );
-		let basename = '';
-		let extension = '';
+	return Object.fromEntries(
+		urls.map( ( url ) => {
+			// We prefer to match the remote filename, if possible.
+			const filename = getFilename( url );
+			let basename = '';
 
-		if ( filename ) {
-			const parts = filename.split( '.' );
-			if ( parts.length > 1 ) {
-				// Assume the last part is the extension.
-				extension = parts.pop();
+			if ( filename ) {
+				const parts = filename.split( '.' );
+				if ( parts.length > 1 ) {
+					// Assume the last part is the extension.
+					parts.pop();
+				}
+				basename = parts.join( '.' );
 			}
-			basename = parts.join( '.' );
-		}
 
-		if ( ! basename ) {
-			// It looks like we don't have a basename, so let's use a UUID.
-			basename = uuid();
-		}
+			if ( ! basename ) {
+				// It looks like we don't have a basename, so let's use a UUID.
+				basename = uuid();
+			}
 
-		if ( basenames.has( basename ) ) {
-			// Append a UUID to deduplicate the basename.
-			// The server will try to deduplicate on its own if we don't do this,
-			// but it may run into a race condition
-			// (see https://github.com/WordPress/gutenberg/issues/64899).
-			// Deduplicating the filenames before uploading is safer.
-			basename = `${ basename }-${ uuid() }`;
-		}
+			if ( basenames.has( basename ) ) {
+				// Append a UUID to deduplicate the basename.
+				// The server will try to deduplicate on its own if we don't do this,
+				// but it may run into a race condition
+				// (see https://github.com/WordPress/gutenberg/issues/64899).
+				// Deduplicating the filenames before uploading is safer.
+				basename = `${ basename }-${ uuid() }`;
+			}
 
-		basenames.add( basename );
+			basenames.add( basename );
 
-		return { url, basename, extension };
-	} );
+			return [ url, basename ];
+		} )
+	);
 }
 
-const mimeTypeToExtension = {
-	'image/apng': 'apng',
-	'image/avif': 'avif',
-	'image/bmp': 'bmp',
-	'image/gif': 'gif',
-	'image/vnd.microsoft.icon': 'ico',
-	'image/jpeg': 'jpg',
-	'image/jxl': 'jxl',
-	'image/png': 'png',
-	'image/svg+xml': 'svg',
-	'image/tiff': 'tiff',
-	'image/webp': 'webp',
-	'video/x-msvideo': 'avi',
-	'video/mp4': 'mp4',
-	'video/mpeg': 'mpeg',
-	'video/ogg': 'ogg',
-	'video/mp2t': 'ts',
-	'video/webm': 'webm',
-	'video/3gpp': '3gp',
-	'video/3gpp2': '3g2',
-};
-
-// Get the file extension to use for a given mime type.
-export function getExtensionFromMimeType( mime ) {
-	mime = ( mime ?? '' ).toLowerCase();
-
-	let extension = mimeTypeToExtension[ mime ];
-
-	if ( ! extension ) {
-		// We don't know which extension to use, so we need to fall back to
-		// something safe. The server should replace it with an appropriate
-		// extension for the mime type.
-		if ( mime.startsWith( 'image/' ) ) {
-			extension = 'png';
-		}
-		if ( mime.startsWith( 'video/' ) ) {
-			extension = 'mp4';
-		}
-	}
-
-	// If all else fails, try an empty extension.
-	// The server will probably reject the upload, but there isn't much
-	// else we can do.
-	return extension || '';
-}
-
-// Returns an array of { url, filePromise } objects, where the promise
-// points to a file built from a fetched blob. Filenames should be unique.
+/**
+ * Fetch a list of URLs, turning those into promises for files with
+ * unique filenames.
+ *
+ * @param {string[]} urls The list of URLs
+ * @return {Record< string, Promise< File > >} A URL => File promise record.
+ */
 export function fetchMedia( urls ) {
-	return generateUniqueFilenames( urls ).map(
-		( { url, basename, extension } ) => {
-			const filePromise = window
-				.fetch( url.includes( '?' ) ? url : url + '?' )
-				.then( ( response ) => response.blob() )
-				.then( ( blob ) => {
-					// Not all remote filenames have an extension, but we need to
-					// provide one, or the server is likely to reject the upload.
-					if ( ! extension ) {
-						extension = getExtensionFromMimeType( blob.type );
-					}
-					return new File( [ blob ], `${ basename }.${ extension }`, {
-						type: blob.type,
+	return Object.fromEntries(
+		Object.entries( generateUniqueBasenames( urls ) ).map(
+			( [ url, basename ] ) => {
+				const filePromise = window
+					.fetch( url.includes( '?' ) ? url : url + '?' )
+					.then( ( response ) => response.blob() )
+					.then( ( blob ) => {
+						// The server will reject the upload if it doesn't have an extension,
+						// even though it'll rewrite the file name to match the mime type.
+						// Here we provide it with a safe extension to get it past that check.
+						return new File( [ blob ], `${ basename }.png`, {
+							type: blob.type,
+						} );
 					} );
-				} );
 
-			return { url, filePromise };
-		}
+				return [ url, filePromise ];
+			}
+		)
 	);
 }

--- a/packages/editor/src/components/post-publish-panel/test/media-util.js
+++ b/packages/editor/src/components/post-publish-panel/test/media-util.js
@@ -1,13 +1,10 @@
 /**
  * Internal dependencies
  */
-import {
-	generateUniqueFilenames,
-	getExtensionFromMimeType,
-} from '../media-util';
+import { generateUniqueBasenames } from '../media-util';
 
-describe( 'generateUniqueFilenames', () => {
-	it( 'should prefer the original filenames', () => {
+describe( 'generateUniqueBasenames', () => {
+	it( 'should prefer the original basenames', () => {
 		const urls = [
 			'https://example.com/images/image1.jpg',
 			'https://example.com/images/image2.jpg',
@@ -15,28 +12,12 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/images/image4.jpg',
 		];
 
-		expect( generateUniqueFilenames( urls ) ).toEqual( [
-			{
-				url: 'https://example.com/images/image1.jpg',
-				basename: 'image1',
-				extension: 'jpg',
-			},
-			{
-				url: 'https://example.com/images/image2.jpg',
-				basename: 'image2',
-				extension: 'jpg',
-			},
-			{
-				url: 'https://example.com/images/image3.jpg',
-				basename: 'image3',
-				extension: 'jpg',
-			},
-			{
-				url: 'https://example.com/images/image4.jpg',
-				basename: 'image4',
-				extension: 'jpg',
-			},
-		] );
+		expect( generateUniqueBasenames( urls ) ).toEqual( {
+			'https://example.com/images/image1.jpg': 'image1',
+			'https://example.com/images/image2.jpg': 'image2',
+			'https://example.com/images/image3.jpg': 'image3',
+			'https://example.com/images/image4.jpg': 'image4',
+		} );
 	} );
 
 	it( 'should handle filenames with no extensions', () => {
@@ -47,28 +28,12 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/images/image4',
 		];
 
-		expect( generateUniqueFilenames( urls ) ).toEqual( [
-			{
-				url: 'https://example.com/images/image1',
-				basename: 'image1',
-				extension: '',
-			},
-			{
-				url: 'https://example.com/images/image2',
-				basename: 'image2',
-				extension: '',
-			},
-			{
-				url: 'https://example.com/images/image3',
-				basename: 'image3',
-				extension: '',
-			},
-			{
-				url: 'https://example.com/images/image4',
-				basename: 'image4',
-				extension: '',
-			},
-		] );
+		expect( generateUniqueBasenames( urls ) ).toEqual( {
+			'https://example.com/images/image1': 'image1',
+			'https://example.com/images/image2': 'image2',
+			'https://example.com/images/image3': 'image3',
+			'https://example.com/images/image4': 'image4',
+		} );
 	} );
 
 	it( 'should handle query parameters correctly', () => {
@@ -79,28 +44,12 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/images/image4.jpg?a=notafile.npg',
 		];
 
-		expect( generateUniqueFilenames( urls ) ).toEqual( [
-			{
-				url: 'https://example.com/images/image1.jpg?a=notafile.npg',
-				basename: 'image1',
-				extension: 'jpg',
-			},
-			{
-				url: 'https://example.com/images/image2.jpg?a=notafile.npg',
-				basename: 'image2',
-				extension: 'jpg',
-			},
-			{
-				url: 'https://example.com/images/image3.jpg?a=notafile.npg',
-				basename: 'image3',
-				extension: 'jpg',
-			},
-			{
-				url: 'https://example.com/images/image4.jpg?a=notafile.npg',
-				basename: 'image4',
-				extension: 'jpg',
-			},
-		] );
+		expect( generateUniqueBasenames( urls ) ).toEqual( {
+			'https://example.com/images/image1.jpg?a=notafile.npg': 'image1',
+			'https://example.com/images/image2.jpg?a=notafile.npg': 'image2',
+			'https://example.com/images/image3.jpg?a=notafile.npg': 'image3',
+			'https://example.com/images/image4.jpg?a=notafile.npg': 'image4',
+		} );
 	} );
 
 	it( 'should deduplicate identical filenames', () => {
@@ -111,18 +60,12 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/image4/image.jpg',
 		];
 
-		const results = generateUniqueFilenames( urls );
-		expect( results.length ).toBe( urls.length );
+		const results = generateUniqueBasenames( urls );
+		const resultLength = Object.entries( results ).length;
+		expect( resultLength ).toBe( urls.length );
 
-		for ( const result of results ) {
-			expect( result.extension ).toBe( 'jpg' );
-		}
-
-		const basenames = new Set(
-			results.map( ( result ) => result.basename )
-		);
-
-		expect( basenames.size ).toBe( results.length );
+		const basenames = new Set( Object.values( results ) );
+		expect( basenames.size ).toBe( resultLength );
 	} );
 
 	it( 'should deduplicate identical basenames', () => {
@@ -133,19 +76,12 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/images/image.avif',
 		];
 
-		const results = generateUniqueFilenames( urls );
-		expect( results.length ).toBe( urls.length );
+		const results = generateUniqueBasenames( urls );
+		const resultLength = Object.entries( results ).length;
+		expect( resultLength ).toBe( urls.length );
 
-		expect( results[ 0 ].extension ).toBe( 'jpg' );
-		expect( results[ 1 ].extension ).toBe( 'png' );
-		expect( results[ 2 ].extension ).toBe( 'webp' );
-		expect( results[ 3 ].extension ).toBe( 'avif' );
-
-		const basenames = new Set(
-			results.map( ( result ) => result.basename )
-		);
-
-		expect( basenames.size ).toBe( results.length );
+		const basenames = new Set( Object.values( results ) );
+		expect( basenames.size ).toBe( resultLength );
 	} );
 
 	it( 'should deduplicate filenames without extensions', () => {
@@ -156,18 +92,12 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/image4/image',
 		];
 
-		const results = generateUniqueFilenames( urls );
-		expect( results.length ).toBe( urls.length );
+		const results = generateUniqueBasenames( urls );
+		const resultLength = Object.entries( results ).length;
+		expect( resultLength ).toBe( urls.length );
 
-		for ( const result of results ) {
-			expect( result.extension ).toBe( '' );
-		}
-
-		const basenames = new Set(
-			results.map( ( result ) => result.basename )
-		);
-
-		expect( basenames.size ).toBe( results.length );
+		const basenames = new Set( Object.values( results ) );
+		expect( basenames.size ).toBe( resultLength );
 	} );
 
 	it( 'should deduplicate paths with no filename', () => {
@@ -178,44 +108,11 @@ describe( 'generateUniqueFilenames', () => {
 			'https://example.com/image4/dir/',
 		];
 
-		const results = generateUniqueFilenames( urls );
-		expect( results.length ).toBe( urls.length );
+		const results = generateUniqueBasenames( urls );
+		const resultLength = Object.entries( results ).length;
+		expect( resultLength ).toBe( urls.length );
 
-		for ( const result of results ) {
-			expect( result.extension ).toBe( '' );
-		}
-
-		const basenames = new Set(
-			results.map( ( result ) => result.basename )
-		);
-
-		expect( basenames.size ).toBe( results.length );
-	} );
-} );
-
-describe( 'getExtensionFromMimeType', () => {
-	it( 'should use the correct extension for common mime types on the web', () => {
-		expect( getExtensionFromMimeType( 'image/png' ) ).toBe( 'png' );
-		expect( getExtensionFromMimeType( 'image/jpeg' ) ).toBe( 'jpg' );
-		expect( getExtensionFromMimeType( 'image/webp' ) ).toBe( 'webp' );
-		expect( getExtensionFromMimeType( 'image/gif' ) ).toBe( 'gif' );
-		expect( getExtensionFromMimeType( 'image/avif' ) ).toBe( 'avif' );
-		expect( getExtensionFromMimeType( 'image/jxl' ) ).toBe( 'jxl' );
-		expect( getExtensionFromMimeType( 'image/svg+xml' ) ).toBe( 'svg' );
-		expect( getExtensionFromMimeType( 'video/mp4' ) ).toBe( 'mp4' );
-		expect( getExtensionFromMimeType( 'video/mpeg' ) ).toBe( 'mpeg' );
-		expect( getExtensionFromMimeType( 'video/webm' ) ).toBe( 'webm' );
-	} );
-
-	it( 'should use a fallback extension for unknown image/video mime types', () => {
-		expect( getExtensionFromMimeType( 'image/fake' ) ).toBe( 'png' );
-		expect( getExtensionFromMimeType( 'video/fake' ) ).toBe( 'mp4' );
-	} );
-
-	it( 'should return an empty extension for non image/video mime types', () => {
-		expect( getExtensionFromMimeType( 'application/json' ) ).toBe( '' );
-		expect( getExtensionFromMimeType( '' ) ).toBe( '' );
-		expect( getExtensionFromMimeType( null ) ).toBe( '' );
-		expect( getExtensionFromMimeType( undefined ) ).toBe( '' );
+		const basenames = new Set( Object.values( results ) );
+		expect( basenames.size ).toBe( resultLength );
 	} );
 } );

--- a/packages/editor/src/components/post-publish-panel/test/media-util.js
+++ b/packages/editor/src/components/post-publish-panel/test/media-util.js
@@ -1,0 +1,221 @@
+/**
+ * Internal dependencies
+ */
+import {
+	generateUniqueFilenames,
+	getExtensionFromMimeType,
+} from '../media-util';
+
+describe( 'generateUniqueFilenames', () => {
+	it( 'should prefer the original filenames', () => {
+		const urls = [
+			'https://example.com/images/image1.jpg',
+			'https://example.com/images/image2.jpg',
+			'https://example.com/images/image3.jpg',
+			'https://example.com/images/image4.jpg',
+		];
+
+		expect( generateUniqueFilenames( urls ) ).toEqual( [
+			{
+				url: 'https://example.com/images/image1.jpg',
+				basename: 'image1',
+				extension: 'jpg',
+			},
+			{
+				url: 'https://example.com/images/image2.jpg',
+				basename: 'image2',
+				extension: 'jpg',
+			},
+			{
+				url: 'https://example.com/images/image3.jpg',
+				basename: 'image3',
+				extension: 'jpg',
+			},
+			{
+				url: 'https://example.com/images/image4.jpg',
+				basename: 'image4',
+				extension: 'jpg',
+			},
+		] );
+	} );
+
+	it( 'should handle filenames with no extensions', () => {
+		const urls = [
+			'https://example.com/images/image1',
+			'https://example.com/images/image2',
+			'https://example.com/images/image3',
+			'https://example.com/images/image4',
+		];
+
+		expect( generateUniqueFilenames( urls ) ).toEqual( [
+			{
+				url: 'https://example.com/images/image1',
+				basename: 'image1',
+				extension: '',
+			},
+			{
+				url: 'https://example.com/images/image2',
+				basename: 'image2',
+				extension: '',
+			},
+			{
+				url: 'https://example.com/images/image3',
+				basename: 'image3',
+				extension: '',
+			},
+			{
+				url: 'https://example.com/images/image4',
+				basename: 'image4',
+				extension: '',
+			},
+		] );
+	} );
+
+	it( 'should handle query parameters correctly', () => {
+		const urls = [
+			'https://example.com/images/image1.jpg?a=notafile.npg',
+			'https://example.com/images/image2.jpg?a=notafile.npg',
+			'https://example.com/images/image3.jpg?a=notafile.npg',
+			'https://example.com/images/image4.jpg?a=notafile.npg',
+		];
+
+		expect( generateUniqueFilenames( urls ) ).toEqual( [
+			{
+				url: 'https://example.com/images/image1.jpg?a=notafile.npg',
+				basename: 'image1',
+				extension: 'jpg',
+			},
+			{
+				url: 'https://example.com/images/image2.jpg?a=notafile.npg',
+				basename: 'image2',
+				extension: 'jpg',
+			},
+			{
+				url: 'https://example.com/images/image3.jpg?a=notafile.npg',
+				basename: 'image3',
+				extension: 'jpg',
+			},
+			{
+				url: 'https://example.com/images/image4.jpg?a=notafile.npg',
+				basename: 'image4',
+				extension: 'jpg',
+			},
+		] );
+	} );
+
+	it( 'should deduplicate identical filenames', () => {
+		const urls = [
+			'https://example.com/image1/image.jpg',
+			'https://example.com/image2/image.jpg',
+			'https://example.com/image3/image.jpg',
+			'https://example.com/image4/image.jpg',
+		];
+
+		const results = generateUniqueFilenames( urls );
+		expect( results.length ).toBe( urls.length );
+
+		for ( const result of results ) {
+			expect( result.extension ).toBe( 'jpg' );
+		}
+
+		const basenames = new Set(
+			results.map( ( result ) => result.basename )
+		);
+
+		expect( basenames.size ).toBe( results.length );
+	} );
+
+	it( 'should deduplicate identical basenames', () => {
+		const urls = [
+			'https://example.com/images/image.jpg',
+			'https://example.com/images/image.png',
+			'https://example.com/images/image.webp',
+			'https://example.com/images/image.avif',
+		];
+
+		const results = generateUniqueFilenames( urls );
+		expect( results.length ).toBe( urls.length );
+
+		expect( results[ 0 ].extension ).toBe( 'jpg' );
+		expect( results[ 1 ].extension ).toBe( 'png' );
+		expect( results[ 2 ].extension ).toBe( 'webp' );
+		expect( results[ 3 ].extension ).toBe( 'avif' );
+
+		const basenames = new Set(
+			results.map( ( result ) => result.basename )
+		);
+
+		expect( basenames.size ).toBe( results.length );
+	} );
+
+	it( 'should deduplicate filenames without extensions', () => {
+		const urls = [
+			'https://example.com/image1/image',
+			'https://example.com/image2/image',
+			'https://example.com/image3/image',
+			'https://example.com/image4/image',
+		];
+
+		const results = generateUniqueFilenames( urls );
+		expect( results.length ).toBe( urls.length );
+
+		for ( const result of results ) {
+			expect( result.extension ).toBe( '' );
+		}
+
+		const basenames = new Set(
+			results.map( ( result ) => result.basename )
+		);
+
+		expect( basenames.size ).toBe( results.length );
+	} );
+
+	it( 'should deduplicate paths with no filename', () => {
+		const urls = [
+			'https://example.com/image1/dir/',
+			'https://example.com/image2/dir/',
+			'https://example.com/image3/dir/',
+			'https://example.com/image4/dir/',
+		];
+
+		const results = generateUniqueFilenames( urls );
+		expect( results.length ).toBe( urls.length );
+
+		for ( const result of results ) {
+			expect( result.extension ).toBe( '' );
+		}
+
+		const basenames = new Set(
+			results.map( ( result ) => result.basename )
+		);
+
+		expect( basenames.size ).toBe( results.length );
+	} );
+} );
+
+describe( 'getExtensionFromMimeType', () => {
+	it( 'should use the correct extension for common mime types on the web', () => {
+		expect( getExtensionFromMimeType( 'image/png' ) ).toBe( 'png' );
+		expect( getExtensionFromMimeType( 'image/jpeg' ) ).toBe( 'jpg' );
+		expect( getExtensionFromMimeType( 'image/webp' ) ).toBe( 'webp' );
+		expect( getExtensionFromMimeType( 'image/gif' ) ).toBe( 'gif' );
+		expect( getExtensionFromMimeType( 'image/avif' ) ).toBe( 'avif' );
+		expect( getExtensionFromMimeType( 'image/jxl' ) ).toBe( 'jxl' );
+		expect( getExtensionFromMimeType( 'image/svg+xml' ) ).toBe( 'svg' );
+		expect( getExtensionFromMimeType( 'video/mp4' ) ).toBe( 'mp4' );
+		expect( getExtensionFromMimeType( 'video/mpeg' ) ).toBe( 'mpeg' );
+		expect( getExtensionFromMimeType( 'video/webm' ) ).toBe( 'webm' );
+	} );
+
+	it( 'should use a fallback extension for unknown image/video mime types', () => {
+		expect( getExtensionFromMimeType( 'image/fake' ) ).toBe( 'png' );
+		expect( getExtensionFromMimeType( 'video/fake' ) ).toBe( 'mp4' );
+	} );
+
+	it( 'should return an empty extension for non image/video mime types', () => {
+		expect( getExtensionFromMimeType( 'application/json' ) ).toBe( '' );
+		expect( getExtensionFromMimeType( '' ) ).toBe( '' );
+		expect( getExtensionFromMimeType( null ) ).toBe( '' );
+		expect( getExtensionFromMimeType( undefined ) ).toBe( '' );
+	} );
+} );


### PR DESCRIPTION
## What?

This PR adds new block types to the post publish upload media dialog, so that external images in them are also considered for upload.

As part of this work, it also deduplicates URLs and generates unique filenames before upload.

This PR fixes #64899.

## Why?

The post publish upload media dialog suggests uploading external media to the media library, for both performance and reliability reasons. However, it currently only does so for Image blocks, which limits its usefulness.

## How?

Custom logic was added to handle `media-text` and `cover` blocks, as well as to generate adequate filenames before uploading.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Clear your media library
2. Start a new post in the editor
3. Paste the below HTML into it

<details>
<summary>Post contents</summary>

```html
<!-- wp:image {"width":"127px","height":"auto","sizeSlug":"large"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://s.w.org/style/images/about/WordPress-logotype-standard.png" alt="WordPress Logotype" style="width:127px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:cover {"url":"https://s.w.org/style/images/about/WordPress-logotype-standard.png","dimRatio":50,"style":{"color":{}}} -->
<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-background-dim"></span><img class="wp-block-cover__image-background" alt="WordPress Logotype in a cover block" src="https://s.w.org/style/images/about/WordPress-logotype-standard.png" data-object-fit="cover"/><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size">Text</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->

<!-- wp:media-text {"mediaType":"image"} -->
<div class="wp-block-media-text is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="https://s.w.org/style/images/about/WordPress-logotype-standard.png" alt="WordPress Logotype in a media-text block"/></figure><div class="wp-block-media-text__content"><!-- wp:paragraph {"placeholder":"Content…"} -->
<p>Text</p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:media-text -->

<!-- wp:image {"width":"127px","height":"auto","sizeSlug":"large"} -->
<figure class="wp-block-image size-large is-resized"><img src="https://s.w.org/style/images/about/WordPress-logotype-standard.png?forceDifferentUrl" alt="A separate copy of the WordPress Logotype, with a different URL" style="width:127px;height:auto"/></figure>
<!-- /wp:image -->
```

</details>

4. Hit Publish
5. Ensure that there are four images in the upload list, and that they all have the correct alt text (which will be different for each of them)
    <img width="281" alt="image" src="https://github.com/user-attachments/assets/cbf35cc9-d7ef-4ea6-ab9a-e1db75916566">
6. Hit Upload
7. Ensure that the post visually looks the same
8. Switch to the code editor, and ensure that all the URLs now point to uploaded media (somewhere in `/wp-content/uploads/`)
9. Consult your media library
10. Ensure exactly two images were uploaded, and that they're named `WordPress-logotype-standard.png` and `WordPress-logotype-standard-<some UUID>.png`. The second file is expected because we used a different URL (via a query parameter) on the last block, and it's expected to have the UUID for deduplication of the filename.

### Testing Instructions for Keyboard
N/A, no UI changes.
