### PR TITLE
Fixed zoom out mode in edit template

### DIFF
--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -28,7 +28,7 @@ import { store as editorStore } from '../../store';
  *                                                                  editor iframe canvas.
  */
 export default function EditTemplateBlocksNotification( { contentRef } ) {
-	const { onNavigateToEntityRecord, templateId, editorMode } = useSelect(
+	const { onNavigateToEntityRecord, templateId, isZoomOut } = useSelect(
 		( select ) => {
 			const { getEditorSettings, getCurrentTemplateId } =
 				select( editorStore );
@@ -38,7 +38,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 				onNavigateToEntityRecord:
 					getEditorSettings().onNavigateToEntityRecord,
 				templateId: getCurrentTemplateId(),
-				editorMode: 'zoom-out' === __unstableGetEditorMode(),
+				isZoomOut: 'zoom-out' === __unstableGetEditorMode(),
 			};
 		},
 		[]
@@ -63,8 +63,8 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 				return;
 			}
 
-			if ( editorMode ) {
-				__unstableSetEditorMode( editorMode ? 'edit' : 'zoom-out' );
+			if ( isZoomOut ) {
+				__unstableSetEditorMode( isZoomOut ? 'edit' : 'zoom-out' );
 				return;
 			}
 
@@ -82,7 +82,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 		return () => {
 			canvas?.removeEventListener( 'dblclick', handleDblClick );
 		};
-	}, [ contentRef, canEditTemplate, editorMode ] );
+	}, [ contentRef, canEditTemplate, isZoomOut ] );
 
 	if ( ! canEditTemplate ) {
 		return null;


### PR DESCRIPTION
## What?
Part of - https://github.com/WordPress/gutenberg/issues/65505

## Why?
Solve - https://github.com/WordPress/gutenberg/issues/65505

## Testing Instructions
1. Open the site editor
2. Go to Pages > any page to edit a page within the site editor
3. Click the Zoom out button in the top bar
4. Double click the post title block
5. Notice that you will edit the post title by double clicking on it.

## Screenshots or screencast <!-- if applicable -->
[Pages ‹ Template ‹ gutenberg ‹ Editor — WordPress.webm](https://github.com/user-attachments/assets/b5c492e9-b97f-4eca-a5e3-e7d203725657)
