### PR TITLE
Interactivity API: Update iterable signals when `deepMerge()` adds new properties

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   Prevent calling `proxifyContext` over an already-proxified context inside `wp-context` ([#65090](https://github.com/WordPress/gutenberg/pull/65090)).
+-   Update iterable signals when `deepMerge()` adds new properties ([#65135](https://github.com/WordPress/gutenberg/pull/65135)).
 
 ## 6.7.0 (2024-09-05)
 

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -276,8 +276,11 @@ const deepMergeRecursive = (
 	override: boolean = true
 ) => {
 	if ( isPlainObject( target ) && isPlainObject( source ) ) {
+		let hasNewKeys = false;
 		for ( const key in source ) {
 			const isNew = ! ( key in target );
+			hasNewKeys = hasNewKeys || isNew;
+
 			const desc = Object.getOwnPropertyDescriptor( source, key );
 			if (
 				typeof desc?.get === 'function' ||
@@ -311,10 +314,10 @@ const deepMergeRecursive = (
 					propSignal.setValue( desc.value );
 				}
 			}
+		}
 
-			if ( isNew && objToIterable.has( target ) ) {
-				objToIterable.get( target )!.value++;
-			}
+		if ( hasNewKeys && objToIterable.has( target ) ) {
+			objToIterable.get( target )!.value++;
 		}
 	}
 };

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -374,5 +374,20 @@ describe( 'Interactivity API', () => {
 
 			expect( spy ).toHaveBeenCalledTimes( 3 );
 		} );
+
+		it( 'should update iterable signals when new keys are added', () => {
+			const target = proxifyState< any >( 'test', { a: 1, b: 2 } );
+			const source = { a: 1, b: 2, c: 3 };
+
+			const spy = jest.fn( () => Object.keys( target ) );
+			effect( spy );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+
+			deepMerge( target, source, false );
+
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( spy ).toHaveLastReturnedWith( [ 'a', 'b', 'c' ] );
+		} );
 	} );
 } );


### PR DESCRIPTION
## What?

Fixes `deepMerge()` to update the corresponding internal signals for property iteration (i.e., `...obj`, `Object.keys( obj )`, `Reflect.ownKeys( obj )`, etc.


## Why?

When a `deepMerge()` call adds new properties to an object, the corresponding `iterable` signal should be updated to ensure subscribed directives react to changes.
## How?

Modifying the corresponding signal for the target object when necessary.

## Testing Instructions

A unit test was added that didn't pass before the bug fix. 
