### PR TITLE
Comment Edit/Reply Links: Add block examples

### DIFF
--- a/packages/block-library/src/comment-edit-link/index.js
+++ b/packages/block-library/src/comment-edit-link/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/comment-reply-link/index.js
+++ b/packages/block-library/src/comment-reply-link/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	edit,
 	icon,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds block example definitions for the Comment Edit/Reply Link blocks.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

- Adds an example to the Comment Edit Link block.
- Adds an example to the Comment Reply Link block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm block examples display for both the Comment Edit and Comment Reply Link blocks.
3. Insert a Comments block, select the Comments Template then click the quick inserter.
4. In the insert popover, select Browse All to open the main inserter, then search for Comment
5. Confirm the example displays in the preview for the Comment Edit/Reply Link blocks


## Screenshots or screencast <!-- if applicable -->

<img width="657" alt="Screenshot 2024-09-24 at 6 49 50 pm" src="https://github.com/user-attachments/assets/f790bd70-ee38-4fff-86b9-ffde50fce5e6">
<img width="656" alt="Screenshot 2024-09-24 at 6 49 42 pm" src="https://github.com/user-attachments/assets/b7120ce5-88b3-4592-8d8a-bb4d82d6503e">
<img width="432" alt="Screenshot 2024-09-24 at 6 49 12 pm" src="https://github.com/user-attachments/assets/09d3f207-3168-491b-9013-32e870594c18">
