### PR TITLE
Fix unable to remove empty blocks on merge

### DIFF
--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -47,7 +47,7 @@ import { PrivateBlockContext } from './private-block-context';
 
 import { unlock } from '../../lock-unlock';
 
-const { isBlockContentUnmodified } = unlock( blocksPrivateApis );
+const { isUnmodifiedBlockContent } = unlock( blocksPrivateApis );
 
 /**
  * Merges wrapper props with special handling for classNames and styles.
@@ -355,7 +355,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 					registry.batch( () => {
 						const firstBlock = getBlock( firstClientId );
 						const isFirstBlockContentUnmodified =
-							isBlockContentUnmodified( firstBlock );
+							isUnmodifiedBlockContent( firstBlock );
 						const defaultBlockName = getDefaultBlockName();
 						const replacement = switchToBlockType(
 							firstBlock,

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -8,7 +8,7 @@ import {
 	getBlockBindingsSource,
 	getBlockBindingsSources,
 } from './registration';
-import { isBlockContentUnmodified } from './utils';
+import { isUnmodifiedBlockContent } from './utils';
 
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
@@ -184,5 +184,5 @@ lock( privateApis, {
 	unregisterBlockBindingsSource,
 	getBlockBindingsSource,
 	getBlockBindingsSources,
-	isBlockContentUnmodified,
+	isUnmodifiedBlockContent,
 } );

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -8,7 +8,7 @@ import {
 	getBlockBindingsSource,
 	getBlockBindingsSources,
 } from './registration';
-import { isAttributeUnmodified } from './utils';
+import { isBlockContentUnmodified } from './utils';
 
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
@@ -184,5 +184,5 @@ lock( privateApis, {
 	unregisterBlockBindingsSource,
 	getBlockBindingsSource,
 	getBlockBindingsSources,
-	isAttributeUnmodified,
+	isBlockContentUnmodified,
 } );

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -8,6 +8,7 @@ import {
 	getBlockBindingsSource,
 	getBlockBindingsSources,
 } from './registration';
+import { isAttributeUnmodified } from './utils';
 
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
@@ -183,4 +184,5 @@ lock( privateApis, {
 	unregisterBlockBindingsSource,
 	getBlockBindingsSource,
 	getBlockBindingsSources,
+	isAttributeUnmodified,
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -37,7 +37,7 @@ const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
  * @param {*}      value               The attribute's value.
  * @return {boolean} Whether the attribute is unmodified.
  */
