### PR TITLE
Image cropping: skip making an API request if there are no changes to apply

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -54,6 +54,13 @@ export default function useSaveImage( {
 			} );
 		}
 
+		if ( modifiers.length === 0 ) {
+			// No changes to apply.
+			setIsInProgress( false );
+			onFinishEditing();
+			return;
+		}
+
 		apiFetch( {
 			path: `/wp/v2/media/${ id }/edit`,
 			method: 'POST',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: https://github.com/WordPress/gutenberg/issues/65383

Skip making an API request to edit an image if there are no changes to make.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #65383, making a request to edit without any edits results in an error appearing. This PR proposes skipping performing an action, so that clicking Apply when there are no changes to make is the equivalent of cancelling.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Reset the state and return early if there are no changes to be made while cropping

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add an image block
2. On trunk, if you click to starting cropping and make no changes, then after you click Apply there'll be an error
3. With this PR applied, there'll be no error
4. Double-check that cropping and rotating otherwise works correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/347010e1-4750-419e-9b84-73744df543b0

### After

https://github.com/user-attachments/assets/3be4af1b-a0eb-4060-81ea-40473c6ad3a0



