### PR TITLE
Zoom out: Move the toggle button to before the device preview dropdown

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -134,6 +134,9 @@ function Header( {
 					 */
 					<PostSavedState forceIsDirty={ forceIsDirty } />
 				) }
+
+				{ isEditorIframed && isWideViewport && <ZoomOutToggle /> }
+
 				<PreviewDropdown
 					forceIsAutosaveable={ forceIsDirty }
 					disabled={ isNestedEntity }
@@ -143,8 +146,6 @@ function Header( {
 					forceIsAutosaveable={ forceIsDirty }
 				/>
 				<PostViewLink />
-
-				{ isEditorIframed && isWideViewport && <ZoomOutToggle /> }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />


### PR DESCRIPTION
> [!NOTE]
> ~~This PR conflicts with #65448. After one of them is merged, I would like to rebase the other one.~~

## What?
<!-- In a few words, what is the PR actually doing? -->

In the post editor, the preview button is located between the device preview button and the zoom out toggle button.

This layout feels unnatural, as device preview and zoom out are supposed to go hand in hand.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/8e115f33-d031-45e7-8c1e-fb207bbe444a)| ![after](https://github.com/user-attachments/assets/08ea4fd6-790f-486e-8b1d-2c4a6c2f59a9) | 


## Testing Instructions

- Open the post editor.
- Check the header toolbar.