### PR TITLE
Editor: Optimize global styles permission check

### DIFF
--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -146,13 +146,17 @@ function useGlobalStylesUserConfig() {
 
 function useGlobalStylesBaseConfig() {
 	const baseConfig = useSelect( ( select ) => {
-		const { __experimentalGetCurrentThemeBaseGlobalStyles, canUser } =
-			select( coreStore );
+		const {
+			__experimentalGetCurrentThemeBaseGlobalStyles,
+			getCurrentTheme,
+			canUser,
+		} = select( coreStore );
+		const currentTheme = getCurrentTheme();
 
-		return (
-			canUser( 'read', { kind: 'root', name: 'theme' } ) &&
-			__experimentalGetCurrentThemeBaseGlobalStyles()
-		);
+		return currentTheme &&
+			canUser( 'read', 'global-styles/themes', currentTheme.stylesheet )
+			? __experimentalGetCurrentThemeBaseGlobalStyles()
+			: undefined;
 	}, [] );
 
 	return [ !! baseConfig, baseConfig ];


### PR DESCRIPTION
## What?
This is a follow-up to https://github.com/WordPress/gutenberg/pull/63812#issuecomment-2257985875.

PR updates the `useGlobalStylesBaseConfig` hook to use the correct REST API resource to check read permissions for the current theme's global styles.

## Why?
Making an `OPTIONS` request to the `/themes` endpoint was expensive and incorrect. Using REST API paths is still the best way to check permissions for non-entity resources.

Hopefully, this will improve "navigate site editor" metrics.

## Testing Instructions
1. Check that global styles are still loaded correctly for admin users.
2. Switch to author user role.
3. Create a post.
4. Confirm there are no 403 network errors in the DevTools console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2024-09-10 at 08 05 00](https://github.com/user-attachments/assets/565d22d9-8c08-45f6-9a66-b1bb04f09c7e)

**After**
![CleanShot 2024-09-10 at 08 04 13](https://github.com/user-attachments/assets/97945ef1-9e2d-4b44-a9a1-2c05c8e6a18b)