### PR TITLE
Block Bindings: Unify logic in `getPostMetaFields` function

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -9,26 +9,65 @@ import { store as coreDataStore } from '@wordpress/core-data';
 import { store as editorStore } from '../store';
 import { unlock } from '../lock-unlock';
 
-function getMetadata( registry, context, registeredFields ) {
-	let metaFields = {};
-	const type = registry.select( editorStore ).getCurrentPostType();
+/**
+ * Get a list of post meta fields with their values and labels
+ * to be consumed in the needed callbacks.
+ * If the value is not available based on context, like in templates,
+ * it falls back to the default value, label, or key.
+ *
+ * @param {Object} registry The registry context exposed through `useRegistry`.
+ * @param {Object} context  The context provided.
+ * @return {Object} List of post meta fields with their value and label.
+ *
+ * @example
+ * ```js
+ * {
+ *     field_1_key: {
+ *         label: 'Field 1 Label',
+ * 	       value: 'Field 1 Value',
+ *     },
+ *     field_2_key: {
+ *         label: 'Field 2 Label',
+ * 	       value: 'Field 2 Value',
+ *     },
+ *     ...
+ * }
+ * ```
+ */
+function getPostMetaFields( registry, context ) {
 	const { getEditedEntityRecord } = registry.select( coreDataStore );
+	const { getRegisteredPostMeta } = unlock(
+		registry.select( coreDataStore )
+	);
 
+	let entityMetaValues;
+	// Try to get the current entity meta values.
 	if ( context?.postType && context?.postId ) {
-		metaFields = getEditedEntityRecord(
+		entityMetaValues = getEditedEntityRecord(
 			'postType',
 			context?.postType,
 			context?.postId
 		).meta;
-	} else if ( type === 'wp_template' ) {
-		// Populate the `metaFields` object with the default values.
-		Object.entries( registeredFields || {} ).forEach(
-			( [ key, props ] ) => {
-				if ( props.default ) {
-					metaFields[ key ] = props.default;
-				}
-			}
-		);
+	}
+
+	const registeredFields = getRegisteredPostMeta( context?.postType );
+	const metaFields = {};
+	Object.entries( registeredFields || {} ).forEach( ( [ key, props ] ) => {
+		// Don't include footnotes or private fields.
+		if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
+			metaFields[ key ] = {
+				label: registeredFields?.[ key ]?.title || key,
+				value:
+					// When using the entity value, an empty string IS a valid value.
+					entityMetaValues?.[ key ] ??
+					// When using the default, an empty string IS NOT a valid value.
+					( props.default || undefined ),
+			};
+		}
+	} );
+
+	if ( ! Object.keys( metaFields || {} ).length ) {
+		return null;
 	}
 
 	return metaFields;
@@ -37,20 +76,15 @@ function getMetadata( registry, context, registeredFields ) {
 export default {
 	name: 'core/post-meta',
 	getValues( { registry, context, bindings } ) {
-		const { getRegisteredPostMeta } = unlock(
-			registry.select( coreDataStore )
-		);
-		const registeredFields = getRegisteredPostMeta( context?.postType );
-		const metaFields = getMetadata( registry, context, registeredFields );
+		const metaFields = getPostMetaFields( registry, context );
 
 		const newValues = {};
 		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
 			// Use the value, the field label, or the field key.
-			const metaKey = source.args.key;
-			newValues[ attributeName ] =
-				metaFields?.[ metaKey ] ??
-				registeredFields?.[ metaKey ]?.title ??
-				metaKey;
+			const fieldKey = source.args.key;
+			const { value: fieldValue, label: fieldLabel } =
+				metaFields?.[ fieldKey ] || {};
+			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
 		}
 		return newValues;
 	},
@@ -110,31 +144,6 @@ export default {
 		return true;
 	},
 	getFieldsList( { registry, context } ) {
-		const { getRegisteredPostMeta } = unlock(
-			registry.select( coreDataStore )
-		);
-		const registeredFields = getRegisteredPostMeta( context?.postType );
-		const metaFields = getMetadata( registry, context, registeredFields );
-
-		if ( ! metaFields || ! Object.keys( metaFields ).length ) {
-			return null;
-		}
-
-		return Object.fromEntries(
-			Object.entries( metaFields )
-				// Remove footnotes or private keys from the list of fields.
-				.filter(
-					( [ key ] ) =>
-						key !== 'footnotes' && key.charAt( 0 ) !== '_'
-				)
-				// Return object with label and value.
-				.map( ( [ key, value ] ) => [
-					key,
-					{
-						label: registeredFields?.[ key ]?.title || key,
-						value,
-					},
-				] )
-		);
+		return getPostMetaFields( registry, context );
 	},
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -56,7 +56,7 @@ function getPostMetaFields( registry, context ) {
 		// Don't include footnotes or private fields.
 		if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
 			metaFields[ key ] = {
-				label: registeredFields?.[ key ]?.title || key,
+				label: props.title || key,
 				value:
 					// When using the entity value, an empty string IS a valid value.
 					entityMetaValues?.[ key ] ??

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -24,11 +24,11 @@ import { unlock } from '../lock-unlock';
  * {
  *     field_1_key: {
  *         label: 'Field 1 Label',
- * 	       value: 'Field 1 Value',
+ *         value: 'Field 1 Value',
  *     },
  *     field_2_key: {
  *         label: 'Field 2 Label',
- * 	       value: 'Field 2 Value',
+ *         value: 'Field 2 Value',
  *     },
  *     ...
  * }

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -10,7 +10,7 @@ import { store as editorStore } from '../store';
 import { unlock } from '../lock-unlock';
 
 /**
- * Get a list of post meta fields with their values and labels
+ * Gets a list of post meta fields with their values and labels
  * to be consumed in the needed callbacks.
  * If the value is not available based on context, like in templates,
  * it falls back to the default value, label, or key.


### PR DESCRIPTION
## What?
There is some improvement over how the post meta source is defined as reported in the following comments:
* https://github.com/WordPress/gutenberg/pull/65099#discussion_r1764666046
* https://github.com/WordPress/gutenberg/pull/65099#discussion_r1764668432

In this pull request, I explored a slightly different approach to the `getPostMetaValues` helper, changing also its name and adding some docs.

## Why?
Code is tricky to understand and this could help navigating and modifying it.

## How?
There are a few aspects to take into account:
* I moved the filtering of footnotes and private keys inside this function.
* I moved the check to return `null` when the list is empty.
* In the case of the `value`, the fallback to label or key can't be abstracted because that is only wanted in `getValues` and not in the list of fields shown by `getFieldsList`.
* I removed the `type === "wp_template"` because I am not sure if it is necessary. With the new code we try to get the entityRecord values and if not, fall back to how the field has been registered. I could add a check if we consider it safer.

## Testing Instructions
Everything should keep working as before and e2e tests should pass.
