### PR TITLE
Try: deal with duplicate color slugs

### DIFF
--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -351,6 +351,56 @@ export default function ColorPanel( {
 			},
 		};
 	}
+	if ( !! settings?.color?.palette?.theme?.length ) {
+		settings = {
+			...settings,
+			color: {
+				...settings.color,
+				palette: {
+					...settings.color.palette,
+					theme: getUniqueBySlug( settings.color.palette.theme ),
+				},
+			},
+		};
+	}
+	if ( !! settings?.color?.gradients?.theme?.length ) {
+		settings = {
+			...settings,
+			color: {
+				...settings.color,
+				gradients: {
+					...settings.color.gradients,
+					theme: getUniqueBySlug( settings.color.gradients.theme ),
+				},
+			},
+		};
+	}
+	if ( !! settings?.color?.palette?.default?.length ) {
+		settings = {
+			...settings,
+			color: {
+				...settings.color,
+				palette: {
+					...settings.color.palette,
+					default: getUniqueBySlug( settings.color.palette.default ),
+				},
+			},
+		};
+	}
+	if ( !! settings?.color?.gradients?.default?.length ) {
+		settings = {
+			...settings,
+			color: {
+				...settings.color,
+				gradients: {
+					...settings.color.gradients,
+					default: getUniqueBySlug(
+						settings.color.gradients.default
+					),
+				},
+			},
+		};
+	}
 
 	const colors = useColorsPerOrigin( settings );
 	const gradients = useGradientsPerOrigin( settings );

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -301,16 +301,6 @@ function ColorPanelDropdown( {
 	);
 }
 
