### PR TITLE
Block Bindings: Only use `canUserEditValue` when `setValues` is defined

### DIFF
--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -404,7 +404,9 @@ export function blockBindingsSources( state = {}, action ) {
 					),
 					getValues: action.getValues,
 					setValues: action.setValues,
-					canUserEditValue: action.canUserEditValue,
+					// Only set `canUserEditValue` if `setValues` is also defined.
+					canUserEditValue:
+						action.setValues && action.canUserEditValue,
 					getFieldsList: action.getFieldsList,
 				},
 			};


### PR DESCRIPTION
## What?
When a block bindings source is registered, I believe we shouldn't allow editing when `setValues` is not defined.

## Why?
It is confusing that users can edit the blocks but nothing will happen.

## How?
Setting `canUserEditValue` to undefined when `setValues` is not defined.

In order to add e2e tests, we need to register custom sources in the client. This is being done as part of [this other pull request](https://github.com/WordPress/gutenberg/pull/65526), so I thought of including the test there.

## Testing Instructions
1. Go to a post or page, open the console, and simulate registering a custom source with the following code. It doesn't have ' setValues` and `canUserEditValue` returns `true`.
```js
const { unlock } =
	wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
		'@wordpress/blocks'
	);

const { registerBlockBindingsSource } = unlock( wp.blocks.privateApis );

registerBlockBindingsSource( {
	name: 'testing/custom-source',
	label: 'Custom Source',
	getValues: () => {
		return {
			'content': 'testing',
		}
	},
	canUserEditValue: () => true,
} );

```
2. Add a paragraph connected to this custom source:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"testing/custom-source"}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
3. Before this change, you could edit the value. After it, editing is locked.
