### PR TITLE
Update elevation in the site editor

### DIFF
--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -8,7 +8,7 @@
 .block-editor-block-draggable-chip {
 	background-color: $gray-900;
 	border-radius: $radius-small;
-	box-shadow: 0 6px 8px rgba($black, 0.3);
+	box-shadow: $elevation-small;
 	color: $white;
 	cursor: grabbing;
 	display: inline-flex;
@@ -77,6 +77,6 @@
 	.block-editor-block-draggable-chip__disabled.block-editor-block-draggable-chip__disabled {
 		background-color: $gray-700;
 		opacity: 1;
-		box-shadow: 0 4px 8px rgba($black, 0.2);
+		box-shadow: $elevation-small;
 	}
 }

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -114,13 +114,17 @@
 		width: calc(100% - #{$canvas-padding});
 
 		.edit-site-resizable-frame__inner-content {
-			box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.8), 0 8px 10px -6px rgba(0, 0, 0, 0.8);
-			transition: border-radius 0.4s;
+			box-shadow: $elevation-x-small;
+			transition: border-radius, box-shadow 0.4s;
 			// This ensure the radius work properly.
 			overflow: hidden;
 
 			.edit-site-layout:not(.is-full-canvas) & {
 				border-radius: $radius-large;
+			}
+
+			&:hover {
+				box-shadow: $elevation-large;
 			}
 		}
 	}

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -250,6 +250,7 @@ html.canvas-mode-edit-transition::view-transition-group(toggle) {
 	flex-grow: 1;
 	margin: 0;
 	overflow: hidden;
+	box-shadow: $elevation-x-small;
 	@include break-medium() {
 		border-radius: 8px;
 		margin: $canvas-padding $canvas-padding $canvas-padding 0;


### PR DESCRIPTION
Follow up to https://github.com/WordPress/gutenberg/pull/65159

## What?
Applies elevation scale values to site editor elements using custom shadows and to any elements that require shadows but currently lack them.

## Why?
Consistency and polish.

So far as I can tell there are only two elements that need updating...

### Drag chip

When dragging blocks (either on the canvas or in list view) a dark chip appears. I've applied `$elevation-small` here:

| Before | After |
| --- | --- |
| <img width="401" alt="drag-before" src="https://github.com/user-attachments/assets/d834451e-6cae-4a19-8775-50831c4fc0c5"> | <img width="401" alt="drag-after" src="https://github.com/user-attachments/assets/317eb432-ec60-4bce-a192-e60957e3a907"> |

### Preview frame

It's tricky to see given it appears on such a dark background, but the preview frame has a strong shadow applied. It's much easier to see if we adjust the main background color:

<img width="1414" alt="Screenshot 2024-09-17 at 16 25 50" src="https://github.com/user-attachments/assets/36bf5daf-d2d1-47fa-b122-68c0d8d7f3ea">

I've switched the resting shadow to `$elevation-x-small` increasing to `$elevation-large` on hover (given the transform animation), in line with the scale outlined in https://github.com/WordPress/gutenberg/pull/64108. This change is barely perceptible currently, but will become more apparent when the color scale is expanded (https://github.com/WordPress/gutenberg/issues/53612) and modes like light/dark become available. In the mean time here's a demo with an adjusted background color as before:

https://github.com/user-attachments/assets/eb218f9d-146a-44aa-98bb-77b8108b77e6


---

In addition to updating the elements above, I've added elevation to the 'Content frame'. Once again this isn't visible now due to the dark background, but will become important later. Here's a demonstration of how this would look in a dedicated "Light mode":

<img width="1125" alt="Screenshot 2024-09-17 at 16 33 55" src="https://github.com/user-attachments/assets/d5100c41-3776-4c9a-b067-24eda1f6c600">



## Testing Instructions
1. Check the updated shadow is applied to drag chips.
2. Check the updated shadow(s) are applied to `.edit-site-resizable-frame__inner-content` including hover effect (this is easier if you change the background color applied to `.edit-site-layout` in dev tools.
3. Check the new shadow is applied to `.edit-site-layout__area`.
