### PR TITLE
Tabs: fix vertical indicator

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Tabs`: restore vertical indicator ([#65385](https://github.com/WordPress/gutenberg/pull/65385)).
 -   `Tabs`: indicator positioning under RTL direction ([#64926](https://github.com/WordPress/gutenberg/pull/64926)).
 -   `Popover`: Update `toolbar` variant radius to match block toolbar ([#65263](https://github.com/WordPress/gutenberg/pull/65263)).
 

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -76,7 +76,7 @@ export const TabListWrapper = styled.div`
 		top: 0;
 		left: 0;
 		width: 100%;
-		width: calc( var( --antialiasing-factor ) * 1px );
+		height: calc( var( --antialiasing-factor ) * 1px );
 		transform: translateY( calc( var( --indicator-top ) * 1px ) )
 			scaleY(
 				calc( var( --indicator-height ) / var( --antialiasing-factor ) )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix a regressiong that caused the vertical indicator to disappear.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

It was a typo. My bad!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try vertical tabs in the Storybook.

## Screenshots or screencast <!-- if applicable -->

Before:

![{951FD2C5-919D-4150-A7DE-382BDF31FFCA}](https://github.com/user-attachments/assets/ba60b2cb-5a67-4c31-810a-33731b36f45d)

After:

![{F2625813-1207-4161-A204-7887C6B78161}](https://github.com/user-attachments/assets/9637f744-8695-44aa-a2d3-641683e07ac3)

