### PR TITLE
Disallow setting grid block rows/columns to zero

### DIFF
--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -74,7 +74,8 @@ export default {
 		// In the experiment we want to also show column control in Auto mode, and
 		// the minimum width control in Manual mode.
 		const showColumnsControl =
-			window.__experimentalEnableGridInteractivity || layout?.columnCount;
+			window.__experimentalEnableGridInteractivity ||
+			!! layout?.columnCount;
 		const showMinWidthControl =
 			window.__experimentalEnableGridInteractivity ||
 			! layout?.columnCount;
@@ -337,7 +338,7 @@ function GridLayoutColumnsAndRowsControl( {
 								}
 							} }
 							value={ columnCount }
-							min={ 0 }
+							min={ 1 }
 							label={ __( 'Columns' ) }
 							hideLabelFromVision={
 								! window.__experimentalEnableGridInteractivity ||
@@ -364,7 +365,7 @@ function GridLayoutColumnsAndRowsControl( {
 									} );
 								} }
 								value={ rowCount }
-								min={ 0 }
+								min={ 1 }
 								label={ __( 'Rows' ) }
 							/>
 						) : (
@@ -378,7 +379,7 @@ function GridLayoutColumnsAndRowsControl( {
 										columnCount: value,
 									} )
 								}
-								min={ 0 }
+								min={ 1 }
 								max={ 16 }
 								withInputField={ false }
 								label={ __( 'Columns' ) }

--- a/packages/block-editor/src/layouts/grid.js
+++ b/packages/block-editor/src/layouts/grid.js
@@ -318,7 +318,7 @@ function GridLayoutColumnsAndRowsControl( {
 									const defaultNewColumnCount =
 										isManualPlacement ? 1 : undefined;
 									const newColumnCount =
-										value === ''
+										value === '' || value === '0'
 											? defaultNewColumnCount
 											: parseInt( value, 10 );
 									onChange( {
@@ -328,7 +328,7 @@ function GridLayoutColumnsAndRowsControl( {
 								} else {
 									// Don't allow unsetting the column count.
 									const newColumnCount =
-										value === ''
+										value === '' || value === '0'
 											? 1
 											: parseInt( value, 10 );
 									onChange( {
@@ -356,7 +356,7 @@ function GridLayoutColumnsAndRowsControl( {
 								onChange={ ( value ) => {
 									// Don't allow unsetting the row count.
 									const newRowCount =
-										value === ''
+										value === '' || value === '0'
 											? 1
 											: parseInt( value, 10 );
 									onChange( {
@@ -372,11 +372,14 @@ function GridLayoutColumnsAndRowsControl( {
 							<RangeControl
 								__next40pxDefaultSize
 								__nextHasNoMarginBottom
-								value={ columnCount ?? 0 }
+								value={ columnCount ?? 1 }
 								onChange={ ( value ) =>
 									onChange( {
 										...layout,
-										columnCount: value,
+										columnCount:
+											value === '' || value === '0'
+												? 1
+												: value,
 									} )
 								}
 								min={ 1 }


### PR DESCRIPTION
## What?
Fixes #65201, by ensuring `0` isn't incorrectly output and then further not allowing a zero value for grid or row counts.

## Why?
IMO, a value of zero doesn't really make sense for grid block columns or rows, I'm not sure what purpose it would have, so I've added some code to disallow it. This also ensures the UI doesn't surprisingly switch between Manual and Auto without the user explicitly setting it.

## How?
- Adds min values to the fields, as well as some additional logic in the `onChange` to prevent `0` from being typed in.
- Updates the boolean rendering logic to ensure it can't output zero

## Testing Instructions
1. Ensure the Grid Experiment is switched off
2. Add a grid block
3. Switch to Manual
4. Try setting the column count to zero

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="272" alt="Screenshot 2024-09-10 at 5 33 31 PM" src="https://github.com/user-attachments/assets/b00f1091-678a-4e7d-aea0-01c4d16d8f91">

#### After
<img width="270" alt="Screenshot 2024-09-10 at 5 33 08 PM" src="https://github.com/user-attachments/assets/a21479fd-e0c8-4bc7-b2d1-6f5cf0c84eff">
