### PR TITLE
Don't force iframe editor when gutenberg plugin and block theme are enabled

### DIFF
--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -6,33 +6,22 @@ import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
-
 export function useShouldIframe() {
-	const {
-		isBlockBasedTheme,
-		hasV3BlocksOnly,
-		isEditingTemplate,
-		isZoomOutMode,
-	} = useSelect( ( select ) => {
-		const { getEditorSettings, getCurrentPostType } = select( editorStore );
-		const { __unstableGetEditorMode } = select( blockEditorStore );
-		const { getBlockTypes } = select( blocksStore );
-		const editorSettings = getEditorSettings();
-		return {
-			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
-			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
-				return type.apiVersion >= 3;
-			} ),
-			isEditingTemplate: getCurrentPostType() === 'wp_template',
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
-		};
-	}, [] );
-
-	return (
-		hasV3BlocksOnly ||
-		( isGutenbergPlugin && isBlockBasedTheme ) ||
-		isEditingTemplate ||
-		isZoomOutMode
+	const { hasV3BlocksOnly, isEditingTemplate, isZoomOutMode } = useSelect(
+		( select ) => {
+			const { getCurrentPostType } = select( editorStore );
+			const { __unstableGetEditorMode } = select( blockEditorStore );
+			const { getBlockTypes } = select( blocksStore );
+			return {
+				hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
+					return type.apiVersion >= 3;
+				} ),
+				isEditingTemplate: getCurrentPostType() === 'wp_template',
+				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			};
+		},
+		[]
 	);
+
+	return hasV3BlocksOnly || isEditingTemplate || isZoomOutMode;
 }


### PR DESCRIPTION
Related to #48286

## What?

This PR removes the special condition for the Gutenberg plugin and block themes from the `useShouldIframe` hook that determines whether the editor should work as an iframe.

## Why?

Whether the editor works as an iframe depends on whether the Gutenberg plugin is enabled.

For example, if all registered blocks are not v3 and a block theme is enabled, the results will be different as follows:

- Gutenberg plugin **enabled**: Editor is an iframe
- Gutenberg plugin **disabled**: Editor is not an iframe

This difference is especially problematic when testing WordPress beta/RC versions.

As seen in #64351, in order to move forward with a fully iframed editor, we need to unify the editor behavior whether Gutenberg is enabled or not.

## How?

Remove `( isGutenbergPlugin && isBlockBasedTheme ) ||` from the conditional statement (Take a look at [this Diff view](https://github.com/WordPress/gutenberg/pull/65372/files?diff=unified&w=1)). This change does not affect the behavior of the editor in core.

When this PR is merged and a new version of the Gutenberg plugin is shipped, the only time it will be affected is if all of the following conditions are met:

- The Gutenberg plugin is enabled
- Block themes are enabled
- All registered blocks are not v3

In this case, the editor that previously worked as an iframe will no longer work as an iframe.

## Testing Instructions

- Activate the Jetpack plugin. This plugin registers blocks lower than v3.
- Activate block themes.
  - trunk: Editor is an iframe
  - This branch: Editor is not an iframe
