### PR TITLE
Interactivity API: Correctly handle lazily added, deeply nested properties with `deepMerge()`

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Correctly handle lazily added, deeply nested properties with `deepMerge()` ([#65465](https://github.com/WordPress/gutenberg/pull/65465)).
+
 ## 6.9.0 (2024-10-03)
 
 ## 6.8.0 (2024-09-19)

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -325,11 +325,25 @@ const deepMergeRecursive = (
 					}
 				}
 			} else if ( isPlainObject( source[ key ] ) ) {
-				if ( isNew ) {
+				if (
+					isNew ||
+					( override && ! isPlainObject( target[ key ] ) )
+				) {
 					target[ key ] = {};
+					const proxy = getProxyFromObject( target );
+					if ( proxy && hasPropSignal( proxy, key ) ) {
+						const propSignal = getPropSignal( proxy, key );
+						propSignal.setValue( target[ key ] );
+					}
 				}
 
-				deepMergeRecursive( target[ key ], source[ key ], override );
+				if ( isPlainObject( target[ key ] ) ) {
+					deepMergeRecursive(
+						target[ key ],
+						source[ key ],
+						override
+					);
+				}
 			} else if ( override || isNew ) {
 				Object.defineProperty( target, key, desc! );
 

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -300,64 +300,57 @@ const deepMergeRecursive = (
 	source: any,
 	override: boolean = true
 ) => {
-	if ( isPlainObject( target ) && isPlainObject( source ) ) {
-		let hasNewKeys = false;
-		for ( const key in source ) {
-			const isNew = ! ( key in target );
-			hasNewKeys = hasNewKeys || isNew;
+	if ( ! ( isPlainObject( target ) && isPlainObject( source ) ) ) {
+		return;
+	}
 
-			const desc = Object.getOwnPropertyDescriptor( source, key );
-			if (
-				typeof desc?.get === 'function' ||
-				typeof desc?.set === 'function'
-			) {
-				if ( override || isNew ) {
-					Object.defineProperty( target, key, {
-						...desc,
-						configurable: true,
-						enumerable: true,
-					} );
+	let hasNewKeys = false;
 
-					const proxy = getProxyFromObject( target );
-					if ( desc?.get && proxy && hasPropSignal( proxy, key ) ) {
-						const propSignal = getPropSignal( proxy, key );
-						propSignal.setGetter( desc.get );
-					}
-				}
-			} else if ( isPlainObject( source[ key ] ) ) {
-				if (
-					isNew ||
-					( override && ! isPlainObject( target[ key ] ) )
-				) {
-					target[ key ] = {};
-					const proxy = getProxyFromObject( target );
-					if ( proxy && hasPropSignal( proxy, key ) ) {
-						const propSignal = getPropSignal( proxy, key );
-						propSignal.setValue( target[ key ] );
-					}
-				}
+	for ( const key in source ) {
+		const isNew = ! ( key in target );
+		hasNewKeys = hasNewKeys || isNew;
 
-				if ( isPlainObject( target[ key ] ) ) {
-					deepMergeRecursive(
-						target[ key ],
-						source[ key ],
-						override
-					);
-				}
-			} else if ( override || isNew ) {
-				Object.defineProperty( target, key, desc! );
+		const desc = Object.getOwnPropertyDescriptor( source, key )!;
+		const proxy = getProxyFromObject( target );
+		const propSignal =
+			!! proxy &&
+			hasPropSignal( proxy, key ) &&
+			getPropSignal( proxy, key );
 
-				const proxy = getProxyFromObject( target );
-				if ( desc?.value && proxy && hasPropSignal( proxy, key ) ) {
-					const propSignal = getPropSignal( proxy, key );
-					propSignal.setValue( desc.value );
+		if (
+			typeof desc.get === 'function' ||
+			typeof desc.set === 'function'
+		) {
+			if ( override || isNew ) {
+				Object.defineProperty( target, key, {
+					...desc,
+					configurable: true,
+					enumerable: true,
+				} );
+				if ( desc.get && propSignal ) {
+					propSignal.setGetter( desc.get );
 				}
 			}
+		} else if ( isPlainObject( source[ key ] ) ) {
+			if ( isNew || ( override && ! isPlainObject( target[ key ] ) ) ) {
+				target[ key ] = {};
+				if ( propSignal ) {
+					propSignal.setValue( target[ key ] );
+				}
+			}
+			if ( isPlainObject( target[ key ] ) ) {
+				deepMergeRecursive( target[ key ], source[ key ], override );
+			}
+		} else if ( override || isNew ) {
+			Object.defineProperty( target, key, desc );
+			if ( propSignal ) {
+				propSignal.setValue( desc.value );
+			}
 		}
+	}
 
-		if ( hasNewKeys && objToIterable.has( target ) ) {
-			objToIterable.get( target )!.value++;
-		}
+	if ( hasNewKeys && objToIterable.has( target ) ) {
+		objToIterable.get( target )!.value++;
 	}
 };
 

--- a/packages/interactivity/src/proxies/test/context-proxy.ts
+++ b/packages/interactivity/src/proxies/test/context-proxy.ts
@@ -6,7 +6,7 @@ import { effect } from '@preact/signals';
 /**
  * Internal dependencies
  */
-import { proxifyContext, proxifyState } from '../';
+import { proxifyContext, proxifyState, deepMerge } from '../';
 
 describe( 'Interactivity API', () => {
 	describe( 'context proxy', () => {
@@ -300,6 +300,37 @@ describe( 'Interactivity API', () => {
 
 				// Add a deeply nested object to the context
 				context.a = { b: { c: { d: 'test value' } } };
+
+				// The effect should be called again
+				expect( spy ).toHaveBeenCalledTimes( 2 );
+				expect( deepValue ).toBe( 'test value' );
+
+				// Reading the value directly should also work
+				expect( context.a.b.c.d ).toBe( 'test value' );
+			} );
+
+			it( 'should handle deeply nested properties that are initially undefined and merged with deepMerge', () => {
+				const fallback: any = proxifyContext(
+					proxifyState( 'test', {} ),
+					{}
+				);
+				const context: any = proxifyContext(
+					proxifyState( 'test', {} ),
+					fallback
+				);
+
+				let deepValue: any;
+				const spy = jest.fn( () => {
+					deepValue = context.a?.b?.c?.d;
+				} );
+				effect( spy );
+
+				// Initial call, the deep value is undefined
+				expect( spy ).toHaveBeenCalledTimes( 1 );
+				expect( deepValue ).toBeUndefined();
+
+				// Use deepMerge to add a deeply nested object to the context
+				deepMerge( context, { a: { b: { c: { d: 'test value' } } } } );
 
 				// The effect should be called again
 				expect( spy ).toHaveBeenCalledTimes( 2 );

--- a/packages/interactivity/src/proxies/test/context-proxy.ts
+++ b/packages/interactivity/src/proxies/test/context-proxy.ts
@@ -277,6 +277,30 @@ describe( 'Interactivity API', () => {
 					'fromFallback',
 				] );
 			} );
+
+			it( 'should handle deeply nested properties that are initially undefined', () => {
+				const context: any = proxifyContext( {}, {} );
+
+				let deepValue: any;
+				const spy = jest.fn( () => {
+					deepValue = context.a?.b?.c?.d;
+				} );
+				effect( spy );
+
+				// Initial call, the deep value is undefined
+				expect( spy ).toHaveBeenCalledTimes( 1 );
+				expect( deepValue ).toBeUndefined();
+
+				// Add a deeply nested object to the context
+				context.a = { b: { c: { d: 'test value' } } };
+
+				// The effect should be called again
+				expect( spy ).toHaveBeenCalledTimes( 2 );
+				expect( deepValue ).toBe( 'test value' );
+
+				// Reading the value directly should also work
+				expect( context.a.b.c.d ).toBe( 'test value' );
+			} );
 		} );
 
 		describe( 'proxifyContext', () => {

--- a/packages/interactivity/src/proxies/test/context-proxy.ts
+++ b/packages/interactivity/src/proxies/test/context-proxy.ts
@@ -279,7 +279,14 @@ describe( 'Interactivity API', () => {
 			} );
 
 			it( 'should handle deeply nested properties that are initially undefined', () => {
-				const context: any = proxifyContext( {}, {} );
+				const fallback: any = proxifyContext(
+					proxifyState( 'test', {} ),
+					{}
+				);
+				const context: any = proxifyContext(
+					proxifyState( 'test', {} ),
+					fallback
+				);
 
 				let deepValue: any;
 				const spy = jest.fn( () => {

--- a/packages/interactivity/src/proxies/test/context-proxy.ts
+++ b/packages/interactivity/src/proxies/test/context-proxy.ts
@@ -310,14 +310,10 @@ describe( 'Interactivity API', () => {
 			} );
 
 			it( 'should handle deeply nested properties that are initially undefined and merged with deepMerge', () => {
-				const fallback: any = proxifyContext(
-					proxifyState( 'test', {} ),
-					{}
-				);
-				const context: any = proxifyContext(
-					proxifyState( 'test', {} ),
-					fallback
-				);
+				const fallbackState = proxifyState( 'test', {} );
+				const fallback: any = proxifyContext( fallbackState, {} );
+				const contextState = proxifyState( 'test', {} );
+				const context: any = proxifyContext( contextState, fallback );
 
 				let deepValue: any;
 				const spy = jest.fn( () => {
@@ -330,7 +326,9 @@ describe( 'Interactivity API', () => {
 				expect( deepValue ).toBeUndefined();
 
 				// Use deepMerge to add a deeply nested object to the context
-				deepMerge( context, { a: { b: { c: { d: 'test value' } } } } );
+				deepMerge( contextState, {
+					a: { b: { c: { d: 'test value' } } },
+				} );
 
 				// The effect should be called again
 				expect( spy ).toHaveBeenCalledTimes( 2 );

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -389,5 +389,29 @@ describe( 'Interactivity API', () => {
 			expect( spy ).toHaveBeenCalledTimes( 2 );
 			expect( spy ).toHaveLastReturnedWith( [ 'a', 'b', 'c' ] );
 		} );
+
+		it( 'should handle deeply nested properties that are initially undefined and merged with deepMerge', () => {
+			const target: any = proxifyState( 'test', {} );
+
+			let deepValue: any;
+			const spy = jest.fn( () => {
+				deepValue = target.a?.b?.c?.d;
+			} );
+			effect( spy );
+
+			// Initial call, the deep value is undefined
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( deepValue ).toBeUndefined();
+
+			// Use deepMerge to add a deeply nested object to the target
+			deepMerge( target, { a: { b: { c: { d: 'test value' } } } } );
+
+			// The effect should be called again
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( deepValue ).toBe( 'test value' );
+
+			// Reading the value directly should also work
+			expect( target.a.b.c.d ).toBe( 'test value' );
+		} );
 	} );
 } );

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -413,5 +413,31 @@ describe( 'Interactivity API', () => {
 			// Reading the value directly should also work
 			expect( target.a.b.c.d ).toBe( 'test value' );
 		} );
+
+		it( 'should overwrite values that become objects', () => {
+			const target: any = proxifyState( 'test', { message: 'hello' } );
+
+			let message: any;
+			const spy = jest.fn( () => ( message = target.message ) );
+			effect( spy );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( message ).toBe( 'hello' );
+
+			deepMerge( target, {
+				message: { content: 'hello', fontStyle: 'italic' },
+			} );
+
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( message ).toEqual( {
+				content: 'hello',
+				fontStyle: 'italic',
+			} );
+
+			expect( target.message ).toEqual( {
+				content: 'hello',
+				fontStyle: 'italic',
+			} );
+		} );
 	} );
 } );

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -439,5 +439,28 @@ describe( 'Interactivity API', () => {
 				fontStyle: 'italic',
 			} );
 		} );
+
+		it( 'should not overwrite values that become objects if `override` is false', () => {
+			const target: any = proxifyState( 'test', { message: 'hello' } );
+
+			let message: any;
+			const spy = jest.fn( () => ( message = target.message ) );
+			effect( spy );
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( message ).toBe( 'hello' );
+
+			deepMerge(
+				target,
+				{ message: { content: 'hello', fontStyle: 'italic' } },
+				false
+			);
+
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( message ).toBe( 'hello' );
+			expect( target.message ).toBe( 'hello' );
+			expect( target.message.content ).toBeUndefined();
+			expect( target.message.fontStyle ).toBeUndefined();
+		} );
 	} );
 } );

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -390,7 +390,7 @@ describe( 'Interactivity API', () => {
 			expect( spy ).toHaveLastReturnedWith( [ 'a', 'b', 'c' ] );
 		} );
 
-		it( 'should handle deeply nested properties that are initially undefined and merged with deepMerge', () => {
+		it( 'should handle deeply nested properties that are initially undefined', () => {
 			const target: any = proxifyState( 'test', {} );
 
 			let deepValue: any;


### PR DESCRIPTION
## Description

This PR addresses an issue in the Interactivity API where deeply nested properties that are initially undefined and later added with the inter`deepMerge()` to either the context or the global state were not being properly handled. The change ensures that effects dependent on these properties are correctly triggered when the properties are added, even if they are initially undefined.

## Changes

- Added a new test case in `packages/interactivity/src/proxies/test/context-proxy.ts` to demonstrate the desired behavior for deeply nested properties.
- Implement the necessary changes in the `deepMerge` function to support this behavior.

## Testing

A new test case has been added to verify the correct handling of deeply nested properties.