### PR TITLE
Fix unintentional block toolbar shadow.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -70,8 +70,11 @@
 	// Raise the specificity.
 	&.components-accessible-toolbar {
 		border: none;
-		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 		border-radius: 0;
+	}
+
+	&.is-unstyled {
+		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	}
 
 	.block-editor-block-toolbar {


### PR DESCRIPTION
## What?

Followup to #64277. That introduced an unintentional drop shadow under the block toolbar:

![before](https://github.com/user-attachments/assets/3ccb35e3-bea8-4826-9f36-8f3810c7e224)

This one removes it again:

![after](https://github.com/user-attachments/assets/d4862941-e936-4d7b-be47-792179b3b450)


## Testing Instructions

Test the block toolbar, observe no drop shadow under it. Test the top toolbar, observe no blurry edge.