### PR TITLE
Improve Parent Page Select Dropdown by Adding Page ID When Searching

### DIFF
--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -111,7 +111,13 @@ export function PageAttributesParent() {
 					label:
 						'— '.repeat( level ) +
 						decodeEntities( treeNode.name ) +
-						( fieldValue ? ` (ID: ${ treeNode.id })` : '' ),
+						( fieldValue
+							? ` (${ sprintf(
+									/* translators: %s: Post ID */
+									__( 'ID: %s' ),
+									treeNode.id
+							  ) })`
+							: '' ),
 					rawName: treeNode.name,
 				},
 				...getOptionsFromTree( treeNode.children || [], level + 1 ),
@@ -152,7 +158,13 @@ export function PageAttributesParent() {
 				value: parentPostId,
 				label:
 					parentPostTitle +
-					( fieldValue ? ` (ID: ${ parentPostId })` : '' ),
+					( fieldValue
+						? ` (${ sprintf(
+								/* translators: %s: Post ID */
+								__( 'ID: %s' ),
+								parentPostId
+						  ) })`
+						: '' ),
 			} );
 		}
 		return opts;

--- a/packages/editor/src/components/page-attributes/parent.js
+++ b/packages/editor/src/components/page-attributes/parent.js
@@ -109,7 +109,9 @@ export function PageAttributesParent() {
 				{
 					value: treeNode.id,
 					label:
-						'— '.repeat( level ) + decodeEntities( treeNode.name ),
+						'— '.repeat( level ) +
+						decodeEntities( treeNode.name ) +
+						( fieldValue ? ` (ID: ${ treeNode.id })` : '' ),
 					rawName: treeNode.name,
 				},
 				...getOptionsFromTree( treeNode.children || [], level + 1 ),
@@ -148,7 +150,9 @@ export function PageAttributesParent() {
 		if ( parentPostTitle && ! optsHasParent ) {
 			opts.unshift( {
 				value: parentPostId,
-				label: parentPostTitle,
+				label:
+					parentPostTitle +
+					( fieldValue ? ` (ID: ${ parentPostId })` : '' ),
 			} );
 		}
 		return opts;


### PR DESCRIPTION
## What?
This PR improves the Parent Page select dropdown in the block editor by adding the page ID next to the page title when performing a search. The hierarchical tree format is preserved when not searching, ensuring clarity in both scenarios.

## Why?
When selecting a parent page in the block editor, pages are displayed hierarchically, making it easy to distinguish between pages with the same name. However, when a search is performed, this hierarchy is lost, and only page titles are shown, leading to confusion when multiple pages share the same title.

This PR addresses issue #65500.

## How?
The `PageAttributesParent` component has been updated to append the page ID next to the page title when a search is performed. When not searching, the existing hierarchical structure is maintained, so there is no disruption to the current user experience.

## Testing Instructions
1. Open the block editor and create or edit a page.
2. In the Page Attributes panel, open the Parent Page dropdown.
3. Without searching, observe that the parent pages are displayed in a hierarchical format.
4. Perform a search by typing part of a page name into the dropdown’s search field.
5. Observe that the page titles now include the page ID next to the title in parentheses, e.g., `Consulting (ID: 42)`.
6. Select a parent page and save the page to ensure the selected parent is saved correctly.

### Testing Instructions for Keyboard
1. Open the block editor and navigate to the Page Attributes panel using the keyboard.
2. Focus on the Parent Page dropdown.
3. Without searching, use the keyboard to navigate through the hierarchical structure.
4. Type in the search field to search for a page, and navigate through the results to observe that the IDs are displayed next to the page titles.
5. Use the keyboard to select a parent page and save the changes, ensuring that everything works as expected without requiring a mouse.

## Screenshots or screencast
**Before**
![Screenshot 2024-09-19 at 4 13 21 PM](https://github.com/user-attachments/assets/b0b75257-2ba0-450d-a259-3e299898e7e1)

**After**
![Screenshot 2024-09-19 at 4 26 29 PM](https://github.com/user-attachments/assets/4fd18cce-6cad-41a0-b0ed-4bdbaf417e25)


