### PR TITLE
Block Editor: Use static access for selector in 'useZoomOutModeExit'

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
@@ -16,10 +16,7 @@ import { unlock } from '../../../lock-unlock';
  * @param {string} clientId Block client ID.
  */
 export function useZoomOutModeExit( { editorMode } ) {
-	const getSettings = useSelect(
-		( select ) => select( blockEditorStore ).getSettings
-	);
-
+	const { getSettings } = useSelect( blockEditorStore );
 	const { __unstableSetEditorMode } = unlock(
 		useDispatch( blockEditorStore )
 	);
@@ -51,6 +48,6 @@ export function useZoomOutModeExit( { editorMode } ) {
 				node.removeEventListener( 'dblclick', onDoubleClick );
 			};
 		},
-		[ editorMode, __unstableSetEditorMode ]
+		[ editorMode, getSettings, __unstableSetEditorMode ]
 	);
 }


### PR DESCRIPTION
## What?
This is a follow-up to #65194.

PR updates the `useZoomOutModeExit` hook to use the static access method for retrieving store selectors.

## Why?
Avoid creating an extra block editor store subscription for each block, which can affect typing performance.

## Testing Instructions
1. Enable Zoom Out experiment.
2. Open a post.
3. Open the global inserter and insert a couple of blocks.
4. Confirm that double clicking on a block exists in zoom-out mode and closes the inserter.

### Testing Instructions for Keyboard
Same.
