### PR TITLE
Make zoom out vertical toolbar consistent

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -94,7 +94,7 @@ function BlockPopover(
 		return {
 			getBoundingClientRect() {
 				if ( isZoomOut() ) {
-					const selectedRect =
+					const selectedBlockRect =
 						getVisibleElementBounds( selectedElement );
 					const parentRect = getVisibleElementBounds(
 						selectedElement.parentElement

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -96,7 +96,7 @@ function BlockPopover(
 				if ( isZoomOut() ) {
 					const selectedBlockRect =
 						getVisibleElementBounds( selectedElement );
-					const parentRect = getVisibleElementBounds(
+					const sectionRootElementRect = getVisibleElementBounds(
 						selectedElement.parentElement
 					);
 					return new window.DOMRectReadOnly(

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -77,44 +77,30 @@ function BlockPopover(
 		};
 	}, [ selectedElement ] );
 
-	const {
-		selectedBlockParentClientIds,
-		isZoomOut,
-		sectionRootClientId,
-		sectionClientIds,
-	} = useSelect( ( select ) => {
-		const {
-			isZoomOut: isZoomOutSelector,
-			getBlockOrder,
-			getSectionRootClientId,
-			getBlockParents,
-			getSelectedBlock,
-		} = unlock( select( blockEditorStore ) );
+	const { isZoomOut, sectionRootClientId, getParentSectionBlock } = useSelect(
+		( select ) => {
+			const {
+				isZoomOut: isZoomOutSelector,
+				getSectionRootClientId,
+				getParentSectionBlock: getParentSectionBlockFn,
+			} = unlock( select( blockEditorStore ) );
 
-		const root = getSectionRootClientId();
-		const sectionRootClientIds = getBlockOrder( root );
-		return {
-			sectionRootClientId: root,
-			sectionClientIds: sectionRootClientIds,
-			isZoomOut: isZoomOutSelector(),
-			selectedBlockParentClientIds: getBlockParents( getSelectedBlock() ),
-		};
-	}, [] );
+			const root = getSectionRootClientId();
+			return {
+				sectionRootClientId: root,
+				isZoomOut: isZoomOutSelector(),
+				getParentSectionBlock: getParentSectionBlockFn,
+			};
+		},
+		[]
+	);
 
 	// These elements are used to position the zoom out view vertical toolbar
 	// correctly, relative to the selected section.
 	const rootSectionElement = useBlockElement( sectionRootClientId );
-	let parentSectionClientId;
-	if ( sectionClientIds.includes( clientId ) ) {
-		parentSectionClientId = clientId;
-	} else {
-		parentSectionClientId =
-			selectedBlockParentClientIds.find( ( parentClientId ) =>
-				sectionClientIds.includes( parentClientId )
-			) ?? clientId;
-	}
-
-	const parentSectionElement = useBlockElement( parentSectionClientId );
+	const parentSectionElement = useBlockElement(
+		getParentSectionBlock( clientId ) ?? clientId
+	);
 
 	const popoverAnchor = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -80,32 +80,34 @@ function BlockPopover(
 	const {
 		isZoomOut,
 		sectionRootClientId,
-		getParentSectionBlock,
-		getBlockOrder,
-	} = useSelect( ( select ) => {
-		const {
-			isZoomOut: isZoomOutSelector,
-			getSectionRootClientId,
-			getParentSectionBlock: getParentSectionBlockSelector,
-			getBlockOrder: getBlockOrderSelector,
-		} = unlock( select( blockEditorStore ) );
+		parentSectionBlock,
+		isSectionSelected,
+	} = useSelect(
+		( select ) => {
+			const {
+				isZoomOut: isZoomOutSelector,
+				getSectionRootClientId,
+				getParentSectionBlock,
+				getBlockOrder,
+			} = unlock( select( blockEditorStore ) );
 
-		return {
-			sectionRootClientId: getSectionRootClientId(),
-			isZoomOut: isZoomOutSelector(),
-			getParentSectionBlock: getParentSectionBlockSelector,
-			getBlockOrder: getBlockOrderSelector,
-		};
-	}, [] );
+			return {
+				sectionRootClientId: getSectionRootClientId(),
+				isZoomOut: isZoomOutSelector(),
+				parentSectionBlock:
+					getParentSectionBlock( clientId ) ?? clientId,
+				isSectionSelected: getBlockOrder(
+					getSectionRootClientId()
+				).includes( clientId ),
+			};
+		},
+		[ clientId ]
+	);
 
 	// These elements are used to position the zoom out view vertical toolbar
 	// correctly, relative to the selected section.
 	const rootSectionElement = useBlockElement( sectionRootClientId );
-	const parentSectionElement = useBlockElement(
-		getParentSectionBlock( clientId ) ?? clientId
-	);
-	const isSectionSelected =
-		getBlockOrder( sectionRootClientId ).includes( clientId );
+	const parentSectionElement = useBlockElement( parentSectionBlock );
 
 	const popoverAnchor = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -115,8 +115,8 @@ function BlockPopover(
 			// than 0. This check is only there to satisfy the correctness of the
 			// exhaustive-deps rule for the `useMemo` hook.
 			popoverDimensionsRecomputeCounter < 0 ||
-			! rootSectionElement ||
-			! parentSectionElement ||
+			( isZoomOut && ! rootSectionElement ) ||
+			( isZoomOut && ! parentSectionElement ) ||
 			! selectedElement ||
 			( bottomClientId && ! lastSelectedElement )
 		) {

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -77,23 +77,27 @@ function BlockPopover(
 		};
 	}, [ selectedElement ] );
 
-	const { isZoomOut, sectionRootClientId, getParentSectionBlock } = useSelect(
-		( select ) => {
-			const {
-				isZoomOut: isZoomOutSelector,
-				getSectionRootClientId,
-				getParentSectionBlock: getParentSectionBlockFn,
-			} = unlock( select( blockEditorStore ) );
+	const {
+		isZoomOut,
+		sectionRootClientId,
+		getParentSectionBlock,
+		getBlockOrder,
+	} = useSelect( ( select ) => {
+		const {
+			isZoomOut: isZoomOutSelector,
+			getSectionRootClientId,
+			getParentSectionBlock: getParentSectionBlockFn,
+			getBlockOrder: getBlockOrderFn,
+		} = unlock( select( blockEditorStore ) );
 
-			const root = getSectionRootClientId();
-			return {
-				sectionRootClientId: root,
-				isZoomOut: isZoomOutSelector(),
-				getParentSectionBlock: getParentSectionBlockFn,
-			};
-		},
-		[]
-	);
+		const root = getSectionRootClientId();
+		return {
+			sectionRootClientId: root,
+			isZoomOut: isZoomOutSelector(),
+			getParentSectionBlock: getParentSectionBlockFn,
+			getBlockOrder: getBlockOrderFn,
+		};
+	}, [] );
 
 	// These elements are used to position the zoom out view vertical toolbar
 	// correctly, relative to the selected section.
@@ -101,6 +105,8 @@ function BlockPopover(
 	const parentSectionElement = useBlockElement(
 		getParentSectionBlock( clientId ) ?? clientId
 	);
+	const isSectionSelected =
+		getBlockOrder( sectionRootClientId ).includes( clientId );
 
 	const popoverAnchor = useMemo( () => {
 		if (
@@ -123,7 +129,7 @@ function BlockPopover(
 				// selected section. This condition changes the anchor of the toolbar
 				// to the section instead of the block to handle blocksn that are
 				// not full width and nested blocks to keep section height.
-				if ( isZoomOut ) {
+				if ( isZoomOut && isSectionSelected ) {
 					// Compute the height based on the parent section of the
 					// selected block, because the selected block may be
 					// shorter than the section.

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -86,16 +86,15 @@ function BlockPopover(
 		const {
 			isZoomOut: isZoomOutSelector,
 			getSectionRootClientId,
-			getParentSectionBlock: getParentSectionBlockFn,
-			getBlockOrder: getBlockOrderFn,
+			getParentSectionBlock: getParentSectionBlockSelector,
+			getBlockOrder: getBlockOrderSelector,
 		} = unlock( select( blockEditorStore ) );
 
-		const root = getSectionRootClientId();
 		return {
-			sectionRootClientId: root,
+			sectionRootClientId: getSectionRootClientId(),
 			isZoomOut: isZoomOutSelector(),
-			getParentSectionBlock: getParentSectionBlockFn,
-			getBlockOrder: getBlockOrderFn,
+			getParentSectionBlock: getParentSectionBlockSelector,
+			getBlockOrder: getBlockOrderSelector,
 		};
 	}, [] );
 

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -108,6 +108,7 @@ function BlockPopover(
 			// than 0. This check is only there to satisfy the correctness of the
 			// exhaustive-deps rule for the `useMemo` hook.
 			popoverDimensionsRecomputeCounter < 0 ||
+			! rootSectionElement ||
 			! selectedElement ||
 			( bottomClientId && ! lastSelectedElement )
 		) {

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -131,8 +131,9 @@ function BlockPopover(
 				// to the section instead of the block to handle blocks that are
 				// not full width and nested blocks to keep section height.
 				if ( isZoomOut && isSectionSelected ) {
-					// if the rootSectionElement is undefined then we need to recurse up the DOM tree
-					// to find the element with ` is-root-container` classname
+					// If the rootSectionElement is undefined then recurse up the DOM tree
+					// to find the element with ` is-root-container` classname.
+					// This can then be used as the anchor point.
 					// FIXME: we should not rely on classnames to find the
 					// root section element
 					if ( ! rootSectionElement ) {

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -109,6 +109,7 @@ function BlockPopover(
 			// exhaustive-deps rule for the `useMemo` hook.
 			popoverDimensionsRecomputeCounter < 0 ||
 			! rootSectionElement ||
+			! parentSectionElement ||
 			! selectedElement ||
 			( bottomClientId && ! lastSelectedElement )
 		) {

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -132,7 +132,9 @@ function BlockPopover(
 				// not full width and nested blocks to keep section height.
 				if ( isZoomOut && isSectionSelected ) {
 					// if the rootSectionElement is undefined then we need to recurse up the DOM tree
-					// to find the element with  wp-block-post-content classname
+					// to find the element with ` is-root-container` classname
+					// FIXME: we should not rely on classnames to find the
+					// root section element
 					if ( ! rootSectionElement ) {
 						postRootElement =
 							selectedElement.closest( '.is-root-container' );

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -94,9 +94,9 @@ function BlockPopover(
 
 		return {
 			getBoundingClientRect() {
-				// The zoom out view has a verical block toolbar that should always
-				// be on the edge of the canvas. This condition chnages the anchor
-				// of the toolbar to the section instead of the block to cover for blocks
+				// The zoom out view has a vertical block toolbar that should always
+				// be on the edge of the canvas. This condition changes the anchor
+				// of the toolbar to the section instead of the block to handle blocks
 				// that are not full width.
 				if ( isZoomOut ) {
 					const selectedBlockRect =

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -115,7 +115,6 @@ function BlockPopover(
 			// than 0. This check is only there to satisfy the correctness of the
 			// exhaustive-deps rule for the `useMemo` hook.
 			popoverDimensionsRecomputeCounter < 0 ||
-			( isZoomOut && ! rootSectionElement ) ||
 			( isZoomOut && ! parentSectionElement ) ||
 			! selectedElement ||
 			( bottomClientId && ! lastSelectedElement )
@@ -125,17 +124,26 @@ function BlockPopover(
 
 		return {
 			getBoundingClientRect() {
+				let postRootElement;
 				// The zoom out view has a vertical block toolbar that should always
 				// be on the edge of the canvas, aligned to the top of the currently
 				// selected section. This condition changes the anchor of the toolbar
 				// to the section instead of the block to handle blocks that are
 				// not full width and nested blocks to keep section height.
 				if ( isZoomOut && isSectionSelected ) {
+					// if the rootSectionElement is undefined then we need to recurse up the DOM tree
+					// to find the element with  wp-block-post-content classname
+					if ( ! rootSectionElement ) {
+						postRootElement =
+							selectedElement.closest( '.is-root-container' );
+					}
+
 					// Compute the height based on the parent section of the
 					// selected block, because the selected block may be
 					// shorter than the section.
-					const rootSectionElementRect =
-						getVisibleElementBounds( rootSectionElement );
+					const rootSectionElementRect = getVisibleElementBounds(
+						rootSectionElement || postRootElement
+					);
 					const parentSectionElementRect =
 						getVisibleElementBounds( parentSectionElement );
 					const anchorHeight =

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -132,13 +132,14 @@ function BlockPopover(
 				// not full width and nested blocks to keep section height.
 				if ( isZoomOut && isSectionSelected ) {
 					// If the rootSectionElement is undefined then recurse up the DOM tree
-					// to find the element with `is-root-container` classname.
+					// to find the element with `block-editor-iframe__body` classname.
 					// This can then be used as the anchor point.
 					// FIXME: we should not rely on classnames to find the
 					// root section element
 					if ( ! rootSectionElement ) {
-						postRootElement =
-							selectedElement.closest( '.is-root-container' );
+						postRootElement = selectedElement.closest(
+							'.block-editor-iframe__body'
+						);
 					}
 
 					// Compute the height based on the parent section of the
@@ -176,11 +177,14 @@ function BlockPopover(
 			contextElement: selectedElement,
 		};
 	}, [
-		bottomClientId,
-		lastSelectedElement,
-		selectedElement,
 		popoverDimensionsRecomputeCounter,
 		isZoomOut,
+		parentSectionElement,
+		selectedElement,
+		bottomClientId,
+		lastSelectedElement,
+		isSectionSelected,
+		rootSectionElement,
 	] );
 
 	if ( ! selectedElement || ( bottomClientId && ! lastSelectedElement ) ) {

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -132,7 +132,7 @@ function BlockPopover(
 				// not full width and nested blocks to keep section height.
 				if ( isZoomOut && isSectionSelected ) {
 					// If the rootSectionElement is undefined then recurse up the DOM tree
-					// to find the element with ` is-root-container` classname.
+					// to find the element with `is-root-container` classname.
 					// This can then be used as the anchor point.
 					// FIXME: we should not rely on classnames to find the
 					// root section element

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -77,8 +77,12 @@ function BlockPopover(
 		};
 	}, [ selectedElement ] );
 
-	const { isZoomOut: isZoomOutFn } = unlock( useSelect( blockEditorStore ) );
-	const isZoomOut = isZoomOutFn();
+	const { isZoomOut } = useSelect(
+		( select ) => ( {
+			isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
+		} ),
+		[]
+	);
 
 	const popoverAnchor = useMemo( () => {
 		if (

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -128,7 +128,7 @@ function BlockPopover(
 				// The zoom out view has a vertical block toolbar that should always
 				// be on the edge of the canvas, aligned to the top of the currently
 				// selected section. This condition changes the anchor of the toolbar
-				// to the section instead of the block to handle blocksn that are
+				// to the section instead of the block to handle blocks that are
 				// not full width and nested blocks to keep section height.
 				if ( isZoomOut && isSectionSelected ) {
 					// Compute the height based on the parent section of the

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -117,12 +117,6 @@ function BlockPopover(
 
 		return {
 			getBoundingClientRect() {
-				// The popover should be positioned relative to the root element of the canvas. The canvas is the container of
-				// content in zoom out mode.
-				// FIXME: This should not be accessed by classname.
-				const canvasElement = selectedElement.closest(
-					'.block-editor-iframe__body'
-				);
 				// The zoom out view has a vertical block toolbar that should always
 				// be on the edge of the canvas, aligned to the top of the currently
 				// selected section. This condition changes the anchor of the toolbar
@@ -132,8 +126,9 @@ function BlockPopover(
 					// Compute the height based on the parent section of the
 					// selected block, because the selected block may be
 					// shorter than the section.
-					const canvasElementRect =
-						getVisibleElementBounds( canvasElement );
+					const canvasElementRect = getVisibleElementBounds(
+						__unstableContentRef.current
+					);
 					const parentSectionElementRect =
 						getVisibleElementBounds( parentSectionElement );
 					const anchorHeight =
@@ -168,6 +163,7 @@ function BlockPopover(
 		bottomClientId,
 		lastSelectedElement,
 		isSectionSelected,
+		__unstableContentRef,
 	] );
 
 	if ( ! selectedElement || ( bottomClientId && ! lastSelectedElement ) ) {

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -117,9 +117,10 @@ function BlockPopover(
 
 		return {
 			getBoundingClientRect() {
-				// The popover should be positioned relative to the root element of the canvas.
+				// The popover should be positioned relative to the root element of the canvas. The canvas is the container of
+				// content in zoom out mode.
 				// FIXME: This should not be accessed by classname.
-				const rootSectionElement = selectedElement.closest(
+				const canvasElement = selectedElement.closest(
 					'.block-editor-iframe__body'
 				);
 				// The zoom out view has a vertical block toolbar that should always
@@ -131,8 +132,8 @@ function BlockPopover(
 					// Compute the height based on the parent section of the
 					// selected block, because the selected block may be
 					// shorter than the section.
-					const rootSectionElementRect =
-						getVisibleElementBounds( rootSectionElement );
+					const canvasElementRect =
+						getVisibleElementBounds( canvasElement );
 					const parentSectionElementRect =
 						getVisibleElementBounds( parentSectionElement );
 					const anchorHeight =
@@ -141,9 +142,9 @@ function BlockPopover(
 
 					// Always use the width of the section root element to make sure
 					// the toolbar is always on the edge of the canvas.
-					const anchorWidth = rootSectionElementRect.width;
+					const anchorWidth = canvasElementRect.width;
 					return new window.DOMRectReadOnly(
-						rootSectionElementRect.left,
+						canvasElementRect.left,
 						parentSectionElementRect.top,
 						anchorWidth,
 						anchorHeight

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -43,9 +43,7 @@ export function useShowBlockTools() {
 			isEmptyDefaultBlock;
 		const isZoomOut = editorMode === 'zoom-out';
 		const _showZoomOutToolbar =
-			isZoomOut &&
-			block?.attributes?.align === 'full' &&
-			! _showEmptyBlockSideInserter;
+			clientId && isZoomOut && ! _showEmptyBlockSideInserter;
 		const _showBlockToolbarPopover =
 			! _showZoomOutToolbar &&
 			! getSettings().hasFixedToolbar &&

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -8,6 +8,7 @@ import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 /**
  * Source of truth for which block tools are showing in the block editor.
@@ -24,7 +25,9 @@ export function useShowBlockTools() {
 			getSettings,
 			__unstableGetEditorMode,
 			isTyping,
-		} = select( blockEditorStore );
+			getBlockOrder,
+			getSectionRootClientId,
+		} = unlock( select( blockEditorStore ) );
 
 		const clientId =
 			getSelectedBlockClientId() || getFirstMultiSelectedBlockClientId();
@@ -42,8 +45,14 @@ export function useShowBlockTools() {
 			editorMode === 'edit' &&
 			isEmptyDefaultBlock;
 		const isZoomOut = editorMode === 'zoom-out';
+		const isSectionSelected = getBlockOrder(
+			getSectionRootClientId()
+		).includes( clientId );
 		const _showZoomOutToolbar =
-			clientId && isZoomOut && ! _showEmptyBlockSideInserter;
+			clientId &&
+			isZoomOut &&
+			! _showEmptyBlockSideInserter &&
+			isSectionSelected;
 		const _showBlockToolbarPopover =
 			! _showZoomOutToolbar &&
 			! getSettings().hasFixedToolbar &&

--- a/packages/block-editor/src/components/block-tools/zoom-out-popover.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-popover.js
@@ -5,7 +5,7 @@ import clsx from 'clsx';
 /**
  * Internal dependencies
  */
-import BlockPopover from '../block-popover';
+import { PrivateBlockPopover as BlockPopover } from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
 import ZoomOutToolbar from './zoom-out-toolbar';
@@ -29,6 +29,7 @@ export default function ZoomOutPopover( { clientId, __unstableContentRef } ) {
 
 	return (
 		<BlockPopover
+			__unstableContentRef={ __unstableContentRef }
 			clientId={ capturingClientId || clientId }
 			bottomClientId={ lastClientId }
 			className={ clsx( 'zoom-out-toolbar-popover', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65785 
Fixes #65570

Make sure all the elements identified as sections - full width or not.- display the same vertical toolbar specific to sections.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistent UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

1. Enable the new `ZoomOutToolbar` for all sections and remove the full width condition.
2. Anchor the toolbar based on parent width so that the position outside of main is preserved (instead of anchoring based on selected element width).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a template
2. Add some patterns
3. Add a block in between patterns
4. Enable zoom out
5. The block should be identified as a small section
6. Select the block
7. Notice the same vertical toolbar specific to zoom out appears


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0cde467c-ba4e-4679-a47c-427c65f45071



Related #63519 - the difference in how in the post editor we only have an html container but no container block is problematic here too.

Co-authored-by: draganescu <andraganescu@git.wordpress.org>
Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: talldan <talldanwp@git.wordpress.org>
Co-authored-by: ciampo <mciampini@git.wordpress.org>
Co-authored-by: jsnajdr <jsnajdr@git.wordpress.org>
Co-authored-by: MaggieCabrera <onemaggie@git.wordpress.org>
Co-authored-by: richtabor <richtabor@git.wordpress.org>
Co-authored-by: stokesman <presstoke@git.wordpress.org>
Co-authored-by: andrewserong <andrewserong@git.wordpress.org>