### PR TITLE
Align popover alt variant styling with block toolbar

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `Tabs`: indicator positioning under RTL direction ([#64926](https://github.com/WordPress/gutenberg/pull/64926)).
+-   `Popover`: Update `toolbar` variant radius to match block toolbar ([#65263](https://github.com/WordPress/gutenberg/pull/65263)).
 
 ### Deprecations
 

--- a/packages/components/src/popover/style.scss
+++ b/packages/components/src/popover/style.scss
@@ -27,9 +27,10 @@ $shadow-popover-border-top-only-alternate: 0 #{-$border-width} 0 $gray-900;
 	box-sizing: border-box;
 	width: min-content;
 
-	// Alternate treatment for popovers that put them at elevation zero with high contrast.
+	// Alternate treatment for popovers that put them at elevation zero with high contrast and smaller radius.
 	.is-alternate & {
 		box-shadow: $shadow-popover-border-default-alternate;
+		border-radius: $radius-small;
 	}
 
 	// A style that gives the popover no visible ui.


### PR DESCRIPTION
The block toolbar has not yet been updated to adopt the radius scale (https://github.com/WordPress/gutenberg/issues/63703). Consequently the dedicated `toolbar` variant of the `popover` component renders a different radius to the toolbar which looks a little clunky. 

This PR restores the old radius until we update the toolbar. 

| Before | After |
| --- | --- |
| <img width="318" alt="Screenshot 2024-09-12 at 09 03 06" src="https://github.com/user-attachments/assets/06a22751-f63a-4133-a657-b6d3b58e81c7"> | <img width="370" alt="Screenshot 2024-09-12 at 09 02 49" src="https://github.com/user-attachments/assets/388c1fd7-2968-4bf8-91f1-de49fce6fe37"> |

