### PR TITLE
Revert "DataViews Sidebar: Display item count on DataViews sidebar"

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/dataview-item.js
@@ -27,7 +27,6 @@ export default function DataViewItem( {
 	isActive,
 	isCustom,
 	suffix,
-	navigationItemSuffix,
 } ) {
 	const {
 		params: { postType },
@@ -56,7 +55,6 @@ export default function DataViewItem( {
 			<SidebarNavigationItem
 				icon={ iconToUse }
 				{ ...linkInfo }
-				suffix={ navigationItemSuffix }
 				aria-current={ isActive ? 'true' : undefined }
 			>
 				{ title }

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -13,7 +13,7 @@ import {
 	notAllowed,
 } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
-import { store as coreStore, useEntityRecords } from '@wordpress/core-data';
+import { store as coreStore } from '@wordpress/core-data';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -67,50 +67,6 @@ const DEFAULT_POST_BASE = {
 	fields: [ 'title', 'author', 'status' ],
 	layout: defaultLayouts[ LAYOUT_LIST ].layout,
 };
-
-export function useDefaultViewsWithItemCounts( { postType } ) {
-	const defaultViews = useDefaultViews( { postType } );
-	const { records, totalItems } = useEntityRecords( 'postType', postType, {
-		per_page: -1,
-		status: [ 'any', 'trash' ],
-	} );
-
-	return useMemo( () => {
-		if ( ! defaultViews ) {
-			return [];
-		}
-
-		// If there are no records, return the default views with no counts.
-		if ( ! records ) {
-			return defaultViews;
-		}
-
-		const counts = {
-			drafts: records.filter( ( record ) => record.status === 'draft' )
-				.length,
-			future: records.filter( ( record ) => record.status === 'future' )
-				.length,
-			pending: records.filter( ( record ) => record.status === 'pending' )
-				.length,
-			private: records.filter( ( record ) => record.status === 'private' )
-				.length,
-			published: records.filter(
-				( record ) => record.status === 'publish'
-			).length,
-			trash: records.filter( ( record ) => record.status === 'trash' )
-				.length,
-		};
-
-		// All items excluding trashed items as per the default "all" status query.
-		counts.all = totalItems ? totalItems - counts.trash : 0;
-
-		// Filter out views with > 0 item counts.
-		return defaultViews.map( ( _view ) => {
-			_view.count = counts[ _view.slug ];
-			return _view;
-		} );
-	}, [ defaultViews, records, totalItems ] );
-}
 
 export function useDefaultViews( { postType } ) {
 	const labels = useSelect(

--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -7,7 +7,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 /**
  * Internal dependencies
  */
-import { useDefaultViewsWithItemCounts } from './default-views';
+import { useDefaultViews } from './default-views';
 import { unlock } from '../../lock-unlock';
 import DataViewItem from './dataview-item';
 import CustomDataViewsList from './custom-dataviews-list';
@@ -18,9 +18,7 @@ export default function DataViewsSidebarContent() {
 	const {
 		params: { postType, activeView = 'all', isCustom = 'false' },
 	} = useLocation();
-
-	const defaultViews = useDefaultViewsWithItemCounts( { postType } );
-
+	const defaultViews = useDefaultViews( { postType } );
 	if ( ! postType ) {
 		return null;
 	}
@@ -36,9 +34,6 @@ export default function DataViewsSidebarContent() {
 							slug={ dataview.slug }
 							title={ dataview.title }
 							icon={ dataview.icon }
-							navigationItemSuffix={
-								<span>{ dataview.count }</span>
-							}
 							type={ dataview.view.type }
 							isActive={
 								! isCustomBoolean &&

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -15,10 +15,6 @@
 		min-width: initial;
 	}
 
-	.edit-site-sidebar-navigation-item.with-suffix {
-		padding-right: $grid-unit-10;
-	}
-
 	&:hover,
 	&:focus,
 	&[aria-current] {


### PR DESCRIPTION
Reverts WordPress/gutenberg#65223

## Why? 

To avoid a `per_page: -1,` request on entities until we come up with another solution, e.g., https://github.com/WordPress/gutenberg/pull/65223#discussion_r1753067847

## Testing

In the Site Editor sidebar (view mode), the page and templates list should work as expected without the individual post status counts.

