### PR TITLE
Data Views: enable pinning items

### DIFF
--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -27,6 +27,9 @@ type DataViewsContextType< Item > = {
 	setOpenedFilter: ( openedFilter: string | null ) => void;
 	getItemId: ( item: Item ) => string;
 	density: number;
+	onPinItem?: ( itemId: string ) => void;
+	onUnpinItem?: ( itemId: string ) => void;
+	pinnedItems: string[];
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -38,12 +41,15 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 		totalItems: 0,
 		totalPages: 0,
 	},
+	pinnedItems: [],
 	selection: [],
 	onChangeSelection: () => {},
 	setOpenedFilter: () => {},
 	openedFilter: null,
 	getItemId: ( item ) => item.id,
 	density: 0,
+	onPinItem: () => {},
+	onUnpinItem: () => {},
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -28,6 +28,9 @@ export default function DataViewsLayout() {
 		onChangeSelection,
 		setOpenedFilter,
 		density,
+		onPinItem,
+		onUnpinItem,
+		pinnedItems = [],
 	} = useContext( DataViewsContext );
 
 	const ViewComponent = VIEW_LAYOUTS.find( ( v ) => v.type === view.type )
@@ -46,6 +49,9 @@ export default function DataViewsLayout() {
 			setOpenedFilter={ setOpenedFilter }
 			view={ view }
 			density={ density }
+			onPinItem={ onPinItem }
+			onUnpinItem={ onUnpinItem }
+			pinnedItems={ pinnedItems }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -25,6 +25,7 @@ import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
+import { __ } from '@wordpress/i18n';
 
 type ItemWithId = { id: string };
 
@@ -135,13 +136,48 @@ export default function DataViews< Item >( {
 		} );
 	}, [ data, getItemId, combinedPinnedItems ] );
 
