### PR TITLE
Dataviews config dropdown: remove style overrides

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -554,7 +554,6 @@ function _DataViewsViewConfig( {
 			<ViewTypeMenu defaultLayouts={ defaultLayouts } />
 			<Dropdown
 				popoverProps={ { placement: 'bottom-end', offset: 9 } }
-				contentClassName="dataviews-view-config"
 				renderToggle={ ( { onToggle } ) => {
 					return (
 						<Button

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -541,6 +541,8 @@ function DataviewsViewConfigContent( {
 	);
 }
 
+const DATAVIEWS_CONFIG_POPOVER_PROPS = { placement: 'bottom-end', offset: 9 };
+
 function _DataViewsViewConfig( {
 	density,
 	setDensity,
@@ -554,7 +556,7 @@ function _DataViewsViewConfig( {
 		<>
 			<ViewTypeMenu defaultLayouts={ defaultLayouts } />
 			<Dropdown
-				popoverProps={ { placement: 'bottom-end', offset: 9 } }
+				popoverProps={ DATAVIEWS_CONFIG_POPOVER_PROPS }
 				renderToggle={ ( { onToggle } ) => {
 					return (
 						<Button

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -49,6 +49,7 @@ import type { SupportedLayouts, View, Field } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
 import DensityPicker from '../../dataviews-layouts/grid/density-picker';
+import { useInstanceId } from '@wordpress/compose';
 
 const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
@@ -519,17 +520,29 @@ function DataviewsViewConfigDropdown( {
 	setDensity: React.Dispatch< React.SetStateAction< number > >;
 } ) {
 	const { view } = useContext( DataViewsContext );
-
+	const popoverId = useInstanceId(
+		_DataViewsViewConfig,
+		'dataviews-view-config-dropdown'
+	);
+	const popoverProps = useMemo(
+		() => ( {
+			...DATAVIEWS_CONFIG_POPOVER_PROPS,
+			id: popoverId,
+		} ),
+		[ popoverId ]
+	);
 	return (
 		<Dropdown
-			popoverProps={ DATAVIEWS_CONFIG_POPOVER_PROPS }
-			renderToggle={ ( { onToggle } ) => {
+			popoverProps={ popoverProps }
+			renderToggle={ ( { onToggle, isOpen } ) => {
 				return (
 					<Button
 						size="compact"
 						icon={ cog }
 						label={ _x( 'View options', 'View is used as a noun' ) }
 						onClick={ onToggle }
+						aria-expanded={ isOpen ? 'true' : 'false' }
+						aria-controls={ popoverId }
 					/>
 				);
 			} }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -8,6 +8,7 @@ import type { ChangeEvent } from 'react';
  */
 import {
 	Button,
+	__experimentalDropdownContentWrapper as DropdownContentWrapper,
 	Dropdown,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
@@ -568,10 +569,12 @@ function _DataViewsViewConfig( {
 					);
 				} }
 				renderContent={ () => (
-					<DataviewsViewConfigContent
-						density={ density }
-						setDensity={ setDensity }
-					/>
+					<DropdownContentWrapper paddingSize="medium">
+						<DataviewsViewConfigContent
+							density={ density }
+							setDensity={ setDensity }
+						/>
+					</DropdownContentWrapper>
 				) }
 			/>
 		</>

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -28,6 +28,7 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
 import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
 import warning from '@wordpress/warning';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -49,7 +50,6 @@ import type { SupportedLayouts, View, Field } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
 import DensityPicker from '../../dataviews-layouts/grid/density-picker';
-import { useInstanceId } from '@wordpress/compose';
 
 const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -511,7 +511,7 @@ function SettingsSection( {
 	);
 }
 
-function DataviewsViewConfigContent( {
+function DataviewsViewConfigDropdown( {
 	density,
 	setDensity,
 }: {
@@ -519,25 +519,43 @@ function DataviewsViewConfigContent( {
 	setDensity: React.Dispatch< React.SetStateAction< number > >;
 } ) {
 	const { view } = useContext( DataViewsContext );
+
 	return (
-		<VStack className="dataviews-view-config" spacing={ 6 }>
-			<SettingsSection title={ __( 'Appearance' ) }>
-				<HStack expanded className="is-divided-in-two">
-					<SortFieldControl />
-					<SortDirectionControl />
-				</HStack>
-				{ view.type === LAYOUT_GRID && (
-					<DensityPicker
-						density={ density }
-						setDensity={ setDensity }
+		<Dropdown
+			popoverProps={ DATAVIEWS_CONFIG_POPOVER_PROPS }
+			renderToggle={ ( { onToggle } ) => {
+				return (
+					<Button
+						size="compact"
+						icon={ cog }
+						label={ _x( 'View options', 'View is used as a noun' ) }
+						onClick={ onToggle }
 					/>
-				) }
-				<ItemsPerPageControl />
-			</SettingsSection>
-			<SettingsSection title={ __( 'Properties' ) }>
-				<FieldControl />
-			</SettingsSection>
-		</VStack>
+				);
+			} }
+			renderContent={ () => (
+				<DropdownContentWrapper paddingSize="medium">
+					<VStack className="dataviews-view-config" spacing={ 6 }>
+						<SettingsSection title={ __( 'Appearance' ) }>
+							<HStack expanded className="is-divided-in-two">
+								<SortFieldControl />
+								<SortDirectionControl />
+							</HStack>
+							{ view.type === LAYOUT_GRID && (
+								<DensityPicker
+									density={ density }
+									setDensity={ setDensity }
+								/>
+							) }
+							<ItemsPerPageControl />
+						</SettingsSection>
+						<SettingsSection title={ __( 'Properties' ) }>
+							<FieldControl />
+						</SettingsSection>
+					</VStack>
+				</DropdownContentWrapper>
+			) }
+		/>
 	);
 }
 
@@ -555,29 +573,9 @@ function _DataViewsViewConfig( {
 	return (
 		<>
 			<ViewTypeMenu defaultLayouts={ defaultLayouts } />
-			<Dropdown
-				popoverProps={ DATAVIEWS_CONFIG_POPOVER_PROPS }
-				renderToggle={ ( { onToggle } ) => {
-					return (
-						<Button
-							size="compact"
-							icon={ cog }
-							label={ _x(
-								'View options',
-								'View is used as a noun'
-							) }
-							onClick={ onToggle }
-						/>
-					);
-				} }
-				renderContent={ () => (
-					<DropdownContentWrapper paddingSize="medium">
-						<DataviewsViewConfigContent
-							density={ density }
-							setDensity={ setDensity }
-						/>
-					</DropdownContentWrapper>
-				) }
+			<DataviewsViewConfigDropdown
+				density={ density }
+				setDensity={ setDensity }
 			/>
 		</>
 	);

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -57,6 +57,8 @@ interface ViewTypeMenuProps {
 	defaultLayouts?: SupportedLayouts;
 }
 
+const DATAVIEWS_CONFIG_POPOVER_PROPS = { placement: 'bottom-end', offset: 9 };
+
 function ViewTypeMenu( {
 	defaultLayouts = { list: {}, grid: {}, table: {} },
 }: ViewTypeMenuProps ) {
@@ -571,8 +573,6 @@ function DataviewsViewConfigDropdown( {
 		/>
 	);
 }
-
-const DATAVIEWS_CONFIG_POPOVER_PROPS = { placement: 'bottom-end', offset: 9 };
 
 function _DataViewsViewConfig( {
 	density,

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -526,16 +526,13 @@ function DataviewsViewConfigDropdown( {
 		_DataViewsViewConfig,
 		'dataviews-view-config-dropdown'
 	);
-	const popoverProps = useMemo(
-		() => ( {
-			...DATAVIEWS_CONFIG_POPOVER_PROPS,
-			id: popoverId,
-		} ),
-		[ popoverId ]
-	);
+
 	return (
 		<Dropdown
-			popoverProps={ popoverProps }
+			popoverProps={ {
+				...DATAVIEWS_CONFIG_POPOVER_PROPS,
+				id: popoverId,
+			} }
 			renderToggle={ ( { onToggle, isOpen } ) => {
 				return (
 					<Button

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -1,12 +1,9 @@
 .dataviews-view-config {
-	.components-popover__content {
-		width: 320px;
-		/* stylelint-disable-next-line property-no-unknown -- the linter needs to be updated to accepted the container-type property */
-		container-type: inline-size;
-		padding: $grid-unit-20;
-		font-size: $default-font-size;
-		line-height: $default-line-height;
-	}
+	width: 320px;
+	/* stylelint-disable-next-line property-no-unknown -- the linter needs to be updated to accepted the container-type property */
+	container-type: inline-size;
+	font-size: $default-font-size;
+	line-height: $default-line-height;
 }
 
 .dataviews-view-config__sort-direction .components-toggle-group-control-option-base {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #65314

Remove style overrides from Dataviews config dropdown

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Style overrides (especially the ones using internal component classnames) should be avoided as much as possible

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the `DropdownContentWrapper` component instead

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the site editor
- Visit the "Pattern" page
- Click on the cog icon, revealing the config dialog
- Make sure the dialog looks like on trunk

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-09-16 at 15 28 52](https://github.com/user-attachments/assets/9deda786-b958-4c21-b118-7979b7ca184b)
