### PR TITLE
Query No Results: Add block example

### DIFF
--- a/packages/block-library/src/query-no-results/block.json
+++ b/packages/block-library/src/query-no-results/block.json
@@ -8,6 +8,16 @@
 	"parent": [ "core/query" ],
 	"textdomain": "default",
 	"usesContext": [ "queryId", "query" ],
+	"example": {
+		"innerBlocks": [
+			{
+				"name": "core/paragraph",
+				"attributes": {
+					"content": "No posts were found."
+				}
+			}
+		]
+	},
 	"supports": {
 		"align": true,
 		"reusable": false,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Query No Results block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Query No Results block.

## Testing Instructions

As the No Results block is only available via the quick inserter when a Query block is selected there's no inserter preview.

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
6. Confirm the Query No Results block is displayed here


## Screenshots or screencast <!-- if applicable -->

<img width="564" alt="Screenshot 2024-09-23 at 3 02 18 pm" src="https://github.com/user-attachments/assets/277a8e21-6822-43b7-93e4-95a64b059cc7">

