### PR TITLE
Interactivity API: Use a11y Script Module in Gutenberg

### DIFF
--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -24,7 +24,10 @@ function gutenberg_reregister_interactivity_script_modules() {
 	wp_register_script_module(
 		'@wordpress/interactivity-router',
 		gutenberg_url( '/build-module/interactivity-router/index.min.js' ),
-		array( '@wordpress/interactivity' ),
+		array(
+			array( 'id' => '@wordpress/a11y', 'import' => 'dynamic' ),
+			'@wordpress/interactivity',
+		),
 		$default_version
 	);
 }

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -31,5 +31,21 @@ function gutenberg_reregister_interactivity_script_modules() {
 		$default_version
 	);
 }
-
 add_action( 'init', 'gutenberg_reregister_interactivity_script_modules' );
+
+function gutenberg_register_interactivity_script_module_data_hooks() {
+		if ( ! has_filter( 'script_module_data_@wordpress/interactivity-router', array( wp_interactivity(), 'filter_script_module_interactivity_router_data' ) ) ) {
+			add_filter(
+				'script_module_data_@wordpress/interactivity-router',
+				function ( $data ) {
+					if ( ! isset( $data['i18n'] ) ) {
+						$data['i18n'] = array();
+					}
+					$data['i18n']['loading'] = __( 'Loading page, please wait.', 'gutenberg' );
+					$data['i18n']['loaded']  = __( 'Page Loaded.', 'gutenberg' );
+					return $data;
+				}
+			);
+		}
+}
+add_action( 'after_setup_theme', 'gutenberg_register_interactivity_script_module_data_hooks', 20 );

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -25,7 +25,10 @@ function gutenberg_reregister_interactivity_script_modules() {
 		'@wordpress/interactivity-router',
 		gutenberg_url( '/build-module/interactivity-router/index.min.js' ),
 		array(
-			array( 'id' => '@wordpress/a11y', 'import' => 'dynamic' ),
+			array(
+				'id'     => '@wordpress/a11y',
+				'import' => 'dynamic',
+			),
 			'@wordpress/interactivity',
 		),
 		$default_version
@@ -34,18 +37,18 @@ function gutenberg_reregister_interactivity_script_modules() {
 add_action( 'init', 'gutenberg_reregister_interactivity_script_modules' );
 
 function gutenberg_register_interactivity_script_module_data_hooks() {
-		if ( ! has_filter( 'script_module_data_@wordpress/interactivity-router', array( wp_interactivity(), 'filter_script_module_interactivity_router_data' ) ) ) {
-			add_filter(
-				'script_module_data_@wordpress/interactivity-router',
-				function ( $data ) {
-					if ( ! isset( $data['i18n'] ) ) {
-						$data['i18n'] = array();
-					}
-					$data['i18n']['loading'] = __( 'Loading page, please wait.', 'default' );
-					$data['i18n']['loaded']  = __( 'Page Loaded.', 'default' );
-					return $data;
+	if ( ! has_filter( 'script_module_data_@wordpress/interactivity-router', array( wp_interactivity(), 'filter_script_module_interactivity_router_data' ) ) ) {
+		add_filter(
+			'script_module_data_@wordpress/interactivity-router',
+			function ( $data ) {
+				if ( ! isset( $data['i18n'] ) ) {
+					$data['i18n'] = array();
 				}
-			);
-		}
+				$data['i18n']['loading'] = __( 'Loading page, please wait.', 'default' );
+				$data['i18n']['loaded']  = __( 'Page Loaded.', 'default' );
+				return $data;
+			}
+		);
+	}
 }
 add_action( 'after_setup_theme', 'gutenberg_register_interactivity_script_module_data_hooks', 20 );

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -36,6 +36,16 @@ function gutenberg_reregister_interactivity_script_modules() {
 }
 add_action( 'init', 'gutenberg_reregister_interactivity_script_modules' );
 
+/**
+ * Adds script data to the interactivity-router script module.
+ *
+ * This filter is registered conditionally anticipating a WordPress Core change to add the script module data.
+ * The filter runs on 'after_setup_theme' (when Core registers Interactivity and Script Modules hooks)
+ * to ensure that the conditional registration happens after Core and correctly determine whether
+ * the filter should be added.
+ *
+ * @see https://github.com/WordPress/wordpress-develop/pull/7304
+ */
 function gutenberg_register_interactivity_script_module_data_hooks() {
 	if ( ! has_filter( 'script_module_data_@wordpress/interactivity-router', array( wp_interactivity(), 'filter_script_module_interactivity_router_data' ) ) ) {
 		add_filter(

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -41,8 +41,8 @@ function gutenberg_register_interactivity_script_module_data_hooks() {
 					if ( ! isset( $data['i18n'] ) ) {
 						$data['i18n'] = array();
 					}
-					$data['i18n']['loading'] = __( 'Loading page, please wait.', 'gutenberg' );
-					$data['i18n']['loaded']  = __( 'Page Loaded.', 'gutenberg' );
+					$data['i18n']['loading'] = __( 'Loading page, please wait.', 'default' );
+					$data['i18n']['loaded']  = __( 'Page Loaded.', 'default' );
 					return $data;
 				}
 			);

--- a/package-lock.json
+++ b/package-lock.json
@@ -54329,6 +54329,7 @@
 			"version": "2.7.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/interactivity": "file:../interactivity"
 			},
 			"engines": {
@@ -69038,6 +69039,7 @@
 		"@wordpress/interactivity-router": {
 			"version": "file:packages/interactivity-router",
 			"requires": {
+				"@wordpress/a11y": "file:../a11y",
 				"@wordpress/interactivity": "file:../interactivity"
 			}
 		},

--- a/packages/interactivity-router/package.json
+++ b/packages/interactivity-router/package.json
@@ -28,6 +28,7 @@
 	"types": "build-types",
 	"wpScriptModuleExports": "./build-module/index.js",
 	"dependencies": {
+		"@wordpress/a11y": "file:../a11y",
 		"@wordpress/interactivity": "file:../interactivity"
 	},
 	"publishConfig": {

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -275,7 +275,7 @@ export const { state, actions } = store( 'core/router', {
 					navigation.hasFinished = false;
 				}
 				if ( screenReaderAnnouncement ) {
-					navigation.message = navigation.texts.loading;
+					a11yAnnounce( navigation.texts.loading );
 				}
 			}, 400 );
 
@@ -315,14 +315,7 @@ export const { state, actions } = store( 'core/router', {
 				}
 
 				if ( screenReaderAnnouncement ) {
-					// Announce that the page has been loaded. If the message is the
-					// same, we use a no-break space similar to the @wordpress/a11y
-					// package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
-					navigation.message =
-						navigation.texts.loaded +
-						( navigation.message === navigation.texts.loaded
-							? '\u00A0'
-							: '' );
+					a11yAnnounce( navigation.texts.loaded );
 				}
 
 				// Scroll to the anchor if exits in the link.
@@ -362,6 +355,23 @@ export const { state, actions } = store( 'core/router', {
 		},
 	},
 } );
+
+/**
+ * Announces a message to screen readers.
+ *
+ * This is a wrapper around the `@wordpress/a11y` package's `speak` function. It handles importing
+ * the package on demand and should be used instead of calling `ally.speak` direacly.
+ *
+ * @param message  The message to be announced by assistive technologies.
+ * @param ariaLive The politeness level for aria-live; default: 'polite'.
+ */
+function a11yAnnounce( message: string, ariaLive?: 'polite' | 'assertive' ) {
+	import( '@wordpress/a11y' ).then(
+		( { speak } ) => speak( message, ariaLive ),
+		// Silence errors.
+		() => undefined
+	);
+}
 
 // Add click and prefetch to all links.
 if ( globalThis.IS_GUTENBERG_PLUGIN ) {

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -366,11 +366,19 @@ export const { state, actions } = store( 'core/router', {
  * @param ariaLive The politeness level for aria-live; default: 'polite'.
  */
 function a11yAnnounce( message: string, ariaLive?: 'polite' | 'assertive' ) {
-	import( '@wordpress/a11y' ).then(
-		( { speak } ) => speak( message, ariaLive ),
-		// Silence errors.
-		() => undefined
-	);
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		import( '@wordpress/a11y' ).then(
+			( { speak } ) => speak( message, ariaLive ),
+			// Silence errors.
+			() => undefined
+		);
+	} else {
+		state.navigation.message =
+			// Announce that the page has been loaded. If the message is the
+			// same, we use a no-break space similar to the @wordpress/a11y
+			// package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
+			message + ( state.navigation.message === message ? '\u00A0' : '' );
+	}
 }
 
 // Add click and prefetch to all links.

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -215,7 +215,26 @@ const navigationTexts = {
 	loaded: 'Page Loaded.',
 };
 
-export const { state, actions } = store( 'core/router', {
+interface Store {
+	state: {
+		url: string;
+		navigation: {
+			hasStarted: boolean;
+			hasFinished: boolean;
+			message: string;
+			texts?: {
+				loading?: string;
+				loaded?: string;
+			};
+		};
+	};
+	actions: {
+		navigate: ( href: string, options?: NavigateOptions ) => void;
+		prefetch: ( url: string, options?: PrefetchOptions ) => void;
+	};
+}
+
+export const { state, actions } = store< Store >( 'core/router', {
 	state: {
 		url: window.location.href,
 		navigation: {

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -277,7 +277,7 @@ export const { state, actions } = store( 'core/router', {
 					navigation.hasFinished = false;
 				}
 				if ( screenReaderAnnouncement ) {
-					a11yAnnounce( 'loading' );
+					a11ySpeak( 'loading' );
 				}
 			}, 400 );
 
@@ -317,7 +317,7 @@ export const { state, actions } = store( 'core/router', {
 				}
 
 				if ( screenReaderAnnouncement ) {
-					a11yAnnounce( 'loaded' );
+					a11ySpeak( 'loaded' );
 				}
 
 				// Scroll to the anchor if exits in the link.
@@ -366,7 +366,7 @@ export const { state, actions } = store( 'core/router', {
  *
  * @param messageKey The message to be announced by assistive technologies.
  */
-function a11yAnnounce( messageKey: keyof typeof navigationTexts ) {
+function a11ySpeak( messageKey: keyof typeof navigationTexts ) {
 	if ( ! hasLoadedNavigationTextsData ) {
 		hasLoadedNavigationTextsData = true;
 		const content = document.getElementById(

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -365,12 +365,8 @@ export const { state, actions } = store( 'core/router', {
  * the package on demand and should be used instead of calling `ally.speak` direacly.
  *
  * @param messageKey The message to be announced by assistive technologies.
- * @param ariaLive   The politeness level for aria-live; default: 'polite'.
  */
-function a11yAnnounce(
-	messageKey: 'loading' | 'loaded',
-	ariaLive?: 'polite' | 'assertive'
-) {
+function a11yAnnounce( messageKey: 'loading' | 'loaded' ) {
 	if ( ! navigationTexts.loadedFromServer ) {
 		navigationTexts.loadedFromServer = true;
 		const content = document.getElementById(
@@ -393,7 +389,7 @@ function a11yAnnounce(
 
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		import( '@wordpress/a11y' ).then(
-			( { speak } ) => speak( message, ariaLive ),
+			( { speak } ) => speak( message ),
 			// Ignore failures to load the a11y module.
 			() => {}
 		);

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -394,16 +394,8 @@ function a11yAnnounce(
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		import( '@wordpress/a11y' ).then(
 			( { speak } ) => speak( message, ariaLive ),
-			// Use the fallback Interactivity API implementation if the a11y
-			// Script Module cannot be loaded.
-			() => {
-				state.navigation.message =
-					// Announce that the page has been loaded. If the message is the
-					// same, we use a no-break space similar to the @wordpress/a11y
-					// package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
-					message +
-					( state.navigation.message === message ? '\u00A0' : '' );
-			}
+			// Ignore failures to load the a11y module.
+			() => {}
 		);
 	} else {
 		state.navigation.message =

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -366,7 +366,7 @@ export const { state, actions } = store( 'core/router', {
  *
  * @param messageKey The message to be announced by assistive technologies.
  */
-function a11yAnnounce( messageKey: 'loading' | 'loaded' ) {
+function a11yAnnounce( messageKey: keyof typeof navigationTexts ) {
 	if ( ! hasLoadedNavigationTextsData ) {
 		hasLoadedNavigationTextsData = true;
 		const content = document.getElementById(

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -394,8 +394,16 @@ function a11yAnnounce(
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		import( '@wordpress/a11y' ).then(
 			( { speak } ) => speak( message, ariaLive ),
-			// Silence errors.
-			() => undefined
+			// Use the fallback Interactivity API implementation if the a11y
+			// Script Module cannot be loaded.
+			() => {
+				state.navigation.message =
+					// Announce that the page has been loaded. If the message is the
+					// same, we use a no-break space similar to the @wordpress/a11y
+					// package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
+					message +
+					( state.navigation.message === message ? '\u00A0' : '' );
+			}
 		);
 	} else {
 		state.navigation.message =

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -209,8 +209,8 @@ const isValidEvent = ( event: MouseEvent ) =>
 // Variable to store the current navigation.
 let navigatingTo = '';
 
+let hasLoadedNavigationTextsData = false;
 const navigationTexts = {
-	loadedFromServer: false,
 	loading: 'Loading page, please wait.',
 	loaded: 'Page Loaded.',
 };
@@ -367,8 +367,8 @@ export const { state, actions } = store( 'core/router', {
  * @param messageKey The message to be announced by assistive technologies.
  */
 function a11yAnnounce( messageKey: 'loading' | 'loaded' ) {
-	if ( ! navigationTexts.loadedFromServer ) {
-		navigationTexts.loadedFromServer = true;
+	if ( ! hasLoadedNavigationTextsData ) {
+		hasLoadedNavigationTextsData = true;
 		const content = document.getElementById(
 			'wp-script-module-data-@wordpress/interactivity-router'
 		)?.textContent;

--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -401,6 +401,14 @@ function a11ySpeak( messageKey: keyof typeof navigationTexts ) {
 					navigationTexts.loaded = parsed.i18n.loaded;
 				}
 			} catch {}
+		} else {
+			// Fallback to localized strings from Interactivity API state.
+			if ( state.navigation.texts?.loading ) {
+				navigationTexts.loading = state.navigation.texts.loading;
+			}
+			if ( state.navigation.texts?.loaded ) {
+				navigationTexts.loaded = state.navigation.texts.loaded;
+			}
 		}
 	}
 

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -7,6 +7,6 @@
 		"checkJs": false,
 		"strict": false
 	},
-	"references": [ { "path": "../interactivity" } ],
+	"references": [ { "path": "../a11y" }, { "path": "../interactivity" } ],
 	"include": [ "src/**/*" ]
 }


### PR DESCRIPTION
## What?

Change the Interactivity Router a11y implementation to use the a11y Script Module introduced in #65101.

The a11y Script Module will be used in Gutenberg only and if it cannot be loaded, the Interactivity API fallback will be used.

Builds on:
- https://github.com/WordPress/gutenberg/pull/65064
- https://github.com/WordPress/gutenberg/pull/65101


https://github.com/WordPress/wordpress-develop/pull/7304 implements the same script data passing for translated strings in Core.


## Why?

Instead of its own 1-off implementation, shared a11y functionality can be used.


## Testing Instructions


Enable client side navigation, for example in the query block turn off the "force page reloads" option.

With the proper accessibility set up, for example macOS voiceover, "Page loaded." should be announced when navigating.

Alternatively, you can inspect the DOM with something like this in a console preview:

```js
[...document.querySelectorAll('[aria-live]')].map(e=>`${e.ariaLive}: ${JSON.stringify(e.textContent)}`)
```

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/2051e761-c0f8-43a5-bf19-6af1862f70d6

