### PR TITLE
Excerpt Block - Fix stripping of HTML tags for custom excerpts

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -168,31 +168,34 @@ export default function PostExcerptEditor( {
 		'is-inline': ! showMoreOnNewLine,
 	} );
 
-	// Only trim the excerpt if it's not a custom excerpt.
+	// By default, use the raw excerpt, which is the user-entered custom excerpt.
 	const hasCustomExcerpt = !! rawExcerpt?.length;
-	const trimmedExcerpt = hasCustomExcerpt
-		? rawExcerpt
-		: getTrimmedExcerpt(
-				strippedRenderedExcerpt,
-				excerptLength,
-				wordCountType
-		  );
+	let excerpt = rawExcerpt;
 
+	// When there's no custom excerpt is not custom, use the auto-generated excerpt, trimmed to the defined length.
+	if ( ! hasCustomExcerpt ) {
+		// Only trim the excerpt if it's not a custom excerpt.
+		excerpt = getTrimmedExcerpt(
+			strippedRenderedExcerpt,
+			excerptLength,
+			wordCountType
+		);
+
+		// Add the ellipsis if the excerpt was trimmed, otherwise the server returns an ellipsis.
+		excerpt =
+			excerpt === strippedRenderedExcerpt ? excerpt : excerpt + ELLIPSIS;
+	}
 	const excerptContent = isEditable ? (
 		<RichText
 			className={ excerptClassName }
 			aria-label={ __( 'Excerpt text' ) }
-			value={
-				( hasCustomExcerpt ? rawExcerpt : trimmedExcerpt + ELLIPSIS ) ||
-				__( 'No excerpt found' )
-			}
+			value={ excerpt || __( 'No excerpt found' ) }
 			onChange={ setExcerpt }
 			tagName="p"
 		/>
 	) : (
 		<p className={ excerptClassName }>
-			{ ( hasCustomExcerpt ? rawExcerpt : trimmedExcerpt + ELLIPSIS ) ||
-				__( 'No excerpt found' ) }
+			{ excerpt || __( 'No excerpt found' ) }
 		</p>
 	);
 	return (

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -20,17 +20,17 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	/*
-	* The purpose of the excerpt length setting is to limit the length of both
-	* automatically generated and user-created excerpts.
-	* Because the excerpt_length filter only applies to auto generated excerpts,
-	* wp_trim_words is used instead.
-	*/
-	$excerpt_length = $attributes['excerptLength'];
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
-	if ( isset( $excerpt_length ) ) {
-		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
-	}
+	// Hook into the excerpt_length filter to apply the `excerptLength` attribute.
+	$excerpt_length        = $attributes['excerptLength'];
+	$filter_excerpt_length = static function () use ( $excerpt_length ) {
+		return $excerpt_length;
+	};
+	add_filter(
+		'excerpt_length',
+		$filter_excerpt_length
+	);
+	$excerpt = get_the_excerpt( $block->context['postId'] );
+	remove_filter( 'excerpt_length', $filter_excerpt_length );
 
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
 	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -31,7 +31,18 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	 */
 	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
 	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {
-		return empty( $more_text ) ? $more : '';
+		// If the block has user input more text, return nothing as this is appended later.
+		$has_block_more_text = ! empty( $more_text );
+		if ( $has_block_more_text ) {
+			return '';
+		}
+		// If the default core more text is in use, replace it with the new block editor-y more text.
+		$default_more = ' ' . '[&hellip;]';
+		if ( $more === $default_more ) {
+			return '&hellip;';
+		}
+		// Otherwise, return the custom filtered more text.
+		return $more;
 	};
 
 	// Hook into the excerpt_length filter to apply the `excerptLength` attribute.

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -46,6 +46,8 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	};
 
 	// Hook into the excerpt_length filter to apply the `excerptLength` attribute.
+	// The `excerptLength` attribute has a default value of 55, so will always be set,
+	// so there's no need to fallback to the filtered excerpt_length value.
 	$excerpt_length        = $attributes['excerptLength'];
 	$filter_excerpt_length = static function () use ( $excerpt_length ) {
 		return $excerpt_length;

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -20,22 +20,6 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 		return '';
 	}
 