-function getUniqueBySlug( data ) {
-	const uniqueData = {};
-
-	for ( const item of data ) {
-		uniqueData[ item.slug ] = item;
-	}
-
-	return Object.values( uniqueData );
-}
-
 export default function ColorPanel( {
 	as: Wrapper = ColorToolsPanel,
 	value,
@@ -321,87 +311,6 @@ export default function ColorPanel( {
 	defaultControls = DEFAULT_CONTROLS,
 	children,
 } ) {
-	/*
-	 * @TODO this is illustrative only. Where the actual implementation
-	 * should be done is up for debate. Possibly in `useSettings`, or even in the
-	 * global styles provider? The idea is to ensure that the custom colors and
-	 * gradients are unique by slug in the UI, however we don't want to mutate the settings.
-	 */
-	if ( !! settings?.color?.palette?.custom?.length ) {
-		settings = {
-			...settings,
-			color: {
-				...settings.color,
-				palette: {
-					...settings.color.palette,
-					custom: getUniqueBySlug( settings.color.palette.custom ),
-				},
-			},
-		};
-	}
-	if ( !! settings?.color?.gradients?.custom?.length ) {
-		settings = {
-			...settings,
-			color: {
-				...settings.color,
-				gradients: {
-					...settings.color.gradients,
-					custom: getUniqueBySlug( settings.color.gradients.custom ),
-				},
-			},
-		};
-	}
-	if ( !! settings?.color?.palette?.theme?.length ) {
-		settings = {
-			...settings,
-			color: {
-				...settings.color,
-				palette: {
-					...settings.color.palette,
-					theme: getUniqueBySlug( settings.color.palette.theme ),
-				},
-			},
-		};
-	}
-	if ( !! settings?.color?.gradients?.theme?.length ) {
-		settings = {
-			...settings,
-			color: {
-				...settings.color,
-				gradients: {
-					...settings.color.gradients,
-					theme: getUniqueBySlug( settings.color.gradients.theme ),
-				},
-			},
-		};
-	}
-	if ( !! settings?.color?.palette?.default?.length ) {
-		settings = {
-			...settings,
-			color: {
-				...settings.color,
-				palette: {
-					...settings.color.palette,
-					default: getUniqueBySlug( settings.color.palette.default ),
-				},
-			},
-		};
-	}
-	if ( !! settings?.color?.gradients?.default?.length ) {
-		settings = {
-			...settings,
-			color: {
-				...settings.color,
-				gradients: {
-					...settings.color.gradients,
-					default: getUniqueBySlug(
-						settings.color.gradients.default
-					),
-				},
-			},
-		};
-	}
-
 	const colors = useColorsPerOrigin( settings );
 	const gradients = useGradientsPerOrigin( settings );
 	const areCustomSolidsEnabled = settings?.color?.custom;

--- a/packages/block-editor/src/components/global-styles/color-panel.js
+++ b/packages/block-editor/src/components/global-styles/color-panel.js
@@ -301,6 +301,16 @@ function ColorPanelDropdown( {
 	);
 }
 
+function getUniqueBySlug( data ) {
+	const uniqueData = {};
+
+	for ( const item of data ) {
+		uniqueData[ item.slug ] = item;
+	}
+
+	return Object.values( uniqueData );
+}
+
 export default function ColorPanel( {
 	as: Wrapper = ColorToolsPanel,
 	value,
@@ -311,6 +321,37 @@ export default function ColorPanel( {
 	defaultControls = DEFAULT_CONTROLS,
 	children,
 } ) {
+	/*
+	 * @TODO this is illustrative only. Where the actual implementation
+	 * should be done is up for debate. Possibly in `useSettings`, or even in the
+	 * global styles provider? The idea is to ensure that the custom colors and
+	 * gradients are unique by slug in the UI, however we don't want to mutate the settings.
+	 */
+	if ( !! settings?.color?.palette?.custom?.length ) {
+		settings = {
+			...settings,
+			color: {
+				...settings.color,
+				palette: {
+					...settings.color.palette,
+					custom: getUniqueBySlug( settings.color.palette.custom ),
+				},
+			},
+		};
+	}
+	if ( !! settings?.color?.gradients?.custom?.length ) {
+		settings = {
+			...settings,
+			color: {
+				...settings.color,
+				gradients: {
+					...settings.color.gradients,
+					custom: getUniqueBySlug( settings.color.gradients.custom ),
+				},
+			},
+		};
+	}
+
 	const colors = useColorsPerOrigin( settings );
 	const gradients = useGradientsPerOrigin( settings );
 	const areCustomSolidsEnabled = settings?.color?.custom;

--- a/packages/block-editor/src/components/global-styles/hooks.js
+++ b/packages/block-editor/src/components/global-styles/hooks.js
@@ -14,7 +14,11 @@ import { _x } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getValueFromVariable, getPresetVariableFromValue } from './utils';
+import {
+	getUniqueByProperty,
+	getValueFromVariable,
+	getPresetVariableFromValue,
+} from './utils';
 import { getValueFromObjectPath, setImmutably } from '../../utils/object';
 import { GlobalStylesContext } from './context';
 import { unlock } from '../../lock-unlock';
@@ -408,7 +412,7 @@ export function useColorsPerOrigin( settings ) {
 					'Theme',
 					'Indicates this palette comes from the theme.'
 				),
-				colors: themeColors,
+				colors: getUniqueByProperty( themeColors, 'slug' ),
 			} );
 		}
 		if (
@@ -421,7 +425,7 @@ export function useColorsPerOrigin( settings ) {
 					'Default',
 					'Indicates this palette comes from WordPress.'
 				),
-				colors: defaultColors,
+				colors: getUniqueByProperty( defaultColors, 'slug' ),
 			} );
 		}
 		if ( customColors && customColors.length ) {
@@ -430,7 +434,7 @@ export function useColorsPerOrigin( settings ) {
 					'Custom',
 					'Indicates this palette is created by the user.'
 				),
-				colors: customColors,
+				colors: getUniqueByProperty( customColors, 'slug' ),
 			} );
 		}
 		return result;
@@ -456,7 +460,7 @@ export function useGradientsPerOrigin( settings ) {
 					'Theme',
 					'Indicates this palette comes from the theme.'
 				),
-				gradients: themeGradients,
+				gradients: getUniqueByProperty( themeGradients, 'slug' ),
 			} );
 		}
 		if (
@@ -469,7 +473,7 @@ export function useGradientsPerOrigin( settings ) {
 					'Default',
 					'Indicates this palette comes from WordPress.'
 				),
-				gradients: defaultGradients,
+				gradients: getUniqueByProperty( defaultGradients, 'slug' ),
 			} );
 		}
 		if ( customGradients && customGradients.length ) {
@@ -478,7 +482,7 @@ export function useGradientsPerOrigin( settings ) {
 					'Custom',
 					'Indicates this palette is created by the user.'
 				),
-				gradients: customGradients,
+				gradients: getUniqueByProperty( customGradients, 'slug' ),
 			} );
 		}
 		return result;

--- a/packages/block-editor/src/components/global-styles/utils.js
+++ b/packages/block-editor/src/components/global-styles/utils.js
@@ -613,3 +613,19 @@ export function getResolvedValue( ruleValue, tree ) {
 
 	return resolvedValue;
 }
