### PR TITLE
updates LayoutTypeSwitcher to use ToggleGroupControl

### DIFF
--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -313,25 +313,25 @@ export default {
 	},
 };
 
-function LayoutTypeSwitcher( { key, onChange } ) {
+function LayoutTypeSwitcher( { type, onChange } ) {
 	return (
 		<ToggleGroupControl
 			__next40pxDefaultSize
 			isBlock
-			label={ __( 'Layout Type Select' ) }
+			label={ __( 'Layout type' ) }
 			__nextHasNoMarginBottom
 			hideLabelFromVision
 			isAdaptiveWidth
+			value={ type }
+			onChange={ onChange }
 		>
 			{ getLayoutTypes().map( ( { name, label } ) => {
 				return (
 					<ToggleGroupControlOption
+						key={ name }
 						value={ name }
-						label={ name }
-						onClick={ () => onChange( name ) }
-					>
-						{ label }
-					</ToggleGroupControlOption>
+						label={ label }
+					/>
 				);
 			} ) }
 		</ToggleGroupControl>

--- a/packages/block-editor/src/hooks/layout.js
+++ b/packages/block-editor/src/hooks/layout.js
@@ -11,8 +11,8 @@ import { addFilter } from '@wordpress/hooks';
 import { getBlockSupport, hasBlockSupport } from '@wordpress/blocks';
 import { useSelect } from '@wordpress/data';
 import {
-	Button,
-	ButtonGroup,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToggleControl,
 	PanelBody,
 	privateApis as componentsPrivateApis,
@@ -313,23 +313,28 @@ export default {
 	},
 };
 
-function LayoutTypeSwitcher( { type, onChange } ) {
+function LayoutTypeSwitcher( { key, onChange } ) {
 	return (
-		<ButtonGroup>
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			isBlock
+			label={ __( 'Layout Type Select' ) }
+			__nextHasNoMarginBottom
+			hideLabelFromVision
+			isAdaptiveWidth
+		>
 			{ getLayoutTypes().map( ( { name, label } ) => {
 				return (
-					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
-						key={ name }
-						isPressed={ type === name }
+					<ToggleGroupControlOption
+						value={ name }
+						label={ name }
 						onClick={ () => onChange( name ) }
 					>
 						{ label }
-					</Button>
+					</ToggleGroupControlOption>
 				);
 			} ) }
-		</ButtonGroup>
+		</ToggleGroupControl>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
PR replaces the ButtonGroup component with ToggleGroupControl in the LayoutTypeSwitcher component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Part Of -[https://github.com/WordPress/gutenberg/issues/65339]( https://github.com/WordPress/gutenberg/issues/65339)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates LayoutTypeSwitcher to use the new ToggleGroupControl in lieu of ButtonGroup component

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Note: the LayoutTypeSwitcher function is no longer used in any core blocks. You will need to adjust the conditional on line 267 to make the controls visible on the block.

`! inherit && allowSwitching &&` to `true &&`

1. Create a new post or page
2. Place a block that has layout controls, such as Group or Cover
3. Block controls should be visible and functional. See screenshot.

<img width="292" alt="Screenshot 2024-09-19 at 8 24 30 AM" src="https://github.com/user-attachments/assets/3983a2db-7f16-4354-a05e-0235a03a6ccf">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Same as above

## Screenshots or screencast <!-- if applicable -->
