### PR TITLE
Query loop format controls: Fix JavaScript error

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/format-controls.js
+++ b/packages/block-library/src/query/edit/inspector-controls/format-controls.js
@@ -68,7 +68,7 @@ export default function FormatControls( { onChange, query: { format } } ) {
 		.filter( Boolean );
 
 	const suggestions = formats
-		.filter( ( item ) => ! format.includes( item.value ) )
+		.filter( ( item ) => ! normalizedFormats.includes( item.value ) )
 		.map( ( item ) => item.label );
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/65550.

This PR fixes a JavaScript error that happens in the `FormatControls` in the query loop block when the
`format` parameter in the `query` block attribute is not an `array`.

This error can occur for example when an **existing** query loop pattern is placed in a post or page, for example
when a block pattern with a query loop is added. Presumably because the 'format' is missing in these existing patterns.

## Why? & How
`FormatControls` already creates a constant called `normalizedFormats` with the purpose of ensuring that `format` is an `array`. - But it was not used in all instances where it was needed:
This PR updates `FormatControls` to use `normalizedFormats` for creating the list of suggested formats in the `FormTokenField`.


## Testing Instructions
First please enable post format support in the active theme, for example in functions.php.
Example:

```
function twentytwentyfour_setup(){
	add_theme_support( 'post-formats', array( 'standard', 'aside', 'gallery', 'audio', 'video', 'link', 'image', 'chat', 'status', 'quote' ) );
}

add_action( 'after_setup_theme', 'twentytwentyfour_setup' );
```

Add some test posts, both with and without post formats assigned.


-**If you are using Twenty Twenty-Four,**  test a page pattern:
Create a new page: You will be prompted with a modal when you create a new page.
In this modal, select the pattern "Portfolio Home with post featured images".

In this portfolio design there are multiple query loop blocks. 
Open the ListView to locate the query loops easier.

Select a query loop and then open the Filters panel in the block settings sidebar.
In the Filters panel, click on "Formats".
Confirm that there are no block validation errors or other issues:
A new input field should show in the Filters panel.
Select the input field, and type or select a post format name.
Confirm that the query loop displays the selected format.


### Test an inserted pattern (any theme)

Create a new post or page.
Open the block inserter in top left corner, and select the Patterns tab.
Select the "Posts" pattern category, and insert any pattern from this list.

Select a query loop and then open the Filters panel in the block settings sidebar.
In the Filters panel, click on "Formats".
Confirm that there are no block validation errors or other issues:
A new input field should show in the Filters panel.
Select the input field, and type or select a post format name.
Confirm that the query loop displays the selected format.




