### PR TITLE
Handle unmatched closers in createInterpolateElement

### DIFF
--- a/packages/element/src/create-interpolate-element.js
+++ b/packages/element/src/create-interpolate-element.js
@@ -216,6 +216,15 @@ function proceed( conversionMap ) {
 			return true;
 
 		case 'closer':
+			// If there was no opener, proceed without converting.
+			if ( 0 === stackDepth ) {
+				// eslint-disable-next-line no-console
+				console.warn(
+					`Unmatched closing tag '${ name }' cannot be converted.`
+				);
+				return false;
+			}
+
 			// If we're not nesting then this is easy - close the block.
 			if ( 1 === stackDepth ) {
 				closeOuterElement( startOffset );


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/60843
* If an unmatched closer is present in the `interpolatedString`, skip it and proceed instead of attempting to convert it to an element.
* Output console warning that an unmatched closer was found and can't be converted.

## Why?
If the `interpolatedString` contains an unmatched closing tag, the attempt to convert it to an element causes a critical error. This skips the unmatched closing tag so the rest of the `interpolatedString` can be converted without issue, and outputs a warning that the closing tag was skipped.

## How?
If the current tag is a closer but the stack of matches is currently empty (i.e. there is no matching opener to be matched), it proceeds without attempting to create the element.

## Testing Instructions
Add the following code inside a component somewhere.
`createInterpolateElement( 'Hello </code>World</code>', {
	code: <code />,
} );`
Confirm that there is NO critical error and a warning identifying the unclosed tag is output to the console.
