### PR TITLE
Pattern block: Ensure consistent editing of overrides in Write Mode

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -7,7 +7,6 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
  * Internal dependencies
  */
 import {
-	getBlockAttributes,
 	getBlockOrder,
 	getBlockParents,
 	getBlockEditingMode,
@@ -18,7 +17,6 @@ import {
 	getClientIdsWithDescendants,
 	isNavigationMode,
 	getBlockRootClientId,
-	__unstableGetEditorMode,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -685,51 +683,6 @@ export function getClosestAllowedInsertionPointForPattern(
  */
 export function getInsertionPoint( state ) {
 	return state.insertionPoint;
-}
-
-/**
- * Retrieves the editing mode of a pattern block and its children.
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId The block client ID.
- *
- * @return {string} The block editing mode.
- */
-export function getPatternBlockEditingMode( state, clientId ) {
-	const parentPatternCount = getParentPatternCount( state, clientId );
-
-	// If there are no parent patterns, use the block's own editing mode.
-	if ( parentPatternCount === 0 ) {
-		return state.blockEditingModes.get( clientId );
-	}
-
-	// Disable nested patterns.
-	if ( parentPatternCount > 1 ) {
-		return 'disabled';
-	}
-
-	// Make the outer pattern block content only mode.
-	if (
-		getBlockName( state, clientId ) === 'core/block' &&
-		parentPatternCount === 0
-	) {
-		return 'contentOnly';
-	}
-
-	// Disable pattern content in zoom-out mode.
-	const _isZoomOut = __unstableGetEditorMode( state ) === 'zoom-out';
-	if ( _isZoomOut ) {
-		return 'disabled';
-	}
-
-	// If the block has a binding of any kind, allow content only editing.
-	const attributes = getBlockAttributes( state, clientId );
-	if ( Object.keys( attributes.metadata?.bindings ?? {} )?.length > 0 ) {
-		return 'contentOnly';
-	}
-
-	// Otherwise, the block is part of the pattern source and should not be editable.
-	return 'disabled';
 }
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -7,6 +7,7 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
  * Internal dependencies
  */
 import {
+	getBlockAttributes,
 	getBlockOrder,
 	getBlockParents,
 	getBlockEditingMode,
@@ -17,6 +18,7 @@ import {
 	getClientIdsWithDescendants,
 	isNavigationMode,
 	getBlockRootClientId,
+	__unstableGetEditorMode,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -683,4 +685,67 @@ export function getClosestAllowedInsertionPointForPattern(
  */
 export function getInsertionPoint( state ) {
 	return state.insertionPoint;
+}
+
+/**
+ * Retrieves the editing mode of a pattern block and its children.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The block client ID.
+ *
+ * @return {string} The block editing mode.
+ */
+export function getPatternBlockEditingMode( state, clientId ) {
+	const parentPatternCount = getParentPatternCount( state, clientId );
+
+	// If there are no parent patterns, use the block's own editing mode.
+	if ( parentPatternCount === 0 ) {
+		return state.blockEditingModes.get( clientId );
+	}
+
+	// Disable nested patterns.
+	if ( parentPatternCount > 1 ) {
+		return 'disabled';
+	}
+
+	// Make the outer pattern block content only mode.
+	if (
+		getBlockName( state, clientId ) === 'core/block' &&
+		parentPatternCount === 0
+	) {
+		return 'contentOnly';
+	}
+
+	// Disable pattern content in zoom-out mode.
+	const _isZoomOut = __unstableGetEditorMode( state ) === 'zoom-out';
+	if ( _isZoomOut ) {
+		return 'disabled';
+	}
+
+	// If the block has a binding of any kind, allow content only editing.
+	const attributes = getBlockAttributes( state, clientId );
+	if ( Object.keys( attributes.metadata?.bindings ?? {} )?.length > 0 ) {
+		return 'contentOnly';
+	}
+
+	// Otherwise, the block is part of the pattern source and should not be editable.
+	return 'disabled';
+}
+
+/**
+ * Retrieves the number of parent pattern blocks.
+ *
+ * @param {Object} state    Global application state.
+ * @param {string} clientId The block client ID.
+ *
+ * @return {number} The number of parent pattern blocks.
+ */
+export function getParentPatternCount( state, clientId ) {
+	const parents = getBlockParents( state, clientId );
+	return parents.reduce( ( count, parent ) => {
+		if ( getBlockName( state, parent ) === 'core/block' ) {
+			return count + 1;
+		}
+		return count;
+	}, 0 );
 }

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -40,6 +40,8 @@ import {
 	getSectionRootClientId,
 	isSectionBlock,
 	getParentSectionBlock,
+	getParentPatternCount,
+	getPatternBlockEditingMode,
 } from './private-selectors';
 
 /**
@@ -2970,6 +2972,10 @@ export const getBlockEditingMode = createRegistrySelector(
 			// rootClientId, but the default rootClientId is actually `''`.
 			if ( clientId === null ) {
 				clientId = '';
+			}
+
+			if ( getParentPatternCount( state, clientId ) > 0 ) {
+				return getPatternBlockEditingMode( state, clientId );
 			}
 
 			// In zoom-out mode, override the behavior set by

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2975,18 +2975,19 @@ export const getBlockEditingMode = createRegistrySelector(
 
 			// Handle pattern blocks (core/block) and the content of those blocks.
 			const parentPatternCount = getParentPatternCount( state, clientId );
+
+			// Make the outer pattern block content only mode.
+			if (
+				getBlockName( state, clientId ) === 'core/block' &&
+				parentPatternCount === 0
+			) {
+				return 'contentOnly';
+			}
+
 			if ( parentPatternCount > 0 ) {
 				// Disable nested patterns.
 				if ( parentPatternCount > 1 ) {
 					return 'disabled';
-				}
-
-				// Make the outer pattern block content only mode.
-				if (
-					getBlockName( state, clientId ) === 'core/block' &&
-					parentPatternCount === 0
-				) {
-					return 'contentOnly';
 				}
 
 				// Disable pattern content editing in zoom-out mode.
@@ -2999,8 +3000,8 @@ export const getBlockEditingMode = createRegistrySelector(
 				// If the block has a binding of any kind, allow content only editing.
 				const attributes = getBlockAttributes( state, clientId );
 				if (
-					Object.keys( attributes.metadata?.bindings ?? {} )?.length >
-					0
+					Object.keys( attributes?.metadata?.bindings ?? {} )
+						?.length > 0
 				) {
 					return 'contentOnly';
 				}

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -428,7 +428,6 @@ describe( 'private selectors', () => {
 							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
 						],
 					] ),
-
 					order: new Map( [
 						[
 							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
@@ -443,6 +442,7 @@ describe( 'private selectors', () => {
 						],
 						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 					] ),
+					byClientId: new Map( [] ),
 				},
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],
@@ -495,6 +495,7 @@ describe( 'private selectors', () => {
 						],
 						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 					] ),
+					byClientId: new Map( [] ),
 				},
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3079,7 +3079,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(
 						Object.entries( {
 							block1: { name: 'core/test-block-ancestor' },
-							block2: { name: 'core/block' },
+							block2: { name: 'core/group' },
 							block3: { name: 'core/test-block-parent' },
 						} )
 					),

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4668,4 +4668,97 @@ describe( 'getBlockEditingMode', () => {
 			)
 		).toBe( 'disabled' );
 	} );
+
+	describe( 'pattern blocks', () => {
+		const patternBlockState = {
+			settings: {},
+			blocks: {
+				byClientId: new Map(
+					Object.entries( {
+						'pattern-a': { name: 'core/block' },
+						'pattern-b': { name: 'core/block' },
+						'heading-a': { name: 'core/heading' },
+						'paragraph-a': { name: 'core/paragraph' },
+						'paragraph-b': { name: 'core/paragraph' },
+					} )
+				),
+				order: new Map(
+					Object.entries( {
+						'': [ 'pattern-a' ],
+						'pattern-a': [
+							'heading-a',
+							'paragraph-a',
+							'pattern-b',
+						],
+						'pattern-b': [ 'paragraph-b' ],
+					} )
+				),
+				parents: new Map(
+					Object.entries( {
+						'paragraph-b': 'pattern-b',
+						'pattern-b': 'pattern-a',
+						'paragraph-a': 'pattern-a',
+						'heading-a': 'pattern-a',
+						'pattern-a': '',
+					} )
+				),
+				blockListSettings: {
+					'pattern-a': {},
+					'pattern-b': {},
+				},
+				attributes: new Map(
+					Object.entries( {
+						'paragraph-a': {
+							metadata: {
+								bindings: {
+									__default: {
+										source: 'core/pattern-overrides',
+									},
+								},
+							},
+						},
+						'paragraph-b': {
+							metadata: {
+								bindings: {
+									__default: {
+										source: 'core/pattern-overrides',
+									},
+								},
+							},
+						},
+					} )
+				),
+			},
+		};
+
+		it( 'should return contentOnly for the outer pattern block', () => {
+			expect(
+				getBlockEditingMode( patternBlockState, 'pattern-a' )
+			).toBe( 'contentOnly' );
+		} );
+
+		it( 'should return contentOnly for blocks with bindings in the outer pattern', () => {
+			expect(
+				getBlockEditingMode( patternBlockState, 'paragraph-a' )
+			).toBe( 'contentOnly' );
+		} );
+
+		it( 'should return disabled for unbound blocks', () => {
+			expect(
+				getBlockEditingMode( patternBlockState, 'heading-a' )
+			).toBe( 'disabled' );
+		} );
+
+		it( 'should return disabled for the nested pattern', () => {
+			expect(
+				getBlockEditingMode( patternBlockState, 'pattern-a' )
+			).toBe( 'contentOnly' );
+		} );
+
+		it( 'should return disabled for blocks with bindings in the nested pattern', () => {
+			expect(
+				getBlockEditingMode( patternBlockState, 'paragraph-b' )
+			).toBe( 'disabled' );
+		} );
+	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4760,5 +4760,22 @@ describe( 'getBlockEditingMode', () => {
 				getBlockEditingMode( patternBlockState, 'paragraph-b' )
 			).toBe( 'disabled' );
 		} );
+
+		it( 'should disable all inner blocks of the outer pattern in zoom out mode with the outer pattern in content only mode', () => {
+			const state = {
+				...patternBlockState,
+				editorMode: 'zoom-out',
+			};
+			expect( getBlockEditingMode( state, 'pattern-a' ) ).toBe(
+				'contentOnly'
+			);
+			[ 'paragraph-a', 'paragraph-b', 'heading-a', 'pattern-b' ].forEach(
+				( block ) => {
+					expect( getBlockEditingMode( state, block ) ).toBe(
+						'disabled'
+					);
+				}
+			);
+		} );
 	} );
 } );


### PR DESCRIPTION
Based on #65204 and merges into that PR.

## What?
The pattern (core/block) block uses an effect to set `blockEditingMode` for its inner blocks to the correct thing. 

This PR moves that calculation to a selector so that it plays better with other modes.

## Why?
The `getBlockEditingMode` has some internal logic for different editing modes (like `zoom-out` and the content only behavior in #65204) that can override the actual block editing state for a pattern's inner blocks.

## How?
Moving the state to the selector it should be possible to make the modes work together with pattern overrides in the expected way.

## Testing Instructions
There's one use case that I can see that doesn't seem to work, but there might be others
1. Add a synced pattern with overrides into the content block of a page in the site editor
2. Wrap that synced pattern in a group
3. Switch to 'Edit' mode
4. Try editing the overrides - notice they're locked.

## Screenshots or screencast <!-- if applicable -->
#### Before
An pattern that's a child of a 'section' group has overrides that can't be edited in Edit Mode (even though they're 'content')
<img width="344" alt="Screenshot 2024-09-17 at 4 33 22 pm" src="https://github.com/user-attachments/assets/c20b2e76-3640-4ab0-925d-9e8eb0136b10">

#### After
The pattern overrides can be selected and edited in Edit Mode
<img width="349" alt="Screenshot 2024-09-17 at 4 32 24 pm" src="https://github.com/user-attachments/assets/4bfa08cc-5807-4108-9582-cf7876468878">