### PR TITLE
fix the issue where block spacing control not shown

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/test/utils.js
@@ -378,41 +378,34 @@ describe( 'getInitialView', () => {
 				VIEWS.custom
 			);
 		} );
+		it( 'should return custom view even if only single side supported', () => {
+			expect( getInitialView( { top: '1em' }, [ 'top' ] ) ).toBe(
+				VIEWS.custom
+			);
+			expect( getInitialView( { right: '1em' }, [ 'right' ] ) ).toBe(
+				VIEWS.custom
+			);
+			expect( getInitialView( { bottom: '1em' }, [ 'bottom' ] ) ).toBe(
+				VIEWS.custom
+			);
+			expect( getInitialView( { left: '1em' }, [ 'left' ] ) ).toBe(
+				VIEWS.custom
+			);
+		} );
 	} );
 
 	describe( 'Single side view', () => {
-		it( 'should return single side when only single side supported', () => {
-			expect( getInitialView( { top: '1em' }, [ 'top' ] ) ).toBe(
-				VIEWS.top
-			);
-		} );
-
 		it( 'should return single side when only single side supported and no value defined', () => {
 			expect( getInitialView( {}, [ 'top' ] ) ).toBe( VIEWS.top );
 		} );
 
-		it( 'should return single side when only single side supported and all values defined', () => {
+		it( 'should return single side when only single side supported and has only axial sides', () => {
 			expect(
-				getInitialView(
-					{ top: '1em', right: '2em', bottom: '1em', left: '2em' },
-					[ 'top' ]
-				)
+				getInitialView( { top: '1em' }, [ 'horizontal', 'vertical' ] )
 			).toBe( VIEWS.top );
-		} );
-
-		it( 'should return single side view when only one side is supported', () => {
-			expect( getInitialView( { top: '1em' }, [ 'top' ] ) ).toBe(
-				VIEWS.top
-			);
-			expect( getInitialView( { right: '1em' }, [ 'right' ] ) ).toBe(
-				VIEWS.right
-			);
-			expect( getInitialView( { bottom: '1em' }, [ 'bottom' ] ) ).toBe(
-				VIEWS.bottom
-			);
-			expect( getInitialView( { left: '1em' }, [ 'left' ] ) ).toBe(
-				VIEWS.left
-			);
+			expect(
+				getInitialView( { left: '4em' }, [ 'horizontal', 'vertical' ] )
+			).toBe( VIEWS.left );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -363,17 +363,34 @@ export function getInitialView( values = {}, sides ) {
 		top === bottom && left === right && ( !! top || !! left );
 	const hasNoValuesAndBalancedSides =
 		! sideValues.length && hasBalancedSidesSupport( sides );
-
-	// Only single side supported and no value defined.
-	if ( sides?.length === 1 ) {
-		return sides[ 0 ];
-	}
+	const hasOnlyAxialSides =
+		sides?.includes( 'horizontal' ) &&
+		sides?.includes( 'vertical' ) &&
+		sides?.length === 2;
 
 	if (
 		hasAxisSupport( sides ) &&
 		( hasMatchingAxialValues || hasNoValuesAndBalancedSides )
 	) {
 		return VIEWS.axial;
+	}
+
+	// Only axial sides are supported and single value defined.
+	// - Ensure the side returned is the first side that has a value.
+	if ( hasOnlyAxialSides && sideValues.length === 1 ) {
+		let side;
+
+		Object.entries( values ).some( ( [ key, value ] ) => {
+			side = key;
+			return value !== undefined;
+		} );
+
+		return side;
+	}
+
+	// Only single side supported and no value defined.
+	if ( sides?.length === 1 && ! sideValues.length ) {
+		return sides[ 0 ];
 	}
 
 	// Default to the Custom (separated sides) view.


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes issue where block spacing control is not shown when only one side is set.
It is a regression introduced in #65193

See [this comment](https://github.com/WordPress/gutenberg/pull/65193#issuecomment-2350935623) for more details on the issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It is because the function `getInitialView` is returning custom when a single side is set. Instead it should render single sided view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Function is reverted to its original state (before #65193) and introduced an additional condition to check if the support for sides is axial only (i.e. horizontal and vertical only)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Test the scenarios where only single side for padding, margin is set in `theme.json` and UI should show the custom view (with all 4 side controls) and corresponding side value should be set.
2. For blockSpacing is set in `theme.json` and it should show single custom control.
3. When nothing is set for any of the padding, margin or block spacing, it should show axial view.

## Screenshots or screencast <!-- if applicable -->

#### when nothing set, or equal values are set for `top,bottom` and `left,right`

<img width="281" alt="image" src="https://github.com/user-attachments/assets/cff42c15-8a1d-4e6c-b70d-01a87d5b19b3">

#### When custom values are set:

<img width="280" alt="image" src="https://github.com/user-attachments/assets/c4eeac29-7e8a-45dc-bafe-000d10194114">
<img width="281" alt="image" src="https://github.com/user-attachments/assets/adb5bb72-6022-4bd0-b72f-080ea0f698a0">

