### PR TITLE
Remove one occurrence of the verb Toggle from Zoom out control.

### DIFF
--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -40,7 +40,7 @@ const ZoomOutToggle = () => {
 		<Button
 			onClick={ handleZoomOut }
 			icon={ zoomOutIcon }
-			label={ __( 'Toggle Zoom Out' ) }
+			label={ __( 'Zoom Out' ) }
 			isPressed={ isZoomOut }
 			size="compact"
 			showTooltip={ ! showIconLabels }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Addresses a part of https://github.com/WordPress/gutenberg/issues/65491

## What?
<!-- In a few words, what is the PR actually doing? -->
The verb 'Toggle' isn't well translatable in many languages and should be avoided. See https://github.com/WordPress/gutenberg/discussions/42492 and https://core.trac.wordpress.org/ticket/34753

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See above.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the verb 'Toggle' from 'Toggle Zoom Out'.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post.
- Hover or focus the zoom out button.
- Observe the text in the button tooltip is now 'Zoom Out'.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