-function isAttributeUnmodified( attributeDefinition, value ) {
+function isUnmodifiedAttribute( attributeDefinition, value ) {
 	// Every attribute that has a default must match the default.
 	if ( attributeDefinition.hasOwnProperty( 'default' ) ) {
 		return value === attributeDefinition.default;
@@ -67,7 +67,7 @@ export function isUnmodifiedBlock( block ) {
 		( [ key, definition ] ) => {
 			const value = block.attributes[ key ];
 
-			return isAttributeUnmodified( definition, value );
+			return isUnmodifiedAttribute( definition, value );
 		}
 	);
 }
@@ -95,7 +95,7 @@ export function isUnmodifiedDefaultBlock( block ) {
  * @param {WPBlock} block Block Object
  * @return {boolean} Whether the block content is unmodified.
  */
-export function isBlockContentUnmodified( block ) {
+export function isUnmodifiedBlockContent( block ) {
 	const contentAttributes = getBlockAttributesNamesByRole(
 		block.name,
 		'content'
@@ -109,7 +109,7 @@ export function isBlockContentUnmodified( block ) {
 		const definition = getBlockType( block.name )?.attributes[ key ];
 		const value = block.attributes[ key ];
 
-		return isAttributeUnmodified( definition, value );
+		return isUnmodifiedAttribute( definition, value );
 	} );
 }
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -31,6 +31,30 @@ extend( [ namesPlugin, a11yPlugin ] );
 const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
 
 /**
+ * Determines whether the block's attribute is equal to the default attribute
+ * which means the attribute is unmodified.
+ * @param {Object} attributeDefinition The attribute's definition of the block type.
+ * @param {*}      value               The attribute's value.
+ * @return {boolean} Whether the attribute is unmodified.
+ */
+export function isAttributeUnmodified( attributeDefinition, value ) {
+	// Every attribute that has a default must match the default.
+	if ( attributeDefinition.hasOwnProperty( 'default' ) ) {
+		return value === attributeDefinition.default;
+	}
+
+	// The rich text type is a bit different from the rest because it
+	// has an implicit default value of an empty RichTextData instance,
+	// so check the length of the value.
+	if ( attributeDefinition.type === 'rich-text' ) {
+		return ! value?.length;
+	}
+
+	// Every attribute that doesn't have a default should be undefined.
+	return value === undefined;
+}
+
+/**
  * Determines whether the block's attributes are equal to the default attributes
  * which means the block is unmodified.
  *
@@ -43,20 +67,7 @@ export function isUnmodifiedBlock( block ) {
 		( [ key, definition ] ) => {
 			const value = block.attributes[ key ];
 
-			// Every attribute that has a default must match the default.
-			if ( definition.hasOwnProperty( 'default' ) ) {
-				return value === definition.default;
-			}
-
-			// The rich text type is a bit different from the rest because it
-			// has an implicit default value of an empty RichTextData instance,
-			// so check the length of the value.
-			if ( definition.type === 'rich-text' ) {
-				return ! value?.length;
-			}
-
-			// Every attribute that doesn't have a default should be undefined.
-			return value === undefined;
+			return isAttributeUnmodified( definition, value );
 		}
 	);
 }

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -37,7 +37,7 @@ const ICON_COLORS = [ '#191e23', '#f8f9f9' ];
  * @param {*}      value               The attribute's value.
  * @return {boolean} Whether the attribute is unmodified.
  */
-export function isAttributeUnmodified( attributeDefinition, value ) {
+function isAttributeUnmodified( attributeDefinition, value ) {
 	// Every attribute that has a default must match the default.
 	if ( attributeDefinition.hasOwnProperty( 'default' ) ) {
 		return value === attributeDefinition.default;
@@ -82,6 +82,35 @@ export function isUnmodifiedBlock( block ) {
  */
 export function isUnmodifiedDefaultBlock( block ) {
 	return block.name === getDefaultBlockName() && isUnmodifiedBlock( block );
+}
+
+/**
+ * Determines whether the block content is unmodified. A block content is
+ * considered unmodified if all the attributes that have a role of 'content'
+ * are equal to the default attributes (or undefined).
+ * If the block does not have any attributes with a role of 'content', it
+ * will be considered unmodified if all the attributes are equal to the default
+ * attributes (or undefined).
+ *
+ * @param {WPBlock} block Block Object
+ * @return {boolean} Whether the block content is unmodified.
+ */
+export function isBlockContentUnmodified( block ) {
+	const contentAttributes = getBlockAttributesNamesByRole(
+		block.name,
+		'content'
+	);
+
+	if ( contentAttributes.length === 0 ) {
+		return isUnmodifiedBlock( block );
+	}
+
+	return contentAttributes.every( ( key ) => {
+		const definition = getBlockType( block.name )?.attributes[ key ];
+		const value = block.attributes[ key ];
+
+		return isAttributeUnmodified( definition, value );
+	} );
 }
 
 /**

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -374,7 +374,7 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 	} );
 
 	// Fix for https://github.com/WordPress/gutenberg/issues/65174.
-	test( 'should handle unwrapping and merging blocks', async ( {
+	test( 'should handle unwrapping and merging blocks with empty contents', async ( {
 		editor,
 		page,
 	} ) => {

--- a/test/e2e/specs/editor/various/splitting-merging.spec.js
+++ b/test/e2e/specs/editor/various/splitting-merging.spec.js
@@ -373,6 +373,103 @@ test.describe( 'splitting and merging blocks (@firefox, @webkit)', () => {
 		);
 	} );
 
+	// Fix for https://github.com/WordPress/gutenberg/issues/65174.
+	test( 'should handle unwrapping and merging blocks', async ( {
+		editor,
+		page,
+	} ) => {
+		const emptyAlignedParagraph = {
+			name: 'core/paragraph',
+			attributes: { content: '', align: 'center', dropCap: false },
+			innerBlocks: [],
+		};
+		const emptyAlignedHeading = {
+			name: 'core/heading',
+			attributes: { content: '', textAlign: 'center', level: 2 },
+			innerBlocks: [],
+		};
+		const headingWithContent = {
+			name: 'core/heading',
+			attributes: { content: 'heading', level: 2 },
+			innerBlocks: [],
+		};
+		const placeholderBlock = { name: 'core/separator' };
+		await editor.insertBlock( {
+			name: 'core/group',
+			innerBlocks: [
+				emptyAlignedParagraph,
+				emptyAlignedHeading,
+				headingWithContent,
+				placeholderBlock,
+			],
+		} );
+		await editor.canvas
+			.getByRole( 'document', { name: 'Empty block' } )
+			.focus();
+
+		await page.keyboard.press( 'Backspace' );
+		await expect
+			.poll( editor.getBlocks, 'Remove the default empty block' )
+			.toEqual( [
+				{
+					name: 'core/group',
+					attributes: { tagName: 'div' },
+					innerBlocks: [
+						emptyAlignedHeading,
+						headingWithContent,
+						expect.objectContaining( placeholderBlock ),
+					],
+				},
+			] );
+
+		// Move the caret to the beginning of the empty heading block.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Backspace' );
+		await expect
+			.poll(
+				editor.getBlocks,
+				'Convert the non-default empty block to a default block'
+			)
+			.toEqual( [
+				{
+					name: 'core/group',
+					attributes: { tagName: 'div' },
+					innerBlocks: [
+						emptyAlignedParagraph,
+						headingWithContent,
+						expect.objectContaining( placeholderBlock ),
+					],
+				},
+			] );
+		await page.keyboard.press( 'Backspace' );
+		await expect.poll( editor.getBlocks ).toEqual( [
+			{
+				name: 'core/group',
+				attributes: { tagName: 'div' },
+				innerBlocks: [
+					headingWithContent,
+					expect.objectContaining( placeholderBlock ),
+				],
+			},
+		] );
+
+		// Move the caret to the beginning of the "heading" heading block.
+		await page.keyboard.press( 'ArrowDown' );
+		await page.keyboard.press( 'Backspace' );
+		await expect
+			.poll( editor.getBlocks, 'Lift the non-empty non-default block' )
+			.toEqual( [
+				headingWithContent,
+				{
+					name: 'core/group',
+					attributes: { tagName: 'div' },
+					innerBlocks: [
+						expect.objectContaining( placeholderBlock ),
+					],
+				},
+			] );
+	} );
+
 	test.describe( 'test restore selection when merge produces more than one block', () => {
 		const snap1 = [
 			{


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and why?
<!-- In a few words, what is the PR actually doing? -->
Fix https://github.com/WordPress/gutenberg/issues/65174.

Arguably considered intended, but it could be clearer for users when trying to delete an empty block on merge.

This PR prevents empty unmodified blocks from being moved to the parent on merge. Modified blocks can still be moved to the parent to retain backward compatibility and user expectations.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor and reorder the `moveFirstItemUp` implementation. Now it follows the following rules:

1. Transform the block to a default block if it's empty and can be transformed.
2. Remove the block if the block is already a default block and empty.
3. Move the block up to the parent if it can be moved.
4. Move the transformed block up to the parent if the block can be transformed to a default block and can be inserted at the new location.
5. Continue the fallback behavior:
  1. Transform the block to a default block if it can be transformed
  2. Remove the block if it's an unmodified default block

An "empty" block is defined as if the `content` attributes are empty.

One use case for these complicated rules is to handle the empty list item v.s. empty heading.

In https://github.com/WordPress/gutenberg/issues/65174, an empty heading is expected to be removed on backspace, but an empty list item should be converted to a default block and lifted to the parent. Both blocks are "empty" and not default blocks. The only difference is that an empty list item cannot be transformed to a default block inline, while an empty heading block can. So we try converting the empty heading block to an empty paragraph block on the first backspace (instead of removing it) to provide users instant feedback on backspace. I think it's an acceptable trade-off but there could be other better solutions!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Added e2e tests `should handle unwrapping and merging blocks`.

Follow the testing instructions in the original issue: https://github.com/WordPress/gutenberg/issues/65174.

Or, you can try copy-paste this markup and try interacting with it.
<details><summary>Code</summary>
<p>

```html
<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"align":"center"} -->
<p class="has-text-align-center"></p>
<!-- /wp:paragraph -->

<!-- wp:heading {"textAlign":"center"} -->
<h2 class="wp-block-heading has-text-align-center"></h2>
<!-- /wp:heading -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Heading</h2>
<!-- /wp:heading -->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity"/>
<!-- /wp:separator --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

</p>
</details>

Otherwise, follow the steps below:

1. Open the post editor.
3. Insert a group block, and insert an empty paragraph in the group block. Insert another arbitrary block at the end of the group block.
4. Focus on the empty block and press <kbd>Backspace</kbd>
5. Expect the block to be deleted rather than moved up.
7. Try the same setup again with a heading block and expect it to be moved to parent and converted to a paragraph block.
8. Try other combinations.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/1d0b88f1-e150-4038-a09b-cfbed64b6e62


