### PR TITLE
Post Content Block: Fix conflict between clearFix and focus ring in the editor

### DIFF
--- a/packages/block-library/src/post-content/style.scss
+++ b/packages/block-library/src/post-content/style.scss
@@ -1,5 +1,3 @@
-.wp-block-post-content::after {
-	content: "";
-	display: table;
-	clear: both;
+.wp-block-post-content {
+	display: flow-root;
 }


### PR DESCRIPTION
Alternatives to #63690

## What?

This PR restores the focus ring in the editor by taking a different approach to solving the issue of left- and right-aligned blocks overflowing their content area.

## Why?

#63690 added a clearfix (`::after` pseudo-element) to the Post Content block to fix overflow issues. In the editor, the `::after` pseudo-element is used as a focus ring when the block is selected, causing conflicts.

## How?

Use `display: flow-root` instead of the `clearfix`. This style determines how to handle floated items in a container and should be equivalent to the `clearfix`. This CSS is supported in major browsers: https://caniuse.com/flow-root

## Testing Instructions

- Open a page or single post template in the site editor. When you select a Post Content block, you should see a focus ring appear on the block.
- Please test the testing steps described in #63690. This PR should not affect any actual content, but I would appreciate it if you could try different content variations.

## Screenshots or screen

### Before

![image](https://github.com/user-attachments/assets/0faa772f-5715-4806-b521-26320dc38875)

### After

![image](https://github.com/user-attachments/assets/46629c43-89bc-4e13-8c51-304eb4ab3fd9)
