### PR TITLE
Hide block transforms in contentOnly mode for non-content blocks

### DIFF
--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -142,11 +142,19 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 	const { activeBlockVariation, variations, isContentOnly } = useSelect(
 		( select ) => {
-			const { getActiveBlockVariation, getBlockVariations } =
-				select( blocksStore );
+			const {
+				getActiveBlockVariation,
+				getBlockVariations,
+				__experimentalHasContentRoleAttribute,
+			} = select( blocksStore );
 			const { getBlockName, getBlockAttributes, getBlockEditingMode } =
 				select( blockEditorStore );
+
 			const name = blockClientId && getBlockName( blockClientId );
+
+			const isContentBlock =
+				__experimentalHasContentRoleAttribute( name );
+
 			return {
 				activeBlockVariation: getActiveBlockVariation(
 					name,
@@ -154,7 +162,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 				),
 				variations: name && getBlockVariations( name, 'transform' ),
 				isContentOnly:
-					getBlockEditingMode( blockClientId ) === 'contentOnly',
+					getBlockEditingMode( blockClientId ) === 'contentOnly' &&
+					! isContentBlock,
 			};
 		},
 		[ blockClientId ]

--- a/packages/block-editor/src/components/block-variation-transforms/index.js
+++ b/packages/block-editor/src/components/block-variation-transforms/index.js
@@ -140,11 +140,11 @@ function VariationsToggleGroupControl( {
 
 function __experimentalBlockVariationTransforms( { blockClientId } ) {
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-	const { activeBlockVariation, variations } = useSelect(
+	const { activeBlockVariation, variations, isContentOnly } = useSelect(
 		( select ) => {
 			const { getActiveBlockVariation, getBlockVariations } =
 				select( blocksStore );
-			const { getBlockName, getBlockAttributes } =
+			const { getBlockName, getBlockAttributes, getBlockEditingMode } =
 				select( blockEditorStore );
 			const name = blockClientId && getBlockName( blockClientId );
 			return {
@@ -153,6 +153,8 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 					getBlockAttributes( blockClientId )
 				),
 				variations: name && getBlockVariations( name, 'transform' ),
+				isContentOnly:
+					getBlockEditingMode( blockClientId ) === 'contentOnly',
 			};
 		},
 		[ blockClientId ]
@@ -181,8 +183,7 @@ function __experimentalBlockVariationTransforms( { blockClientId } ) {
 		} );
 	};
 
-	// Skip rendering if there are no variations
-	if ( ! variations?.length ) {
+	if ( ! variations?.length || isContentOnly ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hides any block transforms when block is in `contentOnly` block editing mode and it is not a "content" block.

Related https://github.com/WordPress/gutenberg/pull/65396

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The user should be focused on content not on transforming. Removes additional UI noise.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Returns early from relevant component based on the mode. This is to avoid having to re-render the inspector controls entirely by adding a subscription to `getBlockEditingMode` which runs often.



## Concerns

- Is this to prescriptive? We should check carefully whether there are situations where transforms are necessary even in `contentOnly`. I'm thinking about the Social Icons block or the Navigation block for example.
- Is this performant?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Select Group block
- Open dev tools console
- Type the following to set the _selected_ block to `contentOnly`:
```
wp.data.dispatch('core/block-editor').setBlockEditingMode( wp.data.select('core/block-editor').getSelectedBlockClientId(), 'contentOnly' )
```
- Check transform UI does not show in inspector controls.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/502ad55d-eda6-41e1-8097-dc5d4f9ccbac

