### PR TITLE
Connected blocks, add backdrop-color.

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -41,6 +41,8 @@
 	&.is-connected {
 		.block-editor-block-switcher .components-button .block-editor-block-icon {
 			color: var(--wp-block-synced-color);
+			background: color-mix(in srgb, var(--wp-block-synced-color) 10%, transparent);
+			border-radius: $radius-small;
 		}
 
 		.components-toolbar-button.block-editor-block-switcher__no-switcher-icon {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -37,13 +37,15 @@
 		border-right: $border-width solid $gray-300;
 	}
 
-	&.is-synced,
 	&.is-connected {
 		.block-editor-block-switcher .components-button::before {
 			background: color-mix(in srgb, var(--wp-block-synced-color) 10%, transparent);
 			border-radius: $radius-small;
 		}
+	}
 
+	&.is-synced,
+	&.is-connected {
 		.block-editor-block-switcher .components-button .block-editor-block-icon {
 			color: var(--wp-block-synced-color);
 		}

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -39,10 +39,13 @@
 
 	&.is-synced,
 	&.is-connected {
-		.block-editor-block-switcher .components-button .block-editor-block-icon {
-			color: var(--wp-block-synced-color);
+		.block-editor-block-switcher .components-button::before {
 			background: color-mix(in srgb, var(--wp-block-synced-color) 10%, transparent);
 			border-radius: $radius-small;
+		}
+
+		.block-editor-block-switcher .components-button .block-editor-block-icon {
+			color: var(--wp-block-synced-color);
 		}
 
 		.components-toolbar-button.block-editor-block-switcher__no-switcher-icon {


### PR DESCRIPTION
## What?

Alternative to #65199. Adds a purple backdrop to the icon itself, so it's easier to tell at a glance. 

Before:

![before](https://github.com/user-attachments/assets/cc21113f-5a9c-4e9b-bf1c-4bf20b2eec60)

After:

![after](https://github.com/user-attachments/assets/d7a94afa-8483-40db-b3c7-3ceaaa1927d2)
