### PR TITLE
Rename edit-post__fade-in-animation and unify keyframe definitions

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -1,4 +1,20 @@
+@mixin keyframes($name) {
+	@keyframes #{$name} {
+		@content;
+	}
+}
+
 @mixin edit-post__fade-in-animation($speed: 0.08s, $delay: 0s) {
+	@include keyframes(edit-post__fade-in-animation) {
+		from {
+			opacity: 0;
+		}
+		to {
+			opacity: 1;
+		}
+	}
+
+
 	animation: edit-post__fade-in-animation $speed linear $delay;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");

--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -4,8 +4,8 @@
 	}
 }
 
-@mixin edit-post__fade-in-animation($speed: 0.08s, $delay: 0s) {
-	@include keyframes(edit-post__fade-in-animation) {
+@mixin animation__fade-in($speed: 0.08s, $delay: 0s) {
+	@include keyframes(__wp-base-styles-fade-in) {
 		from {
 			opacity: 0;
 		}
@@ -15,7 +15,7 @@
 	}
 
 
-	animation: edit-post__fade-in-animation $speed linear $delay;
+	animation: __wp-base-styles-fade-in $speed linear $delay;
 	animation-fill-mode: forwards;
 	@include reduce-motion("animation");
 }
@@ -23,4 +23,10 @@
 @mixin editor-canvas-resize-animation() {
 	transition: all 0.5s cubic-bezier(0.65, 0, 0.45, 1);
 	@include reduce-motion("transition");
+}
+
+// Deprecated
+@mixin edit-post__fade-in-animation($speed: 0.08s, $delay: 0s) {
+	@warn "The `edit-post__fade-in-animation` mixin is deprecated. Use `animation__fade-in` instead.";
+	@include animation__fade-in($speed, $delay);
 }

--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -20,6 +20,22 @@
 	@include reduce-motion("animation");
 }
 
+@mixin animation__fade-out($speed: 0.08s, $delay: 0s) {
+	@include keyframes(__wp-base-styles-fade-out) {
+		from {
+			opacity: 1;
+		}
+		to {
+			opacity: 0;
+		}
+	}
+
+
+	animation: __wp-base-styles-fade-out $speed linear $delay;
+	animation-fill-mode: forwards;
+	@include reduce-motion("animation");
+}
+
 @mixin editor-canvas-resize-animation() {
 	transition: all 0.5s cubic-bezier(0.65, 0, 0.45, 1);
 	@include reduce-motion("transition");

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -272,7 +272,7 @@
 
 	&.is-visible .block-editor-list-view-block-contents {
 		opacity: 1;
-		@include edit-post__fade-in-animation;
+		@include animation__fade-in;
 	}
 
 	.block-editor-block-icon {

--- a/packages/block-editor/src/utils/test/transform-styles.js
+++ b/packages/block-editor/src/utils/test/transform-styles.js
@@ -293,7 +293,7 @@ describe( 'transformStyles', () => {
 
 		it( 'should ignore keyframes', () => {
 			const input = `
-			@keyframes edit-post__fade-in-animation {
+			@keyframes __wp-base-styles-fade-in {
 				from {
 					opacity: 0;
 				}

--- a/packages/components/src/modal/style.scss
+++ b/packages/components/src/modal/style.scss
@@ -8,8 +8,8 @@
 	background-color: rgba($black, 0.35);
 	z-index: z-index(".components-modal__screen-overlay");
 	display: flex;
-	// This animates the appearance of the white background.
-	@include edit-post__fade-in-animation();
+	// This animates the appearance of the backdrop.
+	@include animation__fade-in();
 }
 
 // The modal window element.

--- a/packages/edit-post/src/style.scss
+++ b/packages/edit-post/src/style.scss
@@ -3,22 +3,6 @@
 @import "./components/meta-boxes/meta-boxes-area/style.scss";
 @import "./components/welcome-guide/style.scss";
 
-/**
- * Animations
- */
-
-// These keyframes should not be part of the _animations.scss mixins file.
-// Because keyframe animations can't be defined as mixins properly, they are duplicated.
-// Since hey are intended only for the editor, we add them here instead.
-@keyframes edit-post__fade-in-animation {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}
-
 body.js.block-editor-page {
 	@include wp-admin-reset( ".block-editor" );
 }

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -91,20 +91,4 @@ body.js.site-editor-php {
 	}
 }
 
-/**
- * Animations
- */
-
-// These keyframes should not be part of the _animations.scss mixins file.
-// Because keyframe animations can't be defined as mixins properly, they are duplicated.
-// Since they are intended only for the editor, we add them here instead.
-@keyframes edit-post__fade-in-animation {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}
-
 @include wordpress-admin-schemes();

--- a/storybook/stories/playground/fullpage/style.lazy.scss
+++ b/storybook/stories/playground/fullpage/style.lazy.scss
@@ -46,19 +46,3 @@
 		display: block;
 	}
 }
-
-/**
- * Animations
- */
-
-// These keyframes should not be part of the _animations.scss mixins file.
-// Because keyframe animations can't be defined as mixins properly, they are duplicated.
-// Since hey are intended only for the editor, we add them here instead.
-@keyframes edit-post__fade-in-animation {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
-	}
-}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #65203

Rename the `edit-post__fade-in-animation` to a more generic name (deprecating the previous name), unify underlying keyframe definitions to be under the same package, and add an equivalent "fade out" mixin.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/64580#discussion_r1751728630

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- renamed `edit-post__fade-in-animation` to `animation__fade-in`, deprecated old name
- moved fade in keyframes definition to the same package as the animation mixin (yes, there could be duplication in the output — but IMO it's better to trade off some redundancy if we can get rid off circular dependencies & we don't get the animation keyframes defined across multiple packages.
- added the fade out equivalent, `animation__fade-out`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Make sure that the `Modal` component's enter animation (fade in) works as on trunk, both in Storybook and across various parts of Gutenberg.
