### PR TITLE
Post Navigation Link: Add block examples

### DIFF
--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -34,6 +34,12 @@
 			"default": ""
 		}
 	},
+	"example": {
+		"attributes": {
+			"label": "Next post",
+			"arrow": "arrow"
+		}
+	},
 	"usesContext": [ "postType" ],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/post-navigation-link/variations.js
+++ b/packages/block-library/src/post-navigation-link/variations.js
@@ -15,6 +15,12 @@ const variations = [
 		icon: next,
 		attributes: { type: 'next' },
 		scope: [ 'inserter', 'transform' ],
+		example: {
+			attributes: {
+				label: 'Next post',
+				arrow: 'arrow',
+			},
+		},
 	},
 	{
 		name: 'post-previous',
@@ -25,6 +31,12 @@ const variations = [
 		icon: previous,
 		attributes: { type: 'previous' },
 		scope: [ 'inserter', 'transform' ],
+		example: {
+			attributes: {
+				label: 'Previous post',
+				arrow: 'arrow',
+			},
+		},
 	},
 ];
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds block example definitions for the Next/Previous variations of the Post Navigation Link block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds examples to each block variation for the Post Navigation Link block.

## Testing Instructions

1. In the editor, open the main block inserter from the top left
2. Search for the Next Post block and hover over it
3. Confirm the preview for the block displays correctly
4. Repeat the process for the Previous Post block


## Screenshots or screencast <!-- if applicable -->

| Next Post | Previous Post |
|---|---|
| <img width="679" alt="Screenshot 2024-09-23 at 12 31 35 pm" src="https://github.com/user-attachments/assets/a00540a7-fd50-42c8-ad9e-785b62d356a3"> | <img width="672" alt="Screenshot 2024-09-23 at 12 31 25 pm" src="https://github.com/user-attachments/assets/a3073e46-0d1d-4064-9550-c7c83b9a0a47"> |

