### PR TITLE
Fix image block crash

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -23,6 +23,7 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { image as icon, plugins as pluginsIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
Follow-up #64320

## What?

This PR fixes a crash that occurs when an Image block is inserted.

![image](https://github.com/user-attachments/assets/2a286431-9c03-4569-8a23-4531f71a2977)

## Why?

This is because two PRs were merged at almost the same time 😅

In #64320, a new `useResizeObserver` hook was added to improve the Image block.

This PR itself works correctly, but right after this PR was merged, #64819 was merged. In #64819, the `useResizeObserver` hook was removed, so the import statement no longer exists, causing a critical error.

## Testing Instructions

Make sure you can insert the image block correctly.