### PR TITLE
Script Modules: Centralize (re)registration

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -135,7 +135,9 @@ jobs:
               uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
               with:
                   name: build-assets
-                  path: ./build/
+                  path: |
+                      ./build/
+                      ./build-module/
 
     test-php:
         name: PHP ${{ matrix.php }}${{ matrix.multisite && ' multisite' || '' }}${{ matrix.wordpress != '' && format( ' (WP {0}) ', matrix.wordpress ) || '' }} on ubuntu-latest
@@ -212,7 +214,9 @@ jobs:
               uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
               with:
                   name: build-assets
-                  path: ./build
+                  path: |
+                      ./build
+                      ./build-module
 
             - name: Docker debug information
               run: |

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -214,9 +214,6 @@ jobs:
               uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
               with:
                   name: build-assets
-                  path: |
-                      ./build
-                      ./build-module
 
             - name: Docker debug information
               run: |

--- a/backport-changelog/6.7/7360.md
+++ b/backport-changelog/6.7/7360.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7360
+
+* https://github.com/WordPress/gutenberg/pull/65460

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -614,7 +614,7 @@ function gutenberg_register_script_modules() {
 	 *     'interactivity/debug.min.js' => array('dependencies' => array(…), 'version' => '…'),
 	 *     'interactivity-router/index.min.js' => …
 	 */
-	$assets = include gutenberg_dir_path() . '/build-module/assets.production.php';
+	$assets = include gutenberg_dir_path() . '/build-module/assets.php';
 
 	foreach ( $assets as $file_name => $script_module_data ) {
 		$package_name     = dirname( $file_name );

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -619,8 +619,9 @@ function gutenberg_default_script_modules() {
 	$assets = include gutenberg_dir_path() . '/build-module/assets.php';
 
 	foreach ( $assets as $file_name => $script_module_data ) {
-		$package_name     = dirname( $file_name );
-		$package_sub_name = basename( $file_name, '.min.js' );
+		$package_name = dirname( $file_name );
+		// Account for both `[filename].min.js` and `[filename].js`
+		$package_sub_name = basename( basename( $file_name, '.js' ), '.min' );
 
 		switch ( $package_name ) {
 			/*

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -606,7 +606,7 @@ add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
  *
  * Script modules that are registered by Core will be re-registered by Gutenberg.
  */
-function gutenberg_register_script_modules() {
+function gutenberg_default_script_modules() {
 	/*
 	 * Expects multidimensional array like:
 	 *
@@ -645,11 +645,11 @@ function gutenberg_register_script_modules() {
 		}
 
 		$path = gutenberg_url( "build-module/{$file_name}" );
-		wp_deregister_script_module( $script_module_id );
 		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
 	}
 }
-add_action( 'after_setup_theme', 'gutenberg_register_script_modules', 20 );
+remove_action( 'wp_default_scripts', 'wp_default_script_modules' );
+add_action( 'wp_default_scripts', 'gutenberg_register_script_modules' );
 
 /*
  * Always remove the Core action hook while gutenberg_enqueue_stored_styles() exists to avoid styles being printed twice.

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -626,11 +626,11 @@ function gutenberg_default_script_modules() {
 		 *   - interactivity/debug.min.js  => @wordpress/interactivity/debug
 		 *   - block-library/query/view.js => @wordpress/block-library/query/view
 		 */
-		$script_module_id = '@wordpress/' . preg_replace( '~(?:/index)?(?:\.min)?\.js$~iD', '', $file_name, 1 );
+		$script_module_id = '@wordpress/' . preg_replace( '~(?:/index)?\.min\.js$~D', '', $file_name, 1 );
 		switch ( $script_module_id ) {
 			/*
-			 * Interactivity exposes two entrypoints, `/index` and `/debug`.
-			 * `/debug` should replalce `/index` in devlopment.
+			 * Interactivity exposes two entrypoints, "/index" and "/debug".
+			 * "/debug" should replalce "/index" in devlopment.
 			 */
 			case '@wordpress/interactivity/debug':
 				if ( ! SCRIPT_DEBUG ) {
@@ -645,6 +645,10 @@ function gutenberg_default_script_modules() {
 				break;
 		}
 
+		if ( SCRIPT_DEBUG ) {
+			// Replave ".min.js" with ".js" in devlopment.
+			$file_name = substr( $file_name, 0, -7 ) . '.js';
+		}
 		$path = gutenberg_url( "build-module/{$file_name}" );
 		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -645,10 +645,6 @@ function gutenberg_default_script_modules() {
 				break;
 		}
 
-		if ( SCRIPT_DEBUG ) {
-			// Replave ".min.js" with ".js" in devlopment.
-			$file_name = substr( $file_name, 0, -7 ) . '.js';
-		}
 		$path = gutenberg_url( "build-module/{$file_name}" );
 		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
 	}

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -605,6 +605,8 @@ add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
  * Registers or re-registers Gutenberg Script Modules.
  *
  * Script modules that are registered by Core will be re-registered by Gutenberg.
+ *
+ * @since 19.3.0
  */
 function gutenberg_default_script_modules() {
 	/*
@@ -649,7 +651,7 @@ function gutenberg_default_script_modules() {
 	}
 }
 remove_action( 'wp_default_scripts', 'wp_default_script_modules' );
-add_action( 'wp_default_scripts', 'gutenberg_register_script_modules' );
+add_action( 'wp_default_scripts', 'gutenberg_default_script_modules' );
 
 /*
  * Always remove the Core action hook while gutenberg_enqueue_stored_styles() exists to avoid styles being printed twice.

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -239,55 +239,5 @@ function gutenberg_a11y_script_module_html() {
 		. '<div id="a11y-speak-polite" class="a11y-speak-region" aria-live="polite" aria-relevant="additions text" aria-atomic="true"></div>'
 		. '</div>';
 }
-
-/**
- * Registers Gutenberg Script Modules.
- *
- * @since 19.3
- */
-function gutenberg_register_script_modules() {
-	/*
-	 * Expects multidimensional array like:
-	 *
-	 *     'interactivity/index.min.js' => array('dependencies' => array(…), 'version' => '…'),
-	 *     'interactivity/debug.min.js' => array('dependencies' => array(…), 'version' => '…'),
-	 *     'interactivity-router/index.min.js' => …
-	 */
-	$assets = include gutenberg_dir_path() . '/build-module/assets.production.php';
-
-	foreach ( $assets as $file_name => $script_module_data ) {
-		$package_name     = dirname( $file_name );
-		$package_sub_name = basename( $file_name, '.min.js' );
-
-		switch ( $package_name ) {
-			/*
-			 * Interactivity exposes two entrypoints, `/index` and `/debug`.
-			 * They're the production and development versions of the package.
-			 */
-			case 'interactivity':
-				if ( SCRIPT_DEBUG ) {
-					if ( 'index' === $package_sub_name ) {
-						continue 2;
-					}
-				} else {
-					if ( 'debug' === $package_sub_name ) {
-						continue 2;
-					}
-				}
-				$script_module_id = '@wordpress/interactivity';
-				break;
-
-			default:
-				$script_module_id = 'index' === $package_sub_name ?
-					"@wordpress/{$package_name}" :
-					"@wordpress/{$package_name}/{$package_sub_name}";
-		}
-
-		$path = gutenberg_url( "build-module/{$file_name}" );
-		wp_deregister_script_module( $script_module_id );
-		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
-	}
-}
-add_action( 'after_setup_theme', 'gutenberg_register_script_modules', 20 );
 add_action( 'wp_footer', 'gutenberg_a11y_script_module_html' );
 add_action( 'admin_footer', 'gutenberg_a11y_script_module_html' );

--- a/lib/experimental/script-modules.php
+++ b/lib/experimental/script-modules.php
@@ -246,17 +246,6 @@ function gutenberg_a11y_script_module_html() {
  * @since 19.3
  */
 function gutenberg_register_script_modules() {
-	wp_deregister_script_module( '@wordpress/a11y' );
-	wp_register_script_module(
-		'@wordpress/a11y',
-		gutenberg_url( 'build-module/a11y/index.min.js' ),
-		array(),
-		$default_version
-	);
-
-	$suffix = defined( 'WP_RUN_CORE_TESTS' ) ? '.min' : wp_scripts_get_suffix();
-
-
 	/*
 	 * Expects multidimensional array like:
 	 *
@@ -264,11 +253,11 @@ function gutenberg_register_script_modules() {
 	 *     'interactivity/debug.min.js' => array('dependencies' => array(…), 'version' => '…'),
 	 *     'interactivity-router/index.min.js' => …
 	 */
-	$assets = include gutenberg_dir_path( 'build-module/assets.production.php' );
+	$assets = include gutenberg_dir_path() . '/build-module/assets.production.php';
 
 	foreach ( $assets as $file_name => $script_module_data ) {
 		$package_name     = dirname( $file_name );
-		$package_sub_name = basename( $file_name, "{$suffix}.js" );
+		$package_sub_name = basename( $file_name, '.min.js' );
 
 		switch ( $package_name ) {
 			/*
@@ -295,11 +284,10 @@ function gutenberg_register_script_modules() {
 		}
 
 		$path = gutenberg_url( "build-module/{$file_name}" );
-		wp_deregister_style( $script_module_id );
+		wp_deregister_script_module( $script_module_id );
 		wp_register_script_module( $script_module_id, $path, $script_module_data['dependencies'], $script_module_data['version'] );
 	}
 }
-
-add_action( 'init', 'gutenberg_register_script_modules' );
+add_action( 'after_setup_theme', 'gutenberg_register_script_modules', 20 );
 add_action( 'wp_footer', 'gutenberg_a11y_script_module_html' );
 add_action( 'admin_footer', 'gutenberg_a11y_script_module_html' );

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -6,14 +6,6 @@
  */
 
 /**
- * Deregisters the Core Interactivity API Modules and replace them
- * with the ones from the Gutenberg plugin.
- *
- * @deprecated 19.3.0 Script module registration is handled by {@see gutenberg_default_script_modules()}.
- */
-function gutenberg_reregister_interactivity_script_modules() {}
-
-/**
  * Adds script data to the interactivity-router script module.
  *
  * This filter is registered conditionally anticipating a WordPress Core change to add the script module data.

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -9,32 +9,7 @@
  * Deregisters the Core Interactivity API Modules and replace them
  * with the ones from the Gutenberg plugin.
  */
-function gutenberg_reregister_interactivity_script_modules() {
-	$default_version = defined( 'GUTENBERG_VERSION' ) && ! SCRIPT_DEBUG ? GUTENBERG_VERSION : time();
-	wp_deregister_script_module( '@wordpress/interactivity' );
-	wp_deregister_script_module( '@wordpress/interactivity-router' );
-
-	wp_register_script_module(
-		'@wordpress/interactivity',
-		gutenberg_url( '/build-module/' . ( SCRIPT_DEBUG ? 'interactivity/debug.min.js' : 'interactivity/index.min.js' ) ),
-		array(),
-		$default_version
-	);
-
-	wp_register_script_module(
-		'@wordpress/interactivity-router',
-		gutenberg_url( '/build-module/interactivity-router/index.min.js' ),
-		array(
-			array(
-				'id'     => '@wordpress/a11y',
-				'import' => 'dynamic',
-			),
-			'@wordpress/interactivity',
-		),
-		$default_version
-	);
-}
-add_action( 'init', 'gutenberg_reregister_interactivity_script_modules' );
+function gutenberg_reregister_interactivity_script_modules() {}
 
 /**
  * Adds script data to the interactivity-router script module.

--- a/lib/interactivity-api.php
+++ b/lib/interactivity-api.php
@@ -8,6 +8,8 @@
 /**
  * Deregisters the Core Interactivity API Modules and replace them
  * with the ones from the Gutenberg plugin.
+ *
+ * @deprecated 19.3.0 Script module registration is handled by {@see gutenberg_default_script_modules()}.
  */
 function gutenberg_reregister_interactivity_script_modules() {}
 

--- a/packages/block-library/src/file/index.php
+++ b/packages/block-library/src/file/index.php
@@ -19,18 +19,7 @@
 function render_block_core_file( $attributes, $content ) {
 	// If it's interactive, enqueue the script module and add the directives.
 	if ( ! empty( $attributes['displayPreview'] ) ) {
-		$suffix = wp_scripts_get_suffix();
-		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build-module/block-library/file/view.min.js' );
-		}
-
-		wp_register_script_module(
-			'@wordpress/block-library/file',
-			isset( $module_url ) ? $module_url : includes_url( "blocks/file/view{$suffix}.js" ),
-			array( '@wordpress/interactivity' ),
-			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-		);
-		wp_enqueue_script_module( '@wordpress/block-library/file' );
+		wp_enqueue_script_module( '@wordpress/block-library/file/view' );
 
 		$processor = new WP_HTML_Tag_Processor( $content );
 		$processor->next_tag();

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -70,19 +70,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 		isset( $lightbox_settings['enabled'] ) &&
 		true === $lightbox_settings['enabled']
 	) {
-		$suffix = wp_scripts_get_suffix();
-		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build-module/block-library/image/view.min.js' );
-		}
-
-		wp_register_script_module(
-			'@wordpress/block-library/image',
-			isset( $module_url ) ? $module_url : includes_url( "blocks/image/view{$suffix}.js" ),
-			array( '@wordpress/interactivity' ),
-			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-		);
-
-		wp_enqueue_script_module( '@wordpress/block-library/image' );
+		wp_enqueue_script_module( '@wordpress/block-library/image/view' );
 
 		/*
 		 * This render needs to happen in a filter with priority 15 to ensure that

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -622,18 +622,7 @@ class WP_Navigation_Block_Renderer {
 	 */
 	private static function handle_view_script_module_loading( $attributes, $block, $inner_blocks ) {
 		if ( static::is_interactive( $attributes, $inner_blocks ) ) {
-			$suffix = wp_scripts_get_suffix();
-			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build-module/block-library/navigation/view.min.js' );
-			}
-
-			wp_register_script_module(
-				'@wordpress/block-library/navigation',
-				isset( $module_url ) ? $module_url : includes_url( "blocks/navigation/view{$suffix}.js" ),
-				array( '@wordpress/interactivity' ),
-				defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-			);
-			wp_enqueue_script_module( '@wordpress/block-library/navigation' );
+			wp_enqueue_script_module( '@wordpress/block-library/navigation/view' );
 		}
 	}
 

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -24,27 +24,7 @@ function render_block_core_query( $attributes, $content, $block ) {
 	// Enqueue the script module and add the necessary directives if the block is
 	// interactive.
 	if ( $is_interactive ) {
-		$suffix = wp_scripts_get_suffix();
-		if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-			$module_url = gutenberg_url( '/build-module/block-library/query/view.min.js' );
-		}
-
-		wp_register_script_module(
-			'@wordpress/block-library/query',
-			isset( $module_url ) ? $module_url : includes_url( "blocks/query/view{$suffix}.js" ),
-			array(
-				array(
-					'id'     => '@wordpress/interactivity',
-					'import' => 'static',
-				),
-				array(
-					'id'     => '@wordpress/interactivity-router',
-					'import' => 'dynamic',
-				),
-			),
-			defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-		);
-		wp_enqueue_script_module( '@wordpress/block-library/query' );
+		wp_enqueue_script_module( '@wordpress/block-library/query/view' );
 
 		$p = new WP_HTML_Tag_Processor( $content );
 		if ( $p->next_tag() ) {

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -80,18 +80,7 @@ function render_block_core_search( $attributes ) {
 		// If it's interactive, enqueue the script module and add the directives.
 		$is_expandable_searchfield = 'button-only' === $button_position;
 		if ( $is_expandable_searchfield ) {
-			$suffix = wp_scripts_get_suffix();
-			if ( defined( 'IS_GUTENBERG_PLUGIN' ) && IS_GUTENBERG_PLUGIN ) {
-				$module_url = gutenberg_url( '/build-module/block-library/search/view.min.js' );
-			}
-
-			wp_register_script_module(
-				'@wordpress/block-library/search',
-				isset( $module_url ) ? $module_url : includes_url( "blocks/search/view{$suffix}.js" ),
-				array( '@wordpress/interactivity' ),
-				defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : get_bloginfo( 'version' )
-			);
-			wp_enqueue_script_module( '@wordpress/block-library/search' );
+			wp_enqueue_script_module( '@wordpress/block-library/search/view' );
 
 			$input->set_attribute( 'data-wp-bind--aria-hidden', '!context.isSearchInputVisible' );
 			$input->set_attribute( 'data-wp-bind--tabindex', 'state.tabindex' );

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -108,7 +108,7 @@ module.exports = {
 		...plugins,
 		new DependencyExtractionWebpackPlugin( {
 			combineAssets: true,
-			combinedOutputFile: `./assets.${ baseConfig.mode }.php`,
+			combinedOutputFile: `./assets.php`,
 		} ),
 	],
 	watchOptions: {

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -89,11 +89,11 @@ module.exports = {
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename: './build-module/[name].min.js',
+		filename: './[name].min.js',
 		library: {
 			type: 'module',
 		},
-		path: join( __dirname, '..', '..' ),
+		path: join( __dirname, '..', '..', 'build-module' ),
 		environment: { module: true },
 		module: true,
 		chunkFormat: 'module',
@@ -102,7 +102,13 @@ module.exports = {
 	resolve: {
 		extensions: [ '.js', '.ts', '.tsx' ],
 	},
-	plugins: [ ...plugins, new DependencyExtractionWebpackPlugin() ],
+	plugins: [
+		...plugins,
+		new DependencyExtractionWebpackPlugin( {
+			combineAssets: true,
+			combinedOutputFile: `./assets.${ baseConfig.mode }.php`,
+		} ),
+	],
 	watchOptions: {
 		ignored: [ '**/node_modules' ],
 		aggregateTimeout: 500,

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -89,7 +89,9 @@ module.exports = {
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename: './[name].min.js',
+		filename: `[name]${
+			baseConfig.mode === 'production' ? '.min' : ''
+		}.js`,
 		library: {
 			type: 'module',
 		},

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -89,9 +89,7 @@ module.exports = {
 	},
 	output: {
 		devtoolNamespace: 'wp',
-		filename: `[name]${
-			baseConfig.mode === 'production' ? '.min' : ''
-		}.js`,
+		filename: '[name].min.js',
 		library: {
 			type: 'module',
 		},


### PR DESCRIPTION


## What?

Rework the way that Script Modules are registered in Gutenberg.

- Script Module registration is handled in one central place.
- A combined assets file is used for Script Modules and registration.
- Block library Script Module assets that are enqueued on demand _are registered in a centralized location_. The assets are enqueued on demand. **This requires a Core change** since the block library PHP files are synced to Core and also require centralized Script Module registration (https://github.com/WordPress/wordpress-develop/pull/7360).
  **[This solves the problem where Gutenberg-specific code is being shipped in Core.](https://github.com/WordPress/WordPress/blob/4b9dc0d225844ec0b2542212187936089240dff7/wp-includes/blocks/query.php#L27-L30)**
- The block library Script Module asset Module IDs are renamed to indicate they are view files and align with the naming from #65064, e.g. `@wordpress/block-library/query` is now `@wordpress/block-library/query/view` (indicating it is a view file).



This is sufficient to change Script Modules to use Gutenberg in a backwards compatible way:
- `@wordpress/ineractivity` and `@wordpress/interactivity-router` [were registered on `wp_enqueue_scripts`](https://github.com/WordPress/wordpress-develop/blob/ceedcb5ae956b92288cd370a6e67789c196c95d1/src/wp-includes/interactivity-api/class-wp-interactivity-api.php#L308-L309). That action fires after the `wp_default_scripts` used here. [Registering an already registered Script Module is a no-op](https://github.com/WordPress/wordpress-develop/blob/ceedcb5ae956b92288cd370a6e67789c196c95d1/src/wp-includes/class-wp-script-modules.php#L64-L65), so Gutenberg wins here.
- The only other Script Modules currently available in Core are from the block library. Those have been registered conditionally on use. The ID is changed here, so there's little risk of the wrong version being used.

There is a Core companion at https://github.com/WordPress/wordpress-develop/pull/7360 that is preparing to update Core in the same way with centralized Script Module registration.

## Why?

- Registering Script Modules in several places is messy and difficult to maintain.
- Script Modules dependency arrays and versions have been manually maintained, which is error prone.
- Some block library code (synced to Core) included Gutenberg-specific functions and constants which is undesirable.

## Testing Instructions

Test out this PR. Testing with https://github.com/WordPress/wordpress-develop/pull/7360 is optional.

- The affected blocks should use the Script Modules from Gutenberg correctly when necessary. For example, add an Image block and change its link to "expand the image." This should enqueue its Script Module (and it should work!)
- Try out the full-site client-side navigation experiment. _The experiment has issues_ that are not related to this PR, but can be used to ensure that `interactivity` and `interactivity-router` Script Modules are enqueued from the correct place.
- The a11y Script Module should be enqueued with `interactivity-router` and work correctly.

## Screenshots or screencast <!-- if applicable -->
Correct sources:
![Screenshot 2024-09-19 at 17 26 22](https://github.com/user-attachments/assets/c771488b-0a5d-4f0a-9173-f5059f0099c2)

Image block "expand on click" works in frontend:
![Screenshot 2024-09-19 at 17 26 41](https://github.com/user-attachments/assets/cc4bb23c-5ed0-4c24-ad16-f82b6517e4da)


Closes #65499
