### PR TITLE
Swap position of the Pre-publish checks buttons.

### DIFF
--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { Component, createRef } from '@wordpress/element';
+import { Component } from '@wordpress/element';
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -17,7 +17,6 @@ const noop = () => {};
 export class PostPublishButton extends Component {
 	constructor( props ) {
 		super( props );
-		this.buttonNode = createRef();
 
 		this.createOnClick = this.createOnClick.bind( this );
 		this.closeEntitiesSavedStates =
@@ -26,21 +25,6 @@ export class PostPublishButton extends Component {
 		this.state = {
 			entitiesSavedStatesCallback: false,
 		};
-	}
-
-	componentDidMount() {
-		if ( this.props.focusOnMount ) {
-			// This timeout is necessary to make sure the `useEffect` hook of
-			// `useFocusReturn` gets the correct element (the button that opens the
-			// PostPublishPanel) otherwise it will get this button.
-			this.timeoutID = setTimeout( () => {
-				this.buttonNode.current.focus();
-			}, 0 );
-		}
-	}
-
-	componentWillUnmount() {
-		clearTimeout( this.timeoutID );
 	}
 
 	createOnClick( callback ) {
@@ -182,7 +166,6 @@ export class PostPublishButton extends Component {
 		return (
 			<>
 				<Button
-					ref={ this.buttonNode }
 					{ ...componentProps }
 					className={ `${ componentProps.className } editor-post-publish-button__button` }
 					size="compact"

--- a/packages/editor/src/components/post-publish-panel/index.js
+++ b/packages/editor/src/components/post-publish-panel/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, createRef } from '@wordpress/element';
 import {
 	Button,
 	Spinner,
@@ -27,6 +27,20 @@ export class PostPublishPanel extends Component {
 	constructor() {
 		super( ...arguments );
 		this.onSubmit = this.onSubmit.bind( this );
+		this.cancelButtonNode = createRef();
+	}
+
+	componentDidMount() {
+		// This timeout is necessary to make sure the `useEffect` hook of
+		// `useFocusReturn` gets the correct element (the button that opens the
+		// PostPublishPanel) otherwise it will get this button.
+		this.timeoutID = setTimeout( () => {
+			this.cancelButtonNode.current.focus();
+		}, 0 );
+	}
+
+	componentWillUnmount() {
+		clearTimeout( this.timeoutID );
 	}
 
 	componentDidUpdate( prevProps ) {
@@ -85,15 +99,9 @@ export class PostPublishPanel extends Component {
 						/>
 					) : (
 						<>
-							<div className="editor-post-publish-panel__header-publish-button">
-								<PostPublishButton
-									focusOnMount
-									onSubmit={ this.onSubmit }
-									forceIsDirty={ forceIsDirty }
-								/>
-							</div>
 							<div className="editor-post-publish-panel__header-cancel-button">
 								<Button
+									ref={ this.cancelButtonNode }
 									accessibleWhenDisabled
 									disabled={ isSavingNonPostEntityChanges }
 									onClick={ onClose }
@@ -102,6 +110,12 @@ export class PostPublishPanel extends Component {
 								>
 									{ __( 'Cancel' ) }
 								</Button>
+							</div>
+							<div className="editor-post-publish-panel__header-publish-button">
+								<PostPublishButton
+									onSubmit={ this.onSubmit }
+									forceIsDirty={ forceIsDirty }
+								/>
 							</div>
 						</>
 					) }

--- a/packages/editor/src/components/post-publish-panel/style.scss
+++ b/packages/editor/src/components/post-publish-panel/style.scss
@@ -68,12 +68,12 @@
 }
 
 .editor-post-publish-panel__header-publish-button {
-	padding-right: $grid-unit-05;
+	padding-left: $grid-unit-05;
 	justify-content: center;
 }
 
 .editor-post-publish-panel__header-cancel-button {
-	padding-left: $grid-unit-05;
+	padding-right: $grid-unit-05;
 }
 
 .editor-post-publish-panel__header-published {

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -433,6 +433,16 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
       class="editor-post-publish-panel__header"
     >
       <div
+        class="editor-post-publish-panel__header-cancel-button"
+      >
+        <button
+          class="components-button is-secondary is-compact"
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+      <div
         class="editor-post-publish-panel__header-publish-button"
       >
         <button
@@ -441,16 +451,6 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
           type="button"
         >
           Submit for Review
-        </button>
-      </div>
-      <div
-        class="editor-post-publish-panel__header-cancel-button"
-      >
-        <button
-          class="components-button is-secondary is-compact"
-          type="button"
-        >
-          Cancel
         </button>
       </div>
     </div>
@@ -586,6 +586,16 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
       class="editor-post-publish-panel__header"
     >
       <div
+        class="editor-post-publish-panel__header-cancel-button"
+      >
+        <button
+          class="components-button is-secondary is-compact"
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+      <div
         class="editor-post-publish-panel__header-publish-button"
       >
         <button
@@ -594,16 +604,6 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
           type="button"
         >
           Submit for Review
-        </button>
-      </div>
-      <div
-        class="editor-post-publish-panel__header-cancel-button"
-      >
-        <button
-          class="components-button is-secondary is-compact"
-          type="button"
-        >
-          Cancel
         </button>
       </div>
     </div>
@@ -783,6 +783,16 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
       class="editor-post-publish-panel__header"
     >
       <div
+        class="editor-post-publish-panel__header-cancel-button"
+      >
+        <button
+          class="components-button is-secondary is-compact"
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+      <div
         class="editor-post-publish-panel__header-publish-button"
       >
         <button
@@ -791,16 +801,6 @@ exports[`PostPublishPanel should render the spinner if the post is being saved 1
           type="button"
         >
           Submit for Review
-        </button>
-      </div>
-      <div
-        class="editor-post-publish-panel__header-cancel-button"
-      >
-        <button
-          class="components-button is-secondary is-compact"
-          type="button"
-        >
-          Cancel
         </button>
       </div>
     </div>

--- a/test/e2e/specs/editor/various/publish-panel.spec.js
+++ b/test/e2e/specs/editor/various/publish-panel.spec.js
@@ -58,7 +58,7 @@ test.describe( 'Post publish panel', () => {
 		).toBeFocused();
 	} );
 
-	test( 'should move focus to the publish button in the panel', async ( {
+	test( 'should move focus to the cancel button in the panel', async ( {
 		editor,
 		page,
 	} ) => {
@@ -74,7 +74,7 @@ test.describe( 'Post publish panel', () => {
 			page
 				.getByRole( 'region', { name: 'Editor publish' } )
 				.locator( ':focus' )
-		).toHaveText( 'Publish' );
+		).toHaveText( 'Cancel' );
 	} );
 
 	test( 'should focus on the post list after publishing', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/65315

## What?
<!-- In a few words, what is the PR actually doing? -->
Avoids users to unnecessarily move their mouse when publishng. This way, a two quick mouse clicks are way easier to perform in order to publish without having to move the mouse.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Forcing users to move their pointing device (mouse, trackpad, etc.) to be able to click the second Publish button in the Pre-publish checks panel isn't a great user experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Swaps the buttons position.
- Moves logic for initial focus to the Cancel button, which is now the first focusable control within the panel.
- Adjusts the CSS and updates the snapshot.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps described in the issue https://github.com/WordPress/gutenberg/issues/65315
- Observe you don't need to move your mouse to click the second Publish button any longer.
- Repeat the flow using the keyboard.
- Observe that when the Pre-publish checks panel opens, focus is set to the Cancel button.
- Press Enter to Cancel. The panel closes.
- Observe focus is correctly moved back to the Publish button in the editor top bar.
- Optionally test with the WordPress admin set to a language other than English, to test with longer or shorter translations.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![Screenshot 2024-09-13 at 12 42 31](https://github.com/user-attachments/assets/d44b7c11-abea-40a8-b888-dcd73315193f)

After:

![Screenshot 2024-09-13 at 12 43 09](https://github.com/user-attachments/assets/b7ee8e2c-d3ed-4f3f-8146-9e62028170ab)

Swapped buttons when scheduling and submitting for review:

![Screenshot 2024-09-16 at 11 49 44](https://github.com/user-attachments/assets/95056f66-23d4-4b0b-99bf-2f219d6238f1)

