### PR TITLE
Block Bindings: Prioritize existing `placeholder` over `bindingsPlaceholder`

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -334,7 +334,7 @@ export function RichTextWrapper(
 		selectionStart,
 		selectionEnd,
 		onSelectionChange,
-		placeholder: bindingsPlaceholder || placeholder,
+		placeholder: placeholder || bindingsPlaceholder,
 		__unstableIsSelected: isSelected,
 		__unstableDisableFormats: disableFormats,
 		preserveWhiteSpace,
@@ -406,7 +406,7 @@ export function RichTextWrapper(
 				aria-readonly={ shouldDisableEditing }
 				{ ...props }
 				aria-label={
-					bindingsPlaceholder || props[ 'aria-label' ] || placeholder
+					props[ 'aria-label' ] || placeholder || bindingsPlaceholder
 				}
 				{ ...autocompleteProps }
 				ref={ useMergeRefs( [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Respect existing `placeholder` attribute when it exists over the one provided by the Block Bindings API.

## Why?

We're setting a more helpful placeholder if the block has bindings. While that's awesome and works as intended most of the time, if the block already has an existing placeholder, that value is lost, but it should've been prioritized.

## How?

Prioritize `placeholder` in the applicable places (`placeholder` and `aria-label`.)

## Testing Instructions

Register a new post meta field on the server:

```php
add_action(
	'init',
	function () {
		register_meta(
			'post',
			'details',
			array(
				'type'         => 'string',
				'show_in_rest' => true,
				'single'       => true,
				'default'      => '',
			)
		);
	}
);
```

In Gutenberg...
1. define a placeholder for a Paragraph block, then bind the attribute.
2. create a new Paragraph block and bind the attribute.

The result should match the screenshot below.

Side note: The 2nd paragraph is empty because the value returned from the server is an empty string. I'm not sure that's intended, but that's what we have right now in `trunk`. 🤔 I'm also unable to edit the value, which is weird considering recently we've fixed a similar bug.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/2a660018-33f6-4cdd-ac5b-e9b5e83a137d)
