### PR TITLE
Data views post list: check for id before coercing to string

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -174,7 +174,7 @@ function useView( postType ) {
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
 
 function getItemId( item ) {
-	return item?.id ? item.id.toString() : undefined;
+	return item?.id.toString();
 }
 
 export default function PostList( { postType } ) {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -174,7 +174,7 @@ function useView( postType ) {
 const DEFAULT_STATUSES = 'draft,future,pending,private,publish'; // All but 'trash'.
 
 function getItemId( item ) {
-	return item.id.toString();
+	return item?.id ? item.id.toString() : undefined;
 }
 
 export default function PostList( { postType } ) {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and how?

Checks for id on missing records. 

## Why?
Needed for when there are no records after a filter action.



## Testing Instructions

1. Get some pages ready, then head to the Site Editor
2. Open up the pages list
3. Then filter by status using a status that doesn't exist in the page list, e.g., trash or something else.
4. Check that the browser doesn't crash and you see "No results"



## Screenshots or screencast <!-- if applicable -->

### Before 

https://github.com/user-attachments/assets/c684b42b-62bf-4458-8bf0-51485f9836a8



### After


https://github.com/user-attachments/assets/519365ab-f9fc-4b77-9cfa-b11ea0d66f27


