### PR TITLE
Search: Replace ButtonGroup usage with ToggleGroupControl

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -23,14 +23,14 @@ import { useEffect, useRef } from '@wordpress/element';
 import {
 	ToolbarDropdownMenu,
 	ToolbarGroup,
-	Button,
-	ButtonGroup,
 	ToolbarButton,
 	ResizableBox,
 	PanelBody,
 	__experimentalVStack as VStack,
 	__experimentalUseCustomUnits as useCustomUnits,
 	__experimentalUnitControl as UnitControl,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { Icon, search } from '@wordpress/icons';
@@ -58,6 +58,7 @@ import {
 // Used to calculate border radius adjustment to avoid "fat" corners when
 // button is placed inside wrapper.
 const DEFAULT_INNER_PADDING = '4px';
+const PERCENTAGE_WIDTHS = [ 25, 50, 75, 100 ];
 
 export default function SearchEdit( {
 	className,
@@ -445,33 +446,34 @@ export default function SearchEdit( {
 							value={ `${ width }${ widthUnit }` }
 							units={ units }
 						/>
-						<ButtonGroup
-							className="wp-block-search__components-button-group" // unused, kept for backwards compatibility
-							aria-label={ __( 'Percentage Width' ) }
+						<ToggleGroupControl
+							label={ __( 'Percentage Width' ) }
+							value={
+								PERCENTAGE_WIDTHS.includes( width ) &&
+								widthUnit === '%'
+									? width
+									: undefined
+							}
+							hideLabelFromVision
+							onChange={ ( newWidth ) => {
+								setAttributes( {
+									width: newWidth,
+									widthUnit: '%',
+								} );
+							} }
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
 						>
-							{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+							{ PERCENTAGE_WIDTHS.map( ( widthValue ) => {
 								return (
-									<Button
+									<ToggleGroupControlOption
 										key={ widthValue }
-										size="small"
-										variant={
-											widthValue === width &&
-											widthUnit === '%'
-												? 'primary'
-												: undefined
-										}
-										onClick={ () =>
-											setAttributes( {
-												width: widthValue,
-												widthUnit: '%',
-											} )
-										}
-									>
-										{ widthValue }%
-									</Button>
+										value={ widthValue }
+										label={ `${ widthValue }%` }
+									/>
 								);
 							} ) }
-						</ButtonGroup>
+						</ToggleGroupControl>
 					</VStack>
 				</PanelBody>
 			</InspectorControls>

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -448,7 +448,12 @@ export default function SearchEdit( {
 						/>
 						<ToggleGroupControl
 							label={ __( 'Percentage Width' ) }
-							value={ width }
+							value={
+								PERCENTAGE_WIDTHS.includes( width ) &&
+								widthUnit === '%'
+									? width
+									: undefined
+							}
 							hideLabelFromVision
 							onChange={ ( newWidth ) => {
 								setAttributes( {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -448,12 +448,7 @@ export default function SearchEdit( {
 						/>
 						<ToggleGroupControl
 							label={ __( 'Percentage Width' ) }
-							value={
-								PERCENTAGE_WIDTHS.includes( width ) &&
-								widthUnit === '%'
-									? width
-									: undefined
-							}
+							value={ width }
 							hideLabelFromVision
 							onChange={ ( newWidth ) => {
 								setAttributes( {
@@ -461,6 +456,7 @@ export default function SearchEdit( {
 									widthUnit: '%',
 								} );
 							} }
+							isBlock
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 						>


### PR DESCRIPTION
## What?
PR replaces the `ButtonGroup` component with `ToggleGroupControl` in the Search block controls.

## Why?
Part of #65339.

## Testing Instructions
1. Open a post or page.
2. Insert a Search block.
3. Confirm that the percentage width selector works as before.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|--------|--------|
| ![CleanShot 2024-09-14 at 00 24 59](https://github.com/user-attachments/assets/ff9e92e5-bdf1-4ccc-aa5e-5f74d43e44b0) | ![CleanShot 2024-09-14 at 00 24 21](https://github.com/user-attachments/assets/5ae87389-ffc8-4d14-a416-5be02082f2c1)|
