### PR TITLE
Media placeholders: Add "drag" to the text.

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -323,15 +323,15 @@ export function MediaPlaceholder( {
 
 				if ( isAudio ) {
 					instructions = __(
-						'Upload an audio file, pick one from your media library, or add one with a URL.'
+						'Upload or drag an audio file here, or pick one from your library.'
 					);
 				} else if ( isImage ) {
 					instructions = __(
-						'Upload an image file, pick one from your media library, or add one with a URL.'
+						'Upload or drag an image file here, or pick one from your library.'
 					);
 				} else if ( isVideo ) {
 					instructions = __(
-						'Upload a video file, pick one from your media library, or add one with a URL.'
+						'Upload or drag a video file here, or pick one from your library.'
 					);
 				}
 			}

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -393,7 +393,7 @@ export function ImageEdit( {
 				instructions={
 					! lockUrlControls &&
 					__(
-						'Upload an image file, pick one from your media library, or add one with a URL.'
+						'Upload or drag an image file here, or pick one from your library.'
 					)
 				}
 				style={ {


### PR DESCRIPTION
## What?

The current Image block placeholder text reads this:

> Upload an image file, pick one from your media library, or add one with a URL.

There's very similar text for Audio and Video. Screenshots:

![image](https://github.com/user-attachments/assets/9a54e374-13b5-49e5-9441-d95cdca77f14)

![audio](https://github.com/user-attachments/assets/52677bde-5b26-4543-97f5-672f75cc2e93)

![video](https://github.com/user-attachments/assets/dafcc604-d1c9-4bb8-afd8-4aa09b84db8c)

The fact that you can drag an image, video, or audio file from anywhere, your desktop or the media tab in the inserter, is not clear from this text, yet is arguably a more important affordance than that of adding images via a URL. Since the third button already says "Insert from URL", we can potentially omit that part, both simplifying the overall text, and include that you can drag media. Suggested text:

> Upload or drag an audio file here, or pick one from your library.

Screenshot:

![after](https://github.com/user-attachments/assets/cdf7e5b9-3848-4205-a70b-fb036510ef11)

![after2](https://github.com/user-attachments/assets/5e4d6810-dc90-4e8e-ad47-cd6b1a8a2dfc)

## Testing Instructions

Insert image, video, and audio blocks in their empty state, in a wide desktop context, and observe the updated text.