### PR TITLE
Build: Stop generating unused legacy scripts for core blocks

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -117,3 +117,22 @@ function gutenberg_register_block_style( $block_name, $style_properties ) {
 
 	return $result;
 }
+
+/**
+ * Additional data to expose to the view script module in the Form block.
+ */
+function gutenberg_block_core_form_view_script_module( $data ) {
+	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-form-blocks' ) ) {
+		return $data;
+	}
+
+	$data['nonce']   = wp_create_nonce( 'wp-block-form' );
+	$data['ajaxUrl'] = admin_url( 'admin-ajax.php' );
+	$data['action']  = 'wp_block_form_email_submit';
+
+	return $data;
+}
+add_filter(
+	'script_module_data_@wordpress/block-library/form/view',
+	'gutenberg_block_core_form_view_script_module'
+);

--- a/packages/block-library/package.json
+++ b/packages/block-library/package.json
@@ -28,6 +28,7 @@
 	"wpScript": true,
 	"wpScriptModuleExports": {
 		"./file/view": "./build-module/file/view.js",
+		"./form/view": "./build-module/form/view.js",
 		"./image/view": "./build-module/image/view.js",
 		"./navigation/view": "./build-module/navigation/view.js",
 		"./query/view": "./build-module/query/view.js",

--- a/packages/block-library/src/form/block.json
+++ b/packages/block-library/src/form/block.json
@@ -64,6 +64,5 @@
 			}
 		},
 		"__experimentalSelector": "form"
-	},
-	"viewScript": "file:./view.min.js"
+	}
 }

--- a/packages/block-library/src/form/index.php
+++ b/packages/block-library/src/form/index.php
@@ -14,6 +14,7 @@
  * @return string The content of the block being rendered.
  */
 function render_block_core_form( $attributes, $content ) {
+	wp_enqueue_script_module( '@wordpress/block-library/form/view' );
 
 	$processed_content = new WP_HTML_Tag_Processor( $content );
 	$processed_content->next_tag( 'form' );
@@ -41,26 +42,6 @@ function render_block_core_form( $attributes, $content ) {
 		$processed_content->get_updated_html()
 	);
 }
-
-/**
- * Additional data to add to the view.js script for this block.
- */
-function block_core_form_view_script() {
-	if ( ! gutenberg_is_experiment_enabled( 'gutenberg-form-blocks' ) ) {
-		return;
-	}
-
-	wp_localize_script(
-		'wp-block-form-view',
-		'wpBlockFormSettings',
-		array(
-			'nonce'   => wp_create_nonce( 'wp-block-form' ),
-			'ajaxUrl' => admin_url( 'admin-ajax.php' ),
-			'action'  => 'wp_block_form_email_submit',
-		)
-	);
-}
-add_action( 'wp_enqueue_scripts', 'block_core_form_view_script' );
 
 /**
  * Adds extra fields to the form.

--- a/packages/block-library/src/form/view.js
+++ b/packages/block-library/src/form/view.js
@@ -1,8 +1,21 @@
+let formSettings;
+try {
+	formSettings = JSON.parse(
+		document.getElementById(
+			'wp-script-module-data-@wordpress/block-library/form/view'
+		)?.textContent
+	);
+} catch {}
+
 // eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable no-undef */
 document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
