### PR TITLE
Gutenberg 19.2: Backports for Release

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -80,5 +80,8 @@
 			}
 		}
 	},
-	"style": "wp-block-post-title"
+	"style": "wp-block-post-title",
+	"selectors": {
+		"typography": ".wp-block-post-title, .wp-block-post-title > a"
+	}
 }

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -3,6 +3,30 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
+	&[style*="font-weight"] :where(a) {
+		font-weight: inherit;
+	}
+	&[class*="-font-family"] :where(a),
+	&[style*="font-family"] :where(a) {
+		font-family: inherit;
+	}
+	&[class*="-font-size"] :where(a),
+	&[style*="font-size"] :where(a) {
+		font-size: inherit;
+	}
+	&[style*="line-height"] :where(a) {
+		line-height: inherit;
+	}
+	&[style*="font-style"] :where(a) {
+		font-style: inherit;
+	}
+	&[style*="letter-spacing"] :where(a) {
+		letter-spacing: inherit;
+	}
+	&[style*="text-decoration"] :where(a) {
+		text-decoration: inherit;
+	}
+
 	a {
 		display: inline-block;
 	}

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -75,5 +75,8 @@
 		}
 	},
 	"editorStyle": "wp-block-site-title-editor",
-	"style": "wp-block-site-title"
+	"style": "wp-block-site-title",
+	"selectors": {
+		"typography": ".wp-block-site-title > span, .wp-block-site-title > a"
+	}
 }

--- a/packages/block-library/src/site-title/style.scss
+++ b/packages/block-library/src/site-title/style.scss
@@ -2,6 +2,30 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
+	&[style*="font-weight"] :where(a) {
+		font-weight: inherit;
+	}
+	&[class*="-font-family"] :where(a),
+	&[style*="font-family"] :where(a) {
+		font-family: inherit;
+	}
+	&[class*="-font-size"] :where(a),
+	&[style*="font-size"] :where(a) {
+		font-size: inherit;
+	}
+	&[style*="line-height"] :where(a) {
+		line-height: inherit;
+	}
+	&[style*="font-style"] :where(a) {
+		font-style: inherit;
+	}
+	&[style*="letter-spacing"] :where(a) {
+		letter-spacing: inherit;
+	}
+	&[style*="text-decoration"] :where(a) {
+		text-decoration: inherit;
+	}
+
 	:where(a) {
 		color: inherit;
 	}

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -155,7 +155,7 @@ export const getEntityRecord =
 					}
 				);
 
-				if ( query !== undefined ) {
+				if ( query !== undefined && query._fields ) {
 					query = { ...query, include: [ key ] };
 
 					// The resolution cache won't consider query as reusable based on the

--- a/packages/core-data/src/test/resolvers.js
+++ b/packages/core-data/src/test/resolvers.js
@@ -80,7 +80,6 @@ describe( 'getEntityRecord', () => {
 
 	it( 'accepts a query that overrides default api path', async () => {
 		const query = { context: 'view', _envelope: '1' };
-		const queryObj = { include: [ 'post' ], ...query };
 
 		const select = {
 			hasEntityRecords: jest.fn( () => {} ),
@@ -98,13 +97,6 @@ describe( 'getEntityRecord', () => {
 			query
 		)( { dispatch, select, registry } );
 
-		// Check resolution cache for an existing entity that fulfills the request with query.
-		expect( select.hasEntityRecords ).toHaveBeenCalledWith(
-			'root',
-			'postType',
-			queryObj
-		);
-
 		// Trigger apiFetch, test that the query is present in the url.
 		expect( triggerFetch ).toHaveBeenCalledWith( {
 			path: '/wp/v2/types/post?context=view&_envelope=1',
@@ -116,7 +108,7 @@ describe( 'getEntityRecord', () => {
 			'root',
 			'postType',
 			POST_TYPE,
-			queryObj
+			query
 		);
 
 		// Locks should have been acquired and released.

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Prevent calling `proxifyContext` over an already-proxified context inside `wp-context` ([#65090](https://github.com/WordPress/gutenberg/pull/65090)).
+
 ## 6.7.0 (2024-09-05)
 
 ### Enhancements

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -290,11 +290,10 @@ export default () => {
 						currentValue.current,
 						deepClone( value ) as object
 					);
-					currentValue.current = proxifyContext(
+					result[ namespace ] = proxifyContext(
 						currentValue.current,
 						inheritedValue[ namespace ]
 					);
-					result[ namespace ] = currentValue.current;
 				}
 				return result;
 			}, [ defaultEntry, inheritedValue ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

These are commits tagged with "Backport to Gutenberg RC" that will make it into Gutenberg 19.2 later today.