### PR TITLE
Block Bindings: Only pass context included in `usesContext` from rich text component

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -179,11 +179,17 @@ export function RichTextWrapper(
 			const blockBindingsSource = getBlockBindingsSource(
 				relatedBinding.source
 			);
+			const blockBindingsContext = {};
+			if ( blockBindingsSource?.usesContext?.length ) {
+				for ( const key of blockBindingsSource.usesContext ) {
+					blockBindingsContext[ key ] = blockContext[ key ];
+				}
+			}
 
 			const _disableBoundBlock =
 				! blockBindingsSource?.canUserEditValue?.( {
 					select,
-					context: blockContext,
+					context: blockBindingsContext,
 					args: relatedBinding.args,
 				} );
 
@@ -201,7 +207,7 @@ export function RichTextWrapper(
 			const blockAttributes = getBlockAttributes( clientId );
 			const fieldsList = blockBindingsSource?.getFieldsList?.( {
 				registry,
-				context: blockContext,
+				context: blockBindingsContext,
 			} );
 			const bindingKey =
 				fieldsList?.[ relatedBinding?.args?.key ]?.label ??


### PR DESCRIPTION
## What?
It passes only the context properties included in `usesContext` block bindings definition instead of the whole `blockContext`.

## Why?
It seems safer to limit the context provided to the block bindings editor APIs to only the values defined through `usesContext` property.

## How?
I just added a similar check to what we have in other places like [this](https://github.com/WordPress/gutenberg/blob/67e72757fe37df24a130c17f77064ce3a213722d/packages/block-editor/src/hooks/use-bindings-attributes.js#L140-L143).

I tried getting the BlockEdit context from the rich text, but I don't think that's possible.

## Testing Instructions
Everything should keep working as expected. e2e tests should pass.