-	// Hook into the excerpt_length filter to apply the `excerptLength` attribute.
-	$excerpt_length        = $attributes['excerptLength'];
-	$filter_excerpt_length = static function () use ( $excerpt_length ) {
-		return $excerpt_length;
-	};
-	add_filter(
-		'excerpt_length',
-		$filter_excerpt_length
-	);
-	$excerpt = get_the_excerpt( $block->context['postId'] );
-	remove_filter( 'excerpt_length', $filter_excerpt_length );
-
-	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
-	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {
-		return empty( $more_text ) ? $more : '';
-	};
 	/**
 	 * Some themes might use `excerpt_more` filter to handle the
 	 * `more` link displayed after a trimmed excerpt. Since the
@@ -45,7 +29,28 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	 * `excerpt_more` filter and return nothing. This will
 	 * result in showing only one `read more` link at a time.
 	 */
+	$more_text           = ! empty( $attributes['moreText'] ) ? '<a class="wp-block-post-excerpt__more-link" href="' . esc_url( get_the_permalink( $block->context['postId'] ) ) . '">' . wp_kses_post( $attributes['moreText'] ) . '</a>' : '';
+	$filter_excerpt_more = static function ( $more ) use ( $more_text ) {
+		return empty( $more_text ) ? $more : '';
+	};
+
+	// Hook into the excerpt_length filter to apply the `excerptLength` attribute.
+	$excerpt_length        = $attributes['excerptLength'];
+	$filter_excerpt_length = static function () use ( $excerpt_length ) {
+		return $excerpt_length;
+	};
+
 	add_filter( 'excerpt_more', $filter_excerpt_more );
+	add_filter(
+		'excerpt_length',
+		$filter_excerpt_length
+	);
+
+	$excerpt = get_the_excerpt( $block->context['postId'] );
+
+	remove_filter( 'excerpt_more', $filter_excerpt_more );
+	remove_filter( 'excerpt_length', $filter_excerpt_length );
+
 	$classes = array();
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
@@ -62,7 +67,6 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	} else {
 		$content .= " $more_text</p>";
 	}
-	remove_filter( 'excerpt_more', $filter_excerpt_more );
 	return sprintf( '<div %1$s>%2$s</div>', $wrapper_attributes, $content );
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #49449

The post excerpt block's use of `wp_trim_words` to limit excerpt length caused an unexpected side-effect - any HTML tags like formatting are stripped from the block.

This PR fixes the issue for custom excerpts by no longer applying the excerpt length. 

### Note
This change does mean any existing users of the block will find their previously limited length excerpts might now be unbound, so there needs to be a call on whether this is an acceptable trade-off.

## How?
This PR updates the post excerpt block to work like excerpts have traditionally in WordPress:
- Custom excerpts can no longer be limited using the `exceprtLength` block attribute. The user can instead limit the length by typing fewer words. By avoiding using `wp_trim_words`, formatting and any other html is retained on the front-end.
- Auto-generated excerpts can still be limited using the `excerptLength` and work the way they do in `trunk`.

## Testing Instructions
1. Add some content to a new post and include formatting
2. Add the post excerpt block
3. Experiment with the excerpt length
4. Observe that on the front and backend there's no formatting shown from your post content
5. Edit the excerpt and apply some formatting
6. Observe that the formatting is preserved on the frontend and backend
7. Observe that the 'Max number of words' input isn't visible when editing a custom excerpt

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="211" alt="Screenshot 2024-09-10 at 3 13 52 PM" src="https://github.com/user-attachments/assets/b22d770e-88ee-4503-a494-89f70e87ea1d">

#### After
<img width="191" alt="Screenshot 2024-09-10 at 3 13 32 PM" src="https://github.com/user-attachments/assets/fa4ca22c-bdb8-46e3-bf4d-ba50cdc7d2a3">
