### PR TITLE
Comments Title: Add block example

### DIFF
--- a/packages/block-library/src/comments-title/index.js
+++ b/packages/block-library/src/comments-title/index.js
@@ -18,6 +18,7 @@ export const settings = {
 	icon,
 	edit,
 	deprecated,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Comments Title block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Comments Title block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm the Comments Title block is displayed here
3. Insert a Comments block, select it then click the quick inserter.
4. In the insert popover, select Browse All to open the main inserter
5. Confirm the preview for the Comments Title block example displays when hovering that block


## Screenshots or screencast <!-- if applicable -->

<img width="638" alt="Screenshot 2024-09-23 at 4 32 33 pm" src="https://github.com/user-attachments/assets/da8d0bae-d868-4020-9e96-af80ef1e3018">

<img width="754" alt="Screenshot 2024-09-23 at 4 36 55 pm" src="https://github.com/user-attachments/assets/6e342abc-d41d-4eb3-855d-6f1702baa53f">

