### PR TITLE
Categories List block: Add dropdown for taxonomies

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -79,7 +79,7 @@ Display a list of all categories. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts
+-	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -72,9 +72,9 @@ A calendar of your site’s posts. ([Source](https://github.com/WordPress/gutenb
 -	**Supports:** align, color (background, link, text), interactivity (clientNavigation), typography (fontSize, lineHeight)
 -	**Attributes:** month, year
 
-## Categories List
+## Terms List
 
-Display a list of all categories. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/categories))
+Display a list of all terms of a given taxonomy. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/categories))
 
 -	**Name:** core/categories
 -	**Category:** widgets

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -5,6 +5,7 @@
 	"title": "Terms List",
 	"category": "widgets",
 	"description": "Display a list of all terms of a given taxonomy.",
+	"keywords": [ "categories" ],
 	"textdomain": "default",
 	"attributes": {
 		"taxonomy": {

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -7,6 +7,10 @@
 	"description": "Display a list of all categories.",
 	"textdomain": "default",
 	"attributes": {
+		"taxonomy": {
+			"type": "string",
+			"default": "category"
+		},
 		"displayAsDropdown": {
 			"type": "boolean",
 			"default": false

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -2,9 +2,9 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 3,
 	"name": "core/categories",
-	"title": "Categories List",
+	"title": "Terms List",
 	"category": "widgets",
-	"description": "Display a list of all categories.",
+	"description": "Display a list of all terms of a given taxonomy.",
 	"textdomain": "default",
 	"attributes": {
 		"taxonomy": {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -205,14 +205,14 @@ export default function CategoriesEdit( {
 					{ isHierarchicalTaxonomy && (
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show only top level categories' ) }
+							label={ __( 'Show only top level terms' ) }
 							checked={ showOnlyTopLevel }
 							onChange={ toggleAttribute( 'showOnlyTopLevel' ) }
 						/>
 					) }
 					<ToggleControl
 						__nextHasNoMarginBottom
-						label={ __( 'Show empty categories' ) }
+						label={ __( 'Show empty terms' ) }
 						checked={ showEmpty }
 						onChange={ toggleAttribute( 'showEmpty' ) }
 					/>

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -195,7 +195,7 @@ export default function CategoriesEdit( {
 								label: t.name,
 								value: t.slug,
 							} ) ) }
-							value={ taxonomy }
+							value={ taxonomySlug }
 							onChange={ ( selectedTaxonomy ) =>
 								setAttributes( { taxonomy: selectedTaxonomy } )
 							}

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -33,6 +33,7 @@ export default function CategoriesEdit( {
 		showEmpty,
 		label,
 		showLabel,
+		taxonomy,
 	},
 	setAttributes,
 	className,
@@ -45,7 +46,7 @@ export default function CategoriesEdit( {
 
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
-		'category',
+		taxonomy,
 		query
 	);
 

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -218,7 +218,7 @@ export default function CategoriesEdit( {
 				</PanelBody>
 			</InspectorControls>
 			{ isResolving && (
-				<Placeholder icon={ pin } label={ __( 'Categories' ) }>
+				<Placeholder icon={ pin } label={ __( 'Terms' ) }>
 					<Spinner />
 				</Placeholder>
 			) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -44,11 +44,14 @@ export default function CategoriesEdit( {
 		query.parent = 0;
 	}
 
-	const { record: taxonomy } = useEntityRecord(
+	const { record: taxonomy, isResolvingTaxonomy } = useEntityRecord(
 		'root',
 		'taxonomy',
 		taxonomySlug
 	);
+
+	const isHierarchicalTaxonomy =
+		! isResolvingTaxonomy && taxonomy?.hierarchical;
 
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
@@ -195,19 +198,21 @@ export default function CategoriesEdit( {
 						checked={ showPostCounts }
 						onChange={ toggleAttribute( 'showPostCounts' ) }
 					/>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Show only top level categories' ) }
-						checked={ showOnlyTopLevel }
-						onChange={ toggleAttribute( 'showOnlyTopLevel' ) }
-					/>
+					{ isHierarchicalTaxonomy && (
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show only top level categories' ) }
+							checked={ showOnlyTopLevel }
+							onChange={ toggleAttribute( 'showOnlyTopLevel' ) }
+						/>
+					) }
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Show empty categories' ) }
 						checked={ showEmpty }
 						onChange={ toggleAttribute( 'showEmpty' ) }
 					/>
-					{ ! showOnlyTopLevel && (
+					{ isHierarchicalTaxonomy && ! showOnlyTopLevel && (
 						<ToggleControl
 							__nextHasNoMarginBottom
 							label={ __( 'Show hierarchy' ) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import {
 	PanelBody,
 	Placeholder,
+	SelectControl,
 	Spinner,
 	ToggleControl,
 	VisuallyHidden,
@@ -39,6 +40,10 @@ export default function CategoriesEdit( {
 	className,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
+
+	const { records: taxonomies } = useEntityRecords( 'root', 'taxonomy', {
+		type: 'post',
+	} );
 
 	const { record: taxonomy, isResolvingTaxonomy } = useEntityRecord(
 		'root',
@@ -181,6 +186,21 @@ export default function CategoriesEdit( {
 		<TagName { ...blockProps }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
+					{ Array.isArray( taxonomies ) && (
+						<SelectControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Taxonomy' ) }
+							options={ taxonomies.map( ( t ) => ( {
+								label: t.name,
+								value: t.slug,
+							} ) ) }
+							value={ taxonomy }
+							onChange={ ( selectedTaxonomy ) =>
+								setAttributes( { taxonomy: selectedTaxonomy } )
+							}
+						/>
+					) }
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Display as dropdown' ) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -41,13 +41,12 @@ export default function CategoriesEdit( {
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 
-	const { records: taxonomies, isResolvingTaxonomies } = useEntityRecords(
+	const { records: allTaxonomies, isResolvingTaxonomies } = useEntityRecords(
 		'root',
-		'taxonomy',
-		{
-			type: 'post',
-		}
+		'taxonomy'
 	);
+
+	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );
 
 	const taxonomy = taxonomies?.find( ( t ) => t.slug === taxonomySlug );
 

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -20,9 +20,9 @@ import {
 	RichText,
 } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
-import { useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -33,7 +33,7 @@ export default function CategoriesEdit( {
 		showEmpty,
 		label,
 		showLabel,
-		taxonomy,
+		taxonomy: taxonomySlug,
 	},
 	setAttributes,
 	className,
@@ -44,9 +44,15 @@ export default function CategoriesEdit( {
 		query.parent = 0;
 	}
 
+	const { record: taxonomy } = useEntityRecord(
+		'root',
+		'taxonomy',
+		taxonomySlug
+	);
+
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
-		taxonomy,
+		taxonomySlug,
 		query
 	);
 
@@ -103,7 +109,7 @@ export default function CategoriesEdit( {
 					<RichText
 						className="wp-block-categories__label"
 						aria-label={ __( 'Label text' ) }
-						placeholder={ __( 'Categories' ) }
+						placeholder={ taxonomy.name }
 						withoutInteractiveFormatting
 						value={ label }
 						onChange={ ( html ) =>
@@ -112,11 +118,17 @@ export default function CategoriesEdit( {
 					/>
 				) : (
 					<VisuallyHidden as="label" htmlFor={ selectId }>
-						{ label ? label : __( 'Categories' ) }
+						{ label ? label : taxonomy.name }
 					</VisuallyHidden>
 				) }
 				<select id={ selectId }>
-					<option>{ __( 'Select Category' ) }</option>
+					<option>
+						{ sprintf(
+							/* translators: %s: taxonomy's singular name */
+							__( 'Select %s' ),
+							taxonomy.labels.singular_name
+						) }
+					</option>
 					{ categoriesList.map( ( category ) =>
 						renderCategoryDropdownItem( category, 0 )
 					) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -39,10 +39,6 @@ export default function CategoriesEdit( {
 	className,
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
-	const query = { per_page: -1, hide_empty: ! showEmpty, context: 'view' };
-	if ( showOnlyTopLevel ) {
-		query.parent = 0;
-	}
 
 	const { record: taxonomy, isResolvingTaxonomy } = useEntityRecord(
 		'root',
@@ -52,6 +48,11 @@ export default function CategoriesEdit( {
 
 	const isHierarchicalTaxonomy =
 		! isResolvingTaxonomy && taxonomy?.hierarchical;
+
+	const query = { per_page: -1, hide_empty: ! showEmpty, context: 'view' };
+	if ( isHierarchicalTaxonomy && showOnlyTopLevel ) {
+		query.parent = 0;
+	}
 
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
@@ -76,7 +77,7 @@ export default function CategoriesEdit( {
 		! name ? __( '(Untitled)' ) : decodeEntities( name ).trim();
 
 	const renderCategoryList = () => {
-		const parentId = showHierarchy ? 0 : null;
+		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
 		const categoriesList = getCategoriesList( parentId );
 		return categoriesList.map( ( category ) =>
 			renderCategoryListItem( category )
@@ -92,19 +93,21 @@ export default function CategoriesEdit( {
 					{ renderCategoryName( name ) }
 				</a>
 				{ showPostCounts && ` (${ count })` }
-				{ showHierarchy && !! childCategories.length && (
-					<ul className="children">
-						{ childCategories.map( ( childCategory ) =>
-							renderCategoryListItem( childCategory )
-						) }
-					</ul>
-				) }
+				{ isHierarchicalTaxonomy &&
+					showHierarchy &&
+					!! childCategories.length && (
+						<ul className="children">
+							{ childCategories.map( ( childCategory ) =>
+								renderCategoryListItem( childCategory )
+							) }
+						</ul>
+					) }
 			</li>
 		);
 	};
 
 	const renderCategoryDropdown = () => {
-		const parentId = showHierarchy ? 0 : null;
+		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
 		const categoriesList = getCategoriesList( parentId );
 		return (
 			<>
@@ -149,7 +152,8 @@ export default function CategoriesEdit( {
 				{ renderCategoryName( name ) }
 				{ showPostCounts && ` (${ count })` }
 			</option>,
-			showHierarchy &&
+			isHierarchicalTaxonomy &&
+				showHierarchy &&
 				!! childCategories.length &&
 				childCategories.map( ( childCategory ) =>
 					renderCategoryDropdownItem( childCategory, level + 1 )

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -23,7 +23,7 @@ import {
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
-import { useEntityRecord, useEntityRecords } from '@wordpress/core-data';
+import { useEntityRecords } from '@wordpress/core-data';
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -41,18 +41,18 @@ export default function CategoriesEdit( {
 } ) {
 	const selectId = useInstanceId( CategoriesEdit, 'blocks-category-select' );
 
-	const { records: taxonomies } = useEntityRecords( 'root', 'taxonomy', {
-		type: 'post',
-	} );
-
-	const { record: taxonomy, isResolvingTaxonomy } = useEntityRecord(
+	const { records: taxonomies, isResolvingTaxonomies } = useEntityRecords(
 		'root',
 		'taxonomy',
-		taxonomySlug
+		{
+			type: 'post',
+		}
 	);
 
+	const taxonomy = taxonomies?.find( ( t ) => t.slug === taxonomySlug );
+
 	const isHierarchicalTaxonomy =
-		! isResolvingTaxonomy && taxonomy?.hierarchical;
+		! isResolvingTaxonomies && taxonomy?.hierarchical;
 
 	const query = { per_page: -1, hide_empty: ! showEmpty, context: 'view' };
 	if ( isHierarchicalTaxonomy && showOnlyTopLevel ) {

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -251,15 +251,7 @@ export default function CategoriesEdit( {
 				</Placeholder>
 			) }
 			{ ! isResolving && categories?.length === 0 && (
-				<p>
-					{ sprintf(
-						/* translators: %s: taxonomy's singular name */
-						__(
-							'No terms from the "%s" taxonomy have been assigned to any posts, so there is nothing to display here at the moment.'
-						),
-						taxonomy.name
-					) }
-				</p>
+				<p>{ taxonomy.labels.no_terms }</p>
 			) }
 			{ ! isResolving &&
 				categories?.length > 0 &&

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -252,8 +252,12 @@ export default function CategoriesEdit( {
 			) }
 			{ ! isResolving && categories?.length === 0 && (
 				<p>
-					{ __(
-						'Your site does not have any posts, so there is nothing to display here at the moment.'
+					{ sprintf(
+						/* translators: %s: taxonomy's singular name */
+						__(
+							'No terms from the "%s" taxonomy have been assigned to any posts, so there is nothing to display here at the moment.'
+						),
+						taxonomy.name
 					) }
 				</p>
 			) }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -39,6 +39,8 @@ function render_block_core_categories( $attributes, $content, $block ) {
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
+		$args['name']             = $taxonomy->query_var;
+		$args['value_field']      = 'slug';
 		$args['show_option_none'] = sprintf(
 			/* translators: %s: taxonomy's singular name */
 			__( 'Select %s' ),
@@ -99,8 +101,8 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	( function() {
 		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
 		function onCatChange() {
-			if ( dropdown.options[ dropdown.selectedIndex ].value > 0 ) {
-				location.href = "<?php echo esc_url( home_url() ); ?>/?cat=" + dropdown.options[ dropdown.selectedIndex ].value;
+			if ( dropdown.options[ dropdown.selectedIndex ].value !== -1 ) {
+				location.href = "<?php echo esc_url( home_url() ); ?>/?" + dropdown.name + '=' + dropdown.options[ dropdown.selectedIndex ].value;
 			}
 		}
 		dropdown.onchange = onCatChange;

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -21,6 +21,8 @@ function render_block_core_categories( $attributes, $content, $block ) {
 	static $block_id = 0;
 	++$block_id;
 
+	$taxonomy = get_taxonomy( $attributes['taxonomy'] );
+
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
@@ -37,9 +39,13 @@ function render_block_core_categories( $attributes, $content, $block ) {
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
 		$id                       = 'wp-block-categories-' . $block_id;
 		$args['id']               = $id;
-		$args['show_option_none'] = __( 'Select Category' );
+		$args['show_option_none'] = sprintf(
+			/* translators: %s: taxonomy's singular name */
+			__( 'Select %s' ),
+			$taxonomy->labels->singular_name
+		);
 		$show_label               = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
-		$default_label            = __( 'Categories' );
+		$default_label            = $taxonomy->label;
 		$label_text               = ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
 		$wrapper_markup           = '<div %1$s><label class="wp-block-categories__label' . $show_label . '" for="' . esc_attr( $id ) . '">' . $label_text . '</label>%2$s</div>';
 		$items_markup             = wp_dropdown_categories( $args );

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -26,6 +26,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
 		'orderby'      => 'name',
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
+		'taxonomy'     => $attributes['taxonomy'],
 		'title_li'     => '',
 		'hide_empty'   => empty( $attributes['showEmpty'] ),
 	);

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -122,7 +122,7 @@ function register_block_core_categories() {
 	register_block_type_from_metadata(
 		__DIR__ . '/categories',
 		array(
-			'render_callback'    => 'render_block_core_categories',
+			'render_callback' => 'render_block_core_categories',
 		)
 	);
 }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -46,12 +46,13 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			__( 'Select %s' ),
 			$taxonomy->labels->singular_name
 		);
-		$show_label               = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
-		$default_label            = $taxonomy->label;
-		$label_text               = ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
-		$wrapper_markup           = '<div %1$s><label class="wp-block-categories__label' . $show_label . '" for="' . esc_attr( $id ) . '">' . $label_text . '</label>%2$s</div>';
-		$items_markup             = wp_dropdown_categories( $args );
-		$type                     = 'dropdown';
+
+		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
+		$default_label  = $taxonomy->label;
+		$label_text     = ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+		$wrapper_markup = '<div %1$s><label class="wp-block-categories__label' . $show_label . '" for="' . esc_attr( $id ) . '">' . $label_text . '</label>%2$s</div>';
+		$items_markup   = wp_dropdown_categories( $args );
+		$type           = 'dropdown';
 
 		if ( ! is_admin() ) {
 			// Inject the dropdown script immediately after the select dropdown.

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -114,73 +114,15 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 }
 
 /**
- * Returns the available variations for the `core/categories` block.
- *
- * @since 6.7.0
- *
- * @return array The available variations for the block.
- */
-function block_core_categories_build_variations() {
-	$taxonomies = get_taxonomies(
-		array(
-			'publicly_queryable' => true,
-			'show_in_rest'       => true,
-		),
-		'objects'
-	);
-
-	// Split the available taxonomies to `built_in` and custom ones,
-	// in order to prioritize the `built_in` taxonomies at the
-	// search results.
-	$built_ins         = array();
-	$custom_variations = array();
-
-	// Create and register the eligible taxonomies variations.
-	foreach ( $taxonomies as $taxonomy ) {
-		$variation = array(
-			'name'        => $taxonomy->name,
-			'title'       => sprintf(
-				/* translators: %s: taxonomy's label */
-				__( '%s List' ),
-				$taxonomy->label
-			),
-			'description' => sprintf(
-				/* translators: %s: taxonomy's label */
-				__( 'Display a list of all terms for the taxonomy: %s' ),
-				$taxonomy->label
-			),
-			'attributes'  => array(
-				'taxonomy' => $taxonomy->name,
-			),
-			'isActive'    => array( 'taxonomy' ),
-			'scope'       => array( 'inserter', 'transform' ),
-		);
-		// Set the category variation as the default one.
-		if ( 'category' === $taxonomy->name ) {
-			$variation['isDefault'] = true;
-		}
-		if ( $taxonomy->_builtin ) {
-			$built_ins[] = $variation;
-		} else {
-			$custom_variations[] = $variation;
-		}
-	}
-
-	return array_merge( $built_ins, $custom_variations );
-}
-
-/**
  * Registers the `core/categories` block on server.
  *
  * @since 5.0.0
- * @since 6.7.0 Added the `variation_callback` argument.
  */
 function register_block_core_categories() {
 	register_block_type_from_metadata(
 		__DIR__ . '/categories',
 		array(
 			'render_callback'    => 'render_block_core_categories',
-			'variation_callback' => 'block_core_categories_build_variations',
 		)
 	);
 }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -104,15 +104,73 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 }
 
 /**
+ * Returns the available variations for the `core/categories` block.
+ *
+ * @since 6.7.0
+ *
+ * @return array The available variations for the block.
+ */
+function block_core_categories_build_variations() {
+	$taxonomies = get_taxonomies(
+		array(
+			'publicly_queryable' => true,
+			'show_in_rest'       => true,
+		),
+		'objects'
+	);
+
+	// Split the available taxonomies to `built_in` and custom ones,
+	// in order to prioritize the `built_in` taxonomies at the
+	// search results.
+	$built_ins         = array();
+	$custom_variations = array();
+
+	// Create and register the eligible taxonomies variations.
+	foreach ( $taxonomies as $taxonomy ) {
+		$variation = array(
+			'name'        => $taxonomy->name,
+			'title'       => sprintf(
+				/* translators: %s: taxonomy's label */
+				__( '%s List' ),
+				$taxonomy->label
+			),
+			'description' => sprintf(
+				/* translators: %s: taxonomy's label */
+				__( 'Display a list of terms from the taxonomy: %s' ),
+				$taxonomy->label
+			),
+			'attributes'  => array(
+				'taxonomy' => $taxonomy->name,
+			),
+			'isActive'    => array( 'taxonomy' ),
+			'scope'       => array( 'inserter', 'transform' ),
+		);
+		// Set the category variation as the default one.
+		if ( 'category' === $taxonomy->name ) {
+			$variation['isDefault'] = true;
+		}
+		if ( $taxonomy->_builtin ) {
+			$built_ins[] = $variation;
+		} else {
+			$custom_variations[] = $variation;
+		}
+	}
+
+	return array_merge( $built_ins, $custom_variations );
+}
+
+/**
  * Registers the `core/categories` block on server.
  *
  * @since 5.0.0
+ * @since 6.7.0 Added the `variation_callback` argument.
  */
 function register_block_core_categories() {
 	register_block_type_from_metadata(
 		__DIR__ . '/categories',
 		array(
-			'render_callback' => 'render_block_core_categories',
+			'render_callback'    => 'render_block_core_categories',
+			'variation_callback' => 'block_core_categories_build_variations',
 		)
 	);
 }

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -137,7 +137,7 @@ function block_core_categories_build_variations() {
 			),
 			'description' => sprintf(
 				/* translators: %s: taxonomy's label */
-				__( 'Display a list of terms from the taxonomy: %s' ),
+				__( 'Display a list of all terms for the taxonomy: %s' ),
 				$taxonomy->label
 			),
 			'attributes'  => array(

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -64,6 +64,8 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			);
 		}
 	} else {
+		$args['show_option_none'] = $taxonomy->labels->no_terms;
+
 		$wrapper_markup = '<ul %1$s>%2$s</ul>';
 		$items_markup   = wp_list_categories( $args );
 		$type           = 'list';

--- a/test/integration/fixtures/blocks/core__categories.json
+++ b/test/integration/fixtures/blocks/core__categories.json
@@ -3,6 +3,7 @@
 		"name": "core/categories",
 		"isValid": true,
 		"attributes": {
+			"taxonomy": "category",
 			"displayAsDropdown": false,
 			"showHierarchy": false,
 			"showPostCounts": false,


### PR DESCRIPTION
## What?
Allow using the Categories List block for other taxonomies.

![image](https://github.com/user-attachments/assets/207e81bd-bcfb-4a29-a7d4-fea1ef5a2d4d)

Alternative to #64805.

## Why?
There's been some demand for a "Terms List" block that would render a list of existing taxonomy terms for a given taxonomy -- much like the Categories List block has so far done for categories.

Fixes #33302.
Closes #26555 (which is quite outdated by now).

## How?
By adding a `taxonomy` attribute to the Categories List block, and a dropdown to the block inspector to set that attribute.

The principal choice here was to either use block variations -- or not. I originally filed a PR for the former case (#64805), but feedback indicated that folks preferred the latter.

## What is this _not_?
A full-fledged "Terms Query" block, as requested by #49094.

However, there's been a few issues and PRs floating around for a while for _just_ a "simple" Terms _List_ block (e.g. https://github.com/WordPress/gutenberg/pull/58033, https://github.com/WordPress/gutenberg/pull/26555), and I recently found myself working on a project where I could've used a "Terms List" block myself. I concluded that it might make sense to add such a block after all; this doesn't preclude us from adding a more powerful (and complex) Terms _Query_ block later.

## Testing Instructions
Add the following code (e.g. to your theme's `functions.php`) and use the "Project Types" panel in the block inspector to create a number of "Project Type" terms and assign them to a given post. 

<details>
<summary>
Code
</summary>

```php
function register_taxonomies() {
	/**
	 * Taxonomy: Project Types.
	 */

	 $labels = array(
		'name'          => __( 'Project Types' ),
		'singular_name' => __( 'Project Type' ),
		'add_new_item'  => __( 'Add Project Type' ),
		'new_item_name' => __( 'New Project Type' ),
	);

	$args = array(
		'label'                 => __( 'Project Types' ),
		'labels'                => $labels,
		'public'                => true,
		'publicly_queryable'    => true,
		'hierarchical'          => false,
		'show_ui'               => true,
		'show_in_menu'          => true,
		'show_in_nav_menus'     => true,
		'query_var'             => true,
		'show_admin_column'     => false,
		'show_in_rest'          => true,
		'show_tagcloud'         => false,
		'rest_base'             => 'project_types',
		'rest_controller_class' => 'WP_REST_Terms_Controller',
		'rest_namespace'        => 'wp/v2',
		'show_in_quick_edit'    => false,
		'show_in_graphql'       => false,
		/*
		 * Set the `sort` and `args` properties so that the order of terms as
		 * assigned by the user is retained (rather than sorted alphabetically).
		 * See https://developer.wordpress.org/reference/functions/register_taxonomy/#comment-2687.
		 */
		'sort'                  => true,
		'args'                  => array( 'orderby' => 'term_order' ),
	);

	register_taxonomy( 'project_types', array( 'post' ), $args );
}

add_action( 'init', 'register_taxonomies', 0 );
```
</details>

Then, navigate to the Site Editor and insert the "Terms List" block into a template of your choosing, and select "Project Type" from the Taxonomy dropdown in the block inspector. Save the template, and verify on the frontend that the block does indeed render a list of project type terms.

Furthermore, make sure to test with built-in taxonomies, both hierarchical (Categories) and flat (Tags).

Finally, test the toggles in the block inspector. Specifically, change the block's appearance to a dropdown, and verify that it's rendered correctly both in the editor, and on the frontend. Also verify that selecting individual items from the dropdown on the frontend causes WordPress to navigate to the corresponding taxonomy term's archive page.

## Screenshots or screencast

![post-terms-with-attribute](https://github.com/user-attachments/assets/ad0ac95c-6252-4d7c-a2de-65c3d3b23776)
