### PR TITLE
Revert "Block Bindings: Prioritize existing `placeholder` over `bindingsPlaceholder`"

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -334,7 +334,7 @@ export function RichTextWrapper(
 		selectionStart,
 		selectionEnd,
 		onSelectionChange,
-		placeholder: placeholder || bindingsPlaceholder,
+		placeholder: bindingsPlaceholder || placeholder,
 		__unstableIsSelected: isSelected,
 		__unstableDisableFormats: disableFormats,
 		preserveWhiteSpace,
@@ -406,7 +406,7 @@ export function RichTextWrapper(
 				aria-readonly={ shouldDisableEditing }
 				{ ...props }
 				aria-label={
-					props[ 'aria-label' ] || placeholder || bindingsPlaceholder
+					bindingsPlaceholder || props[ 'aria-label' ] || placeholder
 				}
 				{ ...autocompleteProps }
 				ref={ useMergeRefs( [


### PR DESCRIPTION
Reverts WordPress/gutenberg#65154

There are some edge cases caught by e2e tests that need to get improved. The default text for bound paragraph doesn't look right as it should not allow interactions for inserting blocks:


<img width="640" alt="Screenshot 2024-09-10 at 12 25 11" src="https://github.com/user-attachments/assets/26815acf-4719-4a1d-80dc-85d96e62a901">
