### PR TITLE
ESLint: Fix temp migration rules for the components package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -149,6 +149,67 @@ const restrictedSyntaxComponents = [
 	},
 ];
 
+/** `no-restricted-syntax` rules for components, related to temporary prop migrations. */
+const restrictedSyntaxComponentsTemporary = [
+	// Temporary rules until we're ready to officially deprecate the bottom margins.
+	...[
+		'BaseControl',
+		'CheckboxControl',
+		'ComboboxControl',
+		'DimensionControl',
+		'FocalPointPicker',
+		'RangeControl',
+		'SearchControl',
+		'SelectControl',
+		'TextControl',
+		'TextareaControl',
+		'ToggleControl',
+		'ToggleGroupControl',
+		'TreeSelect',
+	].map( ( componentName ) => ( {
+		selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__nextHasNoMarginBottom"]))`,
+		message:
+			componentName +
+			' should have the `__nextHasNoMarginBottom` prop to opt-in to the new margin-free styles.',
+	} ) ),
+	// Temporary rules until we're ready to officially default to the new size.
+	...[
+		'BorderBoxControl',
+		'BorderControl',
+		'BoxControl',
+		'Button',
+		'ComboboxControl',
+		'CustomSelectControl',
+		'DimensionControl',
+		'FontAppearanceControl',
+		'FontFamilyControl',
+		'FontSizePicker',
+		'FormTokenField',
+		'InputControl',
+		'LetterSpacingControl',
+		'LineHeightControl',
+		'NumberControl',
+		'RangeControl',
+		'SelectControl',
+		'TextControl',
+		'ToggleGroupControl',
+		'UnitControl',
+	].map( ( componentName ) => ( {
+		// Falsy `__next40pxDefaultSize` without a non-default `size` prop.
+		selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
+		message:
+			componentName +
+			' should have the `__next40pxDefaultSize` prop when using the default size.',
+	} ) ),
+	{
+		// Falsy `__next40pxDefaultSize` without a `render` prop.
+		selector:
+			'JSXOpeningElement[name.name="FormFileUpload"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="render"]))',
+		message:
+			'FormFileUpload should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
+	},
+];
+
 module.exports = {
 	root: true,
 	extends: [
@@ -296,63 +357,7 @@ module.exports = {
 					'error',
 					...restrictedSyntax,
 					...restrictedSyntaxComponents,
-					// Temporary rules until we're ready to officially deprecate the bottom margins.
-					...[
-						'BaseControl',
-						'CheckboxControl',
-						'ComboboxControl',
-						'DimensionControl',
-						'FocalPointPicker',
-						'RangeControl',
-						'SearchControl',
-						'SelectControl',
-						'TextControl',
-						'TextareaControl',
-						'ToggleControl',
-						'ToggleGroupControl',
-						'TreeSelect',
-					].map( ( componentName ) => ( {
-						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__nextHasNoMarginBottom"]))`,
-						message:
-							componentName +
-							' should have the `__nextHasNoMarginBottom` prop to opt-in to the new margin-free styles.',
-					} ) ),
-					// Temporary rules until we're ready to officially default to the new size.
-					...[
-						'BorderBoxControl',
-						'BorderControl',
-						'BoxControl',
-						'Button',
-						'ComboboxControl',
-						'CustomSelectControl',
-						'DimensionControl',
-						'FontAppearanceControl',
-						'FontFamilyControl',
-						'FontSizePicker',
-						'FormTokenField',
-						'InputControl',
-						'LetterSpacingControl',
-						'LineHeightControl',
-						'NumberControl',
-						'RangeControl',
-						'SelectControl',
-						'TextControl',
-						'ToggleGroupControl',
-						'UnitControl',
-					].map( ( componentName ) => ( {
-						// Falsy `__next40pxDefaultSize` without a non-default `size` prop.
-						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
-						message:
-							componentName +
-							' should have the `__next40pxDefaultSize` prop when using the default size.',
-					} ) ),
-					{
-						// Falsy `__next40pxDefaultSize` without a `render` prop.
-						selector:
-							'JSXOpeningElement[name.name="FormFileUpload"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="render"]))',
-						message:
-							'FormFileUpload should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
-					},
+					...restrictedSyntaxComponentsTemporary,
 				],
 			},
 		},
@@ -465,6 +470,7 @@ module.exports = {
 					'error',
 					...restrictedSyntax,
 					...restrictedSyntaxComponents,
+					...restrictedSyntaxComponentsTemporary,
 					{
 						selector:
 							':matches(Literal[value=/--wp-admin-theme-/],TemplateElement[value.cooked=/--wp-admin-theme-/])',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -464,6 +464,8 @@ module.exports = {
 			excludedFiles: [
 				'packages/components/src/utils/colors-values.js',
 				'packages/components/src/theme/**',
+				'**/@(test|stories)/**',
+				'**/*.@(native|ios|android).js',
 			],
 			rules: {
 				'no-restricted-syntax': [


### PR DESCRIPTION
## What?
Enable the temp prop migration rules for the component package.

## Why?
They appear to have been unintentionally overwritten and didn't work for the components package.

See https://github.com/WordPress/gutenberg/issues/65018#issuecomment-2345164908

## How?
Moving the rules and reusing them where necessary.

## Testing Instructions
* Follow instructions in https://github.com/WordPress/gutenberg/issues/65018#issuecomment-2345164908
* There should also be 462 `no-restricted-syntax` errors in this branch.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-09-12 at 12 40 45](https://github.com/user-attachments/assets/477825ed-4df9-4eea-9e6b-8ee7b6ebd698)
