### PR TITLE
Build zip artifact on release and wp production branches.

### DIFF
--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -3,7 +3,10 @@ name: Build Gutenberg Plugin Zip
 on:
     pull_request:
     push:
-        branches: [trunk]
+        branches:
+            - trunk
+            - 'release/**'
+            - 'wp/**'
     workflow_dispatch:
         inputs:
             version:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Runs the workflow to create the zip file artifact on each push to `release/*` and `wp/*` branches.

Fixes #65345.

## Why?

These are production branches and having the plugin zip file available will prove handy for testing.

## How?

Adds the branches as wildcards to the push -> branches section of the workflow.

## Testing Instructions

I think this needs to be YOLO merged and monitored once the workflow is committed to trunk.

Please check:

* wildcard syntax against the docs
* prefixes against list of branches

### Testing Instructions for Keyboard

N/A

## Screenshots or screencast <!-- if applicable -->

N/A