### PR TITLE
Update Image block margins for RTL in editor

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -94,14 +94,18 @@ figure.wp-block-image:not(.wp-block) {
 }
 
 .wp-block[data-align="left"] > .wp-block-image {
+	/*rtl:ignore*/
 	margin-right: 1em;
+	/*rtl:ignore*/
 	margin-left: 0;
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;
 }
 
 .wp-block[data-align="right"] > .wp-block-image {
+	/*rtl:ignore*/
 	margin-left: 1em;
+	/*rtl:ignore*/
 	margin-right: 0;
 	margin-top: 0.5em;
 	margin-bottom: 0.5em;


### PR DESCRIPTION
Follow-up to #47617 (issue #44845)

## What?
Adds `/*rtl:ignore*/` comments to adjust the left and right margins of the Image block for RTL languages.

## Why?
- Prevent nearby text from touching the image.
- Match the front.

## Testing Instructions
1. Set the Site Language (and/or your profile language) to a right-to-left language.
2. Activate Twenty Sixteen.
3. Open the post editor.
4. Add an Image block with a small image.
5. Set the Image block's alignment to Align left.
6. Add a Paragraph block immediately following the image.
7. Create a similar Image block, aligned right, and follow that with another paragraph.
8. Resize the viewport (or editor canvas) to confirm that the paragraph text does not touch the image at any screen width.