### PR TITLE
Post Summary Panel: Restore `height:auto` for toggle buttons

### DIFF
--- a/packages/editor/src/components/post-panel-row/style.scss
+++ b/packages/editor/src/components/post-panel-row/style.scss
@@ -28,6 +28,7 @@
 		white-space: normal;
 		text-wrap: balance; // Fallback for Safari.
 		text-wrap: pretty;
+		height: auto;
 		min-height: $button-size-compact;
 	}
 

--- a/packages/editor/src/components/post-status/index.js
+++ b/packages/editor/src/components/post-status/index.js
@@ -173,6 +173,7 @@ export default function PostStatus() {
 					focusOnMount
 					renderToggle={ ( { onToggle, isOpen } ) => (
 						<Button
+							className="editor-post-status__toggle"
 							variant="tertiary"
 							size="compact"
 							onClick={ onToggle }

--- a/packages/editor/src/components/post-status/style.scss
+++ b/packages/editor/src/components/post-status/style.scss
@@ -4,6 +4,11 @@
 	&.is-read-only {
 		padding: 6px 12px;
 	}
+
+	.editor-post-status__toggle.editor-post-status__toggle {
+		padding-top: $grid-unit-05;
+		padding-bottom: $grid-unit-05;
+	}
 }
 
 .editor-change-status__password-fieldset,


### PR DESCRIPTION
Related to #63658

## What?

This PR changes the height of the toggle buttons in the post summary panel from a fixed `32px` to `auto`. This fixes a layout issue that occurred when the button text was long:

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/f34495dd-b18f-42f8-807c-d364c7a4429b) | ![after](https://github.com/user-attachments/assets/d44db4f8-0345-408e-b5e4-3f3f0be48fea) | 

## Why?

#63658 removed the `height:auto;` for the toggle button, so the height was fixed at 32px. This is fine when there is little text, but when it is long, it causes text overflow.

## How?

The height of the toggle button cannot be fixed, so restore `height: auto;`. This makes the size of the post status button with a `24px` icon `36px`.

To solve this, I considered the following two approaches:

- Change the top and bottom padding from `8px` to `4px`.
- Change the icon size from `24px` to `20px`.

I adopted the first approach, which does not cause any visual changes.

## Testing Instructions

- Open the post status panel.
- Set the author name, template name, etc. with long text.
