### PR TITLE
GH Actions: run the tests against PHP 8.3

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -153,6 +153,7 @@ jobs:
                     - '8.0'
                     - '8.1'
                     - '8.2'
+                    - '8.3'
                 multisite: [false, true]
                 wordpress: [''] # Latest WordPress version.
                 include:
@@ -161,7 +162,7 @@ jobs:
                       wordpress: 'previous major version'
                     - php: '7.4'
                       wordpress: 'previous major version'
-                    - php: '8.2'
+                    - php: '8.3'
                       wordpress: 'previous major version'
 
         env:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -196,12 +196,6 @@ jobs:
             - name: Override PHP version in composer.json
               run: composer config platform.php ${{ matrix.php }}
 
-            # The spatie/phpunit-watcher package is not compatible with PHP < 7.2.
-            # It must be removed before running the tests.
-            - name: Remove incompatible Composer packages
-              if: ${{ matrix.php < '7.2' }}
-              run: composer remove spatie/phpunit-watcher --dev --no-update
-
             # Since Composer dependencies are installed using `composer update` and no lock file is in version control,
             # passing a custom cache suffix ensures that the cache is flushed at least once per week.
             - name: Install Composer dependencies


### PR DESCRIPTION
## What?

### GH Actions: run the tests against PHP 8.3

PHP 8.3 was released nearly a year ago. It is unclear to me why the PHP tests are not being run against PHP 8.3, so let's fix this.

### GH Actions/test-php: remove redundant step

This should have been removed when support for PHP < 7.2 was dropped.

