### PR TITLE
Fix: Moving the last page item to the the trash causes a crash.

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -395,6 +395,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 				data.length - 1,
 				Math.max( 0, targetIndex )
 			);
+			if ( ! data[ clampedIndex ] ) {
+				return;
+			}
 			const itemIdPrefix = generateCompositeItemIdPrefix(
 				data[ clampedIndex ]
 			);


### PR DESCRIPTION
Fixes an issue found by @jasmussen, where when there is only a single page available on the all-pages view. Moving the page to the trash crashes the application.


## Testing Instructions
Go to the site editor -> pages.
On the all pages view move all the pages to the trash so there is only a single page left.
Now move that single page to the trash and verify everything worked well on trunk a crash happens.
