### PR TITLE
Build Plugin: Simplify and improve zip contents

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -78,18 +78,6 @@ npm run build
 php bin/generate-gutenberg-php.php > gutenberg.tmp.php
 mv gutenberg.tmp.php gutenberg.php
 
-build_files=$(
-	ls build/*/*.{js,js.map,css,asset.php} \
-	build/block-library/blocks/*.php \
-	build/block-library/blocks/*/block.json \
-	build/block-library/blocks/*/*.{js,js.map,css,asset.php} \
-	build/edit-widgets/blocks/*/block.json \
-	build/widgets/blocks/*.php \
-	build/widgets/blocks/*/block.json \
-	build/style-engine/*.php \
-)
-
-
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
 zip -r gutenberg.zip \
@@ -97,7 +85,7 @@ zip -r gutenberg.zip \
 	lib \
 	packages/block-serialization-default-parser/*.php \
 	post-content.php \
-	$build_files \
+	build \
 	build-module \
 	readme.txt \
 	changelog.txt \

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -80,7 +80,7 @@ mv gutenberg.tmp.php gutenberg.php
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
-zip -rD \
+zip --recurse-paths --no-dir-entries \
 	gutenberg.zip \
 	gutenberg.php \
 	lib \

--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -80,7 +80,8 @@ mv gutenberg.tmp.php gutenberg.php
 
 # Generate the plugin zip file.
 status "Creating archive... 🎁"
-zip -r gutenberg.zip \
+zip -rD \
+	gutenberg.zip \
 	gutenberg.php \
 	lib \
 	packages/block-serialization-default-parser/*.php \


### PR DESCRIPTION
## What?

### Include all of `/build` directory.

I noticed that the `build-plugin-zip` script manually lists nearly all the files in the build directory. Effectively, directories are excluded from the `build` directory but included for the rest of the plugin.

The only difference here is the inclusion of `build/vendors/react-jsx-runtime.min.js.LICENSE.txt` which seems fine (or should be excluded from the build earlier).


### Exclude directory entries.

Directory structure is still preserved.

As far as I can tell, directories are included in zip files when it's important to preserve their properties (such as permissions). There doesn't seem to be a reason to use special permissions in directories included in the plugin zip, so all of the directory entries can likely be excluded from the zip file.

### Use long zip options

This is simply for clarity, rather than `-r` and `-D`, use the long form of the options.

### Changes to zip

You can see in the diff there's a single license text file addition and a number of directory entries are excluded.

The plugin zip file size changes from `11390087` bytes on trunk to `11387680` on this branch. The zip file produced on this branch is ~2KB smaller.

<details>

<summary>Diff of zip contents</summary>

```patch
diff --git before/dev/fd/11 after/dev/fd/14
--- before/dev/fd/11
+++ after/dev/fd/14
@@ -811,6 +811,7 @@ build/vendors/react-dom.js
 build/vendors/react-dom.min.js
 build/vendors/react-jsx-runtime.js
 build/vendors/react-jsx-runtime.min.js
+build/vendors/react-jsx-runtime.min.js.LICENSE.txt
 build/vendors/react.js
 build/vendors/react.min.js
 build/viewport/index.js
@@ -837,10 +838,8 @@ build/wordcount/index.min.js
 build/wordcount/index.min.js.map
 changelog.txt
 gutenberg.php
-lib/
 lib/README.md
 lib/block-editor-settings.php
-lib/block-supports/
 lib/block-supports/background.php
 lib/block-supports/block-style-variations.php
 lib/block-supports/border.php
@@ -864,13 +863,9 @@ lib/class-wp-theme-json-gutenberg.php
 lib/class-wp-theme-json-resolver-gutenberg.php
 lib/class-wp-theme-json-schema-gutenberg.php
 lib/client-assets.php
-lib/compat/
-lib/compat/plugin/
 lib/compat/plugin/edit-site-routes-backwards-compat.php
 lib/compat/plugin/fonts.php
-lib/compat/wordpress-6.6/
 lib/compat/wordpress-6.6/admin-bar.php
-lib/compat/wordpress-6.6/block-bindings/
 lib/compat/wordpress-6.6/block-bindings/pattern-overrides.php
 lib/compat/wordpress-6.6/block-editor.php
 lib/compat/wordpress-6.6/block-template-utils.php
@@ -879,7 +874,6 @@ lib/compat/wordpress-6.6/class-gutenberg-rest-global-styles-revisions-controller
 lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php
 lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php
 lib/compat/wordpress-6.6/compat.php
-lib/compat/wordpress-6.6/html-api/
 lib/compat/wordpress-6.6/html-api/class-gutenberg-html-decoder-6-6.php
 lib/compat/wordpress-6.6/html-api/class-gutenberg-html-open-elements-6-6.php
 lib/compat/wordpress-6.6/html-api/class-gutenberg-html-processor-6-6.php
@@ -891,7 +885,6 @@ lib/compat/wordpress-6.6/option.php
 lib/compat/wordpress-6.6/post.php
 lib/compat/wordpress-6.6/resolve-patterns.php
 lib/compat/wordpress-6.6/rest-api.php
-lib/compat/wordpress-6.7/
 lib/compat/wordpress-6.7/block-bindings.php
 lib/compat/wordpress-6.7/block-templates.php
 lib/compat/wordpress-6.7/blocks.php
@@ -900,7 +893,6 @@ lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php
 lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php
 lib/compat/wordpress-6.7/class-wp-block-templates-registry.php
 lib/compat/wordpress-6.7/compat.php
-lib/compat/wordpress-6.7/html-api/
 lib/compat/wordpress-6.7/html-api/class-gutenberg-html-active-formatting-elements-6-7.php
 lib/compat/wordpress-6.7/html-api/class-gutenberg-html-attribute-token-6-7.php
 lib/compat/wordpress-6.7/html-api/class-gutenberg-html-decoder-6-7.php
@@ -916,8 +908,6 @@ lib/compat/wordpress-6.7/html-api/class-gutenberg-html-unsupported-exception-6-7
 lib/compat/wordpress-6.7/rest-api.php
 lib/compat/wordpress-6.7/script-modules.php
 lib/demo.php
-lib/experimental/
-lib/experimental/assets/
 lib/experimental/assets/tinymce-proxy.js
 lib/experimental/block-editor-settings-mobile.php
 lib/experimental/blocks.php
@@ -926,8 +916,6 @@ lib/experimental/class-wp-rest-block-editor-settings-controller.php
 lib/experimental/data-views.php
 lib/experimental/disable-tinymce.php
 lib/experimental/editor-settings.php
-lib/experimental/font-face/
-lib/experimental/font-face/bc-layer/
 lib/experimental/font-face/bc-layer/class-gutenberg-fonts-api-bc-layer.php
 lib/experimental/font-face/bc-layer/class-wp-fonts-provider-local.php
 lib/experimental/font-face/bc-layer/class-wp-fonts-provider.php
@@ -944,15 +932,12 @@ lib/experimental/full-page-client-side-navigation.php
 lib/experimental/kses-allowed-html.php
 lib/experimental/kses.php
 lib/experimental/l10n.php
-lib/experimental/media/
 lib/experimental/media/class-gutenberg-rest-attachments-controller.php
 lib/experimental/media/load.php
 lib/experimental/navigation-theme-opt-in.php
-lib/experimental/posts/
 lib/experimental/posts/load.php
 lib/experimental/rest-api.php
 lib/experimental/script-modules.php
-lib/experimental/sync/
 lib/experimental/sync/README.md
 lib/experimental/sync/class-gutenberg-http-signaling-server.php
 lib/experimental/synchronization.php
```

</details>

Noticed while working on #65064.

## Testing Instructions

[A good way to test is with the playground.](https://playground.wordpress.net/gutenberg.html) It relies on the plugin zip compiled for this PR. Gutenberg should continue to work as expected.

