### PR TITLE
Fix: Logic for Highlight/text-color format availability

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -75,7 +75,7 @@ function TextColorEdit( {
 		[ contentRef, value, colors ]
 	);
 
-	const hasColorsToChoose = colors.length || ! allowCustomControl;
+	const hasColorsToChoose = !! colors.length || allowCustomControl;
 	if ( ! hasColorsToChoose && ! isActive ) {
 		return null;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Corrects the logic for showing the text-color format, either if a palette is present or if custom colors are allowed, as expected.

## Why?
Previous logic mistakenly resulted in an unusable text color UI when palette was empty and custom was false, but offered no text color UI at all if palette was empty and custom was set to true.

## How?
Flipped test on allowCustomControl.

## Testing Instructions
1. Open theme.json
2. Under color settings, palette to [], custom to false
3. Open a post or page, insert a text block
4. Open the format dropdown, Highlight should be absent

For the inverse:
1. Set color.custom to true
2. Open editor, select/insert text block
3. Open format dropdown, Highlight should be present, selecting will allow custom color selection
