### PR TITLE
Improve the Query Loop block display settings labels.

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -321,7 +321,7 @@ export default function QueryInspectorControls( props ) {
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						label={ __( 'Items' ) }
+						label={ __( 'Items per page' ) }
 						hasValue={ () => perPage > 0 }
 					>
 						<PerPageControl
@@ -341,7 +341,7 @@ export default function QueryInspectorControls( props ) {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
-						label={ __( 'Max Pages to Show' ) }
+						label={ __( 'Max pages to show' ) }
 						hasValue={ () => pages > 0 }
 						onDeselect={ () => setQuery( { pages: 0 } ) }
 					>

--- a/packages/block-library/src/query/edit/inspector-controls/pages-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/pages-control.js
@@ -8,7 +8,7 @@ export const PagesControl = ( { pages, onChange } ) => {
 	return (
 		<NumberControl
 			__next40pxDefaultSize
-			label={ __( 'Max pages' ) }
+			label={ __( 'Max pages to show' ) }
 			value={ pages }
 			min={ 0 }
 			onChange={ ( newPages ) => {

--- a/packages/block-library/src/query/edit/inspector-controls/per-page-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/per-page-control.js
@@ -12,7 +12,7 @@ const PerPageControl = ( { perPage, offset = 0, onChange } ) => {
 		<RangeControl
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
-			label={ __( 'Posts per page' ) }
+			label={ __( 'Items per page' ) }
 			min={ MIN_POSTS_PER_PAGE }
 			max={ MAX_POSTS_PER_PAGE }
 			onChange={ ( newPerPage ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/58207

## What?
<!-- In a few words, what is the PR actually doing? -->
The labels of the Query Loop display settings can be improved for better usability and consistency.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Labels should be consistent and meaningful.

Current:

![Screenshot 2024-09-20 at 10 41 02](https://github.com/user-attachments/assets/c8463df0-d814-4ce9-8be0-eb40994b8ff8)

- 'Posts per page' is hardcoded, but the post types shown by the Query Loop could be anything: posts, pages, custom post types. As such the term 'posts' should be avoided in favor of a more generic 'Items'.
- Notice the label in the popover to toggle the settings visibility is already 'Items'.
- Not sure why 'Pages' and 'Show' are title case in 'Max Pages to Show'. Pages isn't the post type, it's just the paginated pages. Show is a verb. They shouldn't be title case.
- The labels used in the settings panel and the ones in the ToolsPanel to toggle the settings visibility should be consistent. Naming the settings and their toggles in a different way contributes to confusion.
  - 'Posts per page' vs. 'Items'.
  - 'Max pages' vs. 'Max Pages to Show'. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Renames 'Posts per page' to 'Items per page'.
- Renames 'Items' to 'Items per page'.
- Renames 'Max pages' to 'Max pages to show'.
- Removes titlecase from 'Max pages to show' in the ToolsPanel.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a Query Loop block.
- In the Inspector > Display settings, open the ToolsPanel by clicking the ellipsis icon button 'Display options'.
- Enable all the display settings.
- Observe the new labels in the settings panel are consistent with the ones in the ToolsPanel.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![Screenshot 2024-09-20 at 10 41 02](https://github.com/user-attachments/assets/161c86fd-458d-4bc5-a91e-9bf7f70fcc26)

After:

![Screenshot 2024-09-20 at 12 04 10](https://github.com/user-attachments/assets/832058dd-5b48-45a9-9b09-18a0e752c847)
