### PR TITLE
Remove colons from control labels

### DIFF
--- a/docs/reference-guides/block-api/block-context.md
+++ b/docs/reference-guides/block-api/block-context.md
@@ -141,7 +141,7 @@ export default function Edit( props ) {
 	return (
 		<div>
 			<TextControl
-				label={ __( 'Record ID:' ) }
+				label={ __( 'Record ID' ) }
 				value={ recordId }
 				onChange={ ( val ) =>
 					setAttributes( { recordId: Number( val ) } )

--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -53,7 +53,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 					<SelectControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						label={ __( 'Group by:' ) }
+						label={ __( 'Group by' ) }
 						options={ [
 							{ label: __( 'Year' ), value: 'yearly' },
 							{ label: __( 'Month' ), value: 'monthly' },

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -243,7 +243,7 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				{ displayPostContent && (
 					<RadioControl
 						className="wp-block-latest-posts__post-content-radio"
-						label={ __( 'Show:' ) }
+						label={ __( 'Show' ) }
 						selected={ displayPostContentRadio }
 						options={ [
 							{ label: __( 'Excerpt' ), value: 'excerpt' },

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -103,7 +103,7 @@ Render a user interface to select multiple users from a list.
 ```jsx
 <SelectControl
 	multiple
-	label={ __( 'Select some users:' ) }
+	label={ __( 'User' ) }
 	value={ this.state.users } // e.g: value = [ 'a', 'c' ]
 	onChange={ ( users ) => {
 		this.setState( { users } );
@@ -126,7 +126,7 @@ const [ item, setItem ] = useState( '' );
 // ...
 
 <SelectControl
-    label={ __( 'Select an item:' ) }
+    label={ __( 'My dinosaur' ) }
     value={ item } // e.g: value = 'a'
     onChange={ ( selection ) => { setItem( selection ) } }
     __nextHasNoMarginBottom

--- a/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
@@ -29,7 +29,7 @@ export default function WidgetTypeSelector( { selectedId, onSelect } ) {
 		<SelectControl
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
-			label={ __( 'Legacy widget to display' ) }
+			label={ __( 'Legacy widget' ) }
 			value={ selectedId ?? '' }
 			options={ [
 				{ value: '', label: __( 'Select widget' ) },

--- a/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
+++ b/packages/widgets/src/blocks/legacy-widget/edit/widget-type-selector.js
@@ -29,7 +29,7 @@ export default function WidgetTypeSelector( { selectedId, onSelect } ) {
 		<SelectControl
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
-			label={ __( 'Select a legacy widget to display:' ) }
+			label={ __( 'Legacy widget to display' ) }
 			value={ selectedId ?? '' }
 			options={ [
 				{ value: '', label: __( 'Select widget' ) },

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -358,9 +358,7 @@ test.describe( 'Widgets Customizer', () => {
 		const legacyWidgetBlock =
 			await widgetsCustomizerPage.addBlock( 'Legacy Widget' );
 		await page
-			.locator(
-				'role=combobox[name="Select a legacy widget to display:"i]'
-			)
+			.locator( 'role=combobox[name="Legacy widget"i]' )
 			.selectOption( 'test_widget' );
 
 		await expect(


### PR DESCRIPTION
## What?

Removes any trailing colons in the labels of control components.

## Why?

When doing consistency work across the core blocks, I noticed that there are some blocks that have a trailing colon in the label of some of their controls. These are unnecessary and goes against the labeling style of everything else. (This should probably be part of a style guide — cc @mattrwalker @WordPress/gutenberg-design)

## Testing Instructions

See inline comments.
