### PR TITLE
Block Spacing UI: Respect axial support when a single value is defined

### DIFF
--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -150,9 +150,12 @@ function splitStyleValue( value ) {
 function splitGapValue( value ) {
 	// Check for shorthand value (a string value).
 	if ( value && typeof value === 'string' ) {
-		// If the value is a string, treat it as a single side (top) for the spacing controls.
+		// Convert to value for individual sides for BoxControl.
 		return {
 			top: value,
+			right: value,
+			bottom: value,
+			left: value,
 		};
 	}
 
@@ -646,7 +649,9 @@ export default function DimensionsPanel( {
 							onChange={ setGapValues }
 							showSideInLabel={ false }
 							sides={ isAxialGap ? gapSides : [ 'top' ] } // Use 'top' as the shorthand property in non-axial configurations.
-							values={ gapValues }
+							values={
+								isAxialGap ? gapValues : { top: gapValues?.top }
+							}
 							allowReset={ false }
 						/>
 					) }


### PR DESCRIPTION
## What?

This PR fixes the issues discovered in [this comment](https://github.com/WordPress/gutenberg/pull/64971#pullrequestreview-2295600451):

> One thing to note if folks are testing with TT4 theme, is that it sets a single value for the Buttons block's blockgap: `"blockGap": "0.7rem"`. As a result the UI defaults to a single control at the Buttons block level in global styles:
> 
> ![image](https://github.com/user-attachments/assets/d527e615-6c91-4f8d-842c-57dd077f1676)
> 
> If we remove that value from the `theme.json` file, then the axial controls are available:

## Why?

Whether the UI, i.e. the `SpacingSizesControl`, supports the axial gap is evaluated using both the `sides` prop and the `values` ​​prop:

https://github.com/WordPress/gutenberg/blob/1664022139daa11353788a3ef59686fa7f58b262/packages/block-editor/src/components/spacing-sizes-control/index.js#L48

If a theme defines a single string as a block gap, the `splitGapValue()` function converts it to an object with only a `top` property:

https://github.com/WordPress/gutenberg/blob/1664022139daa11353788a3ef59686fa7f58b262/packages/block-editor/src/components/global-styles/dimensions-panel.js#L150-L157

As a result, a SpacingSizeControl component that receives these props will assume that the axial gap is not supported, even if the block itself supports it.

## How?

- Update the `splitGapValue()` function so that if the argument is a string, it converts it to an object with explicit `top`, `right`, `bottom`, and `left` properties.
- If the block doesn't support the axial gap, extract just the `top` property from this object and pass it as the `values` ​​prop.

## Testing Instructions

Define a theme.json for each scenario and check out the block spacing UI in the global styles. This PR fixes the second and fourth scenarios.

### Has Spacing Size Presets

#### 

<details><summary>1. The theme does not have block gap styles defined</summary>

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px"
		}
	}
}
```

As before, whether a block supports the axial gap is respected.

Columns:

![image](https://github.com/user-attachments/assets/1d04b176-239e-4f07-bfa7-05d273b700bc)

Group:

![image](https://github.com/user-attachments/assets/5a813cea-0cef-4c56-bf14-e7e7194ece6b)

</details> 

<details><summary>2. The theme defines the block gap for blocks</summary>

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px"
		}
	},
	"styles": {
		"blocks": {
			"core/columns": {
				"spacing": {
					"blockGap": "2em"
				}
			},
			"core/group": {
				"spacing": {
					"blockGap": "2em"
				}
			}
		}
	}
}
```

This is the scenario that this PR solves. Blocks that support the axial gap (such as the Columns block) will show axial controls instead of a single control if the string is defined in theme.json.

| Before | After |
|--------|--------|
| Cell | ![image](https://github.com/user-attachments/assets/84e59fd1-e86a-46ee-8736-36ffba3dcb0b) | 

</details> 

### No Spacing Size Presets

<details><summary>3. The theme does not have block gap styles defined</summary>

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px"
		},
		"spacing": {
			"defaultSpacingSizes": false,
			"spacingSizes": []
		}
	}
}
```

As before, whether a block supports the axial gap is respected.

Columns:

![image](https://github.com/user-attachments/assets/9b450b95-1dab-4278-a94a-0c79764b475c)

Group:

![image](https://github.com/user-attachments/assets/df236ac5-55f9-41c9-91e0-b02f2dda6cd9)

</details>  

<details><summary>4. The theme defines the block gap for blocks</summary>

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px"
		},
		"spacing": {
			"defaultSpacingSizes": false,
			"spacingSizes": []
		}
	},
	"styles": {
		"blocks": {
			"core/columns": {
				"spacing": {
					"blockGap": "2em"
				}
			},
			"core/group": {
				"spacing": {
					"blockGap": "2em"
				}
			}
		}
	}
}
```

![image](https://github.com/user-attachments/assets/6f170462-d20c-4936-80c4-ae0c5cbede6c)

</details> 


> [!NOTE]
> Note that this is true for the trunk branch as well, but this PR doesn't yet support axis-defined strings (e.g. `"blockGap": "1em 2em"`). This may be addressed in a follow-up.