### PR TITLE
Close inserter on exiting Zoom Out to edit

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
@@ -16,19 +16,13 @@ import { unlock } from '../../../lock-unlock';
  * @param {string} clientId Block client ID.
  */
 export function useZoomOutModeExit( { editorMode } ) {
+	const getSettings = useSelect(
+		( select ) => select( blockEditorStore ).getSettings
+	);
+
 	const { __unstableSetEditorMode } = unlock(
 		useDispatch( blockEditorStore )
 	);
-
-	const { setIsInserterOpened } = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-
-		const { __experimentalSetIsInserterOpened } = getSettings();
-
-		return {
-			setIsInserterOpened: __experimentalSetIsInserterOpened,
-		};
-	}, [] );
 
 	return useRefEffect(
 		( node ) => {
@@ -39,9 +33,13 @@ export function useZoomOutModeExit( { editorMode } ) {
 			function onDoubleClick( event ) {
 				if ( ! event.defaultPrevented ) {
 					event.preventDefault();
-					// Setting may be undefined.
-					if ( typeof setIsInserterOpened === 'function' ) {
-						setIsInserterOpened( false );
+
+					const { __experimentalSetIsInserterOpened } = getSettings();
+
+					if (
+						typeof __experimentalSetIsInserterOpened === 'function'
+					) {
+						__experimentalSetIsInserterOpened( false );
 					}
 					__unstableSetEditorMode( 'edit' );
 				}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -20,6 +20,16 @@ export function useZoomOutModeExit( { editorMode } ) {
 		useDispatch( blockEditorStore )
 	);
 
+	const { setIsInserterOpened } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+
+		const { __experimentalSetIsInserterOpened } = getSettings();
+
+		return {
+			setIsInserterOpened: __experimentalSetIsInserterOpened,
+		};
+	}, [] );
+
 	return useRefEffect(
 		( node ) => {
 			if ( editorMode !== 'zoom-out' ) {
@@ -29,6 +39,10 @@ export function useZoomOutModeExit( { editorMode } ) {
 			function onDoubleClick( event ) {
 				if ( ! event.defaultPrevented ) {
 					event.preventDefault();
+					// Setting may be undefined.
+					if ( typeof setIsInserterOpened === 'function' ) {
+						setIsInserterOpened( false );
+					}
 					__unstableSetEditorMode( 'edit' );
 				}
 			}

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -31,7 +31,12 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 				getPreviousBlockClientId,
 				canRemoveBlock,
 				canMoveBlock,
+				getSettings,
 			} = select( blockEditorStore );
+
+			const { __experimentalSetIsInserterOpened: setIsInserterOpened } =
+				getSettings();
+
 			const { getBlockType } = select( blocksStore );
 			const { name } = getBlock( clientId );
 			const blockType = getBlockType( name );
@@ -63,6 +68,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 				isPrevBlockTemplatePart,
 				canRemove: canRemoveBlock( clientId ),
 				canMove: canMoveBlock( clientId ),
+				setIsInserterOpened,
 			};
 		},
 		[ clientId ]
@@ -75,6 +81,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 		isPrevBlockTemplatePart,
 		canRemove,
 		canMove,
+		setIsInserterOpened,
 	} = selected;
 
 	const { removeBlock, __unstableSetEditorMode } =
@@ -132,6 +139,10 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 					icon={ edit }
 					label={ __( 'Edit' ) }
 					onClick={ () => {
+						// Setting may be undefined.
+						if ( typeof setIsInserterOpened === 'function' ) {
+							setIsInserterOpened( false );
+						}
 						__unstableSetEditorMode( 'edit' );
 						__unstableContentRef.current?.focus();
 					} }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes any open inserter when exiting Zoom Out when the user explicit opts to "edit" the content.

Closes https://github.com/WordPress/gutenberg/issues/65161

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/issues/65161.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Call the relevant function provided on editor settings if available when the current mode is switching to non-zoom out.

## Concerns

I'm not entirely happy with this approach for various reasons.

- ~Do we want to _always_ close the inserter when exiting Zoom Out or just in certain scenarios?~
- ~Should we be batching the dispatch calls within `__unstableSetEditorMode()`? (cc @Mamaduka)~
- Is it sensible to rely on an experimental feature to support Zoom Out? Is there a better way to cross communicate between stores based on the `setEditorMode`?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable Zoom Out experiment.
- Site Editor
- Activate Zoom Out mode
- Open inserter sidebar (global inserter)
- Deactivate Zoom Out mode using one of the following methods:
    - double clicking in canvas
    - clicking `Edit` icon in the zoom out toolbar
- See that the Inserter closes.
- Repeat but this time use the Zoom Out toggle in the Device preview and check the inserter _does not_ close.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/54e88897-47ef-4cd5-8137-e94c6110719b

