### PR TITLE
Modal: add exit animation

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -4,7 +4,7 @@
 	}
 }
 
-@mixin animation__fade-in($speed: 0.08s, $delay: 0s) {
+@mixin animation__fade-in($speed: 0.08s, $delay: 0s, $easing: linear) {
 	@include keyframes(__wp-base-styles-fade-in) {
 		from {
 			opacity: 0;
@@ -15,12 +15,12 @@
 	}
 
 
-	animation: __wp-base-styles-fade-in $speed linear $delay;
+	animation: __wp-base-styles-fade-in $speed $easing $delay;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }
 
-@mixin animation__fade-out($speed: 0.08s, $delay: 0s) {
+@mixin animation__fade-out($speed: 0.08s, $delay: 0s, $easing: linear) {
 	@include keyframes(__wp-base-styles-fade-out) {
 		from {
 			opacity: 1;
@@ -31,7 +31,7 @@
 	}
 
 
-	animation: __wp-base-styles-fade-out $speed linear $delay;
+	animation: __wp-base-styles-fade-out $speed $easing $delay;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -29,6 +29,7 @@
 -   `ResizeableBox`: Adopt elevation scale ([#65159](https://github.com/WordPress/gutenberg/pull/65159)).
 -   `Snackbar`: Adopt elevation scale ([#65159](https://github.com/WordPress/gutenberg/pull/65159)).
 -   `Tooltip`: Adopt elevation scale ([#65159](https://github.com/WordPress/gutenberg/pull/65159)).
+-   `Modal`: add exit animation for internally triggered events ([#65203](https://github.com/WordPress/gutenberg/pull/65203)).
 -   `Card`: Adopt radius scale ([#65053](https://github.com/WordPress/gutenberg/pull/65053)).
 
 ### Bug Fixes

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -41,7 +41,7 @@ import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import { Spacer } from '../spacer';
 
 // Animation duration (ms) extracted to JS in order to be used on a setTimeout.
-const FRAME_ANIMATION_DURATION = 260;
+const FRAME_ANIMATION_DURATION = 200;
 
 // Used to track and dismiss the prior modal when another opens unless nested.
 type Dismissers = Set<

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import clsx from 'clsx';
-import type { ForwardedRef, KeyboardEvent, RefObject, UIEvent } from 'react';
 
 /**
  * WordPress dependencies
@@ -42,7 +41,7 @@ import { useModalExitAnimation } from './use-modal-exit-animation';
 
 // Used to track and dismiss the prior modal when another opens unless nested.
 type Dismissers = Set<
-	RefObject< ModalProps[ 'onRequestClose' ] | undefined >
+	React.RefObject< ModalProps[ 'onRequestClose' ] | undefined >
 >;
 const ModalContext = createContext< Dismissers >( new Set() );
 
@@ -51,7 +50,7 @@ const bodyOpenClasses = new Map< string, number >();
 
 function UnforwardedModal(
 	props: ModalProps,
-	forwardedRef: ForwardedRef< HTMLDivElement >
+	forwardedRef: React.ForwardedRef< HTMLDivElement >
 ) {
 	const {
 		bodyOpenClassName = 'modal-open',
@@ -204,7 +203,9 @@ function UnforwardedModal(
 		};
 	}, [ isContentScrollable, childrenContainerRef ] );
 
-	function handleEscapeKeyDown( event: KeyboardEvent< HTMLDivElement > ) {
+	function handleEscapeKeyDown(
+		event: React.KeyboardEvent< HTMLDivElement >
+	) {
 		if (
 			shouldCloseOnEsc &&
 			( event.code === 'Escape' || event.key === 'Escape' ) &&
@@ -216,7 +217,7 @@ function UnforwardedModal(
 	}
 
 	const onContentContainerScroll = useCallback(
-		( e: UIEvent< HTMLDivElement > ) => {
+		( e: React.UIEvent< HTMLDivElement > ) => {
 			const scrollY = e?.currentTarget?.scrollTop ?? -1;
 
 			if ( ! hasScrolledContent && scrollY > 0 ) {

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -39,9 +39,13 @@ import StyleProvider from '../style-provider';
 import type { ModalProps } from './types';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import { Spacer } from '../spacer';
+import { CONFIG } from '../utils';
 
 // Animation duration (ms) extracted to JS in order to be used on a setTimeout.
-const FRAME_ANIMATION_DURATION = 200;
+const FRAME_ANIMATION_DURATION = CONFIG.transitionDuration;
+const FRAME_ANIMATION_DURATION_NUMBER = Number.parseInt(
+	CONFIG.transitionDuration
+);
 
 // Used to track and dismiss the prior modal when another opens unless nested.
 type Dismissers = Set<
@@ -222,7 +226,7 @@ function UnforwardedModal(
 			const animationTimeout = window.setTimeout( () => {
 				setIsAnimatingOut( false );
 				onRequestCloseRef.current?.( event );
-			}, FRAME_ANIMATION_DURATION );
+			}, FRAME_ANIMATION_DURATION_NUMBER );
 
 			return () => {
 				frameEl.removeEventListener( 'animationend', onAnimationEnd );
@@ -319,7 +323,7 @@ function UnforwardedModal(
 						className
 					) }
 					style={ {
-						'--modal-frame-animation-duration': `${ FRAME_ANIMATION_DURATION }ms`,
+						'--modal-frame-animation-duration': `${ FRAME_ANIMATION_DURATION }`,
 						...style,
 					} }
 					ref={ useMergeRefs( [

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -40,6 +40,9 @@ import type { ModalProps } from './types';
 import { withIgnoreIMEEvents } from '../utils/with-ignore-ime-events';
 import { Spacer } from '../spacer';
 
+// Animation duration (ms) extracted to JS in order to be used on a setTimeout.
+const FRAME_ANIMATION_DURATION = 260;
+
 // Used to track and dismiss the prior modal when another opens unless nested.
 type Dismissers = Set<
 	RefObject< ModalProps[ 'onRequestClose' ] | undefined >
@@ -216,6 +219,10 @@ function UnforwardedModal(
 			frameEl.addEventListener( 'animationend', onAnimationEnd, {
 				once: true,
 			} );
+			const animationTimeout = window.setTimeout( () => {
+				setIsAnimatingOut( false );
+				onRequestCloseRef.current?.( event );
+			}, FRAME_ANIMATION_DURATION );
 
 			return () => {
 				frameEl.removeEventListener( 'animationend', onAnimationEnd );
@@ -311,7 +318,10 @@ function UnforwardedModal(
 						sizeClass,
 						className
 					) }
-					style={ style }
+					style={ {
+						'--modal-frame-animation-duration': `${ FRAME_ANIMATION_DURATION }ms`,
+						...style,
+					} }
 					ref={ useMergeRefs( [
 						frameRef,
 						constrainedTabbingRef,

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -212,7 +212,7 @@ function UnforwardedModal(
 			! event.defaultPrevented
 		) {
 			event.preventDefault();
-			closeModal( () => onRequestClose( event ) );
+			closeModal().then( () => onRequestClose( event ) );
 		}
 	}
 
@@ -251,7 +251,7 @@ function UnforwardedModal(
 			const isSameTarget = target === pressTarget;
 			pressTarget = null;
 			if ( button === 0 && isSameTarget ) {
-				closeModal( () => onRequestClose() );
+				closeModal().then( () => onRequestClose() );
 			}
 		},
 	};
@@ -342,7 +342,7 @@ function UnforwardedModal(
 											onClick={ (
 												event: React.MouseEvent< HTMLButtonElement >
 											) =>
-												closeModal( () =>
+												closeModal().then( () =>
 													onRequestClose( event )
 												)
 											}

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -32,7 +32,7 @@
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;
 	// Animate the modal frame/contents appearing on the page.
-	animation: components-modal__appear-animation 0.26s cubic-bezier(0.29, 0, 0, 1);
+	animation: components-modal__appear-animation var(--modal-frame-animation-duration) cubic-bezier(0.29, 0, 0, 1);
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -10,6 +10,13 @@
 	display: flex;
 	// This animates the appearance of the backdrop.
 	@include animation__fade-in();
+
+	&.is-animating-out {
+		// Note: it's important that the fade-out animation doesn't end after the
+		// modal frame's disappear animation, because the component will be removed
+		// from the DOM when that animation ends.
+		@include animation__fade-out($delay: 0.05s);
+	}
 }
 
 // The modal window element.
@@ -28,6 +35,10 @@
 	animation: components-modal__appear-animation 0.26s cubic-bezier(0.29, 0, 0, 1);
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
+
+	.components-modal__screen-overlay.is-animating-out & {
+		animation-name: components-modal__disappear-animation;
+	}
 
 	// Show a centered modal on bigger screens.
 	@include break-small() {
@@ -85,6 +96,19 @@
 	to {
 		opacity: 1;
 		transform: scale(1);
+	}
+}
+
+// Note: this keyframe definition is also used in the animationend JS event
+// listener — make sure the two instances are kept in sync.
+@keyframes components-modal__disappear-animation {
+	from {
+		opacity: 1;
+		transform: scale(1);
+	}
+	to {
+		opacity: 0;
+		transform: scale(0.95);
 	}
 }
 

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -102,8 +102,8 @@
 	}
 }
 
-// Note: this keyframe definition is also used in the animationend JS event
-// listener — make sure the two instances are kept in sync.
+// Note: this animation is also used in the animationend JS event listener.
+// Make sure that the animation name is kept in sync across the two files.
 @keyframes components-modal__disappear-animation {
 	from {
 		opacity: 1;

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -15,7 +15,7 @@
 		// Note: it's important that the fade-out animation doesn't end after the
 		// modal frame's disappear animation, because the component will be removed
 		// from the DOM when that animation ends.
-		@include animation__fade-out($delay: 0.05s);
+		@include animation__fade-out($delay: 80ms);
 	}
 }
 
@@ -32,12 +32,15 @@
 	// Have the content element fill the vertical space yet not overflow.
 	display: flex;
 	// Animate the modal frame/contents appearing on the page.
-	animation: components-modal__appear-animation var(--modal-frame-animation-duration) cubic-bezier(0.29, 0, 0, 1);
+	animation-name: components-modal__appear-animation;
+	animation-duration: var(--modal-frame-animation-duration);
 	animation-fill-mode: forwards;
+	animation-timing-function: cubic-bezier(0.29, 0, 0, 1);
 	@include reduce-motion("animation");
 
 	.components-modal__screen-overlay.is-animating-out & {
 		animation-name: components-modal__disappear-animation;
+		animation-timing-function: cubic-bezier(1, 0, 0.2, 1);
 	}
 
 	// Show a centered modal on bigger screens.
@@ -108,7 +111,7 @@
 	}
 	to {
 		opacity: 0;
-		transform: scale(0.95);
+		transform: scale(0.9);
 	}
 }
 

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -1,16 +1,4 @@
 /**
- * External dependencies
- */
-import type {
-	AriaRole,
-	CSSProperties,
-	ReactNode,
-	KeyboardEventHandler,
-	KeyboardEvent,
-	SyntheticEvent,
-} from 'react';
-
-/**
  * WordPress dependencies
  */
 import type { useFocusOnMount } from '@wordpress/compose';
@@ -42,7 +30,7 @@ export type ModalProps = {
 	/**
 	 * The children elements.
 	 */
-	children: ReactNode;
+	children: React.ReactNode;
 	/**
 	 * If this property is added, it will an additional class name to the modal
 	 * content `div`.
@@ -77,7 +65,7 @@ export type ModalProps = {
 	 *
 	 * @default null
 	 */
-	headerActions?: ReactNode;
+	headerActions?: React.ReactNode;
 
 	/**
 	 * If this property is added, an icon will be added before the title.
@@ -108,12 +96,12 @@ export type ModalProps = {
 	/**
 	 *  Handle the key down on the modal frame `div`.
 	 */
-	onKeyDown?: KeyboardEventHandler< HTMLDivElement >;
+	onKeyDown?: React.KeyboardEventHandler< HTMLDivElement >;
 	/**
 	 * This function is called to indicate that the modal should be closed.
 	 */
 	onRequestClose: (
-		event?: KeyboardEvent< HTMLDivElement > | SyntheticEvent
+		event?: React.KeyboardEvent< HTMLDivElement > | React.SyntheticEvent
 	) => void;
 	/**
 	 * If this property is added, it will an additional class name to the modal
@@ -126,7 +114,7 @@ export type ModalProps = {
 	 *
 	 * @default 'dialog'
 	 */
-	role?: AriaRole;
+	role?: React.AriaRole;
 	/**
 	 * If this property is added, it will determine whether the modal requests
 	 * to close when a mouse click occurs outside of the modal content.
@@ -144,7 +132,7 @@ export type ModalProps = {
 	/**
 	 * If this property is added, it will be added to the modal frame `div`.
 	 */
-	style?: CSSProperties;
+	style?: React.CSSProperties;
 	/**
 	 * This property is used as the modal header's title.
 	 *

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -1,0 +1,75 @@
+/**
+ * WordPress dependencies
+ */
+import { useReducedMotion } from '@wordpress/compose';
+import { useCallback, useRef, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { CONFIG } from '../utils';
+
+// Animation duration (ms) extracted to JS in order to be used on a setTimeout.
+const FRAME_ANIMATION_DURATION = CONFIG.transitionDuration;
+const FRAME_ANIMATION_DURATION_NUMBER = Number.parseInt(
+	CONFIG.transitionDuration
+);
+
+const EXIT_ANIMATION_NAME = 'components-modal__disappear-animation';
+
+export function useModalExitAnimation() {
+	const frameRef = useRef< HTMLDivElement >();
+	const [ isAnimatingOut, setIsAnimatingOut ] = useState( false );
+	const isReducedMotion = useReducedMotion();
+
+	const closeModal = useCallback(
+		( onAnimationEnd: () => void ) => {
+			function handleAnimationEnd( e: AnimationEvent ) {
+				if ( e.animationName === EXIT_ANIMATION_NAME ) {
+					setIsAnimatingOut( false );
+					onAnimationEnd();
+				}
+			}
+
+			if ( isReducedMotion ) {
+				onAnimationEnd();
+				return;
+			}
+
+			if ( ! frameRef.current ) {
+				return;
+			}
+
+			// Grab a reference to the frame element, to make sure we're referencing
+			// the same reference in the cleanup function.
+			const frameEl = frameRef.current;
+
+			setIsAnimatingOut( true );
+			frameEl.addEventListener( 'animationend', handleAnimationEnd, {
+				once: true,
+			} );
+			const animationTimeout = window.setTimeout( () => {
+				setIsAnimatingOut( false );
+				onAnimationEnd();
+			}, FRAME_ANIMATION_DURATION_NUMBER );
+
+			return () => {
+				frameEl.removeEventListener(
+					'animationend',
+					handleAnimationEnd
+				);
+				window.clearTimeout( animationTimeout );
+			};
+		},
+		[ isReducedMotion ]
+	);
+
+	return {
+		overlayClassname: isAnimatingOut ? 'is-animating-out' : undefined,
+		frameRef,
+		frameStyle: {
+			'--modal-frame-animation-duration': `${ FRAME_ANIMATION_DURATION }ms`,
+		},
+		closeModal,
+	};
+}

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -68,7 +68,7 @@ export function useModalExitAnimation() {
 		overlayClassname: isAnimatingOut ? 'is-animating-out' : undefined,
 		frameRef,
 		frameStyle: {
-			'--modal-frame-animation-duration': `${ FRAME_ANIMATION_DURATION }ms`,
+			'--modal-frame-animation-duration': `${ FRAME_ANIMATION_DURATION }`,
 		},
 		closeModal,
 	};

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -8,6 +8,7 @@ import { useCallback, useRef, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import { CONFIG } from '../utils';
+import warning from '@wordpress/warning';
 
 // Animation duration (ms) extracted to JS in order to be used on a setTimeout.
 const FRAME_ANIMATION_DURATION = CONFIG.transitionDuration;
@@ -29,7 +30,15 @@ export function useModalExitAnimation() {
 				// the value held by the react ref might change at runtime.
 				const frameEl = frameRef.current;
 
-				if ( isReducedMotion || ! frameEl ) {
+				if ( isReducedMotion ) {
+					closeModalResolve();
+					return;
+				}
+
+				if ( ! frameEl ) {
+					warning(
+						"wp.components.Modal: the Modal component can't be closed with an exit animation because of a missing reference to the modal frame element."
+					);
 					closeModalResolve();
 					return;
 				}

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -56,7 +56,10 @@ export function useModalExitAnimation() {
 					new Promise< void >( ( timeoutResolve ) => {
 						setTimeout(
 							() => timeoutResolve(),
-							FRAME_ANIMATION_DURATION_NUMBER + 1
+							// Allow an extra 20% of the animation duration for the
+							// animationend event to fire, in case the animation frame is
+							// slightly delayes by some other events in the event loop.
+							FRAME_ANIMATION_DURATION_NUMBER * 1.2
 						);
 					} );
 

--- a/packages/components/src/modal/use-modal-exit-animation.ts
+++ b/packages/components/src/modal/use-modal-exit-animation.ts
@@ -24,17 +24,12 @@ export function useModalExitAnimation() {
 
 	const closeModal = useCallback(
 		() =>
-			new Promise< void >( ( closeModalResolve, closeModalReject ) => {
+			new Promise< void >( ( closeModalResolve ) => {
 				// Grab a "stable" reference of the frame element, since
 				// the value held by the react ref might change at runtime.
 				const frameEl = frameRef.current;
 
-				if ( ! frameEl ) {
-					closeModalReject();
-					return;
-				}
-
-				if ( isReducedMotion ) {
+				if ( isReducedMotion || ! frameEl ) {
 					closeModalResolve();
 					return;
 				}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #64580

Add an exit animation to the `Modal` component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For a better sense of polish.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding an additional CSS animation, and waiting for it to end before invoking the `onRequestClose` callback prop, which consumers of `Modal` use to conditionally render the component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Test the `Modal` component in Storybook and across the editor
- Make sure that the component continues to work as expected when opened and closed (including being removed from the DOM, and managing focus correctly)
- Make sure the component animates when being closed

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e678fa7b-f63a-4dcb-93ee-53c9b397c88f

