### PR TITLE
Normalize spacing in Layout hook controls

### DIFF
--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -1,23 +1,14 @@
-.block-editor-hooks__layout-controls-units {
-	display: flex;
-	flex-direction: column;
-	gap: $grid-unit-20;
+.block-editor-hooks__layout-constrained {
+	.components-base-control {
+		// Cancel out extra margins added by block inspector
+		margin-bottom: 0;
+	}
 }
 
-.block-editor-block-inspector .block-editor-hooks__layout-controls-unit-input {
-	margin-bottom: 0;
-}
-
-.block-editor-hooks__layout-controls-reset {
-	display: flex;
-	justify-content: flex-end;
-	margin-bottom: $grid-unit-30;
-}
-
-.block-editor-hooks__layout-controls-helptext {
+.block-editor-hooks__layout-constrained-helptext {
 	color: $gray-700;
 	font-size: $helptext-font-size;
-	margin-bottom: $grid-unit-20;
+	margin-bottom: 0;
 }
 
 .block-editor-hooks__flex-layout-justification-controls,

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -1,14 +1,13 @@
 .block-editor-hooks__layout-constrained {
 	.components-base-control {
-		// Cancel out extra margins added by block inspector
-		margin-bottom: 0;
+		margin-bottom: 0; // Cancel out margins added by block inspector
 	}
 }
 
 .block-editor-hooks__layout-constrained-helptext {
 	color: $gray-700;
 	font-size: $helptext-font-size;
-	margin-bottom: 0;
+	margin-bottom: 0; // Cancel out margins added by common.css
 }
 
 .block-editor-hooks__flex-layout-justification-controls,

--- a/packages/block-editor/src/layouts/constrained.js
+++ b/packages/block-editor/src/layouts/constrained.js
@@ -7,6 +7,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import {
@@ -70,12 +71,14 @@ export default {
 			availableUnits: availableUnits || [ '%', 'px', 'em', 'rem', 'vw' ],
 		} );
 		return (
-			<>
+			<VStack
+				spacing={ 4 }
+				className="block-editor-hooks__layout-constrained"
+			>
 				{ allowCustomContentAndWideSize && (
-					<div className="block-editor-hooks__layout-controls-units">
+					<>
 						<UnitControl
 							__next40pxDefaultSize
-							className="block-editor-hooks__layout-controls-unit-input"
 							label={ __( 'Content width' ) }
 							labelPosition="top"
 							value={ contentSize || wideSize || '' }
@@ -98,7 +101,6 @@ export default {
 						/>
 						<UnitControl
 							__next40pxDefaultSize
-							className="block-editor-hooks__layout-controls-unit-input"
 							label={ __( 'Wide width' ) }
 							labelPosition="top"
 							value={ wideSize || contentSize || '' }
@@ -119,12 +121,12 @@ export default {
 								</InputControlPrefixWrapper>
 							}
 						/>
-						<p className="block-editor-hooks__layout-controls-helptext">
+						<p className="block-editor-hooks__layout-constrained-helptext">
 							{ __(
 								'Customize the width for all elements that are assigned to the center or wide columns.'
 							) }
 						</p>
-					</div>
+					</>
 				) }
 				{ allowJustification && (
 					<ToggleGroupControl
@@ -148,7 +150,7 @@ export default {
 						) }
 					</ToggleGroupControl>
 				) }
-			</>
+			</VStack>
 		);
 	},
 	toolBarControls: function DefaultLayoutToolbarControls( {


### PR DESCRIPTION
Prerequisite for #64526

## What?

Removes some excessive margin in the controls for the Layout block editor hook.

The following Core blocks use this hook:

- Column
- Post Content
- Post Template
- Query

## How?

The structure is reworked a bit for efficiency — see inline comments.

## Testing Instructions

Insert any of the affected blocks in the editor and see the block inspector. To enable the Justification control, it will be easiest to change this condition to `true`:

https://github.com/WordPress/gutenberg/blob/60d338fa48798475041b8be3252aed834e7900e8/packages/block-editor/src/layouts/constrained.js#L131

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/66f08fd0-471b-47bb-91fc-b45af1a27df2" alt="Cover block Layout controls, before" width="276">|<img src="https://github.com/user-attachments/assets/1417919b-653d-4f21-b9d7-c492b17a6185" alt="Cover block Layout controls, after" width="276">|