### PR TITLE
Block Bindings: Keep bindings editor calls in their own logic `useSelect`

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -211,7 +211,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 				return;
 			}
 			const _fieldsList = {};
-			const { getBlockBindingsSources } = unlock( blocksPrivateApis );
 			const registeredSources = getBlockBindingsSources();
 			Object.entries( registeredSources ).forEach(
 				( [ sourceName, { getFieldsList, usesContext } ] ) => {

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -144,29 +144,25 @@ test.describe( 'Post Meta source', () => {
 				editor,
 				page,
 			} ) => {
-				/**
-				 * Create connection manually until this issue is solved:
-				 * https://github.com/WordPress/gutenberg/pull/65604
-				 *
-				 * Once solved, block with the binding can be directly inserted.
-				 */
 				await editor.insertBlock( {
 					name: 'core/paragraph',
+					attributes: {
+						content: 'fallback content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'movie_field',
+									},
+								},
+							},
+						},
+					},
 				} );
-				await page.getByLabel( 'Attributes options' ).click();
-				await page
-					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
-					} )
-					.click();
 				const contentBinding = page.getByRole( 'button', {
 					name: 'content',
 				} );
-				await contentBinding.click();
-				await page
-					.getByRole( 'menuitemradio' )
-					.filter( { hasText: 'Movie field label' } )
-					.click();
 				await expect( contentBinding ).toContainText(
 					'Movie field label'
 				);
@@ -175,29 +171,25 @@ test.describe( 'Post Meta source', () => {
 				editor,
 				page,
 			} ) => {
-				/**
-				 * Create connection manually until this issue is solved:
-				 * https://github.com/WordPress/gutenberg/pull/65604
-				 *
-				 * Once solved, block with the binding can be directly inserted.
-				 */
 				await editor.insertBlock( {
 					name: 'core/paragraph',
+					attributes: {
+						content: 'fallback content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: {
+										key: 'field_without_label_or_default',
+									},
+								},
+							},
+						},
+					},
 				} );
-				await page.getByLabel( 'Attributes options' ).click();
-				await page
-					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
-					} )
-					.click();
 				const contentBinding = page.getByRole( 'button', {
 					name: 'content',
 				} );
-				await contentBinding.click();
-				await page
-					.getByRole( 'menuitemradio' )
-					.filter( { hasText: 'field_without_label_or_default' } )
-					.click();
 				await expect( contentBinding ).toContainText(
 					'field_without_label_or_default'
 				);


### PR DESCRIPTION
## What?
Follow-up to these comments where we faced some issues with `useSelect` warning:
* https://github.com/WordPress/gutenberg/pull/64072#discussion_r1764693730
* https://github.com/WordPress/gutenberg/pull/65599#discussion_r1772886078

In that part of the code, we are creating an object outside the `useSelect` to avoid the warning:

```
The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.
```

However, that seems like a workaround and I'm opening this to exploring the different alternatives.

## Why?
That seems like a workaround and I'm opening this to exploring the different alternatives.

## How?
* In the first case, I'm moving the `getFieldsList` to its own `useSelect` as suggested [here](https://github.com/WordPress/gutenberg/pull/64072#discussion_r1771409849). However, that doesn't solve the issue with the warning. After triaging it a bit more I believe the warning is caused because fieldsList is an object of objects. And when we call `isShallowEqual` [here](https://github.com/WordPress/gutenberg/blob/9fef8fb128ef280ed5348c4f4ba3ec93c883fe6a/packages/data/src/components/use-select/index.js#L161), it returns `false` because it doesn't check nested objects.
* In the second case, I just moved the logic needed to `useMemo`, which feels better.

## Testing Instructions
1. Register a post meta field for testing:
```
register_meta(
	'post',
	'text_field',
	array(
		'label'             => 'Text field',
		'show_in_rest'      => true,
		'single'            => true,
		'type'              => 'string',
		'default'           => 'Post Meta Value',
		'revisions_enabled' => true,
	)
);
```

2. Go to a page and add a paragraph connected to that post meta.
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"text_field"}}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
3. Click on the paragraph and check that there are no warnings in the console.
