### PR TITLE
Preferences: Fix back button on mobile

### DIFF
--- a/packages/preferences/src/components/preferences-modal-tabs/index.js
+++ b/packages/preferences/src/components/preferences-modal-tabs/index.js
@@ -110,7 +110,7 @@ export default function PreferencesModalTabs( { sections } ) {
 									return (
 										<NavigatorButton
 											key={ tab.name }
-											path={ tab.name }
+											path={ `/${ tab.name }` }
 											as={ Item }
 											isAction
 										>
@@ -142,7 +142,7 @@ export default function PreferencesModalTabs( { sections } ) {
 						return (
 							<NavigatorScreen
 								key={ `${ section.name }-menu` }
-								path={ section.name }
+								path={ `/${ section.name }` }
 							>
 								<Card isBorderless size="large">
 									<CardHeader


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65109

Fix the back button in the Preferences modal on mobile by ensuring that the paths use a `/` prefix. Kudos @t-hamano for investigating (https://github.com/WordPress/gutenberg/issues/65109#issuecomment-2336739858) and getting to the bottom of the issue and finding a neat fix.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It turns out that the backwards navigation requires a `/` in order to work properly. As Aki found in the issue, here is a comment making that concept explicit: https://github.com/WordPress/gutenberg/pull/63317/files#r1718790198

Prior to this PR the back button in the preferences modal wasn't doing anything in mobile viewport sizes. With this PR applied, it should be fixed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `/` prefixes to the paths used in the modal, for both the tabs and the navigation screen.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* With this PR applied, open up the block editor preferences using a mobile viewport
* Try moving through each of the tabs, and use the back button at the top of the navigation screen to get back to the parent screen
* It should all be working correctly with this PR applied

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/db83f773-cd3e-472d-921a-7dea75a4c2a9

### After

https://github.com/user-attachments/assets/b0c77a33-0e9b-4568-bc77-6bb11b9149ce



