### PR TITLE
ComboboxControl: Add more unit tests

### DIFF
--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -241,9 +241,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		if ( expandOnFocus ) {
 			setIsExpanded( true );
 		}
-
-		onFilterValueChange( '' );
-		setInputValue( '' );
 	};
 
 	const onClick = () => {

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -150,6 +150,12 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	const [ inputValue, setInputValue ] = useState( '' );
 	const inputContainer = useRef< HTMLInputElement >( null );
 
+	useEffect( () => {
+		if ( ! inputHasFocus ) {
+			setInputValue( '' );
+		}
+	}, [ inputHasFocus ] );
+
 	const matchingSuggestions = useMemo( () => {
 		const startsWithMatch: ComboboxControlOption[] = [];
 		const containsMatch: ComboboxControlOption[] = [];
@@ -238,8 +244,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		if ( ! currentOption ) {
 			onFilterValueChange( '' );
 		}
-
-		setInputValue( '' );
 	};
 
 	const onFocus = () => {

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -234,6 +234,12 @@ function ComboboxControl( props: ComboboxControlProps ) {
 
 	const onBlur = () => {
 		setInputHasFocus( false );
+
+		if ( ! currentOption ) {
+			onFilterValueChange( '' );
+		}
+
+		setInputValue( '' );
 	};
 
 	const onFocus = () => {

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -241,6 +241,9 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		if ( expandOnFocus ) {
 			setIsExpanded( true );
 		}
+
+		onFilterValueChange( '' );
+		setInputValue( '' );
 	};
 
 	const onClick = () => {

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -234,12 +234,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 
 	const onBlur = () => {
 		setInputHasFocus( false );
-
-		if ( ! currentOption ) {
-			onFilterValueChange( '' );
-		}
-
-		setInputValue( '' );
 	};
 
 	const onFocus = () => {

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -150,12 +150,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	const [ inputValue, setInputValue ] = useState( '' );
 	const inputContainer = useRef< HTMLInputElement >( null );
 
-	useEffect( () => {
-		if ( ! inputHasFocus ) {
-			setInputValue( '' );
-		}
-	}, [ inputHasFocus ] );
-
 	const matchingSuggestions = useMemo( () => {
 		const startsWithMatch: ComboboxControlOption[] = [];
 		const containsMatch: ComboboxControlOption[] = [];
@@ -244,6 +238,8 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		if ( ! currentOption ) {
 			onFilterValueChange( '' );
 		}
+
+		setInputValue( '' );
 	};
 
 	const onFocus = () => {

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -188,6 +188,46 @@ describe.each( [
 		expect( input ).toHaveValue( targetOption.label );
 	} );
 
+	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
+		const user = userEvent.setup();
+		const onFilterValueChangeSpy = jest.fn();
+		render(
+			<Component
+				options={ timezones }
+				label={ defaultLabelText }
+				onFilterValueChange={ onFilterValueChangeSpy }
+			/>
+		);
+
+		const input = getInput( defaultLabelText );
+
+		await user.type( input, 'a' );
+		expect( onFilterValueChangeSpy ).toHaveBeenCalledWith( 'a' );
+	} );
+
+	it( 'clears the textbox value if there is no selected value on blur', async () => {
+		const user = userEvent.setup();
+		const onFilterValueChangeSpy = jest.fn();
+		render(
+			<Component
+				options={ timezones }
+				label={ defaultLabelText }
+				onFilterValueChange={ onFilterValueChangeSpy }
+			/>
+		);
+		const input = getInput( defaultLabelText );
+
+		await user.type( input, 'a' );
+		expect( input ).toHaveValue( 'a' );
+
+		// Blur and focus the input.
+		await user.tab();
+		await user.click( input );
+
+		expect( input ).toHaveValue( '' );
+		expect( onFilterValueChangeSpy ).toHaveBeenLastCalledWith( '' );
+	} );
+
 	it( 'should select the correct option from a search', async () => {
 		const user = await userEvent.setup();
 		const targetOption = timezones[ 13 ];

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -188,6 +188,26 @@ describe.each( [
 		expect( input ).toHaveValue( targetOption.label );
 	} );
 
+	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = jest.fn();
+		render(
+			<Component
+				options={ timezones }
+				label={ defaultLabelText }
+				onFilterValueChange={ onChangeSpy }
+			/>
+		);
+		const input = getInput( defaultLabelText );
+
+		await user.click( input );
+		expect( onChangeSpy ).not.toHaveBeenCalled();
+
+		await user.type( input, 'a' );
+		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onChangeSpy ).toHaveBeenCalledWith( 'a' );
+	} );
+
 	it( 'should select the correct option from a search', async () => {
 		const user = await userEvent.setup();
 		const targetOption = timezones[ 13 ];

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -188,7 +188,7 @@ describe.each( [
 		expect( input ).toHaveValue( targetOption.label );
 	} );
 
-	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
+	it( 'does not call onFilterValueChange on focus', async () => {
 		const user = userEvent.setup();
 		const onChangeSpy = jest.fn();
 		render(
@@ -202,10 +202,49 @@ describe.each( [
 
 		await user.click( input );
 		expect( onChangeSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = jest.fn();
+		render(
+			<Component
+				options={ timezones }
+				label={ defaultLabelText }
+				onFilterValueChange={ onChangeSpy }
+			/>
+		);
+
+		const input = getInput( defaultLabelText );
 
 		await user.type( input, 'a' );
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeSpy ).toHaveBeenCalledWith( 'a' );
+	} );
+
+	it( 'clears the textbox value if there is no selected value on blur', async () => {
+		const user = userEvent.setup();
+		const onChangeSpy = jest.fn();
+		render(
+			<Component
+				options={ timezones }
+				label={ defaultLabelText }
+				onFilterValueChange={ onChangeSpy }
+			/>
+		);
+		const input = getInput( defaultLabelText );
+
+		await user.type( input, 'a' );
+		expect( input ).toHaveValue( 'a' );
+
+		onChangeSpy.mockReset();
+
+		// Clicking document.body to trigger a blur event on the input.
+		await user.click( document.body );
+
+		expect( input ).toHaveValue( '' );
+		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
+		expect( onChangeSpy ).toHaveBeenCalledWith( '' );
 	} );
 
 	it( 'should select the correct option from a search', async () => {

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -188,26 +188,6 @@ describe.each( [
 		expect( input ).toHaveValue( targetOption.label );
 	} );
 
-	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
-		const user = userEvent.setup();
-		const onChangeSpy = jest.fn();
-		render(
-			<Component
-				options={ timezones }
-				label={ defaultLabelText }
-				onFilterValueChange={ onChangeSpy }
-			/>
-		);
-		const input = getInput( defaultLabelText );
-
-		await user.click( input );
-		expect( onChangeSpy ).not.toHaveBeenCalled();
-
-		await user.type( input, 'a' );
-		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
-		expect( onChangeSpy ).toHaveBeenCalledWith( 'a' );
-	} );
-
 	it( 'should select the correct option from a search', async () => {
 		const user = await userEvent.setup();
 		const targetOption = timezones[ 13 ];

--- a/packages/components/src/combobox-control/test/index.tsx
+++ b/packages/components/src/combobox-control/test/index.tsx
@@ -188,7 +188,7 @@ describe.each( [
 		expect( input ).toHaveValue( targetOption.label );
 	} );
 
-	it( 'does not call onFilterValueChange on focus', async () => {
+	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
 		const user = userEvent.setup();
 		const onChangeSpy = jest.fn();
 		render(
@@ -202,49 +202,10 @@ describe.each( [
 
 		await user.click( input );
 		expect( onChangeSpy ).not.toHaveBeenCalled();
-	} );
-
-	it( 'calls onFilterValueChange whenever the textbox changes', async () => {
-		const user = userEvent.setup();
-		const onChangeSpy = jest.fn();
-		render(
-			<Component
-				options={ timezones }
-				label={ defaultLabelText }
-				onFilterValueChange={ onChangeSpy }
-			/>
-		);
-
-		const input = getInput( defaultLabelText );
 
 		await user.type( input, 'a' );
 		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
 		expect( onChangeSpy ).toHaveBeenCalledWith( 'a' );
-	} );
-
-	it( 'clears the textbox value if there is no selected value on blur', async () => {
-		const user = userEvent.setup();
-		const onChangeSpy = jest.fn();
-		render(
-			<Component
-				options={ timezones }
-				label={ defaultLabelText }
-				onFilterValueChange={ onChangeSpy }
-			/>
-		);
-		const input = getInput( defaultLabelText );
-
-		await user.type( input, 'a' );
-		expect( input ).toHaveValue( 'a' );
-
-		onChangeSpy.mockReset();
-
-		// Clicking document.body to trigger a blur event on the input.
-		await user.click( document.body );
-
-		expect( input ).toHaveValue( '' );
-		expect( onChangeSpy ).toHaveBeenCalledTimes( 1 );
-		expect( onChangeSpy ).toHaveBeenCalledWith( '' );
 	} );
 
 	it( 'should select the correct option from a search', async () => {


### PR DESCRIPTION
## What?

We're clearing the filter and input values whenever the textbox gets focused. This PR modifies this behavior and only clears the filter value on blur and if there's no option selected.

## Why?

The previous behavior was not intuitive and brought unintended consequences (i.e., calling an endpoint with an empty string because the `onFilterValueChange` callback was fired, despite nothing having changed.)

## Testing Instructions

Open the Storybook component and start typing in the box. Blur it and the filter value should be gone. In the unit tests, check that relevant `onFilterValueChange` behaves as expected (i.e., the tests passes.)

## Screencast


https://github.com/user-attachments/assets/ab91f572-4fcb-44c0-8781-28566ff74014

