### PR TITLE
Style book: display registered categories

### DIFF
--- a/packages/edit-site/src/components/style-book/categories.ts
+++ b/packages/edit-site/src/components/style-book/categories.ts
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { getCategories } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import type {
@@ -6,6 +11,10 @@ import type {
 	StyleBookCategory,
 	CategoryExamples,
 } from './types';
+import {
+	STYLE_BOOK_CATEGORIES,
+	STYLE_BOOK_THEME_SUBCATEGORIES,
+} from './constants';
 
 /**
  * Returns category examples for a given category definition and list of examples.
@@ -63,4 +72,20 @@ export function getExamplesByCategory(
 		slug: categoryDefinition.slug,
 		examples: categoryExamples,
 	};
+}
+
+/**
+ * Returns category examples for a given category definition and list of examples.
+ *
+ * @return {StyleBookCategory[]} An array of top-level category definitions.
+ */
+export function getTopLevelStyleBookCategories(): StyleBookCategory[] {
+	const reservedCategories = [
+		...STYLE_BOOK_THEME_SUBCATEGORIES,
+		...STYLE_BOOK_CATEGORIES,
+	].map( ( { slug } ) => slug );
+	const extraCategories = getCategories().filter(
+		( { slug } ) => ! reservedCategories.includes( slug )
+	);
+	return [ ...STYLE_BOOK_CATEGORIES, ...extraCategories ];
 }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -31,7 +31,9 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
 import { unlock } from '../../lock-unlock';
 import EditorCanvasContainer from '../editor-canvas-container';
 import { STYLE_BOOK_CATEGORIES, STYLE_BOOK_IFRAME_STYLES } from './constants';
-import { getExamplesByCategory } from './categories';
+import {
+	getExamplesByCategory, getTopLevelStyleBookCategories,
+} from './categories';
 import { getExamples } from './examples';
 
 const {
@@ -64,7 +66,7 @@ function StyleBook( {
 	const [ examples ] = useState( getExamples );
 	const tabs = useMemo(
 		() =>
-			STYLE_BOOK_CATEGORIES.filter( ( category ) =>
+			getTopLevelStyleBookCategories().filter( ( category ) =>
 				examples.some(
 					( example ) => example.category === category.slug
 				)

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -30,7 +30,7 @@ import { ENTER, SPACE } from '@wordpress/keycodes';
  */
 import { unlock } from '../../lock-unlock';
 import EditorCanvasContainer from '../editor-canvas-container';
-import { STYLE_BOOK_CATEGORIES, STYLE_BOOK_IFRAME_STYLES } from './constants';
+import { STYLE_BOOK_IFRAME_STYLES } from './constants';
 import {
 	getExamplesByCategory, getTopLevelStyleBookCategories,
 } from './categories';
@@ -247,7 +247,7 @@ const StyleBookBody = ( {
 const Examples = memo(
 	( { className, examples, category, label, isSelected, onSelect } ) => {
 		const categoryDefinition = category
-			? STYLE_BOOK_CATEGORIES.find(
+			? getTopLevelStyleBookCategories().find(
 					( _category ) => _category.slug === category
 			  )
 			: null;

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -18,6 +18,10 @@
 }
 
 .edit-site-style-book__tabs {
+	[role="tab"] {
+		white-space: nowrap;
+	}
+
 	[role="tablist"] {
 		background: $white;
 		color: $gray-900;

--- a/packages/edit-site/src/components/style-book/test/categories.js
+++ b/packages/edit-site/src/components/style-book/test/categories.js
@@ -91,8 +91,9 @@ describe( 'utils', () => {
 			expect( getTopLevelStyleBookCategories() ).toEqual( [
 				...STYLE_BOOK_CATEGORIES,
 				{
-					name: 'funky',
+					slug: 'funky',
 					title: 'Funky',
+					icon: 'funky',
 				},
 			] );
 		} );

--- a/packages/edit-site/src/components/style-book/test/categories.js
+++ b/packages/edit-site/src/components/style-book/test/categories.js
@@ -93,7 +93,6 @@ describe( 'utils', () => {
 				{
 					name: 'funky',
 					title: 'Funky',
-					icon: 'funky',
 				},
 			] );
 		} );

--- a/packages/edit-site/src/components/style-book/test/categories.js
+++ b/packages/edit-site/src/components/style-book/test/categories.js
@@ -1,8 +1,35 @@
 /**
  * Internal dependencies
  */
-import { getExamplesByCategory } from '../categories';
+import {
+	getExamplesByCategory,
+	getTopLevelStyleBookCategories,
+} from '../categories';
 import { STYLE_BOOK_CATEGORIES } from '../constants';
+
+jest.mock( '@wordpress/blocks', () => {
+	return {
+		getCategories() {
+			return [
+				{
+					slug: 'text',
+					title: 'Text Registered',
+					icon: 'text',
+				},
+				{
+					slug: 'design',
+					title: 'Design Registered',
+					icon: 'design',
+				},
+				{
+					slug: 'funky',
+					title: 'Funky',
+					icon: 'funky',
+				},
+			];
+		},
+	};
+} );
 
 // Fixtures
 const exampleThemeBlocks = [
@@ -59,6 +86,19 @@ const exampleThemeBlocks = [
 ];
 
 describe( 'utils', () => {
+	describe( 'getTopLevelStyleBookCategories', () => {
+		it( 'returns theme subcategories examples', () => {
+			expect( getTopLevelStyleBookCategories() ).toEqual( [
+				...STYLE_BOOK_CATEGORIES,
+				{
+					name: 'funky',
+					title: 'Funky',
+					icon: 'funky',
+				},
+			] );
+		} );
+	} );
+
 	describe( 'getExamplesByCategory', () => {
 		it( 'returns theme subcategories examples', () => {
 			const themeCategory = STYLE_BOOK_CATEGORIES.find(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of:

- https://github.com/WordPress/gutenberg/issues/64707

## What?

Adds capability to display any other registered block categories (e.g., from a theme).

### TODO

- [ ] Come up with a way to display `n` categories, e.g., a scrollable tab header, or drop down for the overflowing items

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Register some categories:


```php
add_filter(  
    'block_categories_all',  
    function ( $categories ) {  
  
       // Adding new categories.  
       $categories[] = array(  
          'slug'  => 'funky',  
          'title' => 'Funky',  
       );  
  
       $categories[] = array(  
          'slug'  => 'panky',  
          'title' => 'Panky',  
       );  
  
       $categories[] = array(  
          'slug'  => 'weird-and-wonderful',  
          'title' => 'Weird and wonderful',  
       );  
  
       return $categories;  
    }  
);
```

Fire up the site editor. 

Register new blocks by running the following in the console:


```js
[ 'funky', 'panky', 'weird-and-wonderful' ].forEach( ( category ) => {

	wp.blocks.registerBlockType( `custom/${ category }`, {
		title: `${ category } block`,
		category,
		description: `${ category } description`,
		keywords: [ category ],
		edit: () => `This block is in the ${ category } category!!!`,
		save: () => `This block is in the ${ category } category!!!`,
	    example: {}
	} )

} );
```

Visit the style book.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="791" alt="Screenshot 2024-09-20 at 3 41 23 pm" src="https://github.com/user-attachments/assets/ecd4de63-5575-466b-93ef-b94c09aaa47f">


