### PR TITLE
Zoom out: show toggle button on medium viewports

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -50,6 +50,7 @@ function Header( {
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
+	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
 		isTextEditor,
@@ -143,7 +144,7 @@ function Header( {
 				/>
 				<PostViewLink />
 
-				{ isWideViewport && <ZoomOutToggle /> }
+				{ ! isMobileViewport && <ZoomOutToggle /> }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />


### PR DESCRIPTION
> [!NOTE]
> This PR conflicts with #65446. After one of them is merged, I would like to rebase the other one.

Follow-up #65437

## What?

The device preview button and the zoom out toggle button are closely related. Currently, when the browser width is between `783px` and `959px`, the device preview button is visible but the zoom out toggle button is not visible.

To resolve this inconsistency, the zoom out toggle button should also be visible in the medium viewport.

## How?

I first thought about using the existing `isLargeViewport` constant as the rendering condition. But this wasn't ideal because the device preview button would only be visible at exactly `783px`.

![image](https://github.com/user-attachments/assets/3e0c44b6-d5e1-41c7-94c1-9de5839c6682)

I defined a new `isMobileViewport` to exactly match the display condition for the device preview button.

## Testing Instructions

- Open the post editor
- If the browser width is less than `782px`: neither button will be displayed
- If the browser width is more than `783px`: both buttons will be displayed

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/64e09fa7-1dee-4b76-8ab3-66031790b696

