### PR TITLE
Create Block: Update the minimum required PHP version to 7.2

### DIFF
--- a/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-interactive-template/plugin-templates/$slug.php.mustache
@@ -9,7 +9,7 @@
 {{/description}}
  * Version:           {{version}}
  * Requires at least: 6.6
- * Requires PHP:      7.0
+ * Requires PHP:      7.2
 {{#author}}
  * Author:            {{author}}
 {{/author}}

--- a/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
+++ b/packages/create-block-tutorial-template/plugin-templates/$slug.php.mustache
@@ -9,7 +9,7 @@
 {{/description}}
  * Version:           {{version}}
  * Requires at least: 6.6
- * Requires PHP:      7.0
+ * Requires PHP:      7.2
 {{#author}}
  * Author:            {{author}}
 {{/author}}

--- a/packages/create-block/lib/templates/es5/$slug.php.mustache
+++ b/packages/create-block/lib/templates/es5/$slug.php.mustache
@@ -8,7 +8,7 @@
  * Description:       {{description}}
 {{/description}}
  * Requires at least: 6.6
- * Requires PHP:      7.0
+ * Requires PHP:      7.2
  * Version:           {{version}}
 {{#author}}
  * Author:            {{author}}

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -8,7 +8,7 @@
  * Description:       {{description}}
 {{/description}}
  * Requires at least: 6.6
- * Requires PHP:      7.0
+ * Requires PHP:      7.2
  * Version:           {{version}}
 {{#author}}
  * Author:            {{author}}


### PR DESCRIPTION
## What?
PR updates required PHP versions set in `create-block` templates.

See: https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/
See: https://github.com/WordPress/gutenberg/pull/64920#issuecomment-2338518850

## Testing Instructions
Check that the new PHP versions provided match WP standards.