### PR TITLE
Components: Cleanup unused `ToggleGroupControl` config values

### DIFF
--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/styles.ts
@@ -70,7 +70,7 @@ export const buttonView = ( {
 	}
 
 	&:active {
-		background: ${ CONFIG.toggleGroupControlBackgroundColor };
+		background: ${ CONFIG.controlBackgroundColor };
 	}
 
 	${ isDeselectable && deselectable }

--- a/packages/components/src/utils/config-values.js
+++ b/packages/components/src/utils/config-values.js
@@ -7,18 +7,13 @@ import { COLORS } from './colors-values';
 const CONTROL_HEIGHT = '36px';
 
 const CONTROL_PROPS = {
-	controlSurfaceColor: COLORS.white,
-	controlTextActiveColor: COLORS.theme.accent,
-
 	// These values should be shared with TextControl.
 	controlPaddingX: 12,
 	controlPaddingXSmall: 8,
 	controlPaddingXLarge: 12 * 1.3334, // TODO: Deprecate
 
 	controlBackgroundColor: COLORS.white,
-	controlBoxShadow: 'transparent',
 	controlBoxShadowFocus: `0 0 0 0.5px ${ COLORS.theme.accent }`,
-	controlDestructiveBorderColor: COLORS.alert.red,
 	controlHeight: CONTROL_HEIGHT,
 	controlHeightXSmall: `calc( ${ CONTROL_HEIGHT } * 0.6 )`,
 	controlHeightSmall: `calc( ${ CONTROL_HEIGHT } * 0.8 )`,
@@ -26,18 +21,9 @@ const CONTROL_PROPS = {
 	controlHeightXLarge: `calc( ${ CONTROL_HEIGHT } * 1.4 )`,
 };
 
-const TOGGLE_GROUP_CONTROL_PROPS = {
-	toggleGroupControlBackgroundColor: CONTROL_PROPS.controlBackgroundColor,
-	toggleGroupControlBorderColor: COLORS.ui.border,
-	toggleGroupControlBackdropBackgroundColor:
-		CONTROL_PROPS.controlSurfaceColor,
-	toggleGroupControlBackdropBorderColor: COLORS.ui.border,
-	toggleGroupControlButtonColorActive: CONTROL_PROPS.controlBackgroundColor,
-};
-
 // Using Object.assign to avoid creating circular references when emitting
 // TypeScript type declarations.
-export default Object.assign( {}, CONTROL_PROPS, TOGGLE_GROUP_CONTROL_PROPS, {
+export default Object.assign( {}, CONTROL_PROPS, {
 	colorDivider: 'rgba(0, 0, 0, 0.1)',
 	colorScrollbarThumb: 'rgba(0, 0, 0, 0.2)',
 	colorScrollbarThumbHover: 'rgba(0, 0, 0, 0.5)',


### PR DESCRIPTION
Part of #43997

## What?
While reviewing some code related to `ToggleGroupControl` I spotted some unused config values and decided to clean them up. 

I found that there are more unused ones around, but I decided this is enough for a single PR, since I initially headed to clean up solely the `ToggleGroupControl` ones.

## Why?
They're unused and can just be removed:

- `toggleGroupControlBackgroundColor` - updated to use the underlying `controlBackgroundColor`
- `toggleGroupControlBorderColor` (previously `segmentedControlBorderColor`) - never used since creation in #31937
- `toggleGroupControlBackdropBackgroundColor` (previously `segmentedControlBackdropBackgroundColor`) - never used since creation in #31937
- `toggleGroupControlBackdropBorderColor` (previously `segmentedControlBackdropBorderColor`) - never used since creation in #31937
- `toggleGroupControlButtonColorActive`:  (previously `segmentedControlButtonColorActive`) - never used since creation in #31937
- `controlBoxShadow`: no longer in use since #47911
- `controlDestructiveBorderColor`: no longer in use since #47911
- `controlSurfaceColor` - no longer in use after the `toggleGroupControl` values were removed.
- `controlTextActiveColor` - never used since creation in #31937
- `surfaceBackgroundSubtleColor` - not in use since introduced in #31238

As you can see, this also allowed us to remove the entire `TOGGLE_GROUP_CONTROL_PROPS` object. 

## How?
I removed the unused ones and cleaned the code around a little bit. 

## Testing Instructions
Verify the removed config values aren't in use. There should be no visual/functional changes.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None, this has no visual impact. 