### PR TITLE
Don't show tooltip in zoom out toggle button when showIconLabels is true

### DIFF
--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { square as zoomOutIcon } from '@wordpress/icons';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -14,8 +15,12 @@ import { square as zoomOutIcon } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 
 const ZoomOutToggle = () => {
-	const { isZoomOut } = useSelect( ( select ) => ( {
+	const { isZoomOut, showIconLabels } = useSelect( ( select ) => ( {
 		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
+		showIconLabels: select( preferencesStore ).get(
+			'core',
+			'showIconLabels'
+		),
 	} ) );
 
 	const { resetZoomLevel, setZoomLevel, __unstableSetEditorMode } = unlock(
@@ -38,6 +43,7 @@ const ZoomOutToggle = () => {
 			label={ __( 'Toggle Zoom Out' ) }
 			isPressed={ isZoomOut }
 			size="compact"
+			showTooltip={ ! showIconLabels }
 		/>
 	);
 };


### PR DESCRIPTION
Fix the issue raised in [this comment](https://github.com/WordPress/gutenberg/issues/65491#issuecomment-2361119959)

## What?

Change the toggle button so that a tooltip is not displayed when `showIconLabels` is true.

## Why?

The button already has text displayed, so the tooltip text is redundant.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

- Enable "Show button text labels" via the Preferences modal
- Focus/Hover the "Toggle Zoom Out".
- The tooltip should not be displayed.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/bb97e5d9-239c-449d-9565-f33c205d93b0)

### After

![image](https://github.com/user-attachments/assets/90de1d6a-dc09-4ddb-a428-fd9477a55375)
