### PR TITLE
Packages: only add polyfills where needed

### DIFF
--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -11,6 +11,8 @@ module.exports = ( environment = '', file ) => {
 			name: `WP_BUILD_${ environment.toUpperCase() }`,
 		},
 	};
+	// Add `@wordpress/polyfill` import where needed.
+	callerOpts.caller.addPolyfillImport = true;
 	switch ( environment ) {
 		case 'main':
 			// To be merged as a presetEnv option.

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -12,7 +12,7 @@ module.exports = ( environment = '', file ) => {
 		},
 	};
 	// Add `@wordpress/polyfill` import where needed.
-	callerOpts.caller.addPolyfillImport = true;
+	callerOpts.caller.addPolyfillComments = true;
 	switch ( environment ) {
 		case 'main':
 			// To be merged as a presetEnv option.

--- a/bin/packages/get-babel-config.js
+++ b/bin/packages/get-babel-config.js
@@ -11,7 +11,7 @@ module.exports = ( environment = '', file ) => {
 			name: `WP_BUILD_${ environment.toUpperCase() }`,
 		},
 	};
-	// Add `@wordpress/polyfill` import where needed.
+	// Add `/* wp:polyfill */` magic comment where needed.
 	callerOpts.caller.addPolyfillComments = true;
 	switch ( environment ) {
 		case 'main':

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Added `addPolyfillImport` option. When used, it will automatically add `@wordpress/polyfill` imports where needed.
+- Added `addPolyfillComments` option. When used, it will automatically add magic comments to mark files that need `wp-polyfill`.
 
 ## 8.7.0 (2024-09-05)
 

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `addPolyfillImport` option. When used, it will automatically add `@wordpress/polyfill` imports where needed.
+
 ## 8.7.0 (2024-09-05)
 
 ## 8.6.0 (2024-08-21)

--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,6 +1,6 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
-## Unreleased
+## Internal
 
 - Added `addPolyfillComments` option. When used, it will automatically add magic comments to mark files that need `wp-polyfill`.
 

--- a/packages/babel-preset-default/README.md
+++ b/packages/babel-preset-default/README.md
@@ -43,7 +43,7 @@ For example, if you'd like to use a new language feature proposal which has not 
 
 There is a complementary `build/polyfill.js` (minified version – `build/polyfill.min.js`) file available that polyfills ECMAScript features missing in the [browsers supported](https://make.wordpress.org/core/handbook/best-practices/browser-support/) by the WordPress project ([#31279](https://github.com/WordPress/gutenberg/pull/31279)). It's a drop-in replacement for the deprecated `@babel/polyfill` package, and it's also based on [`core-js`](https://github.com/zloirock/core-js) project.
 
-This needs to be included before all your compiled Babel code. You can either prepend it to your compiled code or include it in a `<script>` before it.
+This needs to be included in some cases, if the features being used require polyfills. You can either prepend it to your compiled code or include it in a `<script>` before it.
 
 #### TC39 Proposals
 

--- a/packages/babel-preset-default/bin/index.js
+++ b/packages/babel-preset-default/bin/index.js
@@ -7,13 +7,14 @@ const builder = require( 'core-js-builder' );
 const { minify } = require( 'terser' );
 const { writeFile } = require( 'fs' ).promises;
 
+/**
+ * Internal dependencies
+ */
+const exclusions = require( '../polyfill-exclusions' );
+
 builder( {
 	modules: [ 'es.', 'web.' ],
-	exclude: [
-		// This is an IE-only feature which we don't use, and don't want to polyfill.
-		// @see https://github.com/WordPress/gutenberg/pull/49234
-		'web.immediate',
-	],
+	exclude: exclusions,
 	summary: { console: { size: true, modules: true } },
 	targets: require( '@wordpress/browserslist-config' ),
 	filename: './build/polyfill.js',

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -33,7 +33,7 @@ module.exports = ( api ) => {
 				'proposal-nullish-coalescing-operator',
 				'proposal-logical-assignment-operators',
 			],
-			...( wpBuildOpts.addPolyfillImport
+			...( wpBuildOpts.addPolyfillComments
 				? {
 						useBuiltIns: 'usage',
 						exclude: exclusions,
@@ -95,7 +95,7 @@ module.exports = ( api ) => {
 				},
 			],
 			maybeGetPluginTransformRuntime(),
-			wpBuildOpts.addPolyfillImport && replacePolyfills,
+			wpBuildOpts.addPolyfillComments && replacePolyfills,
 		].filter( Boolean ),
 	};
 };

--- a/packages/babel-preset-default/index.js
+++ b/packages/babel-preset-default/index.js
@@ -3,6 +3,12 @@
  */
 const browserslist = require( 'browserslist' );
 
+/**
+ * Internal dependencies
+ */
+const exclusions = require( './polyfill-exclusions' );
+const replacePolyfills = require( './replace-polyfills' );
+
 module.exports = ( api ) => {
 	let wpBuildOpts = {};
 	const isWPBuild = ( name ) =>
@@ -27,6 +33,13 @@ module.exports = ( api ) => {
 				'proposal-nullish-coalescing-operator',
 				'proposal-logical-assignment-operators',
 			],
+			...( wpBuildOpts.addPolyfillImport
+				? {
+						useBuiltIns: 'usage',
+						exclude: exclusions,
+						corejs: require( 'core-js/package.json' ).version,
+				  }
+				: {} ),
 		};
 
 		if ( isTestEnv ) {
@@ -82,6 +95,7 @@ module.exports = ( api ) => {
 				},
 			],
 			maybeGetPluginTransformRuntime(),
+			wpBuildOpts.addPolyfillImport && replacePolyfills,
 		].filter( Boolean ),
 	};
 };

