### PR TITLE
Decouple "zoom/scaling the canvas" from zoom out mode (without mode rename)

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1027,11 +1027,11 @@ _Parameters_
 
 ### useZoomOut
 
-A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
+A hook used to set the zoomed out view, invoking the hook sets the mode.
 
 _Parameters_
 
--   _zoomOut_ `boolean`: If we should enter into zoomOut mode or not
+-   _zoomOut_ `boolean`: If we should zoom out or not.
 
 ### Warning
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
@@ -16,14 +16,17 @@ import { unlock } from '../../../lock-unlock';
  * @param {string} clientId Block client ID.
  */
 export function useZoomOutModeExit( { editorMode } ) {
-	const { getSettings } = useSelect( blockEditorStore );
-	const { __unstableSetEditorMode } = unlock(
+	const { getSettings, isZoomOut } = unlock( useSelect( blockEditorStore ) );
+	const { __unstableSetEditorMode, resetZoomOut } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
 	return useRefEffect(
 		( node ) => {
-			if ( editorMode !== 'zoom-out' ) {
+			// In "compose" mode.
+			const composeMode = editorMode === 'zoom-out' && isZoomOut();
+
+			if ( ! composeMode ) {
 				return;
 			}
 
@@ -39,6 +42,7 @@ export function useZoomOutModeExit( { editorMode } ) {
 						__experimentalSetIsInserterOpened( false );
 					}
 					__unstableSetEditorMode( 'edit' );
+					resetZoomOut();
 				}
 			}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-zoom-out-mode-exit.js
@@ -17,7 +17,7 @@ import { unlock } from '../../../lock-unlock';
  */
 export function useZoomOutModeExit( { editorMode } ) {
 	const { getSettings, isZoomOut } = unlock( useSelect( blockEditorStore ) );
-	const { __unstableSetEditorMode, resetZoomOut } = unlock(
+	const { __unstableSetEditorMode, resetZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -42,7 +42,7 @@ export function useZoomOutModeExit( { editorMode } ) {
 						__experimentalSetIsInserterOpened( false );
 					}
 					__unstableSetEditorMode( 'edit' );
-					resetZoomOut();
+					resetZoomLevel();
 				}
 			}
 

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -85,7 +85,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 		setIsInserterOpened,
 	} = selected;
 
-	const { removeBlock, __unstableSetEditorMode, resetZoomOut } = unlock(
+	const { removeBlock, __unstableSetEditorMode, resetZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -146,7 +146,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 							setIsInserterOpened( false );
 						}
 						__unstableSetEditorMode( 'edit' );
-						resetZoomOut();
+						resetZoomLevel();
 						__unstableContentRef.current?.focus();
 					} }
 				/>

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -20,6 +20,7 @@ import BlockDraggable from '../block-draggable';
 import BlockMover from '../block-mover';
 import Shuffle from '../block-toolbar/shuffle';
 import NavigableToolbar from '../navigable-toolbar';
+import { unlock } from '../../lock-unlock';
 
 export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 	const selected = useSelect(
@@ -84,8 +85,9 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 		setIsInserterOpened,
 	} = selected;
 
-	const { removeBlock, __unstableSetEditorMode } =
-		useDispatch( blockEditorStore );
+	const { removeBlock, __unstableSetEditorMode, resetZoomOut } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const classNames = clsx( 'zoom-out-toolbar', {
 		'is-block-moving-mode': !! blockMovingMode,
@@ -144,6 +146,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 							setIsInserterOpened( false );
 						}
 						__unstableSetEditorMode( 'edit' );
+						resetZoomOut();
 						__unstableContentRef.current?.focus();
 					} }
 				/>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -18,6 +18,7 @@ import { Icon, edit as editIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 const selectIcon = (
 	<SVG
@@ -35,7 +36,9 @@ function ToolSelector( props, ref ) {
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { __unstableSetEditorMode } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	return (
 		<Dropdown

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -27,15 +27,7 @@ export function useZoomOut( zoomOut = true ) {
 			originalIsZoomOutRef.current = isZoomOut();
 		}
 
-		return () => {
-			if ( isZoomOut() && isZoomOut() !== originalIsZoomOutRef.current ) {
-				setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
-			}
-		};
-	}, [ isZoomOut, setZoomLevel ] );
-
-	// The effect opens the zoom-out view if we want it open and the canvas is not currently zoomed-out.
-	useEffect( () => {
+		// The effect opens the zoom-out view if we want it open and the canvas is not currently zoomed-out.
 		if ( zoomOut && isZoomOut() === false ) {
 			setZoomLevel( 50 );
 		} else if (
@@ -45,5 +37,11 @@ export function useZoomOut( zoomOut = true ) {
 		) {
 			setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
 		}
+
+		return () => {
+			if ( isZoomOut() && isZoomOut() !== originalIsZoomOutRef.current ) {
+				setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
+			}
+		};
 	}, [ isZoomOut, setZoomLevel, zoomOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -20,7 +20,7 @@ export function useZoomOut( zoomOut = true ) {
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	const originalIsZoomOutRef = useRef( null );
-	const currentZoomOutState = isZoomOut();
+	const currentZoomOutState = isZoomOut() ? 50 : 100;
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
@@ -31,7 +31,7 @@ export function useZoomOut( zoomOut = true ) {
 		return () => {
 			// We need to use  isZoomOut() here and not `currentZoomOutState`, as currentZoomOutState may not update on unmount
 			if ( isZoomOut() && isZoomOut() !== originalIsZoomOutRef.current ) {
-				setZoomLevel( originalIsZoomOutRef.current );
+				setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
 			}
 		};
 	}, [ currentZoomOutState, isZoomOut, setZoomLevel ] );
@@ -39,14 +39,13 @@ export function useZoomOut( zoomOut = true ) {
 	// The effect opens the zoom-out view if we want it open and the canvas is not currently zoomed-out.
 	useEffect( () => {
 		if ( zoomOut && currentZoomOutState === false ) {
-			// __unstableSetEditorMode( 'compose' );
-			setZoomLevel( true );
+			setZoomLevel( 50 );
 		} else if (
 			! zoomOut &&
 			isZoomOut() &&
 			originalIsZoomOutRef.current !== currentZoomOutState
 		) {
-			setZoomLevel( originalIsZoomOutRef.current );
+			setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
 		}
 		// currentZoomOutState is deliberately excluded from the dependencies so that the effect does not run when mode changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -20,7 +20,7 @@ export function useZoomOut( zoomOut = true ) {
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	const originalIsZoomOutRef = useRef( null );
-	const currentZoomOutState = isZoomOut() ? 50 : 100;
+	const currentZoomOutState = isZoomOut();
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -16,7 +16,7 @@ import { unlock } from '../lock-unlock';
  * @param {boolean} zoomOut If we should zoom out or not.
  */
 export function useZoomOut( zoomOut = true ) {
-	const { setZoomOut } = unlock( useDispatch( blockEditorStore ) );
+	const { setZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	const originalIsZoomOutRef = useRef( null );
@@ -31,24 +31,24 @@ export function useZoomOut( zoomOut = true ) {
 		return () => {
 			// We need to use  isZoomOut() here and not `currentZoomOutState`, as currentZoomOutState may not update on unmount
 			if ( isZoomOut() && isZoomOut() !== originalIsZoomOutRef.current ) {
-				setZoomOut( originalIsZoomOutRef.current );
+				setZoomLevel( originalIsZoomOutRef.current );
 			}
 		};
-	}, [ currentZoomOutState, isZoomOut, setZoomOut ] );
+	}, [ currentZoomOutState, isZoomOut, setZoomLevel ] );
 
 	// The effect opens the zoom-out view if we want it open and the canvas is not currently zoomed-out.
 	useEffect( () => {
 		if ( zoomOut && currentZoomOutState === false ) {
 			// __unstableSetEditorMode( 'compose' );
-			setZoomOut( true );
+			setZoomLevel( true );
 		} else if (
 			! zoomOut &&
 			isZoomOut() &&
 			originalIsZoomOutRef.current !== currentZoomOutState
 		) {
-			setZoomOut( originalIsZoomOutRef.current );
+			setZoomLevel( originalIsZoomOutRef.current );
 		}
 		// currentZoomOutState is deliberately excluded from the dependencies so that the effect does not run when mode changes.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ isZoomOut, setZoomOut, zoomOut ] );
+	}, [ isZoomOut, setZoomLevel, zoomOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -20,34 +20,30 @@ export function useZoomOut( zoomOut = true ) {
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	const originalIsZoomOutRef = useRef( null );
-	const currentZoomOutState = isZoomOut();
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
 		if ( ! originalIsZoomOutRef.current ) {
-			originalIsZoomOutRef.current = currentZoomOutState;
+			originalIsZoomOutRef.current = isZoomOut();
 		}
 
 		return () => {
-			// We need to use  isZoomOut() here and not `currentZoomOutState`, as currentZoomOutState may not update on unmount
 			if ( isZoomOut() && isZoomOut() !== originalIsZoomOutRef.current ) {
 				setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
 			}
 		};
-	}, [ currentZoomOutState, isZoomOut, setZoomLevel ] );
+	}, [ isZoomOut, setZoomLevel ] );
 
 	// The effect opens the zoom-out view if we want it open and the canvas is not currently zoomed-out.
 	useEffect( () => {
-		if ( zoomOut && currentZoomOutState === false ) {
+		if ( zoomOut && isZoomOut() === false ) {
 			setZoomLevel( 50 );
 		} else if (
 			! zoomOut &&
 			isZoomOut() &&
-			originalIsZoomOutRef.current !== currentZoomOutState
+			originalIsZoomOutRef.current !== isZoomOut()
 		) {
 			setZoomLevel( originalIsZoomOutRef.current ? 50 : 100 );
 		}
-		// currentZoomOutState is deliberately excluded from the dependencies so that the effect does not run when mode changes.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isZoomOut, setZoomLevel, zoomOut ] );
 }

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -402,7 +402,7 @@ export function setZoomOut( zoom = 50 ) {
 	}
 
 	return {
-		type: 'SET_ZOOM_OUT',
+		type: 'SET_ZOOM_LEVEL',
 		zoom: zoomValue,
 	};
 }
@@ -413,6 +413,6 @@ export function setZoomOut( zoom = 50 ) {
  */
 export function resetZoomOut() {
 	return {
-		type: 'RESET_ZOOM',
+		type: 'RESET_ZOOM_LEVEL',
 	};
 }

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -390,20 +390,10 @@ export const modifyContentLockBlock =
  * @param {number} zoom the new zoom level
  * @return {Object} Action object.
  */
-export function setZoomLevel( zoom = 50 ) {
-	let zoomValue;
-
-	if ( zoom === true ) {
-		zoomValue = 50;
-	} else if ( zoom === false ) {
-		zoomValue = 100; // Considered as a reset
-	} else {
-		zoomValue = zoom;
-	}
-
+export function setZoomLevel( zoom = 100 ) {
 	return {
 		type: 'SET_ZOOM_LEVEL',
-		zoom: zoomValue,
+		zoom,
 	};
 }
 
@@ -411,7 +401,7 @@ export function setZoomLevel( zoom = 50 ) {
  * Resets the Zoom state.
  * @return {Object} Action object.
  */
-export function resetZoomOut() {
+export function resetZoomLevel() {
 	return {
 		type: 'RESET_ZOOM_LEVEL',
 	};

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -390,7 +390,7 @@ export const modifyContentLockBlock =
  * @param {number} zoom the new zoom level
  * @return {Object} Action object.
  */
-export function setZoomOut( zoom = 50 ) {
+export function setZoomLevel( zoom = 50 ) {
 	let zoomValue;
 
 	if ( zoom === true ) {

--- a/packages/block-editor/src/store/private-actions.js
+++ b/packages/block-editor/src/store/private-actions.js
@@ -383,3 +383,36 @@ export const modifyContentLockBlock =
 			focusModeToRevert
 		);
 	};
+
+/**
+ * Sets the zoom level.
+ *
+ * @param {number} zoom the new zoom level
+ * @return {Object} Action object.
+ */
+export function setZoomOut( zoom = 50 ) {
+	let zoomValue;
+
+	if ( zoom === true ) {
+		zoomValue = 50;
+	} else if ( zoom === false ) {
+		zoomValue = 100; // Considered as a reset
+	} else {
+		zoomValue = zoom;
+	}
+
+	return {
+		type: 'SET_ZOOM_OUT',
+		zoom: zoomValue,
+	};
+}
+
+/**
+ * Resets the Zoom state.
+ * @return {Object} Action object.
+ */
+export function resetZoomOut() {
+	return {
+		type: 'RESET_ZOOM',
+	};
+}

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -560,3 +560,23 @@ export function isZoomOutMode( state ) {
 export function getSectionRootClientId( state ) {
 	return state.settings?.[ sectionRootClientIdKey ];
 }
+
+/**
+ * Returns the zoom out state.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} The zoom out state.
+ */
+export function getZoomLevel( state ) {
+	return state.zoomLevel;
+}
+
+/**
+ * Returns whether the editor is considered zoomed out.
+ *
+ * @param {Object} state Global application state.
+ * @return {boolean} Whether the editor is zoomed.
+ */
+export function isZoomOut( state ) {
+	return getZoomLevel( state ) < 100;
+}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2095,9 +2095,9 @@ export function hoveredBlockClientId( state = false, action ) {
  */
 export function zoomLevel( state = 100, action ) {
 	switch ( action.type ) {
-		case 'SET_ZOOM_OUT':
+		case 'SET_ZOOM_LEVEL':
 			return action.zoom;
-		case 'RESET_ZOOM':
+		case 'RESET_ZOOM_LEVEL':
 			return 100;
 	}
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2085,6 +2085,25 @@ export function hoveredBlockClientId( state = false, action ) {
 	return state;
 }
 
+/**
+ * Reducer setting zoom out state.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {boolean} Updated state.
+ */
+export function zoomLevel( state = 100, action ) {
+	switch ( action.type ) {
+		case 'SET_ZOOM_OUT':
+			return action.zoom;
+		case 'RESET_ZOOM':
+			return 100;
+	}
+
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2118,6 +2137,7 @@ const combinedReducers = combineReducers( {
 	openedBlockSettingsMenu,
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
+	zoomLevel,
 } );
 
 function withAutomaticChangeReset( reducer ) {

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -32,6 +32,8 @@ import TextEditor from '../text-editor';
 import VisualEditor from '../visual-editor';
 import EditorContentSlotFill from './content-slot-fill';
 
+import { unlock } from '../../lock-unlock';
+
 const interfaceLabels = {
 	/* translators: accessibility text for the editor top bar landmark region. */
 	header: __( 'Editor top bar' ),
@@ -71,12 +73,13 @@ export default function EditorInterface( {
 		nextShortcut,
 		showBlockBreadcrumbs,
 		documentLabel,
-		blockEditorMode,
+		isZoomOut,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const { getEditorSettings, getPostTypeLabel } = select( editorStore );
 		const editorSettings = getEditorSettings();
 		const postTypeLabel = getPostTypeLabel();
+		const { isZoomOut: _isZoomOut } = unlock( select( blockEditorStore ) );
 
 		return {
 			mode: select( editorStore ).getEditorMode(),
@@ -94,8 +97,7 @@ export default function EditorInterface( {
 			showBlockBreadcrumbs: get( 'core', 'showBlockBreadcrumbs' ),
 			// translators: Default label for the Document in the Block Breadcrumb.
 			documentLabel: postTypeLabel || _x( 'Document', 'noun' ),
-			blockEditorMode:
-				select( blockEditorStore ).__unstableGetEditorMode(),
+			isZoomOut: _isZoomOut(),
 		};
 	}, [] );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -206,7 +208,7 @@ export default function EditorInterface( {
 				isLargeViewport &&
 				showBlockBreadcrumbs &&
 				isRichEditingEnabled &&
-				blockEditorMode !== 'zoom-out' &&
+				! isZoomOut &&
 				mode === 'visual' && (
 					<BlockBreadcrumb rootLabelText={ documentLabel } />
 				)

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -174,17 +174,19 @@ function VisualEditor( {
 		hasRootPaddingAwareAlignments,
 		themeHasDisabledLayoutStyles,
 		themeSupportsLayout,
-		isZoomOutMode,
+		isZoomedOut,
 	} = useSelect( ( select ) => {
-		const { getSettings, __unstableGetEditorMode } =
-			select( blockEditorStore );
+		const { getSettings, isZoomOut: _isZoomOut } = unlock(
+			select( blockEditorStore )
+		);
+
 		const _settings = getSettings();
 		return {
 			themeHasDisabledLayoutStyles: _settings.disableLayoutStyles,
 			themeSupportsLayout: _settings.supportsLayout,
 			hasRootPaddingAwareAlignments:
 				_settings.__experimentalFeatures?.useRootPaddingAwareAlignments,
-			isZoomOutMode: __unstableGetEditorMode() === 'zoom-out',
+			isZoomedOut: _isZoomOut(),
 		};
 	}, [] );
 
@@ -336,7 +338,7 @@ function VisualEditor( {
 	] );
 
 	const zoomOutProps =
-		isZoomOutMode && ! isTabletViewport
+		isZoomedOut && ! isTabletViewport
 			? {
 					scale: 'default',
 					frameSize: '48px',
@@ -355,7 +357,7 @@ function VisualEditor( {
 		// Disable resizing in mobile viewport.
 		! isMobileViewport &&
 		// Dsiable resizing in zoomed-out mode.
-		! isZoomOutMode;
+		! isZoomedOut;
 	const shouldIframe =
 		! disableIframe || [ 'Tablet', 'Mobile' ].includes( deviceType );
 

--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -18,12 +18,12 @@ const ZoomOutToggle = () => {
 		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
 	} ) );
 
-	const { setZoomOut, __unstableSetEditorMode } = unlock(
+	const { setZoomLevel, __unstableSetEditorMode } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
 	const handleZoomOut = () => {
-		setZoomOut( isZoomOut ? false : true );
+		setZoomLevel( isZoomOut ? false : true );
 		__unstableSetEditorMode( isZoomOut ? 'edit' : 'zoom-out' );
 	};
 

--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -8,16 +8,23 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { square as zoomOutIcon } from '@wordpress/icons';
 
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
 const ZoomOutToggle = () => {
-	const { isZoomOutMode } = useSelect( ( select ) => ( {
-		isZoomOutMode:
-			select( blockEditorStore ).__unstableGetEditorMode() === 'zoom-out',
+	const { isZoomOut } = useSelect( ( select ) => ( {
+		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
 	} ) );
 
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { setZoomOut, __unstableSetEditorMode } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	const handleZoomOut = () => {
-		__unstableSetEditorMode( isZoomOutMode ? 'edit' : 'zoom-out' );
+		setZoomOut( isZoomOut ? false : true );
+		__unstableSetEditorMode( isZoomOut ? 'edit' : 'zoom-out' );
 	};
 
 	return (
@@ -25,7 +32,7 @@ const ZoomOutToggle = () => {
 			onClick={ handleZoomOut }
 			icon={ zoomOutIcon }
 			label={ __( 'Toggle Zoom Out' ) }
-			isPressed={ isZoomOutMode }
+			isPressed={ isZoomOut }
 			size="compact"
 		/>
 	);

--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -18,12 +18,16 @@ const ZoomOutToggle = () => {
 		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
 	} ) );
 
-	const { setZoomLevel, __unstableSetEditorMode } = unlock(
+	const { resetZoomLevel, setZoomLevel, __unstableSetEditorMode } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
 	const handleZoomOut = () => {
-		setZoomLevel( isZoomOut ? false : true );
+		if ( isZoomOut ) {
+			resetZoomLevel();
+		} else {
+			setZoomLevel( 50 );
+		}
 		__unstableSetEditorMode( isZoomOut ? 'edit' : 'zoom-out' );
 	};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Decouples concept of "zooming the canvas" from "composing with patterns".

In this PR we retain `zoom-out` as the mode name.

Alternative to https://github.com/WordPress/gutenberg/pull/65265

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/65265

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

See https://github.com/WordPress/gutenberg/pull/65265

Only difference is that we do not rename the mode - it remains `zoom-out`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Same as https://github.com/WordPress/gutenberg/pull/65265

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
