### PR TITLE
Block Bindings: Remove key fallback in bindings get values and rely on source label

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -162,9 +162,8 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					let values = {};
 					if ( ! source.getValues ) {
 						Object.keys( bindings ).forEach( ( attr ) => {
-							// Default to the `key` or the source label when `getValues` doesn't exist
-							values[ attr ] =
-								bindings[ attr ].args?.key || source.label;
+							// Default to the the source label when `getValues` doesn't exist.
+							values[ attr ] = source.label;
 						} );
 					} else {
 						values = source.getValues( {

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -66,7 +66,7 @@ test.describe( 'Block bindings', () => {
 				);
 			} );
 
-			test( 'should show the key of the custom field in server sources with key', async ( {
+			test( 'should always show the source label in server-only sources', async ( {
 				editor,
 			} ) => {
 				await editor.insertBlock( {
@@ -78,30 +78,6 @@ test.describe( 'Block bindings', () => {
 								content: {
 									source: 'core/server-source',
 									args: { key: 'text_custom_field' },
-								},
-							},
-						},
-					},
-				} );
-				const paragraphBlock = editor.canvas.getByRole( 'document', {
-					name: 'Block: Paragraph',
-				} );
-				await expect( paragraphBlock ).toHaveText(
-					'text_custom_field'
-				);
-			} );
-
-			test( 'should show the source label in server sources without key', async ( {
-				editor,
-			} ) => {
-				await editor.insertBlock( {
-					name: 'core/paragraph',
-					attributes: {
-						content: 'paragraph default content',
-						metadata: {
-							bindings: {
-								content: {
-									source: 'core/server-source',
 								},
 							},
 						},


### PR DESCRIPTION
## What?
It removes the fallback to the `args.key` when `getValues` doesn't exist. This is the case of sources registered only in the server, for example.

## Why?
As explained [here](https://github.com/WordPress/gutenberg/pull/65099#discussion_r1763128374), In that pull request, we stopped treating the `args.key` as a special argument and rely only on the label, which is always provided by the source. It seems it wasn't removed from this part of the code.

## How?
I just removed the fallback to the key and relied on the server source. Additionally, I changed the e2e tests to reflect that.

## Testing Instructions
1. Register a source only in the server:
```php
	register_block_bindings_source(
		'core/server-source',
		array(
			'label'              => 'Server Source',
			'get_value_callback' => function () {},
		)
	);
```
2. Add a paragraph connected to this source with `args.key`:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/server-source","args":{"key":"global"}}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->

```
3. Check that it shows the source label "Server Source".