### PR TITLE
Add prompt to zoom out separator

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -414,7 +414,8 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	font-size: 1.5em;
+	font-size: $default-font-size;
+	font-family: $default-font;
 
 	&.is-dragged-over {
 		background: $gray-400;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -411,6 +411,10 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	margin-left: -1px;
 	margin-right: -1px;
 	transition: background-color 0.3s ease;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-size: 1.5em;
 
 	&.is-dragged-over {
 		background: $gray-400;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -417,6 +417,11 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	font-size: $default-font-size;
 	font-family: $default-font;
 
+	.is-zoomed-out & {
+		// Scale the font size based on the zoom level.
+		font-size: calc(#{$default-font-size} * ( 2 - var(--wp-block-editor-iframe-zoom-out-scale)  ));
+	}
+
 	&.is-dragged-over {
 		background: $gray-400;
 	}

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -416,6 +416,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	justify-content: center;
 	font-size: $default-font-size;
 	font-family: $default-font;
+	color: $black;
 	font-weight: normal;
 
 	.is-zoomed-out & {

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -416,6 +416,7 @@ _::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-b
 	justify-content: center;
 	font-size: $default-font-size;
 	font-family: $default-font;
+	font-weight: normal;
 
 	.is-zoomed-out & {
 		// Scale the font size based on the zoom level.

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -13,6 +13,7 @@ import {
 import { useReducedMotion } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -103,7 +104,9 @@ export function ZoomOutSeparator( {
 					data-is-insertion-point="true"
 					onDragOver={ () => setIsDraggedOver( true ) }
 					onDragLeave={ () => setIsDraggedOver( false ) }
-				></motion.div>
+				>
+					{ __( 'Drag and drop a pattern.' ) }
+				</motion.div>
 			) }
 		</AnimatePresence>
 	);

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -114,9 +114,7 @@ export function ZoomOutSeparator( {
 							duration: 0.1,
 						} }
 					>
-						{ isDraggedOver
-							? __( 'Drop pattern.' )
-							: __( 'Insert a pattern here.' ) }
+						{ __( 'Drop pattern.' ) }
 					</motion.div>
 				</motion.div>
 			) }

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -105,7 +105,19 @@ export function ZoomOutSeparator( {
 					onDragOver={ () => setIsDraggedOver( true ) }
 					onDragLeave={ () => setIsDraggedOver( false ) }
 				>
-					{ __( 'Drag and drop a pattern.' ) }
+					<motion.div
+						initial={ { opacity: 0 } }
+						animate={ { opacity: 1 } }
+						exit={ { opacity: 0 } }
+						transition={ {
+							type: 'tween',
+							duration: 0.1,
+						} }
+					>
+						{ isDraggedOver
+							? __( 'Drop pattern.' )
+							: __( 'Insert a pattern here.' ) }
+					</motion.div>
 				</motion.div>
 			) }
 		</AnimatePresence>

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ The Gutenberg plugin adds editing, customization, and site building to WordPress
 
 Following the introduction of post block editing in December 2018, Gutenberg later introduced full site editing (FSE) in 2021, <a href="https://wordpress.org/news/2022/01/josephine/">which shipped with WordPress 5.9 in early 2022</a>.
 
-### What Does Gutenberg Do ?
+### What Does Gutenberg Do?
 
 Gutenberg is WordPress's “block editor”, and introduces a modular approach to modifying your entire site. Edit individual content blocks on posts or pages. Add and adjust widgets. Even design your site headers, footers, and navigation with full site editing support.
 

--- a/readme.txt
+++ b/readme.txt
@@ -13,7 +13,7 @@ The Gutenberg plugin adds editing, customization, and site building to WordPress
 
 Following the introduction of post block editing in December 2018, Gutenberg later introduced full site editing (FSE) in 2021, <a href="https://wordpress.org/news/2022/01/josephine/">which shipped with WordPress 5.9 in early 2022</a>.
 
-### What Does Gutenberg Do?
+### What Does Gutenberg Do ?
 
 Gutenberg is WordPress's “block editor”, and introduces a modular approach to modifying your entire site. Edit individual content blocks on posts or pages. Add and adjust widgets. Even design your site headers, footers, and navigation with full site editing support.
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a user prompt to "drag and drop patterns" to Zoom Out separators.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To encourage users to inserter patterns / drag and drop into the canvas.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds prompt.

I fully expect this will need design input

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable experiment
- Engage Zoom Out
- Click Inserter
- See prompt

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="2998" alt="Screen Shot 2024-09-17 at 09 52 15" src="https://github.com/user-attachments/assets/3a188ecd-fbc9-473b-b01c-2c39ecbe341b">
