### PR TITLE
Link autocompleter: decode post title HTML entities

### DIFF
--- a/packages/block-editor/src/autocompleters/link.js
+++ b/packages/block-editor/src/autocompleters/link.js
@@ -6,6 +6,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { Icon, page, post } from '@wordpress/icons';
+import { decodeEntities } from '@wordpress/html-entities';
 
 const SHOWN_SUGGESTIONS = 10;
 
@@ -46,7 +47,7 @@ function createLinkCompleter() {
 						key="icon"
 						icon={ item.subtype === 'page' ? page : post }
 					/>
-					{ item.title }
+					{ decodeEntities( item.title ) }
 				</>
 			);
 		},


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Resolves https://github.com/WordPress/gutenberg/issues/65578


For link autocompleters, make `title` property consistent with that in `fetchLinkSuggestions` where the `rendered` title (containing HTML entities) is also being decoded

## Why?

So that the post titles are rendered correctly.

## How?

Running post titles through `decodeEntities`, which is consistent with [navigation links](https://github.com/WordPress/gutenberg/blob/0ae504e73de9aa2063b3abbc76637db6efc61eda/packages/block-library/src/navigation-link/link-ui.js#L180-L180) and [fetchLinkSuggestions](https://github.com/WordPress/gutenberg/blob/0ae504e73de9aa2063b3abbc76637db6efc61eda/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts#L150-L150).

## Testing Instructions

1. Create post with an apostrophe or other character in the title, e.g., `Bob's "post" !@#$%^&*`
2. In another post, enter `[[` to trigger link autocomplete
3. Check that the characters are decoded.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Header | Header |
|--------|--------|
| <img width="557" alt="Screenshot 2024-09-24 at 10 31 49 am" src="https://github.com/user-attachments/assets/9a3696b0-d10d-4ebc-af65-1075f5955f87"> | <img width="339" alt="Screenshot 2024-09-24 at 10 31 25 am" src="https://github.com/user-attachments/assets/88bc7e39-e48a-4e08-889a-a8465788774d"> | 





