### PR TITLE
Added keywords to query loop block

### DIFF
--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -5,7 +5,7 @@
 	"title": "Query Loop",
 	"category": "theme",
 	"description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
-	"keywords": [ "posts", "list", "blog", "blogs", "post types" ],
+	"keywords": [ "posts", "list", "blog", "blogs", "custom post types" ],
 	"textdomain": "default",
 	"attributes": {
 		"queryId": {

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -5,6 +5,7 @@
 	"title": "Query Loop",
 	"category": "theme",
 	"description": "An advanced block that allows displaying post types based on different query parameters and visual configurations.",
+	"keywords": [ "posts", "list", "blog", "blogs", "post types" ],
 	"textdomain": "default",
 	"attributes": {
 		"queryId": {


### PR DESCRIPTION
## What?
Resolves issue : - [65493](https://github.com/WordPress/gutenberg/issues/65493)

## Why?
To help make query loop block more discoverable.

## How?
By adding following keywords key to packages/block-library/src/query/block.json which includes some common terms or aliases, such as:

- posts
- list
- blog
- blogs
- post types