### PR TITLE
Fixed the focus cutoff of the editor buttons in the widgets editor

### DIFF
--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -82,7 +82,7 @@
 	padding-right: $grid-unit-10;
 	padding-left: $grid-unit-20;
 	overflow: hidden;
-	height: 60px;
+	height: $header-height;
 }
 
 .edit-widgets-header__title {

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -81,7 +81,6 @@
 	flex-shrink: 2;
 	padding-right: $grid-unit-10;
 	padding-left: $grid-unit-20;
-	overflow: hidden;
 }
 
 .edit-widgets-header__title {

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -81,6 +81,8 @@
 	flex-shrink: 2;
 	padding-right: $grid-unit-10;
 	padding-left: $grid-unit-20;
+	overflow: hidden;
+	height: 60px;
 }
 
 .edit-widgets-header__title {


### PR DESCRIPTION
## What?
I found that the focus ring of the editor buttons in the header is cut off in the widgets editor.

## Why?
This PR resolves the issue:- https://github.com/WordPress/gutenberg/issues/65393

## How?
Removed the CSS property overflow:hidden to resolve the issue.

## Testing Instructions
1)  Activate the Twenty Twenty one theme
2) Then navigate to the widgets under appearance section
3) move the cursor to the editor buttons as shown in screenshot
4) you could see that the focus box is not cutting off

![outline-issue](https://github.com/user-attachments/assets/a71db353-92ed-4a19-bc13-f0353eba9bdc) 