### PR TITLE
Query Title: Add block example

### DIFF
--- a/packages/block-library/src/query-title/block.json
+++ b/packages/block-library/src/query-title/block.json
@@ -29,6 +29,11 @@
 			"default": true
 		}
 	},
+	"example": {
+		"attributes": {
+			"type": "search"
+		}
+	},
 	"supports": {
 		"align": [ "wide", "full" ],
 		"html": false,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Query Title block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Query Title block.

## Testing Instructions

1. In the editor, open the main block inserter from the top left
2. Search for the Archive Title variation of the Query Title block and hover over it
3. Confirm the preview for the block displays correctly
4. Repeat that for the Search Results Title variation
5. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
6. Confirm the Query Title block is displayed here


## Screenshots or screencast <!-- if applicable -->

| Style Book | Archive Title (Inserter) | Search Results Title (Inserter) |
|---|---|---|
| <img width="783" alt="Screenshot 2024-09-23 at 2 34 05 pm" src="https://github.com/user-attachments/assets/9740ccb7-11ce-4a49-a27b-68c981f9ab1c"> | <img width="671" alt="Screenshot 2024-09-23 at 2 34 24 pm" src="https://github.com/user-attachments/assets/34398f6a-9a51-4813-be25-f0dcf84e3b20"> | <img width="675" alt="Screenshot 2024-09-23 at 2 35 56 pm" src="https://github.com/user-attachments/assets/d7e0b7cc-a6d5-45cd-ae36-b56eb029b35a"> |
