### PR TITLE
Add JSDoc block for getSectionRootClientId in block editor package

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -548,11 +548,13 @@ export function isZoomOutMode( state ) {
 }
 
 /**
- * Retrieves the root client ID for a section from the state.
+ * Retrieves the client ID of the block which contains the blocks
+ * acting as "sections" in the editor. This is typically the "main content"
+ * of the template/post.
  *
  * @param {Object} state Editor state.
  *
- * @return {string|undefined} The root client ID for the section, or undefined if not set.
+ * @return {string|undefined} The section root client ID or undefined if not set.
  */
 export function getSectionRootClientId( state ) {
 	return state.settings?.[ sectionRootClientIdKey ];

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -547,6 +547,13 @@ export function isZoomOutMode( state ) {
 	return state.editorMode === 'zoom-out';
 }
 
+/**
+ * Retrieves the root client ID for a section from the state.
+ *
+ * @param {Object} state Editor state.
+ *
+ * @return {string|undefined} The root client ID for the section, or undefined if not set.
+ */
 export function getSectionRootClientId( state ) {
 	return state.settings?.[ sectionRootClientIdKey ];
 }


### PR DESCRIPTION
## What?
Addresses #65213 

## Why?
Adding documentation to existing block-editor components can help with any of the following:

- encourages knowledge sharing and quicker onboarding for future devs
- supports maintenance and troubleshooting
- mitigates risk

## How?
Add JSDocs formatted doc blocks to existing `getSectionRootClientId`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
n/a
