### PR TITLE
Remove zoom out toggle when editor is not iframed

### DIFF
--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -139,6 +139,7 @@ export default function EditorInterface( {
 						customSaveButton={ customSaveButton }
 						forceDisableBlockTools={ forceDisableBlockTools }
 						title={ title }
+						isEditorIframed={ ! disableIframe }
 					/>
 				)
 			}

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -47,6 +47,7 @@ function Header( {
 	forceDisableBlockTools,
 	setEntitiesSavedStatesCallback,
 	title,
+	isEditorIframed,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -143,7 +144,7 @@ function Header( {
 				/>
 				<PostViewLink />
 
-				{ isWideViewport && <ZoomOutToggle /> }
+				{ isEditorIframed && isWideViewport && <ZoomOutToggle /> }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65311

Disables the zoom out control in the UI (header) when the editor is not in an iframe - hence there is nothing to scale.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Pass the `disableIframe` prop from editor interface to its header child component.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enable a classic theme
2. Install Jetpack
3. Go to the post editor
4. **There should be no zoom out toggle in the header**
5. Enable a block theme
6. Go to the post editor
7.  **There should be a zoom out toggle in the header**

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/00b22679-566b-4156-ae66-0a08d6f9f644


