### PR TITLE
Decouple "Zooming" from "Composing with Patterns/Sections"

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1027,11 +1027,11 @@ _Parameters_
 
 ### useZoomOut
 
-A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
+A hook used to set the zoomed out view, invoking the hook sets the mode.
 
 _Parameters_
 
--   _zoomOut_ `boolean`: If we should enter into zoomOut mode or not
+-   _zoomOut_ `boolean`: If we should zoom out or not.
 
 ### Warning
 

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -683,7 +683,7 @@ function BlockListBlockProvider( props ) {
 					! isDragging(),
 				initialPosition:
 					_isSelected &&
-					( editorMode === 'edit' || editorMode === 'zoom-out' ) // Don't recalculate the initialPosition when toggling in/out of zoom-out mode
+					( editorMode === 'edit' || editorMode === 'compose' ) // Don't recalculate the initialPosition when toggling in/out of zoom-out mode
 						? getSelectedBlocksInitialCaretPosition()
 						: undefined,
 				isHighlighted: isBlockHighlighted( clientId ),

--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -177,7 +177,7 @@ function Items( {
 	const hasCustomAppender = !! CustomAppender;
 	const {
 		order,
-		isZoomOut,
+		isComposeMode,
 		selectedBlocks,
 		visibleBlocks,
 		shouldRenderAppender,
@@ -209,10 +209,10 @@ function Items( {
 				order: _order,
 				selectedBlocks: getSelectedBlockClientIds(),
 				visibleBlocks: __unstableGetVisibleBlocks(),
-				isZoomOut: __unstableGetEditorMode() === 'zoom-out',
+				isComposeMode: __unstableGetEditorMode() === 'compose',
 				shouldRenderAppender:
 					hasAppender &&
-					__unstableGetEditorMode() !== 'zoom-out' &&
+					__unstableGetEditorMode() !== 'compose' &&
 					( hasCustomAppender
 						? ! getTemplateLock( rootClientId ) &&
 						  getBlockEditingMode( rootClientId ) !== 'disabled'
@@ -237,7 +237,7 @@ function Items( {
 						! selectedBlocks.includes( clientId )
 					}
 				>
-					{ isZoomOut && (
+					{ isComposeMode && (
 						<ZoomOutSeparator
 							clientId={ clientId }
 							rootClientId={ rootClientId }
@@ -248,7 +248,7 @@ function Items( {
 						rootClientId={ rootClientId }
 						clientId={ clientId }
 					/>
-					{ isZoomOut && (
+					{ isComposeMode && (
 						<ZoomOutSeparator
 							clientId={ clientId }
 							rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -36,7 +36,7 @@ export function useFocusFirstElement( { clientId, initialPosition } ) {
 		if (
 			! isBlockSelected( clientId ) ||
 			isMultiSelecting() ||
-			__unstableGetEditorMode() === 'zoom-out'
+			__unstableGetEditorMode() === 'compose'
 		) {
 			return;
 		}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
@@ -16,29 +16,30 @@ import { unlock } from '../../../lock-unlock';
  * @param {string} clientId Block client ID.
  */
 export function useZoomOutModeExit( { editorMode } ) {
-	const { getSettings } = useSelect( blockEditorStore );
-	const { __unstableSetEditorMode } = unlock(
+	const { getEditorMode } = useSelect( ( select ) => {
+		const { __unstableGetEditorMode } = select( blockEditorStore );
+		return {
+			getEditorMode: __unstableGetEditorMode,
+		};
+	}, [] );
+
+	const { __unstableSetEditorMode, setZoomOut } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
 	return useRefEffect(
 		( node ) => {
-			if ( editorMode !== 'zoom-out' ) {
+			if ( editorMode !== 'compose' ) {
 				return;
 			}
 
 			function onDoubleClick( event ) {
 				if ( ! event.defaultPrevented ) {
 					event.preventDefault();
-
-					const { __experimentalSetIsInserterOpened } = getSettings();
-
-					if (
-						typeof __experimentalSetIsInserterOpened === 'function'
-					) {
-						__experimentalSetIsInserterOpened( false );
+					if ( getEditorMode() === 'compose' ) {
+						__unstableSetEditorMode( 'edit' );
+						setZoomOut( false );
 					}
-					__unstableSetEditorMode( 'edit' );
 				}
 			}
 
@@ -48,6 +49,6 @@ export function useZoomOutModeExit( { editorMode } ) {
 				node.removeEventListener( 'dblclick', onDoubleClick );
 			};
 		},
-		[ editorMode, getSettings, __unstableSetEditorMode ]
+		[ editorMode, __unstableSetEditorMode ]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -17,7 +17,7 @@ export function useInBetweenInserter() {
 	const isInBetweenInserterDisabled = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getSettings().isDistractionFree ||
-			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+			select( blockEditorStore ).__unstableGetEditorMode() === 'compose',
 		[]
 	);
 	const {

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -46,7 +46,7 @@ function selector( select ) {
 		clientId,
 		hasFixedToolbar: getSettings().hasFixedToolbar,
 		isTyping: isTyping(),
-		isZoomOutMode: editorMode === 'zoom-out',
+		isComposeMode: editorMode === 'compose',
 	};
 }
 
@@ -64,7 +64,7 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode } = useSelect(
+	const { clientId, hasFixedToolbar, isTyping, isComposeMode } = useSelect(
 		selector,
 		[]
 	);
@@ -202,7 +202,7 @@ export default function BlockTools( {
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div { ...props } onKeyDown={ onKeyDown }>
 			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
-				{ ! isTyping && ! isZoomOutMode && (
+				{ ! isTyping && ! isComposeMode && (
 					<InsertionPoint
 						__unstableContentRef={ __unstableContentRef }
 					/>
@@ -239,7 +239,7 @@ export default function BlockTools( {
 				) }
 
 				{ /* Used for the inline rich text toolbar. Until this toolbar is combined into BlockToolbar, someone implementing their own BlockToolbar will also need to use this to see the image caption toolbar. */ }
-				{ ! isZoomOutMode && ! hasFixedToolbar && (
+				{ ! isComposeMode && ! hasFixedToolbar && (
 					<Popover.Slot
 						name="block-toolbar"
 						ref={ blockToolbarRef }
@@ -251,7 +251,7 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
-				{ isZoomOutMode && (
+				{ isComposeMode && (
 					<ZoomOutModeInserters
 						__unstableContentRef={ __unstableContentRef }
 					/>

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -38,7 +38,7 @@ function InbetweenInsertionPointPopover( {
 		isInserterShown,
 		isDistractionFree,
 		isNavigationMode,
-		isZoomOutMode,
+		isComposeMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockOrder,
@@ -81,7 +81,7 @@ function InbetweenInsertionPointPopover( {
 			isNavigationMode: _isNavigationMode(),
 			isDistractionFree: settings.isDistractionFree,
 			isInserterShown: insertionPoint?.__unstableWithInserter,
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			isComposeMode: __unstableGetEditorMode() === 'compose',
 		};
 	}, [] );
 	const { getBlockEditingMode } = useSelect( blockEditorStore );
@@ -152,7 +152,7 @@ function InbetweenInsertionPointPopover( {
 	// Other operations such as "group" are when the editor tries to create a row
 	// block by grouping the block being dragged with the block it's being dropped
 	// onto.
-	if ( isZoomOutMode && operation !== 'insert' ) {
+	if ( isComposeMode && operation !== 'insert' ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -47,9 +47,9 @@ export function useShowBlockTools() {
 			! hasMultiSelection() &&
 			editorMode === 'navigation';
 
-		const isZoomOut = editorMode === 'zoom-out';
+		const isComposeMode = editorMode === 'compose';
 		const _showZoomOutToolbar =
-			isZoomOut &&
+			isComposeMode &&
 			block?.attributes?.align === 'full' &&
 			! _showEmptyBlockSideInserter &&
 			! maybeShowBreadcrumb;

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -84,7 +84,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 		setIsInserterOpened,
 	} = selected;
 
-	const { removeBlock, __unstableSetEditorMode } =
+	const { removeBlock, __unstableSetEditorMode, setZoomOut } =
 		useDispatch( blockEditorStore );
 
 	const classNames = clsx( 'zoom-out-toolbar', {
@@ -144,6 +144,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 							setIsInserterOpened( false );
 						}
 						__unstableSetEditorMode( 'edit' );
+						setZoomOut( false );
 						__unstableContentRef.current?.focus();
 					} }
 				/>

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -20,6 +20,7 @@ import BlockDraggable from '../block-draggable';
 import BlockMover from '../block-mover';
 import Shuffle from '../block-toolbar/shuffle';
 import NavigableToolbar from '../navigable-toolbar';
+import { unlock } from '../../lock-unlock';
 
 export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 	const selected = useSelect(
@@ -84,8 +85,9 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 		setIsInserterOpened,
 	} = selected;
 
-	const { removeBlock, __unstableSetEditorMode, setZoomOut } =
-		useDispatch( blockEditorStore );
+	const { removeBlock, __unstableSetEditorMode, resetZoomOut } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const classNames = clsx( 'zoom-out-toolbar', {
 		'is-block-moving-mode': !! blockMovingMode,
@@ -144,7 +146,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 							setIsInserterOpened( false );
 						}
 						__unstableSetEditorMode( 'edit' );
-						setZoomOut( false );
+						resetZoomOut();
 						__unstableContentRef.current?.focus();
 					} }
 				/>

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -221,7 +221,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 
 			_isDropZoneDisabled = blockEditingMode === 'disabled';
 
-			if ( __unstableGetEditorMode() === 'zoom-out' ) {
+			if ( __unstableGetEditorMode() === 'compose' ) {
 				// In zoom out mode, we want to disable the drop zone for the sections.
 				// The inner blocks belonging to the section drop zone is
 				// already disabled by the blocks themselves being disabled.

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -44,9 +44,9 @@ export function PatternCategoryPreviews( {
 	category,
 	showTitlesAsTooltip,
 } ) {
-	const isZoomOutMode = useSelect(
+	const isComposeMode = useSelect(
 		( select ) =>
-			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+			select( blockEditorStore ).__unstableGetEditorMode() === 'compose',
 		[]
 	);
 	const [ allPatterns, , onClickPattern ] = usePatternsState(
@@ -172,7 +172,7 @@ export function PatternCategoryPreviews( {
 			</VStack>
 			{ currentCategoryPatterns.length > 0 && (
 				<>
-					{ isZoomOutMode && (
+					{ isComposeMode && (
 						<Text
 							size="12"
 							as="p"

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -52,9 +52,9 @@ function InserterMenu(
 	},
 	ref
 ) {
-	const isZoomOutMode = useSelect(
+	const isComposeMode = useSelect(
 		( select ) =>
-			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+			select( blockEditorStore ).__unstableGetEditorMode() === 'compose',
 		[]
 	);
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
@@ -71,7 +71,7 @@ function InserterMenu(
 			return __experimentalInitialTab;
 		}
 
-		if ( isZoomOutMode ) {
+		if ( isComposeMode ) {
 			return 'patterns';
 		}
 	}
@@ -307,7 +307,7 @@ function InserterMenu(
 		<div
 			className={ clsx( 'block-editor-inserter__menu', {
 				'show-panel': showPatternPanel || showMediaPanel,
-				'is-zoom-out': isZoomOutMode,
+				'is-zoom-out': isComposeMode,
 			} ) }
 			ref={ ref }
 		>

--- a/packages/block-editor/src/components/list-view/appender.js
+++ b/packages/block-editor/src/components/list-view/appender.js
@@ -28,7 +28,7 @@ export const Appender = forwardRef(
 
 				return (
 					!! getTemplateLock( clientId ) ||
-					__unstableGetEditorMode() === 'zoom-out'
+					__unstableGetEditorMode() === 'compose'
 				);
 			},
 			[ clientId ]

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -12,7 +12,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
-import { Icon, edit as editIcon } from '@wordpress/icons';
+import {
+	Icon,
+	edit as editIcon,
+	blockTable as composeIcon,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -30,12 +34,20 @@ const selectIcon = (
 	</SVG>
 );
 
+// write an icon map of mode => icon
+const ICON_MAPPING = {
+	edit: editIcon,
+	navigation: selectIcon,
+	compose: composeIcon,
+};
+
 function ToolSelector( props, ref ) {
 	const mode = useSelect(
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode, setZoomOut } =
+		useDispatch( blockEditorStore );
 
 	return (
 		<Dropdown
@@ -45,7 +57,7 @@ function ToolSelector( props, ref ) {
 					__next40pxDefaultSize={ false }
 					{ ...props }
 					ref={ ref }
-					icon={ mode === 'navigation' ? selectIcon : editIcon }
+					icon={ ICON_MAPPING[ mode ] }
 					aria-expanded={ isOpen }
 					aria-haspopup="true"
 					onClick={ onToggle }
@@ -58,10 +70,13 @@ function ToolSelector( props, ref ) {
 				<>
 					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>
 						<MenuItemsChoice
-							value={
-								mode === 'navigation' ? 'navigation' : 'edit'
-							}
-							onSelect={ __unstableSetEditorMode }
+							value={ mode }
+							onSelect={ ( newVal ) => {
+								if ( newVal === 'compose' ) {
+									setZoomOut( true );
+								}
+								__unstableSetEditorMode( newVal );
+							} }
 							choices={ [
 								{
 									value: 'edit',
@@ -78,6 +93,15 @@ function ToolSelector( props, ref ) {
 										<>
 											{ selectIcon }
 											{ __( 'Select' ) }
+										</>
+									),
+								},
+								{
+									value: 'compose',
+									label: (
+										<>
+											<Icon icon={ composeIcon } />
+											{ __( 'Compose' ) }
 										</>
 									),
 								},

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -22,6 +22,7 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const selectIcon = (
 	<SVG
@@ -46,8 +47,9 @@ function ToolSelector( props, ref ) {
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { __unstableSetEditorMode, setZoomOut } =
-		useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode, setZoomOut } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	return (
 		<Dropdown

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -96,15 +96,6 @@ function ToolSelector( props, ref ) {
 										</>
 									),
 								},
-								{
-									value: 'compose',
-									label: (
-										<>
-											<Icon icon={ composeIcon } />
-											{ __( 'Compose' ) }
-										</>
-									),
-								},
 							] }
 						/>
 					</NavigableMenu>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -22,7 +22,6 @@ import {
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
 
 const selectIcon = (
 	<SVG
@@ -47,9 +46,7 @@ function ToolSelector( props, ref ) {
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { __unstableSetEditorMode, setZoomOut } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	return (
 		<Dropdown
@@ -73,12 +70,7 @@ function ToolSelector( props, ref ) {
 					<NavigableMenu role="menu" aria-label={ __( 'Tools' ) }>
 						<MenuItemsChoice
 							value={ mode }
-							onSelect={ ( newVal ) => {
-								if ( newVal === 'compose' ) {
-									setZoomOut( true );
-								}
-								__unstableSetEditorMode( newVal );
-							} }
+							onSelect={ __unstableSetEditorMode }
 							choices={ [
 								{
 									value: 'edit',

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -330,7 +330,7 @@ export default function useBlockDropZone( {
 		getAllowedBlocks,
 		isDragging,
 		isGroupable,
-		isZoomOutMode,
+		isComposeMode,
 		getSectionRootClientId,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
@@ -383,7 +383,7 @@ export default function useBlockDropZone( {
 				// do not allow dropping as the drop target is not within the root (that which is
 				// treated as "the content" by Zoom Out Mode).
 				if (
-					isZoomOutMode() &&
+					isComposeMode() &&
 					sectionRootClientId !== targetRootClientId
 				) {
 					return;
@@ -439,7 +439,7 @@ export default function useBlockDropZone( {
 				const [ targetIndex, operation, nearestSide ] =
 					dropTargetPosition;
 
-				if ( isZoomOutMode() && operation !== 'insert' ) {
+				if ( isComposeMode() && operation !== 'insert' ) {
 					return;
 				}
 
@@ -514,7 +514,7 @@ export default function useBlockDropZone( {
 				getDraggedBlockClientIds,
 				getBlockType,
 				getSectionRootClientId,
-				isZoomOutMode,
+				isComposeMode,
 				getBlocks,
 				getBlockListSettings,
 				dropZoneElement,

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -30,7 +30,7 @@ export function useZoomOut( zoomOut = true ) {
 		return () => {
 			// We need to use  __unstableGetEditorMode() here and not `mode`, as mode may not update on unmount
 			if (
-				__unstableGetEditorMode() === 'zoom-out' &&
+				__unstableGetEditorMode() === 'compose' &&
 				__unstableGetEditorMode() !== originalEditingModeRef.current
 			) {
 				__unstableSetEditorMode( originalEditingModeRef.current );
@@ -40,11 +40,11 @@ export function useZoomOut( zoomOut = true ) {
 
 	// The effect opens the zoom-out view if we want it open and it's not currently in zoom-out mode.
 	useEffect( () => {
-		if ( zoomOut && mode !== 'zoom-out' ) {
-			__unstableSetEditorMode( 'zoom-out' );
+		if ( zoomOut && mode !== 'compose' ) {
+			__unstableSetEditorMode( 'compose' );
 		} else if (
 			! zoomOut &&
-			__unstableGetEditorMode() === 'zoom-out' &&
+			__unstableGetEditorMode() === 'compose' &&
 			originalEditingModeRef.current !== mode
 		) {
 			__unstableSetEditorMode( originalEditingModeRef.current );

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -8,46 +8,47 @@ import { useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
 
 /**
- * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
+ * A hook used to set the zoomed out view, invoking the hook sets the mode.
  *
- * @param {boolean} zoomOut If we should enter into zoomOut mode or not
+ * @param {boolean} zoomOut If we should zoom out or not.
  */
 export function useZoomOut( zoomOut = true ) {
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
-	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
+	const { setZoomOut } = unlock( useDispatch( blockEditorStore ) );
+	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
-	const originalEditingModeRef = useRef( null );
-	const mode = __unstableGetEditorMode();
+	const originalIsZoomOutRef = useRef( null );
+	const currentZoomOutState = isZoomOut();
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
-		if ( ! originalEditingModeRef.current ) {
-			originalEditingModeRef.current = mode;
+		if ( ! originalIsZoomOutRef.current ) {
+			originalIsZoomOutRef.current = currentZoomOutState;
 		}
 
 		return () => {
-			// We need to use  __unstableGetEditorMode() here and not `mode`, as mode may not update on unmount
-			if (
-				__unstableGetEditorMode() === 'compose' &&
-				__unstableGetEditorMode() !== originalEditingModeRef.current
-			) {
-				__unstableSetEditorMode( originalEditingModeRef.current );
+			// We need to use  isZoomOut() here and not `currentZoomOutState`, as currentZoomOutState may not update on unmount
+			if ( isZoomOut() && isZoomOut() !== originalIsZoomOutRef.current ) {
+				setZoomOut( originalIsZoomOutRef.current );
 			}
 		};
-	}, [] );
+	}, [ currentZoomOutState, isZoomOut, setZoomOut ] );
 
-	// The effect opens the zoom-out view if we want it open and it's not currently in zoom-out mode.
+	// The effect opens the zoom-out view if we want it open and the canvas is not currently zoomed-out.
 	useEffect( () => {
-		if ( zoomOut && mode !== 'compose' ) {
-			__unstableSetEditorMode( 'compose' );
+		if ( zoomOut && currentZoomOutState === false ) {
+			// __unstableSetEditorMode( 'compose' );
+			setZoomOut( true );
 		} else if (
 			! zoomOut &&
-			__unstableGetEditorMode() === 'compose' &&
-			originalEditingModeRef.current !== mode
+			isZoomOut() &&
+			originalIsZoomOutRef.current !== currentZoomOutState
 		) {
-			__unstableSetEditorMode( originalEditingModeRef.current );
+			setZoomOut( originalIsZoomOutRef.current );
 		}
-	}, [ __unstableGetEditorMode, __unstableSetEditorMode, zoomOut ] ); // Mode is deliberately excluded from the dependencies so that the effect does not run when mode changes.
+		// currentZoomOutState is deliberately excluded from the dependencies so that the effect does not run when mode changes.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isZoomOut, setZoomOut, zoomOut ] );
 }

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2189,3 +2189,17 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
+
+/**
+ * Sets the zoom out state.
+ *
+ * @param {boolean} zoomOut The new zoom out state.
+ *
+ * @return {Object} Action object.
+ */
+export function setZoomOut( zoomOut ) {
+	return {
+		type: 'SET_ZOOM_OUT',
+		zoomOut,
+	};
+}

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -2189,17 +2189,3 @@ export function unsetBlockEditingMode( clientId = '' ) {
 		clientId,
 	};
 }
-
-/**
- * Sets the zoom out state.
- *
- * @param {boolean} zoomOut The new zoom out state.
- *
- * @return {Object} Action object.
- */
-export function setZoomOut( zoomOut ) {
-	return {
-		type: 'SET_ZOOM_OUT',
-		zoomOut,
-	};
-}

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -383,3 +383,36 @@ export const modifyContentLockBlock =
 			focusModeToRevert
 		);
 	};
+
+/**
+ * Sets the zoom level.
+ *
+ * @param {number} zoom the new zoom level
+ * @return {Object} Action object.
+ */
+export function setZoomOut( zoom = 50 ) {
+	let zoomValue;
+
+	if ( zoom === true ) {
+		zoomValue = 50;
+	} else if ( zoom === false ) {
+		zoomValue = 100; // Considered as a reset
+	} else {
+		zoomValue = zoom;
+	}
+
+	return {
+		type: 'SET_ZOOM_OUT',
+		zoom: zoomValue,
+	};
+}
+
+/**
+ * Resets the Zoom state.
+ * @return {Object} Action object.
+ */
+export function resetZoomOut() {
+	return {
+		type: 'RESET_ZOOM',
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -560,3 +560,23 @@ export function isComposeMode( state ) {
 export function getSectionRootClientId( state ) {
 	return state.settings?.[ sectionRootClientIdKey ];
 }
+
+/**
+ * Returns the zoom out state.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} The zoom out state.
+ */
+export function getZoomLevel( state ) {
+	return state.zoomLevel;
+}
+
+/**
+ * Returns whether the editor is considered zoomed out.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} Whether the editor is zoomed.
+ */
+export function isZoomOut( state ) {
+	return getZoomLevel( state ) < 100;
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -544,8 +544,8 @@ export const getBlockStyles = createSelector(
  *
  * @return {boolean} Is zoom out mode enabled.
  */
-export function isZoomOutMode( state ) {
-	return state.editorMode === 'zoom-out';
+export function isComposeMode( state ) {
+	return state.editorMode === 'compose';
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2085,6 +2085,23 @@ export function hoveredBlockClientId( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer setting zoom out state.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function zoomOut( state = false, action ) {
+	switch ( action.type ) {
+		case 'SET_ZOOM_OUT':
+			return action.zoomOut;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2118,6 +2135,7 @@ const combinedReducers = combineReducers( {
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
+	zoomOut,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2093,10 +2093,12 @@ export function hoveredBlockClientId( state = false, action ) {
  *
  * @return {boolean} Updated state.
  */
-export function zoomOut( state = false, action ) {
+export function zoomLevel( state = 100, action ) {
 	switch ( action.type ) {
 		case 'SET_ZOOM_OUT':
-			return action.zoomOut;
+			return action.zoom;
+		case 'RESET_ZOOM':
+			return 100;
 	}
 
 	return state;
@@ -2135,7 +2137,7 @@ const combinedReducers = combineReducers( {
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
-	zoomOut,
+	zoomLevel,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2837,7 +2837,7 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 	const editorMode = __unstableGetEditorMode( state );
 
 	// In zoom-out mode, the block overlay is always active for section level blocks.
-	if ( editorMode === 'zoom-out' ) {
+	if ( editorMode === 'compose' ) {
 		const sectionRootClientId = getSectionRootClientId( state );
 		if ( sectionRootClientId ) {
 			const sectionClientIds = getBlockOrder(
@@ -2930,7 +2930,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			// __unstableSetBlockEditingMode to only allow editing the top-level
 			// sections.
 			const editorMode = __unstableGetEditorMode( state );
-			if ( editorMode === 'zoom-out' ) {
+			if ( editorMode === 'compose' ) {
 				const sectionRootClientId = getSectionRootClientId( state );
 
 				if ( clientId === '' /* ROOT_CONTAINER_CLIENT_ID */ ) {
@@ -3093,4 +3093,14 @@ export function __unstableGetTemporarilyEditingFocusModeToRevert( state ) {
 		}
 	);
 	return getTemporarilyEditingFocusModeToRevert( state );
+}
+
+/**
+ * Returns the zoom out state.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} The zoom out state.
+ */
+export function isZoomOut( state ) {
+	return state.zoomOut;
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3094,13 +3094,3 @@ export function __unstableGetTemporarilyEditingFocusModeToRevert( state ) {
 	);
 	return getTemporarilyEditingFocusModeToRevert( state );
 }
-
-/**
- * Returns the zoom out state.
- *
- * @param {Object} state Global application state.
- * @return {boolean} The zoom out state.
- */
-export function isZoomOut( state ) {
-	return state.zoomOut;
-}

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -78,7 +78,7 @@ function useEditorStyles() {
 	const {
 		hasThemeStyleSupport,
 		editorSettings,
-		isZoomedOutView,
+		isComposeMode,
 		renderingMode,
 		postType,
 	} = useSelect( ( select ) => {
@@ -89,7 +89,7 @@ function useEditorStyles() {
 			hasThemeStyleSupport:
 				select( editPostStore ).isFeatureActive( 'themeStyles' ),
 			editorSettings: select( editorStore ).getEditorSettings(),
-			isZoomedOutView: __unstableGetEditorMode() === 'zoom-out',
+			isComposeMode: __unstableGetEditorMode() === 'compose',
 			renderingMode: getRenderingMode(),
 			postType: _postType,
 		};
@@ -134,7 +134,7 @@ function useEditorStyles() {
 		// Add a space for the typewriter effect. When typing in the last block,
 		// there needs to be room to scroll up.
 		if (
-			! isZoomedOutView &&
+			! isComposeMode &&
 			renderingMode === 'post-only' &&
 			! DESIGN_POST_TYPES.includes( postType )
 		) {

--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -5,34 +5,37 @@ import { store as editorStore } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
 
 const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
 
 export function useShouldIframe() {
-	const {
-		isBlockBasedTheme,
-		hasV3BlocksOnly,
-		isEditingTemplate,
-		isZoomOutMode,
-	} = useSelect( ( select ) => {
-		const { getEditorSettings, getCurrentPostType } = select( editorStore );
-		const { __unstableGetEditorMode } = select( blockEditorStore );
-		const { getBlockTypes } = select( blocksStore );
-		const editorSettings = getEditorSettings();
-		return {
-			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
-			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
-				return type.apiVersion >= 3;
-			} ),
-			isEditingTemplate: getCurrentPostType() === 'wp_template',
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
-		};
-	}, [] );
+	const { isBlockBasedTheme, hasV3BlocksOnly, isEditingTemplate, isZoomOut } =
+		useSelect( ( select ) => {
+			const { getEditorSettings, getCurrentPostType } =
+				select( editorStore );
+			const { isZoomOut: _isZoomOut } = select(
+				unlock( blockEditorStore )
+			);
+			const { getBlockTypes } = select( blocksStore );
+			const editorSettings = getEditorSettings();
+			return {
+				isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
+				hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
+					return type.apiVersion >= 3;
+				} ),
+				isEditingTemplate: getCurrentPostType() === 'wp_template',
+				isZoomOut: _isZoomOut(),
+			};
+		}, [] );
 
 	return (
 		hasV3BlocksOnly ||
 		( isGutenbergPlugin && isBlockBasedTheme ) ||
 		isEditingTemplate ||
-		isZoomOutMode
+		isZoomOut
 	);
 }

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -3,7 +3,9 @@
  */
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useZoomOut } from '@wordpress/block-editor';
+import { store as blockEditorStore, useZoomOut } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -14,7 +16,16 @@ import SidebarNavigationScreenGlobalStylesContent from '../sidebar-navigation-sc
 function ScreenStyleVariations() {
 	// Move to zoom out mode when this component is mounted
 	// and back to the previous mode when unmounted.
-	useZoomOut();
+	// useZoomOut();
+
+	const { setZoomOut } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		setZoomOut( true );
+		return () => {
+			setZoomOut( false );
+		};
+	}, [ setZoomOut ] );
 
 	return (
 		<>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -3,30 +3,18 @@
  */
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { store as blockEditorStore } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useZoomOut } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
 import ScreenHeader from './header';
 import SidebarNavigationScreenGlobalStylesContent from '../sidebar-navigation-screen-global-styles/content';
-import { unlock } from '../../lock-unlock';
 
 function ScreenStyleVariations() {
-	// Move to zoom out mode when this component is mounted
-	// and back to the previous mode when unmounted.
-	// useZoomOut();
-
-	const { setZoomOut } = unlock( useDispatch( blockEditorStore ) );
-
-	useEffect( () => {
-		setZoomOut( true );
-		return () => {
-			setZoomOut( false );
-		};
-	}, [ setZoomOut ] );
+	// Zoom canvas when component is mounted
+	// and back to the previous zoom when unmounted.
+	useZoomOut();
 
 	return (
 		<>

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -3,7 +3,7 @@
  */
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { store as blockEditorStore, useZoomOut } from '@wordpress/block-editor';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 
@@ -12,13 +12,14 @@ import { useEffect } from '@wordpress/element';
  */
 import ScreenHeader from './header';
 import SidebarNavigationScreenGlobalStylesContent from '../sidebar-navigation-screen-global-styles/content';
+import { unlock } from '../../lock-unlock';
 
 function ScreenStyleVariations() {
 	// Move to zoom out mode when this component is mounted
 	// and back to the previous mode when unmounted.
 	// useZoomOut();
 
-	const { setZoomOut } = useDispatch( blockEditorStore );
+	const { setZoomOut } = unlock( useDispatch( blockEditorStore ) );
 
 	useEffect( () => {
 		setZoomOut( true );

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -64,7 +64,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isVisualMode: getEditorMode() === 'visual',
-			isZoomedOutView: __unstableGetEditorMode() === 'zoom-out',
+			isComposeMode: __unstableGetEditorMode() === 'compose',
 		};
 	}, [] );
 

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -32,6 +32,8 @@ import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
 import EditorContentSlotFill from './content-slot-fill';
 
+import { unlock } from '../../lock-unlock';
+
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
 	header: __( 'Editor top bar' ),
@@ -71,12 +73,13 @@ export default function EditorInterface( {
 		nextShortcut,
 		showBlockBreadcrumbs,
 		documentLabel,
-		blockEditorMode,
+		isZoomOut,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
 		const editorSettings = getEditorSettings();
 		const postTypeLabel = getPostTypeLabel();
+		const { isZoomOut: _isZoomOut } = unlock( select( blockEditorStore ) );
 
 		return {
 			mode: select( editorStore ).getEditorMode(),
@@ -94,8 +97,7 @@ export default function EditorInterface( {
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
-			blockEditorMode:
-				select( blockEditorStore ).__unstableGetEditorMode(),
+			isZoomOut: _isZoomOut(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -205,7 +207,7 @@ export default function EditorInterface( {
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
 				isRichEditingEnabled &&
-				blockEditorMode !== 'compose' &&
+				! isZoomOut &&
 				mode === 'visual' && (
 					<BlockBreadcrumb rootLabelText={ documentLabel } />
 				)

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -205,7 +205,7 @@ export default function EditorInterface( {
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
 				isRichEditingEnabled &&
-				blockEditorMode !== 'zoom-out' &&
+				blockEditorMode !== 'compose' &&
 				mode === 'visual' && (
 					<BlockBreadcrumb rootLabelText={ documentLabel } />
 				)

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -76,7 +76,7 @@ function Header( {
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
 			isNestedEntity:
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
-			isZoomedOutView: __unstableGetEditorMode() === 'zoom-out',
+			isComposeMode: __unstableGetEditorMode() === 'compose',
 		};
 	}, [] );
 

--- a/packages/editor/src/components/inserter-sidebar/index.js
+++ b/packages/editor/src/components/inserter-sidebar/index.js
@@ -41,7 +41,7 @@ export default function InserterSidebar() {
 		const { get } = select( preferencesStore );
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const getBlockSectionRootClientId = () => {
-			if ( __unstableGetEditorMode() === 'zoom-out' ) {
+			if ( __unstableGetEditorMode() === 'compose' ) {
 				const sectionRootClientId = getSectionRootClientId();
 
 				if ( sectionRootClientId ) {

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -174,17 +174,22 @@ function VisualEditor( {
 		hasRootPaddingAwareAlignments,
 		themeHasDisabledLayoutStyles,
 		themeSupportsLayout,
-		isZoomOutMode,
+		isComposeMode,
+		isZoomOut,
 	} = useSelect( ( select ) => {
-		const { getSettings, __unstableGetEditorMode } =
-			select( blockEditorStore );
+		const {
+			getSettings,
+			__unstableGetEditorMode,
+			isZoomOut: _isZoomOut,
+		} = select( blockEditorStore );
 		const _settings = getSettings();
 		return {
 			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
 			themeSupportsLayout: _settings.supportsLayout,
 			hasRootPaddingAwareAlignments:
 				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			isComposeMode: __unstableGetEditorMode() === 'compose',
+			isZoomOut: _isZoomOut(),
 		};
 	}, [] );
 
@@ -336,7 +341,7 @@ function VisualEditor( {
 	] );
 
 	const zoomOutProps =
-		isZoomOutMode && ! isTabletViewport
+		isZoomOut && ! isTabletViewport
 			? {
 					scale: 'default',
 					frameSize: '48px',
@@ -355,7 +360,7 @@ function VisualEditor( {
 		// Disable resizing in mobile viewport.
 		! isMobileViewport &&
 		// Dsiable resizing in zoomed-out mode.
-		! isZoomOutMode;
+		! isComposeMode;
 	const shouldIframe =
 		! disableIframe || [ 'Tablet', 'Mobile' ].includes( deviceType );
 

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -181,7 +181,8 @@ function VisualEditor( {
 			getSettings,
 			__unstableGetEditorMode,
 			isZoomOut: _isZoomOut,
-		} = select( blockEditorStore );
+		} = unlock( select( blockEditorStore ) );
+
 		const _settings = getSettings();
 		return {
 			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,

--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -8,16 +8,23 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { square as zoomOutIcon } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
 const ZoomOutToggle = () => {
-	const { isZoomOutMode } = useSelect( ( select ) => ( {
-		isZoomOutMode:
-			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+	const { isZoomOut } = useSelect( ( select ) => ( {
+		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
 	} ) );
 
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { setZoomOut, __unstableSetEditorMode } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const handleZoomOut = () => {
-		__unstableSetEditorMode( isZoomOutMode ? 'edit' : 'zoom-out' );
+		setZoomOut( isZoomOut ? false : true );
+		__unstableSetEditorMode( isZoomOut ? 'edit' : 'compose' );
 	};
 
 	return (
@@ -25,7 +32,7 @@ const ZoomOutToggle = () => {
 			onClick={ handleZoomOut }
 			icon={ zoomOutIcon }
 			label={ __( 'Toggle Zoom Out' ) }
-			isPressed={ isZoomOutMode }
+			isPressed={ isZoomOut }
 			size="compact"
 		/>
 	);

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1279,7 +1279,7 @@ export function getRenderingMode( state ) {
 export const getDeviceType = createRegistrySelector(
 	( select ) => ( state ) => {
 		const editorMode = select( blockEditorStore ).__unstableGetEditorMode();
-		if ( editorMode === 'zoom-out' ) {
+		if ( editorMode === 'compose' ) {
 			return 'Desktop';
 		}
 		return state.deviceType;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Decouples "Zooming the canvas" from "Composing with Patterns".

- Removes `zoom-out` as a mode and replaces with `compose`. 
- Adds new state to control canvas zoom level.

Related https://github.com/WordPress/gutenberg/pull/65482

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Working on Zoom Out, I've noticed that sometimes we may want to "zoom out" on the canvas without going into a mode which prioritises "Composing with Sections".

For example, if you click `Styles -> Browse Styles` the canvas will "zoom out". But in this mode you might not want to start composing your page. There may be other examples already or in the future.

Also the term "Zoom Out" does not accurately describe the new mode. We are no longer just "zooming out on the canvas". Rather we are switching to a mode which prioritises "Composing a page using Patterns as Sections". The fact that the canvas is "zoomed" is really a byproduct.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Renames the mode to `compose`
- Creates a separate state to control canvas Zooming.




## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


#### General

- Enable Zoom Out experiment
- Site Editor
- Click Zoom Out toggle
- See same zoom out experience as on `trunk` - there should be no discernible difference in functionality.

#### Browse Styles Toggle

- Site Editor
- Go to (Global) Styles to open panel on right hand side.
- Click `Browse Styles`
- See Editor scale
- Check `compose` mode is _not_ active
- Check that closing the `Browse Styles` UI reverts to the original zoom scale.
- Try toggling zoom out and then opening `Browse Styles` - the Zoom level should be unaffected as you open/close that UI. The original Zoom should be preserved.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/02c73005-6a20-4a01-8aff-345a4b4c8ee2

## Props

Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: ajlende <ajlende@git.wordpress.org>
Co-authored-by: richtabor <richtabor@git.wordpress.org>
Co-authored-by: draganescu <andraganescu@git.wordpress.org>
Co-authored-by: MaggieCabrera <onemaggie@git.wordpress.org>