### PR TITLE
Block Bindings: Fix passing bindings context to `canUserEditValue`

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -103,11 +103,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		const sources = useSelect( ( select ) =>
 			unlock( select( blocksStore ) ).getAllBlockBindingsSources()
 		);
-		const { name, clientId, context } = props;
-		const hasParentPattern = !! props.context[ 'pattern/overrides' ];
-		const hasPatternOverridesDefaultBinding =
-			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
-				?.source === 'core/pattern-overrides';
+		const { name, clientId, context, setAttributes } = props;
 		const blockBindings = useMemo(
 			() =>
 				replacePatternOverrideDefaultBindings(
@@ -196,7 +192,10 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 			sources,
 		] );
 
-		const { setAttributes } = props;
+		const hasParentPattern = !! updatedContext[ 'pattern/overrides' ];
+		const hasPatternOverridesDefaultBinding =
+			props.attributes.metadata?.bindings?.[ DEFAULT_ATTRIBUTE ]
+				?.source === 'core/pattern-overrides';
 
 		const _setAttributes = useCallback(
 			( nextAttributes ) => {


### PR DESCRIPTION
## What?
This PR ensure the `usesContext` property from registered sources is taken into account in all the scenarios, including `canUserEditValue` which isn't working as expected right now.

## Why?
After this core commit, the context is populated dynamically both in the server and in the editor depending on the block bindings existing. However, the updated context is only pass to `getValues` and `setValues`.

This is causing e2e tests to fail.

## How?
I'm passing the updated context as `props.context` to ensure it is always available. This context is only updated once the block is connected to the relevant sources.

## Testing Instructions
Failing e2e tests should pass. Manual testing:

1. Create a custom field to test with:
```
register_meta(
	'post',
	'url_field',
	array(
		'label'             => 'URL field',
		'show_in_rest'      => true,
		'single'            => true,
		'type'              => 'string',
		'default'           => 'https://wp.org',
		'revisions_enabled' => true,
	)
);
```
2. Go to a page and add a button connected to this field:
```
<!-- wp:buttons -->
<div class="wp-block-buttons"><!-- wp:button {"metadata":{"bindings":{"url":{"source":"core/post-meta","args":{"key":"url_field"}}}}} -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Original content</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons -->
```
3. Check you can edit the URL. Previously this wasn't possible.
