### PR TITLE
Time To Read: Add block example

### DIFF
--- a/packages/block-library/src/post-time-to-read/index.js
+++ b/packages/block-library/src/post-time-to-read/index.js
@@ -12,6 +12,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a simple example for the Time To Read block. 

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds the simplest example possible for the block.

## Testing Instructions

1. In the editor, open the main block inserter from the top left
2. Search for the Time to Read block and hover over it
3. Confirm the preview for the block displays the example


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="670" alt="Screenshot 2024-09-20 at 4 01 15 pm" src="https://github.com/user-attachments/assets/4333d547-6b7a-4052-97e7-f8cb77188e22"> | <img width="667" alt="Screenshot 2024-09-20 at 4 02 06 pm" src="https://github.com/user-attachments/assets/43216673-18c6-4906-82ab-13fd08964608"> | 