### PR TITLE
BoxControl: Unify input filed width whether linked or not

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `Tabs`: indicator positioning under RTL direction ([#64926](https://github.com/WordPress/gutenberg/pull/64926)).
 -   `Popover`: Update `toolbar` variant radius to match block toolbar ([#65263](https://github.com/WordPress/gutenberg/pull/65263)).
+-   `BoxControl`: Unify input filed width whether linked or not ([#65348](https://github.com/WordPress/gutenberg/pull/65348)).
 
 ### Deprecations
 

--- a/packages/components/src/box-control/all-input-control.tsx
+++ b/packages/components/src/box-control/all-input-control.tsx
@@ -10,7 +10,6 @@ import {
 	FlexedRangeControl,
 	StyledUnitControl,
 } from './styles/box-control-styles';
-import { HStack } from '../h-stack';
 import type { BoxControlInputControlProps } from './types';
 import { parseQuantityAndUnitFromRawValue } from '../unit-control';
 import {
@@ -72,7 +71,7 @@ export default function AllInputControl( {
 	};
 
 	return (
-		<HStack>
+		<>
 			<StyledUnitControl
 				{ ...props }
 				__next40pxDefaultSize={ __next40pxDefaultSize }
@@ -104,6 +103,6 @@ export default function AllInputControl( {
 				value={ parsedQuantity ?? 0 }
 				withInputField={ false }
 			/>
-		</HStack>
+		</>
 	);
 }


### PR DESCRIPTION
## What?

This PR may be very minor, but it fixes the misalignment of the width of input fields inside the `BoxControl` component that occurs when the link state is changed in a narrow container.

| Before  | After |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/366627fa-4aec-4c0c-9cea-cead35613920">  | <video src="https://github.com/user-attachments/assets/aca3ed76-a55d-4a3c-b4d4-f3218a2b9d55">|

This should also fix a misalignment in the block sidebar margin, padding, and block spacing UI (when there are no spacing presets), although results may vary depending on the OS and browser. Below is a comparison of the Columns Block Sidebar on Windows OS/Chrome:

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/5fb4f4cc-e6d7-4873-b955-50062a70b83f) | ![after](https://github.com/user-attachments/assets/084a9b67-adf7-4c62-bb97-54df106b6456) |

## Why?

The row of the `BoxControl` component is composed of the `AllInputControl`, `AxialInputControls`, and `InputControls` components, but only the `AllInputControl` component has a different component configuration, as shown below:

```jsx
// AllInputControl (isLinked)
<InputWrapper>
	<FlexedBoxControlIcon />
	<HStack>
		<StyledUnitControl />
		<FlexedRangeControl />
	</HStack>
</InputWrapper>

// AxialInputControls (! isLinked && splitOnAxis)
<InputWrapper>
	<FlexedBoxControlIcon />
	<Tooltip>
		<StyledUnitControl />
		<FlexedRangeControl />
	</Tooltip>
</InputWrapper>
<InputWrapper>
	<FlexedBoxControlIcon />
	<Tooltip>
		<StyledUnitControl />
		<FlexedRangeControl />
	</Tooltip>
</InputWrapper>

// InputControls (! isLinked && ! splitOnAxis)
<InputWrapper>
	<FlexedBoxControlIcon />
	<Tooltip>
		<StyledUnitControl />
		<FlexedRangeControl />
	</Tooltip>
</InputWrapper>
// ...
```

## How?

Delete the wrapper `HStack` component from the `AllInputControl` component.

## Testing Instructions

### Storybook

- Start Storybook and access http://localhost:50240/?path=/story/components-experimental-boxcontrol--default.
- Narrow the browser width to about 260px.
- Change the link status.

### Block Editor

Enable Empotytheme and update theme.json as follows. This is required to render spacing-related UI as hoge components:

<details><summary>theme.json</summary>

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"layout": {
			"contentSize": "840px"
		},
		"spacing": {
			"spacingSizes": [],
			"defaultSpacingSizes": false
		}
	}
}
```

</details> 

- Insert a Group or Columns block.
- Open the block sidebar and change the link status of the margin or padding or block spacing UI.