### PR TITLE
Remove background-color and box-shadow from actions

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useInstanceId, usePrevious } from '@wordpress/compose';
+import { useInstanceId, usePrevious, useRefEffect } from '@wordpress/compose';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -144,12 +144,15 @@ function ListItem< Item >( {
 	const labelId = `${ idPrefix }-label`;
 	const descriptionId = `${ idPrefix }-description`;
 
+	const [ actionsWidth, setActionsWidth ] = useState( 0 );
+	const measureActionsWidth = useRefEffect< HTMLElement >( ( node ) => {
+		setActionsWidth( node.offsetWidth );
+	}, [] );
+
 	const [ isHovered, setIsHovered ] = useState( false );
-	const handleMouseEnter = () => {
-		setIsHovered( true );
-	};
-	const handleMouseLeave = () => {
-		setIsHovered( false );
+	const handleHover: React.MouseEventHandler = ( { type } ) => {
+		const isHover = type === 'mouseenter';
+		setIsHovered( isHover );
 	};
 
 	useEffect( () => {
@@ -187,6 +190,11 @@ function ListItem< Item >( {
 		<primaryField.render item={ item } />
 	) : null;
 
+	const primaryFieldInlineStyle =
+		isHovered || isSelected
+			? { paddingInlineEnd: actionsWidth }
+			: undefined;
+
 	return (
 		<Composite.Row
 			ref={ itemRef }
@@ -196,8 +204,8 @@ function ListItem< Item >( {
 				'is-selected': isSelected,
 				'is-hovered': isHovered,
 			} ) }
-			onMouseEnter={ handleMouseEnter }
-			onMouseLeave={ handleMouseLeave }
+			onMouseEnter={ handleHover }
+			onMouseLeave={ handleHover }
 		>
 			<HStack
 				className="dataviews-view-list__item-wrapper"
@@ -230,6 +238,7 @@ function ListItem< Item >( {
 								<span
 									className="dataviews-view-list__primary-field"
 									id={ labelId }
+									style={ primaryFieldInlineStyle }
 								>
 									{ renderedPrimaryField }
 								</span>
@@ -267,6 +276,7 @@ function ListItem< Item >( {
 							flexShrink: '0',
 							width: 'auto',
 						} }
+						ref={ measureActionsWidth }
 					>
 						{ primaryAction && (
 							<PrimaryActionGridCell

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -23,7 +23,8 @@ ul.dataviews-view-list {
 			position: absolute;
 			top: $grid-unit-20;
 			right: 0;
-
+			// Pads __primary-field’s text truncation on hover (done in JS; see ./index.tsx).
+			padding-inline-start: $grid-unit-10;
 
 			> div {
 				height: $button-size-small;
@@ -45,7 +46,6 @@ ul.dataviews-view-list {
 		&.is-hovered,
 		&:focus-within {
 			.dataviews-view-list__item-actions {
-				padding-left: $grid-unit-10;
 				margin-right: $grid-unit-30;
 
 				.components-button {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -45,22 +45,13 @@ ul.dataviews-view-list {
 		&.is-hovered,
 		&:focus-within {
 			.dataviews-view-list__item-actions {
-				background: #f8f8f8;
 				padding-left: $grid-unit-10;
 				margin-right: $grid-unit-30;
-				box-shadow: -12px 0 8px 0 #f8f8f8;
 
 				.components-button {
 					opacity: 1;
 					position: static;
 				}
-			}
-		}
-
-		&.is-selected {
-			.dataviews-view-list__item-actions {
-				background-color: rgb(247 248 255);
-				box-shadow: -12px 0 8px 0 rgb(247 248 255);
 			}
 		}
 


### PR DESCRIPTION
## What?
Addresses #65215. The hard-coded colors are not ideal. I've removed the `background-color` and `box-shadow` altogether, because it seemed like they were unnecessary for `.is-selected` and even `:hover`, `focus-within`. If there is a Figma design for this or further insight on what/why this small UI needs bg then let me know and I'm happy to adjust.

## Why?
See #65215 

## How?
Remove CSS for bg color and box shadow for the small actions area.
<img width="683" alt="Screenshot 2024-09-10 at 5 19 48 PM" src="https://github.com/user-attachments/assets/2791890f-914e-4b02-8e23-fb6cde2a1061">

## Testing Instructions
1. Open the Site Editor
2. Navigate into 'Pages' and click to select one of the list items
