### PR TITLE
Fix some docblock types related to the Template Registration API

### DIFF
--- a/backport-changelog/6.7/7125.md
+++ b/backport-changelog/6.7/7125.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/7125
 
 * https://github.com/WordPress/gutenberg/pull/61577
 * https://github.com/WordPress/gutenberg/pull/64610
+* https://github.com/WordPress/gutenberg/pull/65187

--- a/backport-changelog/6.7/7125.md
+++ b/backport-changelog/6.7/7125.md
@@ -2,4 +2,3 @@ https://github.com/WordPress/wordpress-develop/pull/7125
 
 * https://github.com/WordPress/gutenberg/pull/61577
 * https://github.com/WordPress/gutenberg/pull/64610
-* https://github.com/WordPress/gutenberg/pull/65187

--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -32,7 +32,7 @@ if ( ! function_exists( 'wp_unregister_block_template' ) ) {
 	 * Unregister a template.
 	 *
 	 * @param string $template_name Template name in the form of `plugin_uri//template_name`.
-	 * @return WP_Block_Template|WP_Error The registered template object on success, WP_Error object on failure or if
+	 * @return WP_Block_Template|WP_Error The unregistered template object on success, WP_Error object on failure or if
 	 *                                    the template doesn't exist.
 	 */
 	function wp_unregister_block_template( $template_name ) {

--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -10,7 +10,6 @@ if ( ! function_exists( 'wp_register_block_template' ) ) {
 	 * Register a template.
 	 *
 	 * @param string       $template_name  Template name in the form of `plugin_uri//template_name`.
-	 * @param array|string $args           Object type or array of object types with which the taxonomy should be associated.
 	 * @param array|string $args           {
 	 *     @type string        $title                 Optional. Title of the template as it will be shown in the Site Editor
 	 *                                                and other UI elements.
@@ -33,7 +32,7 @@ if ( ! function_exists( 'wp_unregister_block_template' ) ) {
 	 * Unregister a template.
 	 *
 	 * @param string $template_name Template name in the form of `plugin_uri//template_name`.
-	 * @return true|WP_Error True on success, WP_Error on failure or if the template doesn't exist.
+	 * @return WP_Block_Template|WP_Error True on success, WP_Error on failure or if the template doesn't exist.
 	 */
 	function wp_unregister_block_template( $template_name ) {
 		return WP_Block_Templates_Registry::get_instance()->unregister( $template_name );

--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -32,7 +32,8 @@ if ( ! function_exists( 'wp_unregister_block_template' ) ) {
 	 * Unregister a template.
 	 *
 	 * @param string $template_name Template name in the form of `plugin_uri//template_name`.
-	 * @return WP_Block_Template|WP_Error True on success, WP_Error on failure or if the template doesn't exist.
+	 * @return WP_Block_Template|WP_Error The registered template object on success, WP_Error object on failure or if
+	 *                                    the template doesn't exist.
 	 */
 	function wp_unregister_block_template( $template_name ) {
 		return WP_Block_Templates_Registry::get_instance()->unregister( $template_name );

--- a/lib/compat/wordpress-6.7/class-wp-block-templates-registry.php
+++ b/lib/compat/wordpress-6.7/class-wp-block-templates-registry.php
@@ -36,7 +36,7 @@ if ( ! class_exists( 'WP_Block_Templates_Registry' ) ) {
 		 *
 		 * @param string $template_name Template name including namespace.
 		 * @param array  $args          Optional. Array of template arguments.
-		 * @return WP_Block_Template|WP_Error The registered template on success, or false on failure.
+		 * @return WP_Block_Template|WP_Error The registered template on success, or WP_Error on failure.
 		 */
 		public function register( $template_name, $args = array() ) {
 
@@ -100,7 +100,7 @@ if ( ! class_exists( 'WP_Block_Templates_Registry' ) ) {
 		 *
 		 * @since 6.7.0
 		 *
-		 * @return WP_Block_Template[]|false Associative array of `$template_name => $template` pairs.
+		 * @return WP_Block_Template[] Associative array of `$template_name => $template` pairs.
 		 */
 		public function get_all_registered() {
 			return $this->registered_templates;
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WP_Block_Templates_Registry' ) ) {
 		 * @since 6.7.0
 		 *
 		 * @param string $template_name Template name including namespace.
-		 * @return WP_Block_Template|null|false The registered template, or null if it is not registered.
+		 * @return WP_Block_Template|null The registered template, or null if it is not registered.
 		 */
 		public function get_registered( $template_name ) {
 			if ( ! $this->is_registered( $template_name ) ) {
@@ -216,7 +216,7 @@ if ( ! class_exists( 'WP_Block_Templates_Registry' ) ) {
 		 * @since 6.7.0
 		 *
 		 * @param string $template_name Template name including namespace.
-		 * @return WP_Block_Template|false The unregistered template on success, or false on failure.
+		 * @return WP_Block_Template|WP_Error The unregistered template on success, or WP_Error on failure.
 		 */
 		public function unregister( $template_name ) {
 			if ( ! $this->is_registered( $template_name ) ) {


### PR DESCRIPTION
## What?

This PR applies changes introduced in https://github.com/WordPress/wordpress-develop/pull/7125 during the code review phase. These changes correct incorrect types in PHP function doc blocks.

Kudos to @anton-vlasenko for finding those issues.

## Why?

During the refactor in https://github.com/WordPress/gutenberg/pull/61577, I missed updating some doc blocks. They were identified during the WP core PR review, so I'm applying the corrections to Gutenberg as well.

## How?

The changes are limited to correcting the wrong type data in doc block comments.

## Testing Instructions

Since the changes are purely within the doc block comments, no functionality testing is required. Simply verify the accuracy of the updated doc blocks.

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast

N/A