### PR TITLE
Remove unnecessary margin on Layout hook toggle

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -233,7 +233,6 @@ function LayoutPanelPure( {
 						<>
 							<ToggleControl
 								__nextHasNoMarginBottom
-								className="block-editor-hooks__toggle-control"
 								label={ __( 'Inner blocks use content width' ) }
 								checked={
 									layoutType?.name === 'constrained' ||

--- a/packages/block-editor/src/hooks/layout.scss
+++ b/packages/block-editor/src/hooks/layout.scss
@@ -17,7 +17,3 @@
 		margin-bottom: $grid-unit-10;
 	}
 }
-
-.block-editor-hooks__toggle-control.block-editor-hooks__toggle-control {
-	margin-bottom: $grid-unit-20;
-}


### PR DESCRIPTION
Stacked on #64526

## What?

Removes a margin override on the Layout hook toggle that will become unnecessary after #64526.

The following Core blocks use this hook:

- Column
- Post Content
- Post Template
- Query

## Testing Instructions

Insert any of the affected blocks in the editor and see the block inspector.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/f1bcbce9-5e12-4608-b377-17812a5c0831" alt="Layout hook toggle, before" width="276">|<img src="https://github.com/user-attachments/assets/42cb08bc-9b18-43f6-bd72-0236165bcaa2" alt="Layout hook toggle, after" width="276">|

No visual changes when the toggle is enabled:

<img src="https://github.com/user-attachments/assets/75202e33-07cd-4d4a-9d10-f8acdc9371ce" alt="Layout hook toggle" width="276">
