### PR TITLE
Blocks: Update '__experimentalHasContentRoleAttribute' deprecation

### DIFF
--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -828,7 +828,6 @@ export const __experimentalHasContentRoleAttribute = ( ...args ) => {
 	deprecated( '__experimentalHasContentRoleAttribute', {
 		since: '6.7',
 		version: '6.8',
-		alternative: 'hasContentRoleAttribute',
 		hint: 'This is a private selector.',
 	} );
 	return privateHasContentRoleAttribute( ...args );


### PR DESCRIPTION
## What?
This is a follow-up to #65484.

PR removes alternative suggestion from `__experimentalHasContentRoleAttribute` selector deprecation.

## Why?
The suggested alternative is a private API. Public API deprecations shouldn't recommend private APIs, as they make deprecation unactionable for consumers.

## Testing Instructions
None.
