### PR TITLE
correct spelling of arguments rich-text README.md

### DIFF
--- a/packages/rich-text/README.md
+++ b/packages/rich-text/README.md
@@ -430,7 +430,7 @@ Create an HTML string from a Rich Text value.
 
 _Parameters_
 
--   _$1_ `Object`: Named argements.
+-   _$1_ `Object`: Named arguments.
 -   _$1.value_ `RichTextValue`: Rich text value.
 -   _$1.preserveWhiteSpace_ `[boolean]`: Preserves newlines if true.
 


### PR DESCRIPTION
spelling correction
- from: `argements`
- to: `arguments`

`toHtmlString` [documentation](<https://developer.wordpress.org/block-editor/reference-guides/packages/packages-rich-text/#tohtmlstring>)
___
```text
$1 Object: Named argements.
```