### PR TITLE
Block Editor: Remove reset styles RTL from the iframe

### DIFF
--- a/packages/block-editor/src/components/iframe/get-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/get-compatibility-styles.js
@@ -40,7 +40,12 @@ export function getCompatibilityStyles() {
 			// Don't try to add the reset styles, which were removed as a dependency
 			// from `edit-blocks` for the iframe since we don't need to reset admin
 			// styles.
-			if ( ownerNode.id === 'wp-reset-editor-styles-css' ) {
+			if (
+				[
+					'wp-reset-editor-styles-css',
+					'wp-reset-editor-styles-rtl-css',
+				].includes( ownerNode.id )
+			) {
 				return accumulator;
 			}
 


### PR DESCRIPTION
## What?
Fixes #65137.
Similar to #33204.

PR adds `wp-reset-editor-styles-rtl-css` to the ignored compatibility styles list.

## Why?
The iframed editors don't need to reset admin styles. The RTL file was missing from the original fix.

## Testing Instructions
1. Install RTL Tester plugin - https://wordpress.org/plugins/rtl-tester/.
2. Switch to RTL from the admin menu bar.
3. Open a post.
4. Confirm that the warning is no longer logged.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-09-09 at 15 43 57](https://github.com/user-attachments/assets/2ba64c8e-caff-4667-8ad4-cbf123f37131)
