### PR TITLE
CheckboxControl: Add background transition

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Enhancements
 
 -   `Modal`: Decrease close button size and remove horizontal offset ([#65131](https://github.com/WordPress/gutenberg/pull/65131)).
+-   `CheckboxControl`: Add background transition ([#65212](https://github.com/WordPress/gutenberg/pull/65212)).
 
 ### Internal
 

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -32,7 +32,7 @@
 	height: var(--checkbox-input-size);
 
 	appearance: none;
-	transition: 0.1s border-color ease-in-out;
+	transition: 0.1s border-color ease-in-out, 0.1s background ease-in-out;
 	@include reduce-motion("transition");
 
 	&:focus {

--- a/packages/components/src/checkbox-control/style.scss
+++ b/packages/components/src/checkbox-control/style.scss
@@ -84,9 +84,24 @@ svg.components-checkbox-control__indeterminate {
 	@include break-small() {
 		--checkmark-size: calc(var(--checkbox-input-size) + 4px);
 	}
+
+
+	animation: components-checkbox__appear-animation 0.1s ease-in-out;
 }
 
 .components-checkbox-control__help {
 	display: inline-block;
 	margin-inline-start: calc(var(--checkbox-input-size) + var(--checkbox-input-margin));
+}
+
+
+@keyframes components-checkbox__appear-animation {
+	from {
+		opacity: 0;
+		transform: translate(-50%, -50%) scale(0);
+	}
+	to {
+		opacity: 1;
+		transform: translate(-50%, -50%) scale(1);
+	}
 }


### PR DESCRIPTION
## What?
This PR updates `CheckboxControl` to also add a transition to the background color.

## Why?
Previously, we were only doing it for border color. Animating the background color makes checking of the checkbox more visually appealing. 

## How?
We're just adding a `background` transition.

## Testing Instructions
* Test the `CheckboxControl` component in Storybook: http://localhost:50240/?path=/docs/components-checkboxcontrol--docs
* Test with the Categories panel in the post editor.
* Verify the animation looks good. 
* Verify the animation is not enabled when `prefers-reduced-motion` is enabled.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/208bd189-f537-4204-a4b2-315233882350" />  |  <video src="https://github.com/user-attachments/assets/4223b7ed-8511-4cd9-846c-0fd8b24a9109" />  |
| <video src="https://github.com/user-attachments/assets/a8a49216-9930-4410-9b73-db3241effa1c" />  |  <video src="https://github.com/user-attachments/assets/7a5b04c5-9774-4728-b0d3-464724174923" />  |










