### PR TITLE
Build Tooling: Correctly generate PHP files for server-side rendering of blocks on Windows OS

### DIFF
--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -135,7 +135,7 @@ module.exports = [
 						{
 							from: `${ from }/**/*.php`,
 							to( { absoluteFilename } ) {
-								const [ , dirname, _basename ] =
+								const [ , dirname, fileBasename ] =
 									absoluteFilename.match(
 										new RegExp(
 											`([\\w-]+)${ escapeRegExp(
@@ -143,13 +143,13 @@ module.exports = [
 											) }([\\w-]+)\\.php$`
 										)
 									);
-								if ( _basename === 'index' ) {
+								if ( fileBasename === 'index' ) {
 									return join( to, `${ dirname }.php` );
 								}
 								return join(
 									to,
 									dirname,
-									`${ _basename }.php`
+									`${ fileBasename }.php`
 								);
 							},
 							filter: ( filepath ) => {

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
-const { join, sep } = require( 'path' );
+const { join, sep, basename } = require( 'path' );
 const fastGlob = require( 'fast-glob' );
 const { realpathSync } = require( 'fs' );
 
@@ -135,7 +135,7 @@ module.exports = [
 						{
 							from: `${ from }/**/*.php`,
 							to( { absoluteFilename } ) {
-								const [ , dirname, basename ] =
+								const [ , dirname, _basename ] =
 									absoluteFilename.match(
 										new RegExp(
 											`([\\w-]+)${ escapeRegExp(
@@ -143,15 +143,18 @@ module.exports = [
 											) }([\\w-]+)\\.php$`
 										)
 									);
-
-								if ( basename === 'index' ) {
+								if ( _basename === 'index' ) {
 									return join( to, `${ dirname }.php` );
 								}
-								return join( to, dirname, `${ basename }.php` );
+								return join(
+									to,
+									dirname,
+									`${ _basename }.php`
+								);
 							},
 							filter: ( filepath ) => {
 								return (
-									filepath.endsWith( sep + 'index.php' ) ||
+									basename( filepath ) === 'index.php' ||
 									PhpFilePathsPlugin.paths.includes(
 										realpathSync( filepath ).replace(
 											/\\/g,


### PR DESCRIPTION
Fixes #65244

## What?

This PR correctly generates PHP files for server-side rendering of blocks when running `npm run {start|build}` on a Windows _host_ OS.

## Why?

This issue was caused by #63311.

After investigating the `tools\webpack\blocks.js` file, which is a custom setting for the Gutenberg project, I found that the `filepath` argument to the `filter` option of the `CopyWebpackPlugin` plugin uses forward slashes instead of backslashes even on Windows OS.

Example of `filepath`: `D:/Desktop/path/to/gutenberg/packages/block-library/src/archives/index.php`

On the other hand, `path.sep` is a backslash on Windows OS, so it does not match the following conditional statement.

```javascript
filepath.endsWith( sep + 'index.php' )
```

## How?

It is probably better to check the file name accurately with `path.basename` rather than checking the file name with `endsWith` method.

Just to be sure, I ran `npm run build` on WSL2 (Ubuntu OS) and Windows host OS and got the diff of the entire `build/` directory, and the file configuration of each build directory is completely consistent in this PR.

## Testing Instructions

- This PR should have no effect on Mac OS. When you run `npm run {start|build}`, make sure that the PHP file is generated in `build/block-library/blocks/`. as before.
- In addition, make sure that the test procedure presented in [#63311](https://github.com/WordPress/gutenberg/pull/63311) is still successful. On Windows OS, I have confirmed that the correct results are obtained when I follow this procedure.
