### PR TITLE
Make `wordpress/fields` a private package

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1698,12 +1698,6 @@
 		"parent": "packages"
 	},
 	{
-		"title": "@wordpress/fields",
-		"slug": "packages-fields",
-		"markdown_source": "../packages/fields/README.md",
-		"parent": "packages"
-	},
-	{
 		"title": "@wordpress/format-library",
 		"slug": "packages-format-library",
 		"markdown_source": "../packages/format-library/README.md",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -9,6 +9,7 @@
 		"gutenberg",
 		"dataviews"
 	],
+	"private": true,
 	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/fields/README.md",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/65230#issuecomment-2343996092

Makes the `field` package a private one, until it's used by core.
