### PR TITLE
Block Bindings: Try gap 0 on attribute items.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -98,7 +98,7 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
 	return (
-		<VStack className="block-editor-bindings__item">
+		<VStack className="block-editor-bindings__item" spacing={ 0 }>
 			<Text truncate>{ attribute }</Text>
 			{ !! binding && (
 				<Text

--- a/packages/block-editor/src/hooks/block-bindings.scss
+++ b/packages/block-editor/src/hooks/block-bindings.scss
@@ -3,4 +3,7 @@ div.block-editor-bindings__panel {
 	button:hover .block-editor-bindings__item span {
 		color: inherit;
 	}
+	.block-editor-bindings__item {
+		gap: 0;
+	}
 }

--- a/packages/block-editor/src/hooks/block-bindings.scss
+++ b/packages/block-editor/src/hooks/block-bindings.scss
@@ -3,7 +3,4 @@ div.block-editor-bindings__panel {
 	button:hover .block-editor-bindings__item span {
 		color: inherit;
 	}
-	.block-editor-bindings__item {
-		gap: 0;
-	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Block bindings items shown on the block panel are done with a Vstack.

https://github.com/WordPress/gutenberg/blob/53ab67d10749766b598381536deb1326c6cc5857/packages/block-editor/src/hooks/block-bindings.js#L95-L116

@jasmussen  spotted that line height is quite big right now. We can use the spacing property to adjust it as needed.

<img width="554" alt="Screenshot 2024-09-12 at 12 49 32" src="https://github.com/user-attachments/assets/81b4e086-cc47-42d8-9eb0-eb3d909acd8c">
