### PR TITLE
Block Bindings: Remove extra filtering of empty sources

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -218,7 +218,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 							context,
 						} );
 						// Only add source if the list is not empty.
-						if ( sourceList ) {
+						if ( Object.keys( sourceList || {} ).length ) {
 							_fieldsList[ sourceName ] = { ...sourceList };
 						}
 					}
@@ -240,12 +240,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 		return null;
 	}
-	// Remove empty sources from the list of fields.
-	Object.entries( fieldsList ).forEach( ( [ key, value ] ) => {
-		if ( ! Object.keys( value ).length ) {
-			delete fieldsList[ key ];
-		}
-	} );
 	// Filter bindings to only show bindable attributes and remove pattern overrides.
 	const { bindings } = metadata || {};
 	const filteredBindings = { ...bindings };


### PR DESCRIPTION
## What?
As suggested [here](https://github.com/WordPress/gutenberg/pull/64072#discussion_r1764697066), we could keep only one filter to prevent including empty sources in the fields list in block bindings.

## Why?
Code quality. It is unnecessary code.

## How?
Remove the old filter used and modify the new one contemplating the different scenarios.

## Testing Instructions
Everything should keep working as before and e2e tests should pass.
