### PR TITLE
Global Styles: Update REST controller override method and backport changes from Core

### DIFF
--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -675,6 +675,9 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 
 		$variations = WP_Theme_JSON_Resolver_Gutenberg::get_style_variations();
 
+		error_log( '-------WP_Theme_JSON_Resolver_Gutenberg::get_style_variations()' );
+		error_log( print_r( $variations, true ) );
+
 		// Add resolved theme asset links.
 		foreach ( $variations as $variation ) {
 			$variation_theme_json = new WP_Theme_JSON_Gutenberg( $variation );

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -60,7 +60,12 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 						),
 					),
 				),
-			)
+			),
+			/*
+			 * $override is set to true to avoid conflicts with the core endpoint.
+			 * Do not sync to WordPress core.
+			 */
+			true
 		);
 
 		// List themes global styles.
@@ -89,7 +94,12 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 						),
 					),
 				),
-			)
+			),
+			/*
+			 * $override is set to true to avoid conflicts with the core endpoint.
+			 * Do not sync to WordPress core.
+			 */
+			true
 		);
 
 		// Lists/updates a single global style variation based on the given id.
@@ -117,7 +127,12 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 				),
 				'schema'      => array( $this, 'get_public_item_schema' ),
 				'allow_batch' => $this->allow_batch,
-			)
+			),
+			/*
+			 * $override is set to true to avoid conflicts with the core endpoint.
+			 * Do not sync to WordPress core.
+			 */
+			true
 		);
 	}
 
@@ -674,9 +689,6 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 		gutenberg_register_block_style_variations_from_theme_json_partials( $partials );
 
 		$variations = WP_Theme_JSON_Resolver_Gutenberg::get_style_variations();
-
-		error_log( '-------WP_Theme_JSON_Resolver_Gutenberg::get_style_variations()' );
-		error_log( print_r( $variations, true ) );
 
 		// Add resolved theme asset links.
 		foreach ( $variations as $variation ) {

--- a/lib/class-wp-rest-global-styles-controller-gutenberg.php
+++ b/lib/class-wp-rest-global-styles-controller-gutenberg.php
@@ -59,6 +59,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 							'type'        => 'string',
 						),
 					),
