### PR TITLE
Patterns: Change deprecated social icons for standard in e2e

### DIFF
--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-chromium.txt
@@ -2,10 +2,18 @@
 <p>Dummy text</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","metadata":{"categories":["call-to-action"],"patternName":"core/social-links-shared-background-color","name":"Social links with a shared background color"},"className":"has-icon-color"} -->
-<ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->
+<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"metadata":{"categories":["posts"],"patternName":"core/query-standard-posts","name":"Standard"}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title {"isLink":true} /-->
 
-<!-- wp:social-link {"url":"#","service":"chain"} /-->
+<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
-<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>
-<!-- /wp:social-links -->
+<!-- wp:post-excerpt /-->
+
+<!-- wp:separator {"opacity":"css"} -->
+<hr class="wp-block-separator has-css-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:post-date /-->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
+++ b/test/e2e/specs/editor/various/__snapshots__/Inserting-blocks-firefox-webkit-inserts-p-59603-ragging-and-dropping-from-the-global-inserter-1-webkit.txt
@@ -2,10 +2,18 @@
 <p>Dummy text</p>
 <!-- /wp:paragraph -->
 
-<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","metadata":{"categories":["call-to-action"],"patternName":"core/social-links-shared-background-color","name":"Social links with a shared background color"},"className":"has-icon-color"} -->
-<ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->
+<!-- wp:query {"queryId":1,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"metadata":{"categories":["posts"],"patternName":"core/query-standard-posts","name":"Standard"}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:post-title {"isLink":true} /-->
 
-<!-- wp:social-link {"url":"#","service":"chain"} /-->
+<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
 
-<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>
-<!-- /wp:social-links -->
+<!-- wp:post-excerpt /-->
+
+<!-- wp:separator {"opacity":"css"} -->
+<hr class="wp-block-separator has-css-opacity"/>
+<!-- /wp:separator -->
+
+<!-- wp:post-date /-->
+<!-- /wp:post-template --></div>
+<!-- /wp:query -->

--- a/test/e2e/specs/editor/various/adding-patterns.spec.js
+++ b/test/e2e/specs/editor/various/adding-patterns.spec.js
@@ -14,15 +14,13 @@ test.describe( 'adding patterns', () => {
 		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
-			'Social links with a shared background color'
+			'Standard'
 		);
 
-		await page.click(
-			'role=option[name="Social links with a shared background color"i]'
-		);
+		await page.click( 'role=option[name="Standard"i]' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
-				name: 'core/social-links',
+				name: 'core/query',
 			},
 		] );
 	} );

--- a/test/e2e/specs/editor/various/adding-patterns.spec.js
+++ b/test/e2e/specs/editor/various/adding-patterns.spec.js
@@ -17,7 +17,7 @@ test.describe( 'adding patterns', () => {
 			'Standard'
 		);
 
-		await page.click( 'role=option[name="Standard"i]' );
+		await page.getByRole( 'option', { name: 'Standard' } ).click();
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/query',

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -197,7 +197,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		const PATTERN_NAME = 'Standard';
 
 		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Standard"i]',
+			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
 			PATTERN_NAME
 		);
 

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -194,10 +194,10 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
-		const PATTERN_NAME = 'Social links with a shared background color';
+		const PATTERN_NAME = 'Standard';
 
 		await page.fill(
-			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',
+			'role=region[name="Block Library"i] >> role=searchbox[name="Standard"i]',
 			PATTERN_NAME
 		);
 
@@ -350,7 +350,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
 		);
 
