### PR TITLE
Make the Settings panel toggle button show its keyboard shortcut in its tooltip

### DIFF
--- a/packages/editor/src/components/plugin-sidebar/index.js
+++ b/packages/editor/src/components/plugin-sidebar/index.js
@@ -3,7 +3,6 @@
  */
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { ComplementaryArea } from '@wordpress/interface';
 
 /**
@@ -77,12 +76,9 @@ import { store as editorStore } from '../../store';
  * ```
  */
 export default function PluginSidebar( { className, ...props } ) {
-	const { postTitle, shortcut } = useSelect( ( select ) => {
+	const { postTitle } = useSelect( ( select ) => {
 		return {
 			postTitle: select( editorStore ).getEditedPostAttribute( 'title' ),
-			shortcut: select(
-				keyboardShortcutsStore
-			).getShortcutRepresentation( 'core/editor/toggle-sidebar' ),
 		};
 	}, [] );
 	return (
@@ -91,7 +87,6 @@ export default function PluginSidebar( { className, ...props } ) {
 			className="editor-sidebar"
 			smallScreenTitle={ postTitle || __( '(no title)' ) }
 			scope="core"
-			toggleShortcut={ shortcut }
 			{ ...props }
 		/>
 	);

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -17,6 +17,7 @@ function ComplementaryAreaToggle( {
 	icon,
 	selectedIcon,
 	name,
+	shortcut,
 	...props
 } ) {
 	const ComponentToUse = as;
@@ -26,8 +27,15 @@ function ComplementaryAreaToggle( {
 			identifier,
 		[ identifier, scope ]
 	);
+
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
+
+	const isPostEditorComplementaryArea = [
+		'edit-post/document',
+		'edit-post/block',
+	].includes( identifier );
+
 	return (
 		<ComponentToUse
 			icon={ selectedIcon && isSelected ? selectedIcon : icon }
@@ -39,6 +47,7 @@ function ComplementaryAreaToggle( {
 					enableComplementaryArea( scope, identifier );
 				}
 			} }
+			shortcut={ isPostEditorComplementaryArea ? shortcut : undefined }
 			{ ...props }
 		/>
 	);

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -31,11 +31,6 @@ function ComplementaryAreaToggle( {
 	const { enableComplementaryArea, disableComplementaryArea } =
 		useDispatch( interfaceStore );
 
-	const isPostEditorComplementaryArea = [
-		'edit-post/document',
-		'edit-post/block',
-	].includes( identifier );
-
 	return (
 		<ComponentToUse
 			icon={ selectedIcon && isSelected ? selectedIcon : icon }
@@ -47,7 +42,7 @@ function ComplementaryAreaToggle( {
 					enableComplementaryArea( scope, identifier );
 				}
 			} }
-			shortcut={ isPostEditorComplementaryArea ? shortcut : undefined }
+			shortcut={ shortcut }
 			{ ...props }
 		/>
 	);

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -275,6 +275,7 @@ function ComplementaryArea( {
 							showTooltip={ ! showIconLabels }
 							variant={ showIconLabels ? 'tertiary' : undefined }
 							size="compact"
+							shortcut={ toggleShortcut }
 						/>
 					) }
 				</PinnedItems>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/65310

## What?
<!-- In a few words, what is the PR actually doing? -->
The Settings button doesn't show its keyboard shortcut in its tooltip.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All buttons that have an associated keyboard shortcut are expected to visually expose the shortcut in their tooltip.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Passes down the shortcut.
- Checks whether the toggle button belongs to the gutenberg core sidebars that use the shortcut.

Note:
I would have liked there was a better way to check whether a ComplementaryArea comes from core or plugins. I see that the complementary area [scope](https://github.com/WordPress/gutenberg/blob/dfc28b08c077818cda4b7ac29cc7efebfa865aba/packages/interface/src/components/complementary-area/README.md#scope) prop is required and it appears to be used for this purpose. However, in my testing, I found that it isn't reliable.
- Dumping `identifier` and `scope` for the Jetpack sidebar, the returned values are `jetpack-sidebar/jetpack`, which is correct, and `core` which appears to be incorrect. I guess it would be good to inform the Jetpack plugin authors to double check. 
- Other plugins return a value that appears to be more correct e.g. `seo-sidebar`.
- However, it seems there's nothing that prevents plugins to use `core` as the scope value? I guess this value should be reserved. Plugins should be enforced to use a prefixed, unique, scope.
- I had to resort to check the identifier, which means hardcoding the values `edit-post/document` and `edit-post/block`. I see similar hardcoded values are already in place [when the keyboard shortcut is registered](https://github.com/WordPress/gutenberg/blob/dfc28b08c077818cda4b7ac29cc7efebfa865aba/packages/editor/src/components/global-keyboard-shortcuts/index.js#L102-L109), so I guess it's not terribly bad. However, there should be a better way to check whether a complementary area sidebar comes from core or not. even better, to check if it is associated with a keyboard shortcut. If anyone has better idea to check this, please let me know.

Also note:
The Widgets page Settings panel isn't associated with a keyboard shortcut. A decision shoul dbe made on whether to add the shortcut in the first place but that's out of the scope of this PR.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Install one or more plugins that add their own settings panel e.g. Jetpack or Yoast SEO and activate them.
- Go to the post editor.
- Hover or focus the Settings button in the top bar.
- Observe the button tooltip does show the keyboard shortcut.
- Hover or focus the Jetpack or Yoast SEO buttons in the top bar.
- Observe the btutons tooltip does _not_ show any keyboard shortcut.
- Go to the Site editor.
- Hover or focus the Settings button in the top bar.
- Observe the button tooltip does show the keyboard shortcut.
- Hover or focus the Styles button in the top bar.
- Observe the button tooltip does _not_ show any keyboard shortcut.
- Test with the 'Show button text labels' preference enabled.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/user-attachments/assets/84e3e8d7-3f25-48ca-a1c9-d6a8521fd302)

After:

![after](https://github.com/user-attachments/assets/8b413d59-edf7-4ed0-ae60-a9be4adadc74)


