### PR TITLE
Query Loop: Remove is_singular() check and fix test

### DIFF
--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -67,7 +67,7 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 
 			// If in a single post of any post type, default to the 'post' post type.
 			if ( is_singular() ) {
-				query_posts( array( 'post_type' => 'post' ) );
+				$query->set( 'post_type', 'post' );
 			}
 		} else {
 			$query = $wp_query;

--- a/packages/block-library/src/post-template/index.php
+++ b/packages/block-library/src/post-template/index.php
@@ -64,11 +64,6 @@ function render_block_core_post_template( $attributes, $content, $block ) {
 		if ( in_the_loop() ) {
 			$query = clone $wp_query;
 			$query->rewind_posts();
-
-			// If in a single post of any post type, default to the 'post' post type.
-			if ( is_singular() ) {
-				$query->set( 'post_type', 'post' );
-			}
 		} else {
 			$query = $wp_query;
 		}

--- a/phpunit/blocks/render-post-template-test.php
+++ b/phpunit/blocks/render-post-template-test.php
@@ -122,7 +122,7 @@ END;
 		global $wp_query, $wp_the_query;
 
 		// Query block with post template block.
-		$content  = '<!-- wp:query {"query":{"inherit":true}} -->';
+		$content  = '<!-- wp:query {"query":{"inherit":false}} -->';
 		$content .= '<!-- wp:post-template {"align":"wide"} -->';
 		$content .= '<!-- wp:post-title /-->';
 		$content .= '<!-- /wp:post-template -->';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is a follow-up to https://github.com/WordPress/gutenberg/pull/65067 to improve the implementation of querying 'post' post types.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As `inherit` is now automatically set to `false` when a Query Loop is inserted within content (a single post/page/CPT), we don't need to manually update the query in an `is_singular()` check.

Also, `query_posts()` should generally be avoided as it could cause some unwanted side effects. See [this comment](https://github.com/WordPress/gutenberg/pull/65067#issuecomment-2360018678) for more details.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the `is_singular()` check from the Post Template server-side render, and updates the `test_rendering_post_template_with_main_query_loop_already_started` test so that it is correctly using `inherit: false` in the test block markup.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert a query loop block in a singular page/post/CPT
2. Ensure that it defaults to displaying posts in both the Editor and front-end
3. Ensure that the post type can be changed in the Editor and, if customised, that it shows the custom query on the front-end
4. Ensure the `test_rendering_post_template_with_main_query_loop_already_started` PHP unit test passes