### PR TITLE
i18n: Replace `sprintf-js` with `@tannin/sprintf`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
 			"hasInstallScript": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@tannin/sprintf": "1.2.0",
 				"@wordpress/a11y": "file:packages/a11y",
 				"@wordpress/annotations": "file:packages/annotations",
 				"@wordpress/api-fetch": "file:packages/api-fetch",
@@ -14123,6 +14124,12 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
+		},
+		"node_modules/@tannin/sprintf": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.2.0.tgz",
+			"integrity": "sha512-T0ORaQrH6kNFGzTg285RVPK+NCYZxOoA+r0QfKgHqK+yk5RuYPSKDa18XCLtycCNq+VWKpfyDpzGUGhYgCV+kw==",
+			"license": "MIT"
 		},
 		"node_modules/@testing-library/dom": {
 			"version": "9.3.1",
@@ -46857,7 +46864,8 @@
 		"node_modules/sprintf-js": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-			"integrity": "sha512-h/U+VScR2Ft+aXDjGTLtguUEIrYuOjTj79BAOElUvdahYMaaa7SNLjJpOIn+Uzt0hsgHfYvlbcno3e9yXOSo8Q=="
+			"integrity": "sha512-h/U+VScR2Ft+aXDjGTLtguUEIrYuOjTj79BAOElUvdahYMaaa7SNLjJpOIn+Uzt0hsgHfYvlbcno3e9yXOSo8Q==",
+			"dev": true
 		},
 		"node_modules/ssri": {
 			"version": "6.0.2",
@@ -54262,10 +54270,10 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/runtime": "^7.16.0",
+				"@tannin/sprintf": "^1.2.0",
 				"@wordpress/hooks": "file:../hooks",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			},
 			"bin": {
@@ -65551,6 +65559,11 @@
 			"resolved": "https://registry.npmjs.org/@tannin/postfix/-/postfix-1.1.0.tgz",
 			"integrity": "sha512-oocsqY7g0cR+Gur5jRQLSrX2OtpMLMse1I10JQBm8CdGMrDkh1Mg2gjsiquMHRtBs4Qwu5wgEp5GgIYHk4SNPw=="
 		},
+		"@tannin/sprintf": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/@tannin/sprintf/-/sprintf-1.2.0.tgz",
+			"integrity": "sha512-T0ORaQrH6kNFGzTg285RVPK+NCYZxOoA+r0QfKgHqK+yk5RuYPSKDa18XCLtycCNq+VWKpfyDpzGUGhYgCV+kw=="
+		},
 		"@testing-library/dom": {
 			"version": "9.3.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
@@ -68956,10 +68969,10 @@
 			"version": "file:packages/i18n",
 			"requires": {
 				"@babel/runtime": "^7.16.0",
+				"@tannin/sprintf": "^1.2.0",
 				"@wordpress/hooks": "file:../hooks",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
-				"sprintf-js": "^1.1.1",
 				"tannin": "^1.2.0"
 			}
 		},
@@ -92357,7 +92370,8 @@
 		"sprintf-js": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-			"integrity": "sha512-h/U+VScR2Ft+aXDjGTLtguUEIrYuOjTj79BAOElUvdahYMaaa7SNLjJpOIn+Uzt0hsgHfYvlbcno3e9yXOSo8Q=="
