### PR TITLE
Revert "Don't force iframe editor when gutenberg plugin and block the me are enabled (#65372)"

### DIFF
--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -6,22 +6,33 @@ import { useSelect } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 
-export function useShouldIframe() {
-	const { hasV3BlocksOnly, isEditingTemplate, isZoomOutMode } = useSelect(
-		( select ) => {
-			const { getCurrentPostType } = select( editorStore );
-			const { __unstableGetEditorMode } = select( blockEditorStore );
-			const { getBlockTypes } = select( blocksStore );
-			return {
-				hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
-					return type.apiVersion >= 3;
-				} ),
-				isEditingTemplate: getCurrentPostType() === 'wp_template',
-				isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
-			};
-		},
-		[]
-	);
+const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
 
-	return hasV3BlocksOnly || isEditingTemplate || isZoomOutMode;
+export function useShouldIframe() {
+	const {
+		isBlockBasedTheme,
+		hasV3BlocksOnly,
+		isEditingTemplate,
+		isZoomOutMode,
+	} = useSelect( ( select ) => {
+		const { getEditorSettings, getCurrentPostType } = select( editorStore );
+		const { __unstableGetEditorMode } = select( blockEditorStore );
+		const { getBlockTypes } = select( blocksStore );
+		const editorSettings = getEditorSettings();
+		return {
+			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
+			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
+				return type.apiVersion >= 3;
+			} ),
+			isEditingTemplate: getCurrentPostType() === 'wp_template',
+			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+		};
+	}, [] );
+
+	return (
+		hasV3BlocksOnly ||
+		( isGutenbergPlugin && isBlockBasedTheme ) ||
+		isEditingTemplate ||
+		isZoomOutMode
+	);
 }


### PR DESCRIPTION
## What?

This PR reverts commit 99fefd79c2644f65fb885fad82e0c11e7593eca0 (#65372).

## Why?

I removed one condition from the `useShouldIframe` hook to match the behavior of the editor in core and Gutenberg, but this didn't seem ideal, so I'm reverting. See [this discussion](https://github.com/WordPress/gutenberg/pull/65372#issuecomment-2355614075).

