### PR TITLE
Add: Multiple media field support and content field to pages/posts.

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -37,6 +37,7 @@ import {
 	SORTING_DIRECTIONS,
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
+	LAYOUT_LIST,
 	sortIcons,
 	sortLabels,
 } from '../../constants';
@@ -247,10 +248,11 @@ interface FieldItemProps {
 	index: number;
 	isVisible: boolean;
 	isHidable: boolean;
+	isMediaField?: boolean;
 }
 
 function FieldItem( {
-	field: { id, label, index, isVisible, isHidable },
+	field: { id, label, index, isVisible, isHidable, isMediaField },
 	fields,
 	view,
 	onChangeView,
@@ -338,6 +340,39 @@ function FieldItem( {
 						accessibleWhenDisabled
 						size="compact"
 						onClick={ () => {
+							if (
+								! isVisible &&
+								isMediaField &&
+								( view.type === LAYOUT_GRID ||
+									view.type === LAYOUT_LIST )
+							) {
+								onChangeView( {
+									...view,
+									fields: [
+										...visibleFieldIds.filter(
+											( fieldId ) => {
+												const field = fields.find(
+													( possibleField ) => {
+														return (
+															possibleField.id ===
+															fieldId
+														);
+													}
+												);
+												if ( ! field ) {
+													return false;
+												}
+												return ! field.isMediaField;
+											}
+										),
+										id,
+									],
+									layout: {
+										...view.layout,
+										mediaField: id,
+									},
+								} );
+							} else {
 							onChangeView( {
 								...view,
 								fields: isVisible
@@ -346,6 +381,7 @@ function FieldItem( {
 									  )
 									: [ ...visibleFieldIds, id ],
 							} );
+							}
 							// Focus the visibility button to avoid focus loss.
 							// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.
 							// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
@@ -397,7 +433,7 @@ function FieldControl() {
 
 	const visibleFields = fields
 		.filter( ( { id } ) => visibleFieldIds.includes( id ) )
-		.map( ( { id, label, enableHiding } ) => {
+		.map( ( { id, label, enableHiding, isMediaField } ) => {
 			return {
 				id,
 				label,
@@ -406,6 +442,7 @@ function FieldControl() {
 				isHidable: notHidableFieldIds.includes( id )
 					? false
 					: enableHiding,
+				isMediaField,
 			};
 		} );
 	if ( view.type === LAYOUT_TABLE && view.layout?.combinedFields ) {
@@ -416,20 +453,44 @@ function FieldControl() {
 				index: visibleFieldIds.indexOf( id ),
 				isVisible: true,
 				isHidable: notHidableFieldIds.includes( id ),
+				isMediaField: false,
 			} );
 		} );
+	}
+	if (
+		( view.type === LAYOUT_GRID || view.type === LAYOUT_LIST ) &&
+		view.layout?.mediaField
+	) {
+		if (
+			! visibleFields.find( ( { id } ) => id === view.layout?.mediaField )
+		) {
+			const field = fields.find(
+				( { id } ) => id === view.layout?.mediaField
+			);
+			if ( field ) {
+				visibleFields.push( {
+					id: field.id,
+					label: field.label,
+					index: visibleFieldIds.indexOf( field.id ),
+					isVisible: true,
+					isHidable: notHidableFieldIds.includes( field.id ),
+					isMediaField: field.isMediaField,
+				} );
+			}
+		}
 	}
 	visibleFields.sort( ( a, b ) => a.index - b.index );
 
 	const hiddenFields = fields
 		.filter( ( { id } ) => hiddenFieldIds.includes( id ) )
-		.map( ( { id, label, enableHiding }, index ) => {
+		.map( ( { id, label, enableHiding, isMediaField }, index ) => {
 			return {
 				id,
 				label,
 				index,
 				isVisible: false,
 				isHidable: enableHiding,
+				isMediaField,
 			};
 		} );
 

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -75,6 +75,17 @@ function getCombinedFieldIds( view: View ): string[] {
 	return combinedFields;
 }
 
+function getMediaFieldIds( view: View ): string[] {
+	const mediaFields: string[] = [];
+	if ( view.type === LAYOUT_GRID && view.layout?.mediaField ) {
+		mediaFields.push( view.layout.mediaField );
+	}
+	if ( view.type === LAYOUT_LIST && view.layout?.mediaField ) {
+		mediaFields.push( view.layout.mediaField );
+	}
+	return mediaFields;
+}
+
 export function getVisibleFieldIds(
 	view: View,
 	fields: Field< any >[]
@@ -97,13 +108,6 @@ export function getVisibleFieldIds(
 				.filter( ( { id } ) => ! fieldsToExclude.includes( id ) )
 				.map( ( { id } ) => id )
 		);
-	}
-	if (
-		( view.type === LAYOUT_GRID || view.type === LAYOUT_LIST ) &&
-		view.layout?.mediaField &&
-		! visibleFields.includes( view.layout?.mediaField )
-	) {
-		visibleFields.push( view.layout?.mediaField );
 	}
 
 	return visibleFields;

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -81,21 +81,30 @@ export function getVisibleFieldIds(
 ): string[] {
 	const fieldsToExclude = getCombinedFieldIds( view );
 
+	let visibleFields = [];
 	if ( view.fields ) {
-		return view.fields.filter( ( id ) => ! fieldsToExclude.includes( id ) );
-	}
-
-	const visibleFields = [];
-	if ( view.type === LAYOUT_TABLE && view.layout?.combinedFields ) {
+		visibleFields = view.fields.filter(
+			( id ) => ! fieldsToExclude.includes( id )
+		);
+	} else {
+		if ( view.type === LAYOUT_TABLE && view.layout?.combinedFields ) {
+			visibleFields.push(
+				...view.layout.combinedFields.map( ( { id } ) => id )
+			);
+		}
 		visibleFields.push(
-			...view.layout.combinedFields.map( ( { id } ) => id )
+			...fields
+				.filter( ( { id } ) => ! fieldsToExclude.includes( id ) )
+				.map( ( { id } ) => id )
 		);
 	}
-	visibleFields.push(
-		...fields
-			.filter( ( { id } ) => ! fieldsToExclude.includes( id ) )
-			.map( ( { id } ) => id )
-	);
+	if (
+		( view.type === LAYOUT_GRID || view.type === LAYOUT_LIST ) &&
+		view.layout?.mediaField &&
+		! visibleFields.includes( view.layout?.mediaField )
+	) {
+		visibleFields.push( view.layout?.mediaField );
+	}
 
 	return visibleFields;
 }

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -69,6 +69,7 @@ export function normalizeFields< Item >(
 			Edit,
 			enableHiding: field.enableHiding ?? true,
 			enableSorting: field.enableSorting ?? true,
+			isMediaField: field.isMediaField ?? false,
 		};
 	} );
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -153,6 +153,11 @@ export type Field< Item > = {
 	 * Defaults to `item[ field.id ]`.
 	 */
 	getValue?: ( args: { item: Item } ) => any;
+
+	/**
+	 * True if the field is supposed to be used as a media field.
+	 */
+	isMediaField?: boolean;
 };
 
 export type NormalizedField< Item > = Field< Item > & {
@@ -165,6 +170,7 @@ export type NormalizedField< Item > = Field< Item > & {
 	isValid: ( item: Item, context?: ValidationContext ) => boolean;
 	enableHiding: boolean;
 	enableSorting: boolean;
+	isMediaField: boolean;
 };
 
 /**

--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -110,6 +110,7 @@ export const previewField = {
 	id: 'preview',
 	render: PreviewField,
 	enableSorting: false,
+	isMediaField: true,
 };
 
 function TitleField( { item } ) {

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -78,6 +78,7 @@ export const previewField = {
 	id: 'preview',
 	render: PreviewField,
 	enableSorting: false,
+	isMediaField: true,
 };
 
 function TitleField( { item } ) {

--- a/packages/edit-site/src/components/post-fields/style.scss
+++ b/packages/edit-site/src/components/post-fields/style.scss
@@ -1,0 +1,33 @@
+.edit-site-post-list-content-preview {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	border-radius: $radius-medium;
+
+	.dataviews-view-table & {
+		width: 96px;
+		flex-grow: 0;
+	}
+
+	.edit-site-post-list-content-preview__button {
+		box-shadow: none;
+		border: none;
+		padding: 0;
+		background-color: unset;
+		box-sizing: border-box;
+		cursor: pointer;
+		overflow: hidden;
+		height: 100%;
+		border-radius: $grid-unit-05;
+
+		&:focus-visible {
+			box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			// Windows High Contrast mode will show this outline, but not the box-shadow.
+			outline: 2px solid transparent;
+		}
+
+		&[aria-disabled="true"] {
+			cursor: default;
+		}
+	}
+}

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -42,14 +42,14 @@ export const defaultLayouts = {
 	},
 	[ LAYOUT_GRID ]: {
 		layout: {
-			mediaField: 'featured-image',
+			mediaField: 'content-preview',
 			primaryField: 'title',
 		},
 	},
 	[ LAYOUT_LIST ]: {
 		layout: {
 			primaryField: 'title',
-			mediaField: 'featured-image',
+			mediaField: 'content-preview',
 		},
 	},
 };

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -29,6 +29,7 @@
 @import "./components/style-book/style.scss";
 @import "./components/editor-canvas-container/style.scss";
 @import "./components/post-edit/style.scss";
+@import "./components/post-fields/style.scss";
 @import "./components/post-list/style.scss";
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/63719.
cc: @jameskoster, @jasmussen 

This PR implements the following changes:
- A preview field for posts and pages displaying content similar to patterns and templates. And makes that the default media field replacing the featured image.
- Adds the ability to have multiple media fields in the APIs. A field can indicate it is a media field by setting isMediaField to true.
- The user can switch the media field by showing a different media field. E.g: if we go to the view settings and show the featured image field the featured image becomes the media field.

Most pages don't have a featured image so this PR fixes the issue of having a gray square as a page media as the UI shown most of the time.

## Testing Instructions
- Verify the page content as correctly displayed in the media field.
- Verify it is possible on both the grid and list layout to switch back to the featured image as the media field by showing the featured image field.

## Screenshots or screen
<img width="1499" alt="Screenshot 2024-09-13 at 17 15 32" src="https://github.com/user-attachments/assets/af0f8367-d05c-4321-b177-4b54388a0c1b">
<img width="1505" alt="Screenshot 2024-09-13 at 17 15 15" src="https://github.com/user-attachments/assets/e4b28373-56b6-44df-92ab-08b674c78318">
cast <!-- if applicable -->


