### PR TITLE
Add __next40pxDefaultSize for files in editor 4

### DIFF
--- a/packages/editor/src/components/start-template-options/index.js
+++ b/packages/editor/src/components/start-template-options/index.js
@@ -156,8 +156,7 @@ function StartModal( { slug, isCustom, onClose, postType } ) {
 			>
 				<FlexItem>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ onClose }
 					>

--- a/packages/editor/src/components/table-of-contents/index.js
+++ b/packages/editor/src/components/table-of-contents/index.js
@@ -30,8 +30,7 @@ function TableOfContents(
 			contentClassName="table-of-contents__popover"
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					__next40pxDefaultSize
 					{ ...props }
 					ref={ ref }
 					onClick={ hasBlocks ? onToggle : undefined }

--- a/packages/editor/src/components/text-editor/index.js
+++ b/packages/editor/src/components/text-editor/index.js
@@ -40,8 +40,7 @@ export default function TextEditor( { autoFocus = false } ) {
 				<div className="editor-text-editor__toolbar">
 					<h2>{ __( 'Editing code' ) }</h2>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ () => switchEditorMode( 'visual' ) }
 						shortcut={ shortcut }

--- a/packages/editor/src/components/text-editor/style.scss
+++ b/packages/editor/src/components/text-editor/style.scss
@@ -63,7 +63,7 @@
 	}
 
 	h2 {
-		line-height: $button-size;
+		line-height: $button-size-next-default-40px;
 		margin: 0 auto 0 0;
 		font-size: $default-font-size;
 		color: $gray-900;

--- a/packages/editor/src/dataviews/actions/reset-post.tsx
+++ b/packages/editor/src/dataviews/actions/reset-post.tsx
@@ -114,8 +114,7 @@ const resetPost: Action< Post > = {
 				</Text>
 				<HStack justify="right">
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ closeModal }
 						disabled={ isBusy }
@@ -124,8 +123,7 @@ const resetPost: Action< Post > = {
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="primary"
 						onClick={ async () => {
 							setIsBusy( true );

--- a/packages/editor/src/dataviews/actions/trash-post.tsx
+++ b/packages/editor/src/dataviews/actions/trash-post.tsx
@@ -67,8 +67,7 @@ const trashPost: Action< PostWithPermissions > = {
 				</Text>
 				<HStack justify="right">
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="tertiary"
 						onClick={ closeModal }
 						disabled={ isBusy }
@@ -77,8 +76,7 @@ const trashPost: Action< PostWithPermissions > = {
 						{ __( 'Cancel' ) }
 					</Button>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="primary"
 						onClick={ async () => {
 							setIsBusy( true );


### PR DESCRIPTION
Part of - https://github.com/WordPress/gutenberg/issues/65018

## What?
Issue - https://github.com/WordPress/gutenberg/issues/65018, To use default to 40px for the button.

## Why?
To make the consistent button across Gutenberg, and we would have a lint rule added once fixed, all the button usage.

## How?
Change from __next40pxDefaultSize={ false } to __next40pxDefaultSize on component.


