### PR TITLE
Blocks: Don't memoize 'hasContentRoleAttribute' selector

### DIFF
--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -225,8 +225,8 @@ export const hasContentRoleAttribute = ( state, blockTypeName ) => {
 		return false;
 	}
 
-	return Object.entries( blockType.attributes ).some(
-		( [ , { role, __experimentalRole } ] ) => {
+	return Object.values( blockType.attributes ).some(
+		( { role, __experimentalRole } ) => {
 			if ( role === 'content' ) {
 				return true;
 			}

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -219,32 +219,27 @@ export function getBlockBindingsSource( state, sourceName ) {
  * @param {string} blockTypeName Block type name.
  * @return {boolean} Whether block type has content role attribute.
  */
-export const hasContentRoleAttribute = createSelector(
-	( state, blockTypeName ) => {
-		const blockType = getBlockType( state, blockTypeName );
-		if ( ! blockType ) {
+export const hasContentRoleAttribute = ( state, blockTypeName ) => {
+	const blockType = getBlockType( state, blockTypeName );
+	if ( ! blockType ) {
+		return false;
+	}
+
+	return Object.entries( blockType.attributes ).some(
+		( [ , { role, __experimentalRole } ] ) => {
+			if ( role === 'content' ) {
+				return true;
+			}
+			if ( __experimentalRole === 'content' ) {
+				deprecated( '__experimentalRole attribute', {
+					since: '6.7',
+					version: '6.8',
+					alternative: 'role attribute',
+					hint: `Check the block.json of the ${ blockTypeName } block.`,
+				} );
+				return true;
+			}
 			return false;
 		}
-
-		return Object.entries( blockType.attributes ).some(
-			( [ , { role, __experimentalRole } ] ) => {
-				if ( role === 'content' ) {
-					return true;
-				}
-				if ( __experimentalRole === 'content' ) {
-					deprecated( '__experimentalRole attribute', {
-						since: '6.7',
-						version: '6.8',
-						alternative: 'role attribute',
-						hint: `Check the block.json of the ${ blockTypeName } block.`,
-					} );
-					return true;
-				}
-				return false;
-			}
-		);
-	},
-	( state, blockTypeName ) => [
-		state.blockTypes[ blockTypeName ]?.attributes,
-	]
-);
+	);
+};


### PR DESCRIPTION
## What?
This is a follow-up to #65484.

PR removes memoization for the private `hasContentRoleAttribute` selector.

## Why?
The selector returns primitive boolean values; there should be no need to memorize. It's hard to anticipate performance improvements for similar optimizations without real data like [CodeVitals](https://www.codevitals.run/project/gutenberg).

## Testing Instructions
CI checks should be green.