### PR TITLE
Fix typo in Slot Fills documentation

### DIFF
--- a/docs/reference-guides/slotfills/README.md
+++ b/docs/reference-guides/slotfills/README.md
@@ -166,7 +166,7 @@ import { __ } from '@wordpress/i18n';
  */
 const SiteEditorDocumentSettingPanel = () => {
 	// Retrieve information about the current post type.
-	const { isViewable } = useSelect( ( select ) => {
+	const isViewable = useSelect( ( select ) => {
 		const postTypeName = select( editorStore ).getCurrentPostType();
 		const postTypeObject = select( coreStore ).getPostType( postTypeName );
 


### PR DESCRIPTION
Fix typo in code example for section "Restricting fills to the Side Editor".  

## What?
Fixes error in code example provided in documentation for Slot Fills.

## Why?
Current example was not working for me, the correct way is the same as in the section "Restricting fills to the Post Editor" above.
