### PR TITLE
Add null value handling to sorting logic and update tests

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -696,3 +696,22 @@ export const fields: Field< SpaceObject >[] = [
 		enableSorting: false,
 	},
 ];
+
+export const sortDataWithNull = [
+	{
+		id: 1,
+		message: null,
+	},
+	{
+		id: 2,
+		message: 'Something went wrong',
+	},
+	{
+		id: 3,
+		message: null,
+	},
+	{
+		id: 4,
+		message: 'An error has occurred',
+	},
+];

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -701,17 +701,25 @@ export const sortDataWithNull = [
 	{
 		id: 1,
 		message: null,
+		count: null,
+		login_at: null,
 	},
 	{
 		id: 2,
 		message: 'Something went wrong',
+		count: 1,
+		login_at: '2021-01-01T00:00:00Z',
 	},
 	{
 		id: 3,
 		message: null,
+		count: null,
+		login_at: null,
 	},
 	{
 		id: 4,
 		message: 'An error has occurred',
+		count: 5,
+		login_at: '2024-01-01T00:00:00Z',
 	},
 ];

--- a/packages/dataviews/src/field-types/datetime.tsx
+++ b/packages/dataviews/src/field-types/datetime.tsx
@@ -4,6 +4,9 @@
 import type { SortDirection, ValidationContext } from '../types';
 
 function sort( a: any, b: any, direction: SortDirection ) {
+	if (a === null) return 1;
+	if (b === null) return -1;
+
 	const timeA = new Date( a ).getTime();
 	const timeB = new Date( b ).getTime();
 

--- a/packages/dataviews/src/field-types/index.tsx
+++ b/packages/dataviews/src/field-types/index.tsx
@@ -27,13 +27,16 @@ export default function getFieldTypeDefinition( type?: FieldType ) {
 
 	return {
 		sort: ( a: any, b: any, direction: SortDirection ) => {
+			if (a === null) return 1;
+			if (b === null) return -1;
+
 			if ( typeof a === 'number' && typeof b === 'number' ) {
 				return direction === 'asc' ? a - b : b - a;
 			}
 
 			return direction === 'asc'
-				? a.localeCompare( b )
-				: b.localeCompare( a );
+				? a.localeCompare(b)
+				: b.localeCompare(a);
 		},
 		isValid: ( value: any, context?: ValidationContext ) => {
 			if ( context?.elements ) {

--- a/packages/dataviews/src/field-types/integer.tsx
+++ b/packages/dataviews/src/field-types/integer.tsx
@@ -4,6 +4,9 @@
 import type { SortDirection, ValidationContext } from '../types';
 
 function sort( a: any, b: any, direction: SortDirection ) {
+	if (a === null) return 1;
+	if (b === null) return -1;
+
 	return direction === 'asc' ? a - b : b - a;
 }
 

--- a/packages/dataviews/src/field-types/text.tsx
+++ b/packages/dataviews/src/field-types/text.tsx
@@ -4,6 +4,8 @@
 import type { SortDirection, ValidationContext } from '../types';
 
 function sort( valueA: any, valueB: any, direction: SortDirection ) {
+	if (valueA === null) return 1;
+	if (valueB === null) return -1;
 	return direction === 'asc'
 		? valueA.localeCompare( valueB )
 		: valueB.localeCompare( valueA );

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -365,7 +365,7 @@ describe( 'sorting', () => {
 	it( 'should asc sort null values to end for fields without type definition', () => {
 		testSorting(
 			sortDataWithNull,
-			[ { label: 'Error Message', id: 'message' } ],
+			[ { id: 'message' } ],
 			'asc',
 			expectedNullableResults.asc
 		);
@@ -374,7 +374,7 @@ describe( 'sorting', () => {
 	it( 'should desc sort null values to end for fields without type definition', () => {
 		testSorting(
 			sortDataWithNull,
-			[ { label: 'Error Message', id: 'message' } ],
+			[ { id: 'message' } ],
 			'desc',
 			expectedNullableResults.desc
 		);
@@ -395,6 +395,42 @@ describe( 'sorting', () => {
 			[ { id: 'message', type: 'text' } ],
 			'desc',
 			expectedNullableResults.desc
+		);
+	} );
+
+	it( 'should asc sort null values to end for integer fields type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { id: 'count', type: 'integer' } ],
+			'asc',
+			[ 1, 5, null, null ]
+		);
+	} );
+
+	it( 'should desc sort null values to end for integer fields type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { id: 'count', type: 'integer' } ],
+			'desc',
+			[ 5, 1, null, null ]
+		);
+	} );
+
+	it( 'should asc sort null values to end for datetime fields type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { id: 'login_at', type: 'datetime' } ],
+			'asc',
+			[ '2021-01-01T00:00:00Z', '2024-01-01T00:00:00Z', null, null ]
+		);
+	} );
+
+	it( 'should desc sort null values to end for datetime fields type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { id: 'login_at', type: 'datetime' } ],
+			'desc',
+			[ '2024-01-01T00:00:00Z', '2021-01-01T00:00:00Z', null, null ]
 		);
 	} );
 } );

--- a/packages/dataviews/src/test/filter-and-sort-data-view.js
+++ b/packages/dataviews/src/test/filter-and-sort-data-view.js
@@ -2,7 +2,11 @@
  * Internal dependencies
  */
 import { filterSortAndPaginate } from '../filter-and-sort-data-view';
-import { data, fields } from '../components/dataviews/stories/fixtures';
+import {
+	data,
+	fields,
+	sortDataWithNull,
+} from '../components/dataviews/stories/fixtures';
 
 describe( 'filters', () => {
 	it( 'should return empty if the data is empty', () => {
@@ -337,6 +341,61 @@ describe( 'sorting', () => {
 		expect( result ).toHaveLength( 2 );
 		expect( result[ 0 ].title ).toBe( 'Uranus' );
 		expect( result[ 1 ].title ).toBe( 'Neptune' );
+	} );
+
+	const testSorting = ( data, fields, sortDirection, expectedResults ) => {
+		const { data: result } = filterSortAndPaginate(
+			data,
+			{
+				sort: { field: fields[ 0 ].id, direction: sortDirection },
+			},
+			fields
+		);
+
+		result.forEach( ( item, index ) => {
+			expect( item[ fields[ 0 ].id ] ).toBe( expectedResults[ index ] );
+		} );
+	};
+
+	const expectedNullableResults = {
+		asc: [ 'An error has occurred', 'Something went wrong', null, null ],
+		desc: [ 'Something went wrong', 'An error has occurred', null, null ],
+	};
+
+	it( 'should asc sort null values to end for fields without type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { label: 'Error Message', id: 'message' } ],
+			'asc',
+			expectedNullableResults.asc
+		);
+	} );
+
+	it( 'should desc sort null values to end for fields without type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { label: 'Error Message', id: 'message' } ],
+			'desc',
+			expectedNullableResults.desc
+		);
+	} );
+
+	it( 'should asc sort null values to end for text fields type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { id: 'message', type: 'text' } ],
+			'asc',
+			expectedNullableResults.asc
+		);
+	} );
+
+	it( 'should desc sort null values to end for text fields type definition', () => {
+		testSorting(
+			sortDataWithNull,
+			[ { id: 'message', type: 'text' } ],
+			'desc',
+			expectedNullableResults.desc
+		);
 	} );
 } );
 


### PR DESCRIPTION
## What?
Adjusted sorting functions to handle null values by placing them at the end for both asc & desc directions.
The decision to move null values to the end of the list is to make sorting more beneficial to the user by consistently providing values above empty ones. 

## Why?
Currently throws TypeError if you attempt to sort data with null values:
Uncaught TypeError: Cannot read properties of null (reading 'localeCompare')
    at Object.sort (app.js?ver=2ec77682ff5b8736892f:1:10684)
    at N.e.map.s [as sort] (app.js?ver=2ec77682ff5b8736892f:1:10950)


## Testing Instructions
Updated test cases to validate the new sorting behavior and included new fixture data for testing scenarios with null values.
`npm run test:unit packages/dataviews`
