### PR TITLE
Modal: Decrease close button size

### DIFF
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -9,7 +9,6 @@ import {
 	Button,
 	Flex,
 	FlexItem,
-	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -25,20 +24,17 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 	}
 
 	return (
-		<>
-			<Button
-				size="small"
-				onClick={ onClick }
-				icon={ fullscreen }
-				isPressed={ isModalFullScreen }
-				label={
-					isModalFullScreen
-						? __( 'Exit fullscreen' )
-						: __( 'Enter fullscreen' )
-				}
-			/>
-			<Spacer marginBottom={ 0 } marginRight={ 3 } />
-		</>
+		<Button
+			size="small"
+			onClick={ onClick }
+			icon={ fullscreen }
+			isPressed={ isModalFullScreen }
+			label={
+				isModalFullScreen
+					? __( 'Exit fullscreen' )
+					: __( 'Enter fullscreen' )
+			}
+		/>
 	);
 }
 

--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -9,6 +9,7 @@ import {
 	Button,
 	Flex,
 	FlexItem,
+	__experimentalSpacer as Spacer,
 } from '@wordpress/components';
 import { useEffect, useState, RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -24,18 +25,20 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 	}
 
 	return (
-		<Button
-			// TODO: Switch to `true` (40px size) if possible
-			__next40pxDefaultSize={ false }
-			onClick={ onClick }
-			icon={ fullscreen }
-			isPressed={ isModalFullScreen }
-			label={
-				isModalFullScreen
-					? __( 'Exit fullscreen' )
-					: __( 'Enter fullscreen' )
-			}
-		/>
+		<>
+			<Button
+				size="small"
+				onClick={ onClick }
+				icon={ fullscreen }
+				isPressed={ isModalFullScreen }
+				label={
+					isModalFullScreen
+						? __( 'Exit fullscreen' )
+						: __( 'Enter fullscreen' )
+				}
+			/>
+			<Spacer marginBottom={ 0 } marginRight={ 3 } />
+		</>
 	);
 }
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 -   `Composite`: add stable version of the component ([#63569](https://github.com/WordPress/gutenberg/pull/63569)).
 
+### Enhancements
+
+-   `Modal`: Decrease close button size and remove horizontal offset ([#65131](https://github.com/WordPress/gutenberg/pull/65131)).
+
 ### Internal
 
 -   `Composite`: Remove from private APIs ([#63569](https://github.com/WordPress/gutenberg/pull/63569)).

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -37,6 +37,7 @@ import Button from '../button';
 import StyleProvider from '../style-provider';
 import type { ModalProps } from './types';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
+import { Spacer } from '../spacer';
 
 // Used to track and dismiss the prior modal when another opens unless nested.
 type Dismissers = Set<
@@ -323,14 +324,21 @@ function UnforwardedModal(
 								</div>
 								{ headerActions }
 								{ isDismissible && (
-									<Button
-										size="small"
-										onClick={ onRequestClose }
-										icon={ close }
-										label={
-											closeButtonLabel || __( 'Close' )
-										}
-									/>
+									<>
+										<Spacer
+											marginBottom={ 0 }
+											marginLeft={ 3 }
+										/>
+										<Button
+											size="small"
+											onClick={ onRequestClose }
+											icon={ close }
+											label={
+												closeButtonLabel ||
+												__( 'Close' )
+											}
+										/>
+									</>
 								) }
 							</div>
 						) }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -324,6 +324,7 @@ function UnforwardedModal(
 								{ headerActions }
 								{ isDismissible && (
 									<Button
+										size="small"
 										onClick={ onRequestClose }
 										icon={ close }
 										label={

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -7,7 +7,7 @@ import type { StoryFn, Meta } from '@storybook/react';
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { starEmpty, starFilled } from '@wordpress/icons';
+import { fullscreen } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -16,6 +16,7 @@ import Button from '../../button';
 import InputControl from '../../input-control';
 import Modal from '../';
 import type { ModalProps } from '../types';
+import { Spacer } from '../../spacer';
 
 const meta: Meta< typeof Modal > = {
 	component: Modal,
@@ -103,22 +104,19 @@ WithsizeSmall.args = {
 };
 WithsizeSmall.storyName = 'With size: small';
 
-const LikeButton = () => {
-	const [ isLiked, setIsLiked ] = useState( false );
-	return (
-		<Button
-			icon={ isLiked ? starFilled : starEmpty }
-			label="Like"
-			onClick={ () => setIsLiked( ! isLiked ) }
-		/>
-	);
-};
-
+/**
+ * The `headerActions` prop can be used to add auxiliary actions to the header, for example a fullscreen mode toggle.
+ */
 export const WithHeaderActions: StoryFn< typeof Modal > = Template.bind( {} );
 WithHeaderActions.args = {
 	...Default.args,
-	headerActions: <LikeButton />,
-	isDismissible: false,
+	headerActions: (
+		<>
+			<Button icon={ fullscreen } label="Fullscreen mode" size="small" />
+			<Spacer marginBottom={ 0 } marginRight={ 3 } />
+		</>
+	),
+	children: <div style={ { height: '200px' } } />,
 };
 WithHeaderActions.parameters = {
 	...Default.parameters,

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -16,7 +16,6 @@ import Button from '../../button';
 import InputControl from '../../input-control';
 import Modal from '../';
 import type { ModalProps } from '../types';
-import { Spacer } from '../../spacer';
 
 const meta: Meta< typeof Modal > = {
 	component: Modal,
@@ -111,10 +110,7 @@ export const WithHeaderActions: StoryFn< typeof Modal > = Template.bind( {} );
 WithHeaderActions.args = {
 	...Default.args,
 	headerActions: (
-		<>
-			<Button icon={ fullscreen } label="Fullscreen mode" size="small" />
-			<Spacer marginBottom={ 0 } marginRight={ 3 } />
-		</>
+		<Button icon={ fullscreen } label="Fullscreen mode" size="small" />
 	),
 	children: <div style={ { height: '200px' } } />,
 };

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -116,11 +116,6 @@
 		margin: 0;
 	}
 
-	.components-button {
-		position: relative;
-		left: $grid-unit-10;
-	}
-
 	.components-modal__content.has-scrolled-content:not(.hide-header) & {
 		border-bottom-color: $gray-300;
 	}


### PR DESCRIPTION
Closes #65102

## What?

Decreases the size of the close button in the Modal component, and remove the optical adjustment to make it flush with the content width.

## Why?

The current close button uses the old 36px size which will be deprecated. We need to switch it to one of the new sizes, which was discussed in #65102.

## Testing Instructions

- See the stories for Modal in Storybook.
- Smoke test some modals in the app.
- Insert a Freeform block in the editor to see the only in-app instance of a Modal with a header action injected.

### Testing Instructions for Keyboard

Use keyboard to navigate the modals.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/9d843c3c-38e2-4dcb-9996-3497cc8cac78

---

## ✍️ Dev Note

### Modal: Buttons in `headerActions` should use `"small"` size

The close button in the Modal component is now using the `"small"` Button size (currently 24px), down from the 36px default size in the old sizing scheme.

If you are using the `headerActions` prop to inject buttons beside the close button, we recommend you also use the `"small"` Button size variant to match.

```jsx
<Modal
  headerActions={ <Button icon={ fullscreen } label="Fullscreen mode" size="small" /> }
/>
```