+	const createDefaultActions = useCallback(
+		( callback: ( items: Item[], context: any ) => void ) => {
+			return [
+				{
+					id: 'pin',
+					label: __( 'Pin' ),
+					callback: ( items: Item[], context: any ) => {
+						items.forEach( ( item ) =>
+							onPinItem( getItemId( item ) )
+						);
+						callback( items, context );
+					},
+				},
+				{
+					id: 'unpin',
+					label: __( 'Unpin' ),
+					callback: ( items: Item[], context: any ) => {
+						items.forEach( ( item ) =>
+							onUnpinItem( getItemId( item ) )
+						);
+						callback( items, context );
+					},
+				},
+			];
+		},
+		[ getItemId, onPinItem, onUnpinItem ]
+	);
+
+	const actionsWithDefaultActions = useMemo( () => {
+		const defaultActions = createDefaultActions(
+			( items, context ) => context.onActionPerformed?.( items )
+		);
+		return [ ...defaultActions, ...actions ];
+	}, [ actions, createDefaultActions ] );
+
 	return (
 		<DataViewsContext.Provider
 			value={ {
 				view,
 				onChangeView,
 				fields: _fields,
-				actions,
+				actions: actionsWithDefaultActions,
 				data: dataWithPinnedItems,
 				isLoading,
 				paginationInfo,

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -23,9 +23,16 @@ import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
 import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
-import type { Action, Field, View, SupportedLayouts } from '../../types';
+import type {
+	Action,
+	Field,
+	View,
+	SupportedLayouts,
+	ActionContext,
+} from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
 import { __ } from '@wordpress/i18n';
+import { pin } from '@wordpress/icons';
 
 type ItemWithId = { id: string };
 
@@ -140,35 +147,40 @@ export default function DataViews< Item >( {
 		( callback: ( items: Item[], context: any ) => void ) => {
 			return [
 				{
-					id: 'pin',
-					label: __( 'Pin' ),
-					callback: ( items: Item[], context: any ) => {
-						items.forEach( ( item ) =>
-							onPinItem( getItemId( item ) )
-						);
-						callback( items, context );
+					id: 'togglePin',
+					label: ( items: Item[] ) => {
+						const itemId = getItemId( items[ 0 ] );
+						return combinedPinnedItems.includes( itemId )
+							? __( 'Unpin' )
+							: __( 'Pin' );
 					},
-				},
-				{
-					id: 'unpin',
-					label: __( 'Unpin' ),
-					callback: ( items: Item[], context: any ) => {
-						items.forEach( ( item ) =>
-							onUnpinItem( getItemId( item ) )
-						);
+					isPrimary: true,
+					icon: pin,
+					callback: (
+						items: Item[],
+						context: ActionContext< Item >
+					) => {
+						items.forEach( ( item ) => {
+							const itemId = getItemId( item );
+							if ( combinedPinnedItems.includes( itemId ) ) {
+								onUnpinItem( itemId );
+							} else {
+								onPinItem( itemId );
+							}
+						} );
 						callback( items, context );
 					},
 				},
 			];
 		},
-		[ getItemId, onPinItem, onUnpinItem ]
+		[ getItemId, onPinItem, onUnpinItem, combinedPinnedItems ]
 	);
 
 	const actionsWithDefaultActions = useMemo( () => {
 		const defaultActions = createDefaultActions(
 			( items, context ) => context.onActionPerformed?.( items )
 		);
-		return [ ...defaultActions, ...actions ];
+		return [ ...defaultActions, ...actions ]; // Combine default and custom actions
 	}, [ actions, createDefaultActions ] );
 
 	return (

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -56,6 +56,7 @@ type DataViewsProps< Item > = {
 	onPinItem?: ( itemId: string ) => void;
 	onUnpinItem?: ( itemId: string ) => void;
 	pinnedItems?: string[];
+	enablePinnedItems?: boolean;
 } & ( Item extends ItemWithId
 	? { getItemId?: ( item: Item ) => string }
 	: { getItemId: ( item: Item ) => string } );
@@ -78,6 +79,7 @@ export default function DataViews< Item >( {
 	onChangeSelection,
 	header,
 	pinnedItems = [],
+	enablePinnedItems = false,
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const [ density, setDensity ] = useState< number >( 0 );
@@ -127,6 +129,10 @@ export default function DataViews< Item >( {
 
 	// Sort pinned items to the top of the data array
 	const dataWithPinnedItems = useMemo( () => {
+		if ( ! enablePinnedItems ) {
+			return data;
+		}
+
 		return [ ...data ].sort( ( a, b ) => {
 			const aId = getItemId( a );
 			const bId = getItemId( b );
@@ -141,10 +147,13 @@ export default function DataViews< Item >( {
 			}
 			return 0;
 		} );
-	}, [ data, getItemId, combinedPinnedItems ] );
+	}, [ enablePinnedItems, data, getItemId, combinedPinnedItems ] );
 
 	const createDefaultActions = useCallback(
 		( callback: ( items: Item[], context: any ) => void ) => {
+			if ( ! enablePinnedItems ) {
+				return [];
+			}
 			return [
 				{
 					id: 'togglePin',
@@ -173,15 +182,24 @@ export default function DataViews< Item >( {
 				},
 			];
 		},
-		[ getItemId, onPinItem, onUnpinItem, combinedPinnedItems ]
+		[
+			enablePinnedItems,
+			getItemId,
+			onPinItem,
+			onUnpinItem,
+			combinedPinnedItems,
+		]
 	);
 
 	const actionsWithDefaultActions = useMemo( () => {
+		if ( ! enablePinnedItems ) {
+			return actions;
+		}
 		const defaultActions = createDefaultActions(
 			( items, context ) => context.onActionPerformed?.( items )
 		);
 		return [ ...defaultActions, ...actions ]; // Combine default and custom actions
-	}, [ actions, createDefaultActions ] );
+	}, [ enablePinnedItems, actions, createDefaultActions ] );
 
 	return (
 		<DataViewsContext.Provider

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -184,3 +184,39 @@ export const CombinedFields = () => {
 		/>
 	);
 };
+
+export const PinnedItems = () => {
+	const [ view, setView ] = useState< View >( {
+		...DEFAULT_VIEW,
+		fields: [ 'title', 'description', 'categories' ],
+	} );
+	const { data: shownData, paginationInfo } = useMemo( () => {
+		return filterSortAndPaginate( data, view, fields );
+	}, [ view ] );
+	// Pin the first item
+	const [ pinnedItems, setPinnedItems ] = useState< string[] >( [
+		...shownData[ 0 ].id.toString(),
+	] );
+
+	return (
+		<DataViews
+			getItemId={ ( item ) => item.id.toString() }
+			paginationInfo={ paginationInfo }
+			data={ shownData }
+			enablePinnedItems
+			pinnedItems={ pinnedItems }
+			onPinItem={ ( itemId: string ) => {
+				setPinnedItems( ( prev ) => [ ...prev, itemId ] );
+			} }
+			onUnpinItem={ ( itemId: string ) => {
+				setPinnedItems( ( prev ) =>
+					prev.filter( ( id ) => id !== itemId )
+				);
+			} }
+			onChangeView={ setView }
+			defaultLayouts={ defaultLayouts }
+			view={ view }
+			fields={ fields }
+		/>
+	);
+};

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -472,17 +472,16 @@ export interface ActionModal< Item > extends ActionBase< Item > {
 	modalHeader?: string;
 }
 
+export interface ActionContext< Item > {
+	registry: any;
+	onActionPerformed?: ( items: Item[] ) => void;
+}
+
 export interface ActionButton< Item > extends ActionBase< Item > {
 	/**
 	 * The callback to execute when the action is triggered.
 	 */
-	callback: (
-		items: Item[],
-		context: {
-			registry: any;
-			onActionPerformed?: ( items: Item[] ) => void;
-		}
-	) => void;
+	callback: ( items: Item[], context: ActionContext< Item > ) => void;
 }
 
 export type Action< Item > = ActionModal< Item > | ActionButton< Item >;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -499,6 +499,9 @@ export interface ViewBaseProps< Item > {
 	setOpenedFilter: ( fieldId: string ) => void;
 	view: View;
 	density: number;
+	onPinItem?: ( itemId: string ) => void;
+	onUnpinItem?: ( itemId: string ) => void;
+	pinnedItems: string[];
 }
 
 export interface ViewTableProps< Item > extends ViewBaseProps< Item > {

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -200,6 +200,16 @@ function usePostFields( viewType ) {
 				enableSorting: false,
 			},
 			{
+				id: 'is-pinned',
+				label: __( 'Pinned' ),
+				getValue: ( { item } ) =>
+					item.id === frontPageId || item.id === postsPageId,
+				enableSorting: false,
+				render: ( { item } ) =>
+					item.id === frontPageId ||
+					( item.id === postsPageId && <span>Pinned</span> ),
+			},
+			{
 				label: __( 'Title' ),
 				id: 'title',
 				type: 'text',

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -294,6 +294,16 @@ export default function PostList( { postType } ) {
 		totalPages,
 	} = useEntityRecordsWithPermissions( 'postType', postType, queryArgs );
 
+	const pinnedItems = useMemo( () => {
+		return records
+			?.filter( ( record ) =>
+				fields
+					.find( ( f ) => f.id === 'is-pinned' )
+					?.getValue( { item: record } )
+			)
+			.map( ( record ) => getItemId( record ) );
+	}, [ records, fields ] );
+
 	// The REST API sort the authors by ID, but we want to sort them by name.
 	const data = useMemo( () => {
 		if ( ! isLoadingFields && view?.sort?.field === 'author' ) {
@@ -404,6 +414,7 @@ export default function PostList( { postType } ) {
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
 				defaultLayouts={ defaultLayouts }
+				pinnedItems={ pinnedItems }
 				header={
 					window.__experimentalQuickEditDataViews &&
 					view.type !== LAYOUT_LIST &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## To-do

- [x] Implement pinning logic in Data Views.
- [x] Implement pinning actions in the UI.
- [ ] Q: Should default pins be unpinnable?
- [ ] Persist options.

## What?
Enable pinning items in the page list and data views, with pinned pages sorted at the top.

## Why?
This PR is a WIP Proof of Concept for issues [#65379](https://github.com/WordPress/gutenberg/issues/65379) and https://github.com/WordPress/gutenberg/issues/64678, which highlighted a problem where important pages like the homepage and posts page were hard to locate in the page list when not pinned to the top. By adding the ability to pin items, it becomes easier to access and manage these important pages.

## How?
The implementation introduces an 'is-pinned' attribute to the post fields, determines pinned pages based on their ID, and sorts these pinned items at the top of the list in the post list component. This change helps ensure that key pages are always easily accessible.

<img width="386" alt="image" src="https://github.com/user-attachments/assets/86f9928d-6626-4b20-b93c-d0f30a686fda">


