### PR TITLE
Comments Pagination: Fix warning returned by comments pagination blocks

### DIFF
--- a/packages/block-library/src/comments-pagination-next/index.php
+++ b/packages/block-library/src/comments-pagination-next/index.php
@@ -37,7 +37,7 @@ function render_block_core_comments_pagination_next( $attributes, $content, $blo
 		$label .= $pagination_arrow;
 	}
 
-	$next_comments_link = get_next_comments_link( $label, $max_page, $comment_vars['paged'] );
+	$next_comments_link = get_next_comments_link( $label, $max_page, $comment_vars['paged'] ?? null );
 
 	remove_filter( 'next_posts_link_attributes', $filter_link_attributes );
 

--- a/packages/block-library/src/comments-pagination-previous/index.php
+++ b/packages/block-library/src/comments-pagination-previous/index.php
@@ -30,7 +30,7 @@ function render_block_core_comments_pagination_previous( $attributes, $content, 
 	add_filter( 'previous_comments_link_attributes', $filter_link_attributes );
 
 	$comment_vars           = build_comment_query_vars_from_block( $block );
-	$previous_comments_link = get_previous_comments_link( $label, $comment_vars['paged'] );
+	$previous_comments_link = get_previous_comments_link( $label, $comment_vars['paged'] ?? null );
 
 	remove_filter( 'previous_comments_link_attributes', $filter_link_attributes );
 


### PR DESCRIPTION
## What?
Fixes https://github.com/WordPress/gutenberg/issues/65424

## Why?
It shouldn't return a warning in that scenario.

## How?
I added a safety check to return null when `$comment_vars['paged']` is not defined.

I couldn't adapt the e2e tests because the testing instance has `WP_DEBUG` set to false and doesn't show warnings.

## Testing Instructions
1. Go to Settings->Discussion and check you have "Break comments into pages with **2** top level comments per page and the **last** page displayed by default.
2. Go to a post with NO comments and add the comments block.
3. Go to the frontend and check that the warning is not there anymore.

