### PR TITLE
DataViews Sidebar: Display item count on DataViews sidebar

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -27,6 +27,7 @@ export default function DataViewItem( {
 	isActive,
 	isCustom,
 	suffix,
+	navigationItemSuffix,
 } ) {
 	const {
 		params: { postType },
@@ -55,6 +56,7 @@ export default function DataViewItem( {
 			<SidebarNavigationItem
 				icon={ iconToUse }
 				{ ...linkInfo }
+				suffix={ navigationItemSuffix }
 				aria-current={ isActive ? 'true' : undefined }
 			>
 				{ title }

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -76,8 +76,12 @@ export function useDefaultViewsWithItemCounts( { postType } ) {
 	} );
 
 	return useMemo( () => {
-		if ( ! records || ! defaultViews ) {
+		if ( ! defaultViews ) {
 			return [];
+		}
+
+		if ( ! records ) {
+			return defaultViews;
 		}
 
 		const counts = {
@@ -98,14 +102,10 @@ export function useDefaultViewsWithItemCounts( { postType } ) {
 		};
 
 		// Filter out views with > 0 item counts.
-		return defaultViews
-			.map( ( _view ) => {
-				if ( counts?.[ _view.slug ] > 0 ) {
-					_view.count = counts[ _view.slug ];
-				}
-				return _view;
-			} )
-			.filter( ( view ) => !! view.count );
+		return defaultViews.map( ( _view ) => {
+			_view.count = counts[ _view.slug ];
+			return _view;
+		} );
 	}, [ defaultViews, records, totalItems ] );
 }
 

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -111,10 +111,12 @@ export function useDefaultViewsWithItemCounts( { postType } ) {
 
 export function useDefaultViews( { postType } ) {
 	const labels = useSelect(
-		( select ) => select( coreStore ).getPostType( postType )?.labels,
+		( select ) => {
+			const { getPostType } = select( coreStore );
+			return getPostType( postType )?.labels;
+		},
 		[ postType ]
 	);
-
 	return useMemo( () => {
 		return [
 			{

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -71,6 +71,7 @@ const DEFAULT_POST_BASE = {
 
 function useDataViewItemCounts( { postType } ) {
 	const { records, totalItems } = useEntityRecords( 'postType', postType, {
+		per_page: -1,
 		status: [ 'any', 'trash' ],
 	} );
 	return useMemo( () => {

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -80,12 +80,12 @@ export function useDefaultViewsWithItemCounts( { postType } ) {
 			return [];
 		}
 
+		// If there are no records, return the default views with no counts.
 		if ( ! records ) {
 			return defaultViews;
 		}
 
 		const counts = {
-			all: totalItems,
 			drafts: records.filter( ( record ) => record.status === 'draft' )
 				.length,
 			future: records.filter( ( record ) => record.status === 'future' )
@@ -100,6 +100,9 @@ export function useDefaultViewsWithItemCounts( { postType } ) {
 			trash: records.filter( ( record ) => record.status === 'trash' )
 				.length,
 		};
+
+		// All items excluding trashed items as per the default "all" status query.
+		counts.all = totalItems ? totalItems - counts.trash : 0;
 
 		// Filter out views with > 0 item counts.
 		return defaultViews.map( ( _view ) => {

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -220,6 +220,6 @@ export function useDefaultViews( { postType } ) {
 				},
 				count: counts?.trash,
 			},
-		].filter( ( { count } ) => count > 0 );
+		];
 	}, [ labels, counts ] );
 }

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -7,7 +7,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { useDefaultViews } from './default-views';
+import { useDefaultViewsWithItemCounts } from './default-views';
 import { unlock } from '../../lock-unlock';
 import DataViewItem from './dataview-item';
 import CustomDataViewsList from './custom-dataviews-list';
@@ -18,7 +18,9 @@ export default function DataViewsSidebarContent() {
 	const {
 		params: { postType, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
-	const defaultViews = useDefaultViews( { postType } );
+
+	const defaultViews = useDefaultViewsWithItemCounts( { postType } );
+
 	if ( ! postType ) {
 		return null;
 	}
@@ -34,7 +36,9 @@ export default function DataViewsSidebarContent() {
 							slug={ dataview.slug }
 							title={ dataview.title }
 							icon={ dataview.icon }
-							suffix={ <span>{ dataview.count }</span> }
+							navigationItemSuffix={
+								<span>{ dataview.count }</span>
+							}
 							type={ dataview.view.type }
 							isActive={
 								! isCustomBoolean &&

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -34,6 +34,7 @@ export default function DataViewsSidebarContent() {
 							slug={ dataview.slug }
 							title={ dataview.title }
 							icon={ dataview.icon }
+							suffix={ <span>{ dataview.count }</span> }
 							type={ dataview.view.type }
 							isActive={
 								! isCustomBoolean &&

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -15,6 +15,10 @@
 		min-width: initial;
 	}
 
+	.edit-site-sidebar-navigation-item.with-suffix {
+		padding-right: $grid-unit-10;
+	}
+
 	&:hover,
 	&:focus,
 	&[aria-current] {


### PR DESCRIPTION

Resolves https://github.com/WordPress/gutenberg/issues/57072

## What?

Displays item count on DataViews sidebar.

> [!NOTE]
> Props to @Souptik2001 for starting this work, and also to the following contributors: https://github.com/WordPress/gutenberg/pull/62028#issuecomment-2133482231 Please include these handles when merging.
 

## Why?


From https://github.com/WordPress/gutenberg/pull/62028

> In the Pattern management sidebar each category is represented by a menu item. Inside each menu item is a count indicating how many patterns there are in the category.

> Therefore, it would be good to also display that on the "Pages" management sidebar, so that anyone can get the count of each view without visiting it.



## How?

From https://github.com/WordPress/gutenberg/pull/62028

> Display the page count beside each view.
> Achieved by fetching all the pages and then doing a filter using Javascript.

## Testing Instructions

1. Go to site-editor.
2. Go to "Pages".
3. On the sidebar, you will see that you have the count of each item/view.



## Screenshots or screencast <!-- if applicable -->

<img width="276" alt="Screenshot 2024-09-11 at 12 47 16 PM" src="https://github.com/user-attachments/assets/440d3de4-36c6-49e6-ac6e-9623f9bfcec8">

