### PR TITLE
Comment Content: Add block example

### DIFF
--- a/packages/block-library/src/comment-content/index.js
+++ b/packages/block-library/src/comment-content/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds a block example definition for the Comment Content block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

Adds an example to the Comment Content block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm the Comment Content block is displayed here
3. Insert a Comments block, select the Comments Template then click the quick inserter.
4. In the insert popover, select Browse All to open the main inserter, then search for Comment Content
5. Confirm the preview for the Comment Content block example displays when hovering that block


## Screenshots or screencast <!-- if applicable -->

<img width="459" alt="Screenshot 2024-09-23 at 5 05 41 pm" src="https://github.com/user-attachments/assets/db93f1aa-6c31-4e19-8460-2d3dc1397aa6">
<img width="763" alt="Screenshot 2024-09-23 at 5 05 12 pm" src="https://github.com/user-attachments/assets/64245954-097d-4753-bd8b-e3e41ac7bd08">

