### PR TITLE
Block Bindings: Fix label in pattern overrides

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -45,7 +45,7 @@ const DEFAULT_ATTRIBUTE = '__default';
  *
  * @return {Object} The bindings with default replaced for pattern overrides.
  */
-function replacePatternOverrideDefaultBindings( blockName, bindings ) {
+export function replacePatternOverrideDefaultBindings( blockName, bindings ) {
 	// The `__default` binding currently only works for pattern overrides.
 	if (
 		bindings?.[ DEFAULT_ATTRIBUTE ]?.source === 'core/pattern-overrides'

--- a/packages/block-library/src/paragraph/index.js
+++ b/packages/block-library/src/paragraph/index.js
@@ -30,17 +30,20 @@ export const settings = {
 	__experimentalLabel( attributes, { context } ) {
 		const customName = attributes?.metadata?.name;
 
-		if ( context === 'list-view' && customName ) {
-			return customName;
-		}
-
 		if ( context === 'accessibility' ) {
-			if ( customName ) {
+			if (
+				customName &&
+				! attributes?.metadata?.bindings?.source === 'pattern/overrides'
+			) {
 				return customName;
 			}
 
 			const { content } = attributes;
 			return ! content || content.length === 0 ? __( 'Empty' ) : content;
+		}
+
+		if ( context === 'list-view' && customName ) {
+			return customName;
 		}
 	},
 	transforms,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR builds on top of https://github.com/WordPress/gutenberg/pull/65114 to fix the label in patterns.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
https://github.com/WordPress/gutenberg/pull/65114 does not work for patterns, and it's important for screen readers to announce accurate content when users are navigating and editing.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It adds pattern information to the current block context in the BlockSelectionButton by searching the parent blocks, then passes that context to the normal block bindings logic, allowing us to retrieve the override values.

It also modifies `__experimentalLabel` in the paragraph block so that the override value is used.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a new synced pattern
2. Add a heading and paragraph; enable overrides for them
3. Save and close the pattern
4. Insert the pattern into a new post and modify the heading and paragraph values
5. Using a screenreader, enter Navigation Mode and navigate between the pattern's blocks
6. See that the overrides are announced

<!-- ### Testing Instructions for Keyboard
 How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

<!-- ## Screenshots or screencast if applicable -->
