### PR TITLE
Don't set contentEditableWrapper as true unless multiselect

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-selection-observer.js
+++ b/packages/block-editor/src/components/writing-flow/use-selection-observer.js
@@ -195,12 +195,10 @@ export default function useSelectionObserver() {
 					return;
 				}
 
-				setContentEditableWrapper(
-					node,
-					!! ( startClientId && endClientId )
-				);
-
 				const isSingularSelection = startClientId === endClientId;
+
+				setContentEditableWrapper( node, ! isSingularSelection );
+
 				if ( isSingularSelection ) {
 					if ( ! isMultiSelecting() ) {
 						if ( getSelectedBlockClientId() !== startClientId ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The `contentEditableWrapper` is getting toggled to true when still on a single block selection, which moves focus to the wrapper and causes screen readers to announce focus in the wrong location.

Fixes https://github.com/WordPress/gutenberg/issues/65267

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This changes to only set that content editable wrapper when multiselecting so selection within the same block doesn't move focus.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
### JAWS + Chrome or VoiceOver + Safari
- create a new content - post, page, it's the same.
- type a single character, then select it with shift+arrows. JAWS screen reader won't read it. Let's take as a sample, to write - the number "1".
- after the "1", write a "2". Then, select the "2", it won't read it. But it'll then read the "1" typed before, as it'll be the second character selected sequentially.
- Try the same flow with words. And then, with the "select all" (ctrl+a keystroke) in the single block.
### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