-	// Bail If the form is not using the mailto: action.
-	if ( ! form.action || ! form.action.startsWith( 'mailto:' ) ) {
+	// Bail If the form settings not provided or the form is not using the mailto: action.
+	if (
+		! formSettings ||
+		! form.action ||
+		! form.action.startsWith( 'mailto:' )
+	) {
 		return;
 	}
 
@@ -18,13 +31,13 @@ document.querySelectorAll( 'form.wp-block-form' ).forEach( function ( form ) {
 		// Get the form data and merge it with the form action and nonce.
 		const formData = Object.fromEntries( new FormData( form ).entries() );
 		formData.formAction = form.action;
-		formData._ajax_nonce = wpBlockFormSettings.nonce;
-		formData.action = wpBlockFormSettings.action;
+		formData._ajax_nonce = formSettings.nonce;
+		formData.action = formSettings.action;
 		formData._wp_http_referer = window.location.href;
 		formData.formAction = form.action;
 
 		try {
-			const response = await fetch( wpBlockFormSettings.ajaxUrl, {
+			const response = await fetch( formSettings.ajaxUrl, {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/x-www-form-urlencoded',

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -3,26 +3,17 @@
  */
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
 const { join, sep, basename } = require( 'path' );
-const fastGlob = require( 'fast-glob' );
 const { realpathSync } = require( 'fs' );
 
 /**
  * WordPress dependencies
  */
-const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const { PhpFilePathsPlugin } = require( '@wordpress/scripts/utils' );
 
 /**
  * Internal dependencies
  */
 const { baseConfig, plugins, stylesTransform } = require( './shared' );
-
-/*
- * Matches a block's filepaths in the form build-module/<filename>.js
- */
-const blockViewRegex = new RegExp(
-	/build-module\/(?<filename>.*\/view.*).js$/
-);
 
 /**
  * We need to automatically rename some functions when they are called inside block files,
@@ -50,6 +41,7 @@ function escapeRegExp( string ) {
 	return string.replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' );
 }
 
+<<<<<<< HEAD
 const createEntrypoints = () => {
 	/*
 	 * Returns an array of paths to block view files within the `@wordpress/block-library` package.
@@ -79,19 +71,18 @@ const createEntrypoints = () => {
 	}, {} );
 };
 
+=======
+>>>>>>> ee59af9d23 (Build: Stop generating unused legacy scripts for core blocks)
 module.exports = [
 	{
 		...baseConfig,
 		name: 'blocks',
-		entry: createEntrypoints(),
+		entry: {},
 		output: {
-			devtoolNamespace: 'wp',
-			filename: './build/block-library/blocks/[name].min.js',
 			path: join( __dirname, '..', '..' ),
 		},
 		plugins: [
 			...plugins,
-			new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
 			new PhpFilePathsPlugin( {
 				context: './packages/block-library/src/',
 				props: [ 'render', 'variations' ],

--- a/tools/webpack/blocks.js
+++ b/tools/webpack/blocks.js
@@ -41,38 +41,6 @@ function escapeRegExp( string ) {
 	return string.replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' );
 }
 
-<<<<<<< HEAD
-const createEntrypoints = () => {
-	/*
-	 * Returns an array of paths to block view files within the `@wordpress/block-library` package.
-	 * These paths can be matched by the regex `blockViewRegex` in order to extract
-	 * the block's filename. All blocks were migrated to script modules but the Form block.
-	 *
-	 * Returns an empty array if no files were found.
-	 */
-	const blockViewScriptPaths = fastGlob.sync(
-		'./packages/block-library/build-module/form/view.js'
-	);
-
-	/*
-	 * Go through the paths found above, in order to define webpack entry points for
-	 * each block's view.js file.
-	 */
-	return blockViewScriptPaths.reduce( ( entries, scriptPath ) => {
-		const result = scriptPath.match( blockViewRegex );
-		if ( ! result?.groups?.filename ) {
-			return entries;
-		}
-
-		return {
-			...entries,
-			[ result.groups.filename ]: scriptPath,
-		};
-	}, {} );
-};
-
-=======
->>>>>>> ee59af9d23 (Build: Stop generating unused legacy scripts for core blocks)
 module.exports = [
 	{
 		...baseConfig,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up for https://github.com/WordPress/gutenberg/pull/65064.

From https://github.com/WordPress/gutenberg/pull/65064#issuecomment-2343006595:

> I see that the `view.js` files for blocks are produced twice:
> 
> <img width="1867" alt="Screenshot 2024-09-11 at 10 32 42" src="https://github.com/user-attachments/assets/193a5df2-1e6c-4433-ad37-c2fc98b30762">

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> It's a preexisting issue as that was missed during the refactoring. It's probably some artifacts from WP 6.4. It would also explain why you run into issues with the order of configs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Basically remove all related entry points and corresponding logic and config options.

> Code to refactor is here:
> 
> https://github.com/WordPress/gutenberg/blob/f5e2162648276d8cf37b7597636cbd189a740283/tools/webpack/blocks.js#L53-L80
> 
> It probably means there would be no entry points, so we will also have to think how to structure configs. Having blocks independently from entry points was the strategy in the old world of scripts.

These changes apply to the following blocks:
- File
- Image
- Navigation
- Query
- Search

There will be present moving forward in `build-module/block-library` only.

## Screenshots or screencast <!-- if applicable -->

After:



## Testing instructions for Form block

1. Ensure to enable the experiment for Form and input block:
  <img width="487" alt="Screenshot 2024-09-12 at 11 41 42" src="https://github.com/user-attachments/assets/41a131e4-35aa-427b-9bc2-ffccb7b3e7ab">

2. Create a new post.
3. Insert an Experimental Comment Form block variation: <img width="1912" alt="Screenshot 2024-12-02 at 10 42 26" src="https://github.com/user-attachments/assets/76cf3ab0-e852-4770-bc63-99c7e0af7196">
4. Publish the post.
5. Go to the post and inspect the source code:
  <img width="1457" alt="Screenshot 2024-12-02 at 10 44 13" src="https://github.com/user-attachments/assets/633c0239-9abd-4b95-854a-2f951aceb7ee">
  <img width="849" alt="Screenshot 2024-12-02 at 10 44 31" src="https://github.com/user-attachments/assets/46b1e658-410c-4837-a3b1-0a8649b4c317">

6. Fill in the form data:
   <img width="712" alt="Screenshot 2024-12-02 at 10 45 52" src="https://github.com/user-attachments/assets/cfd1abdd-7fbe-45cc-a671-179d207a6be7">

7. Send the form and check the success message: 
<img width="888" alt="Screenshot 2024-12-02 at 10 46 02" src="https://github.com/user-attachments/assets/274ced7e-1053-46d7-95f6-23c3c1acb4da">
 