### PR TITLE
Term Description: Add block example

### DIFF
--- a/packages/block-library/src/term-description/index.js
+++ b/packages/block-library/src/term-description/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Term Description block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Term Description block.

## Testing Instructions

1. In the editor, open the main block inserter from the top left
2. Search for the Term Description block and hover over it
3. Confirm the preview for the block displays correctly
4. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
5. Confirm the Term Description block is displayed here


## Screenshots or screencast <!-- if applicable -->

| Style Book | Inserter Preview |
|---|---|
| <img width="496" alt="Screenshot 2024-09-23 at 2 13 35 pm" src="https://github.com/user-attachments/assets/7da09aee-cd51-4b67-9424-2e9138bb0627"> | <img width="682" alt="Screenshot 2024-09-23 at 2 12 57 pm" src="https://github.com/user-attachments/assets/f9cdef79-4ee0-46a1-ac04-4118c3b21a34"> |

