### PR TITLE
DataForm - Add combined fields support

### DIFF
--- a/packages/dataviews/src/components/dataform-combined-edit/index.tsx
+++ b/packages/dataviews/src/components/dataform-combined-edit/index.tsx
@@ -39,14 +39,13 @@ function DataFormCombinedEdit< Item >( {
 			( childField ): childField is NormalizedField< Item > =>
 				!! childField
 		);
-	const children = visibleChildren.map( ( child, index ) => {
+	const children = visibleChildren.map( ( child ) => {
 		return (
 			<div className="dataforms-combined-edit__field" key={ child.id }>
 				<child.Edit
 					data={ data }
 					field={ child }
 					onChange={ onChange }
-					hideLabelFromVision={ hideLabelFromVision && index === 0 }
 				/>
 			</div>
 		);

--- a/packages/dataviews/src/components/dataform-combined-edit/index.tsx
+++ b/packages/dataviews/src/components/dataform-combined-edit/index.tsx
@@ -13,12 +13,9 @@ import {
  */
 import type { DataFormCombinedEditProps, NormalizedField } from '../../types';
 
-function FieldHeader( { title }: { title: string } ) {
+function Header( { title }: { title: string } ) {
 	return (
-		<VStack
-			className="dataforms-layouts-panel__dropdown-header"
-			spacing={ 4 }
-		>
+		<VStack className="dataforms-layouts__dropdown-header" spacing={ 4 }>
 			<HStack alignment="center">
 				<Heading level={ 2 } size={ 13 }>
 					{ title }
@@ -33,6 +30,7 @@ function DataFormCombinedEdit< Item >( {
 	field,
 	data,
 	onChange,
+	hideLabelFromVision,
 }: DataFormCombinedEditProps< Item > ) {
 	const className = 'dataforms-combined-edit';
 	const visibleChildren = ( field.children ?? [] )
@@ -44,28 +42,28 @@ function DataFormCombinedEdit< Item >( {
 	const children = visibleChildren.map( ( child, index ) => {
 		return (
 			<div className="dataforms-combined-edit__field" key={ child.id }>
-				{ index !== 0 && <FieldHeader title={ child.label } /> }
+				{ index !== 0 && hideLabelFromVision && (
+					<Header title={ child.label } />
+				) }
 				<child.Edit
 					data={ data }
 					field={ child }
 					onChange={ onChange }
-					hideLabelFromVision
+					hideLabelFromVision={ hideLabelFromVision }
 				/>
 			</div>
 		);
 	} );
 
-	if ( field.direction === 'horizontal' ) {
-		return (
-			<HStack spacing={ 4 } className={ className }>
-				{ children }
-			</HStack>
-		);
-	}
+	const Stack = field.direction === 'horizontal' ? HStack : VStack;
+
 	return (
-		<VStack spacing={ 4 } className={ className }>
-			{ children }
-		</VStack>
+		<>
+			{ ! hideLabelFromVision && <Header title={ field.label } /> }
+			<Stack spacing={ 4 } className={ className }>
+				{ children }
+			</Stack>
+		</>
 	);
 }
 

--- a/packages/dataviews/src/components/dataform-combined-edit/index.tsx
+++ b/packages/dataviews/src/components/dataform-combined-edit/index.tsx
@@ -1,0 +1,72 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalHeading as Heading,
+	__experimentalSpacer as Spacer,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { DataFormCombinedEditProps, NormalizedField } from '../../types';
+
+function FieldHeader( { title }: { title: string } ) {
+	return (
+		<VStack
+			className="dataforms-layouts-panel__dropdown-header"
+			spacing={ 4 }
+		>
+			<HStack alignment="center">
+				<Heading level={ 2 } size={ 13 }>
+					{ title }
+				</Heading>
+				<Spacer />
+			</HStack>
+		</VStack>
+	);
+}
+
+function DataFormCombinedEdit< Item >( {
+	field,
+	data,
+	onChange,
+}: DataFormCombinedEditProps< Item > ) {
+	const className = 'dataforms-combined-edit';
+	const visibleChildren = ( field.children ?? [] )
+		.map( ( fieldId ) => field.fields.find( ( { id } ) => id === fieldId ) )
+		.filter(
+			( childField ): childField is NormalizedField< Item > =>
+				!! childField
+		);
+	const children = visibleChildren.map( ( child, index ) => {
+		return (
+			<div className="dataforms-combined-edit__field" key={ child.id }>
+				{ index !== 0 && <FieldHeader title={ child.label } /> }
+				<child.Edit
+					data={ data }
+					field={ child }
+					onChange={ onChange }
+					hideLabelFromVision
+				/>
+			</div>
+		);
+	} );
+
+	if ( field.direction === 'horizontal' ) {
+		return (
+			<HStack spacing={ 4 } className={ className }>
+				{ children }
+			</HStack>
+		);
+	}
+	return (
+		<VStack spacing={ 4 } className={ className }>
+			{ children }
+		</VStack>
+	);
+}
+
+export default DataFormCombinedEdit;

--- a/packages/dataviews/src/components/dataform-combined-edit/index.tsx
+++ b/packages/dataviews/src/components/dataform-combined-edit/index.tsx
@@ -57,7 +57,7 @@ function DataFormCombinedEdit< Item >( {
 	return (
 		<>
 			{ ! hideLabelFromVision && <Header title={ field.label } /> }
-			<Stack spacing={ 4 } className={ className }>
+			<Stack spacing={ 4 } className={ className } as="fieldset">
 				{ children }
 			</Stack>
 		</>

--- a/packages/dataviews/src/components/dataform-combined-edit/index.tsx
+++ b/packages/dataviews/src/components/dataform-combined-edit/index.tsx
@@ -42,14 +42,11 @@ function DataFormCombinedEdit< Item >( {
 	const children = visibleChildren.map( ( child, index ) => {
 		return (
 			<div className="dataforms-combined-edit__field" key={ child.id }>
-				{ index !== 0 && hideLabelFromVision && (
-					<Header title={ child.label } />
-				) }
 				<child.Edit
 					data={ data }
 					field={ child }
 					onChange={ onChange }
-					hideLabelFromVision={ hideLabelFromVision }
+					hideLabelFromVision={ hideLabelFromVision && index === 0 }
 				/>
 			</div>
 		);

--- a/packages/dataviews/src/components/dataform-combined-edit/style.scss
+++ b/packages/dataviews/src/components/dataform-combined-edit/style.scss
@@ -1,6 +1,8 @@
-.dataforms-combined-edit {
-	&__field:not(:first-child) {
-		border-top: $border-width solid $gray-200;
-		padding-top: $grid-unit-20;
+.dataforms-layouts-panel__field-dropdown {
+	.dataforms-combined-edit {
+		&__field:not(:first-child) {
+			border-top: $border-width solid $gray-200;
+			padding-top: $grid-unit-20;
+		}
 	}
 }

--- a/packages/dataviews/src/components/dataform-combined-edit/style.scss
+++ b/packages/dataviews/src/components/dataform-combined-edit/style.scss
@@ -2,11 +2,6 @@
 	.dataforms-combined-edit {
 		border: none;
 		padding: 0;
-
-		&__field:not(:first-child) {
-			border-top: $border-width solid $gray-200;
-			padding-top: $grid-unit-20;
-		}
 	}
 }
 

--- a/packages/dataviews/src/components/dataform-combined-edit/style.scss
+++ b/packages/dataviews/src/components/dataform-combined-edit/style.scss
@@ -1,0 +1,6 @@
+.dataforms-combined-edit {
+	&__field:not(:first-child) {
+		border-top: $border-width solid $gray-200;
+		padding-top: $grid-unit-20;
+	}
+}

--- a/packages/dataviews/src/components/dataform-combined-edit/style.scss
+++ b/packages/dataviews/src/components/dataform-combined-edit/style.scss
@@ -1,8 +1,17 @@
 .dataforms-layouts-panel__field-dropdown {
 	.dataforms-combined-edit {
+		border: none;
+		padding: 0;
+
 		&__field:not(:first-child) {
 			border-top: $border-width solid $gray-200;
 			padding-top: $grid-unit-20;
 		}
+	}
+}
+
+.dataforms-combined-edit {
+	&__field {
+		flex: 1 1 auto;
 	}
 }

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -125,7 +125,13 @@ export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
 	);
 };
 
-export const CombinedFields = ( { type }: { type: 'panel' | 'regular' } ) => {
+const CombinedFieldsComponent = ( {
+	type = 'regular',
+	combinedFieldDirection = 'vertical',
+}: {
+	type: 'panel' | 'regular';
+	combinedFieldDirection: 'vertical' | 'horizontal';
+} ) => {
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
 		order: 2,
@@ -140,7 +146,7 @@ export const CombinedFields = ( { type }: { type: 'panel' | 'regular' } ) => {
 				id: 'status_and_visibility',
 				label: 'Status & Visibility',
 				children: [ 'status', 'password' ],
-				direction: 'vertical',
+				direction: combinedFieldDirection,
 				render: ( { item } ) => item.status,
 			},
 		] as CombinedFormField< any >[],
@@ -162,4 +168,18 @@ export const CombinedFields = ( { type }: { type: 'panel' | 'regular' } ) => {
 			}
 		/>
 	);
+};
+
+export const CombinedFields = {
+	title: 'DataViews/CombinedFields',
+	render: CombinedFieldsComponent,
+	argTypes: {
+		...meta.argTypes,
+		combinedFieldDirection: {
+			control: { type: 'select' },
+			description:
+				'Chooses the direction of the combined field. "vertical" is the default layout.',
+			options: [ 'vertical', 'horizontal' ],
+		},
+	},
 };

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -7,6 +7,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import DataForm from '../index';
+import type { CombinedFormField } from '../../../types';
 
 const meta = {
 	title: 'DataViews/DataForm',
@@ -76,6 +77,11 @@ const fields = [
 			{ value: 'published', label: 'Published' },
 		],
 	},
+	{
+		id: 'password',
+		label: 'Password',
+		type: 'text' as const,
+	},
 ];
 
 export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
@@ -99,6 +105,47 @@ export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
 			'date',
 			'birthdate',
 		],
+	};
+
+	return (
+		<DataForm
+			data={ post }
+			fields={ fields }
+			form={ {
+				...form,
+				type,
+			} }
+			onChange={ ( edits ) =>
+				setPost( ( prev ) => ( {
+					...prev,
+					...edits,
+				} ) )
+			}
+		/>
+	);
+};
+
+export const CombinedFields = ( { type }: { type: 'panel' | 'regular' } ) => {
+	const [ post, setPost ] = useState( {
+		title: 'Hello, World!',
+		order: 2,
+		author: 1,
+		status: 'draft',
+	} );
+
+	const form = {
+		fields: [ 'title', 'status_and_visibility', 'order', 'author' ],
+		layout: {
+			combinedFields: [
+				{
+					id: 'status_and_visibility',
+					label: 'Status & Visibility',
+					children: [ 'status', 'password' ],
+					direction: 'vertical',
+					render: ( { item } ) => item.status,
+				},
+			] as CombinedFormField< any >[],
+		},
 	};
 
 	return (

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -135,17 +135,15 @@ export const CombinedFields = ( { type }: { type: 'panel' | 'regular' } ) => {
 
 	const form = {
 		fields: [ 'title', 'status_and_visibility', 'order', 'author' ],
-		layout: {
-			combinedFields: [
-				{
-					id: 'status_and_visibility',
-					label: 'Status & Visibility',
-					children: [ 'status', 'password' ],
-					direction: 'vertical',
-					render: ( { item } ) => item.status,
-				},
-			] as CombinedFormField< any >[],
-		},
+		combinedFields: [
+			{
+				id: 'status_and_visibility',
+				label: 'Status & Visibility',
+				children: [ 'status', 'password' ],
+				direction: 'vertical',
+				render: ( { item } ) => item.status,
+			},
+		] as CombinedFormField< any >[],
 	};
 
 	return (

--- a/packages/dataviews/src/dataforms-layouts/get-visible-fields.ts
+++ b/packages/dataviews/src/dataforms-layouts/get-visible-fields.ts
@@ -1,0 +1,29 @@
+/**
+ * Internal dependencies
+ */
+import { normalizeCombinedFields } from '../normalize-fields';
+import type {
+	Field,
+	CombinedFormField,
+	NormalizedCombinedFormField,
+} from '../types';
+
+export function getVisibleFields(
+	fields: Field< any >[],
+	formFields: string[] = [],
+	combinedFields?: CombinedFormField< any >[]
+): Field< any >[] {
+	const visibleFields: Array<
+		Field< any > | NormalizedCombinedFormField< any >
+	> = [ ...fields ];
+	if ( combinedFields ) {
+		visibleFields.push(
+			...normalizeCombinedFields( combinedFields, fields )
+		);
+	}
+	return formFields
+		.map( ( fieldId ) =>
+			visibleFields.find( ( { id } ) => id === fieldId )
+		)
+		.filter( ( field ): field is Field< any > => !! field );
+}

--- a/packages/dataviews/src/dataforms-layouts/get-visible-fields.ts
+++ b/packages/dataviews/src/dataforms-layouts/get-visible-fields.ts
@@ -8,13 +8,13 @@ import type {
 	NormalizedCombinedFormField,
 } from '../types';
 
-export function getVisibleFields(
-	fields: Field< any >[],
+export function getVisibleFields< Item >(
+	fields: Field< Item >[],
 	formFields: string[] = [],
-	combinedFields?: CombinedFormField< any >[]
-): Field< any >[] {
+	combinedFields?: CombinedFormField< Item >[]
+): Field< Item >[] {
 	const visibleFields: Array<
-		Field< any > | NormalizedCombinedFormField< any >
+		Field< Item > | NormalizedCombinedFormField< Item >
 	> = [ ...fields ];
 	if ( combinedFields ) {
 		visibleFields.push(
@@ -25,5 +25,5 @@ export function getVisibleFields(
 		.map( ( fieldId ) =>
 			visibleFields.find( ( { id } ) => id === fieldId )
 		)
-		.filter( ( field ): field is Field< any > => !! field );
+		.filter( ( field ): field is Field< Item > => !! field );
 }

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -16,8 +16,17 @@ import { closeSmall } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import { normalizeFields } from '../../normalize-fields';
-import type { DataFormProps, NormalizedField, Field } from '../../types';
+import {
+	normalizeFields,
+	normalizeCombinedFields,
+} from '../../normalize-fields';
+import type {
+	DataFormProps,
+	NormalizedField,
+	Field,
+	CombinedFormField,
+	NormalizedCombinedFormField,
+} from '../../types';
 
 interface FormFieldProps< Item > {
 	data: Item;
@@ -133,6 +142,26 @@ function FormField< Item >( {
 	);
 }
 
+export function getVisibleFields(
+	fields: Field< any >[],
+	formFields: string[] = [],
+	combinedFields?: CombinedFormField< any >[]
+): Field< any >[] {
+	const visibleFields: Array<
+		Field< any > | NormalizedCombinedFormField< any >
+	> = [ ...fields ];
+	if ( combinedFields ) {
+		visibleFields.push(
+			...normalizeCombinedFields( combinedFields, fields )
+		);
+	}
+	return formFields
+		.map( ( fieldId ) =>
+			visibleFields.find( ( { id } ) => id === fieldId )
+		)
+		.filter( ( field ): field is Field< any > => !! field );
+}
+
 export default function FormPanel< Item >( {
 	data,
 	fields,
@@ -142,13 +171,13 @@ export default function FormPanel< Item >( {
 	const visibleFields = useMemo(
 		() =>
 			normalizeFields(
-				( form.fields ?? [] )
-					.map( ( fieldId ) =>
-						fields.find( ( { id } ) => id === fieldId )
-					)
-					.filter( ( field ): field is Field< Item > => !! field )
+				getVisibleFields(
+					fields,
+					form.fields,
+					form.layout?.combinedFields
+				)
 			),
-		[ fields, form.fields ]
+		[ fields, form.fields, form.layout?.combinedFields ]
 	);
 
 	return (

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -143,7 +143,7 @@ export default function FormPanel< Item >( {
 	const visibleFields = useMemo(
 		() =>
 			normalizeFields(
-				getVisibleFields(
+				getVisibleFields< Item >(
 					fields,
 					form.fields,
 					form.layout?.combinedFields

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -146,10 +146,10 @@ export default function FormPanel< Item >( {
 				getVisibleFields< Item >(
 					fields,
 					form.fields,
-					form.layout?.combinedFields
+					form.combinedFields
 				)
 			),
-		[ fields, form.fields, form.layout?.combinedFields ]
+		[ fields, form.fields, form.combinedFields ]
 	);
 
 	return (

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -16,17 +16,9 @@ import { closeSmall } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import {
-	normalizeFields,
-	normalizeCombinedFields,
-} from '../../normalize-fields';
-import type {
-	DataFormProps,
-	NormalizedField,
-	Field,
-	CombinedFormField,
-	NormalizedCombinedFormField,
-} from '../../types';
+import { normalizeFields } from '../../normalize-fields';
+import { getVisibleFields } from '../get-visible-fields';
+import type { DataFormProps, NormalizedField } from '../../types';
 
 interface FormFieldProps< Item > {
 	data: Item;
@@ -140,26 +132,6 @@ function FormField< Item >( {
 			</div>
 		</HStack>
 	);
-}
-
-export function getVisibleFields(
-	fields: Field< any >[],
-	formFields: string[] = [],
-	combinedFields?: CombinedFormField< any >[]
-): Field< any >[] {
-	const visibleFields: Array<
-		Field< any > | NormalizedCombinedFormField< any >
-	> = [ ...fields ];
-	if ( combinedFields ) {
-		visibleFields.push(
-			...normalizeCombinedFields( combinedFields, fields )
-		);
-	}
-	return formFields
-		.map( ( fieldId ) =>
-			visibleFields.find( ( { id } ) => id === fieldId )
-		)
-		.filter( ( field ): field is Field< any > => !! field );
 }
 
 export default function FormPanel< Item >( {

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -23,10 +23,10 @@ export default function FormRegular< Item >( {
 				getVisibleFields< Item >(
 					fields,
 					form.fields,
-					form.layout?.combinedFields
+					form.combinedFields
 				)
 			),
-		[ fields, form.fields, form.layout?.combinedFields ]
+		[ fields, form.fields, form.combinedFields ]
 	);
 
 	return (

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -8,7 +8,8 @@ import { useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import { normalizeFields } from '../../normalize-fields';
-import type { DataFormProps, Field } from '../../types';
+import { getVisibleFields } from '../get-visible-fields';
+import type { DataFormProps } from '../../types';
 
 export default function FormRegular< Item >( {
 	data,
@@ -19,13 +20,13 @@ export default function FormRegular< Item >( {
 	const visibleFields = useMemo(
 		() =>
 			normalizeFields(
-				( form.fields ?? [] )
-					.map( ( fieldId ) =>
-						fields.find( ( { id } ) => id === fieldId )
-					)
-					.filter( ( field ): field is Field< Item > => !! field )
+				getVisibleFields(
+					fields,
+					form.fields,
+					form.layout?.combinedFields
+				)
 			),
-		[ fields, form.fields ]
+		[ fields, form.fields, form.layout?.combinedFields ]
 	);
 
 	return (

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -20,7 +20,7 @@ export default function FormRegular< Item >( {
 	const visibleFields = useMemo(
 		() =>
 			normalizeFields(
-				getVisibleFields(
+				getVisibleFields< Item >(
 					fields,
 					form.fields,
 					form.layout?.combinedFields

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -93,7 +93,7 @@ export function normalizeCombinedFields< Item >(
 					.map( ( fieldId ) =>
 						fields.find( ( { id } ) => id === fieldId )
 					)
-					.filter( ( field ): field is Field< any > => !! field )
+					.filter( ( field ): field is Field< Item > => !! field )
 			),
 		};
 	} );

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -2,8 +2,14 @@
  * Internal dependencies
  */
 import getFieldTypeDefinition from './field-types';
-import type { Field, NormalizedField } from './types';
+import type {
+	CombinedFormField,
+	Field,
+	NormalizedField,
+	NormalizedCombinedFormField,
+} from './types';
 import { getControl } from './dataform-controls';
+import DataFormCombinedEdit from './components/dataform-combined-edit';
 
 /**
  * Apply default values and normalize the fields config.
@@ -63,6 +69,32 @@ export function normalizeFields< Item >(
 			Edit,
 			enableHiding: field.enableHiding ?? true,
 			enableSorting: field.enableSorting ?? true,
+		};
+	} );
+}
+
+/**
+ * Apply default values and normalize the fields config.
+ *
+ * @param combinedFields combined field list.
+ * @param fields         Fields config.
+ * @return Normalized fields config.
+ */
+export function normalizeCombinedFields< Item >(
+	combinedFields: CombinedFormField< Item >[],
+	fields: Field< Item >[]
+): NormalizedCombinedFormField< Item >[] {
+	return combinedFields.map( ( combinedField ) => {
+		return {
+			...combinedField,
+			Edit: DataFormCombinedEdit,
+			fields: normalizeFields(
+				combinedField.children
+					.map( ( fieldId ) =>
+						fields.find( ( { id } ) => id === fieldId )
+					)
+					.filter( ( field ): field is Field< any > => !! field )
+			),
 		};
 	} );
 }

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -6,6 +6,7 @@
 @import "./components/dataviews-item-actions/style.scss";
 @import "./components/dataviews-selection-checkbox/style.scss";
 @import "./components/dataviews-view-config/style.scss";
+@import "./components/dataform-combined-edit/style.scss";
 
 @import "./dataviews-layouts/grid/style.scss";
 @import "./dataviews-layouts/list/style.scss";

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -174,14 +174,6 @@ export type Fields< Item > = Field< Item >[];
 
 export type Data< Item > = Item[];
 
-/**
- * The form configuration.
- */
-export type Form = {
-	type?: 'regular' | 'panel';
-	fields?: string[];
-};
-
 export type DataFormControlProps< Item > = {
 	data: Item;
 	field: NormalizedField< Item >;
@@ -524,9 +516,38 @@ export interface SupportedLayouts {
 	table?: Omit< ViewTable, 'type' >;
 }
 
+export interface CombinedFormField< Item > extends CombinedField {
+	render?: ComponentType< { item: Item } >;
+}
+
+export interface DataFormCombinedEditProps< Item > {
+	field: NormalizedCombinedFormField< Item >;
+	data: Item;
+	onChange: ( value: Record< string, any > ) => void;
+}
+
+export type NormalizedCombinedFormField< Item > = CombinedFormField< Item > & {
+	fields: NormalizedField< Item >[];
+	Edit?: ComponentType< DataFormCombinedEditProps< Item > >;
+};
+
+/**
+ * The form configuration.
+ */
+export type Form< Item > = {
+	type?: 'regular' | 'panel';
+	fields?: string[];
+	layout?: {
+		/**
+		 * The fields to combine.
+		 */
+		combinedFields?: CombinedFormField< Item >[];
+	};
+};
+
 export interface DataFormProps< Item > {
 	data: Item;
 	fields: Field< Item >[];
-	form: Form;
+	form: Form< Item >;
 	onChange: ( value: Record< string, any > ) => void;
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -524,6 +524,7 @@ export interface DataFormCombinedEditProps< Item > {
 	field: NormalizedCombinedFormField< Item >;
 	data: Item;
 	onChange: ( value: Record< string, any > ) => void;
+	hideLabelFromVision?: boolean;
 }
 
 export type NormalizedCombinedFormField< Item > = CombinedFormField< Item > & {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -538,12 +538,10 @@ export type NormalizedCombinedFormField< Item > = CombinedFormField< Item > & {
 export type Form< Item > = {
 	type?: 'regular' | 'panel';
 	fields?: string[];
-	layout?: {
-		/**
-		 * The fields to combine.
-		 */
-		combinedFields?: CombinedFormField< Item >[];
-	};
+	/**
+	 * The fields to combine.
+	 */
+	combinedFields?: CombinedFormField< Item >[];
 };
 
 export interface DataFormProps< Item > {

--- a/packages/dataviews/src/validation.ts
+++ b/packages/dataviews/src/validation.ts
@@ -7,7 +7,7 @@ import type { Field, Form } from './types';
 export function isItemValid< Item >(
 	item: Item,
 	fields: Field< Item >[],
-	form: Form
+	form: Form< Item >
 ): boolean {
 	const _fields = normalizeFields(
 		fields.filter( ( { id } ) => !! form.fields?.includes( id ) )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR adds support for combinedFields layout support to the DataForm panel view. This follows a similar configuration as `combinedFields` in DataViews.

cc: @youknowriad, @oandregal 

## Why?

This is needed to allow fields multiple fields to be rendered as part of a single row, similar to how currently the the [post status field](https://github.com/WordPress/gutenberg/blob/7bd8f8e0256cb106066faa1af9e582cb47e265aa/packages/editor/src/components/post-status/index.js#L196) works within the site editor. This will be needed for the DataForms as well.

Part of https://github.com/WordPress/gutenberg/issues/64519 and an initial step to implementing the Password field.

## How?

This adds a `layout` option to the form config that accepts a `combinedFields` array. A combined field can contain children and direction, it also accepts a custom `render` function to display the data. This follows the same format as introduced [here](https://github.com/WordPress/gutenberg/pull/63236) for DataViews.

Open questions:
- In the design the field label is different from the top label within the modal, do we provide a separate config for this?
- How would this look in the `regular` view?

An alternative to consider, is not to alter this through the `layout`, but provide a `layout` type as part of the field type definition that supports a `direction` and `children`. 
```
{
  type: 'layout',
  children: [ 'title', 'status' ],
  direction: 'vertical'
}
```

## Testing Instructions

1. Run storybook: `npm run storybook:dev`
2. Go to the **DataViews > DataForm > Combined Fields** story
3. See the combined field label `Status & Visibility` and the two fields underneath ( status & password )
4. Now change the form type to `panel`
5. Select the `Status & Visibility` field, it should render a status and password field.
6. Edits should be correctly reflected within status & password fields across the form types.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a0051e13-e6e0-4c60-b1b0-b0afca6448cf


