### PR TITLE
Editor: Remove edit template menu item from block settings menu in blocks outside template.

### DIFF
--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -18,7 +18,7 @@ import { __, _x } from '@wordpress/i18n';
 import { unlock } from '../../lock-unlock';
 
 function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
-	const { entity, onNavigateToEntityRecord, canEditTemplates } = useSelect(
+	const { entity, onNavigateToEntityRecord } = useSelect(
 		( select ) => {
 			const {
 				getBlockParentsByBlockName,
@@ -30,18 +30,14 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 				'core/block',
 				true
 			)[ 0 ];
-
-			const _canEditTemplates = select( coreStore ).canUser( 'create', {
-				kind: 'postType',
-				name: 'wp_template',
-			} );
 			return {
-				canEditTemplates: _canEditTemplates,
-				entity: select( coreStore ).getEntityRecord(
-					'postType',
-					'wp_block',
-					getBlockAttributes( patternParent ).ref
-				),
+				entity:
+					patternParent &&
+					select( coreStore ).getEntityRecord(
+						'postType',
+						'wp_block',
+						getBlockAttributes( patternParent ).ref
+					),
 				onNavigateToEntityRecord:
 					getSettings().onNavigateToEntityRecord,
 			};
@@ -68,20 +64,19 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 							postType: entity.type,
 						} );
 					} }
-					disabled={ ! canEditTemplates }
 				>
 					{ __( 'Edit pattern' ) }
 				</MenuItem>
-				<Text
-					variant="muted"
-					as="p"
-					className="editor-content-only-settings-menu__description"
-				>
-					{ __(
-						'Edit the pattern to move, delete, or make further changes to this block.'
-					) }
-				</Text>
 			</BlockSettingsMenuFirstItem>
+			<Text
+				variant="muted"
+				as="p"
+				className="editor-content-only-settings-menu__description"
+			>
+				{ __(
+					'Edit the pattern to move, delete, or make further changes to this block.'
+				) }
+			</Text>
 		</>
 	);
 }


### PR DESCRIPTION
Related #60021 
Follow-up to #65204 
Closes #65548

## What?

For template blocks, we shown an "edit template" menu in the block settings menu. To do that we check that the block is not within a "post" block. That said, we should limit this to "template-locked" rendering mode as otherwise the template is not even rendered. 

In trunk, that menu is being incorrectly shown for any block.

## Testing Instructions

1- Open the post editor
2- add a block and open the block settings menu
3- you shouldn't see the "edit template" menu item.

Also check these instructions https://github.com/WordPress/gutenberg/pull/65560#issuecomment-2367620873