### PR TITLE
Drag and Drop: When dragging a mix of video, audio, and image blocks, create individual blocks as appropriate

### DIFF
--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -24,50 +24,29 @@ const transforms = {
 					const blobURL = createBlobURL( file );
 
 					// File will be uploaded in componentDidMount()
-					blocks.push(
-						createBlock( 'core/file', {
-							blob: blobURL,
-							fileName: file.name,
-						} )
-					);
-				} );
-
-				return blocks;
-			},
-		},
-		{
-			type: 'files',
-			isMatch( files ) {
-				return (
-					files.length > 0 &&
-					files.every(
-						( file ) =>
-							file.type.startsWith( 'video' ) ||
-							file.type.startsWith( 'image/' ) ||
-							file.type.startsWith( 'audio/' )
-					)
-				);
-			},
-			transform( files ) {
-				const blocks = [];
-
-				files.forEach( ( file ) => {
 					if ( file.type.startsWith( 'video/' ) ) {
 						blocks.push(
 							createBlock( 'core/video', {
-								src: createBlobURL( file ),
+								blob: createBlobURL( file ),
 							} )
 						);
 					} else if ( file.type.startsWith( 'image/' ) ) {
 						blocks.push(
 							createBlock( 'core/image', {
-								url: createBlobURL( file ),
+								blob: createBlobURL( file ),
 							} )
 						);
 					} else if ( file.type.startsWith( 'audio/' ) ) {
 						blocks.push(
 							createBlock( 'core/audio', {
-								src: createBlobURL( file ),
+								blob: createBlobURL( file ),
+							} )
+						);
+					} else {
+						blocks.push(
+							createBlock( 'core/file', {
+								blob: blobURL,
+								fileName: file.name,
 							} )
 						);
 					}

--- a/packages/block-library/src/file/transforms.js
+++ b/packages/block-library/src/file/transforms.js
@@ -36,6 +36,47 @@ const transforms = {
 			},
 		},
 		{
+			type: 'files',
+			isMatch( files ) {
+				return (
+					files.length > 0 &&
+					files.every(
+						( file ) =>
+							file.type.startsWith( 'video' ) ||
+							file.type.startsWith( 'image/' ) ||
+							file.type.startsWith( 'audio/' )
+					)
+				);
+			},
+			transform( files ) {
+				const blocks = [];
+
+				files.forEach( ( file ) => {
+					if ( file.type.startsWith( 'video/' ) ) {
+						blocks.push(
+							createBlock( 'core/video', {
+								src: createBlobURL( file ),
+							} )
+						);
+					} else if ( file.type.startsWith( 'image/' ) ) {
+						blocks.push(
+							createBlock( 'core/image', {
+								url: createBlobURL( file ),
+							} )
+						);
+					} else if ( file.type.startsWith( 'audio/' ) ) {
+						blocks.push(
+							createBlock( 'core/audio', {
+								src: createBlobURL( file ),
+							} )
+						);
+					}
+				} );
+
+				return blocks;
+			},
+		},
+		{
 			type: 'block',
 			blocks: [ 'core/audio' ],
 			transform: ( attributes ) => {

--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -3,9 +3,6 @@
  */
 import { createBlobURL, isBlobURL } from '@wordpress/blob';
 import { createBlock, getBlockAttributes } from '@wordpress/blocks';
-import { dispatch } from '@wordpress/data';
-import { store as noticesStore } from '@wordpress/notices';
-import { __ } from '@wordpress/i18n';
 
 export function stripFirstImage( attributes, { shortcode } ) {
 	const { body } = document.implementation.createHTMLDocument( '' );
@@ -138,26 +135,6 @@ const transforms = {
 			// creating a new gallery.
 			type: 'files',
 			isMatch( files ) {
-				// The following check is intended to catch non-image files when dropped together with images.
-				if (
-					files.some(
-						( file ) => file.type.indexOf( 'image/' ) === 0
-					) &&
-					files.some(
-						( file ) => file.type.indexOf( 'image/' ) !== 0
-					)
-				) {
-					const { createErrorNotice } = dispatch( noticesStore );
-					createErrorNotice(
-						__(
-							'If uploading to a gallery all files need to be image formats'
-						),
-						{
-							id: 'gallery-transform-invalid-file',
-							type: 'snackbar',
-						}
-					);
-				}
 				return files.every(
 					( file ) => file.type.indexOf( 'image/' ) === 0
 				);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #65074, and follow-up to: https://github.com/WordPress/gutenberg/pull/65030

Allow dragging a mix of File, Audio, and Image blocks onto the editor canvas to create one of each block as appropriate.

This PR borrows the approach used by @swissspidy in the media-experiments plugin, as suggested in this comment: https://github.com/WordPress/gutenberg/pull/65030#issuecomment-2328277913

> Can't we just make it work? I find these notices very annoying and unnecessary when we could actually make it work.
> Here's how I solved it in my project:
https://github.com/swissspidy/media-experiments/blob/b1d0910bec2835158f31e971702393117889055b/packages/editor/src/transforms/index.ts
> When you drop e.g. an audio file, image and a video at the same time, it will insert an audio block, image block, and a > video block. Anything else could be a file block.

The approach here differs slightly from that link, as here we can combine the logic with the fallback transform of the File block, since we're not working in a plugin.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently if you attempt to drag a mix of file types, you'll wind up with a File block for each file type. It's likely that a user dragging a mix of media files would expect media blocks to be in use rather than File blocks which are typically used to allow visitors to download the original file.

This PR proposes allowing image, video, and audio blocks to be created where appropriate, while still falling back to File blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Update the fallback transform for the File block for handling multiple files being dragged and dropped to attempt to create Image, Video, and Audio blocks where appropriate
* Remove one of the warnings about dragging non image blocks into the Gallery block (within one of the Image transforms). This error notice was a little greedier than desired as it'd show up when dragging mixed blocks outside of a Gallery block. Since the usefulness of the error notice is debatable, this PR errs on the side of showing it less frequently.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Try dragging a mix of video, audio, and image files from your computer's desktop onto an empty post / empty paragraph block
* Note that in `trunk` it'll just create a bunch of File blocks
* With this PR applied, it should create the appropriate blocks for each file dragged, including the File block if one of the files isn't an image, video, or audio file (I used a simple text file as the example in my testing)
* Double-check that other kinds of media dragging (e.g. single or multiple images into Image and Gallery blocks) continues to function correctly.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/37890e4a-025b-4cfa-9777-3bfa1d90e5a0


