### PR TITLE
Typography: Make title blocks apply typographic styles consistently

### DIFF
--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -80,8 +80,5 @@
 			}
 		}
 	},
-	"style": "wp-block-post-title",
-	"selectors": {
-		"typography": ".wp-block-post-title, .wp-block-post-title > a"
-	}
+	"style": "wp-block-post-title"
 }

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -3,31 +3,15 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
-	&[style*="font-weight"] :where(a) {
-		font-weight: inherit;
-	}
-	&[class*="-font-family"] :where(a),
-	&[style*="font-family"] :where(a) {
-		font-family: inherit;
-	}
-	&[class*="-font-size"] :where(a),
-	&[style*="font-size"] :where(a) {
-		font-size: inherit;
-	}
-	&[style*="line-height"] :where(a) {
-		line-height: inherit;
-	}
-	&[style*="font-style"] :where(a) {
-		font-style: inherit;
-	}
-	&[style*="letter-spacing"] :where(a) {
-		letter-spacing: inherit;
-	}
-	&[style*="text-decoration"] :where(a) {
-		text-decoration: inherit;
-	}
-
-	a {
+	:where(a) {
 		display: inline-block;
+		color: inherit;
+		font-family: inherit;
+		font-size: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		letter-spacing: inherit;
+		line-height: inherit;
+		text-decoration: inherit;
 	}
 }

--- a/packages/block-library/src/post-title/style.scss
+++ b/packages/block-library/src/post-title/style.scss
@@ -5,7 +5,6 @@
 
 	:where(a) {
 		display: inline-block;
-		color: inherit;
 		font-family: inherit;
 		font-size: inherit;
 		font-style: inherit;

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -75,8 +75,5 @@
 		}
 	},
 	"editorStyle": "wp-block-site-title-editor",
-	"style": "wp-block-site-title",
-	"selectors": {
-		"typography": ".wp-block-site-title > span, .wp-block-site-title > a"
-	}
+	"style": "wp-block-site-title"
 }

--- a/packages/block-library/src/site-title/style.scss
+++ b/packages/block-library/src/site-title/style.scss
@@ -2,31 +2,14 @@
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 
-	&[style*="font-weight"] :where(a) {
-		font-weight: inherit;
-	}
-	&[class*="-font-family"] :where(a),
-	&[style*="font-family"] :where(a) {
-		font-family: inherit;
-	}
-	&[class*="-font-size"] :where(a),
-	&[style*="font-size"] :where(a) {
-		font-size: inherit;
-	}
-	&[style*="line-height"] :where(a) {
-		line-height: inherit;
-	}
-	&[style*="font-style"] :where(a) {
-		font-style: inherit;
-	}
-	&[style*="letter-spacing"] :where(a) {
-		letter-spacing: inherit;
-	}
-	&[style*="text-decoration"] :where(a) {
-		text-decoration: inherit;
-	}
-
 	:where(a) {
 		color: inherit;
+		font-family: inherit;
+		font-size: inherit;
+		font-style: inherit;
+		font-weight: inherit;
+		letter-spacing: inherit;
+		line-height: inherit;
+		text-decoration: inherit;
 	}
 }


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/65169

Addresses issues introduced by https://github.com/WordPress/gutenberg/pull/64911

## What?

When title related blocks (Site Title and Post Title) are set to contain a link, typographic styles from the wrapping heading are enforced on the inner link.

## Why?

See discussion here: https://github.com/WordPress/gutenberg/issues/65169#issuecomment-2345321749

TL;DR

- These blocks are conceptually headings regardless of the presence of an inner link
- Inner link styles could still be applied on a block instance or through the `elements` within a block type definition in theme.json
- Currently, the blocks have a `heading > link` structure and so global element styles for links and headings conflict
- Recent changes so that global styles for the block type get applied over global link element styles introduced a couple of bugs e.g. styles being inconsistently applied between editor and frontend.

## How?

- Remove custom typography selectors introduced in https://github.com/WordPress/gutenberg/pull/64911 (fixes inconsistent styling issue)
- Consolidates "inheritance" styles in block library to enforce typographic style inheritance on links within the title blocks.

## Testing Instructions

1. Activate emptytheme or remove `fontSize` from TT4's Site Title styles in theme.json.
2. Create a post with multiple Site Title and Post Title blocks. Make sure that each block type has one that is set to contain a link and one without.
3. Save the post and navigate to Appearance > Editor > Styles > Typography
4. Apply some link element styles, save, then confirm these do not apply to the Site Title and Post Title blocks in the previous post.
5. Back in Global Styles, apply some global heading element typography styles. This time confirm this does apply to the Site Title and Post Title blocks. 
6. Confirm the styling is consistently applied in both the editor and frontend.
7. Back in the site editor, navigate to Styles > Blocks. Apply typographic styles for both block types, then save.
8. Confirm that the global block type styles override the global heading element styles.

<details>
<summary>Example block markup for testing</summary>

```html
<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>Site Title with inner link</p>
<!-- /wp:paragraph -->

<!-- wp:site-title /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>Site Title without inner link</p>
<!-- /wp:paragraph -->

<!-- wp:site-title {"isLink":false} /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:separator {"className":"is-style-wide"} -->
<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:columns -->
<div class="wp-block-columns"><!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>Post Title with inner link</p>
<!-- /wp:paragraph -->

<!-- wp:post-title {"isLink":true} /--></div>
<!-- /wp:column -->

<!-- wp:column -->
<div class="wp-block-column"><!-- wp:paragraph -->
<p>Post Title without inner link</p>
<!-- /wp:paragraph -->

<!-- wp:post-title /--></div>
<!-- /wp:column --></div>
<!-- /wp:columns -->

<!-- wp:separator {"className":"is-style-wide"} -->
<hr class="wp-block-separator has-alpha-channel-opacity is-style-wide"/>
<!-- /wp:separator -->

<!-- wp:heading -->
<h2 class="wp-block-heading">Heading</h2>
<!-- /wp:heading -->

<!-- wp:paragraph -->
<p>Paragraph with a <a href="http://www.wordpress.org">link</a></p>
<!-- /wp:paragraph -->
```

</details>

## Screenshots or screencast <!-- if applicable -->

| Frontend Before | Frontend After |
|---|---|
| <img width="1204" alt="Screenshot 2024-09-13 at 3 32 17 PM" src="https://github.com/user-attachments/assets/c1808636-3a89-4970-ad2d-b3aefb1d8def"> | <img width="1205" alt="Screenshot 2024-09-13 at 3 36 16 PM" src="https://github.com/user-attachments/assets/3c269d45-8cdf-4851-9d70-ab96f8621d18"> |

Demo adjusting global link, heading element and block type styles

https://github.com/user-attachments/assets/e37e9250-80f6-493c-b1fd-11c540631038



