### PR TITLE
Code Quality: Remove needless handler callback wrappers

### DIFF
--- a/packages/block-editor/src/components/block-variation-picker/index.js
+++ b/packages/block-editor/src/components/block-variation-picker/index.js
@@ -67,7 +67,7 @@ function BlockVariationPicker( {
 						// TODO: Switch to `true` (40px size) if possible
 						__next40pxDefaultSize={ false }
 						variant="link"
-						onClick={ () => onSelect() }
+						onClick={ onSelect }
 					>
 						{ __( 'Skip' ) }
 					</Button>

--- a/packages/block-editor/src/components/default-block-appender/index.js
+++ b/packages/block-editor/src/components/default-block-appender/index.js
@@ -82,7 +82,7 @@ export default function DefaultBlockAppender( { rootClientId } ) {
 						onAppend();
 					}
 				} }
-				onClick={ () => onAppend() }
+				onClick={ onAppend }
 				onFocus={ () => {
 					if ( showPrompt ) {
 						onAppend();

--- a/packages/block-editor/src/components/global-styles/README.md
+++ b/packages/block-editor/src/components/global-styles/README.md
@@ -14,7 +14,7 @@ import { useGlobalStylesReset } from '@wordpress/block-editor';
 function MyComponent() {
 	const [ canReset, reset ] = useGlobalStylesReset();
 
-	return canReset ? <Button onClick={ () => reset() }>Reset</Button> : null;
+	return canReset ? <Button onClick={ reset }>Reset</Button> : null;
 }
 ```
 

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -249,7 +249,7 @@ export default function BorderPanel( {
 				<ToolsPanelItem
 					hasValue={ () => isDefinedBorder( value?.border ) }
 					label={ __( 'Border' ) }
-					onDeselect={ () => resetBorder() }
+					onDeselect={ resetBorder }
 					isShownByDefault={ showBorderByDefault }
 					panelId={ panelId }
 				>

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -67,9 +67,7 @@ const InserterDraggableBlocks = ( {
 					serialize( parsedBlocks )
 				);
 			} }
-			onDragEnd={ () => {
-				stopDragging();
-			} }
+			onDragEnd={ stopDragging }
 			__experimentalDragComponent={
 				<BlockDraggableChip
 					count={ blocks.length }

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -179,9 +179,7 @@ class Inserter extends Component {
 
 		return (
 			<InserterMenu
-				onSelect={ () => {
-					onClose();
-				} }
+				onSelect={ onClose }
 				rootClientId={ rootClientId }
 				clientId={ clientId }
 				isAppender={ isAppender }

--- a/packages/block-editor/src/components/inserter/tabs.js
+++ b/packages/block-editor/src/components/inserter/tabs.js
@@ -44,7 +44,7 @@ function InserterTabs( { onSelect, children, onClose, selectedTab }, ref ) {
 						className="block-editor-inserter__close-button"
 						icon={ closeSmall }
 						label={ __( 'Close block inserter' ) }
-						onClick={ () => onClose() }
+						onClick={ onClose }
 						size="small"
 					/>
 

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -439,9 +439,7 @@ export function MediaPlaceholder( {
 					// TODO: Switch to `true` (40px size) if possible
 					__next40pxDefaultSize={ false }
 					variant="secondary"
-					onClick={ () => {
-						open();
-					} }
+					onClick={ open }
 				>
 					{ __( 'Media Library' ) }
 				</Button>

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -184,9 +184,7 @@ const MediaReplaceFlow = ( {
 									return (
 										<MenuItem
 											icon={ upload }
-											onClick={ () => {
-												openFileDialog();
-											} }
+											onClick={ openFileDialog }
 										>
 											{ __( 'Upload' ) }
 										</MenuItem>

--- a/packages/block-editor/src/components/tabbed-sidebar/index.js
+++ b/packages/block-editor/src/components/tabbed-sidebar/index.js
@@ -32,7 +32,7 @@ function TabbedSidebar(
 						className="block-editor-tabbed-sidebar__close-button"
 						icon={ closeSmall }
 						label={ closeButtonLabel }
-						onClick={ () => onClose() }
+						onClick={ onClose }
 						size="small"
 					/>
 

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -55,14 +55,14 @@ export function IndentUI( { clientId } ) {
 				title={ __( 'Outdent' ) }
 				description={ __( 'Outdent list item' ) }
 				disabled={ ! canOutdent }
-				onClick={ () => outdentListItem() }
+				onClick={ outdentListItem }
 			/>
 			<ToolbarButton
 				icon={ isRTL() ? formatIndentRTL : formatIndent }
 				title={ __( 'Indent' ) }
 				description={ __( 'Indent list item' ) }
 				disabled={ ! canIndent }
-				onClick={ () => indentListItem() }
+				onClick={ indentListItem }
 			/>
 		</>
 	);

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -314,9 +314,7 @@ export default function PostFeaturedImageEdit( {
 							label={ label }
 							showTooltip
 							tooltipPosition="top center"
-							onClick={ () => {
-								open();
-							} }
+							onClick={ open }
 						/>
 					);
 				} }

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -679,9 +679,7 @@ export default function LogoEdit( {
 								label={ __( 'Choose logo' ) }
 								showTooltip
 								tooltipPosition="middle right"
-								onClick={ () => {
-									open();
-								} }
+								onClick={ open }
 							/>
 						);
 					} }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -303,9 +303,7 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 											return (
 												<MenuItem
 													icon={ upload }
-													onClick={ () => {
-														openFileDialog();
-													} }
+													onClick={ openFileDialog }
 												>
 													{ __( 'Upload' ) }
 												</MenuItem>

--- a/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
+++ b/packages/components/src/custom-gradient-picker/gradient-bar/control-points.tsx
@@ -344,9 +344,7 @@ function InsertPoint( {
 		<GradientColorPickerDropdown
 			isRenderedInSidebar={ __experimentalIsRenderedInSidebar }
 			className="components-custom-gradient-picker__inserter"
-			onClose={ () => {
-				onCloseInserter();
-			} }
+			onClose={ onCloseInserter }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					aria-expanded={ isOpen }

--- a/packages/components/src/tools-panel/tools-panel/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel/component.tsx
@@ -72,7 +72,7 @@ const UnconnectedToolsPanel = (
  *       <ToolsPanelItem
  *         hasValue={ () => !! height }
  *         label={ __( 'Height' ) }
- *         onDeselect={ () => setHeight() }
+ *         onDeselect={ setHeight }
  *       >
  *         <UnitControl
  *           label={ __( 'Height' ) }
@@ -83,7 +83,7 @@ const UnconnectedToolsPanel = (
  *       <ToolsPanelItem
  *         hasValue={ () => !! width }
  *         label={ __( 'Width' ) }
- *         onDeselect={ () => setWidth() }
+ *         onDeselect={ setWidth }
  *       >
  *         <UnitControl
  *           label={ __( 'Width' ) }

--- a/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
+++ b/packages/edit-site/src/components/add-new-template/add-custom-generic-template-modal-content.js
@@ -61,9 +61,7 @@ function AddCustomGenericTemplateModalContent( { onClose, createTemplate } ) {
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"
-						onClick={ () => {
-							onClose();
-						} }
+						onClick={ onClose }
 					>
 						{ __( 'Cancel' ) }
 					</Button>

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -310,9 +310,7 @@ function ShadowEditor( { shadow, onChange } ) {
 							size="small"
 							icon={ plus }
 							label={ __( 'Add shadow' ) }
-							onClick={ () => {
-								onAddShadowPart();
-							} }
+							onClick={ onAddShadowPart }
 						/>
 					</FlexItem>
 				</HStack>

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -109,9 +109,7 @@ function ShadowList( { label, shadows, category, canCreate, onCreate } ) {
 							size="small"
 							icon={ plus }
 							label={ __( 'Add shadow' ) }
-							onClick={ () => {
-								handleAddShadow();
-							} }
+							onClick={ handleAddShadow }
 						/>
 					</FlexItem>
 				) }

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -105,7 +105,7 @@ const SiteHub = memo(
 								__next40pxDefaultSize={ false }
 								className="edit-site-site-hub_toggle-command-center"
 								icon={ search }
-								onClick={ () => openCommandCenter() }
+								onClick={ openCommandCenter }
 								label={ __( 'Open command palette' ) }
 								shortcut={ displayShortcut.primary( 'k' ) }
 							/>
@@ -190,7 +190,7 @@ export const SiteHubMobile = memo(
 								__next40pxDefaultSize={ false }
 								className="edit-site-site-hub_toggle-command-center"
 								icon={ search }
-								onClick={ () => openCommandCenter() }
+								onClick={ openCommandCenter }
 								label={ __( 'Open command palette' ) }
 								shortcut={ displayShortcut.primary( 'k' ) }
 							/>

--- a/packages/editor/src/components/create-template-part-modal/index.js
+++ b/packages/editor/src/components/create-template-part-modal/index.js
@@ -186,9 +186,7 @@ export function CreateTemplatePartModalContents( {
 					<Button
 						__next40pxDefaultSize
 						variant="tertiary"
-						onClick={ () => {
-							closeModal();
-						} }
+						onClick={ closeModal }
 					>
 						{ __( 'Cancel' ) }
 					</Button>

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -152,7 +152,7 @@ export default function DocumentBar( props ) {
 			) : (
 				<Button
 					className="editor-document-bar__command"
-					onClick={ () => openCommandCenter() }
+					onClick={ openCommandCenter }
 					size="compact"
 				>
 					<motion.div

--- a/packages/editor/src/components/pattern-duplicate-modal/index.js
+++ b/packages/editor/src/components/pattern-duplicate-modal/index.js
@@ -43,7 +43,7 @@ export default function PatternDuplicateModal() {
 	return (
 		<DuplicatePatternModal
 			onClose={ closeModal }
-			onSuccess={ () => closeModal() }
+			onSuccess={ closeModal }
 			pattern={ record }
 		/>
 	);

--- a/packages/editor/src/components/start-template-options/index.js
+++ b/packages/editor/src/components/start-template-options/index.js
@@ -144,9 +144,7 @@ function StartModal( { slug, isCustom, onClose, postType } ) {
 					slug={ slug }
 					isCustom={ isCustom }
 					postType={ postType }
-					onChoosePattern={ () => {
-						onClose();
-					} }
+					onChoosePattern={ onClose }
 				/>
 			</div>
 			<Flex

--- a/packages/list-reusable-blocks/src/components/import-form/index.js
+++ b/packages/list-reusable-blocks/src/components/import-form/index.js
@@ -72,7 +72,7 @@ function ImportForm( { instanceId, onUpload } ) {
 			ref={ formRef }
 		>
 			{ error && (
-				<Notice status="error" onRemove={ () => onDismissError() }>
+				<Notice status="error" onRemove={ onDismissError }>
 					{ error }
 				</Notice>
 			) }


### PR DESCRIPTION
## What?
This PR removes needless extra event handler callback wrappers.

I spotted this while reviewing another PR.

## Why?
Because it's shorter and more optimal - one less unmemoized callback might even sometimes mean fewer rerenders.

## How?
We're simplifying handlers like this:

Before:

```js
onClick={ () => onClick() }
```

After:

```js
onClick={ onClick }
```

## Testing Instructions
This is a code style change and no testing should be necessary. Just do a code review.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
None.