### PR TITLE
Combobox Control: Add placeholder attribute

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### New Features
 
 -   `Composite`: add stable version of the component ([#63569](https://github.com/WordPress/gutenberg/pull/63569)).
+-   `ComboboxControl`: add support for `placeholder` attribute ([#65254](https://github.com/WordPress/gutenberg/pull/65254)).
 
 ### Enhancements
 

--- a/packages/components/src/combobox-control/README.md
+++ b/packages/components/src/combobox-control/README.md
@@ -111,6 +111,13 @@ If the control is clicked, the dropdown will expand regardless of this prop.
 -   Required: No
 -   Default: `true`
 
+### placeholder
+
+If passed, the combobox input will show a placeholder string if no values are present.
+
+-   Type: `string`
+-   Required: No
+
 #### __experimentalRenderItem
 
 Custom renderer invoked for each option in the suggestion list. The render prop receives as its argument an object containing, under the `item` key, the single option's data (directly from the array of data passed to the `options` prop).

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -129,6 +129,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		},
 		__experimentalRenderItem,
 		expandOnFocus = true,
+		placeholder,
 	} = useDeprecated36pxDefaultSizeProp( props );
 
 	const [ value, setValue ] = useControlledValue( {
@@ -340,6 +341,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 								className="components-combobox-control__input"
 								instanceId={ instanceId }
 								ref={ inputContainer }
+								placeholder={ placeholder }
 								value={ isExpanded ? inputValue : currentLabel }
 								onFocus={ onFocus }
 								onBlur={ onBlur }

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -80,6 +80,7 @@ Default.args = {
 	allowReset: false,
 	label: 'Select a country',
 	options: countryOptions,
+	placeholder: 'Optional placeholder',
 };
 
 /**

--- a/packages/components/src/combobox-control/stories/index.story.tsx
+++ b/packages/components/src/combobox-control/stories/index.story.tsx
@@ -80,7 +80,6 @@ Default.args = {
 	allowReset: false,
 	label: 'Select a country',
 	options: countryOptions,
-	placeholder: 'Optional placeholder',
 };
 
 /**

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -82,4 +82,8 @@ export type ComboboxControlProps = Pick<
 	 * The current value of the control.
 	 */
 	value?: string | null;
+	/**
+	 * The placeholder for the Combobox.
+	 */
+	placeholder?: string;
 };

--- a/packages/components/src/combobox-control/types.ts
+++ b/packages/components/src/combobox-control/types.ts
@@ -83,7 +83,7 @@ export type ComboboxControlProps = Pick<
 	 */
 	value?: string | null;
 	/**
-	 * The placeholder for the Combobox.
+	 * If passed, the combobox input will show a placeholder string if no values are present.
 	 */
 	placeholder?: string;
 };


### PR DESCRIPTION
## What?

Title.

## Why?

Increase UX of the Combobox control by making possible to specify a placeholder for it.

## How?

Accepts a `placeholder` prop and passes it to the `<TokenInput />` element.

## Testing Instructions

Open Storybook and pick the Components > ComboboxControl component. You should see the placeholder applied.

## Screenshots or screencast

![image](https://github.com/user-attachments/assets/2a045217-1a34-4b0c-b37f-13ade09e93d6)
