### PR TITLE
Block Bindings: Always prioritize using context in post meta source logic

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -14,7 +14,13 @@ function getMetadata( registry, context, registeredFields ) {
 	const type = registry.select( editorStore ).getCurrentPostType();
 	const { getEditedEntityRecord } = registry.select( coreDataStore );
 
-	if ( type === 'wp_template' ) {
+	if ( context?.postType && context?.postId ) {
+		metaFields = getEditedEntityRecord(
+			'postType',
+			context?.postType,
+			context?.postId
+		).meta;
+	} else if ( type === 'wp_template' ) {
 		// Populate the `metaFields` object with the default values.
 		Object.entries( registeredFields || {} ).forEach(
 			( [ key, props ] ) => {
@@ -23,12 +29,6 @@ function getMetadata( registry, context, registeredFields ) {
 				}
 			}
 		);
-	} else {
-		metaFields = getEditedEntityRecord(
-			'postType',
-			context?.postType,
-			context?.postId
-		).meta;
 	}
 
 	return metaFields;

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -11,7 +11,7 @@ import { unlock } from '../lock-unlock';
 
 function getMetadata( registry, context, registeredFields ) {
 	let metaFields = {};
-	const { type } = registry.select( editorStore ).getCurrentPost();
+	const type = registry.select( editorStore ).getCurrentPostType();
 	const { getEditedEntityRecord } = registry.select( coreDataStore );
 
 	if ( type === 'wp_template' ) {


### PR DESCRIPTION
## What?
This pull request covers two aspects:
* As reported [here](https://github.com/WordPress/gutenberg/pull/64072#discussion_r1764427326), it changes the conditional to ensure it uses `context.postType` and `context.postId` when they exist and only run the logic for `wp_template`.
* As reported [here](https://github.com/WordPress/gutenberg/pull/64072#discussion_r1764420031), it uses `getCurrentPostType` selector.

## Why?
It looks better this way.

## How?
I just changed the conditional and the selector used.

## Testing Instructions
Everything should keep working as expected and e2e tests should pass.
