### PR TITLE
Global styles menu: Avoid visible labels and accessible names mismatch

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -20,7 +20,7 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { useCallback } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -167,10 +167,7 @@ const LabeledColorIndicators = ( { indicators, label } ) => (
 				</Flex>
 			) ) }
 		</ZStack>
-		<FlexItem
-			className="block-editor-panel-color-gradient-settings__color-name"
-			title={ label }
-		>
+		<FlexItem className="block-editor-panel-color-gradient-settings__color-name">
 			{ label }
 		</FlexItem>
 	</HStack>
@@ -231,11 +228,6 @@ function ColorPanelDropdown( {
 							{ 'is-open': isOpen }
 						),
 						'aria-expanded': isOpen,
-						'aria-label': sprintf(
-							/* translators: %s is the type of color property, e.g., "background" */
-							__( 'Color %s styles' ),
-							label
-						),
 					};
 
 					return (

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -5,15 +5,18 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalVStack as VStack,
+	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { shuffle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 import ColorVariations from './variations/variations-color';
+import { useColorRandomizer } from './hooks';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 const mobilePopoverProps = { placement: 'bottom-start', offset: 8 };
@@ -49,21 +52,36 @@ export default function ColorPalettePanel( { name } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
 
+	const [ randomizeThemeColors ] = useColorRandomizer();
+
 	return (
 		<VStack
 			className="edit-site-global-styles-color-palette-panel"
 			spacing={ 8 }
 		>
 			{ !! themeColors && !! themeColors.length && (
-				<PaletteEdit
-					canReset={ themeColors !== baseThemeColors }
-					canOnlyChangeValues
-					colors={ themeColors }
-					onChange={ setThemeColors }
-					paletteLabel={ __( 'Theme' ) }
-					paletteLabelHeadingLevel={ 3 }
-					popoverProps={ popoverProps }
-				/>
+				<>
+					<PaletteEdit
+						canReset={ themeColors !== baseThemeColors }
+						canOnlyChangeValues
+						colors={ themeColors }
+						onChange={ setThemeColors }
+						paletteLabel={ __( 'Theme' ) }
+						paletteLabelHeadingLevel={ 3 }
+						popoverProps={ popoverProps }
+					/>
+					{ window.__experimentalEnableColorRandomizer &&
+						themeColors?.length > 0 && (
+							<Button
+								__next40pxDefaultSize
+								variant="secondary"
+								icon={ shuffle }
+								onClick={ randomizeThemeColors }
+							>
+								{ __( 'Randomize colors' ) }
+							</Button>
+						) }
+				</>
 			) }
 			{ !! defaultColors &&
 				!! defaultColors.length &&

--- a/packages/edit-site/src/components/global-styles/color-palette-panel.js
+++ b/packages/edit-site/src/components/global-styles/color-palette-panel.js
@@ -5,18 +5,15 @@ import { useViewportMatch } from '@wordpress/compose';
 import {
 	__experimentalPaletteEdit as PaletteEdit,
 	__experimentalVStack as VStack,
-	Button,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { shuffle } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
 import ColorVariations from './variations/variations-color';
-import { useColorRandomizer } from './hooks';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 const mobilePopoverProps = { placement: 'bottom-start', offset: 8 };
@@ -52,36 +49,21 @@ export default function ColorPalettePanel( { name } ) {
 	const isMobileViewport = useViewportMatch( 'small', '<' );
 	const popoverProps = isMobileViewport ? mobilePopoverProps : undefined;
 
-	const [ randomizeThemeColors ] = useColorRandomizer();
-
 	return (
 		<VStack
 			className="edit-site-global-styles-color-palette-panel"
 			spacing={ 8 }
 		>
 			{ !! themeColors && !! themeColors.length && (
-				<>
-					<PaletteEdit
-						canReset={ themeColors !== baseThemeColors }
-						canOnlyChangeValues
-						colors={ themeColors }
-						onChange={ setThemeColors }
-						paletteLabel={ __( 'Theme' ) }
-						paletteLabelHeadingLevel={ 3 }
-						popoverProps={ popoverProps }
-					/>
-					{ window.__experimentalEnableColorRandomizer &&
-						themeColors?.length > 0 && (
-							<Button
-								__next40pxDefaultSize
-								variant="secondary"
-								icon={ shuffle }
-								onClick={ randomizeThemeColors }
-							>
-								{ __( 'Randomize colors' ) }
-							</Button>
-						) }
-				</>
+				<PaletteEdit
+					canReset={ themeColors !== baseThemeColors }
+					canOnlyChangeValues
+					colors={ themeColors }
+					onChange={ setThemeColors }
+					paletteLabel={ __( 'Theme' ) }
+					paletteLabelHeadingLevel={ 3 }
+					popoverProps={ popoverProps }
+				/>
 			) }
 			{ !! defaultColors &&
 				!! defaultColors.length &&

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes-count.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes-count.js
@@ -23,10 +23,7 @@ function FontSizes() {
 				<Subtitle level={ 3 }>{ __( 'Font Sizes' ) }</Subtitle>
 			</HStack>
 			<ItemGroup isBordered isSeparated>
-				<NavigationButtonAsItem
-					path="/typography/font-sizes"
-					aria-label={ __( 'Edit font size presets' ) }
-				>
+				<NavigationButtonAsItem path="/typography/font-sizes">
 					<HStack direction="row">
 						<FlexItem>{ __( 'Font size presets' ) }</FlexItem>
 						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -3,15 +3,12 @@
  */
 import {
 	__experimentalItemGroup as ItemGroup,
-	Flex,
 	__experimentalHStack as HStack,
-	__experimentalZStack as ZStack,
 	__experimentalVStack as VStack,
-	ColorIndicator,
-	Button,
+	FlexItem,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
-import { Icon, shuffle, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -20,8 +17,6 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import Subtitle from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
-import { useColorRandomizer } from './hooks';
-import ColorIndicatorWrapper from './color-indicator-wrapper';
 import { unlock } from '../../lock-unlock';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
@@ -37,8 +32,6 @@ function Palette( { name } ) {
 		'color.defaultPalette',
 		name
 	);
-
-	const [ randomizeThemeColors ] = useColorRandomizer();
 
 	const colors = useMemo(
 		() => [
@@ -66,37 +59,11 @@ function Palette( { name } ) {
 			<ItemGroup isBordered isSeparated>
 				<NavigationButtonAsItem path={ screenPath }>
 					<HStack direction="row">
-						<Flex direction="column" gap={ hasColors ? 2 : 0 }>
-							<div>{ paletteButtonText }</div>
-							<ZStack isLayered={ false } offset={ -8 }>
-								{ colors
-									.slice( 0, 5 )
-									.map( ( { color }, index ) => (
-										<ColorIndicatorWrapper
-											key={ `${ color }-${ index }` }
-										>
-											<ColorIndicator
-												colorValue={ color }
-											/>
-										</ColorIndicatorWrapper>
-									) ) }
-							</ZStack>
-						</Flex>
+						<FlexItem>{ paletteButtonText }</FlexItem>
 						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>
-			{ window.__experimentalEnableColorRandomizer &&
-				themeColors?.length > 0 && (
-					<Button
-						__next40pxDefaultSize
-						variant="secondary"
-						icon={ shuffle }
-						onClick={ randomizeThemeColors }
-					>
-						{ __( 'Randomize colors' ) }
-					</Button>
-				) }
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -3,7 +3,7 @@
  */
 import {
 	__experimentalItemGroup as ItemGroup,
-	FlexItem,
+	Flex,
 	__experimentalHStack as HStack,
 	__experimentalZStack as ZStack,
 	__experimentalVStack as VStack,
@@ -51,35 +51,37 @@ function Palette( { name } ) {
 		[ customColors, themeColors, defaultColors, defaultPaletteEnabled ]
 	);
 
+	const hasColors = colors.length > 0;
+
 	const screenPath = ! name
 		? '/colors/palette'
 		: '/blocks/' + encodeURIComponent( name ) + '/colors/palette';
-	const paletteButtonText =
-		colors.length > 0 ? __( 'Edit palette' ) : __( 'Add colors' );
+	const paletteButtonText = hasColors
+		? __( 'Edit palette' )
+		: __( 'Add colors' );
 
 	return (
 		<VStack spacing={ 3 }>
 			<Subtitle level={ 3 }>{ __( 'Palette' ) }</Subtitle>
 			<ItemGroup isBordered isSeparated>
-				<NavigationButtonAsItem
-					path={ screenPath }
-					aria-label={ paletteButtonText }
-				>
+				<NavigationButtonAsItem path={ screenPath }>
 					<HStack direction="row">
-						{ colors.length <= 0 && (
-							<FlexItem>{ __( 'Add colors' ) }</FlexItem>
-						) }
-						<ZStack isLayered={ false } offset={ -8 }>
-							{ colors
-								.slice( 0, 5 )
-								.map( ( { color }, index ) => (
-									<ColorIndicatorWrapper
-										key={ `${ color }-${ index }` }
-									>
-										<ColorIndicator colorValue={ color } />
-									</ColorIndicatorWrapper>
-								) ) }
-						</ZStack>
+						<Flex direction="column" gap={ hasColors ? 2 : 0 }>
+							<div>{ paletteButtonText }</div>
+							<ZStack isLayered={ false } offset={ -8 }>
+								{ colors
+									.slice( 0, 5 )
+									.map( ( { color }, index ) => (
+										<ColorIndicatorWrapper
+											key={ `${ color }-${ index }` }
+										>
+											<ColorIndicator
+												colorValue={ color }
+											/>
+										</ColorIndicatorWrapper>
+									) ) }
+							</ZStack>
+						</Flex>
 						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 					</HStack>
 				</NavigationButtonAsItem>

--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -3,12 +3,15 @@
  */
 import {
 	__experimentalItemGroup as ItemGroup,
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
 	FlexItem,
+	__experimentalHStack as HStack,
+	__experimentalZStack as ZStack,
+	__experimentalVStack as VStack,
+	ColorIndicator,
+	Button,
 } from '@wordpress/components';
 import { isRTL, __ } from '@wordpress/i18n';
-import { Icon, chevronLeft, chevronRight } from '@wordpress/icons';
+import { Icon, shuffle, chevronLeft, chevronRight } from '@wordpress/icons';
 import { useMemo } from '@wordpress/element';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 
@@ -17,6 +20,8 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import Subtitle from './subtitle';
 import { NavigationButtonAsItem } from './navigation-button';
+import { useColorRandomizer } from './hooks';
+import ColorIndicatorWrapper from './color-indicator-wrapper';
 import { unlock } from '../../lock-unlock';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
@@ -33,6 +38,8 @@ function Palette( { name } ) {
 		name
 	);
 
+	const [ randomizeThemeColors ] = useColorRandomizer();
+
 	const colors = useMemo(
 		() => [
 			...( customColors || EMPTY_COLORS ),
@@ -44,14 +51,9 @@ function Palette( { name } ) {
 		[ customColors, themeColors, defaultColors, defaultPaletteEnabled ]
 	);
 
-	const hasColors = colors.length > 0;
-
 	const screenPath = ! name
 		? '/colors/palette'
 		: '/blocks/' + encodeURIComponent( name ) + '/colors/palette';
-	const paletteButtonText = hasColors
-		? __( 'Edit palette' )
-		: __( 'Add colors' );
 
 	return (
 		<VStack spacing={ 3 }>
@@ -59,11 +61,43 @@ function Palette( { name } ) {
 			<ItemGroup isBordered isSeparated>
 				<NavigationButtonAsItem path={ screenPath }>
 					<HStack direction="row">
-						<FlexItem>{ paletteButtonText }</FlexItem>
+						{ colors.length > 0 ? (
+							<>
+								<ZStack isLayered={ false } offset={ -8 }>
+									{ colors
+										.slice( 0, 5 )
+										.map( ( { color }, index ) => (
+											<ColorIndicatorWrapper
+												key={ `${ color }-${ index }` }
+											>
+												<ColorIndicator
+													colorValue={ color }
+												/>
+											</ColorIndicatorWrapper>
+										) ) }
+								</ZStack>
+								<FlexItem isBlock>
+									{ __( 'Edit palette' ) }
+								</FlexItem>
+							</>
+						) : (
+							<FlexItem>{ __( 'Add colors' ) }</FlexItem>
+						) }
 						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 					</HStack>
 				</NavigationButtonAsItem>
 			</ItemGroup>
+			{ window.__experimentalEnableColorRandomizer &&
+				themeColors?.length > 0 && (
+					<Button
+						__next40pxDefaultSize
+						variant="secondary"
+						icon={ shuffle }
+						onClick={ randomizeThemeColors }
+					>
+						{ __( 'Randomize colors' ) }
+					</Button>
+				) }
 		</VStack>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/root-menu.js
+++ b/packages/edit-site/src/components/global-styles/root-menu.js
@@ -48,17 +48,12 @@ function RootMenu() {
 					<NavigationButtonAsItem
 						icon={ typography }
 						path="/typography"
-						aria-label={ __( 'Typography styles' ) }
 					>
 						{ __( 'Typography' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasColorPanel && (
-					<NavigationButtonAsItem
-						icon={ color }
-						path="/colors"
-						aria-label={ __( 'Colors styles' ) }
-					>
+					<NavigationButtonAsItem icon={ color } path="/colors">
 						{ __( 'Colors' ) }
 					</NavigationButtonAsItem>
 				) }
@@ -72,20 +67,12 @@ function RootMenu() {
 					</NavigationButtonAsItem>
 				) }
 				{ hasShadowPanel && (
-					<NavigationButtonAsItem
-						icon={ shadowIcon }
-						path="/shadows"
-						aria-label={ __( 'Shadow styles' ) }
-					>
+					<NavigationButtonAsItem icon={ shadowIcon } path="/shadows">
 						{ __( 'Shadows' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasLayoutPanel && (
-					<NavigationButtonAsItem
-						icon={ layout }
-						path="/layout"
-						aria-label={ __( 'Layout styles' ) }
-					>
+					<NavigationButtonAsItem icon={ layout } path="/layout">
 						{ __( 'Layout' ) }
 					</NavigationButtonAsItem>
 				) }

--- a/packages/edit-site/src/components/global-styles/screen-block-list.js
+++ b/packages/edit-site/src/components/global-styles/screen-block-list.js
@@ -86,16 +86,9 @@ function BlockMenuItem( { block } ) {
 		return null;
 	}
 
-	const navigationButtonLabel = sprintf(
-		// translators: %s: is the name of a block e.g., 'Image' or 'Table'.
-		__( '%s block styles' ),
-		block.title
-	);
-
 	return (
 		<NavigationButtonAsItem
 			path={ '/blocks/' + encodeURIComponent( block.name ) }
-			aria-label={ navigationButtonLabel }
 		>
 			<HStack justify="flex-start">
 				<BlockIcon icon={ block.icon } />

--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -67,10 +67,7 @@ function ScreenRoot() {
 					</Card>
 					{ hasVariations && (
 						<ItemGroup>
-							<NavigationButtonAsItem
-								path="/variations"
-								aria-label={ __( 'Browse styles' ) }
-							>
+							<NavigationButtonAsItem path="/variations">
 								<HStack justify="space-between">
 									<FlexItem>
 										{ __( 'Browse styles' ) }
@@ -107,10 +104,7 @@ function ScreenRoot() {
 					) }
 				</Spacer>
 				<ItemGroup>
-					<NavigationButtonAsItem
-						path="/blocks"
-						aria-label={ __( 'Blocks styles' ) }
-					>
+					<NavigationButtonAsItem path="/blocks">
 						<HStack justify="space-between">
 							<FlexItem>{ __( 'Blocks' ) }</FlexItem>
 							<IconWithCurrentColor
@@ -136,10 +130,7 @@ function ScreenRoot() {
 							) }
 						</Spacer>
 						<ItemGroup>
-							<NavigationButtonAsItem
-								path="/css"
-								aria-label={ __( 'Additional CSS' ) }
-							>
+							<NavigationButtonAsItem path="/css">
 								<HStack justify="space-between">
 									<FlexItem>
 										{ __( 'Additional CSS' ) }

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -135,10 +135,6 @@ function ShadowItem( { shadow, category } ) {
 	return (
 		<NavigationButtonAsItem
 			path={ `/shadows/edit/${ category }/${ shadow.slug }` }
-			aria-label={
-				// translators: %s: name of the shadow
-				sprintf( 'Edit shadow %s', shadow.name )
-			}
 			icon={ shadowIcon }
 		>
 			{ shadow.name }

--- a/packages/edit-site/src/components/global-styles/typography-elements.js
+++ b/packages/edit-site/src/components/global-styles/typography-elements.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
@@ -36,17 +36,8 @@ function ElementItem( { parentMenu, element, label } ) {
 	const [ gradientValue ] = useGlobalStyle( prefix + 'color.gradient' );
 	const [ color ] = useGlobalStyle( prefix + 'color.text' );
 
-	const navigationButtonLabel = sprintf(
-		// translators: %s: is a subset of Typography, e.g., 'text' or 'links'.
-		__( 'Typography %s styles' ),
-		label
-	);
-
 	return (
-		<NavigationButtonAsItem
-			path={ parentMenu + '/typography/' + element }
-			aria-label={ navigationButtonLabel }
-		>
+		<NavigationButtonAsItem path={ parentMenu + '/typography/' + element }>
 			<HStack justify="flex-start">
 				<FlexItem
 					className="edit-site-global-styles-screen-typography__indicator"
@@ -61,6 +52,7 @@ function ElementItem( { parentMenu, element, label } ) {
 						fontWeight,
 						...extraStyles,
 					} }
+					aria-hidden="true"
 				>
 					{ __( 'Aa' ) }
 				</FlexItem>

--- a/packages/edit-site/src/components/global-styles/variations/variations-panel.js
+++ b/packages/edit-site/src/components/global-styles/variations/variations-panel.js
@@ -55,7 +55,6 @@ export function VariationsPanel( { name } ) {
 							'/variations/' +
 							encodeURIComponent( style.name )
 						}
-						aria-label={ style.label }
 					>
 						{ style.label }
 					</NavigationButtonAsItem>

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -291,11 +291,11 @@ test.describe( 'Buttons', () => {
 			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
 		);
 		await page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Color Text styles"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
 		await page.click( 'role=option[name="Color: Cyan bluish gray"i]' );
 		await page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Color Background styles"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=option[name="Color: Vivid red"i]' );
 
@@ -320,13 +320,13 @@ test.describe( 'Buttons', () => {
 			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
 		);
 		await page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Color Text styles"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Text"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
 		await page.fill( 'role=textbox[name="Hex color"i]', 'ff0000' );
 
 		await page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Color Background styles"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=button[name="Custom color picker."i]' );
 		await page.fill( 'role=textbox[name="Hex color"i]', '00ff00' );
@@ -355,7 +355,7 @@ test.describe( 'Buttons', () => {
 			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
 		);
 		await page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Color Background styles"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=tab[name="Gradient"i]' );
 		await page.click( 'role=option[name="Gradient: Purple to yellow"i]' );
@@ -384,7 +384,7 @@ test.describe( 'Buttons', () => {
 			`role=region[name="Editor settings"i] >> role=tab[name="Styles"i]`
 		);
 		await page.click(
-			'role=region[name="Editor settings"i] >> role=button[name="Color Background styles"i]'
+			'role=region[name="Editor settings"i] >> role=button[name="Background"i]'
 		);
 		await page.click( 'role=tab[name="Gradient"i]' );
 		await page.click(

--- a/test/e2e/specs/editor/blocks/navigation-colors.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-colors.spec.js
@@ -91,14 +91,12 @@ test.describe( 'Navigation colors', () => {
 		// In the sidebar inspector we add a link color and link hover color to the group block.
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Color Text styles' } ).click();
+		await page.getByRole( 'button', { name: 'Text' } ).click();
 		await page
 			.getByRole( 'option', { name: 'Color: White' } )
 			.click( { force: true } );
 
-		await page
-			.getByRole( 'button', { name: 'Color Background styles' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Background' } ).click();
 		await page
 			.getByRole( 'option', { name: 'Color: Black' } )
 			.click( { force: true } );
@@ -148,7 +146,7 @@ test.describe( 'Navigation colors', () => {
 			.getByRole( 'menuitemcheckbox', { name: 'Show Link' } )
 			.click();
 		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Color Link styles' } ).click();
+		await page.getByRole( 'button', { name: 'Link' } ).click();
 		// rga(207, 46 ,46) is the color of the "vivid red" color preset.
 		await page
 			.getByRole( 'option', { name: 'Color: Vivid red' } )

--- a/test/e2e/specs/editor/blocks/navigation-colors.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-colors.spec.js
@@ -96,7 +96,9 @@ test.describe( 'Navigation colors', () => {
 			.getByRole( 'option', { name: 'Color: White' } )
 			.click( { force: true } );
 
-		await page.getByRole( 'button', { name: 'Background' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Background', exact: true } )
+			.click();
 		await page
 			.getByRole( 'option', { name: 'Color: Black' } )
 			.click( { force: true } );

--- a/test/e2e/specs/editor/blocks/navigation-colors.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-colors.spec.js
@@ -146,7 +146,7 @@ test.describe( 'Navigation colors', () => {
 			.getByRole( 'menuitemcheckbox', { name: 'Show Link' } )
 			.click();
 		await page.getByRole( 'tab', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Link' } ).click();
+		await page.getByRole( 'button', { name: 'Link', exact: true } ).click();
 		// rga(207, 46 ,46) is the color of the "vivid red" color preset.
 		await page
 			.getByRole( 'option', { name: 'Color: Vivid red' } )

--- a/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
+++ b/test/e2e/specs/editor/various/keep-styles-on-block-transforms.spec.js
@@ -17,7 +17,7 @@ test.describe( 'Keep styles on block transforms', () => {
 			.locator( 'role=button[name="Add default block"i]' )
 			.click();
 		await page.keyboard.type( '## Heading' );
-		await page.click( 'role=button[name="Color Text styles"i]' );
+		await page.click( 'role=button[name="Text"i]' );
 		await page.click( 'role=option[name="Color: Luminous vivid orange"i]' );
 
 		await page.click( 'role=button[name="Heading"i]' );

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -184,7 +184,7 @@ test.describe( 'Font Library', () => {
 			// Check CSS preset was created.
 			await page.getByRole( 'button', { name: 'Close' } ).click();
 			await page
-				.getByRole( 'button', { name: 'Typography Headings styles' } )
+				.getByRole( 'button', { name: 'Headings', exact: true } )
 				.click();
 			await page.getByLabel( 'Font' ).selectOption( 'Exo 2' );
 			await expect(

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -24,9 +24,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
 				.click();
-			await page
-				.getByRole( 'button', { name: 'Typography Styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 			await page
 				.getByRole( 'button', {
 					name: 'Add fonts',
@@ -43,9 +41,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
 				.click();
-			await page
-				.getByRole( 'button', { name: 'Typography Styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 			const manageFontsIcon = page.getByRole( 'button', {
 				name: 'Manage fonts',
 			} );
@@ -71,9 +67,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
 				.click();
-			await page
-				.getByRole( 'button', { name: 'Typography Styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 			const manageFontsIcon = page.getByRole( 'button', {
 				name: 'Manage fonts',
 			} );
@@ -87,9 +81,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
 				.click();
-			await page
-				.getByRole( 'button', { name: 'Typography Styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 			await page
 				.getByRole( 'button', {
 					name: 'Manage fonts',
@@ -108,9 +100,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
 				.click();
-			await page
-				.getByRole( 'button', { name: 'Typography Styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 			await page
 				.getByRole( 'button', {
 					name: 'Manage fonts',
@@ -160,9 +150,7 @@ test.describe( 'Font Library', () => {
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
 				.click();
-			await page
-				.getByRole( 'button', { name: 'Typography Styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 			await page
 				.getByRole( 'button', {
 					name: 'Add fonts',
@@ -252,9 +240,7 @@ test.describe( 'Font Library', () => {
 			// Click "Back" button
 			await page.getByRole( 'button', { name: 'Back' } ).click();
 
-			await page
-				.getByRole( 'button', { name: 'Typography styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 
 			// Click "Jost 2 variants" button
 			await page
@@ -286,9 +272,7 @@ test.describe( 'Font Library', () => {
 			// Click "Back" button
 			await page.getByRole( 'button', { name: 'Back' } ).click();
 
-			await page
-				.getByRole( 'button', { name: 'Typography styles' } )
-				.click();
+			await page.getByRole( 'button', { name: 'Typography' } ).click();
 
 			// Click Cardo font-family.
 			await page

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Global styles sidebar', () => {
 			.click();
 		await page
 			.getByRole( 'region', { name: 'Editor settings' } )
-			.getByRole( 'button', { name: 'Blocks styles' } )
+			.getByRole( 'button', { name: 'Blocks' } )
 			.click();
 
 		await page

--- a/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
+++ b/test/e2e/specs/site-editor/global-styles-sidebar.spec.js
@@ -38,11 +38,11 @@ test.describe( 'Global styles sidebar', () => {
 		// Matches both Heading and Table of Contents blocks.
 		// The latter contains "heading" in its description.
 		await expect(
-			page.getByRole( 'button', { name: 'Heading block styles' } )
+			page.getByRole( 'button', { name: 'Heading', exact: true } )
 		).toBeVisible();
 		await expect(
 			page.getByRole( 'button', {
-				name: 'Table of Contents block styles',
+				name: 'Table of Contents',
 			} )
 		).toBeVisible();
 	} );

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -29,11 +29,14 @@ test.describe( 'Push to Global Styles button', () => {
 		await page.keyboard.type( 'A heading' );
 
 		const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
+		const settingsPanel = page.getByRole( 'region', {
+			name: 'Editor settings',
+		} );
 
 		// Navigate to Styles -> Blocks -> Heading -> Typography
 		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Blocks' } ).click();
-		await page.getByRole( 'button', { name: 'Heading' } ).click();
+		await settingsPanel.getByRole( 'button', { name: 'Blocks' } ).click();
+		await settingsPanel.getByRole( 'button', { name: 'Heading' } ).click();
 
 		// Headings should not have uppercase
 		await expect(
@@ -94,8 +97,8 @@ test.describe( 'Push to Global Styles button', () => {
 			.getByRole( 'button', { name: 'Styles', exact: true } )
 			.click();
 		await page.getByRole( 'button', { name: 'Blocks' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Heading block styles' } )
+		await settingsPanel
+			.getByRole( 'button', { name: 'Heading', exact: true } )
 			.click();
 
 		// Headings should now have uppercase

--- a/test/e2e/specs/site-editor/push-to-global-styles.spec.js
+++ b/test/e2e/specs/site-editor/push-to-global-styles.spec.js
@@ -32,10 +32,8 @@ test.describe( 'Push to Global Styles button', () => {
 
 		// Navigate to Styles -> Blocks -> Heading -> Typography
 		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Blocks styles' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Heading block styles' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Blocks' } ).click();
+		await page.getByRole( 'button', { name: 'Heading' } ).click();
 
 		// Headings should not have uppercase
 		await expect(
@@ -95,7 +93,7 @@ test.describe( 'Push to Global Styles button', () => {
 		await page
 			.getByRole( 'button', { name: 'Styles', exact: true } )
 			.click();
-		await page.getByRole( 'button', { name: 'Blocks styles' } ).click();
+		await page.getByRole( 'button', { name: 'Blocks' } ).click();
 		await page
 			.getByRole( 'button', { name: 'Heading block styles' } )
 			.click();

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -97,8 +97,8 @@ test.describe( 'Style Book', () => {
 	test( 'should allow to return Global Styles root when example is clicked', async ( {
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Blocks styles"]' );
-		await page.click( 'role=button[name="Heading block styles"]' );
+		await page.click( 'role=button[name="Blocks"]' );
+		await page.click( 'role=button[name="Heading"]' );
 
 		await page
 			.frameLocator( '[name="style-book-canvas"]' )
@@ -111,7 +111,7 @@ test.describe( 'Style Book', () => {
 		await page.click( 'role=button[name="Back"]' );
 
 		await expect(
-			page.locator( 'role=button[name="Blocks styles"]' )
+			page.locator( 'role=button[name="Blocks"]' )
 		).toBeVisible();
 	} );
 

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -78,7 +78,7 @@ test.describe( 'Global styles variations', () => {
 		await siteEditorStyleVariations.browseStyles();
 		await page.click( 'role=button[name="pink"i]' );
 		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Colors styles"i]' );
+		await page.click( 'role=button[name="Colors"i]' );
 
 		await expect(
 			page.locator(
@@ -93,7 +93,7 @@ test.describe( 'Global styles variations', () => {
 		).toHaveCSS( 'background', /rgb\(74, 7, 74\)/ );
 
 		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Typography styles"i]' );
+		await page.click( 'role=button[name="Typography"i]' );
 		await page.click( 'role=button[name="Typography Text styles"i]' );
 
 		await expect(
@@ -114,7 +114,7 @@ test.describe( 'Global styles variations', () => {
 		await siteEditorStyleVariations.browseStyles();
 		await page.click( 'role=button[name="yellow"i]' );
 		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Colors styles"i]' );
+		await page.click( 'role=button[name="Colors"i]' );
 
 		await expect(
 			page.locator(
@@ -129,7 +129,7 @@ test.describe( 'Global styles variations', () => {
 		).toHaveCSS( 'background', /rgb\(25, 25, 17\)/ );
 
 		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Typography styles"i]' );
+		await page.click( 'role=button[name="Typography"i]' );
 		await page.click( 'role=button[name="Typography Text styles"i]' );
 
 		// TODO: to avoid use classnames to locate these elements,
@@ -156,7 +156,7 @@ test.describe( 'Global styles variations', () => {
 		await siteEditorStyleVariations.browseStyles();
 		await page.click( 'role=button[name="pink"i]' );
 		await page.click( 'role=button[name="Back"i]' );
-		await page.click( 'role=button[name="Colors styles"i]' );
+		await page.click( 'role=button[name="Colors"i]' );
 		await page.click( 'role=button[name="Edit palette"i]' );
 
 		await expect(

--- a/test/e2e/specs/site-editor/style-variations.spec.js
+++ b/test/e2e/specs/site-editor/style-variations.spec.js
@@ -82,19 +82,19 @@ test.describe( 'Global styles variations', () => {
 
 		await expect(
 			page.locator(
-				'role=button[name="Color Background styles"i] >> .component-color-indicator'
+				'role=button[name="Background"i] >> .component-color-indicator'
 			)
 		).toHaveCSS( 'background', /rgb\(202, 105, 211\)/ );
 
 		await expect(
 			page.locator(
-				'role=button[name="Color Text styles"i] >> .component-color-indicator'
+				'role=button[name="Text"i] >> .component-color-indicator'
 			)
 		).toHaveCSS( 'background', /rgb\(74, 7, 74\)/ );
 
 		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Typography"i]' );
-		await page.click( 'role=button[name="Typography Text styles"i]' );
+		await page.click( 'role=button[name="Text"i]' );
 
 		await expect(
 			page.locator( 'css=.components-font-size-picker__header__hint' )
@@ -118,19 +118,19 @@ test.describe( 'Global styles variations', () => {
 
 		await expect(
 			page.locator(
-				'role=button[name="Color Background styles"i] >> .component-color-indicator'
+				'role=button[name="Background"i] >> .component-color-indicator'
 			)
 		).toHaveCSS( 'background', /rgb\(255, 239, 11\)/ );
 
 		await expect(
 			page.locator(
-				'role=button[name="Color Text styles"i] >> .component-color-indicator'
+				'role=button[name="Text"i] >> .component-color-indicator'
 			)
 		).toHaveCSS( 'background', /rgb\(25, 25, 17\)/ );
 
 		await page.click( 'role=button[name="Back"i]' );
 		await page.click( 'role=button[name="Typography"i]' );
-		await page.click( 'role=button[name="Typography Text styles"i]' );
+		await page.click( 'role=button[name="Text"i]' );
 
 		// TODO: to avoid use classnames to locate these elements,
 		//  we could provide accessible attributes to the source code in packages/components/src/font-size-picker/index.js.

--- a/test/e2e/specs/site-editor/styles.spec.js
+++ b/test/e2e/specs/site-editor/styles.spec.js
@@ -40,7 +40,7 @@ test.describe( 'Styles', () => {
 		const topBar = page.getByRole( 'region', { name: 'Editor top bar' } );
 		// Navigate to Styles -> Blocks -> Heading -> Typography
 		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Blocks styles' } ).click();
+		await page.getByRole( 'button', { name: 'Blocks' } ).click();
 		await page
 			.getByRole( 'button', { name: 'Social Icons block styles' } )
 			.click();

--- a/test/e2e/specs/site-editor/styles.spec.js
+++ b/test/e2e/specs/site-editor/styles.spec.js
@@ -41,9 +41,7 @@ test.describe( 'Styles', () => {
 		// Navigate to Styles -> Blocks -> Heading -> Typography
 		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Blocks' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Social Icons block styles' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Social Icons' } ).click();
 
 		// Find the second padding control and change the padding value
 		await page

--- a/test/e2e/specs/site-editor/styles.spec.js
+++ b/test/e2e/specs/site-editor/styles.spec.js
@@ -41,7 +41,9 @@ test.describe( 'Styles', () => {
 		// Navigate to Styles -> Blocks -> Heading -> Typography
 		await topBar.getByRole( 'button', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Blocks' } ).click();
-		await page.getByRole( 'button', { name: 'Social Icons' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Social Icons', exact: true } )
+			.click();
 
 		// Find the second padding control and change the padding value
 		await page

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -75,7 +75,7 @@ test.describe( 'Style Revisions', () => {
 	} ) => {
 		await editor.canvas.locator( 'body' ).click();
 		await userGlobalStylesRevisions.openStylesPanel();
-		await page.getByRole( 'button', { name: 'Colors styles' } ).click();
+		await page.getByRole( 'button', { name: 'Colors' } ).click();
 		await page
 			.getByRole( 'button', { name: 'Color Background styles' } )
 			.click();

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -76,9 +76,7 @@ test.describe( 'Style Revisions', () => {
 		await editor.canvas.locator( 'body' ).click();
 		await userGlobalStylesRevisions.openStylesPanel();
 		await page.getByRole( 'button', { name: 'Colors' } ).click();
-		await page
-			.getByRole( 'button', { name: 'Color Background styles' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Background' } ).click();
 		await page
 			.getByRole( 'option', { name: 'Color: Luminous vivid amber' } )
 			.click( { force: true } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/65112

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes most aria-label that:
- Either alter the accessible name thus introducing a mismatch between visible label and actual accessible name
- Or just repeat the visible text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In such cases, the labels are unnecessary or even harmful for accessibility. Always prefer the visible label to determine the accessible name.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Removes unnecessary aria-labels.
- Adjust the tests.
- Special case: Adds a visible label to the 'Palette' button. Note: this is the only visual change in this PR.
- Removes an unnecessary HTML `title` attribute.

Screenshot of the Palette butto, before and after:

![Screenshot 2024-09-06 at 14 54 06](https://github.com/user-attachments/assets/b501395e-261a-4c6e-8a1d-875ff084cb14)



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site Editor > Styles
- Observe the button items in the root menu and in the various submenus have an accessible name determined by the visible label i.e. no `aria-label` attribute.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