+					'allow_batch'         => $this->allow_batch,
 				),
 			),
 			/*
@@ -93,6 +94,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 							'sanitize_callback' => array( $this, '_sanitize_global_styles_callback' ),
 						),
 					),
+					'allow_batch'         => $this->allow_batch,
 				),
 			),
 			/*
@@ -246,18 +248,6 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 		}
 
 		return true;
-	}
-
-	/**
-	 * Checks if a global style can be edited.
-	 *
-	 * @since 5.9.0
-	 *
-	 * @param WP_Post $post Post object.
-	 * @return bool Whether the post can be edited.
-	 */
-	protected function check_update_permission( $post ) {
-		return current_user_can( 'edit_post', $post->ID );
 	}
 
 	/**
@@ -465,21 +455,6 @@ class WP_REST_Global_Styles_Controller_Gutenberg extends WP_REST_Posts_Controlle
 		}
 
 		return $rels;
-	}
-
-	/**
-	 * Overwrites the default protected title format.
-	 *
-	 * By default, WordPress will show password protected posts with a title of
-	 * "Protected: %s", as the REST API communicates the protected status of a post
-	 * in a machine readable format, we remove the "Protected: " prefix.
-	 *
-	 * @since 5.9.0
-	 *
-	 * @return string Protected title format.
-	 */
-	public function protected_title_format() {
-		return '%s';
 	}
 
 	/**

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @return array Array of arguments for registering a post type.
  */
 function gutenberg_override_global_styles_endpoint( array $args ): array {
-	$args['rest_controller_class'] = 'WP_REST_Global_Styles_Controller_Gutenberg';
+	$args['rest_controller_class']           = 'WP_REST_Global_Styles_Controller_Gutenberg';
 	$args['revisions_rest_controller_class'] = 'Gutenberg_REST_Global_Styles_Revisions_Controller_6_6';
 
 	return $args;

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function gutenberg_override_global_styles_endpoint( array $args, string $post_type ): array {
 	if ( 'wp_global_styles' === $post_type ) {
-		$args['rest_controller_class'] = WP_REST_Global_Styles_Controller_Gutenberg::class;
+		$args['rest_controller_class'] = 'WP_REST_Global_Styles_Controller_Gutenberg';
 	}
 
 	return $args;

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -28,6 +28,14 @@ function gutenberg_override_global_styles_endpoint( array $args, string $post_ty
 }
 add_filter( 'register_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 2 );
 
+/**
+ * Registers the Global Styles REST API routes.
+ */
+function gutenberg_register_global_styles_endpoints() {
+	$global_styles_controller = new WP_REST_Global_Styles_Controller_Gutenberg();
+	$global_styles_controller->register_routes();
+}
+add_action( 'rest_api_init', 'gutenberg_register_global_styles_endpoints' );
 
 /**
  * Registers the Edit Site Export REST API routes.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -19,23 +19,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @return array Array of arguments for registering a post type.
  */
-function gutenberg_override_global_styles_endpoint( array $args, string $post_type ): array {
-	if ( 'wp_global_styles' === $post_type ) {
-		$args['rest_controller_class'] = 'WP_REST_Global_Styles_Controller_Gutenberg';
-	}
+function gutenberg_override_global_styles_endpoint( array $args ): array {
+	$args['rest_controller_class'] = 'WP_REST_Global_Styles_Controller_Gutenberg';
+	$args['revisions_rest_controller_class'] = 'Gutenberg_REST_Global_Styles_Revisions_Controller_6_6';
 
 	return $args;
 }
-add_filter( 'register_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 2 );
-
-/**
- * Registers the Global Styles REST API routes.
- */
-function gutenberg_register_global_styles_endpoints() {
-	$global_styles_controller = new WP_REST_Global_Styles_Controller_Gutenberg();
-	$global_styles_controller->register_routes();
-}
-add_action( 'rest_api_init', 'gutenberg_register_global_styles_endpoints' );
+add_filter( 'register_wp_global_styles_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 2 );
 
 /**
  * Registers the Edit Site Export REST API routes.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -22,6 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 function gutenberg_override_global_styles_endpoint( array $args ): array {
 	$args['rest_controller_class']           = 'WP_REST_Global_Styles_Controller_Gutenberg';
 	$args['revisions_rest_controller_class'] = 'Gutenberg_REST_Global_Styles_Revisions_Controller_6_6';
+	$args['late_route_registration']         = true;
+	$args['show_in_rest']                    = true;
+	$args['rest_base']                       = 'global-styles';
 
 	return $args;
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -11,13 +11,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Registers the Global Styles REST API routes.
+ * Overrides the REST controller for the `wp_global_styles` post type.
+ *
+ * @param array  $args      Array of arguments for registering a post type.
+ *                          See the register_post_type() function for accepted arguments.
+ * @param string $post_type Post type key.
+ *
+ * @return array Array of arguments for registering a post type.
  */
-function gutenberg_register_global_styles_endpoints() {
-	$global_styles_controller = new WP_REST_Global_Styles_Controller_Gutenberg();
-	$global_styles_controller->register_routes();
+function gutenberg_override_global_styles_endpoint( array $args, string $post_type ): array {
+	if ( 'wp_global_styles' === $post_type ) {
+		$args['rest_controller_class'] = WP_REST_Global_Styles_Controller_Gutenberg::class;
+	}
+
+	return $args;
 }
-add_action( 'rest_api_init', 'gutenberg_register_global_styles_endpoints' );
+add_filter( 'register_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 2 );
 
 
 /**

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -86,7 +86,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 			'Single global style based on the given ID route does not exist'
 		);
 		$this->assertCount(
-			4, // Double core because both sets get registered in the plugin.
+			2,
 			$routes['/wp/v2/global-styles/(?P<id>[\/\w-]+)'],
 			'Single global style based on the given ID route does not have exactly two elements'
 		);
@@ -96,7 +96,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 			'Theme global styles route does not exist'
 		);
 		$this->assertCount(
-			2, // Double core because both sets get registered in the plugin.
+			1,
 			$routes['/wp/v2/global-styles/themes/(?P<stylesheet>[^\/:<>\*\?"\|]+(?:\/[^\/:<>\*\?"\|]+)?)'],
 			'Theme global styles route does not have exactly one element'
 		);

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -79,6 +79,10 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 	 * @covers WP_REST_Global_Styles_Controller_Gutenberg::register_routes
 	 */
 	public function test_register_routes() {
+		// Register routes so that they overwrite identical Core routes.
+		$global_styles_controller = new WP_REST_Global_Styles_Controller_Gutenberg();
+		$global_styles_controller->register_routes();
+
 		$routes = rest_get_server()->get_routes();
 		$this->assertArrayHasKey(
 			'/wp/v2/global-styles/(?P<id>[\/\w-]+)',

--- a/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
+++ b/phpunit/class-wp-rest-global-styles-controller-gutenberg-test.php
@@ -86,7 +86,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 			'Single global style based on the given ID route does not exist'
 		);
 		$this->assertCount(
-			2,
+			4, // Double core because both sets get registered in the plugin.
 			$routes['/wp/v2/global-styles/(?P<id>[\/\w-]+)'],
 			'Single global style based on the given ID route does not have exactly two elements'
 		);
@@ -96,7 +96,7 @@ class WP_REST_Global_Styles_Controller_Gutenberg_Test extends WP_Test_REST_Contr
 			'Theme global styles route does not exist'
 		);
 		$this->assertCount(
-			1,
+			2, // Double core because both sets get registered in the plugin.
 			$routes['/wp/v2/global-styles/themes/(?P<stylesheet>[^\/:<>\*\?"\|]+(?:\/[^\/:<>\*\?"\|]+)?)'],
 			'Theme global styles route does not have exactly one element'
 		);


### PR DESCRIPTION
## What?
Updates Global Styles REST controller method override to use post-type registration filter instead of initializing.

## Why?
This avoids extra work and prevents both controls from initializing, which are later merged, and the core class is discarded. 

See [`register_rest_route`](https://developer.wordpress.org/reference/functions/register_rest_route/) for more details (the `$override` argument is the key 😄).

## Testing Instructions
1. Set logger somewhere in `WP_REST_Global_Styles_Controller_Gutenberg`.
2. Open a post or page.
3. Confirm that test messages are logged.

### Testing Instructions for Keyboard
Same.
