### PR TITLE
Added: DropZone when sitelogo is present

### DIFF
--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -564,7 +564,7 @@ export default function LogoEdit( {
 					iconId={ siteIconId }
 					canUserEdit={ canUserEdit }
 				/>
-				<DropZone onFilesDrop={ onFilesDrop } />
+				{ canUserEdit && <DropZone onFilesDrop={ onFilesDrop } /> }
 			</>
 		);
 	}

--- a/packages/block-library/src/site-logo/edit.js
+++ b/packages/block-library/src/site-logo/edit.js
@@ -564,6 +564,7 @@ export default function LogoEdit( {
 					iconId={ siteIconId }
 					canUserEdit={ canUserEdit }
 				/>
+				<DropZone onFilesDrop={ onFilesDrop } />
 			</>
 		);
 	}


### PR DESCRIPTION
## What?
Resolves issue :- [65571](https://github.com/WordPress/gutenberg/issues/65571) 

## Why?
This PR resolves the issue of Site logo block is missing DropZone when a logo is present.

## How?
By adding the dropzone component in to the site logo.

## Testing Instructions
- open the site editor and select any site logo block or can select any pattern containing site logo
- add site logo in to the block
- now again add the logo by dragging the file on to it

## Screenshots or screencast <!-- if applicable -->

[Edit Site Logo.webm](https://github.com/user-attachments/assets/19e6ff13-b909-4a32-9baf-5b8988866f84)
