### PR TITLE
Terms List block: Add Categories-specific variation

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -46,11 +46,7 @@ export default function CategoriesEdit( {
 		'taxonomy'
 	);
 
-	const taxonomies = allTaxonomies?.filter(
-		( t ) =>
-			t.visibility.public &&
-			( taxonomySlug === 'category' ) === ( t.slug === 'category' )
-	);
+	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );
 
 	const taxonomy = taxonomies?.find( ( t ) => t.slug === taxonomySlug );
 
@@ -189,24 +185,23 @@ export default function CategoriesEdit( {
 		<TagName { ...blockProps }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					{ taxonomySlug !== 'category' && // For back-compat, the Category taxonomy has its own block variation.
-						Array.isArray( taxonomies ) && (
-							<SelectControl
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-								label={ __( 'Taxonomy' ) }
-								options={ taxonomies.map( ( t ) => ( {
-									label: t.name,
-									value: t.slug,
-								} ) ) }
-								value={ taxonomySlug }
-								onChange={ ( selectedTaxonomy ) =>
-									setAttributes( {
-										taxonomy: selectedTaxonomy,
-									} )
-								}
-							/>
-						) }
+					{ Array.isArray( taxonomies ) && (
+						<SelectControl
+							__nextHasNoMarginBottom
+							__next40pxDefaultSize
+							label={ __( 'Taxonomy' ) }
+							options={ taxonomies.map( ( t ) => ( {
+								label: t.name,
+								value: t.slug,
+							} ) ) }
+							value={ taxonomySlug }
+							onChange={ ( selectedTaxonomy ) =>
+								setAttributes( {
+									taxonomy: selectedTaxonomy,
+								} )
+							}
+						/>
+					) }
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Display as dropdown' ) }

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -46,7 +46,11 @@ export default function CategoriesEdit( {
 		'taxonomy'
 	);
 
-	const taxonomies = allTaxonomies?.filter( ( t ) => t.visibility.public );
+	const taxonomies = allTaxonomies?.filter(
+		( t ) =>
+			t.visibility.public &&
+			( taxonomySlug === 'category' ) === ( t.slug === 'category' )
+	);
 
 	const taxonomy = taxonomies?.find( ( t ) => t.slug === taxonomySlug );
 
@@ -185,21 +189,24 @@ export default function CategoriesEdit( {
 		<TagName { ...blockProps }>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					{ Array.isArray( taxonomies ) && (
-						<SelectControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
-							label={ __( 'Taxonomy' ) }
-							options={ taxonomies.map( ( t ) => ( {
-								label: t.name,
-								value: t.slug,
-							} ) ) }
-							value={ taxonomySlug }
-							onChange={ ( selectedTaxonomy ) =>
-								setAttributes( { taxonomy: selectedTaxonomy } )
-							}
-						/>
-					) }
+					{ taxonomySlug !== 'category' && // For back-compat, the Category taxonomy has its own block variation.
+						Array.isArray( taxonomies ) && (
+							<SelectControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Taxonomy' ) }
+								options={ taxonomies.map( ( t ) => ( {
+									label: t.name,
+									value: t.slug,
+								} ) ) }
+								value={ taxonomySlug }
+								onChange={ ( selectedTaxonomy ) =>
+									setAttributes( {
+										taxonomy: selectedTaxonomy,
+									} )
+								}
+							/>
+						) }
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Display as dropdown' ) }

--- a/packages/block-library/src/categories/index.js
+++ b/packages/block-library/src/categories/index.js
@@ -9,6 +9,7 @@ import { category as icon } from '@wordpress/icons';
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
 import edit from './edit';
+import variations from './variations';
 
 const { name } = metadata;
 
@@ -18,6 +19,7 @@ export const settings = {
 	icon,
 	example: {},
 	edit,
+	variations,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/categories/variations.js
+++ b/packages/block-library/src/categories/variations.js
@@ -30,6 +30,7 @@ const variations = [
 			taxonomy: 'category',
 		},
 		isActive: [ 'taxonomy' ],
+		isDefault: true,
 	},
 ];
 

--- a/packages/block-library/src/categories/variations.js
+++ b/packages/block-library/src/categories/variations.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { category as icon } from '@wordpress/icons';
+
+const variations = [
+	{
+		name: 'terms',
+		title: __( 'Terms List' ),
+		icon,
+		attributes: {
+			// We need to set an attribute here that will be set when inserting the block.
+			// We cannot leave this empty, as that would be interpreted as the default value,
+			// which is `category` -- for which we're defining a distinct variation below,
+			// for backwards compatibility reasons.
+			// The logical fallback is thus the only other built-in and public taxonomy: Tags.
+			taxonomy: 'post_tag',
+		},
+		isActive: ( blockAttributes ) =>
+			// This variation is used for any taxonomy other than `category`.
+			blockAttributes.taxonomy !== 'category',
+	},
+	{
+		name: 'categories',
+		title: __( 'Categories List' ),
+		description: __( 'Display a list of all categories.' ),
+		icon,
+		attributes: {
+			taxonomy: 'category',
+		},
+		isActive: [ 'taxonomy' ],
+	},
+];
+
+export default variations;

--- a/packages/block-library/src/categories/variations.js
+++ b/packages/block-library/src/categories/variations.js
@@ -30,6 +30,9 @@ const variations = [
 			taxonomy: 'category',
 		},
 		isActive: [ 'taxonomy' ],
+		// The following is needed to prevent "Terms List" from showing up twice in the inserter
+		// (once for the block, once for the variation). Fortunately, it does not collide with
+		// `categories` being the default value of the `taxonomy` attribute.
 		isDefault: true,
 	},
 ];


### PR DESCRIPTION
## What?
Add two variations to the Terms List block (i.e. `core/categories` and named "Categories List" prior to #65272): One for Categories, and another one for all other taxonomies.

## Why?
Mostly for better discoverability of what used to be the Categories List block under its new name. For more background, please refer to [this thread](https://github.com/WordPress/gutenberg/pull/65272#discussion_r1759108638).

## How?
By creating two block variations.

## Drawbacks
Also discussed in [this thread](https://github.com/WordPress/gutenberg/pull/65272#discussion_r1759108638).

## Alternatives
One alternative would be to create a block variation for each individual taxonomy. This has been explored in https://github.com/WordPress/gutenberg/pull/64805. (That PR is now closed, but it can be reopened anytime.)

## Testing Instructions
TBD, but largely similar to https://github.com/WordPress/gutenberg/pull/65272 or https://github.com/WordPress/gutenberg/pull/64805.

## Screenshots or screencast

> ![dropdown-includes everything](https://github.com/user-attachments/assets/69b61f8d-3222-46bf-9c61-e212617108ad)
