### PR TITLE
Zoom out: hide toolbar icon on smaller viewports

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -143,7 +143,7 @@ function Header( {
 				/>
 				<PostViewLink />
 
-				<ZoomOutToggle />
+				{ isWideViewport && <ZoomOutToggle /> }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/65431

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Zoom out doesn't make sense on mobile, so we might as well hide it


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Checks for the viewport width to conditionally render the zoom out button on the toolbar

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that the icon is not showing when on smaller viewports

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before | After 
--- | ---
<img width="426" alt="Screenshot 2024-09-18 at 11 54 24" src="https://github.com/user-attachments/assets/f1677514-c1b9-42d5-8f7e-1d14b39fead4"> | <img width="441" alt="Screenshot 2024-09-18 at 11 54 32" src="https://github.com/user-attachments/assets/a2c7e0cd-51d2-461f-ae64-9f05907b45ea">