### PR TITLE
Show top level sections in List View

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -121,8 +121,6 @@ function ListViewBranch( props ) {
 		blockIndexes,
 		expandedState,
 		draggedClientIds,
-		sectionBlockClientIds,
-		isZoomOutMode,
 	} = useListViewContext();
 
 	if ( ! canParentExpand ) {
@@ -176,14 +174,8 @@ function ListViewBranch( props ) {
 						: `${ position }`;
 				const hasNestedBlocks = !! innerBlocks?.length;
 
-				const isZoomOutSectionBlock =
-					isZoomOutMode &&
-					sectionBlockClientIds?.includes( clientId );
-
 				const shouldExpand =
-					! isZoomOutSectionBlock &&
-					hasNestedBlocks &&
-					shouldShowInnerBlocks
+					hasNestedBlocks && shouldShowInnerBlocks
 						? expandedState[ clientId ] ?? isExpanded
 						: undefined;
 

--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -121,6 +121,8 @@ function ListViewBranch( props ) {
 		blockIndexes,
 		expandedState,
 		draggedClientIds,
+		sectionBlockClientIds,
+		isZoomOutMode,
 	} = useListViewContext();
 
 	if ( ! canParentExpand ) {
@@ -174,8 +176,14 @@ function ListViewBranch( props ) {
 						: `${ position }`;
 				const hasNestedBlocks = !! innerBlocks?.length;
 
+				const isZoomOutSectionBlock =
+					isZoomOutMode &&
+					sectionBlockClientIds?.includes( clientId );
+
 				const shouldExpand =
-					hasNestedBlocks && shouldShowInnerBlocks
+					! isZoomOutSectionBlock &&
+					hasNestedBlocks &&
+					shouldShowInnerBlocks
 						? expandedState[ clientId ] ?? isExpanded
 						: undefined;
 

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -119,20 +119,16 @@ function ListViewComponent(
 	const blockIndexes = useListViewBlockIndexes( clientIdsTree );
 
 	const { getBlock } = useSelect( blockEditorStore );
-	const { visibleBlockCount, shouldShowInnerBlocks } = useSelect(
+	const { visibleBlockCount } = useSelect(
 		( select ) => {
-			const {
-				getGlobalBlockCount,
-				getClientIdsOfDescendants,
-				__unstableGetEditorMode,
-			} = select( blockEditorStore );
+			const { getGlobalBlockCount, getClientIdsOfDescendants } =
+				select( blockEditorStore );
 			const draggedBlockCount =
 				draggedClientIds?.length > 0
 					? getClientIdsOfDescendants( draggedClientIds ).length + 1
 					: 0;
 			return {
 				visibleBlockCount: getGlobalBlockCount() - draggedBlockCount,
-				shouldShowInnerBlocks: __unstableGetEditorMode() !== 'zoom-out',
 			};
 		},
 		[ draggedClientIds ]
@@ -397,7 +393,6 @@ function ListViewComponent(
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
 						isExpanded={ isExpanded }
-						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						showAppender={ showAppender }
 					/>
 				</ListViewContext.Provider>

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -45,6 +45,8 @@ import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dro
 import { focusListItem } from './utils';
 import useClipboardHandler from './use-clipboard-handler';
 
+import { unlock } from '../../lock-unlock';
+
 const expanded = ( state, action ) => {
 	if ( action.type === 'clear' ) {
 		return {};
@@ -119,24 +121,36 @@ function ListViewComponent(
 	const blockIndexes = useListViewBlockIndexes( clientIdsTree );
 
 	const { getBlock } = useSelect( blockEditorStore );
-	const { visibleBlockCount, shouldShowInnerBlocks } = useSelect(
-		( select ) => {
-			const {
-				getGlobalBlockCount,
-				getClientIdsOfDescendants,
-				__unstableGetEditorMode,
-			} = select( blockEditorStore );
-			const draggedBlockCount =
-				draggedClientIds?.length > 0
-					? getClientIdsOfDescendants( draggedClientIds ).length + 1
-					: 0;
-			return {
-				visibleBlockCount: getGlobalBlockCount() - draggedBlockCount,
-				shouldShowInnerBlocks: __unstableGetEditorMode() !== 'zoom-out',
-			};
-		},
-		[ draggedClientIds ]
-	);
+
+	const { sectionBlockClientIds, isZoomOutMode, visibleBlockCount } =
+		useSelect(
+			( select ) => {
+				const {
+					getGlobalBlockCount,
+					getClientIdsOfDescendants,
+					__unstableGetEditorMode,
+					getSectionRootClientId,
+					getBlockOrder,
+				} = unlock( select( blockEditorStore ) );
+				const draggedBlockCount =
+					draggedClientIds?.length > 0
+						? getClientIdsOfDescendants( draggedClientIds ).length +
+						  1
+						: 0;
+
+				const _isZoomOutMode = __unstableGetEditorMode() === 'zoom-out';
+
+				return {
+					visibleBlockCount:
+						getGlobalBlockCount() - draggedBlockCount,
+					sectionBlockClientIds: getBlockOrder(
+						getSectionRootClientId()
+					),
+					isZoomOutMode: _isZoomOutMode,
+				};
+			},
+			[ draggedClientIds ]
+		);
 
 	const { updateBlockSelection } = useBlockSelection();
 
@@ -305,6 +319,8 @@ function ListViewComponent(
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
 			rootClientId,
+			sectionBlockClientIds,
+			isZoomOutMode,
 		} ),
 		[
 			blockDropPosition,
@@ -322,6 +338,8 @@ function ListViewComponent(
 			insertedBlock,
 			setInsertedBlock,
 			rootClientId,
+			sectionBlockClientIds,
+			isZoomOutMode,
 		]
 	);
 
@@ -397,7 +415,6 @@ function ListViewComponent(
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
 						isExpanded={ isExpanded }
-						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						showAppender={ showAppender }
 					/>
 				</ListViewContext.Provider>

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -45,8 +45,6 @@ import { BlockSettingsDropdown } from '../block-settings-menu/block-settings-dro
 import { focusListItem } from './utils';
 import useClipboardHandler from './use-clipboard-handler';
 
-import { unlock } from '../../lock-unlock';
-
 const expanded = ( state, action ) => {
 	if ( action.type === 'clear' ) {
 		return {};
@@ -121,36 +119,24 @@ function ListViewComponent(
 	const blockIndexes = useListViewBlockIndexes( clientIdsTree );
 
 	const { getBlock } = useSelect( blockEditorStore );
-
-	const { sectionBlockClientIds, isZoomOutMode, visibleBlockCount } =
-		useSelect(
-			( select ) => {
-				const {
-					getGlobalBlockCount,
-					getClientIdsOfDescendants,
-					__unstableGetEditorMode,
-					getSectionRootClientId,
-					getBlockOrder,
-				} = unlock( select( blockEditorStore ) );
-				const draggedBlockCount =
-					draggedClientIds?.length > 0
-						? getClientIdsOfDescendants( draggedClientIds ).length +
-						  1
-						: 0;
-
-				const _isZoomOutMode = __unstableGetEditorMode() === 'zoom-out';
-
-				return {
-					visibleBlockCount:
-						getGlobalBlockCount() - draggedBlockCount,
-					sectionBlockClientIds: getBlockOrder(
-						getSectionRootClientId()
-					),
-					isZoomOutMode: _isZoomOutMode,
-				};
-			},
-			[ draggedClientIds ]
-		);
+	const { visibleBlockCount, shouldShowInnerBlocks } = useSelect(
+		( select ) => {
+			const {
+				getGlobalBlockCount,
+				getClientIdsOfDescendants,
+				__unstableGetEditorMode,
+			} = select( blockEditorStore );
+			const draggedBlockCount =
+				draggedClientIds?.length > 0
+					? getClientIdsOfDescendants( draggedClientIds ).length + 1
+					: 0;
+			return {
+				visibleBlockCount: getGlobalBlockCount() - draggedBlockCount,
+				shouldShowInnerBlocks: __unstableGetEditorMode() !== 'zoom-out',
+			};
+		},
+		[ draggedClientIds ]
+	);
 
 	const { updateBlockSelection } = useBlockSelection();
 
@@ -319,8 +305,6 @@ function ListViewComponent(
 			setInsertedBlock,
 			treeGridElementRef: elementRef,
 			rootClientId,
-			sectionBlockClientIds,
-			isZoomOutMode,
 		} ),
 		[
 			blockDropPosition,
@@ -338,8 +322,6 @@ function ListViewComponent(
 			insertedBlock,
 			setInsertedBlock,
 			rootClientId,
-			sectionBlockClientIds,
-			isZoomOutMode,
 		]
 	);
 
@@ -415,6 +397,7 @@ function ListViewComponent(
 						fixedListWindow={ fixedListWindow }
 						selectedClientIds={ selectedClientIds }
 						isExpanded={ isExpanded }
+						shouldShowInnerBlocks={ shouldShowInnerBlocks }
 						showAppender={ showAppender }
 					/>
 				</ListViewContext.Provider>

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -114,6 +114,7 @@ export const getEnabledClientIdsTree = createSelector(
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,
+		state.editorMode,
 	]
 );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Shows the top level "sections" in the List View when in Zoom Out mode.

Closes https://github.com/WordPress/gutenberg/issues/64260

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's expected that you can see the editable sections in the List View.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Remove the hard limit on showing inner blocks in list view when in Zoom Out mode. Allow default of `true`.
- ~Refactor list view to only hide children of "Sections".~
- Recompute the visible list view blocks when switching editor modes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable Zoom Out experiment.
- Site Editor
- Open List View
- See Blocks including Header and Footer.
- Toggle Zoom Out
- See only the "Section Root" block and the sub "sections" are shown in List View. Everything else is hidden.
- Switch back out of Zoom Out and check that all blocks are restored to the List View.
- Edit a Page in the Site Editor
- Check that this time only the `Content` block and it's sub blocks are shown.
- Switch back out of Zoom Out and check that all blocks are restored to the List View.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/04926056-7083-488b-ad11-d948be7807d6

