### PR TITLE
Composer: update minimum required PHPUnit Polyfills

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"wp-coding-standards/wpcs": "^3.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
 		"spatie/phpunit-watcher": "^1.23",
-		"yoast/phpunit-polyfills": "^1.0",
+		"yoast/phpunit-polyfills": "^1.1.0",
 		"gutenberg/gutenberg-coding-standards": "@dev"
 	},
 	"repositories": [


### PR DESCRIPTION
## What?
For compatibility with the WP Core tests, the same (minimum) version of the PHPUnit Polyfills should be required.

This has been v1.1.0 since over a year ago.

Ref: https://core.trac.wordpress.org/ticket/59150

