### PR TITLE
Post Editor: Support keyboard resizing of meta boxes pane

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -290,7 +290,13 @@ function MetaBoxesMain( { isLegacy } ) {
 				max,
 				Math.max( min, delta + fromHeight )
 			);
-			resizableBoxRef.current.updateSize( { height: nextHeight } );
+			resizableBoxRef.current.updateSize( {
+				height: nextHeight,
+				// Oddly, if left unspecified a subsequent drag gesture applies a fixed
+				// width and the pane fails to shrink/grow with parent width changes from
+				// sidebars opening/closing or window resizes.
+				width: 'auto',
+			} );
 			setPreference(
 				'core/edit-post',
 				'metaBoxesMainOpenHeight',

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -251,12 +251,10 @@ function MetaBoxesMain( { isLegacy } ) {
 		usedMax = isAutoHeight && isUntouched ? max / 2 : max;
 	}
 
-	const getAriaValueNow = ( current, total ) =>
-		Math.round( ( ( current - min ) / ( total - min ) ) * 100 );
+	const getAriaValueNow = ( height ) =>
+		Math.round( ( ( height - min ) / ( max - min ) ) * 100 );
 	const usedAriaValueNow =
-		max === undefined || isAutoHeight
-			? 50
-			: getAriaValueNow( openHeight, max );
+		max === undefined || isAutoHeight ? 50 : getAriaValueNow( openHeight );
 
 	if ( isShort ) {
 		return (
@@ -340,11 +338,10 @@ function MetaBoxesMain( { isLegacy } ) {
 					setIsUntouched( false );
 				}
 			} }
-			onResize={ ( event, direction, elementRef, delta ) => {
-				const fromHeight = resizableBoxRef.current.state.height;
-				const nextHeight = fromHeight + delta.height;
+			onResize={ () => {
+				const { height } = resizableBoxRef.current.state;
 				const separator = separatorRef.current;
-				separator.ariaValueNow = getAriaValueNow( nextHeight, max );
+				separator.ariaValueNow = getAriaValueNow( height );
 			} }
 			onResizeStop={ () => {
 				const nextHeight = resizableBoxRef.current.state.height;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -190,7 +190,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	// Keeps the resizable area’s size constraints updated taking into account
 	// editor notices. The constraints are also used to derive the value for the
 	// aria-valuenow attribute on the seperator.
-	const effectSizeContraints = useRefEffect( ( node ) => {
+	const effectSizeConstraints = useRefEffect( ( node ) => {
 		const container = node.closest(
 			'.interface-interface-skeleton__content'
 		);
@@ -380,7 +380,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				),
 			} }
 		>
-			<meta ref={ effectSizeContraints } />
+			<meta ref={ effectSizeConstraints } />
 			{ contents }
 		</ResizableBox>
 	);

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -36,46 +36,26 @@
 	height: 23px;
 	box-shadow: 0 $border-width $gray-300;
 
-	&:hover > button::before,
-	&:hover > button::after {
-		background-color: var(--wp-admin-theme-color);
-	}
-	&:hover > button::before {
-		transform: translateX(-$grid-unit-20);
-	}
-	&:hover > button::after {
-		transform: translateX($grid-unit-20);
-	}
-
 	& > button {
 		appearance: none;
 		cursor: inherit;
 		margin: auto;
 		padding: 0;
 		border: none;
-		background: none;
 		outline: none;
-		display: grid;
-		grid-template: auto / auto;
+		background-color: $gray-300;
+		// The visible width is the first unit, the rest is clipped when not hovered/focused.
+		width: $grid-unit-80 + $grid-unit-10 * 2;
+		height: $grid-unit-05;
+		clip-path: inset(0 $grid-unit-10 round $grid-unit-05);
+		transition: clip-path 0.3s ease-out;
+		@include reduce-motion("transition");
+	}
 
-		&:is(:focus, :active)::before,
-		&:is(:focus, :active)::after {
-			background-color: var(--wp-admin-theme-color);
-		}
-
-		&::before,
-		&::after {
-			content: "";
-			grid-area: 1 / 1;
-			display: block;
-			// Other resize handles are 68px when not hovered and this grid unit is close.
-			width: $grid-unit-80;
-			height: $grid-unit-05;
-			background-color: $gray-300;
-			border-radius: $grid-unit-05;
-			transition: transform 0.3s ease-out;
-			@include reduce-motion("transition");
-		}
+	&:hover > button,
+	> button:focus {
+		background-color: var(--wp-admin-theme-color);
+		clip-path: inset(0 0 round $grid-unit-05);
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -44,18 +44,17 @@
 		border: none;
 		outline: none;
 		background-color: $gray-300;
-		// The visible width is the first unit, the rest is clipped when not hovered/focused.
-		width: $grid-unit-80 + $grid-unit-10 * 2;
+		width: $grid-unit-80;
 		height: $grid-unit-05;
-		clip-path: inset(0 $grid-unit-10 round $grid-unit-05);
-		transition: clip-path 0.3s ease-out;
+		border-radius: $radius-small;
+		transition: width 0.3s ease-out;
 		@include reduce-motion("transition");
 	}
 
 	&:hover > button,
 	> button:focus {
 		background-color: var(--wp-admin-theme-color);
-		clip-path: inset(0 0 round $grid-unit-05);
+		width: $grid-unit-80 + $grid-unit-20;
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -6,10 +6,6 @@
 	&:not(details) {
 		padding-top: 23px;
 		max-height: 100%;
-
-		&:not(.has-user-size) {
-			max-height: 50% !important;
-		}
 	}
 
 	// The component renders as a details element in short viewports.
@@ -31,24 +27,54 @@
 			z-index: 1;
 		}
 	}
+}
 
-	& .components-resizable-box__handle-top {
-		top: 0;
-		box-shadow: 0 $border-width $gray-300;
+.edit-post-meta-boxes-main__resize-handle {
+	display: flex;
+	// The position is absolute by default inline style of ResizableBox.
+	inset: 0 0 auto 0;
+	height: 23px;
+	box-shadow: 0 $border-width $gray-300;
+
+	&:hover > button::before,
+	&:hover > button::after {
+		background-color: var(--wp-admin-theme-color);
 	}
-	& .components-resizable-box__side-handle::before {
-		border-radius: 0;
-		top: 0;
-		height: $border-width;
+	&:hover > button::before {
+		transform: translateX(-$grid-unit-20);
 	}
-	& .components-resizable-box__handle::after {
-		background-color: $gray-300;
-		box-shadow: none;
-		border-radius: 4px;
-		height: $grid-unit-05;
-		top: calc(50% - #{$grid-unit-05} / 2);
-		width: 100px;
-		right: calc(50% - 50px);
+	&:hover > button::after {
+		transform: translateX($grid-unit-20);
+	}
+
+	& > button {
+		appearance: none;
+		cursor: inherit;
+		margin: auto;
+		padding: 0;
+		border: none;
+		background: none;
+		outline: none;
+		display: grid;
+		grid-template: auto / auto;
+
+		&:is(:focus, :active)::before,
+		&:is(:focus, :active)::after {
+			background-color: var(--wp-admin-theme-color);
+		}
+
+		&::before,
+		&::after {
+			content: "";
+			grid-area: 1 / 1;
+			display: block;
+			// Other resize handles are 68px when not hovered and this grid unit is close.
+			width: $grid-unit-80;
+			height: $grid-unit-05;
+			background-color: $gray-300;
+			border-radius: $grid-unit-05;
+			transition: transform 0.3s ease-out;
+		}
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -74,6 +74,7 @@
 			background-color: $gray-300;
 			border-radius: $grid-unit-05;
 			transition: transform 0.3s ease-out;
+			@include reduce-motion("transition");
 		}
 	}
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -7,7 +7,6 @@ $resize-handle-height: $grid-unit-30;
 
 	&:not(details) {
 		padding-top: $resize-handle-height;
-		max-height: 100%;
 	}
 
 	// The component renders as a details element in short viewports.

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,10 +1,12 @@
+$resize-handle-height: $grid-unit-30;
+
 .edit-post-meta-boxes-main {
 	filter: drop-shadow(0 -1px rgba($color: #000, $alpha: 0.133)); // 0.133 = $gray-200 but with alpha.
 	background-color: $white;
 	clear: both; // This is seemingly only needed in case the canvas is not iframe’d.
 
 	&:not(details) {
-		padding-top: 23px;
+		padding-top: $resize-handle-height;
 		max-height: 100%;
 	}
 
@@ -33,7 +35,7 @@
 	display: flex;
 	// The position is absolute by default inline style of ResizableBox.
 	inset: 0 0 auto 0;
-	height: 23px;
+	height: $resize-handle-height;
 	box-shadow: 0 $border-width $gray-300;
 
 	& > button {


### PR DESCRIPTION
## What?
A follow up to #64351 adding keyboard support to resize the meta box pane.

## Why?
a11y

## How?
Implements a custom resize handle with `role="separator"`, `aria-valuenow`, `aria-label` and `aria-describedby` attributes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/7e8dcc47-50cb-4be4-936c-20dac83230e4