-		const PATTERN_NAME = 'Social links with a shared background color';
+		const PATTERN_NAME = 'Standard';
 
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search for blocks and patterns"i]',

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -595,13 +595,13 @@ test.describe( 'Post Editor Performance', () => {
 					source: 'core',
 				},
 				{
-					name: 'core/social-links-shared-background-color',
-					title: 'Social links with a shared background color',
+					name: 'core/standard',
+					title: 'Standard',
 					content:
-						'<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","className":"has-icon-color"} -->\n\t\t\t\t\t\t<ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"chain"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>\n\t\t\t\t\t\t<!-- /wp:social-links -->',
+						'<!-- wp:query {"queryId":8,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"metadata":{"categories":["posts"],"patternName":"core/query-standard-posts","name":"Standard"}} --><div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title {"isLink":true} /--><!-- wp:post-featured-image {"isLink":true,"align":"wide"} /--><!-- wp:post-excerpt /--><!-- wp:separator {"opacity":"css"} --><hr class="wp-block-separator has-css-opacity"/><!-- /wp:separator --><!-- wp:post-date /--><!-- /wp:post-template --></div><!-- /wp:query -->',
 					viewportWidth: 500,
 					categories: [ 'test' ],
-					blockTypes: [ 'core/social-links' ],
+					blockTypes: [ 'core/query' ],
 					source: 'core',
 				},
 				{

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -595,13 +595,13 @@ test.describe( 'Post Editor Performance', () => {
 					source: 'core',
 				},
 				{
-					name: 'core/standard',
-					title: 'Standard',
+					name: 'core/social-links-shared-background-color',
+					title: 'Social links with a shared background color',
 					content:
-						'<!-- wp:query {"queryId":8,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"metadata":{"categories":["posts"],"patternName":"core/query-standard-posts","name":"Standard"}} --><div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title {"isLink":true} /--><!-- wp:post-featured-image {"isLink":true,"align":"wide"} /--><!-- wp:post-excerpt /--><!-- wp:separator {"opacity":"css"} --><hr class="wp-block-separator has-css-opacity"/><!-- /wp:separator --><!-- wp:post-date /--><!-- /wp:post-template --></div><!-- /wp:query -->',
+						'<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","className":"has-icon-color"} -->\n\t\t\t\t\t\t<ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"chain"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>\n\t\t\t\t\t\t<!-- /wp:social-links -->',
 					viewportWidth: 500,
 					categories: [ 'test' ],
-					blockTypes: [ 'core/query' ],
+					blockTypes: [ 'core/social-links' ],
 					source: 'core',
 				},
 				{
@@ -623,13 +623,13 @@ test.describe( 'Post Editor Performance', () => {
 					source: 'core',
 				},
 				{
-					name: 'core/standard-2',
-					title: 'Standard 2',
+					name: 'core/social-links-shared-background-color-2',
+					title: 'Social links with a shared background color 2',
 					content:
-						'<!-- wp:query {"queryId":8,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"metadata":{"categories":["posts"],"patternName":"core/query-standard-posts","name":"Standard"}} --><div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title {"isLink":true} /--><!-- wp:post-featured-image {"isLink":true,"align":"wide"} /--><!-- wp:post-excerpt /--><!-- wp:separator {"opacity":"css"} --><hr class="wp-block-separator has-css-opacity"/><!-- /wp:separator --><!-- wp:post-date /--><!-- /wp:post-template --></div><!-- /wp:query -->',
+						'<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","className":"has-icon-color"} -->\n\t\t\t\t\t\t<ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"chain"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>\n\t\t\t\t\t\t<!-- /wp:social-links -->',
 					viewportWidth: 500,
 					categories: [ 'test' ],
-					blockTypes: [ 'core/query' ],
+					blockTypes: [ 'core/social-links' ],
 					source: 'core',
 				},
 			];

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -623,13 +623,13 @@ test.describe( 'Post Editor Performance', () => {
 					source: 'core',
 				},
 				{
-					name: 'core/social-links-shared-background-color-2',
-					title: 'Social links with a shared background color 2',
+					name: 'core/standard-2',
+					title: 'Standard 2',
 					content:
-						'<!-- wp:social-links {"customIconColor":"#ffffff","iconColorValue":"#ffffff","customIconBackgroundColor":"#3962e3","iconBackgroundColorValue":"#3962e3","className":"has-icon-color"} -->\n\t\t\t\t\t\t<ul class="wp-block-social-links has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"https://wordpress.org","service":"wordpress"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"chain"} /-->\n\t\t\t\t\t\t<!-- wp:social-link {"url":"#","service":"mail"} /--></ul>\n\t\t\t\t\t\t<!-- /wp:social-links -->',
+						'<!-- wp:query {"queryId":8,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"metadata":{"categories":["posts"],"patternName":"core/query-standard-posts","name":"Standard"}} --><div class="wp-block-query"><!-- wp:post-template --><!-- wp:post-title {"isLink":true} /--><!-- wp:post-featured-image {"isLink":true,"align":"wide"} /--><!-- wp:post-excerpt /--><!-- wp:separator {"opacity":"css"} --><hr class="wp-block-separator has-css-opacity"/><!-- /wp:separator --><!-- wp:post-date /--><!-- /wp:post-template --></div><!-- /wp:query -->',
 					viewportWidth: 500,
 					categories: [ 'test' ],
-					blockTypes: [ 'core/social-links' ],
+					blockTypes: [ 'core/query' ],
 					source: 'core',
 				},
 			];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Social links shared background color has been deprecated in Core: https://github.com/WordPress/wordpress-develop/commit/a78540b0881a195ec8488bb6bdf878114d75f8b8


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To fix CI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Using the standard pattern for testing.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

e2e should pass.
