### PR TITLE
Global styles: do not navigate twice to home screen when opening the sidebar

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -280,10 +280,9 @@ function GlobalStylesEditorCanvasContainerLink() {
 				 * Exclude revisions panel from this behavior,
 				 * as it should close when the editorCanvasContainerView doesn't correspond.
 				 */
-				if ( path !== '/' && ! isRevisionsOpen ) {
-					return;
+				if ( path !== '/' && isRevisionsOpen ) {
+					goTo( '/' );
 				}
-				goTo( '/' );
 				break;
 		}
 	}, [ editorCanvasContainerView, isRevisionsOpen, goTo ] );

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -272,18 +272,6 @@ function GlobalStylesEditorCanvasContainerLink() {
 					goTo( '/' );
 				}
 				break;
-			default:
-				/*
-				 * Example: the user has navigated to "Browse styles" or elsewhere
-				 * and changes the editorCanvasContainerView, e.g., closes the style book.
-				 * The panel should not be affected.
-				 * Exclude revisions panel from this behavior,
-				 * as it should close when the editorCanvasContainerView doesn't correspond.
-				 */
-				if ( path !== '/' && isRevisionsOpen ) {
-					goTo( '/' );
-				}
-				break;
 		}
 	}, [ editorCanvasContainerView, isRevisionsOpen, goTo ] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #64777

Prevent `Navigator` from navigating twice to the home screen when opening the Global Styles sidebar.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The double navigation cause the first screen displayed in the Global Styles sidebar to animate, which is not the expected behavior (the enter animation should be skipped on the first screen)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By inverting the logic of a check inside a `useEffect` in the global styles sidebar code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- (important) Reload the site editor
- Open the global styles sidebar
- Make sure that the initial navigator screen doesn't slide from the right when opening the sidebar

## Screenshots or screencast <!-- if applicable -->

| Before (`trunk`) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/d53d07c7-4cf2-4454-bfa8-cb0c501e85ed" /> | <video src="https://github.com/user-attachments/assets/8a227c69-84c0-425a-8953-b9a9842e2404" /> |