### PR TITLE
Add __next40pxDefaultSize for files in editor 3

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -428,8 +428,7 @@ export function HierarchicalTermSelector( { slug } ) {
 			{ ! loading && hasCreateAction && (
 				<FlexItem>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						onClick={ onToggleForm }
 						className="editor-post-taxonomies__hierarchical-terms-add"
 						aria-expanded={ showForm }

--- a/packages/editor/src/components/post-taxonomies/most-used-terms.js
+++ b/packages/editor/src/components/post-taxonomies/most-used-terms.js
@@ -62,8 +62,7 @@ export default function MostUsedTerms( { onSelect, taxonomy } ) {
 				{ terms.map( ( term ) => (
 					<li key={ term.id }>
 						<Button
-							// TODO: Switch to `true` (40px size) if possible
-							__next40pxDefaultSize={ false }
+							__next40pxDefaultSize
 							variant="link"
 							onClick={ () => onSelect( term ) }
 						>

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -36,6 +36,6 @@
 	}
 
 	.components-button {
-		font-size: 12px;
+		font-size: 13px;
 	}
 }

--- a/packages/editor/src/components/post-taxonomies/style.scss
+++ b/packages/editor/src/components/post-taxonomies/style.scss
@@ -34,8 +34,4 @@
 		display: inline-block;
 		margin-right: $grid-unit-10;
 	}
-
-	.components-button {
-		font-size: 13px;
-	}
 }

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -177,7 +177,8 @@ function PostTemplateDropdownContent( { onClose } ) {
 			{ canEdit && onNavigateToEntityRecord && (
 				<p>
 					<Button
-						__next40pxDefaultSize
+						// TODO: Switch to `true` (40px size) if possible
+						__next40pxDefaultSize={ false }
 						variant="link"
 						onClick={ () => {
 							onNavigateToEntityRecord( {

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -177,8 +177,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 			{ canEdit && onNavigateToEntityRecord && (
 				<p>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="link"
 						onClick={ () => {
 							onNavigateToEntityRecord( {

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -11,6 +11,7 @@ import {
 	Button,
 	__experimentalInputControl as InputControl,
 	__experimentalInputControlPrefixWrapper as InputControlPrefixWrapper,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
@@ -109,12 +110,14 @@ export default function PostURL( { onClose } ) {
 								</InputControlPrefixWrapper>
 							}
 							suffix={
-								<Button
-									__next40pxDefaultSize
-									icon={ copySmall }
-									ref={ copyButtonRef }
-									label={ __( 'Copy' ) }
-								/>
+								<InputControlSuffixWrapper variant="control">
+									<Button
+										icon={ copySmall }
+										ref={ copyButtonRef }
+										size="small"
+										label="Copy"
+									/>
+								</InputControlSuffixWrapper>
 							}
 							label={ __( 'Link' ) }
 							hideLabelFromVision

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -110,8 +110,7 @@ export default function PostURL( { onClose } ) {
 							}
 							suffix={
 								<Button
-									// TODO: Switch to `true` (40px size) if possible
-									__next40pxDefaultSize={ false }
+									__next40pxDefaultSize
 									icon={ copySmall }
 									ref={ copyButtonRef }
 									label={ __( 'Copy' ) }

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -71,8 +71,7 @@ export default function SavePublishPanels( {
 		unmountableContent = (
 			<div className="editor-layout__toggle-publish-panel">
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					variant="secondary"
 					className="editor-layout__toggle-publish-panel-button"
 					onClick={ togglePublishSidebar }
@@ -86,8 +85,7 @@ export default function SavePublishPanels( {
 		unmountableContent = (
 			<div className="editor-layout__toggle-entities-saved-states-panel">
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					variant="secondary"
 					className="editor-layout__toggle-entities-saved-states-panel-button"
 					onClick={ openEntitiesSavedStates }

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -73,7 +73,6 @@ export default function SavePublishPanels( {
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"
-					className="editor-layout__toggle-publish-panel-button"
 					onClick={ togglePublishSidebar }
 					aria-expanded={ false }
 				>
@@ -87,7 +86,6 @@ export default function SavePublishPanels( {
 				<Button
 					__next40pxDefaultSize
 					variant="secondary"
-					className="editor-layout__toggle-entities-saved-states-panel-button"
 					onClick={ openEntitiesSavedStates }
 					aria-expanded={ false }
 					disabled={ ! isDirty }


### PR DESCRIPTION
Part of - https://github.com/WordPress/gutenberg/issues/65018

## What?
Issue - https://github.com/WordPress/gutenberg/issues/65018, To use default to 40px for the button.


## Why?
To make the consistent button across Gutenberg, and we would have a lint rule added once fixed, all the button usage.


## How?
Add  __next40pxDefaultSize in button on the component.

## Testing Instructions
Screenshots added as comments in file changes