+			"integrity": "sha512-h/U+VScR2Ft+aXDjGTLtguUEIrYuOjTj79BAOElUvdahYMaaa7SNLjJpOIn+Uzt0hsgHfYvlbcno3e9yXOSo8Q==",
+			"dev": true
 		},
 		"ssri": {
 			"version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
 		"@wordpress/viewport": "file:packages/viewport",
 		"@wordpress/warning": "file:packages/warning",
 		"@wordpress/widgets": "file:packages/widgets",
-		"@wordpress/wordcount": "file:packages/wordcount"
+		"@wordpress/wordcount": "file:packages/wordcount",
+		"@tannin/sprintf": "1.2.0"
 	},
 	"devDependencies": {
 		"@actions/core": "1.9.1",

--- a/packages/components/src/navigation/menu/menu-title-search.tsx
+++ b/packages/components/src/navigation/menu/menu-title-search.tsx
@@ -77,7 +77,7 @@ function MenuTitleSearch( {
 	const placeholder = sprintf(
 		/* translators: placeholder for menu search box. %s: menu title */
 		__( 'Search %s' ),
-		title?.toLowerCase()
+		title?.toLowerCase() ?? ''
 	).trim();
 
 	return (

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -176,7 +176,7 @@ function Option< T extends Color | Gradient >( {
 	slugPrefix,
 	isGradient,
 }: OptionProps< T > ) {
-	const value = isGradient ? element.gradient : element.color;
+	const value = isGradient ? element.gradient! : element.color!;
 	const [ isEditingColor, setIsEditingColor ] = useState( false );
 
 	// Use internal state instead of a ref to make sure that the component

--- a/packages/editor/src/dataviews/actions/permanently-delete-post.tsx
+++ b/packages/editor/src/dataviews/actions/permanently-delete-post.tsx
@@ -74,7 +74,7 @@ const permanentlyDeletePost: Action< PostWithPermissions > = {
 				}
 				// If we were trying to permanently delete multiple posts
 			} else {
-				const errorMessages = new Set();
+				const errorMessages = new Set< string >();
 				const failedPromises = promiseResult.filter(
 					( { status } ) => status === 'rejected'
 				);

--- a/packages/editor/src/dataviews/actions/restore-post.tsx
+++ b/packages/editor/src/dataviews/actions/restore-post.tsx
@@ -92,7 +92,7 @@ const restorePost: Action< PostWithPermissions > = {
 				}
 				// If we were trying to move multiple posts to the trash
 			} else {
-				const errorMessages = new Set();
+				const errorMessages = new Set< string >();
 				const failedPromises = promiseResult.filter(
 					( { status } ) => status === 'rejected'
 				);

--- a/packages/editor/src/dataviews/actions/trash-post.tsx
+++ b/packages/editor/src/dataviews/actions/trash-post.tsx
@@ -139,7 +139,7 @@ const trashPost: Action< PostWithPermissions > = {
 									}
 									// If we were trying to delete multiple items.
 								} else {
-									const errorMessages = new Set();
+									const errorMessages = new Set< string >();
 									const failedPromises = promiseResult.filter(
 										( { status } ) => status === 'rejected'
 									);

--- a/packages/i18n/README.md
+++ b/packages/i18n/README.md
@@ -117,7 +117,7 @@ Returns a formatted string. If an error occurs in applying the format, the origi
 
 _Related_
 
--   <https://www.npmjs.com/package/sprintf-js>
+-   <https://www.npmjs.com/package/@tannin/sprintf>
 
 _Parameters_
 

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -31,10 +31,10 @@
 	},
 	"dependencies": {
 		"@babel/runtime": "^7.16.0",
+		"@tannin/sprintf": "^1.2.0",
 		"@wordpress/hooks": "file:../hooks",
 		"gettext-parser": "^1.3.1",
 		"memize": "^2.1.0",
-		"sprintf-js": "^1.1.1",
 		"tannin": "^1.2.0"
 	},
 	"publishConfig": {

--- a/packages/i18n/src/sprintf.js
+++ b/packages/i18n/src/sprintf.js
@@ -1,17 +1,7 @@
 /**
  * External dependencies
  */
-import memoize from 'memize';
-import sprintfjs from 'sprintf-js';
-
-/**
- * Log to console, once per message; or more precisely, per referentially equal
- * argument set. Because Jed throws errors, we log these to the console instead
- * to avoid crashing the application.
- *
- * @param {...*} args Arguments to pass to `console.error`
- */
-const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
+import sprintf from '@tannin/sprintf';
 
 /**
  * Returns a formatted string. If an error occurs in applying the format, the
@@ -20,17 +10,8 @@ const logErrorOnce = memoize( console.error ); // eslint-disable-line no-console
  * @param {string} format The format of the string to generate.
  * @param {...*}   args   Arguments to apply to the format.
  *
- * @see https://www.npmjs.com/package/sprintf-js
+ * @see https://www.npmjs.com/package/@tannin/sprintf
  *
  * @return {string} The formatted string.
  */
-export function sprintf( format, ...args ) {
-	try {
-		return sprintfjs.sprintf( format, ...args );
-	} catch ( error ) {
-		if ( error instanceof Error ) {
-			logErrorOnce( 'sprintf error: \n\n' + error.toString() );
-		}
-		return format;
-	}
-}
+export { sprintf };

--- a/packages/i18n/src/test/sprintf.js
+++ b/packages/i18n/src/test/sprintf.js
@@ -9,15 +9,6 @@ import { sprintf } from '../sprintf';
 
 describe( 'i18n', () => {
 	describe( 'sprintf', () => {
-		it( 'absorbs errors', () => {
-			// Disable reason: Failing case is the purpose of the test.
-			// eslint-disable-next-line @wordpress/valid-sprintf
-			const result = sprintf( 'Hello %(placeholder-not-provided)s' );
-
-			expect( console ).toHaveErrored();
-			expect( result ).toBe( 'Hello %(placeholder-not-provided)s' );
-		} );
-
 		it( 'replaces placeholders', () => {
 			const result = sprintf( 'bonjour %s', 'Riad' );
 

--- a/patches/@tannin+sprintf+1.2.0.patch
+++ b/patches/@tannin+sprintf+1.2.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/@tannin/sprintf/index.d.ts b/node_modules/@tannin/sprintf/index.d.ts
+index 1ac529e..41d5e9b 100644
+--- a/node_modules/@tannin/sprintf/index.d.ts
++++ b/node_modules/@tannin/sprintf/index.d.ts
+@@ -19,6 +19,4 @@
+  *
+  * @return {string} Formatted string.
+  */
+-export default function sprintf(string: string, ...args: (string | string[] | {
+-    [x: string]: string;
+-})[]): string;
++export default function sprintf(string: string, ...args: ReadonlyArray<string | number>): string;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Experiment for:
- https://github.com/WordPress/gutenberg/pull/65123

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
