### PR TITLE
Zoom Out: Try a cursor change to zoom in

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -257,6 +257,10 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 		.rich-text {
 			cursor: auto;
 		}
+
+		.is-zoomed-out & {
+			cursor: move;
+		}
 	}
 
 	&.is-hovered:not(.is-selected),

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -34,13 +34,14 @@
 	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
 	$prev-container-width: var(--wp-block-editor-iframe-zoom-out-prev-container-width);
 
-	transform: scale(#{$scale});
-
 	background-color: $gray-300;
 
 	// Firefox and Safari don't render margin-bottom here and margin-bottom is needed for Chrome
 	// layout, so we use border matching the background instead of margins.
 	border: calc(#{$frame-size} / #{$scale}) solid $gray-300;
+
+	// Indicate to users that they can zoom back in by clicking on the canvas.
+	cursor: zoom-in;
 
 	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 	// so we need to adjust the height of the content to match the scale by using negative margins.
@@ -50,6 +51,17 @@
 	margin-bottom: calc(-1 * #{$total-height});
 
 	body {
+		transform: scale(#{$scale});
+		transform-origin: center top;
+
+		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+		// so we need to adjust the height of the content to match the scale by using negative margins.
+		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+		$total-frame-height: calc(2 * #{$frame-size});
+		$total-height: calc(#{$extra-content-height} + 2px);
+		margin-bottom: calc(-1 * #{$total-height});
+
+		cursor: default;
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 		display: flex;
 		flex-direction: column;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -22,7 +22,7 @@ import {
 	useDisabled,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -131,21 +131,31 @@ function Iframe( {
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
 
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
 			setIframeDocument( node.contentDocument );
 		};
 		let iFrameDocument;
+		let documentElement;
 		// Prevent the default browser action for files dropped outside of dropzones.
 		function preventFileDropDefault( event ) {
 			event.preventDefault();
 		}
+
+		function zoomIn( event ) {
+			if ( event.target === event.currentTarget ) {
+				__unstableSetEditorMode( 'edit' );
+			}
+		}
 		function onLoad() {
 			const { contentDocument, ownerDocument } = node;
-			const { documentElement } = contentDocument;
+			documentElement = contentDocument.documentElement;
 			iFrameDocument = contentDocument;
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
+			documentElement.addEventListener( 'click', zoomIn, false );
 
 			clearerRef( documentElement );
 
@@ -206,6 +216,7 @@ function Iframe( {
 				'drop',
 				preventFileDropDefault
 			);
+			documentElement?.removeEventListener( 'click', zoomIn );
 		};
 	}, [] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This experiments with changing the cursor and adding a click handler to the iframe to make it easier to escape zoom out.

Also tries out a move cursor on sections.

## Why?
There are some cases where it's quite difficult for users to escape zoom out mode. This adds another affordance to make it easier to get back to edit mode.

## How?
1. Add a click handler to the iframe which disables zoom out mode
2. Add `cursor: zoom-in` to the iframe when zoomed out. This required moving the scale calculation for the iframe from the html to the body, which could have other side effects.

## Testing Instructions
0. Enable the zoom out experiment
1. Open the site editor
2. Use the toggle in the top toolbar to zoom out the canvas
3. Hover the canvas and confirm that you see a zoom in cursor
4. Click the canvas and confirm that you are zoomed in.

### Testing Instructions for Keyboard
This change only impacts mouse users (I think?)

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/fd5a926d-444d-445e-a5cf-d134e05809fd



