### PR TITLE
Remove es-module shims and importmap-polyfill

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,8 +79,7 @@
 				"@wordpress/viewport": "file:packages/viewport",
 				"@wordpress/warning": "file:packages/warning",
 				"@wordpress/widgets": "file:packages/widgets",
-				"@wordpress/wordcount": "file:packages/wordcount",
-				"es-module-shims": "^1.8.2"
+				"@wordpress/wordcount": "file:packages/wordcount"
 			},
 			"devDependencies": {
 				"@actions/core": "1.9.1",
@@ -24842,11 +24841,6 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
 			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true
-		},
-		"node_modules/es-module-shims": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.8.2.tgz",
-			"integrity": "sha512-7vIYVzpOhXtpc3Yn03itB+GSgVZFW7oL4kdydA+iL+IEi7HiSLBUxM05QFw4SxTl6e++pMpGqZPo2+vdNs3TbA=="
 		},
 		"node_modules/es-set-tostringtag": {
 			"version": "2.0.1",
@@ -75263,11 +75257,6 @@
 			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.1.tgz",
 			"integrity": "sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==",
 			"dev": true
-		},
-		"es-module-shims": {
-			"version": "1.8.2",
-			"resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-1.8.2.tgz",
-			"integrity": "sha512-7vIYVzpOhXtpc3Yn03itB+GSgVZFW7oL4kdydA+iL+IEi7HiSLBUxM05QFw4SxTl6e++pMpGqZPo2+vdNs3TbA=="
 		},
 		"es-set-tostringtag": {
 			"version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
 		"@wordpress/viewport": "file:packages/viewport",
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
-		"@wordpress/wordcount": "file:packages/wordcount",
-		"es-module-shims": "^1.8.2"
+		"@wordpress/wordcount": "file:packages/wordcount"
 	},
 	"devDependencies": {
 		"@actions/core": "1.9.1",

--- a/tools/webpack/interactivity.js
+++ b/tools/webpack/interactivity.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const { join } = require( 'path' );
-const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+
 /**
  * WordPress dependencies
  */
@@ -66,19 +66,7 @@ module.exports = {
 			},
 		],
 	},
-	plugins: [
-		...plugins,
-		// TODO: Move it to a different Webpack file.
-		new CopyWebpackPlugin( {
-			patterns: [
-				{
-					from: './node_modules/es-module-shims/dist/es-module-shims.wasm.js',
-					to: './build/modules/importmap-polyfill.min.js',
-				},
-			],
-		} ),
-		new DependencyExtractionWebpackPlugin(),
-	],
+	plugins: [ ...plugins, new DependencyExtractionWebpackPlugin() ],
 	watchOptions: {
 		ignored: [ '**/node_modules' ],
 		aggregateTimeout: 500,


### PR DESCRIPTION

## What?
Remove `es-module-shims` dependency and `wp-importmap-polyfill` interactivity webpack configuration.

These are no longer used in Core or Gutenberg.

See https://core.trac.wordpress.org/ticket/60970

This only seems to have existed in the 6.5 compat directory, which was removed in https://github.com/WordPress/gutenberg/pull/64096.

There are no occurances of `wp-polyfill-importmap` in the codebase now.

Noticed while working on #65064.

## Why?

Unused and unnecessary.

## How?

Remove them.

## Testing Instructions

Search the codebase for mentions. CI builds and e2e tests should pass.
