### PR TITLE
Navigator: fix isInitial logic

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `ToolsPanel`: atomic one-step state update when (un)registering panels ([#65564](https://github.com/WordPress/gutenberg/pull/65564)).
+-   `Navigator`: fix `isInitial` logic ([#65527](https://github.com/WordPress/gutenberg/pull/65527)).
 
 ## 28.8.0 (2024-09-19)
 

--- a/packages/components/src/navigator/navigator-provider/component.tsx
+++ b/packages/components/src/navigator/navigator-provider/component.tsx
@@ -66,7 +66,7 @@ function goTo(
 	options: NavigateOptions = {}
 ) {
 	const { focusSelectors } = state;
-	const currentLocation = { ...state.currentLocation, isInitial: false };
+	const currentLocation = { ...state.currentLocation };
 
 	const {
 		// Default assignments
@@ -114,6 +114,7 @@ function goTo(
 	return {
 		currentLocation: {
 			...restOptions,
+			isInitial: false,
 			path,
 			isBack,
 			hasRestoredFocus: false,
@@ -129,7 +130,7 @@ function goToParent(
 	options: NavigateToParentOptions = {}
 ) {
 	const { screens, focusSelectors } = state;
-	const currentLocation = { ...state.currentLocation, isInitial: false };
+	const currentLocation = { ...state.currentLocation };
 	const currentPath = currentLocation.path;
 	if ( currentPath === undefined ) {
 		return { currentLocation, focusSelectors };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Discovered while working on #65523

Set the `isInitial` flag to `false` in the internal `Navigator` reducer only when effectively navigating to a new screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Previously, the `isInitial` flag was set to `false` on every navigation, even the ones that were not leading to effectively navigating to a new screen. This was causing unwanted side effects, like the one flagged in #65523

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `isInitial` flag is set to `false` only when navigating to a new location.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In Storybook:
- Apply the following diff

```diff
diff --git a/packages/components/src/navigator/stories/index.story.tsx b/packages/components/src/navigator/stories/index.story.tsx
index 30b9c71a36..8d4881a563 100644
--- a/packages/components/src/navigator/stories/index.story.tsx
+++ b/packages/components/src/navigator/stories/index.story.tsx
@@ -64,6 +64,10 @@ export const Default: StoryObj< typeof NavigatorProvider > = {
 					<h2>This is the home screen.</h2>
 
 					<VStack alignment="left">
+						<NavigatorButton variant="primary" path="/">
+							Go to home screen.
+						</NavigatorButton>
+
 						<NavigatorButton variant="primary" path="/child">
 							Go to child screen.
 						</NavigatorButton>

```
- Load the default Storybook example for `Navigator`
- Click on the "Go to home screen" button
- Make sure the screen doesn't animate


In the editor:
- Open site editor
- Open the global styles sidebar
- Make sure the initial screen doesn't animate



## Screenshots or screencast <!-- if applicable -->

| Before (`trunk`) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/d53d07c7-4cf2-4454-bfa8-cb0c501e85ed" /> | <video src="https://github.com/user-attachments/assets/8a227c69-84c0-425a-8953-b9a9842e2404" /> |