### PR TITLE
DataViews: Use Dropdown for views config dialog

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -8,7 +8,7 @@ import type { ChangeEvent } from 'react';
  */
 import {
 	Button,
-	Popover,
+	Dropdown,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	__experimentalToggleGroupControlOptionIcon as ToggleGroupControlOptionIcon,
@@ -24,7 +24,7 @@ import {
 	BaseControl,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { memo, useContext, useState, useMemo } from '@wordpress/element';
+import { memo, useContext, useMemo } from '@wordpress/element';
 import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
 import warning from '@wordpress/warning';
 
@@ -549,34 +549,32 @@ function _DataViewsViewConfig( {
 	setDensity: React.Dispatch< React.SetStateAction< number > >;
 	defaultLayouts?: SupportedLayouts;
 } ) {
-	const [ isShowingViewPopover, setIsShowingViewPopover ] =
-		useState< boolean >( false );
-
 	return (
 		<>
 			<ViewTypeMenu defaultLayouts={ defaultLayouts } />
-			<div>
-				<Button
-					size="compact"
-					icon={ cog }
-					label={ _x( 'View options', 'View is used as a noun' ) }
-					onClick={ () => setIsShowingViewPopover( true ) }
-				/>
-				{ isShowingViewPopover && (
-					<Popover
-						placement="bottom-end"
-						onClose={ () => {
-							setIsShowingViewPopover( false );
-						} }
-						focusOnMount
-					>
-						<DataviewsViewConfigContent
-							density={ density }
-							setDensity={ setDensity }
+			<Dropdown
+				popoverProps={ { placement: 'bottom-end', offset: 9 } }
+				contentClassName="dataviews-view-config"
+				renderToggle={ ( { onToggle } ) => {
+					return (
+						<Button
+							size="compact"
+							icon={ cog }
+							label={ _x(
+								'View options',
+								'View is used as a noun'
+							) }
+							onClick={ onToggle }
 						/>
-					</Popover>
+					);
+				} }
+				renderContent={ () => (
+					<DataviewsViewConfigContent
+						density={ density }
+						setDensity={ setDensity }
+					/>
 				) }
-			</div>
+			/>
 		</>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -1,11 +1,14 @@
 .dataviews-view-config {
-	width: 320px;
-	/* stylelint-disable-next-line property-no-unknown -- the linter needs to be updated to accepted the container-type property */
-	container-type: inline-size;
-	padding: $grid-unit-20;
-	font-size: $default-font-size;
-	line-height: $default-line-height;
+	.components-popover__content {
+		width: 320px;
+		/* stylelint-disable-next-line property-no-unknown -- the linter needs to be updated to accepted the container-type property */
+		container-type: inline-size;
+		padding: $grid-unit-20;
+		font-size: $default-font-size;
+		line-height: $default-line-height;
+	}
 }
+
 .dataviews-view-config__sort-direction .components-toggle-group-control-option-base {
 	text-transform: uppercase;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I observed in DataViews view config dialog that when you clicked the `trigger`, the dialog would always reopen. After checking, Riad also [mentions](https://github.com/WordPress/gutenberg/pull/64175#discussion_r1750073081) some inconsistencies and the not necessary usage of the lower level Popover component:
1. Spacing from anchor. I currently used `offset` for this for now.
2. The `modal` behavior is something implemented only in DropdownMenuV2 right now. This should be handled properly I think when the `DropdownV2` is implemented. --cc @ciampo @mirka 


<!-- In a few words, what is the PR actually doing? -->

Before            |  After
:-------------------------:|:-------------------------:
 <img width="525" alt="Screenshot 2024-09-13 at 12 41 54 PM" src="https://github.com/user-attachments/assets/e1975ab9-57c3-43c5-a4e5-40d349d55050"> | <img width="525" alt="Screenshot 2024-09-13 at 12 42 07 PM" src="https://github.com/user-attachments/assets/e4d5f836-d56c-4dae-9501-3c25855d575a">

It's not an impactful change and while it doesn't fix the `modal` behavior, I think it can be merged..


## Testing Instructions
In DataViews the view config dialog should be exactly as before, except:
1. the position from the anchor matches the layout dropdown menu
3. clicking the trigger, toggles the dialog
