### PR TITLE
Search block: reset size correctly when clearing unit control

### DIFF
--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -424,11 +424,12 @@ export default function SearchEdit( {
 							}
 							step={ 1 }
 							onChange={ ( newWidth ) => {
-								const parsedNewWidth = parseInt( newWidth, 10 );
-								setAttributes( {
-									width: Number.isNaN( parsedNewWidth )
+								const parsedNewWidth =
+									newWidth === ''
 										? undefined
-										: parsedNewWidth,
+										: parseInt( newWidth, 10 );
+								setAttributes( {
+									width: parsedNewWidth,
 								} );
 							} }
 							onUnitChange={ ( newUnit ) => {

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -424,13 +424,11 @@ export default function SearchEdit( {
 							}
 							step={ 1 }
 							onChange={ ( newWidth ) => {
-								const filteredWidth =
-									widthUnit === '%' &&
-									parseInt( newWidth, 10 ) > 100
-										? 100
-										: newWidth;
+								const parsedNewWidth = parseInt( newWidth, 10 );
 								setAttributes( {
-									width: parseInt( filteredWidth, 10 ),
+									width: Number.isNaN( parsedNewWidth )
+										? undefined
+										: parsedNewWidth,
 								} );
 							} }
 							onUnitChange={ ( newUnit ) => {
@@ -566,7 +564,11 @@ export default function SearchEdit( {
 
 			<ResizableBox
 				size={ {
-					width: `${ width }${ widthUnit }`,
+					width:
+						width === undefined
+							? 'auto'
+							: `${ width }${ widthUnit }`,
+					height: 'auto',
 				} }
 				className={ clsx(
 					'wp-block-search__inside-wrapper',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/pull/65340

Fix resetting the `width` of the Search block when clearing the `UnitControl` value in the block inspector sidebar

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The behaviour on `trunk` is buggy and doesn't reset correctly the width

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

There are two bug fixes:

- in the `onChange` callback for the `UnitControl` component, the value is parsed from string to number, but is never checked for `NaN` (which happens when the input is cleared). The new code sets the width back to `undefined` instead of `NaN`
- the value of the `ResizableBox`'s `size` prop was incorrect:
  - it's expected to be an object with `width` and `height` properties, but only `width` was specified. Now, `height` is specified too;
  - the `width` was sometimes set to `NaN`, but that's implicitly fixed with the changes to the `UnitControl`'s `onChange` handler

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Add a "Search" block
- Notice how, when the block is first added and a width is not specific, the block takes the full width of content;
- Set a width by doing one of the three following things:
  - Drag the resize handle in the editor
  - Use the `ButtonGroup` in the block inspector sidebar
  - Use the `UnitControl` in the block inspector sidebar
- The Search block should adapt to the new width
- Clear the value in the `UnitControl` in the block inspector sidebar:
  - On trunk, nothing happens (which is a bug)
  - On this PR, the Search block's width resets to be full width (like when it first loaded)

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/a110f607-87ac-4e30-9eb8-9b04f246295e" /> | <video src="https://github.com/user-attachments/assets/47335b83-e11a-4476-bff5-d7bca5fec5d4" /> |

