### PR TITLE
Revert "Make `wordpress/fields` a private package"

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1698,6 +1698,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/fields",
+		"slug": "packages-fields",
+		"markdown_source": "../packages/fields/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/format-library",
 		"slug": "packages-format-library",
 		"markdown_source": "../packages/format-library/README.md",

--- a/packages/fields/package.json
+++ b/packages/fields/package.json
@@ -9,7 +9,6 @@
 		"gutenberg",
 		"dataviews"
 	],
-	"private": true,
 	"homepage": "https://github.com/WordPress/gutenberg/tree/HEAD/packages/fields/README.md",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
This reverts WordPress/gutenberg#65269 which marked the `@wordpress/fields` package private. In other words, this PR makes it public.

The problem with making `@wordpress/fields` private is that it **is** used by Core/Gutenberg. Specifically, it's a dependency of `@wordpress/editor`:

https://github.com/WordPress/gutenberg/blob/fe25bf19feddeb6675d01067f9dab0b5d9087048/packages/editor/package.json#L50

This means that if you run `npm install @wordpress/editor` (which we have to do to update packages in Core for 6.7) you get a 404 error when npm tries to download `@wordpress/fields`.

I don't see a good way to "conditionally depend" on a package so I think the best thing to do is to just publish `@wordpress/fields`. It's already a bundled package so there won't be a `wp.fields` entry point. It would behave much like `@wordpress/dataviews`.

Before I publish, I want to check with @oandregal, @youknowriad and @gziolo as it sounded like they might have had some reservations e.g. about the name https://github.com/WordPress/gutenberg/pull/65230#issuecomment-2343996092.