### PR TITLE
Handle zoom out when changing device preview

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -26,6 +26,7 @@ import { ActionItem } from '@wordpress/interface';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import PostPreviewButton from '../post-preview-button';
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
@@ -44,6 +45,12 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			};
 		}, [] );
 	const { setDeviceType } = useDispatch( editorStore );
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+
+	const handleDevicePreviewChange = ( newDeviceType ) => {
+		setDeviceType( newDeviceType );
+		__unstableSetEditorMode( 'edit' );
+	};
 
 	const isMobile = useViewportMatch( 'medium', '<' );
 	if ( isMobile ) {
@@ -113,7 +120,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 						<MenuItemsChoice
 							choices={ choices }
 							value={ deviceType }
-							onSelect={ setDeviceType }
+							onSelect={ handleDevicePreviewChange }
 						/>
 					</MenuGroup>
 					{ isTemplate && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65411

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The device preview and zoom out toggle are two components that live in the same place in the component tree so they can be aware of the same mechanism and states of the UI. So I added a call to disable zoom out if a preview size is selected.

## Testing Instructions

- in the site editor
- select from the top right device dropdown a preview size (mobile)
- toggle the control next to it on (zoom out)
- change the preview size (tablet)
- notice zoom out is disengaged

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5b59739f-5a9b-41e1-aa41-6694d7d1e5d8



