### PR TITLE
Fix Tabs styling in Font Library modal

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -66,8 +66,8 @@ function FontLibraryModal( {
 			isFullScreen
 			className="font-library-modal"
 		>
-			<div className="font-library-modal__tabs">
-				<Tabs defaultTabId={ defaultTabId }>
+			<Tabs defaultTabId={ defaultTabId }>
+				<div className="font-library-modal__tablist">
 					<Tabs.TabList>
 						{ tabs.map( ( { id, title } ) => (
 							<Tabs.Tab key={ id } tabId={ id }>
@@ -75,30 +75,30 @@ function FontLibraryModal( {
 							</Tabs.Tab>
 						) ) }
 					</Tabs.TabList>
-					{ tabs.map( ( { id } ) => {
-						let contents;
-						switch ( id ) {
-							case 'upload-fonts':
-								contents = <UploadFonts />;
-								break;
-							case 'installed-fonts':
-								contents = <InstalledFonts />;
-								break;
-							default:
-								contents = <FontCollection slug={ id } />;
-						}
-						return (
-							<Tabs.TabPanel
-								key={ id }
-								tabId={ id }
-								focusable={ false }
-							>
-								{ contents }
-							</Tabs.TabPanel>
-						);
-					} ) }
-				</Tabs>
-			</div>
+				</div>
+				{ tabs.map( ( { id } ) => {
+					let contents;
+					switch ( id ) {
+						case 'upload-fonts':
+							contents = <UploadFonts />;
+							break;
+						case 'installed-fonts':
+							contents = <InstalledFonts />;
+							break;
+						default:
+							contents = <FontCollection slug={ id } />;
+					}
+					return (
+						<Tabs.TabPanel
+							key={ id }
+							tabId={ id }
+							focusable={ false }
+						>
+							{ contents }
+						</Tabs.TabPanel>
+					);
+				} ) }
+			</Tabs>
 		</Modal>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/style.scss
@@ -129,17 +129,16 @@ $footer-height: 70px;
 	padding-bottom: $grid-unit-20;
 }
 
-.font-library-modal__tabs {
-	[role="tablist"] {
-		position: sticky;
-		top: 0;
-		border-bottom: 1px solid $gray-300;
-		background: $white;
-		margin: 0 #{$grid-unit-40 * -1};
-		padding: 0 $grid-unit-20;
-		z-index: 1;
-	}
+.font-library-modal__tablist {
+	position: sticky;
+	top: 0;
+	border-bottom: 1px solid $gray-300;
+	background: $white;
+	margin: 0 #{$grid-unit-40 * -1};
+	padding: 0 $grid-unit-20;
+	z-index: 1;
 }
+
 
 .font-library-modal__upload-area {
 	align-items: center;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes a regression in the tablist styling in the Font Library modal.

## How?

The regression is likely due to the new focus indicator animations in Tabs not working well with the style overrides in Font Library modal. I changed the structure a bit so the style overrides are non-invasive.

## Testing Instructions

To see the Font Library modal, go to Site Editor ▸ Global Styles ▸ Typography ▸ Manage Fonts.

### Testing Instructions for Keyboard

Move the focus indicators with a keyboard.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/383324f0-1cbf-4890-859e-a7d71195c2ca" alt="Font Library modal tabs, before" width="922">|<img src="https://github.com/user-attachments/assets/7bf4195e-2737-4158-811b-d97950be5a81" alt="Font Library modal tabs, after" width="933">|

For reference, this is what it looked like before it regressed:

<img width="612" alt="Font Library modal, before regression" src="https://github.com/user-attachments/assets/9e2d3fff-b10b-42ba-bc55-96e9b531fbef">