--- a/packages/babel-preset-default/polyfill-exclusions.js
+++ b/packages/babel-preset-default/polyfill-exclusions.js
@@ -1,0 +1,10 @@
+module.exports = [
+	// Ignore excessively strict polyfilling of `Array.prototype.push` to work
+	// around an obscure bug involving non-writable arrays.
+	// See https://issues.chromium.org/issues/42202623 for the details of the
+	// bug that leads to the polyfilling, and which we are choosing to ignore.
+	'es.array.push',
+	// This is an IE-only feature which we don't use, and don't want to polyfill.
+	// @see https://github.com/WordPress/gutenberg/pull/49234
+	'web.immediate',
+];

--- a/packages/babel-preset-default/replace-polyfills.js
+++ b/packages/babel-preset-default/replace-polyfills.js
@@ -1,5 +1,6 @@
 // Babel plugin that looks for `core-js` imports (or requires)
-// and replaces them with `@wordpress/polyfill`.
+// and replaces them magic comments to mark the file as depending
+// on wp-polyfill.
 function replacePolyfills() {
 	return {
 		pre() {
@@ -10,10 +11,7 @@ function replacePolyfills() {
 				exit( path ) {
 					if ( this.hasAddedPolyfills ) {
 						// Add magic comment to top of file.
-						path.addComment(
-							'leading',
-							' wordpress: needs wp-polyfill '
-						);
+						path.addComment( 'leading', ' wp:polyfill ' );
 					}
 				},
 			},

--- a/packages/babel-preset-default/replace-polyfills.js
+++ b/packages/babel-preset-default/replace-polyfills.js
@@ -1,6 +1,6 @@
 // Babel plugin that looks for `core-js` imports (or requires)
-// and replaces them magic comments to mark the file as depending
-// on wp-polyfill.
+// and replaces them with magic comments to mark the file as
+// depending on wp-polyfill.
 function replacePolyfills() {
 	return {
 		pre() {

--- a/packages/babel-preset-default/replace-polyfills.js
+++ b/packages/babel-preset-default/replace-polyfills.js
@@ -1,0 +1,60 @@
+// Babel plugin that looks for `core-js` imports (or requires)
+// and replaces them with `@wordpress/polyfill`.
+function replacePolyfills() {
+	return {
+		pre() {
+			this.hasAddedPolyfills = false;
+		},
+		visitor: {
+			// Handle `import` syntax.
+			ImportDeclaration( path ) {
+				const source = path?.node?.source;
+				const name = source?.value || '';
+
+				// Look for imports from `core-js`.
+				if ( name.startsWith( 'core-js/' ) ) {
+					if ( this.hasAddedPolyfills ) {
+						// Remove duplicate import.
+						path.remove();
+					} else {
+						// Replace with `@wordpress/polyfill`.
+						source.value = '@wordpress/polyfill';
+						this.hasAddedPolyfills = true;
+					}
+				}
+			},
+
+			// Handle `require` syntax.
+			CallExpression( path ) {
+				const callee = path?.node?.callee;
+				const arg = path?.node?.arguments[ 0 ];
+
+				if (
+					! callee ||
+					! arg ||
+					callee.type !== 'Identifier' ||
+					callee.name !== 'require'
+				) {
+					return;
+				}
+
+				// Look for requires for `core-js`.
+				if (
+					arg.type === 'StringLiteral' &&
+					arg.value.startsWith( 'core-js/' )
+				) {
+					if ( this.hasAddedPolyfills ) {
+						// Remove duplicate import.
+						path.remove();
+					} else {
+						// Replace with `@wordpress/polyfill`.
+						arg.value = '@wordpress/polyfill';
+						this.hasAddedPolyfills = true;
+					}
+				}
+			},
+		},
+	};
+}
+
+module.exports = replacePolyfills;

--- a/packages/babel-preset-default/replace-polyfills.js
+++ b/packages/babel-preset-default/replace-polyfills.js
@@ -6,6 +6,17 @@ function replacePolyfills() {
 			this.hasAddedPolyfills = false;
 		},
 		visitor: {
+			Program: {
+				exit( path ) {
+					if ( this.hasAddedPolyfills ) {
+						// Add magic comment to top of file.
+						path.addComment(
+							'leading',
+							' wordpress: needs wp-polyfill '
+						);
+					}
+				},
+			},
 			// Handle `import` syntax.
 			ImportDeclaration( path ) {
 				const source = path?.node?.source;
@@ -13,14 +24,9 @@ function replacePolyfills() {
 
 				// Look for imports from `core-js`.
 				if ( name.startsWith( 'core-js/' ) ) {
-					if ( this.hasAddedPolyfills ) {
-						// Remove duplicate import.
-						path.remove();
-					} else {
-						// Replace with `@wordpress/polyfill`.
-						source.value = '@wordpress/polyfill';
-						this.hasAddedPolyfills = true;
-					}
+					// Remove import.
+					path.remove();
+					this.hasAddedPolyfills = true;
 				}
 			},
 
@@ -43,14 +49,9 @@ function replacePolyfills() {
 					arg.type === 'StringLiteral' &&
 					arg.value.startsWith( 'core-js/' )
 				) {
-					if ( this.hasAddedPolyfills ) {
-						// Remove duplicate import.
-						path.remove();
-					} else {
-						// Replace with `@wordpress/polyfill`.
-						arg.value = '@wordpress/polyfill';
-						this.hasAddedPolyfills = true;
-					}
+					// Remove import.
+					path.remove();
+					this.hasAddedPolyfills = true;
 				}
 			},
 		},

--- a/packages/babel-preset-default/test/fixtures/polyfill.js
+++ b/packages/babel-preset-default/test/fixtures/polyfill.js
@@ -1,0 +1,6 @@
+// Note: this fixture may need to be updated when the browserslist or the
+// core-js dependencies are updated.
+// It should always test a feature that is supported, but requires
+// a polyfill to work across all supported browsers.
+const foo = new URLSearchParams();
+window.fooSize = foo.size;

--- a/packages/babel-preset-default/test/index.js
+++ b/packages/babel-preset-default/test/index.js
@@ -24,4 +24,22 @@ describe( 'Babel preset default', () => {
 
 		expect( output.code ).toMatchSnapshot();
 	} );
+
+	test( 'transpilation includes magic comment when using the addPolyfillComments option', () => {
+		const filename = path.join( __dirname, '/fixtures/polyfill.js' );
+		const input = readFileSync( filename );
+
+		const output = transform( input, {
+			filename,
+			configFile: false,
+			envName: 'production',
+			presets: [ babelPresetDefault ],
+			caller: {
+				name: 'WP_BUILD_MAIN',
+				addPolyfillComments: true,
+			},
+		} );
+
+		expect( output.code ).toContain( '/* wp:polyfill */' );
+	} );
 } );

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -287,11 +287,7 @@ class DependencyExtractionWebpackPlugin {
 			// Prepare to look for magic comments, in order to decide whether
 			// `wp-polyfill` is needed.
 			const processContentsForMagicComments = ( content ) => {
-				if (
-					content
-						.toString()
-						.includes( '/* wordpress: needs wp-polyfill */' )
-				) {
+				if ( content.toString().includes( '/* wp:polyfill */' ) ) {
 					chunkStaticDeps.add( 'wp-polyfill' );
 				}
 			};

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -97,16 +97,6 @@ class DependencyExtractionWebpackPlugin {
 		}
 
 		if ( externalRequest ) {
-			// Special case for modules.
-			// Since `@wordpress/polyfill` is a script and not a module, we need
-			// to exclude it from the list of externalised deps.
-			if (
-				this.useModules &&
-				externalRequest.includes( '@wordpress/polyfill' )
-			) {
-				return callback( null, '' );
-			}
-
 			this.externalizedDeps.add( request );
 
 			return callback( null, externalRequest );

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -287,7 +287,7 @@ class DependencyExtractionWebpackPlugin {
 			// Prepare to look for magic comments, in order to decide whether
 			// `wp-polyfill` is needed.
 			const processContentsForMagicComments = ( content ) => {
-				if ( content.toString().includes( '/* wp:polyfill */' ) ) {
+				if ( content.includes( '/* wp:polyfill */' ) ) {
 					chunkStaticDeps.add( 'wp-polyfill' );
 				}
 			};

--- a/packages/dependency-extraction-webpack-plugin/lib/index.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/index.js
@@ -97,6 +97,16 @@ class DependencyExtractionWebpackPlugin {
 		}
 
 		if ( externalRequest ) {
+			// Special case for modules.
+			// Since `@wordpress/polyfill` is a script and not a module, we need
+			// to exclude it from the list of externalised deps.
+			if (
+				this.useModules &&
+				externalRequest.includes( '@wordpress/polyfill' )
+			) {
+				return callback( null, '' );
+			}
+
 			this.externalizedDeps.add( request );
 
 			return callback( null, externalRequest );

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -93,7 +93,6 @@ function defaultRequestToExternalModule( request ) {
 	switch ( request ) {
 		case '@wordpress/interactivity-router':
 		case '@wordpress/a11y':
-		case '@wordpress/polyfill':
 			return `import ${ request }`;
 	}
 

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -93,6 +93,7 @@ function defaultRequestToExternalModule( request ) {
 	switch ( request ) {
 		case '@wordpress/interactivity-router':
 		case '@wordpress/a11y':
+		case '@wordpress/polyfill':
 			return `import ${ request }`;
 	}
 

--- a/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
+++ b/packages/dependency-extraction-webpack-plugin/test/__snapshots__/build.js.snap
@@ -235,6 +235,13 @@ exports[`DependencyExtractionWebpackPlugin modules Webpack \`overrides\` should 
 ]
 `;
 
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('wp-polyfill'), 'version' => '9725ab782f6b09598d3d', 'type' => 'module');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin modules Webpack \`polyfill-magic-comment\` should produce expected output: External modules should match snapshot 1`] = `[]`;
+
 exports[`DependencyExtractionWebpackPlugin modules Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('@wordpress/blob'), 'version' => 'a1906cfc819b623c86f8', 'type' => 'module');
 "
@@ -618,6 +625,13 @@ exports[`DependencyExtractionWebpackPlugin scripts Webpack \`overrides\` should 
   },
 ]
 `;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment\` should produce expected output: Asset file 'main.asset.php' should match snapshot 1`] = `
+"<?php return array('dependencies' => array('wp-polyfill'), 'version' => '464c785b5c938d4fde3f');
+"
+`;
+
+exports[`DependencyExtractionWebpackPlugin scripts Webpack \`polyfill-magic-comment\` should produce expected output: External modules should match snapshot 1`] = `[]`;
 
 exports[`DependencyExtractionWebpackPlugin scripts Webpack \`runtime-chunk-single\` should produce expected output: Asset file 'a.asset.php' should match snapshot 1`] = `
 "<?php return array('dependencies' => array('wp-blob'), 'version' => 'd3cda564b538b44d38ef');

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/index.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/index.js
@@ -1,0 +1,3 @@
+/* wp:polyfill */
+
+// Nothing else, really.

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/webpack.config.js
@@ -1,0 +1,14 @@
+/**
+ * Internal dependencies
+ */
+const DependencyExtractionWebpackPlugin = require( '../../..' );
+
+module.exports = {
+	plugins: [
+		new DependencyExtractionWebpackPlugin( {
+			requestToExternalModule( request ) {
+				return request.startsWith( '@wordpress/' );
+			},
+		} ),
+	],
+};

--- a/packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/webpack.config.js
+++ b/packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/webpack.config.js
@@ -4,11 +4,5 @@
 const DependencyExtractionWebpackPlugin = require( '../../..' );
 
 module.exports = {
-	plugins: [
-		new DependencyExtractionWebpackPlugin( {
-			requestToExternalModule( request ) {
-				return request.startsWith( '@wordpress/' );
-			},
-		} ),
-	],
+	plugins: [ new DependencyExtractionWebpackPlugin() ],
 };

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -146,7 +146,7 @@ module.exports = {
 	},
 	plugins: [
 		...plugins,
-		new DependencyExtractionWebpackPlugin( { injectPolyfill: true } ),
+		new DependencyExtractionWebpackPlugin( { injectPolyfill: false } ),
 		new CopyWebpackPlugin( {
 			patterns: gutenbergPackages
 				.map( ( packageName ) => ( {

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -25,7 +25,7 @@ const baseConfig = {
 				parallel: true,
 				terserOptions: {
 					output: {
-						comments: /translators:/i,
+						comments: /(translators|wordpress):/i,
 					},
 					compress: {
 						passes: 2,

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -25,7 +25,7 @@ const baseConfig = {
 				parallel: true,
 				terserOptions: {
 					output: {
-						comments: /(translators|wp):/i,
+						comments: /(translators:|wp:polyfill)/i,
 					},
 					compress: {
 						passes: 2,

--- a/tools/webpack/shared.js
+++ b/tools/webpack/shared.js
@@ -25,7 +25,7 @@ const baseConfig = {
 				parallel: true,
 				terserOptions: {
 					output: {
-						comments: /(translators|wordpress):/i,
+						comments: /(translators|wp):/i,
 					},
 					compress: {
 						passes: 2,


### PR DESCRIPTION
## What?
Currently, all packages depend on `wp-polyfill`, even when it's not really needed.

This PR changes that, and automatically determines at build time whether a dependency on `wp-polyfill` is needed, taking usage and browser support into account.

This PR fixes #65216.

## Why?
Packages like `wp-hooks` and `wp-i18n` are often enqueued in the head, which means that their dependencies are placed there as well. `wp-polyfill` is rather large, and so we want to avoid loading it in the critical path whenever possible.

## How?
A new option was added to `packages/babel-preset-default`, that enables adding magic comments.

Enabling this option turns on the babel `useBuiltIns: 'usage'` option, which adds `core-js` imports to the output. These are then transformed by a small plugin into a `/* wp:polyfill */` magic comment instead.

The webpack build then looks for the magic comments, and enables the polyfill dependency if it finds them.

In order to make this PR minimally effective, a new polyfill exclusion was also added, to avoid pedantically polyfilling `Array.prototype.push` due to an obscure bug on some older browsers.

## Testing Instructions
Since this is a build-level change, the best approach is probably to build and smoke-test all of Gutenberg.

In particular, ensure that:
- Packages like `wp-i18n` and `wp-hooks` do not end up depending on `wp-polyfill`
- Packages like `wp-url` and `wp-block-library` *do* end up depending on `wp-polyfill`
- Modules like `interactivity` and `interactivity-router` do not break
- Well, nothing breaks, really! 😄

### Testing Instructions for Keyboard
N/A