### PR TITLE
BoxControl: Add lint rule for 40px size prop usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -321,6 +321,7 @@ module.exports = {
 					...[
 						'BorderBoxControl',
 						'BorderControl',
+						'BoxControl',
 						'ComboboxControl',
 						'CustomSelectControl',
 						'DimensionControl',

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -100,3 +100,10 @@ A handler for onMouseOver events.
 A handler for onMouseOut events.
 
 -   Required: No
+
+### `__next40pxDefaultSize`: `boolean`
+
+Start opting into the larger default size that will become the default size in a future version.
+
+-   Required: No
+-   Default: `false`


### PR DESCRIPTION
Part of #63871

## What?

Add a lint rule to prevent people from introducing new usages of BoxControl that do not adhere to the new default size.

## Why?

When I saw #65300 I noticed that I'd somehow missed this component 😅 

### Testing Instructions

The lint error should trigger for violations [as expected](https://github.com/WordPress/gutenberg/pull/64410#discussion_r1712431913).