### PR TITLE
Editor topbar: reorder the actions on the right

### DIFF
--- a/packages/edit-widgets/src/components/header/index.js
+++ b/packages/edit-widgets/src/components/header/index.js
@@ -61,8 +61,8 @@ function Header() {
 					) }
 				</div>
 				<div className="edit-widgets-header__actions">
-					<SaveButton />
 					<PinnedItems.Slot scope="core/edit-widgets" />
+					<SaveButton />
 					<MoreMenu />
 				</div>
 			</div>

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -74,11 +74,11 @@ function Editor( {
 					<EditorInterface { ...props }>
 						{ extraContent }
 					</EditorInterface>
+					{ children }
 					<Sidebar
 						onActionPerformed={ onActionPerformed }
 						extraPanels={ extraSidebarPanels }
 					/>
-					{ children }
 				</ExperimentalEditorProvider>
 			) }
 		</>

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -142,6 +142,9 @@ function Header( {
 					forceIsAutosaveable={ forceIsDirty }
 				/>
 				<PostViewLink />
+				{ ( isWideViewport || ! showIconLabels ) && (
+					<PinnedItems.Slot scope="core" />
+				) }
 				{ ! customSaveButton && (
 					<PostPublishButtonOrToggle
 						forceIsDirty={ forceIsDirty }
@@ -151,9 +154,6 @@ function Header( {
 					/>
 				) }
 				{ customSaveButton }
-				{ ( isWideViewport || ! showIconLabels ) && (
-					<PinnedItems.Slot scope="core" />
-				) }
 				<MoreMenu />
 			</motion.div>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Addresses part of #64339

Moves the Save/Publish buttons to the right of the Settings and Global Styles (pinned items) buttons.

Also reorders the Global Styles and Settings buttons, though I'm not sure how reliable this is when plugins register items (see the comment), so I'm still experimenting and looking for feedback on that change.

## Why?
As mentioned in the issue, the way the buttons change order can be confusing for users

## How?
Swap some lines of code around

## Testing Instructions
Test the Post, Site, or Widget editors

1. Open the editor
2. Observe that the Publish / Save button is now the penultimate item in the topbar 
3. In the site editor, observe the global styles sidebar toggle is before the settings sidebar toggle

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="272" alt="Screenshot 2024-09-09 at 4 55 56 PM" src="https://github.com/user-attachments/assets/6dea34f6-b078-4b82-a189-dddb8270a3d4">

#### After
<img width="268" alt="Screenshot 2024-09-09 at 5 35 30 PM" src="https://github.com/user-attachments/assets/440a7548-2e82-40aa-ba41-a4b32455c7e2">

