### PR TITLE
Build: Remove babel from script-modules build

### DIFF
--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -102,29 +102,6 @@ module.exports = {
 	resolve: {
 		extensions: [ '.js', '.ts', '.tsx' ],
 	},
-	module: {
-		rules: [
-			{
-				test: /\.(j|t)sx?$/,
-				exclude: /node_modules/,
-				use: [
-					{
-						loader: require.resolve( 'babel-loader' ),
-						options: {
-							cacheDirectory:
-								process.env.BABEL_CACHE_DIRECTORY || true,
-							babelrc: false,
-							configFile: false,
-							presets: [
-								'@babel/preset-typescript',
-								'@babel/preset-react',
-							],
-						},
-					},
-				],
-			},
-		],
-	},
 	plugins: [ ...plugins, new DependencyExtractionWebpackPlugin() ],
 	watchOptions: {
 		ignored: [ '**/node_modules' ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Remove babel processing from the script-modules build.

## Why?

It's not necessary. This build is now similar to the packages build in that packages themselves are compiled first, then their compiled assets are moved into a plugin build directory (build-module in this case).

This changed with #65064 where compiled files from the package started to be used instead of compiling from original source in this phase.

## How?

Remove it.

## Testing Instructions

Test out the Interactivity API and the Interactivity router on this PR. [The playground is a good option.](https://playground.wordpress.net/gutenberg.html)
