### PR TITLE
Pages: fix featured image appearance in list layout

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -138,6 +138,10 @@ ul.dataviews-view-list {
 		background-color: $gray-100;
 		border-radius: $grid-unit-05;
 
+		.fields-controls__featured-image-container {
+			height: 100%;
+		}
+
 		img {
 			width: 100%;
 			height: 100%;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -138,10 +138,6 @@ ul.dataviews-view-list {
 		background-color: $gray-100;
 		border-radius: $grid-unit-05;
 
-		.fields-controls__featured-image-container {
-			height: 100%;
-		}
-
 		img {
 			width: 100%;
 			height: 100%;

--- a/packages/edit-site/src/components/post-fields/style.scss
+++ b/packages/edit-site/src/components/post-fields/style.scss
@@ -1,0 +1,3 @@
+.fields-controls__featured-image-container {
+	height: 100%;
+}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -29,6 +29,7 @@
 @import "./components/style-book/style.scss";
 @import "./components/editor-canvas-container/style.scss";
 @import "./components/post-edit/style.scss";
+@import "./components/post-fields/style.scss";
 @import "./components/post-list/style.scss";
 @import "./components/resizable-frame/style.scss";
 @import "./hooks/push-changes-to-global-styles/style.scss";


### PR DESCRIPTION
Featured images of certain dimensions are not appearing correctly in the Pages data view. This PR fixes it by ensuring the container fills the available space vertically.

| Trunk | This PR |
| --- | --- |
| <img width="406" alt="Screenshot 2024-09-20 at 13 04 03" src="https://github.com/user-attachments/assets/0d144882-3437-4ba7-afb7-3606dec6bf50"> | <img width="402" alt="Screenshot 2024-09-20 at 13 04 41" src="https://github.com/user-attachments/assets/54ccb137-31ec-4cdf-af5c-05e66565b4ff"> |



## Testing Instructions
1. Disable the Posts experiment if you have it active
2. Go to the Pages data view
3. Ensure all featured images are square
