### PR TITLE
Try replacing getBlockInsertionPoint with getInsertionCue

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -48,11 +48,11 @@ export default function BlockListAppender( {
 	const isDragOver = useSelect(
 		( select ) => {
 			const {
-				getBlockInsertionPoint,
+				getInsertionCue,
 				isBlockInsertionPointVisible,
 				getBlockCount,
 			} = select( blockEditorStore );
-			const insertionPoint = getBlockInsertionPoint();
+			const insertionPoint = getInsertionCue();
 			// Ideally we should also check for `isDragging` but currently it
 			// requires a lot more setup. We can revisit this once we refactor
 			// the DnD utility hooks.

--- a/packages/block-editor/src/components/block-list/block-list-item.native.js
+++ b/packages/block-editor/src/components/block-list/block-list-item.native.js
@@ -64,13 +64,13 @@ function BlockListItemContent( {
 		( select ) => {
 			const {
 				getBlockAttributes,
-				getBlockInsertionPoint,
+				getInsertionCue,
 				getBlockName,
 				getBlockOrder,
 				isBlockInsertionPointVisible,
 			} = select( blockEditorStore );
 			const blockClientIds = getBlockOrder( rootClientId );
-			const insertionPoint = getBlockInsertionPoint();
+			const insertionPoint = getInsertionCue();
 
 			const insertionPointVisibleInCurrentRoot =
 				! isStackedHorizontally &&

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -33,7 +33,7 @@ export function ZoomOutSeparator( {
 		blockInsertionPointVisible,
 	} = useSelect( ( select ) => {
 		const {
-			getBlockInsertionPoint,
+			getInsertionCue,
 			getBlockOrder,
 			isBlockInsertionPointVisible,
 			getSectionRootClientId,
@@ -45,7 +45,7 @@ export function ZoomOutSeparator( {
 			sectionRootClientId: root,
 			sectionClientIds: sectionRootClientIds,
 			blockOrder: getBlockOrder( root ),
-			blockInsertionPoint: getBlockInsertionPoint(),
+			blockInsertionPoint: getInsertionCue(),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 		};
 	}, [] );

--- a/packages/block-editor/src/components/block-popover/drop-zone.js
+++ b/packages/block-editor/src/components/block-popover/drop-zone.js
@@ -22,9 +22,8 @@ function BlockDropZonePopover( {
 	__unstableContentRef,
 } ) {
 	const { clientId } = useSelect( ( select ) => {
-		const { getBlockOrder, getBlockInsertionPoint } =
-			select( blockEditorStore );
-		const insertionPoint = getBlockInsertionPoint();
+		const { getBlockOrder, getInsertionCue } = select( blockEditorStore );
+		const insertionPoint = getInsertionCue();
 		const order = getBlockOrder( insertionPoint.rootClientId );
 
 		if ( ! order.length ) {

--- a/packages/block-editor/src/components/block-tools/insertion-point.js
+++ b/packages/block-editor/src/components/block-tools/insertion-point.js
@@ -43,7 +43,7 @@ function InbetweenInsertionPointPopover( {
 		const {
 			getBlockOrder,
 			getBlockListSettings,
-			getBlockInsertionPoint,
+			getInsertionCue,
 			isBlockBeingDragged,
 			getPreviousBlockClientId,
 			getNextBlockClientId,
@@ -51,7 +51,7 @@ function InbetweenInsertionPointPopover( {
 			isNavigationMode: _isNavigationMode,
 			__unstableGetEditorMode,
 		} = select( blockEditorStore );
-		const insertionPoint = getBlockInsertionPoint();
+		const insertionPoint = getInsertionCue();
 		const order = getBlockOrder( insertionPoint.rootClientId );
 
 		if ( ! order.length ) {
@@ -226,11 +226,11 @@ export default function InsertionPoint( props ) {
 	const { insertionPoint, isVisible, isBlockListEmpty } = useSelect(
 		( select ) => {
 			const {
-				getBlockInsertionPoint,
+				getInsertionCue,
 				isBlockInsertionPointVisible,
 				getBlockCount,
 			} = select( blockEditorStore );
-			const blockInsertionPoint = getBlockInsertionPoint();
+			const blockInsertionPoint = getInsertionCue();
 			return {
 				insertionPoint: blockInsertionPoint,
 				isVisible: isBlockInsertionPointVisible(),

--- a/packages/block-editor/src/components/block-tools/use-selected-block-tool-props.js
+++ b/packages/block-editor/src/components/block-tools/use-selected-block-tool-props.js
@@ -21,7 +21,7 @@ export default function useSelectedBlockToolProps( clientId ) {
 				getBlockParents,
 				__experimentalGetBlockListSettingsForBlocks,
 				isBlockInsertionPointVisible,
-				getBlockInsertionPoint,
+				getInsertionCue,
 				getBlockOrder,
 				hasMultiSelection,
 				getLastMultiSelectedBlockClientId,
@@ -44,7 +44,7 @@ export default function useSelectedBlockToolProps( clientId ) {
 
 			let isInsertionPointVisible = false;
 			if ( isBlockInsertionPointVisible() ) {
-				const insertionPoint = getBlockInsertionPoint();
+				const insertionPoint = getInsertionCue();
 				const order = getBlockOrder( insertionPoint.rootClientId );
 				isInsertionPointVisible =
 					order[ insertionPoint.index ] === clientId;

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -26,7 +26,7 @@ function ZoomOutModeInserters() {
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
-			getBlockInsertionPoint,
+			getInsertionCue,
 			getBlockOrder,
 			getSelectionStart,
 			getSelectedBlockClientId,
@@ -39,7 +39,7 @@ function ZoomOutModeInserters() {
 
 		return {
 			hasSelection: !! getSelectionStart().clientId,
-			blockInsertionPoint: getBlockInsertionPoint(),
+			blockInsertionPoint: getInsertionCue(),
 			blockOrder: getBlockOrder( root ),
 			blockInsertionPointVisible: isBlockInsertionPointVisible(),
 			sectionRootClientId: root,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1488,6 +1488,10 @@ export const getBlockInsertionPoint = createSelector(
 	]
 );
 
+export function getInsertionCue( state ) {
+	return state.insertionPoint;
+}
+
 /**
  * Returns true if we should show the block insertion point.
  *


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Seeing if things break/performance improves if we only return the insertion point rather than also a fallback flow.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part of exploring https://github.com/WordPress/gutenberg/issues/65290 to see if there are simpler ways to refactor to avoid common issues and performance regressions.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Replace all getBlockInsertionPoint selectors with getInsertionCue (which returns `state.insertionPoint` directly).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
