### PR TITLE
BoxControl: Fix critical error when null value is passed

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -28,6 +28,7 @@
 -   `Tabs`: improved performance of the indicator animation ([#64926](https://github.com/WordPress/gutenberg/pull/64926)).
 -   `Composite`: Remove from private APIs ([#63569](https://github.com/WordPress/gutenberg/pull/63569)).
 -   use local copy of `use-lilius` instead of `npm` dependency ([#65097](https://github.com/WordPress/gutenberg/pull/65097)).
+-   `BoxControl`: Fix critical error when null value is passed ([#65287](https://github.com/WordPress/gutenberg/pull/65287)).
 
 ## 28.7.0 (2024-09-05)
 

--- a/packages/components/src/box-control/utils.ts
+++ b/packages/components/src/box-control/utils.ts
@@ -179,8 +179,7 @@ export function isValuesMixed(
  */
 export function isValuesDefined( values?: BoxControlValue ) {
 	return (
-		values !== undefined &&
-		values !== null &&
+		values &&
 		Object.values( values ).filter(
 			// Switching units when input is empty causes values only
 			// containing units. This gives false positive on mixed values

--- a/packages/components/src/box-control/utils.ts
+++ b/packages/components/src/box-control/utils.ts
@@ -180,6 +180,7 @@ export function isValuesMixed(
 export function isValuesDefined( values?: BoxControlValue ) {
 	return (
 		values !== undefined &&
+		values !== null &&
 		Object.values( values ).filter(
 			// Switching units when input is empty causes values only
 			// containing units. This gives false positive on mixed values


### PR DESCRIPTION
Found this while researching this comment: https://github.com/WordPress/gutenberg/pull/64971#issuecomment-2345175928

## What?

This PR fixes a critical error that occurs when `null` is passed to the `values` ​​prop of the `BoxControl` component.

The only time this error can occur in Gutenberg project is if the following conditions are met:

- The active theme is a block theme
- The theme supports `blockGap` (`settings.appearanceTools` is `true` or `settings/spacing.blockGap` is `true`)
- There is no spacing preset
- Access blocks with axial gap support via the global styles (e.g. Columns block)

https://github.com/user-attachments/assets/8561a628-2491-40df-a4e6-6e81da5c6eab

<details><summary>Browser error log</summary>

```
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.values (<anonymous>)
    at isValuesDefined (utils.ts:183:10)
    at BoxControl (index.tsx:93:41)
    at renderWithHooks (react-dom.js?ver=18:15496:20)
    at mountIndeterminateComponent (react-dom.js?ver=18:20113:15)
    at beginWork (react-dom.js?ver=18:21636:18)
    at HTMLUnknownElement.callCallback (react-dom.js?ver=18:4151:16)
    at Object.invokeGuardedCallbackDev (react-dom.js?ver=18:4200:18)
    at invokeGuardedCallback (react-dom.js?ver=18:4264:33)
    at beginWork$1 (react-dom.js?ver=18:27500:9)
```

</details> 

## Why?

If the theme does not have a spacing preset and the block supports the axial gap, the block spacing UI will be rendered as a `BoxControl` component here:

https://github.com/WordPress/gutenberg/blob/d329bfb23807f422d44731b8b031832e5afa8488/packages/block-editor/src/components/global-styles/dimensions-panel.js#L619-L628

Moreover, the initial value of the block gap is `null`, which is passed as the value of the `values` ​​prop here.

https://github.com/WordPress/gutenberg/blob/d329bfb23807f422d44731b8b031832e5afa8488/packages/block-editor/src/components/global-styles/dimensions-panel.js#L625

As a result, a critical error occurs in the `isValuesDefined()` function when `Object.values( null ).filter` is executed:

https://github.com/WordPress/gutenberg/blob/d329bfb23807f422d44731b8b031832e5afa8488/packages/components/src/box-control/utils.ts#L180-L183

## How?

Perhaps the ideal solution would be to investigate why the initial value of the blockGap is `null` and convert it to `undefined`. However, the `SpacingSizesControl` component also has the `isValuesDefined()` function, which checks for `null` in addition to `undefined`:

https://github.com/WordPress/gutenberg/blob/0f0c68a57fe9e2f9edf3f6c73877cffcb01a258b/packages/block-editor/src/components/spacing-sizes-control/utils.js#L238-L243

Therefore, it seems better to add a `null` check to the `BoxControl` component itself as well.

## Testing Instructions

- Activate the Emptytheme and update `theme.json` as follows:
  ```json
  {
  	"version": 3,
  	"settings": {
  		"appearanceTools": true,
  		"layout": {
  			"contentSize": "840px"
  		},
  		"spacing": {
  			"spacingSizes": [],
  			"defaultSpacingSizes": false
  		}
  	}
  }
  ```
- Access the Site Editor > Global styles > Blocks > Columns
  - trunk: The critical error occurs.
  - This PR: The critical error does not occur and the block spacing UI is rendered.