### PR TITLE
Block Editor: Validate options for the 'HeadingLevelDropdown' component

### DIFF
--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.js
@@ -40,9 +40,11 @@ export default function HeadingLevelDropdown( {
 	value,
 	onChange,
 } ) {
-	const validOptions = options.filter(
-		( option ) => option === 0 || HEADING_LEVELS.includes( option )
-	);
+	const validOptions = options
+		.filter(
+			( option ) => option === 0 || HEADING_LEVELS.includes( option )
+		)
+		.sort( ( a, b ) => a - b ); // Sorts numerically in ascending order;
 
 	return (
 		<ToolbarDropdownMenu

--- a/packages/block-editor/src/components/block-heading-level-dropdown/index.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/index.js
@@ -40,12 +40,16 @@ export default function HeadingLevelDropdown( {
 	value,
 	onChange,
 } ) {
+	const validOptions = options.filter(
+		( option ) => option === 0 || HEADING_LEVELS.includes( option )
+	);
+
 	return (
 		<ToolbarDropdownMenu
 			popoverProps={ POPOVER_PROPS }
 			icon={ <HeadingLevelIcon level={ value } /> }
 			label={ __( 'Change level' ) }
-			controls={ options.map( ( targetLevel ) => {
+			controls={ validOptions.map( ( targetLevel ) => {
 				const isActive = targetLevel === value;
 				return {
 					icon: <HeadingLevelIcon level={ targetLevel } />,


### PR DESCRIPTION
Resolves #65422

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR prevents values that would end up as invalid heading levels from appearing in the `HeaderLevelDropdown`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We do not want to allow options that will result in heading tags that do not exist.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The values passed to `options` are filtered to only allow values that are included in `HEADING_LEVELS`. This PR still allows `0` as an option as well, in order to handle the case where [passing 0 will result in a `p` tag](https://github.com/WordPress/gutenberg/blob/7f9c3402f8bbfd0895c688371f53bd66797c1a90/packages/block-library/src/post-title/edit.js#L30).  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
 1. Open a post or page. 
2. Insert a heading block via the code editor. 
```
 <!-- wp:heading {"level":4,"levelOptions":[4,5,6,7,"foo"],"className":"wp-block-heading"} -->
<h4 class="wp-block-heading">Markup example</h4>
<!-- /wp:heading -->
```
3. Switch to the `Visual editor` only `h4, h5, h6` are available as choices
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
