### PR TITLE
ButtonGroup: Fix story to show what the component does

### DIFF
--- a/packages/components/src/button-group/stories/index.story.tsx
+++ b/packages/components/src/button-group/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 
 /**
  * Internal dependencies
@@ -22,18 +22,13 @@ const meta: Meta< typeof ButtonGroup > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof ButtonGroup > = ( args ) => {
-	const style = { margin: '0 4px' };
-	return (
-		<ButtonGroup { ...args }>
-			<Button variant="primary" style={ style }>
-				Button 1
-			</Button>
-			<Button variant="primary" style={ style }>
-				Button 2
-			</Button>
-		</ButtonGroup>
-	);
+export const Default: StoryObj< typeof ButtonGroup > = {
+	args: {
+		children: (
+			<>
+				<Button variant="primary">Button 1</Button>
+				<Button>Button 2</Button>
+			</>
+		),
+	},
 };
-
-export const Default: StoryFn< typeof ButtonGroup > = Template.bind( {} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Tweaks the `ButtonGroup` story so it actually highlights what the component does (styling).

## Why?

In the current story, the buttons have a margin, and that doesn't show how the ButtonGroup component handles styling to make them look like a single segmented control.

## Testing Instructions

See Storybook story for ButtonGroup.


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/7f5a37fa-e091-4c92-8747-30d39cbae849" alt="ButtonGroup story, before" width="185">|<img src="https://github.com/user-attachments/assets/4771a64f-f382-4716-a55e-c12a2591ae95" alt="ButtonGroup story, after" width="185">|