+
+/**
+ * Returns a unique collection of objects by specific property,
+ * preferring the last occurrence of each property value..
+ *
+ * @param {Array<Object>} collection A collection of items.
+ * @param {string}        property   The property to use for uniqueness.
+ * @return {Array<Object>} The filtered collection.
+ */
+export function getUniqueByProperty( collection, property ) {
+	return Array.from(
+		new Map(
+			collection.map( ( item ) => [ item[ property ], item ] )
+		).values()
+	);
+}

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -58,13 +58,14 @@ import type {
 
 const DEFAULT_COLOR = '#000';
 
-function NameInput( { value, onChange, label }: NameInputProps ) {
+function NameInput( { value, onChange, label, className }: NameInputProps ) {
 	return (
 		<NameInputControl
 			label={ label }
 			hideLabelFromVision
 			value={ value }
 			onChange={ onChange }
+			className={ className }
 		/>
 	);
 }
@@ -196,6 +197,7 @@ function Option< T extends PaletteElement >( {
 	popoverProps: receivedPopoverProps,
 	slugPrefix,
 	isGradient,
+	isDuplicate,
 }: OptionProps< T > ) {
 	const value = isGradient ? element.gradient : element.color;
 	const [ isEditingColor, setIsEditingColor ] = useState( false );
@@ -231,6 +233,10 @@ function Option< T extends PaletteElement >( {
 				<FlexItem>
 					{ ! canOnlyChangeValues ? (
 						<NameInput
+							className={ clsx(
+								'components-palette-edit__name-input',
+								{ 'is-duplicate': isDuplicate }
+							) }
 							label={
 								isGradient
 									? __( 'Gradient name' )
@@ -306,7 +312,13 @@ function PaletteEditListView< T extends PaletteElement >( {
 			onChange( deduplicateElementSlugs( updatedElements ) ),
 		100
 	);
-
+	const isDuplicate = useCallback(
+		( optionElement: PaletteElement ) =>
+			elements.filter(
+				( element ) => element.slug === optionElement.slug
+			).length > 1,
+		[ elements ]
+	);
 	return (
 		<VStack spacing={ 3 }>
 			<ItemGroup isRounded>
@@ -316,6 +328,7 @@ function PaletteEditListView< T extends PaletteElement >( {
 						canOnlyChangeValues={ canOnlyChangeValues }
 						key={ index }
 						element={ element }
+						isDuplicate={ isDuplicate( element ) }
 						onChange={ ( newElement ) => {
 							debounceOnChange(
 								elements.map(
@@ -631,16 +644,22 @@ export function PaletteEdit( {
 								disableCustomColors
 							/>
 						) ) }
-					{ ! isEditing && duplicateSlugs?.length > 0 && (
-						<p>
-							One of more of your colors have the same name. To
-							ensure your styles do not conflict, make sure they
-							have unique names.{ ' ' }
-							<button onClick={ () => setIsEditing( true ) }>
-								{ __( 'Edit colors now' ) }
-							</button>
-						</p>
-					) }
+					{ ! canOnlyChangeValues &&
+						! isEditing &&
+						duplicateSlugs?.length > 0 && (
+							<div className="components-palette-edit__warning">
+								Some items in this palette have identical names.
+								To prevent styles conflicts, give each item a
+								unique name.
+								<Button
+									className="components-palette-edit__edit_palette_button"
+									variant="link"
+									onClick={ () => setIsEditing( true ) }
+								>
+									{ __( 'Edit this palette.' ) }
+								</Button>
+							</div>
+						) }
 				</PaletteEditContents>
 			) }
 			{ ! hasElements && emptyMessage && (

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -387,6 +387,22 @@ export function PaletteEdit( {
 }: PaletteEditProps ) {
 	const isGradient = !! gradients;
 	const elements = isGradient ? gradients : colors;
+	const duplicateSlugs = elements?.length
+		? elements.filter( ( element, index ) => {
+				const slug = element.slug;
+				return (
+					!! slug &&
+					elements.findIndex( ( otherElement, otherIndex ) => {
+						return (
+							otherIndex !== index &&
+							otherElement.slug === slug &&
+							otherElement.slug !== undefined
+						);
+					} ) !== -1
+				);
+		  } )
+		: [];
+
 	const [ isEditing, setIsEditing ] = useState( false );
 	const [ editingElement, setEditingElement ] = useState<
 		number | null | undefined
@@ -615,6 +631,16 @@ export function PaletteEdit( {
 								disableCustomColors
 							/>
 						) ) }
+					{ ! isEditing && duplicateSlugs?.length > 0 && (
+						<p>
+							One of more of your colors have the same name. To
+							ensure your styles do not conflict, make sure they
+							have unique names.{ ' ' }
+							<button onClick={ () => setIsEditing( true ) }>
+								{ __( 'Edit colors now' ) }
+							</button>
+						</p>
+					) }
 				</PaletteEditContents>
 			) }
 			{ ! hasElements && emptyMessage && (

--- a/packages/components/src/palette-edit/style.scss
+++ b/packages/components/src/palette-edit/style.scss
@@ -7,3 +7,15 @@
 		width: 100%;
 	}
 }
+.components-palette-edit__warning {
+	margin: $grid-unit-20 0 $grid-unit-10 0;
+	padding: $grid-unit-10 $grid-unit-15;
+	border-left: 4px solid $alert-yellow;
+	background-color: lighten($alert-yellow, 35%);
+	.components-palette-edit__edit_palette_button {
+		margin-left: $grid-unit-05;
+	}
+}
+.components-palette-edit__name-input.is-duplicate {
+	border: 1px solid $alert-red;
+}

--- a/packages/components/src/palette-edit/types.ts
+++ b/packages/components/src/palette-edit/types.ts
@@ -109,6 +109,7 @@ export type NameInputProps = {
 	label: string;
 	onChange: ( nextName?: PaletteElement[ 'name' ] ) => void;
 	value: PaletteElement[ 'name' ];
+	className?: string;
 };
 
 export type OptionProps< T extends Color | Gradient > = {
@@ -120,6 +121,7 @@ export type OptionProps< T extends Color | Gradient > = {
 	onRemove: MouseEventHandler< HTMLButtonElement >;
 	popoverProps?: PaletteEditProps[ 'popoverProps' ];
 	slugPrefix: string;
+	isDuplicate: boolean;
 };
 
 export type PaletteEditListViewProps< T extends Color | Gradient > = {


### PR DESCRIPTION
Related to:

- https://github.com/WordPress/gutenberg/issues/43197
- https://github.com/WordPress/gutenberg/pull/65772

A test branch to illustrate how the UI might deal with existing, custom duplicate custom color slugs.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

Test theme.json

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true,
		"color": {
			"duotone": [
				{
					"colors": ["#111111", "#ffffff"],
					"slug": "duotone-1",
					"name": "Black and white"
				},
				{
					"colors": ["#111111", "#C2A990"],
					"slug": "duotone-1",
					"name": "Black and white"
				},
				{
					"colors": ["#111111", "#D8613C"],
					"slug": "duotone-1",
					"name": "Black and rust"
				},
				{
					"colors": ["#111111", "#B1C5A4"],
					"slug": "duotone-4",
					"name": "Black and sage"
				}
			],
			"gradients": [
				{
					"slug": "gradient-1",
					"gradient": "linear-gradient(to bottom, #cfcabe 0%, #F9F9F9 100%)",
					"name": "Vertical soft beige to white"
				},
				{
					"slug": "gradient-1",
					"gradient": "linear-gradient(to bottom, #C2A990 0%, #F9F9F9 100%)",
					"name": "Vertical soft beige to white"
				},
				{
					"slug": "gradient-1",
					"gradient": "linear-gradient(to bottom, #D8613C 0%, #F9F9F9 100%)",
					"name": "Vertical soft rust to white"
				},
				{
					"slug": "gradient-4",
					"gradient": "linear-gradient(to bottom, #B1C5A4 0%, #F9F9F9 100%)",
					"name": "Vertical soft sage to white"
				}
			],
			"palette": [
				{
					"color": "#f9f9f9",
					"name": "Base",
					"slug": "base"
				},
				{
					"color": "#ffffff",
					"name": "Base",
					"slug": "base"
				},
				{
					"color": "#111111",
					"name": "Contrast",
					"slug": "base"
				},
				{
					"color": "#636363",
					"name": "Contrast / Two",
					"slug": "contrast-2"
				}
			]
		}
	}
}
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/7ac37c9c-675f-46fe-8277-42c46e2de520



https://github.com/user-attachments/assets/46cd4e54-e631-49aa-82b2-bebf3a332780




