### PR TITLE
Revert "Font Library: Group fonts by source (#63211)"

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import {
 	__experimentalText as Text,
 	__experimentalItemGroup as ItemGroup,
@@ -61,14 +61,9 @@ function FontFamilies() {
 			) }
 
 			<VStack spacing={ 4 }>
-				{ themeFonts.length > 0 && (
-					<VStack>
-						<Subtitle level={ 3 }>
-							{
-								/* translators: Heading for a list of fonts provided by the theme. */
-								_x( 'Theme', 'font source' )
-							}
-						</Subtitle>
+				{ [ ...themeFonts, ...customFonts ].length > 0 && (
+					<>
+						<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 						<ItemGroup size="large" isBordered isSeparated>
 							{ themeFonts.map( ( font ) => (
 								<FontFamilyItem
@@ -77,25 +72,7 @@ function FontFamilies() {
 								/>
 							) ) }
 						</ItemGroup>
-					</VStack>
-				) }
-				{ customFonts.length > 0 && (
-					<VStack>
-						<Subtitle level={ 3 }>
-							{
-								/* translators: Heading for a list of fonts installed by the user. */
-								_x( 'Custom', 'font source' )
-							}
-						</Subtitle>
-						<ItemGroup size="large" isBordered isSeparated>
-							{ customFonts.map( ( font ) => (
-								<FontFamilyItem
-									key={ font.slug }
-									font={ font }
-								/>
-							) ) }
-						</ItemGroup>
-					</VStack>
+					</>
 				) }
 				{ ! hasFonts && (
 					<VStack>

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -27,7 +27,7 @@ function ScreenTypography() {
 			<ScreenHeader
 				title={ __( 'Typography' ) }
 				description={ __(
-					'Available fonts, typographic styles, and the application of those styles on site elements.'
+					'Available fonts, typographic styles, and the application of those styles.'
 				) }
 			/>
 			<div className="edit-site-global-styles-screen">

--- a/packages/edit-site/src/components/global-styles/screen-typography.js
+++ b/packages/edit-site/src/components/global-styles/screen-typography.js
@@ -27,7 +27,7 @@ function ScreenTypography() {
 			<ScreenHeader
 				title={ __( 'Typography' ) }
 				description={ __(
-					'Typography styles and the application of those styles on site elements.'
+					'Available fonts, typographic styles, and the application of those styles on site elements.'
 				) }
 			/>
 			<div className="edit-site-global-styles-screen">


### PR DESCRIPTION
This reverts commit e7bf3b62589fc433a16ebc664f7287c136eaec42.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## Todo
- [x] [Make sure e2e tests pass](https://github.com/WordPress/gutenberg/actions/runs/11004877632/job/30559719678?pr=65590#step:7:177). Figure out if the merge removed valid code (there were conflicts that needed to be solved before reverting the commit.
- [x] Update Global Styles Typography screen description to better explain what can be found in that panel.

## What?
Following up on this discussion on  https://github.com/WordPress/gutenberg/issues/63505, this PR reverts the changes introduced in #63211, which grouped fonts by their sources (theme and custom) in the Font Library.

## Why?
Users only need to interact with active fonts within the Typography panel, regardless of whether they come from the theme or are custom additions. 

## How?
The implementation involves:
- Removing the grouping of fonts by source in the Typography panel.
- Restoring the previous singular font group display where all active fonts are shown together.
- Adjusting the relevant components and styles to reflect the pre-grouping state.

## Testing Instructions
1. **Global Styles Testing**
    - Navigate to the Global Styles settings in the site editor.
    - Open the Typography panel.
    - Verify that all active fonts are displayed together without distinction between theme and custom fonts.
    - Ensure you can manage (add, remove, or disable) fonts.

2. **Font Management**
    - Open the Font Library modal.
    - Test the management of active fonts, ensuring that font operations (e.g., disabling a font from the library) are working as expected.

## Screenshots

| Before this PR | Now |
|-|-|
|<img width="280" alt="image" src="https://github.com/user-attachments/assets/6f95e1e8-854b-4412-a849-f278eaab0d9f">|<img width="280" alt="image" src="https://github.com/user-attachments/assets/e8abe619-ae19-4388-93b2-0020ce0746e8">|





cc. @richtabor 

