### PR TITLE
Command Palette: "Add new page" within the site editor creates new page in site editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53340,6 +53340,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/router": "file:../router",
 				"@wordpress/url": "file:../url"
@@ -68362,6 +68363,7 @@
 				"@wordpress/html-entities": "file:../html-entities",
 				"@wordpress/i18n": "file:../i18n",
 				"@wordpress/icons": "file:../icons",
+				"@wordpress/notices": "file:../notices",
 				"@wordpress/private-apis": "file:../private-apis",
 				"@wordpress/router": "file:../router",
 				"@wordpress/url": "file:../url"

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -37,6 +37,7 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
+		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/router": "file:../router",
 		"@wordpress/url": "file:../url"

--- a/packages/core-commands/package.json
+++ b/packages/core-commands/package.json
@@ -37,7 +37,6 @@
 		"@wordpress/html-entities": "file:../html-entities",
 		"@wordpress/i18n": "file:../i18n",
 		"@wordpress/icons": "file:../icons",
-		"@wordpress/notices": "file:../notices",
 		"@wordpress/private-apis": "file:../private-apis",
 		"@wordpress/router": "file:../router",
 		"@wordpress/url": "file:../url"

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -1,9 +1,83 @@
 /**
  * WordPress dependencies
  */
-import { useCommand } from '@wordpress/commands';
+import { useCommand, useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { getPath } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+import { store as noticesStore } from '@wordpress/notices';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from './lock-unlock';
+
+const { useHistory } = unlock( routerPrivateApis );
+
+function useAddNewPageCommand() {
+	const isSiteEditor = getPath( window.location.href )?.includes(
+		'site-editor.php'
+	);
+	const history = useHistory();
+	const { saveEntityRecord } = useDispatch( coreStore );
+	const { createErrorNotice } = useDispatch( noticesStore );
+
+	const createPageEntity = async ( { close } ) => {
+		try {
+			const page = await saveEntityRecord(
+				'postType',
+				'page',
+				{
+					status: 'draft',
+				},
+				{
+					throwOnError: true,
+				}
+			);
+			if ( page?.id ) {
+				history.push( {
+					postId: page.id,
+					postType: 'page',
+					canvas: 'edit',
+				} );
+			}
+		} catch ( error ) {
+			const errorMessage =
+				error.message && error.code !== 'unknown_error'
+					? error.message
+					: __( 'An error occurred while creating the item.' );
+
+			createErrorNotice( errorMessage, {
+				type: 'snackbar',
+			} );
+		} finally {
+			close();
+		}
+	};
+
+	const commands = useMemo( () => {
+		const addNewPage = isSiteEditor
+			? createPageEntity
+			: () => ( document.location.href = 'post-new.php?post_type=page' );
+		return [
+			{
+				name: 'core/add-new-page',
+				label: __( 'Add new page' ),
+				icon: plus,
+				callback: addNewPage,
+			},
+		];
+	}, [ createPageEntity, isSiteEditor ] );
+
+	return {
+		isLoading: false,
+		commands,
+	};
+}
 
 export function useAdminNavigationCommands() {
 	useCommand( {
@@ -14,12 +88,9 @@ export function useAdminNavigationCommands() {
 			document.location.href = 'post-new.php';
 		},
 	} );
-	useCommand( {
+
+	useCommandLoader( {
 		name: 'core/add-new-page',
-		label: __( 'Add new page' ),
-		icon: plus,
-		callback: () => {
-			document.location.href = 'post-new.php?post_type=page';
-		},
+		hook: useAddNewPageCommand,
 	} );
 }

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -1,9 +1,76 @@
 /**
  * WordPress dependencies
  */
-import { useCommand } from '@wordpress/commands';
+import { useCommand, useCommandLoader } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+import { getPath } from '@wordpress/url';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useMemo, useCallback } from '@wordpress/element';
+
+function useAddNewPageCommand() {
+	const isSiteEditor = getPath( window.location.href )?.includes(
+		'site-editor.php'
+	);
+	const { userCanCreatePages } = useSelect( ( select ) => {
+		const { canUser } = select( coreStore );
+		return {
+			userCanCreatePages: canUser( 'create', {
+				kind: 'postType',
+				name: 'page',
+			} ),
+		};
+	}, [] );
+	const { saveEntityRecord } = useDispatch( coreStore );
+	/**
+	 * Creates a Post entity.
+	 *
+	 * @param {Object} options parameters for the post being created. These mirror those used on 3rd param of saveEntityRecord.
+	 * @return {Object} the post type object that was created.
+	 */
+	const createPageEntity = useCallback(
+		( options ) => {
+			if ( ! userCanCreatePages ) {
+				return Promise.reject( {
+					message: __(
+						'You do not have permission to create Pages.'
+					),
+				} );
+			}
+			return saveEntityRecord( 'postType', 'page', options );
+		},
+		[ saveEntityRecord, userCanCreatePages ]
+	);
+
+	const commands = useMemo( () => {
+		if ( ! userCanCreatePages ) {
+			return [];
+		}
+		return [
+			{
+				name: 'core/add-new-page',
+				label: __( 'Add new page' ),
+				icon: plus,
+				callback: async () => {
+					if ( isSiteEditor ) {
+						const page = await createPageEntity( {
+							status: 'draft',
+						} );
+						document.location.href = `/wp-admin/site-editor.php?postId=${ page.id }&postType=page&canvas=edit`;
+						return;
+					}
+					document.location.href = 'post-new.php?post_type=page';
+				},
+			},
+		];
+	}, [ createPageEntity, isSiteEditor, userCanCreatePages ] );
+
+	return {
+		isLoading: false,
+		commands,
+	};
+}
 
 export function useAdminNavigationCommands() {
 	useCommand( {
@@ -14,12 +81,9 @@ export function useAdminNavigationCommands() {
 			document.location.href = 'post-new.php';
 		},
 	} );
-	useCommand( {
+
+	useCommandLoader( {
 		name: 'core/add-new-page',
-		label: __( 'Add new page' ),
-		icon: plus,
-		callback: () => {
-			document.location.href = 'post-new.php?post_type=page';
-		},
+		hook: useAddNewPageCommand,
 	} );
 }

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -35,7 +35,7 @@ function useAddNewPageCommand() {
 	const { saveEntityRecord } = useDispatch( coreStore );
 	const { createErrorNotice } = useDispatch( noticesStore );
 
-	const createPageEntity = async () => {
+	const createPageEntity = async ( { close } ) => {
 		try {
 			const page = await saveEntityRecord(
 				'postType',
@@ -63,6 +63,8 @@ function useAddNewPageCommand() {
 			createErrorNotice( errorMessage, {
 				type: 'snackbar',
 			} );
+		} finally {
+			close();
 		}
 	};
 

--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -1,97 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { useCommand, useCommandLoader } from '@wordpress/commands';
+import { useCommand } from '@wordpress/commands';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
-import { getPath } from '@wordpress/url';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
-import { store as noticesStore } from '@wordpress/notices';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
-
-/**
- * Internal dependencies
- */
-import { unlock } from './lock-unlock';
-
-const { useHistory } = unlock( routerPrivateApis );
-
-function useAddNewPageCommand() {
-	const isSiteEditor = getPath( window.location.href )?.includes(
-		'site-editor.php'
-	);
-	const history = useHistory();
-	const { userCanCreatePages } = useSelect( ( select ) => {
-		const { canUser } = select( coreStore );
-		return {
-			userCanCreatePages: canUser( 'create', {
-				kind: 'postType',
-				name: 'page',
-			} ),
-		};
-	}, [] );
-	const { saveEntityRecord } = useDispatch( coreStore );
-	const { createErrorNotice } = useDispatch( noticesStore );
-
-	const createPageEntity = async ( { close } ) => {
-		try {
-			const page = await saveEntityRecord(
-				'postType',
-				'page',
-				{
-					status: 'draft',
-				},
-				{
-					throwOnError: true,
-				}
-			);
-			if ( page?.id ) {
-				history.push( {
-					postId: page.id,
-					postType: 'page',
-					canvas: 'edit',
-				} );
-			}
-		} catch ( error ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while creating the item.' );
-
-			createErrorNotice( errorMessage, {
-				type: 'snackbar',
-			} );
-		} finally {
-			close();
-		}
-	};
-
-	const redirectToPostEditor = () =>
-		( document.location.href = 'post-new.php?post_type=page' );
-
-	const addNewPage = ! isSiteEditor ? redirectToPostEditor : createPageEntity;
-
-	const commands = useMemo( () => {
-		if ( ! userCanCreatePages ) {
-			return [];
-		}
-		return [
-			{
-				name: 'core/add-new-page',
-				label: __( 'Add new page' ),
-				icon: plus,
-				callback: addNewPage,
-			},
-		];
-	}, [ addNewPage, userCanCreatePages ] );
-
-	return {
-		isLoading: false,
-		commands,
-	};
-}
 
 export function useAdminNavigationCommands() {
 	useCommand( {
@@ -102,9 +14,12 @@ export function useAdminNavigationCommands() {
 			document.location.href = 'post-new.php';
 		},
 	} );
-
-	useCommandLoader( {
+	useCommand( {
 		name: 'core/add-new-page',
-		hook: useAddNewPageCommand,
+		label: __( 'Add new page' ),
+		icon: plus,
+		callback: () => {
+			document.location.href = 'post-new.php?post_type=page';
+		},
 	} );
 }

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -209,7 +209,7 @@ function useAddNewPageCommand() {
 	const commands = useMemo( () => {
 		return [
 			{
-				name: 'core/edit-site/add-new-page',
+				name: 'core/add-new-page',
 				label: __( 'Add new page' ),
 				icon: plus,
 				callback: createPageEntity,
@@ -228,7 +228,7 @@ export function useEditModeCommands() {
 	unregisterCommand( 'core/add-new-page' );
 
 	useCommandLoader( {
-		name: 'core/edit-site/add-new-page',
+		name: 'core/add-new-page',
 		hook: useAddNewPageCommand,
 	} );
 

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -3,21 +3,11 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf, isRTL } from '@wordpress/i18n';
-import {
-	trash,
-	rotateLeft,
-	rotateRight,
-	layout,
-	page,
-	plus,
-} from '@wordpress/icons';
-import { useCommandLoader, store as commandsStore } from '@wordpress/commands';
+import { trash, rotateLeft, rotateRight, layout, page } from '@wordpress/icons';
+import { useCommandLoader } from '@wordpress/commands';
 import { decodeEntities } from '@wordpress/html-entities';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as editorStore } from '@wordpress/editor';
-import { store as coreStore } from '@wordpress/core-data';
-import { store as noticesStore } from '@wordpress/notices';
-import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -168,70 +158,7 @@ function useManipulateDocumentCommands() {
 	};
 }
 
-function useAddNewPageCommand() {
-	const history = useHistory();
-	const { saveEntityRecord } = useDispatch( coreStore );
-	const { createErrorNotice } = useDispatch( noticesStore );
-
-	const createPageEntity = async ( { close } ) => {
-		try {
-			const _page = await saveEntityRecord(
-				'postType',
-				'page',
-				{
-					status: 'draft',
-				},
-				{
-					throwOnError: true,
-				}
-			);
-			if ( _page?.id ) {
-				history.push( {
-					postId: _page.id,
-					postType: 'page',
-					canvas: 'edit',
-				} );
-			}
-		} catch ( error ) {
-			const errorMessage =
-				error.message && error.code !== 'unknown_error'
-					? error.message
-					: __( 'An error occurred while creating the item.' );
-
-			createErrorNotice( errorMessage, {
-				type: 'snackbar',
-			} );
-		} finally {
-			close();
-		}
-	};
-
-	const commands = useMemo( () => {
-		return [
-			{
-				name: 'core/add-new-page',
-				label: __( 'Add new page' ),
-				icon: plus,
-				callback: createPageEntity,
-			},
-		];
-	}, [ createPageEntity ] );
-
-	return {
-		isLoading: false,
-		commands,
-	};
-}
-
 export function useEditModeCommands() {
-	const { unregisterCommand } = useDispatch( commandsStore );
-	unregisterCommand( 'core/add-new-page' );
-
-	useCommandLoader( {
-		name: 'core/add-new-page',
-		hook: useAddNewPageCommand,
-	} );
-
 	useCommandLoader( {
 		name: 'core/edit-site/page-content-focus',
 		hook: usePageContentFocusCommands,

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -30,6 +30,9 @@ test.describe( 'Site editor command palette', () => {
 		await expect( page ).toHaveURL(
 			'/wp-admin/post-new.php?post_type=page'
 		);
+		await expect( page ).toHaveURL(
+			/\/wp-admin\/site-editor.php\?postId=(\d+)&postType=page&canvas=edit/
+		);
 		await expect(
 			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
 		).toBeVisible();

--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -28,13 +28,12 @@ test.describe( 'Site editor command palette', () => {
 		await page.keyboard.type( 'new page' );
 		await page.getByRole( 'option', { name: 'Add new page' } ).click();
 		await expect( page ).toHaveURL(
-			'/wp-admin/post-new.php?post_type=page'
-		);
-		await expect( page ).toHaveURL(
 			/\/wp-admin\/site-editor.php\?postId=(\d+)&postType=page&canvas=edit/
 		);
 		await expect(
-			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
+			editor.canvas
+				.getByLabel( 'Block: Title' )
+				.locator( '[data-rich-text-placeholder="No title"]' )
 		).toBeVisible();
 	} );
 


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/65473

## What?

First pass at forking the add page command depending on context.

## Why?

@andrewserong is right - it's a bit disconcerting to be taken away from the site editor when creating a new page.

## How?

Forking the command based on the environment (whether `site-editor.php` is in the URL, which seems to be the most common mode of detection)

## Testing Instructions

In the site editor, open the command center (Cmd/Ctrl + K) and type/select "Add new page"

A new page should be created in the site editor.

Do the same in the post editor, you should stay in the post editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/63ac39f8-17b4-4847-baff-f5a53e28d8fe


