### PR TITLE
Composer: allow composer/installers 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
 		}
 	],
 	"require": {
-		"composer/installers": "~1.0"
+		"composer/installers": "^1.0 || ^2.0"
 	},
 	"scripts": {
 		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",


### PR DESCRIPTION
## What?

Composer released the first version of `composer/installers` 2.x over three years ago.

The 2.x range has a minimum PHP version of PHP 7.2. While WordPress and Gutenberg still supported PHP < 7.2, the requirement could have been set to `^1.0 || ^2.0`, but as support for PHP < 7.2 has now been dropped, I see no reason not to require the package at `^2.0` outright.

Having said that, there may still be other plugins out there which don't allow for the `composer/installers` 2.x package yet and if one such plugins would be installed as a dependency alongside Gutenberg, this would lead to an unresolvable conflict when running `composer install` for such a project.

So with that in mind, I'm erring on the side of caution and propose to change the requirements to `^1.0 || ^2.0`.

Note: this will also get rid of a PHP 8.4 deprecation notice when running various Composer commands.

Refs:
* https://github.com/composer/installers/blob/main/CHANGELOG.md
* https://github.com/composer/installers/releases


