### PR TITLE
Avatar: Add block example

### DIFF
--- a/packages/block-library/src/avatar/index.js
+++ b/packages/block-library/src/avatar/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a simple example for the Avatar block. 

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently this is dependent on blocks having an example defined.

## How?

Adds the simplest example possible for the block.

## Alternatives

The Avatar block renders a placeholder when it doesn't have a user with avatar assigned. It might be a better experience to retrieve the current user and use that in the block example.

To be able to achieve this a custom static example might be required in the Style Book. Additionally, it might also still be desirable to see the placeholder state. Perhaps a future iteration could be to define a custom example that actually renders two Avatar blocks, one with a gravatar and one in the placeholder.

## Testing Instructions

1. In the editor, open the main block inserter from the top left
2. Search for the Avatar block and hover over it
3. Confirm the preview for the block displays the Avatar block in a placeholder state


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="664" alt="Screenshot 2024-09-20 at 3 57 19 pm" src="https://github.com/user-attachments/assets/c56ffe66-393e-447f-b9c7-de0ac6ca1511"> | <img width="663" alt="Screenshot 2024-09-20 at 3 57 07 pm" src="https://github.com/user-attachments/assets/5ab01028-8231-4f8e-8399-90f91029af94"> |
