### PR TITLE
Make sections `contentOnly` in Zoom Out

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2926,6 +2926,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			if ( clientId === null ) {
 				clientId = '';
 			}
+
 			// In zoom-out mode, override the behavior set by
 			// __unstableSetBlockEditingMode to only allow editing the top-level
 			// sections.
@@ -2943,9 +2944,13 @@ export const getBlockEditingMode = createRegistrySelector(
 					state,
 					sectionRootClientId
 				);
-				if ( ! sectionsClientIds?.includes( clientId ) ) {
-					return 'disabled';
+
+				// Sections are always contentOnly.
+				if ( sectionsClientIds?.includes( clientId ) ) {
+					return 'contentOnly';
 				}
+
+				return 'disabled';
 			}
 
 			const blockEditingMode = state.blockEditingModes.get( clientId );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Makes all section blocks `contentOnly` in Zoom Out mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Removing unnecessary UI and cleaning up the interface to focus on the content. Also ensures things like transforms are hidden once https://github.com/WordPress/gutenberg/pull/65394 is merged.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Returns `contentOnly` from the `getBlockEditingMode` selector for sections when in zoom out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Enable Zoom Out experiment
- Site Editor
- Select a Section 
- Open dev tools console and run:
```
wp.data.select('core/block-editor').getBlockEditingMode( wp.data.select('core/block-editor').getSelectedBlockClientId() )
```
- The result should be `contentOnly`.
- Also visually verify the block is in contentOnly mode.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
