### PR TITLE
Post editor: fix meta boxes accessibility

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -257,6 +257,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				'edit-post-layout__metaboxes',
 				! isLegacy && 'edit-post-meta-boxes-main__liner'
 			) }
+			hidden={ ! isLegacy && ! isOpen }
 		>
 			<MetaBoxes location="normal" />
 			<MetaBoxes location="advanced" />
@@ -300,7 +301,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	if ( isShort ) {
 		Pane = NavigableRegion;
 		paneProps = {
-			className: clsx( className, 'is-toggle-only', isOpen && 'is-open' ),
+			className: clsx( className, 'is-toggle-only' ),
 		};
 	} else {
 		Pane = ResizableBox;

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -368,8 +368,8 @@ function MetaBoxesMain( { isLegacy } ) {
 		<Pane aria-label={ paneLabel } { ...paneProps }>
 			{ isShort ? (
 				<button
+					aria-expanded={ isOpen }
 					className="edit-post-meta-boxes-main__presenter"
-					aria-label={ __( 'Expand or collapse meta boxes pane' ) }
 					onClick={ toggle }
 				>
 					{ paneLabel }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -202,7 +202,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		const resizeHandle = container.querySelector(
 			'.edit-post-meta-boxes-main__presenter'
 		);
-		const actualize = () => {
+		const deriveConstraints = () => {
 			const fullHeight = container.offsetHeight;
 			let nextMax = fullHeight;
 			for ( const element of noticeLists ) {
@@ -211,7 +211,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			const nextMin = resizeHandle.offsetHeight;
 			setHeightConstraints( { min: nextMin, max: nextMax } );
 		};
-		const observer = new window.ResizeObserver( actualize );
+		const observer = new window.ResizeObserver( deriveConstraints );
 		observer.observe( container );
 		for ( const element of noticeLists ) {
 			observer.observe( element );
@@ -223,7 +223,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	const separatorHelpId = useId();
 
 	const [ isUntouched, setIsUntouched ] = useState( true );
-	const actualizeHeight = ( candidateHeight, isPersistent, isInstant ) => {
+	const applyHeight = ( candidateHeight, isPersistent, isInstant ) => {
 		const nextHeight = Math.min( max, Math.max( min, candidateHeight ) );
 		if ( isPersistent ) {
 			setPreference(
@@ -291,7 +291,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			const pane = metaBoxesMainRef.current.resizable;
 			const fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
 			const nextHeight = delta + fromHeight;
-			actualizeHeight( nextHeight, true, true );
+			applyHeight( nextHeight, true, true );
 			event.preventDefault();
 		}
 	};
@@ -354,14 +354,14 @@ function MetaBoxesMain( { isLegacy } ) {
 				if ( isAutoHeight ) {
 					// Sets the starting height to avoid visual jumps in height and
 					// aria-valuenow being `NaN` for the first (few) resize events.
-					actualizeHeight( elementRef.offsetHeight, false, true );
+					applyHeight( elementRef.offsetHeight, false, true );
 					setIsUntouched( false );
 				}
 			},
 			onResize: () =>
-				actualizeHeight( metaBoxesMainRef.current.state.height ),
+				applyHeight( metaBoxesMainRef.current.state.height ),
 			onResizeStop: () =>
-				actualizeHeight( metaBoxesMainRef.current.state.height, true ),
+				applyHeight( metaBoxesMainRef.current.state.height, true ),
 		} );
 	}
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -305,62 +305,65 @@ function MetaBoxesMain( { isLegacy } ) {
 			actualizeHeight( delta + fromHeight, true );
 		}
 	};
-
+	const className = 'edit-post-meta-boxes-main';
 	const paneLabel = __( 'Meta Boxes' );
+	let paneProps, paneButtonProps;
+	if ( isShort ) {
+		paneProps = {
+			className: clsx( className, 'is-toggle-only', isOpen && 'is-open' ),
+		};
+		paneButtonProps = {
+			'aria-label': __( 'Expand or collapse meta boxes pane' ),
+			onClick: toggle,
+			children: (
+				<>
+					{ paneLabel }
+					<Icon icon={ isOpen ? chevronUp : chevronDown } />
+				</>
+			),
+		};
+	} else {
+		paneProps = {
+			ref: metaBoxesMainRef,
+			className: clsx( className, 'is-resizable' ),
+			style: { height: openHeight, maxHeight: usedMax },
+		};
+		paneButtonProps = {
+			ref: separatorRef,
+			role: 'separator',
+			'aria-valuenow': usedAriaValueNow,
+			'aria-label': __( 'Drag to resize' ),
+			'aria-describedby': separatorHelpId,
+			onKeyDown: onSeparatorKeyDown,
+			onMouseDown: startDrag,
+			onMouseUp: endDrag,
+			// Avoids hiccups while dragging over objects like iframes and ensures that
+			// the event to end the drag is captured by the target (resize handle)
+			// whether or not it’s under the pointer.
+			onPointerDown: ( { pointerId, target } ) => {
+				target.setPointerCapture( pointerId );
+			},
+			children: (
+				<Tooltip text={ __( 'Drag to resize' ) }>
+					<div tabIndex={ -1 }>
+						<VisuallyHidden id={ separatorHelpId }>
+							{ __(
+								'Use up and down arrow keys to resize the metabox pane.'
+							) }
+						</VisuallyHidden>
+					</div>
+				</Tooltip>
+			),
+		};
+	}
 
 	return (
-		<aside
-			aria-label={ paneLabel }
-			className={ clsx(
-				'edit-post-meta-boxes-main',
-				isShort && isOpen && 'is-open',
-				isShort ? 'is-toggle-only' : 'is-resizable'
-			) }
-			ref={ metaBoxesMainRef }
-			style={
-				isShort ? null : { height: openHeight, maxHeight: usedMax }
-			}
-		>
+		<aside aria-label={ paneLabel } { ...paneProps }>
 			{ ! isShort && <meta ref={ effectSizeConstraints } /> }
 			<button
 				className="edit-post-meta-boxes-main__presenter"
-				ref={ isShort ? null : separatorRef }
-				role={ isShort ? null : 'separator' }
-				aria-valuenow={ ! isShort ? usedAriaValueNow : null }
-				aria-label={
-					isShort
-						? __( 'Expand or collapse meta boxes pane' )
-						: __( 'Drag to resize' )
-				}
-				aria-describedby={ isShort ? null : separatorHelpId }
-				onMouseDown={ isShort ? null : startDrag }
-				onMouseUp={ isShort ? null : endDrag }
-				// Avoids hiccups while dragging over objects like iframes and ensures that
-				// the event to end the drag is captured by the target (resize handle)
-				// whether or not it’s under the pointer.
-				onPointerDown={ ( { pointerId, target } ) => {
-					target.setPointerCapture( pointerId );
-				} }
-				onClick={ isShort ? toggle : null }
-				onKeyDown={ isShort ? null : onSeparatorKeyDown }
-			>
-				{ isShort ? (
-					<>
-						{ paneLabel }
-						<Icon icon={ isOpen ? chevronUp : chevronDown } />
-					</>
-				) : (
-					<Tooltip text={ __( 'Drag to resize' ) }>
-						<div tabIndex={ -1 }>
-							<VisuallyHidden id={ separatorHelpId }>
-								{ __(
-									'Use up and down arrow keys to resize the metabox pane.'
-								) }
-							</VisuallyHidden>
-						</div>
-					</Tooltip>
-				) }
-			</button>
+				{ ...paneButtonProps }
+			/>
 			{ contents }
 		</aside>
 	);

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -77,7 +77,7 @@ import useNavigateToEntityRecord from '../../hooks/use-navigate-to-entity-record
 const { getLayoutStyles } = unlock( blockEditorPrivateApis );
 const { useCommands } = unlock( coreCommandsPrivateApis );
 const { useCommandContext } = unlock( commandsPrivateApis );
-const { Editor, FullscreenMode } = unlock( editorPrivateApis );
+const { Editor, FullscreenMode, NavigableRegion } = unlock( editorPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 const DESIGN_POST_TYPES = [
 	'wp_template',
@@ -298,14 +298,14 @@ function MetaBoxesMain( { isLegacy } ) {
 	const paneLabel = __( 'Meta Boxes' );
 	let Pane, paneProps;
 	if ( isShort ) {
-		Pane = 'aside';
+		Pane = NavigableRegion;
 		paneProps = {
 			className: clsx( className, 'is-toggle-only', isOpen && 'is-open' ),
 		};
 	} else {
 		Pane = ResizableBox;
 		paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
-			as: 'aside',
+			as: NavigableRegion,
 			ref: metaBoxesMainRef,
 			className: clsx( className, 'is-resizable' ),
 			defaultSize: { height: openHeight },

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -303,6 +303,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			const pane = metaBoxesMainRef.current;
 			const fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
 			actualizeHeight( delta + fromHeight, true );
+			event.preventDefault();
 		}
 	};
 	const className = 'edit-post-meta-boxes-main';

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -257,7 +257,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				'edit-post-layout__metaboxes',
 				! isLegacy && 'edit-post-meta-boxes-main__liner'
 			) }
-			hidden={ ! isLegacy && ! isOpen }
+			hidden={ ! isLegacy && isShort && ! isOpen }
 		>
 			<MetaBoxes location="normal" />
 			<MetaBoxes location="advanced" />

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -32,7 +32,7 @@
 		&:focus-visible::after {
 			content: "";
 			position: absolute;
-			inset: 2px 3px 2px 2px;
+			inset: var(--wp-admin-border-width-focus);
 			@include button-style__focus();
 		}
 	}
@@ -57,8 +57,8 @@
 				content: "";
 				background-color: $gray-300;
 				position: absolute;
-				inset: 50% auto auto 50%;
-				transform: translate(-50%, -50%);
+				inset-block: calc(50% - #{$grid-unit-05} / 2) auto;
+				transform: translateX(-50%);
 				width: inherit;
 				height: $grid-unit-05;
 				border-radius: $radius-small;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -3,7 +3,6 @@
 	// Windows High Contrast mode will show this outline, but not the shadow.
 	outline: 1px solid transparent;
 	background-color: $white;
-	clear: both; // This is seemingly only needed in case the canvas is not iframe’d.
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
@@ -104,6 +103,11 @@
 	.is-toggle-only:not(.is-open) > & {
 		height: 0;
 	}
+}
+
+// In case the canvas is not iframe’d.
+.edit-post-layout__metaboxes {
+	clear: both;
 }
 
 .has-metaboxes .editor-visual-editor {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -37,10 +37,6 @@
 		}
 	}
 
-	.is-toggle-only:not(.is-open) > & {
-		overflow: hidden;
-	}
-
 	.is-resizable > & {
 		cursor: row-resize;
 		height: $grid-unit-30;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,69 +1,87 @@
-$resize-handle-height: $grid-unit-30;
-
 .edit-post-meta-boxes-main {
 	filter: drop-shadow(0 -1px rgba($color: #000, $alpha: 0.133)); // 0.133 = $gray-200 but with alpha.
 	background-color: $white;
 	clear: both; // This is seemingly only needed in case the canvas is not iframe’d.
-
-	&:not(details) {
-		padding-top: $resize-handle-height;
-	}
-
-	// The component renders as a details element in short viewports.
-	&:is(details) {
-		& > summary {
-			cursor: pointer;
-			color: $gray-900;
-			background-color: $white;
-			height: $button-size-compact;
-			line-height: $button-size-compact;
-			font-size: 13px;
-			padding-left: $grid-unit-30;
-			box-shadow: 0 $border-width $gray-300;
-		}
-
-		&[open] > summary {
-			position: sticky;
-			top: 0;
-			z-index: 1;
-		}
-	}
+	display: flex;
+	flex-direction: column;
+	overflow: hidden;
 }
 
-.edit-post-meta-boxes-main__resize-handle {
+.edit-post-meta-boxes-main__presenter {
+	flex-shrink: 0;
 	display: flex;
-	// The position is absolute by default inline style of ResizableBox.
-	inset: 0 0 auto 0;
-	height: $resize-handle-height;
 	box-shadow: 0 $border-width $gray-300;
+	position: relative;
+	z-index: 1;
+	appearance: none;
+	padding: 0;
+	border: none;
+	outline: none;
+	background-color: transparent;
 
-	& > button {
-		appearance: none;
-		cursor: inherit;
-		margin: auto;
-		padding: 0;
-		border: none;
-		outline: none;
-		background-color: $gray-300;
-		width: $grid-unit-80;
-		height: $grid-unit-05;
-		border-radius: $radius-small;
-		transition: width 0.3s ease-out;
-		@include reduce-motion("transition");
+	.is-toggle-only > & {
+		cursor: pointer;
+		height: $button-size-compact;
+		justify-content: space-between;
+		align-items: center;
+		padding-inline: $grid-unit-30 $grid-unit-15;
+
+		&:is(:hover, :focus-visible) {
+			color: var(--wp-admin-theme-color);
+		}
+		&:focus-visible::after {
+			content: "";
+			position: absolute;
+			inset: 2px 3px 2px 2px;
+			@include button-style__focus();
+		}
 	}
 
-	&:hover > button,
-	> button:focus {
-		background-color: var(--wp-admin-theme-color);
-		width: $grid-unit-80 + $grid-unit-20;
+	.is-toggle-only:not(.is-open) > & {
+		overflow: hidden;
+	}
+
+	.is-resizable > & {
+		cursor: row-resize;
+		height: $grid-unit-30;
+		@media (pointer: coarse) {
+			height: $button-size-compact;
+		}
+
+		> div {
+			width: $grid-unit-80;
+			height: inherit;
+			margin: auto;
+
+			&::before {
+				content: "";
+				background-color: $gray-300;
+				position: absolute;
+				inset: 50% auto auto 50%;
+				transform: translate(-50%, -50%);
+				width: inherit;
+				height: $grid-unit-05;
+				border-radius: $radius-small;
+				transition: width 0.3s ease-out;
+				@include reduce-motion("transition");
+			}
+		}
+
+		&:is(:hover, :focus) > div::before {
+			background-color: var(--wp-admin-theme-color);
+			width: $grid-unit-80 + $grid-unit-20;
+		}
 	}
 }
 
 .edit-post-meta-boxes-main__liner {
 	overflow: auto;
-	max-height: 100%;
 	// Keep the contents behind the resize handle or details summary.
 	isolation: isolate;
+
+	.is-toggle-only:not(.is-open) > & {
+		height: 0;
+	}
 }
 
 .has-metaboxes .editor-visual-editor {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -17,6 +17,8 @@
 	flex-shrink: 0;
 	display: flex;
 	box-shadow: 0 $border-width $gray-300;
+	// Windows High Contrast mode will show this outline, but not the shadow.
+	outline: 1px solid transparent;
 	position: relative;
 	z-index: 1;
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -99,10 +99,6 @@
 	overflow: auto;
 	// Keep the contents behind the resize handle or details summary.
 	isolation: isolate;
-
-	.is-toggle-only:not(.is-open) > & {
-		height: 0;
-	}
 }
 
 // In case the canvas is not iframe’d.

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -14,7 +14,6 @@
 }
 
 .edit-post-meta-boxes-main__presenter {
-	flex-shrink: 0;
 	display: flex;
 	box-shadow: 0 $border-width $gray-300;
 	// Windows High Contrast mode will show this outline, but not the shadow.
@@ -33,6 +32,7 @@
 	}
 
 	.is-toggle-only > & {
+		flex-shrink: 0;
 		cursor: pointer;
 		height: $button-size-compact;
 		justify-content: space-between;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -5,6 +5,10 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
+
+	&.is-resizable {
+		padding-block-start: $grid-unit-30;
+	}
 }
 
 .edit-post-meta-boxes-main__presenter {
@@ -13,11 +17,16 @@
 	box-shadow: 0 $border-width $gray-300;
 	position: relative;
 	z-index: 1;
-	appearance: none;
-	padding: 0;
-	border: none;
-	outline: none;
-	background-color: transparent;
+
+	// Button style reset for both toggle or resizable.
+	.is-toggle-only > &,
+	.is-resizable.edit-post-meta-boxes-main & > button {
+		appearance: none;
+		padding: 0;
+		border: none;
+		outline: none;
+		background-color: transparent;
+	}
 
 	.is-toggle-only > & {
 		cursor: pointer;
@@ -37,16 +46,13 @@
 		}
 	}
 
-	.is-resizable > & {
-		cursor: row-resize;
-		height: $grid-unit-30;
-		@media (pointer: coarse) {
-			height: $button-size-compact;
-		}
+	.is-resizable.edit-post-meta-boxes-main & {
+		inset: 0 0 auto;
 
-		> div {
+		> button {
+			cursor: inherit;
 			width: $grid-unit-80;
-			height: inherit;
+			height: $grid-unit-30;
 			margin: auto;
 
 			&::before {
@@ -63,9 +69,19 @@
 			}
 		}
 
-		&:is(:hover, :focus) > div::before {
+		&:is(:hover, :focus-within) > button::before {
 			background-color: var(--wp-admin-theme-color);
 			width: $grid-unit-80 + $grid-unit-20;
+		}
+	}
+}
+
+@media (pointer: coarse) {
+	.is-resizable.edit-post-meta-boxes-main {
+		padding-block-start: $button-size-compact;
+
+		.edit-post-meta-boxes-main__presenter > button {
+			height: $button-size-compact;
 		}
 	}
 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -1,5 +1,7 @@
 .edit-post-meta-boxes-main {
 	filter: drop-shadow(0 -1px rgba($color: #000, $alpha: 0.133)); // 0.133 = $gray-200 but with alpha.
+	// Windows High Contrast mode will show this outline, but not the shadow.
+	outline: 1px solid transparent;
 	background-color: $white;
 	clear: both; // This is seemingly only needed in case the canvas is not iframe’d.
 	display: flex;
@@ -44,6 +46,9 @@
 			inset: var(--wp-admin-border-width-focus);
 			@include button-style__focus();
 		}
+		> svg {
+			fill: currentColor;
+		}
 	}
 
 	.is-resizable.edit-post-meta-boxes-main & {
@@ -58,6 +63,9 @@
 			&::before {
 				content: "";
 				background-color: $gray-300;
+				// Windows High Contrast mode will show this outline, but not the background-color.
+				outline: 2px solid transparent;
+				outline-offset: -2px;
 				position: absolute;
 				inset-block: calc(50% - #{$grid-unit-05} / 2) auto;
 				transform: translateX(-50%);

--- a/packages/interface/src/components/navigable-region/index.js
+++ b/packages/interface/src/components/navigable-region/index.js
@@ -1,24 +1,29 @@
 /**
+ * WordPress dependencies
+ */
+import { forwardRef } from '@wordpress/element';
+
+/**
  * External dependencies
  */
 import clsx from 'clsx';
 
-export default function NavigableRegion( {
-	children,
-	className,
-	ariaLabel,
-	as: Tag = 'div',
-	...props
-} ) {
-	return (
-		<Tag
-			className={ clsx( 'interface-navigable-region', className ) }
-			aria-label={ ariaLabel }
-			role="region"
-			tabIndex="-1"
-			{ ...props }
-		>
-			{ children }
-		</Tag>
-	);
-}
+const NavigableRegion = forwardRef(
+	( { children, className, ariaLabel, as: Tag = 'div', ...props }, ref ) => {
+		return (
+			<Tag
+				ref={ ref }
+				className={ clsx( 'interface-navigable-region', className ) }
+				aria-label={ ariaLabel }
+				role="region"
+				tabIndex="-1"
+				{ ...props }
+			>
+				{ children }
+			</Tag>
+		);
+	}
+);
+
+NavigableRegion.displayName = 'NavigableRegion';
+export default NavigableRegion;


### PR DESCRIPTION
## What?
A fix for meta box headings being absent from accessibility tree when their container is collapsed.

## Why?
Meta boxes are expected to be accessible even if their container is collapsed.

To fix #65406.

## How?
1. Replaces the `details` element with a custom expandable (using `aria-expanded`).
2. Makes the meta boxes container a region and includes it in the navigable regions.

### Testing Instructions for Keyboard
Have a plugin activated that creates meta boxes or have the custom fields preference on and open a post or page in the Post editor.
#### Toggle (short viewport)
1. Make sure your window is short enough (less than 550 pixels tall)
3. Verify the meta box headings are in the document hierarchy whether or not they are visually hidden.

<!-- ## Screenshots or screencast if applicable -->
