### PR TITLE
Revert "Writing flow: fix triple click inside text blocks"

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -4,7 +4,6 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
 import { create } from '@wordpress/rich-text';
-import { isSelectionForward } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -52,14 +51,6 @@ function extractSelectionEndNode( selection ) {
 
 	if ( focusOffset === focusNode.childNodes.length ) {
 		return focusNode;
-	}
-
-	// When the selection is forward (the selection ends with the focus node),
-	// the selection may extend into the next element with an offset of 0. This
-	// may trigger multi selection even though the selection does not visually
-	// end in the next block.
-	if ( focusOffset === 0 && isSelectionForward( selection ) ) {
-		return focusNode.previousSibling ?? focusNode.parentElement;
 	}
 
 	return focusNode.childNodes[ focusOffset ];

--- a/packages/dom/README.md
+++ b/packages/dom/README.md
@@ -239,22 +239,6 @@ _Returns_
 
 -   `boolean`: True if rtl, false if ltr.
 
-### isSelectionForward
-
-Returns true if the given selection object is in the forward direction, or false otherwise.
-
-_Related_
-
--   <https://developer.mozilla.org/en-US/docs/Web/API/Node/compareDocumentPosition>
-
-_Parameters_
-
--   _selection_ `Selection`: Selection object to check.
-
-_Returns_
-
--   `boolean`: Whether the selection is forward.
-
 ### isTextContent
 
 _Parameters_

--- a/packages/dom/src/dom/index.js
+++ b/packages/dom/src/dom/index.js
@@ -24,4 +24,3 @@ export { default as isEmpty } from './is-empty';
 export { default as removeInvalidHTML } from './remove-invalid-html';
 export { default as isRTL } from './is-rtl';
 export { default as safeHTML } from './safe-html';
-export { default as isSelectionForward } from './is-selection-forward';


### PR DESCRIPTION
Reverts WordPress/gutenberg#64928

Testing to see if reverting fixes https://github.com/WordPress/gutenberg/issues/65267.