### PR TITLE
Docs: Update the content of the API version 3 section in the Block API Reference

### DIFF
--- a/docs/reference-guides/block-api/block-api-versions.md
+++ b/docs/reference-guides/block-api/block-api-versions.md
@@ -3,7 +3,7 @@
 This document lists the changes made between the different API versions.
 
 ## Version 3 (>= WordPress 6.3)
-- The post editor will be iframed if all registered blocks have a Block API version 3 or higher and the editor has no classic meta boxes below the blocks. Adding version 3 support means that the block should work inside an iframe, though the block may still be rendered outside the iframe if not all blocks support version 3.
+- The post editor will be iframed if all registered blocks have a Block API version 3 or higher. Adding version 3 support means that the block should work inside an iframe, though the block may still be rendered outside the iframe if not all blocks support version 3.
 
 ## Version 2 (>= WordPress 5.6)
 


### PR DESCRIPTION
Follow-up #64351

## What?

As of #64351, the presence of the classic meta boxes is no longer a factor in determining whether the editor should run as an iframe. Basically, it's determined by whether all blocks are version 3 or not.

I'll update [the Block API Reference](https://github.com/WordPress/gutenberg/blob/c80fc61804e99268eec4441e2915b33368c30b18/docs/reference-guides/block-api/block-api-versions.md#version-3--wordpress-63) to comply with this specification.