### PR TITLE
Update to use a11y script module package in Core.

### DIFF
--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -221,11 +221,6 @@ interface Store {
 		navigation: {
 			hasStarted: boolean;
 			hasFinished: boolean;
-			message: string;
-			texts?: {
-				loading?: string;
-				loaded?: string;
-			};
 		};
 	};
 	actions: {
@@ -240,7 +235,6 @@ export const { state, actions } = store< Store >( 'core/router', {
 		navigation: {
 			hasStarted: false,
 			hasFinished: false,
-			message: '',
 		},
 	},
 	actions: {
@@ -403,10 +397,16 @@ function a11ySpeak( messageKey: keyof typeof navigationTexts ) {
 			} catch {}
 		} else {
 			// Fallback to localized strings from Interactivity API state.
+			// @todo This block is for Core < 6.7.0. Remove when support is dropped.
+
+			// @ts-expect-error
 			if ( state.navigation.texts?.loading ) {
+				// @ts-expect-error
 				navigationTexts.loading = state.navigation.texts.loading;
 			}
+			// @ts-expect-error
 			if ( state.navigation.texts?.loaded ) {
+				// @ts-expect-error
 				navigationTexts.loaded = state.navigation.texts.loaded;
 			}
 		}
@@ -414,19 +414,11 @@ function a11ySpeak( messageKey: keyof typeof navigationTexts ) {
 
 	const message = navigationTexts[ messageKey ];
 
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		import( '@wordpress/a11y' ).then(
-			( { speak } ) => speak( message ),
-			// Ignore failures to load the a11y module.
-			() => {}
-		);
-	} else {
-		state.navigation.message =
-			// Announce that the page has been loaded. If the message is the
-			// same, we use a no-break space similar to the @wordpress/a11y
-			// package: https://github.com/WordPress/gutenberg/blob/c395242b8e6ee20f8b06c199e4fc2920d7018af1/packages/a11y/src/filter-message.js#L20-L26
-			message + ( state.navigation.message === message ? '\u00A0' : '' );
-	}
+	import( '@wordpress/a11y' ).then(
+		( { speak } ) => speak( message ),
+		// Ignore failures to load the a11y module.
+		() => {}
+	);
 }
 
 // Add click and prefetch to all links.


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/pull/7304.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Update the interactivity-router package to always use the `@wordpress/a11y` module for its aria-live regions.

This was behind a Gutenberg-only flag, but since landing in Core in 6.7 (with compatibility in Gutenberg for previous versions) the flag can be removed to always use the a11y module.

## Why?

It's preferable to use the shared package that implements this functionality instead of a one-off implementation. Now that a11y is available as a script module, it should be used.

## How?

Remove the `IS_GUTENBERG_PLUGIN` conditionals.

## Testing Instructions


This PR is difficult to test on its own because it requires the package to be updated as a Core dependency for proper testing. It does not affect Gutenberg behavior, only the package's behavior in Core. There are other ways of doing it but this works:

- Get a checkout of Core from https://github.com/WordPress/wordpress-develop/pull/7304. This is the build that will be running.
- Run `npm ci` in the Core checkout to install packages.
- Build the package from this PR (`npm run build:packages` in Gutenberg).
- Replace the `@wordpress/interactivity-router` package in Core's `node_modules` (`node_modules/@wordpress/interactivity-router`) with the package directory in Gutenberg (remove the directory and copy the directory from Gutenberg `packages/interactivity-router`).
- In Core, run the npm build script you use, in my case `npm run dev`.

Then test out that the interactivity router a11y functionality is working. A good way to test is the query block with "force page reload" option disabled. Specifically, the aria-live regions of the page should be updated (with localized text if in non-English locale) announcing "Page loaded."