### PR TITLE
Unit tests: mock matchMedia to enforce prefers-reduce-motion

### DIFF
--- a/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
+++ b/packages/nux/src/components/dot-tip/test/__snapshots__/index.js.snap
@@ -7,7 +7,7 @@ exports[`DotTip should render correctly 1`] = `
   data-wp-c16t="true"
   data-wp-component="Popover"
   role="dialog"
-  style="position: absolute; top: 0px; left: 0px; opacity: 1; transform: translateX(0px) translateY(0px) translateX(0em) scale(1) translateZ(0); transform-origin: 0% 50% 0;"
+  style="position: absolute; top: 0px; left: 0px; transform: none;"
   tabindex="-1"
 >
   <div

--- a/test/unit/jest.config.js
+++ b/test/unit/jest.config.js
@@ -19,7 +19,10 @@ module.exports = {
 		'<rootDir>/test/unit/config/global-mocks.js',
 		'<rootDir>/test/unit/config/gutenberg-env.js',
 	],
-	setupFilesAfterEnv: [ '<rootDir>/test/unit/config/testing-library.js' ],
+	setupFilesAfterEnv: [
+		'<rootDir>/test/unit/config/testing-library.js',
+		'<rootDir>/test/unit/mocks/match-media.js',
+	],
 	testEnvironmentOptions: {
 		url: 'http://localhost/',
 	},

--- a/test/unit/mocks/match-media.js
+++ b/test/unit/mocks/match-media.js
@@ -1,0 +1,22 @@
+// Mock `matchMedia` so that all animations are skipped,
+// since js-dom does not fully support CSS animations.
+// Example: https://github.com/jsdom/jsdom/issues/3239
+const originalMatchMedia = window.matchMedia;
+const mockedMatchMedia = jest.fn( ( query ) => {
+	if ( /prefers-reduced-motion/.test( query ) ) {
+		return {
+			...originalMatchMedia( query ),
+			matches: true,
+		};
+	}
+
+	return originalMatchMedia( query );
+} );
+
+beforeAll( () => {
+	window.matchMedia = jest.fn( mockedMatchMedia );
+} );
+
+afterAll( () => {
+	window.matchMedia = originalMatchMedia;
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Enforce the `prefers-reduced-motion` media feature on all Jest unit tests.

Props to @tyxla for pushing the solution proposed in this PR as part of the work in #65203

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Working on a few animations (for example, #65203 and #64777) we realised that `js-dom` doesn't fully support CSS animations. We think that disabling animations via enforcing the `prefers-reduced-motion` option can improve unit test reliability.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added a global Jest mock that forces the `window.matchMedia` function to always match the `prefers-reduced-motion` query.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

All unit tests should continue passing.