### PR TITLE
DataViews: improve UX of bundled views for Pages

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -205,7 +205,7 @@ export default function PostList( { postType } ) {
 
 	const getActiveViewFilters = ( views, match ) => {
 		const found = views.find( ( { slug } ) => slug === match );
-		return found?.filterDataBy ?? [];
+		return found?.filters ?? [];
 	};
 
 	const { isLoading: isLoadingFields, fields: _fields } = usePostFields(

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -179,6 +179,7 @@ function getItemId( item ) {
 
 export default function PostList( { postType } ) {
 	const [ view, setView ] = useView( postType );
+	const defaultViews = useDefaultViews( { postType } );
 	const history = useHistory();
 	const location = useLocation();
 	const {
@@ -202,7 +203,26 @@ export default function PostList( { postType } ) {
 		[ history ]
 	);
 
-	const { isLoading: isLoadingFields, fields } = usePostFields( view.type );
+	const getActiveViewFilters = ( views, match ) => {
+		const found = views.find( ( { slug } ) => slug === match );
+		return found?.filterDataBy ?? [];
+	};
+
+	const { isLoading: isLoadingFields, fields: _fields } = usePostFields(
+		view.type
+	);
+	const fields = useMemo( () => {
+		const activeViewFilters = getActiveViewFilters(
+			defaultViews,
+			activeView
+		).map( ( { field } ) => field );
+		return _fields.map( ( field ) => ( {
+			...field,
+			elements: activeViewFilters.includes( field.id )
+				? []
+				: field.elements,
+		} ) );
+	}, [ _fields, defaultViews, activeView ] );
 
 	const queryArgs = useMemo( () => {
 		const filters = {};
@@ -225,6 +245,32 @@ export default function PostList( { postType } ) {
 				filters.author_exclude = filter.value;
 			}
 		} );
+
+		// The bundled views want data filtered without displaying the filter.
+		const activeViewFilters = getActiveViewFilters(
+			defaultViews,
+			activeView
+		);
+		activeViewFilters.forEach( ( filter ) => {
+			if (
+				filter.field === 'status' &&
+				filter.operator === OPERATOR_IS_ANY
+			) {
+				filters.status = filter.value;
+			}
+			if (
+				filter.field === 'author' &&
+				filter.operator === OPERATOR_IS_ANY
+			) {
+				filters.author = filter.value;
+			} else if (
+				filter.field === 'author' &&
+				filter.operator === OPERATOR_IS_NONE
+			) {
+				filters.author_exclude = filter.value;
+			}
+		} );
+
 		// We want to provide a different default item for the status filter
 		// than the REST API provides.
 		if ( ! filters.status || filters.status === '' ) {
@@ -240,7 +286,7 @@ export default function PostList( { postType } ) {
 			search: view.search,
 			...filters,
 		};
-	}, [ view ] );
+	}, [ view, activeView, defaultViews ] );
 	const {
 		records,
 		isResolving: isLoadingData,

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -89,7 +89,7 @@ export function useDefaultViews( { postType } ) {
 				slug: 'published',
 				icon: published,
 				view: DEFAULT_POST_BASE,
-				filterDataBy: [
+				filters: [
 					{
 						field: 'status',
 						operator: OPERATOR_IS_ANY,
@@ -102,7 +102,7 @@ export function useDefaultViews( { postType } ) {
 				slug: 'future',
 				icon: scheduled,
 				view: DEFAULT_POST_BASE,
-				filterDataBy: [
+				filters: [
 					{
 						field: 'status',
 						operator: OPERATOR_IS_ANY,
@@ -115,7 +115,7 @@ export function useDefaultViews( { postType } ) {
 				slug: 'drafts',
 				icon: drafts,
 				view: DEFAULT_POST_BASE,
-				filterDataBy: [
+				filters: [
 					{
 						field: 'status',
 						operator: OPERATOR_IS_ANY,
@@ -128,7 +128,7 @@ export function useDefaultViews( { postType } ) {
 				slug: 'pending',
 				icon: pending,
 				view: DEFAULT_POST_BASE,
-				filterDataBy: [
+				filters: [
 					{
 						field: 'status',
 						operator: OPERATOR_IS_ANY,
@@ -141,7 +141,7 @@ export function useDefaultViews( { postType } ) {
 				slug: 'private',
 				icon: notAllowed,
 				view: DEFAULT_POST_BASE,
-				filterDataBy: [
+				filters: [
 					{
 						field: 'status',
 						operator: OPERATOR_IS_ANY,
@@ -158,7 +158,7 @@ export function useDefaultViews( { postType } ) {
 					type: LAYOUT_TABLE,
 					layout: defaultLayouts[ LAYOUT_TABLE ].layout,
 				},
-				filterDataBy: [
+				filters: [
 					{
 						field: 'status',
 						operator: OPERATOR_IS_ANY,

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -88,76 +88,66 @@ export function useDefaultViews( { postType } ) {
 				title: __( 'Published' ),
 				slug: 'published',
 				icon: published,
-				view: {
-					...DEFAULT_POST_BASE,
-					filters: [
-						{
-							field: 'status',
-							operator: OPERATOR_IS_ANY,
-							value: 'publish',
-						},
-					],
-				},
+				view: DEFAULT_POST_BASE,
+				filterDataBy: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'publish',
+					},
+				],
 			},
 			{
 				title: __( 'Scheduled' ),
 				slug: 'future',
 				icon: scheduled,
-				view: {
-					...DEFAULT_POST_BASE,
-					filters: [
-						{
-							field: 'status',
-							operator: OPERATOR_IS_ANY,
-							value: 'future',
-						},
-					],
-				},
+				view: DEFAULT_POST_BASE,
+				filterDataBy: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'future',
+					},
+				],
 			},
 			{
 				title: __( 'Drafts' ),
 				slug: 'drafts',
 				icon: drafts,
-				view: {
-					...DEFAULT_POST_BASE,
-					filters: [
-						{
-							field: 'status',
-							operator: OPERATOR_IS_ANY,
-							value: 'draft',
-						},
-					],
-				},
+				view: DEFAULT_POST_BASE,
+				filterDataBy: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'draft',
+					},
+				],
 			},
 			{
 				title: __( 'Pending' ),
 				slug: 'pending',
 				icon: pending,
-				view: {
-					...DEFAULT_POST_BASE,
-					filters: [
-						{
-							field: 'status',
-							operator: OPERATOR_IS_ANY,
-							value: 'pending',
-						},
-					],
-				},
+				view: DEFAULT_POST_BASE,
+				filterDataBy: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'pending',
+					},
+				],
 			},
 			{
 				title: __( 'Private' ),
 				slug: 'private',
 				icon: notAllowed,
-				view: {
-					...DEFAULT_POST_BASE,
-					filters: [
-						{
-							field: 'status',
-							operator: OPERATOR_IS_ANY,
-							value: 'private',
-						},
-					],
-				},
+				view: DEFAULT_POST_BASE,
+				filterDataBy: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'private',
+					},
+				],
 			},
 			{
 				title: __( 'Trash' ),
@@ -167,14 +157,14 @@ export function useDefaultViews( { postType } ) {
 					...DEFAULT_POST_BASE,
 					type: LAYOUT_TABLE,
 					layout: defaultLayouts[ LAYOUT_TABLE ].layout,
-					filters: [
-						{
-							field: 'status',
-							operator: OPERATOR_IS_ANY,
-							value: 'trash',
-						},
-					],
 				},
+				filterDataBy: [
+					{
+						field: 'status',
+						operator: OPERATOR_IS_ANY,
+						value: 'trash',
+					},
+				],
 			},
 		];
 	}, [ labels ] );


### PR DESCRIPTION
Alternative to https://github.com/WordPress/gutenberg/pull/62157 and https://github.com/WordPress/gutenberg/pull/65264
Partially addresses https://github.com/WordPress/gutenberg/issues/60468

## What

Makes bundled views declare how they filter the data without displaying that filter to users.

## Why

See https://github.com/WordPress/gutenberg/issues/60468

## How

Bundled views no longer provide filters for the view — those would be visible to users. Instead, they provide filters for the dataset via the `filterDataBy` property — the name is intentionally different from `filters` so there's no confusion.

## How to test

Go to the Pages view and select any of the bundled views (left sidebar). In any of them (but "All") you should see that:

- data is filtered by corresponding status
- the status filter is not present anywhere (filter toggle, table column header)
- reseting the view still maintains the status filter

https://github.com/user-attachments/assets/10eca0d4-94c5-452f-a351-ff93291ef9e3

## Props

Add props to @Souptik2001 for the original PR:

```
Co-authored-by: Souptik2001 <souptik@git.wordpress.org>
```