### PR TITLE
Pattern Inserter: Fix pattern list overflow

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -170,42 +170,33 @@ export function PatternCategoryPreviews( {
 					</Text>
 				) }
 			</VStack>
-			<VStack
-				spacing={ 4 }
-				className="block-editor-inserter__patterns-category-panel-body"
-			>
-				{ currentCategoryPatterns.length > 0 && (
-					<>
-						{ isZoomOutMode && (
-							<Text
-								size="12"
-								as="p"
-								className="block-editor-inserter__help-text"
-							>
-								{ __(
-									'Drag and drop patterns into the canvas.'
-								) }
-							</Text>
-						) }
-						<BlockPatternsList
-							ref={ scrollContainerRef }
-							shownPatterns={
-								pagingProps.categoryPatternsAsyncList
-							}
-							blockPatterns={ pagingProps.categoryPatterns }
-							onClickPattern={ onClickPattern }
-							onHover={ onHover }
-							label={ category.label }
-							orientation="vertical"
-							category={ category.name }
-							isDraggable
-							showTitlesAsTooltip={ showTitlesAsTooltip }
-							patternFilter={ patternSourceFilter }
-							pagingProps={ pagingProps }
-						/>
-					</>
-				) }
-			</VStack>
+			{ currentCategoryPatterns.length > 0 && (
+				<>
+					{ isZoomOutMode && (
+						<Text
+							size="12"
+							as="p"
+							className="block-editor-inserter__help-text"
+						>
+							{ __( 'Drag and drop patterns into the canvas.' ) }
+						</Text>
+					) }
+					<BlockPatternsList
+						ref={ scrollContainerRef }
+						shownPatterns={ pagingProps.categoryPatternsAsyncList }
+						blockPatterns={ pagingProps.categoryPatterns }
+						onClickPattern={ onClickPattern }
+						onHover={ onHover }
+						label={ category.label }
+						orientation="vertical"
+						category={ category.name }
+						isDraggable
+						showTitlesAsTooltip={ showTitlesAsTooltip }
+						patternFilter={ patternSourceFilter }
+						pagingProps={ pagingProps }
+					/>
+				</>
+			) }
 		</>
 	);
 }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -170,7 +170,10 @@ export function PatternCategoryPreviews( {
 					</Text>
 				) }
 			</VStack>
-			<VStack spacing={ 4 }>
+			<VStack
+				spacing={ 4 }
+				className="block-editor-inserter__patterns-category-panel-body"
+			>
 				{ currentCategoryPatterns.length > 0 && (
 					<>
 						{ isZoomOutMode && (

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -333,6 +333,10 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
+.block-editor-inserter__patterns-category-panel-body {
+	overflow-y: hidden;
+}
+
 .block-editor-inserter__patterns-category-no-results {
 	margin-top: $grid-unit-30;
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -333,10 +333,6 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__patterns-category-panel-body {
-	overflow-y: hidden;
-}
-
 .block-editor-inserter__patterns-category-no-results {
 	margin-top: $grid-unit-30;
 }
@@ -715,5 +711,5 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-tabbed-sidebar__tabpanel .block-editor-inserter__help-text {
-	padding: 0 $grid-unit-30;
+	padding: 0 $grid-unit-30 $grid-unit-20;
 }


### PR DESCRIPTION
Fixes #65189
Follow-up #65115

## What?

This PR fixes an issue where the pattern list could not be scrolled correctly when opened from the pattern inserter.

## Why?

The following CSS is expected to make the `BlockPatternsList` scroll automatically if the content is long:

https://github.com/WordPress/gutenberg/blob/57e0b9cb658669e2bcc8d4cb2daa537e7d678d4b/packages/block-editor/src/components/inserter/style.scss#L340-L345

However, it appears that this component was wrapped by the `VStack` component, causing unintended behavior.

## How?

~~There are probably a few different approaches we could take, but adding `overflow:hidden` to a VStack component seems like the easiest approach.~~ Based on [this discussion](https://github.com/WordPress/gutenberg/pull/65192#discussion_r1751916904), I removed the `VStack` component and applied a bottom padding to the text instead.

## Testing Instructions

- Open the Site Editor or Post Editor
- Main Inserter > Patterns tab > click any pattern category
- Make sure the pattern category is scrollable
- Enable Zoom Out experiment
- Open the Site Editor
- Enable "Desktop (50%)" view
- Main Inserter > Patterns tab > click any pattern category
- Make sure the pattern category is scrollable

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/f69da219-abc8-4c7a-97d1-2f52ddd32081

### After

https://github.com/user-attachments/assets/fce6c3cd-e080-4e04-bb1c-75e511279768