### PR TITLE
Combine the release steps to ensure that releases are tagged

### DIFF
--- a/.github/workflows/upload-release-to-plugin-repo.yml
+++ b/.github/workflows/upload-release-to-plugin-repo.yml
@@ -168,7 +168,9 @@ jobs:
 
         steps:
             - name: Check out Gutenberg trunk from WP.org plugin repo
-              run: svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+              run: |
+                  svn checkout "$PLUGIN_REPO_URL/trunk" --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                  svn checkout "$PLUGIN_REPO_URL/tags" --depth=immediates --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
 
             - name: Delete everything
               working-directory: ./trunk
@@ -182,7 +184,7 @@ jobs:
                   unzip gutenberg.zip -d trunk
                   rm gutenberg.zip
 
-            - name: Replace the stable tag placeholder with the existing stable tag on the SVN repository
+            - name: Replace the stable tag placeholder with the new version
               env:
                   STABLE_TAG_PLACEHOLDER: 'Stable tag: V\.V\.V'
               run: |
@@ -194,27 +196,16 @@ jobs:
                   name: changelog trunk
                   path: trunk
 
-            - name: Commit the content changes
+            - name: Commit the release
               working-directory: ./trunk
               run: |
                   svn st | grep '^?' | awk '{print $2}' | xargs -r svn add
                   svn st | grep '^!' | awk '{print $2}' | xargs -r svn rm
-                  svn commit -m "Committing version $VERSION" \
+                  svn cp . "../tags/$VERSION"
+                  svn commit . "../tags/$VERSION" \
+                   -m "Releasing version $VERSION" \
                    --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD" \
-                   --config-option=servers:global:http-timeout=300
-
-            - name: Create the SVN tag
-              working-directory: ./trunk
-              run: |
-                  svn copy "$PLUGIN_REPO_URL/trunk" "$PLUGIN_REPO_URL/tags/$VERSION" -m "Tagging version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
-
-            - name: Update the plugin's stable version
-              working-directory: ./trunk
-              run: |
-                  sed -i "s/Stable tag: ${STABLE_VERSION_REGEX}/Stable tag: ${VERSION}/g" ./readme.txt
-                  svn commit -m "Releasing version $VERSION" \
-                   --no-auth-cache --non-interactive  --username "$SVN_USERNAME" --password "$SVN_PASSWORD"
+                   --config-option=servers:global:http-timeout=600
 
     upload-tag:
         name: Publish as tag


### PR DESCRIPTION
See #55295

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


Currently the release process is timing out. This is due to the 5 minute timeout included in the trunk commit command.

Additionally; The current steps appear to be attempting to set the `Stable Tag` to the current stable (not the current release) but is setting it to the upcoming release anyway. This was broken in 68fa80a0a8cb2c242f0ed280d3552efd9f04aacc.

Ultimately, this process can be simplified by combining the Stable Tag / Trunk Commit / SVN copy into a single commit.
This will avoid situations where the trunk commit passes but the tag is not created.

Raising the timeout to 10 minutes (which is the default in SVN) should also hopefully resolve the timeout issues run into during the process.
Increasing it to 15 or 20 minutes to be on the safe side would also not be out of the question.
However is not strictly needed, as since this is now the last command in the action as long as the timeout is due to the post-commit server-side scripts taking a while, this should not cause any issue, as the commits are succeessful.

The main benefit that increasing the timeout provides is that the action on GitHub will appear to have succeeded where currently it fails.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I have not actually tested this **yet**, and while the commands appear correct, additional care should be taken prior to merging.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->
