### PR TITLE
Revert "Block Insertion: Clear the insertion point when selecting a d…

### DIFF
--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, SearchControl } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -82,8 +82,6 @@ export default function QuickInserter( {
 		}
 	}, [ setInserterIsOpened ] );
 
-	const { showInsertionPoint } = useDispatch( blockEditorStore );
-
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
@@ -93,7 +91,6 @@ export default function QuickInserter( {
 			filterValue,
 			onSelect,
 		} );
-		showInsertionPoint( rootClientId, insertionIndex );
 	};
 
 	let maxBlockPatterns = 0;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1624,8 +1624,6 @@ export function insertionPoint( state = null, action ) {
 		}
 
 		case 'HIDE_INSERTION_POINT':
-		case 'CLEAR_SELECTED_BLOCK':
-		case 'SELECT_BLOCK':
 			return null;
 	}
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -22,7 +22,6 @@ const { PrivateInserterLibrary } = unlock( blockEditorPrivateApis );
 
 export default function InserterSidebar() {
 	const {
-		blockInsertionPoint,
 		blockSectionRootClientId,
 		inserterSidebarToggleRef,
 		insertionPoint,
@@ -35,7 +34,6 @@ export default function InserterSidebar() {
 			isPublishSidebarOpened,
 		} = unlock( select( editorStore ) );
 		const {
-			getBlockInsertionPoint,
 			getBlockRootClientId,
 			__unstableGetEditorMode,
 			getSectionRootClientId,
@@ -53,7 +51,6 @@ export default function InserterSidebar() {
 			return getBlockRootClientId();
 		};
 		return {
-			blockInsertionPoint: getBlockInsertionPoint(),
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			insertionPoint: getInsertionPoint(),
 			showMostUsedBlocks: get( 'core', 'mostUsedBlocks' ),
@@ -92,9 +89,9 @@ export default function InserterSidebar() {
 				showInserterHelpPanel
 				shouldFocusBlock={ isMobileViewport }
 				rootClientId={
-					blockSectionRootClientId ?? blockInsertionPoint.rootClientId
+					blockSectionRootClientId ?? insertionPoint.rootClientId
 				}
-				__experimentalInsertionIndex={ blockInsertionPoint.index }
+				__experimentalInsertionIndex={ insertionPoint.insertionIndex }
 				onSelect={ insertionPoint.onSelect }
 				__experimentalInitialTab={ insertionPoint.tab }
 				__experimentalInitialCategory={ insertionPoint.category }


### PR DESCRIPTION
…ifferent block or clearing block selection (#64048)"



<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This reverts commit c73aa361c4bd82d8b3ee004e5195a22158cad1bf.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The [inserter was relying on getBlockInsertionPoint()](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/components/inserter-sidebar/index.js#L56), which will update depending on what block is https://github.com/WordPress/gutenberg/pull/64048, which causes the inserter sidebar to rerender rapidly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Reverts back to using getInsertionPoint. A follow-up tor reimplement the fix from #64048 is in progress at https://github.com/WordPress/gutenberg/pull/65098

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### For hovering item sidebar rerenders
- Open the inserter
- Add a buttons block into the canvas
- Hover items within the sidebar
- The inserter should not jump around from rerenders

### For pattern rerenders
- Open the inserter
- Go to the patterns tab
- Select a category
- Hover the canvas
- The patterns should not be reloading

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
