### PR TITLE
Comment Author Name: Add block example

### DIFF
--- a/packages/block-library/src/comment-author-name/index.js
+++ b/packages/block-library/src/comment-author-name/index.js
@@ -18,6 +18,7 @@ export const settings = {
 	icon,
 	edit,
 	deprecated,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Comment Author Name block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Comment Author Name block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm the Comment Author Name block is displayed here
3. Insert a Comments block, select the Comments Template within it, then click the quick inserter.
4. In the insert popover, select Browse All to open the main inserter
5. Confirm the preview for the Comment Author Name block example displays when hovering that block


## Screenshots or screencast <!-- if applicable -->
<img width="751" alt="Screenshot 2024-09-23 at 4 51 38 pm" src="https://github.com/user-attachments/assets/e3cd3c30-0231-47f0-a284-7a94bbf5f9e5">
<img width="466" alt="Screenshot 2024-09-23 at 4 50 03 pm" src="https://github.com/user-attachments/assets/40a12740-0805-4089-9fbc-2c97eb456162">

