### PR TITLE
Categories block: Escape label

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -49,7 +49,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 
 		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 		$default_label  = $taxonomy->label;
-		$label_text     = ! empty( $attributes['label'] ) ? $attributes['label'] : $default_label;
+		$label_text     = ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
 		$wrapper_markup = '<div %1$s><label class="wp-block-categories__label' . $show_label . '" for="' . esc_attr( $id ) . '">' . $label_text . '</label>%2$s</div>';
 		$items_markup   = wp_dropdown_categories( $args );
 		$type           = 'dropdown';

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -49,7 +49,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 
 		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 		$default_label  = $taxonomy->label;
-		$label_text     = ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
+		$label_text     = ! empty( $attributes['label'] ) ? wp_kses_post( $attributes['label'] ) : $default_label;
 		$wrapper_markup = '<div %1$s><label class="wp-block-categories__label' . $show_label . '" for="' . esc_attr( $id ) . '">' . $label_text . '</label>%2$s</div>';
 		$items_markup   = wp_dropdown_categories( $args );
 		$type           = 'dropdown';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR escapes the `label` block attribute in the categories block with `wp_kses_post() `before printing it inside the `<label>` HTML element.
The PR addresses feedback left during [code review of the package sync for WordPress 6.7.](https://github.com/WordPress/wordpress-develop/pull/7226#discussion_r1766068455)

## Why?
For security reasons it is best practise to escape user-provided content late, before output.
`wp_kses_post()` is used to allow the HTML tags allowed in the RichText field, and to be consistent with the escaping of other similar labels in other blocks.

## How?
This PR escapes the `label` block attribute with `wp_kses_post() `before printing it inside the `<label>` HTML element.

## Testing Instructions
Add a categories block.
In the block settings sidebar, enable the options "Display as dropdown" and "Show label".
Enter a custom label text. Type some random HTML tags, then select parts of the text and enable a style setting such as bold, or use the dropdown option to add an inline image, etc.

In the editor, the label is entered inside a RichText field and escaped with the help of the esc-html package.
View the content of the label in the editor and front and confirm that there are no issues that may be caused by double escaping. The style and inline image should continue to work on the front of the site.