### PR TITLE
Provide default algorithm for section root in block editor

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -17,6 +17,8 @@ import {
 	getClientIdsWithDescendants,
 	isNavigationMode,
 	getBlockRootClientId,
+	getBlocksByName,
+	getBlockAttributes,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -563,10 +565,24 @@ export const getBlockStyles = createSelector(
  *
  * @param {Object} state Editor state.
  *
- * @return {string|undefined} The section root client ID or undefined if not set.
+ * @return {string} The section root client ID.
  */
 export function getSectionRootClientId( state ) {
-	return state.settings?.[ sectionRootClientIdKey ];
+	const settingsRootClientId = state.settings?.[ sectionRootClientIdKey ];
+
+	// Specifically check that the setting was not provided to avoid
+	// cases where the provided setting is an empty string to signify
+	// the "root block" of the editor.
+	if ( settingsRootClientId !== undefined ) {
+		return settingsRootClientId;
+	}
+
+	return (
+		getBlocksByName( state, 'core/group' ).find(
+			( clientId ) =>
+				getBlockAttributes( state, clientId )?.tagName === 'main'
+		) ?? ''
+	);
 }
 
 /**

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -133,8 +133,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			} = select( coreStore );
 			const { get } = select( preferencesStore );
 			const { getBlockTypes } = select( blocksStore );
-			const { getBlocksByName, getBlockAttributes } =
-				select( blockEditorStore );
+			const { getBlocksByName } = select( blockEditorStore );
 			const siteSettings = canUser( 'read', {
 				kind: 'root',
 				name: 'site',
@@ -144,15 +143,11 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 
 			function getSectionRootBlock() {
 				if ( renderingMode === 'template-locked' ) {
-					return getBlocksByName( 'core/post-content' )?.[ 0 ] ?? '';
+					return getBlocksByName( 'core/post-content' )?.[ 0 ];
 				}
 
-				return (
-					getBlocksByName( 'core/group' ).find(
-						( clientId ) =>
-							getBlockAttributes( clientId )?.tagName === 'main'
-					) ?? ''
-				);
+				// Allow default algorithm to determine the section root block.
+				return undefined;
 			}
 
 			return {

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -143,7 +143,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 
 			function getSectionRootBlock() {
 				if ( renderingMode === 'template-locked' ) {
-					return getBlocksByName( 'core/post-content' )?.[ 0 ];
+					return getBlocksByName( 'core/post-content' )?.[ 0 ] ?? ''
 				}
 
 				// Allow default algorithm to determine the section root block.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65400. 

Adds a WordPress-agnostic default algorithm for determining "section root" in the block editor.

Continues to allow override via setting.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently if the setting that provides the `sectionRootClientId` is not provided then the editor experience in "Zoom Out" is quite degraded. You just end up with the root block selectable and nothing else.

By providing a default algorithm that is WordPress agnostic, we allow this block editor based feature to function "standalone" whilst still allow for WordPress to provide its own algorithm as required.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Moves the bit of the algorithm that targets `main` into the block editor package.
- Returns the setting value unless it's not defined (i.e. `undefined`).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### On trunk

` `npm run dev` in your dev environment
- Set the following line to be `undefined`
https://github.com/WordPress/gutenberg/blob/5e37a1316d0a39bc880bf6efff9b9f26db381690/packages/editor/src/components/provider/use-block-editor-settings.js#L192
- Site Editor
- Enable Zoom Out - confirm the feature is broken and you can only select the root block of the editor.

### On this PR

- Do the same steps as above but this time you will see the feature behaves correctly in the Site Editor.
- Also try removing the change to the `sectionRootClientId` setting and confirm everything still works as per `trunk`.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
