### PR TITLE
Data Views list layout: revise for improved text truncation

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -262,7 +262,7 @@ function ListItem< Item >( {
 							spacing={ 1 }
 							className="dataviews-view-list__field-wrapper"
 						>
-							<HStack>
+							<HStack spacing={ 0 }>
 								<div
 									className="dataviews-view-list__primary-field"
 									id={ labelId }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useInstanceId, usePrevious } from '@wordpress/compose';
+import { useInstanceId, usePrevious, useRefEffect } from '@wordpress/compose';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -144,12 +144,14 @@ function ListItem< Item >( {
 	const labelId = `${ idPrefix }-label`;
 	const descriptionId = `${ idPrefix }-description`;
 
+	const [ actionsWidth, setActionsWidth ] = useState( 0 );
+	const measureActionsWidth = useRefEffect< HTMLElement >( ( node ) => {
+		setActionsWidth( node.offsetWidth );
+	}, [] );
 	const [ isHovered, setIsHovered ] = useState( false );
-	const handleMouseEnter = () => {
-		setIsHovered( true );
-	};
-	const handleMouseLeave = () => {
-		setIsHovered( false );
+	const handleHover: React.MouseEventHandler = ( { type } ) => {
+		const isHover = type === 'mouseenter';
+		setIsHovered( isHover );
 	};
 
 	useEffect( () => {
@@ -186,6 +188,10 @@ function ListItem< Item >( {
 	const renderedPrimaryField = primaryField?.render ? (
 		<primaryField.render item={ item } />
 	) : null;
+	const primaryFieldInlineStyle =
+		isHovered || isSelected
+			? { paddingInlineEnd: actionsWidth }
+			: undefined;
 
 	return (
 		<Composite.Row
@@ -196,8 +202,8 @@ function ListItem< Item >( {
 				'is-selected': isSelected,
 				'is-hovered': isHovered,
 			} ) }
-			onMouseEnter={ handleMouseEnter }
-			onMouseLeave={ handleMouseLeave }
+			onMouseEnter={ handleHover }
+			onMouseLeave={ handleHover }
 		>
 			<HStack
 				className="dataviews-view-list__item-wrapper"
@@ -230,6 +236,7 @@ function ListItem< Item >( {
 								<span
 									className="dataviews-view-list__primary-field"
 									id={ labelId }
+									style={ primaryFieldInlineStyle }
 								>
 									{ renderedPrimaryField }
 								</span>
@@ -267,6 +274,7 @@ function ListItem< Item >( {
 							flexShrink: '0',
 							width: 'auto',
 						} }
+						ref={ measureActionsWidth }
 					>
 						{ primaryAction && (
 							<PrimaryActionGridCell

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useInstanceId, usePrevious, useRefEffect } from '@wordpress/compose';
+import { useInstanceId, usePrevious } from '@wordpress/compose';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
@@ -144,10 +144,6 @@ function ListItem< Item >( {
 	const labelId = `${ idPrefix }-label`;
 	const descriptionId = `${ idPrefix }-description`;
 
-	const [ actionsWidth, setActionsWidth ] = useState( 0 );
-	const measureActionsWidth = useRefEffect< HTMLElement >( ( node ) => {
-		setActionsWidth( node.offsetWidth );
-	}, [] );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const handleHover: React.MouseEventHandler = ( { type } ) => {
 		const isHover = type === 'mouseenter';
@@ -188,10 +184,45 @@ function ListItem< Item >( {
 	const renderedPrimaryField = primaryField?.render ? (
 		<primaryField.render item={ item } />
 	) : null;
-	const primaryFieldInlineStyle =
-		isHovered || isSelected
-			? { paddingInlineEnd: actionsWidth }
-			: undefined;
+
+	const usedActions = eligibleActions?.length > 0 && (
+		<HStack spacing={ 3 } className="dataviews-view-list__item-actions">
+			{ primaryAction && (
+				<PrimaryActionGridCell
+					idPrefix={ idPrefix }
+					primaryAction={ primaryAction }
+					item={ item }
+				/>
+			) }
+			<div role="gridcell">
+				<DropdownMenu
+					trigger={
+						<Composite.Item
+							id={ generateDropdownTriggerCompositeId(
+								idPrefix
+							) }
+							render={
+								<Button
+									size="small"
+									icon={ moreVertical }
+									label={ __( 'Actions' ) }
+									accessibleWhenDisabled
+									disabled={ ! actions.length }
+									onKeyDown={ onDropdownTriggerKeyDown }
+								/>
+							}
+						/>
+					}
+					placement="bottom-end"
+				>
+					<ActionsDropdownMenuGroup
+						actions={ eligibleActions }
+						item={ item }
+					/>
+				</DropdownMenu>
+			</div>
+		</HStack>
+	);
 
 	return (
 		<Composite.Row
@@ -212,108 +243,58 @@ function ListItem< Item >( {
 			>
 				<div role="gridcell">
 					<Composite.Item
-						render={ <div /> }
-						role="button"
 						id={ generateItemWrapperCompositeId( idPrefix ) }
 						aria-pressed={ isSelected }
 						aria-labelledby={ labelId }
 						aria-describedby={ descriptionId }
 						className="dataviews-view-list__item"
 						onClick={ () => onSelect( item ) }
-					>
-						<HStack
-							spacing={ 3 }
-							justify="start"
-							alignment="flex-start"
-						>
-							<div className="dataviews-view-list__media-wrapper">
-								{ renderedMediaField }
-							</div>
-							<VStack
-								spacing={ 1 }
-								className="dataviews-view-list__field-wrapper"
-							>
-								<span
-									className="dataviews-view-list__primary-field"
-									id={ labelId }
-									style={ primaryFieldInlineStyle }
-								>
-									{ renderedPrimaryField }
-								</span>
-								<div
-									className="dataviews-view-list__fields"
-									id={ descriptionId }
-								>
-									{ visibleFields.map( ( field ) => (
-										<div
-											key={ field.id }
-											className="dataviews-view-list__field"
-										>
-											<VisuallyHidden
-												as="span"
-												className="dataviews-view-list__field-label"
-											>
-												{ field.label }
-											</VisuallyHidden>
-											<span className="dataviews-view-list__field-value">
-												<field.render item={ item } />
-											</span>
-										</div>
-									) ) }
-								</div>
-							</VStack>
-						</HStack>
-					</Composite.Item>
-				</div>
-				{ eligibleActions?.length > 0 && (
+					/>
 					<HStack
 						spacing={ 3 }
-						justify="flex-end"
-						className="dataviews-view-list__item-actions"
-						style={ {
-							flexShrink: '0',
-							width: 'auto',
-						} }
-						ref={ measureActionsWidth }
+						justify="start"
+						alignment="flex-start"
 					>
-						{ primaryAction && (
-							<PrimaryActionGridCell
-								idPrefix={ idPrefix }
-								primaryAction={ primaryAction }
-								item={ item }
-							/>
-						) }
-						<div role="gridcell">
-							<DropdownMenu
-								trigger={
-									<Composite.Item
-										id={ generateDropdownTriggerCompositeId(
-											idPrefix
-										) }
-										render={
-											<Button
-												size="small"
-												icon={ moreVertical }
-												label={ __( 'Actions' ) }
-												accessibleWhenDisabled
-												disabled={ ! actions.length }
-												onKeyDown={
-													onDropdownTriggerKeyDown
-												}
-											/>
-										}
-									/>
-								}
-								placement="bottom-end"
-							>
-								<ActionsDropdownMenuGroup
-									actions={ eligibleActions }
-									item={ item }
-								/>
-							</DropdownMenu>
+						<div className="dataviews-view-list__media-wrapper">
+							{ renderedMediaField }
 						</div>
+						<VStack
+							spacing={ 1 }
+							className="dataviews-view-list__field-wrapper"
+						>
+							<HStack>
+								<div
+									className="dataviews-view-list__primary-field"
+									id={ labelId }
+								>
+									{ renderedPrimaryField }
+								</div>
+								{ usedActions }
+							</HStack>
+							<div
+								className="dataviews-view-list__fields"
+								id={ descriptionId }
+							>
+								{ visibleFields.map( ( field ) => (
+									<div
+										key={ field.id }
+										className="dataviews-view-list__field"
+									>
+										<VisuallyHidden
+											as="span"
+											className="dataviews-view-list__field-label"
+										>
+											{ field.label }
+										</VisuallyHidden>
+										<span className="dataviews-view-list__field-value">
+											<field.render item={ item } />
+										</span>
+									</div>
+								) ) }
+							</div>
+						</VStack>
 					</HStack>
-				) }
+				</div>
 			</HStack>
 		</Composite.Row>
 	);

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -236,11 +236,7 @@ function ListItem< Item >( {
 			onMouseEnter={ handleHover }
 			onMouseLeave={ handleHover }
 		>
-			<HStack
-				className="dataviews-view-list__item-wrapper"
-				alignment="center"
-				spacing={ 0 }
-			>
+			<HStack className="dataviews-view-list__item-wrapper" spacing={ 0 }>
 				<div role="gridcell">
 					<Composite.Item
 						id={ generateItemWrapperCompositeId( idPrefix ) }
@@ -250,51 +246,47 @@ function ListItem< Item >( {
 						className="dataviews-view-list__item"
 						onClick={ () => onSelect( item ) }
 					/>
-					<HStack
-						spacing={ 3 }
-						justify="start"
-						alignment="flex-start"
-					>
-						<div className="dataviews-view-list__media-wrapper">
-							{ renderedMediaField }
-						</div>
-						<VStack
-							spacing={ 1 }
-							className="dataviews-view-list__field-wrapper"
-						>
-							<HStack spacing={ 0 }>
-								<div
-									className="dataviews-view-list__primary-field"
-									id={ labelId }
-								>
-									{ renderedPrimaryField }
-								</div>
-								{ usedActions }
-							</HStack>
-							<div
-								className="dataviews-view-list__fields"
-								id={ descriptionId }
-							>
-								{ visibleFields.map( ( field ) => (
-									<div
-										key={ field.id }
-										className="dataviews-view-list__field"
-									>
-										<VisuallyHidden
-											as="span"
-											className="dataviews-view-list__field-label"
-										>
-											{ field.label }
-										</VisuallyHidden>
-										<span className="dataviews-view-list__field-value">
-											<field.render item={ item } />
-										</span>
-									</div>
-								) ) }
-							</div>
-						</VStack>
-					</HStack>
 				</div>
+				<HStack spacing={ 3 } justify="start" alignment="flex-start">
+					<div className="dataviews-view-list__media-wrapper">
+						{ renderedMediaField }
+					</div>
+					<VStack
+						spacing={ 1 }
+						className="dataviews-view-list__field-wrapper"
+					>
+						<HStack spacing={ 0 }>
+							<div
+								className="dataviews-view-list__primary-field"
+								id={ labelId }
+							>
+								{ renderedPrimaryField }
+							</div>
+							{ usedActions }
+						</HStack>
+						<div
+							className="dataviews-view-list__fields"
+							id={ descriptionId }
+						>
+							{ visibleFields.map( ( field ) => (
+								<div
+									key={ field.id }
+									className="dataviews-view-list__field"
+								>
+									<VisuallyHidden
+										as="span"
+										className="dataviews-view-list__field-label"
+									>
+										{ field.label }
+									</VisuallyHidden>
+									<span className="dataviews-view-list__field-value">
+										<field.render item={ item } />
+									</span>
+								</div>
+							) ) }
+						</div>
+					</VStack>
+				</HStack>
 			</HStack>
 		</Composite.Row>
 	);

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -45,22 +45,13 @@ ul.dataviews-view-list {
 		&.is-hovered,
 		&:focus-within {
 			.dataviews-view-list__item-actions {
-				background: #f8f8f8;
 				padding-left: $grid-unit-10;
 				margin-right: $grid-unit-30;
-				box-shadow: -12px 0 8px 0 #f8f8f8;
 
 				.components-button {
 					opacity: 1;
 					position: static;
 				}
-			}
-		}
-
-		&.is-selected {
-			.dataviews-view-list__item-actions {
-				background-color: rgb(247 248 255);
-				box-shadow: -12px 0 8px 0 rgb(247 248 255);
 			}
 		}
 

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -23,6 +23,8 @@ ul.dataviews-view-list {
 			position: absolute;
 			top: $grid-unit-20;
 			right: 0;
+			// Pads __primary-field’s text truncation on hover (done in JS; see ./index.tsx).
+			padding-inline-start: $grid-unit-10;
 
 
 			> div {
@@ -45,7 +47,6 @@ ul.dataviews-view-list {
 		&.is-hovered,
 		&:focus-within {
 			.dataviews-view-list__item-actions {
-				padding-left: $grid-unit-10;
 				margin-right: $grid-unit-30;
 
 				.components-button {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -13,10 +13,6 @@ ul.dataviews-view-list {
 		.dataviews-view-list__item-wrapper {
 			position: relative;
 			padding: $grid-unit-20 $grid-unit-30;
-
-			> * {
-				width: 100%;
-			}
 		}
 
 		.dataviews-view-list__item-actions {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -39,6 +39,7 @@ ul.dataviews-view-list {
 			.dataviews-view-list__item-actions {
 				flex-basis: min-content;
 				overflow: unset;
+				margin-inline: $grid-unit-10 0;
 
 				.components-button {
 					opacity: 1;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -13,6 +13,7 @@ ul.dataviews-view-list {
 		.dataviews-view-list__item-wrapper {
 			position: relative;
 			border-radius: $grid-unit-05;
+			padding: $grid-unit-20 $grid-unit-30;
 
 			> * {
 				width: 100%;
@@ -20,38 +21,27 @@ ul.dataviews-view-list {
 		}
 
 		.dataviews-view-list__item-actions {
-			position: absolute;
-			top: $grid-unit-20;
-			right: 0;
-			// Pads __primary-field’s text truncation on hover (done in JS; see ./index.tsx).
-			padding-inline-start: $grid-unit-10;
-
+			flex: 0;
+			overflow: hidden;
 
 			> div {
 				height: $button-size-small;
 			}
 
 			.components-button {
+				position: relative;
+				z-index: 1;
 				opacity: 0;
 			}
 		}
 
-		&:has(.dataviews-view-list__fields:empty) {
+		&:where(.is-selected, .is-hovered, :focus-within) {
 			.dataviews-view-list__item-actions {
-				top: 50%;
-				transform: translateY(-50%);
-			}
-		}
-
-		&.is-selected,
-		&.is-hovered,
-		&:focus-within {
-			.dataviews-view-list__item-actions {
-				margin-right: $grid-unit-30;
+				flex-basis: min-content;
+				overflow: unset;
 
 				.components-button {
 					opacity: 1;
-					position: static;
 				}
 			}
 		}
@@ -97,28 +87,33 @@ ul.dataviews-view-list {
 	}
 
 	.dataviews-view-list__item {
-		box-sizing: border-box;
-		padding: $grid-unit-20 $grid-unit-30;
-		width: 100%;
+		position: absolute;
+		inset: 0;
 		scroll-margin: $grid-unit-10 0;
+		appearance: none;
+		border: none;
+		background: none;
+		padding: 0;
 
 		&:focus-visible {
+			outline: none;
+
 			&::before {
 				position: absolute;
 				content: "";
-				top: var(--wp-admin-border-width-focus);
-				right: var(--wp-admin-border-width-focus);
-				bottom: var(--wp-admin-border-width-focus);
-				left: var(--wp-admin-border-width-focus);
+				inset: var(--wp-admin-border-width-focus);
 				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 				border-radius: $radius-small;
+				// Windows High Contrast mode will show this outline, but not the box-shadow.
+				outline: 2px solid transparent;
 			}
 		}
-		.dataviews-view-list__primary-field {
-			min-height: $grid-unit-30;
-			line-height: $grid-unit-30;
-			overflow: hidden;
-		}
+	}
+	.dataviews-view-list__primary-field {
+		flex: 1;
+		min-height: $grid-unit-30;
+		line-height: $grid-unit-30;
+		overflow: hidden;
 	}
 
 	.dataviews-view-list__media-wrapper {
@@ -156,6 +151,7 @@ ul.dataviews-view-list {
 
 	.dataviews-view-list__field-wrapper {
 		min-height: $grid-unit-05 * 13; // Ensures title is centrally aligned when all fields are hidden
+		flex-grow: 1;
 	}
 
 	.dataviews-view-list__fields {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -12,7 +12,6 @@ ul.dataviews-view-list {
 
 		.dataviews-view-list__item-wrapper {
 			position: relative;
-			border-radius: $grid-unit-05;
 			padding: $grid-unit-20 $grid-unit-30;
 
 			> * {

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -7,7 +7,6 @@ ul.dataviews-view-list {
 
 	li {
 		margin: 0;
-		cursor: pointer;
 		border-top: 1px solid $gray-100;
 
 		.dataviews-view-list__item-wrapper {
@@ -84,12 +83,14 @@ ul.dataviews-view-list {
 
 	.dataviews-view-list__item {
 		position: absolute;
+		z-index: 1;
 		inset: 0;
 		scroll-margin: $grid-unit-10 0;
 		appearance: none;
 		border: none;
 		background: none;
 		padding: 0;
+		cursor: pointer;
 
 		&:focus-visible {
 			outline: none;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -111,6 +111,10 @@ ul.dataviews-view-list {
 		min-height: $grid-unit-30;
 		line-height: $grid-unit-30;
 		overflow: hidden;
+		// The field should be in front of the main button in case it has a link/button.
+		&:has(a, button) {
+			z-index: 1;
+		}
 	}
 
 	.dataviews-view-list__media-wrapper {

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -235,12 +235,7 @@ test.describe( 'Site Editor Performance', () => {
 				}
 
 				await metrics.startTracing();
-				await page
-					.getByRole( 'button', {
-						name: 'Single Posts',
-						exact: true,
-					} )
-					.click();
+				await page.getByText( 'Single Posts', { exact: true } ).click();
 				await metrics.stopTracing();
 
 				// Get the durations.

--- a/test/performance/specs/site-editor.spec.js
+++ b/test/performance/specs/site-editor.spec.js
@@ -235,7 +235,12 @@ test.describe( 'Site Editor Performance', () => {
 				}
 
 				await metrics.startTracing();
-				await page.getByText( 'Single Posts', { exact: true } ).click();
+				await page
+					.getByRole( 'button', {
+						name: 'Single Posts',
+						exact: true,
+					} )
+					.click();
 				await metrics.stopTracing();
 
 				// Get the durations.


### PR DESCRIPTION
## What?
A revision of markup and style.

## Why?
To fix #65215.

The list layout design is tricky to implement—particularly, its hover/focus/selected states. The current layout trick relies on an opaque layer to further "truncate" the title text while hovered/selected/focused. Right now, there doesn’t seem to be a way to avoid the hardcoded colors while retaining the current layout trick.

The approach in this PR avoids hardcoded colors. Besides that, I think it’s nicer that the ellipsis remain visible in all states.

## How?
Makes the actions (`__item-actions`) a sibling of the title (`__primary_field`) so when the latter appears, the former truncates as much as needed. This is permitted by making the item’s primary button absolutely positioned and moving its contents out to avoid buttons or other `gridcell` roles from nesting.

## Testing Instructions
Inspect/scrutinize all interactions with the list view in all contexts (viewing templates/pages/patterns) and with all "View options" combinations of available properties visible/hidden

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|--------|--------|
| <img width="411" alt="list-layout-before" src="https://github.com/user-attachments/assets/48e1d8a4-c9c3-4f20-95ab-ea09aecd40b9"> | <img width="411" alt="list-layout-after" src="https://github.com/user-attachments/assets/81d65f17-afb5-4ce6-8678-351232715777"> |

### Overlaid before and after to verify preserved metrics

https://github.com/user-attachments/assets/3edb08b1-a1c6-4ab8-a9bb-3cf89f79fab9

