### PR TITLE
Add block sidebar toggle to block settings menu

### DIFF
--- a/packages/editor/src/hooks/block-settings-inspector-toggle.js
+++ b/packages/editor/src/hooks/block-settings-inspector-toggle.js
@@ -19,7 +19,7 @@ import { drawerLeft, drawerRight } from '@wordpress/icons';
  *
  * @return {Component} Wrapped component.
  */
-const withBlockToolbar = createHigherOrderComponent(
+const withBlockSettingsInspectorToggle = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
 		return (
 			<>
@@ -28,7 +28,7 @@ const withBlockToolbar = createHigherOrderComponent(
 			</>
 		);
 	},
-	'withBlockToolbar'
+	'withBlockSettingsInspectorToggle'
 );
 
 const BlockInspectorToggle = () => {
@@ -59,5 +59,5 @@ const BlockInspectorToggle = () => {
 addFilter(
 	'editor.BlockEdit',
 	'core/editor/with-block-settings-inspector-toggle',
-	withBlockToolbar
+	withBlockSettingsInspectorToggle
 );

--- a/packages/editor/src/hooks/block-settings-inspector-toggle.js
+++ b/packages/editor/src/hooks/block-settings-inspector-toggle.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { addFilter } from '@wordpress/hooks';
+import { createHigherOrderComponent } from '@wordpress/compose';
+import { __unstableBlockSettingsMenuFirstItem as BlockSettingsMenuFirstItem } from '@wordpress/block-editor';
+import { MenuItem } from '@wordpress/components';
+import { store as interfaceStore } from '@wordpress/interface';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, isRTL } from '@wordpress/i18n';
+import { drawerLeft, drawerRight } from '@wordpress/icons';
+
+/**
+ * Override the default edit UI to include a new block inspector control for
+ * assigning a partial syncing controls to supported blocks in the pattern editor.
+ * Currently, only the `core/paragraph` block is supported.
+ *
+ * @param {Component} BlockEdit Original component.
+ *
+ * @return {Component} Wrapped component.
+ */
+const withBlockToolbar = createHigherOrderComponent(
+	( BlockEdit ) => ( props ) => {
+		return (
+			<>
+				<BlockEdit key="edit" { ...props } />
+				{ props.isSelected && <BlockInspectorToggle /> }
+			</>
+		);
+	},
+	'withBlockToolbar'
+);
+
+const BlockInspectorToggle = () => {
+	const { enableComplementaryArea } = useDispatch( interfaceStore );
+
+	const isOpen = useSelect(
+		( select ) =>
+			select( interfaceStore ).getActiveComplementaryArea( 'core' ) ===
+			'edit-post/block',
+		[]
+	);
+
+	return (
+		<BlockSettingsMenuFirstItem>
+			<MenuItem
+				onClick={ () => {
+					enableComplementaryArea( 'core', 'edit-post/block' );
+				} }
+				icon={ isRTL() ? drawerLeft : drawerRight }
+				disabled={ isOpen }
+			>
+				{ __( 'Open Block settings' ) }
+			</MenuItem>
+		</BlockSettingsMenuFirstItem>
+	);
+};
+
+addFilter(
+	'editor.BlockEdit',
+	'core/editor/with-block-settings-inspector-toggle',
+	withBlockToolbar
+);

--- a/packages/editor/src/hooks/block-settings-inspector-toggle.js
+++ b/packages/editor/src/hooks/block-settings-inspector-toggle.js
@@ -48,7 +48,7 @@ const BlockInspectorToggle = () => {
 					enableComplementaryArea( 'core', 'edit-post/block' );
 				} }
 				icon={ isRTL() ? drawerLeft : drawerRight }
-				disabled={ isOpen }
+				aria-disabled={ isOpen }
 			>
 				{ __( 'Open Block settings' ) }
 			</MenuItem>

--- a/packages/editor/src/hooks/block-settings-inspector-toggle.js
+++ b/packages/editor/src/hooks/block-settings-inspector-toggle.js
@@ -50,7 +50,7 @@ const BlockInspectorToggle = () => {
 				icon={ isRTL() ? drawerLeft : drawerRight }
 				aria-disabled={ isOpen }
 			>
-				{ __( 'Open Block settings' ) }
+				{ __( 'Block settings' ) }
 			</MenuItem>
 		</BlockSettingsMenuFirstItem>
 	);

--- a/packages/editor/src/hooks/block-settings-inspector-toggle.js
+++ b/packages/editor/src/hooks/block-settings-inspector-toggle.js
@@ -11,9 +11,8 @@ import { __, isRTL } from '@wordpress/i18n';
 import { drawerLeft, drawerRight } from '@wordpress/icons';
 
 /**
- * Override the default edit UI to include a new block inspector control for
- * assigning a partial syncing controls to supported blocks in the pattern editor.
- * Currently, only the `core/paragraph` block is supported.
+ * Override the default edit UI to include a new block options menu item
+ * to toggle the block's inspector controls open.
  *
  * @param {Component} BlockEdit Original component.
  *

--- a/packages/editor/src/hooks/index.js
+++ b/packages/editor/src/hooks/index.js
@@ -5,3 +5,4 @@ import './custom-sources-backwards-compatibility';
 import './default-autocompleters';
 import './media-upload';
 import './pattern-overrides';
+import './block-settings-inspector-toggle';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds ability to access Block Inspector Controls sidebar from block settings menu.

Alternative / complementary to https://github.com/WordPress/gutenberg/pull/65118

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/pull/65118 it's very difficult for users to find the block sidebar.

This is one step towards making that easier again as suggested by @mtias in https://github.com/WordPress/gutenberg/pull/65118#issuecomment-2336399332.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds as first item in block setitngs dropdown. Disables if the sidebar is already opened.

Note I tried removing the menu item if the toggle is open but the experience seemed quite jarring as the menu remains open even after you toggle it resulting in the item you just clicked being removed from the dropdown menu.

<details>
<summary>Video showing remove on click</summary>

https://github.com/user-attachments/assets/d8e4a406-a90d-4158-a477-4660effe3914

</details>




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Please ensure you read the `How` section above.

- Select block
- Click on block settings 
- See new menu item as first option
- Click to see block sidebar opened

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Same instructions as above but use keyboard to navigate. 

Must ensure that focus is logical and no focus losses occur.



## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/523e96cb-bab3-4a03-a7fb-c2cad54a41ec

