### PR TITLE
Button: Replace ButtonGroup usage with ToggleGroupControl

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -16,13 +16,13 @@ import removeAnchorTag from '../utils/remove-anchor-tag';
 import { __ } from '@wordpress/i18n';
 import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
 import {
-	Button,
-	ButtonGroup,
 	TextControl,
 	ToolbarButton,
 	Popover,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -115,46 +115,38 @@ function useEnter( props ) {
 }
 
 function WidthPanel( { selectedWidth, setAttributes } ) {
-	function handleChange( newWidth ) {
-		// Check if we are toggling the width off
-		const width = selectedWidth === newWidth ? undefined : newWidth;
-
-		// Update attributes.
-		setAttributes( { width } );
-	}
-
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
-			resetAll={ () => {
-				handleChange( undefined );
-			} }
+			resetAll={ () => setAttributes( { width: undefined } ) }
 		>
 			<ToolsPanelItem
 				label={ __( 'Button width' ) }
-				__nextHasNoMarginBottom
 				isShownByDefault
 				hasValue={ () => !! selectedWidth }
-				onDeselect={ () => handleChange( undefined ) }
+				onDeselect={ () => setAttributes( { width: undefined } ) }
+				__nextHasNoMarginBottom
 			>
-				<ButtonGroup aria-label={ __( 'Button width' ) }>
+				<ToggleGroupControl
+					label={ __( 'Button width' ) }
+					value={ selectedWidth }
+					onChange={ ( newWidth ) =>
+						setAttributes( { width: newWidth } )
+					}
+					isBlock
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+				>
 					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
 						return (
-							<Button
+							<ToggleGroupControlOption
 								key={ widthValue }
-								size="small"
-								variant={
-									widthValue === selectedWidth
-										? 'primary'
-										: undefined
-								}
-								onClick={ () => handleChange( widthValue ) }
-							>
-								{ widthValue }%
-							</Button>
+								value={ widthValue }
+								label={ `${ widthValue }%` }
+							/>
 						);
 					} ) }
-				</ButtonGroup>
+				</ToggleGroupControl>
 			</ToolsPanelItem>
 		</ToolsPanel>
 	);

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -263,12 +263,14 @@ test.describe( 'Buttons', () => {
 		await editor.insertBlock( { name: 'core/buttons' } );
 		await page.keyboard.type( 'Content' );
 		await editor.openDocumentSettingsSidebar();
-		await page.click(
-			`role=region[name="Editor settings"i] >> role=tab[name="Settings"i]`
-		);
-		await page.click(
-			'role=group[name="Button width"i] >> role=button[name="25%"i]'
-		);
+		await page
+			.getByRole( 'region', { name: 'Editor settings' } )
+			.getByRole( 'tab', { name: 'Settings' } )
+			.click();
+		await page
+			.getByRole( 'radiogroup', { name: 'Button width' } )
+			.getByRole( 'radio', { name: '25%' } )
+			.click();
 
 		// Check the content.
 		const content = await editor.getEditedPostContent();


### PR DESCRIPTION
## What?
Fixes #65378.

PR replaces the `ButtonGroup` component with `ToggleGroupControl` in the Button block controls.

## Why?
Part of #65339.

## Testing Instructions
1. Open a post or page.
2. Insert a Buttons block.
3. Confirm that the width controls work as before.

### Testing Instructions for Keyboard
Same.

## Screenshot
| Before | After |
|--------|--------|
| ![CleanShot 2024-09-14 at 02 48 25](https://github.com/user-attachments/assets/587c14d9-83d7-4dff-a91a-1b8d236e203c) | ![CleanShot 2024-09-24 at 16 16 11](https://github.com/user-attachments/assets/42cc511d-2aa3-4508-b9ce-777af2df32a2) |

