### PR TITLE
Block Bindings: Add background color to bound blocks

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -137,6 +137,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 					'--wp-admin-theme-color': 'var(--wp-block-synced-color)',
 					'--wp-admin-theme-color--rgb':
 						'var(--wp-block-synced-color--rgb)',
+					backgroundColor:
+						'color-mix( in srgb, var(--wp-block-synced-color) 20%, transparent 0% )',
 			  }
 			: {};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds a background color to bound blocks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We'd like to visually indicate when blocks are bound.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds an inline style inside `use-block-props`, where other global bindings styles are set.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
<details>
<summary>1. Register post meta by adding this snippet to your theme's functions.php</summary>

```php
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_field',
		array(
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'default'           => 'default text value',
		)
	);
}
```
</details>
</summary>

2. In the post editor, add a new block and bind to the post meta field.
3. See that the block background is now set to the bindings color.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

<img width="706" alt="Screenshot 2024-09-10 at 8 40 15 AM" src="https://github.com/user-attachments/assets/2f456d8e-1705-4619-9c7f-29fe5fae4f12">

### After

<img width="740" alt="Screenshot 2024-09-10 at 8 39 28 AM" src="https://github.com/user-attachments/assets/37f964fc-2e58-45c8-bcbb-586be6127cb2">
