### PR TITLE
Upgrade Playwright to v1.47

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.46.0",
+				"@playwright/test": "1.47.0",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -6950,12 +6950,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
-			"integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
+			"integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.46.0"
+				"playwright": "1.47.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41081,12 +41081,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
-			"integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
+			"integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.46.0"
+				"playwright-core": "1.47.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41099,9 +41099,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
-			"integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
+			"integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -54834,7 +54834,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.46.0",
+				"@playwright/test": "^1.47.0",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
@@ -60247,12 +60247,12 @@
 			}
 		},
 		"@playwright/test": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.46.0.tgz",
-			"integrity": "sha512-/QYft5VArOrGRP5pgkrfKksqsKA6CEFyGQ/gjNe6q0y4tZ1aaPfq4gIjudr1s3D+pXyrPRdsy4opKDrjBabE5w==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
+			"integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
 			"dev": true,
 			"requires": {
-				"playwright": "1.46.0"
+				"playwright": "1.47.0"
 			}
 		},
 		"@pmmmwh/react-refresh-webpack-plugin": {
@@ -87571,19 +87571,19 @@
 			"dev": true
 		},
 		"playwright": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.46.0.tgz",
-			"integrity": "sha512-XYJ5WvfefWONh1uPAUAi0H2xXV5S3vrtcnXe6uAOgdGi3aSpqOSXX08IAjXW34xitfuOJsvXU5anXZxPSEQiJw==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
+			"integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
 			"dev": true,
 			"requires": {
 				"fsevents": "2.3.2",
-				"playwright-core": "1.46.0"
+				"playwright-core": "1.47.0"
 			}
 		},
 		"playwright-core": {
-			"version": "1.46.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.46.0.tgz",
-			"integrity": "sha512-9Y/d5UIwuJk8t3+lhmMSAJyNP1BUC/DqP3cQJDQQL/oWqAiuPTLgy7Q5dzglmTLwcBRdetzgNM/gni7ckfTr6A==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
+			"integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
 			"dev": true
 		},
 		"please-upgrade-node": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.46.0",
+		"@playwright/test": "1.47.0",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -94,7 +94,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.46.0",
+		"@playwright/test": "^1.47.0",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.47

## What's new?
https://playwright.dev/docs/release-notes#version-147

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.