### PR TITLE
Update z-index hierarchy

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,7 +33,7 @@ $z-layers: (
 	".edit-widgets-header": 30,
 	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 0, // Overlay area inside block cover need to be higher than the video background.
-	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
+	".block-library-cover__padding-visualizer": 1, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
 	".wp-block-cover__image-background": -1, // Image background inside cover block.
 	".wp-block-cover__video-background": -1, // Video background inside cover block.
 	".wp-block-template-part__placeholder-preview-filter-input": 1,

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -31,12 +31,11 @@ $z-layers: (
 	".interface-interface-skeleton__header": 30,
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,
-	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block.
 	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
-	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
+	".wp-block-cover.has-background-dim::before": 0, // Overlay area inside block cover need to be higher than the video background.
 	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
-	".wp-block-cover__image-background": 0, // Image background inside cover block.
-	".wp-block-cover__video-background": 0, // Video background inside cover block.
+	".wp-block-cover__image-background": -1, // Image background inside cover block.
+	".wp-block-cover__video-background": -1, // Video background inside cover block.
 	".wp-block-template-part__placeholder-preview-filter-input": 1,
 
 	// Fixed position appender:

--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -33,7 +33,6 @@ $z-layers: (
 	".edit-widgets-header": 30,
 	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
 	".wp-block-cover.has-background-dim::before": 0, // Overlay area inside block cover need to be higher than the video background.
-	".block-library-cover__padding-visualizer": 1, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
 	".wp-block-cover__image-background": -1, // Image background inside cover block.
 	".wp-block-cover__video-background": -1, // Video background inside cover block.
 	".wp-block-template-part__placeholder-preview-filter-input": 1,

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -42,7 +42,6 @@
 	// Shown while media is being uploaded
 	.components-spinner {
 		position: absolute;
-		z-index: z-index(".wp-block-cover__inner-container");
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%); // Account for spinner dimensions

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -95,8 +95,8 @@
 	}
 
 	.wp-block-cover__inner-container {
+		position: relative;
 		width: 100%;
-		z-index: z-index(".wp-block-cover__inner-container");
 		color: inherit;
 		// Reset the fixed LTR direction at the root of the block in RTL languages.
 		/*rtl:raw: direction: rtl; */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue where the menu would have bad behavior when used inside a cover block. The issue happened when the menu was open on a small screen (the layer on top of the content).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Many users are having and reporting this issue.
See
- https://github.com/WordPress/gutenberg/issues/45353
- https://github.com/Automattic/wp-calypso/issues/75439
- https://github.com/Automattic/wp-calypso/issues/79317

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Before, we had the following index hierarchy inside the cover block:

- Cover (z-index: auto - `position: relative;`)
  - Cover background (z-index: 1 - `position: absolute; z-index: 1;`)
  - Cover image (z-index: 0 - `position: absolute; z-index: 0;`)
  - Cover container (z-index: 1 - `z-index: 1;`)
    - Content here, where the Navigation could be added and navigation has a `position: fixed; z-index: 100000`.

It repurposes the hierarchy to also have a z-index: auto (not set) in the Cover container, so the z-index inside it works properly without the interference of a parent (not forming a [stacking context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context)).

### Considered alternatives

Ideally, the solution would be in the navigation block creating an element in an independent context for the open menu, so the issue would never happen regardless of where the menu is added. But it would have a huge impact and it is probably not worth it.

Another alternative would be to change the order of the elements so that we could clean up a bit the z-index from the elements, but this would demand a deprecation and a migration for users that already saved it, so I decided not to touch this.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a template or a post add a Cover block.
2. Inside the cover block, add a Navigation block.
3. After the previously created Cover block, add another Cover block.
4. Visit the site in the frontend, on a small screen.
5. Open the menu, and make sure it's displayed over the whole content.

Please, also test other scenarios that I didn't cover here or in the following video if you see something I missed.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/40689179-2afa-4bdb-ab4c-2acd69de95fb