### PR TITLE
Block Bindings: Improve getRegisteredPostMeta resolver

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -993,20 +993,25 @@ export const getRevision =
 export const getRegisteredPostMeta =
 	( postType ) =>
 	async ( { dispatch, resolveSelect } ) => {
+		let options;
 		try {
 			const {
 				rest_namespace: restNamespace = 'wp/v2',
 				rest_base: restBase,
 			} = ( await resolveSelect.getPostType( postType ) ) || {};
-			const options = await apiFetch( {
+			options = await apiFetch( {
 				path: `${ restNamespace }/${ restBase }/?context=edit`,
 				method: 'OPTIONS',
 			} );
+		} catch ( error ) {
+			// Do nothing if the request comes back with an API error.
+			return;
+		}
+
+		if ( options ) {
 			dispatch.receiveRegisteredPostMeta(
 				postType,
 				options?.schema?.properties?.meta?.properties
 			);
-		} catch {
-			dispatch.receiveRegisteredPostMeta( postType, false );
 		}
 	};

--- a/packages/core-data/src/selectors.ts
+++ b/packages/core-data/src/selectors.ts
@@ -47,7 +47,7 @@ export interface State {
 	navigationFallbackId: EntityRecordKey;
 	userPatternCategories: Array< UserPatternCategory >;
 	defaultTemplates: Record< string, string >;
-	registeredPostMeta: Record< string, { postType: string } >;
+	registeredPostMeta: Record< string, Object >;
 }
 
 type EntityRecordKey = string | number;


### PR DESCRIPTION
## What?
This PR covers two points reported [here](https://github.com/WordPress/gutenberg/pull/64072#discussion_r1764411253):
* It should be called with `false` when there is an error.
* The State record has to be updated.

## Why?
It doesn't seem right at the moment.

## How?
For handling the error, I followed a similar approach to other resolvers like [this one](https://github.com/WordPress/gutenberg/blob/3fa2af18a0ff8d8669f49fb309b3fd9e7864a0ae/packages/core-data/src/resolvers.js#L480-L491), [this one](https://github.com/WordPress/gutenberg/blob/3fa2af18a0ff8d8669f49fb309b3fd9e7864a0ae/packages/core-data/src/resolvers.js#L574-L585), or [this one](https://github.com/WordPress/gutenberg/blob/3fa2af18a0ff8d8669f49fb309b3fd9e7864a0ae/packages/core-data/src/resolvers.js#L855-L864).

Additionally, I updated the second parameter of Record to be `Object`.

## Testing Instructions
Everything should keep working as expected and e2e tests should pass.
