### PR TITLE
Fix: Makes edit mode selector persistent in top toolbar mode.

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -38,10 +38,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		listViewShortcut,
 		inserterSidebarToggleRef,
 		listViewToggleRef,
-		hasFixedToolbar,
 		showIconLabels,
 	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
 		const { get } = select( preferencesStore );
 		const {
 			isListViewOpened,
@@ -60,7 +58,6 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			),
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			listViewToggleRef: getListViewToggleRef(),
-			hasFixedToolbar: getSettings().hasFixedToolbar,
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isVisualMode: getEditorMode() === 'visual',
@@ -137,7 +134,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 				) }
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
-						{ isLargeViewport && ! hasFixedToolbar && (
+						{ isLargeViewport && (
 							<ToolbarItem
 								as={ ToolSelector }
 								showTooltip={ ! showIconLabels }


### PR DESCRIPTION
## What?
Fixes: #65508 

## Why?
Edit mode selector was not persistent when we switch to Top toolbar mode in site editor.

## How?
This PR makes that button persistent even after toggling to Top toolbar mode.

## Testing Instructions
1. Open the site editor
2. Click the pointer icon at the top left and toggle to the edit mode
3. In the settings at the top right of the editor, switch to the top toolbar mode
4. Notice that you can switch editing modes at the top left

## Screenshots or screencast 

https://github.com/user-attachments/assets/88abdb0d-55ae-4cc7-8c1d-0964aa77a2da


