### PR TITLE
Combobox Control: Sync props.value with internal inputValue

### DIFF
--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -273,6 +273,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 
 	const handleOnReset = () => {
 		setValue( null );
+		setSelectedSuggestion( null );
 		inputContainer.current?.focus();
 	};
 

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -183,7 +183,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 		setValue( newSelectedSuggestion.value );
 		speak( messages.selected, 'assertive' );
 		setSelectedSuggestion( newSelectedSuggestion );
-		setInputValue( '' );
 		setIsExpanded( false );
 	};
 

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -13,6 +13,7 @@ import {
 	useMemo,
 	useRef,
 	useEffect,
+	useLayoutEffect,
 } from '@wordpress/element';
 import { useInstanceId } from '@wordpress/compose';
 import { speak } from '@wordpress/a11y';
@@ -137,7 +138,6 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	} );
 
 	const currentOption = options.find( ( option ) => option.value === value );
-	const currentLabel = currentOption?.label ?? '';
 	// Use a custom prefix when generating the `instanceId` to avoid having
 	// duplicate input IDs when rendering this component and `FormTokenField`
 	// in the same page (see https://github.com/WordPress/gutenberg/issues/42112).
@@ -148,6 +148,13 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ inputHasFocus, setInputHasFocus ] = useState( false );
 	const [ inputValue, setInputValue ] = useState( '' );
+
+	const currentLabel = currentOption?.label;
+
+	useLayoutEffect( () => {
+		setInputValue( currentLabel ?? '' );
+	}, [ currentLabel ] );
+
 	const inputContainer = useRef< HTMLInputElement >( null );
 
 	const matchingSuggestions = useMemo( () => {
@@ -234,6 +241,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 
 	const onBlur = () => {
 		setInputHasFocus( false );
+		setInputValue( currentLabel ?? '' );
 	};
 
 	const onFocus = () => {
@@ -340,7 +348,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 								className="components-combobox-control__input"
 								instanceId={ instanceId }
 								ref={ inputContainer }
-								value={ isExpanded ? inputValue : currentLabel }
+								value={ inputValue }
 								onFocus={ onFocus }
 								onBlur={ onBlur }
 								onClick={ onClick }


### PR DESCRIPTION
Blocked by https://github.com/WordPress/gutenberg/pull/65255.

## What?

The Combobox was displaying a blank value when expanded, even though there was a selection. My guess is it was like that so all the suggestions show up. But that's a bit weird considering there is already a selected value, so we should narrow the options to the selected value.

## Why?

Displays a consistent value regardless of the Combobox Control state, which improves UX.

## How?

Uses a `useLayoutEffect` hook to make sure the value from outside is copied into `inputValue` whenever it changes.

## Testing Instructions

Open Storybook > Components > Combobox Control and type anything. Blur the input and the value should be gone. Start typing again but this time select an option. Blur the input and the value should remain. Rinse and repeat.

## Screenshots or screencast


https://github.com/user-attachments/assets/518e9ddd-68bc-41fb-b25d-861037734bf5

