### PR TITLE
Fix search box design issues and make it consistent.

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -58,6 +58,7 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		// Prevent unintended text wrapping.
 		flex-shrink: 0;
 		max-width: 100%;
+		margin-left: 1rem;
 	}
 
 	// Ensure minimum input field width in small viewports.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I have created this PR to add little bit gap between search button and input field when we choose button position to "Button Only".

## Why?
I have reviewed the "Search Block" and found design consistent issue, When we change button position to "Button only", there is no gap between the search (or search icon) button and the input field. It looks inconsistent.

## Testing Instructions

- Add the Search block.
- Choose the button position to "Button only" option
- Update and visit the page.
- Click on the Search button.

### Testing Instructions for Keyboard
I have checked this changes into the local PC and its looks good.

## Screenshots or screencast <!-- if applicable -->

Here, I have provided its screenshots:

**Editor-end:**
![after-resolved-search-block-editor](https://github.com/user-attachments/assets/e7b8ba99-adf1-4090-8696-f40349dfc772)

**Front-end:**
<img width="1436" alt="after-resolved-search-block-front-end" src="https://github.com/user-attachments/assets/4cda4987-b638-48b1-8633-2f52f642f1b0">

Thanks,