### PR TITLE
Compose: Correctly call timer cleanup in 'useFocusOnMount'

### DIFF
--- a/packages/compose/src/hooks/use-focus-on-mount/index.js
+++ b/packages/compose/src/hooks/use-focus-on-mount/index.js
@@ -64,19 +64,17 @@ export default function useFocusOnMount( focusOnMount = 'firstElement' ) {
 			return;
 		}
 
-		if ( focusOnMountRef.current === 'firstElement' ) {
-			timerIdRef.current = setTimeout( () => {
-				const firstTabbable = focus.tabbable.find( node )[ 0 ];
-
-				if ( firstTabbable ) {
-					setFocus( firstTabbable );
-				}
-			}, 0 );
-
+		if ( focusOnMountRef.current !== 'firstElement' ) {
+			setFocus( node );
 			return;
 		}
 
-		setFocus( node );
+		timerIdRef.current = setTimeout( () => {
+			const firstTabbable = focus.tabbable.find( node )[ 0 ];
+			if ( firstTabbable ) {
+				setFocus( firstTabbable );
+			}
+		}, 0 );
 
 		return () => {
 			if ( timerIdRef.current ) {


### PR DESCRIPTION
## What?
PR updates the `useFocusOnMount` to call the correct cleanup after scheduling a timer.

## Why?
The timer cleanup was never called due to an early return statement. I missed this when working on the previous fix - #62053 😓 

## Testing Instructions
CI checks should be green.

### Testing Instructions for Keyboard
Same.