### PR TITLE
Babel preset: Add missing pkg files

### DIFF
--- a/packages/babel-preset-default/CHANGELOG.md
+++ b/packages/babel-preset-default/CHANGELOG.md
@@ -1,8 +1,16 @@
 <!-- Learn how to maintain this file at https://github.com/WordPress/gutenberg/tree/HEAD/packages#maintaining-changelogs. -->
 
-## Internal
+## Unreleased
 
-- Added `addPolyfillComments` option. When used, it will automatically add magic comments to mark files that need `wp-polyfill`.
+### Bug Fixes
+
+-   Fix a bug in 8.8.1 due to missing files in the published package ([#65481](https://github.com/WordPress/gutenberg/pull/65481)).
+
+## 8.8.0 (2024-09-19)
+
+### Internal
+
+-   Added `addPolyfillComments` option. When used, it will automatically add magic comments to mark files that need `wp-polyfill` ([#65292](https://github.com/WordPress/gutenberg/pull/65292)).
 
 ## 8.7.0 (2024-09-05)
 

--- a/packages/babel-preset-default/package.json
+++ b/packages/babel-preset-default/package.json
@@ -26,7 +26,9 @@
 	},
 	"files": [
 		"build",
-		"index.js"
+		"index.js",
+		"polyfill-exclusions.js",
+		"replace-polyfills.js"
 	],
 	"main": "index.js",
 	"dependencies": {


### PR DESCRIPTION

## What?

Fix an issue where some files are not included in the npm package: https://github.com/WordPress/gutenberg/pull/65292#issuecomment-2360175109


## How?

Add the missing files to the package's `package.json` `files` field.

## Testing Instructions

You can do `npm publish --dry-run` from the package to see the included files. Here's a comparison with trunk:

```diff
diff --git before/trunk.txt after/branch.txt
index 6e0db7576f..0a3705e5c7 100644
--- before/trunk.txt
+++ after/branch.txt
@@ -1,7 +1,8 @@
 npm notice 📦  @wordpress/babel-preset-default@8.8.0
 npm notice Tarball Contents
 npm notice 3.8kB README.md
 npm notice 128.8kB build/polyfill.js
 npm notice 39.0kB build/polyfill.min.js
 npm notice 2.2kB index.js
 npm notice 1.3kB package.json
+npm notice 480B polyfill-exclusions.js
+npm notice 1.3kB replace-polyfills.js
```

The added files from the commit are as follows:

```sh
# git diff bf639061fe54dfde3d1f80c9ddbaf02eba52fe31~ bf639061fe54dfde3d1f80c9ddbaf02eba52fe31 --diff-filter=A --name-only
packages/babel-preset-default/polyfill-exclusions.js
packages/babel-preset-default/replace-polyfills.js
packages/babel-preset-default/test/fixtures/polyfill.js
packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/index.js
packages/dependency-extraction-webpack-plugin/test/fixtures/polyfill-magic-comment/webpack.config.js
```