### PR TITLE
Query Pagination: Add block example

### DIFF
--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -20,6 +20,7 @@ export const settings = {
 	edit,
 	save,
 	deprecated,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Query Pagination block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Query Pagination block.

## Testing Instructions

As the Query Pagination block is only available via the quick inserter when a Query block is selected there's no inserter preview.

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
6. Confirm the Query Pagination block is displayed here


## Screenshots or screencast <!-- if applicable -->

<img width="587" alt="Screenshot 2024-09-23 at 3 30 09 pm" src="https://github.com/user-attachments/assets/12aa68e0-01e6-436e-b4fb-e5d3d7dc021d">

