### PR TITLE
PHP unit tests: remove WP_RUN_CORE_TESTS const

### DIFF
--- a/phpunit/bootstrap.php
+++ b/phpunit/bootstrap.php
@@ -24,12 +24,6 @@ if ( ! defined( 'LOCAL_WP_ENVIRONMENT_TYPE' ) ) {
 define( 'GUTENBERG_DIR_TESTDATA', __DIR__ . '/data/' );
 define( 'GUTENBERG_DIR_TESTFIXTURES', __DIR__ . '/fixtures/' );
 
-// Pretend that these are Core unit tests. This is needed so that
-// wp_theme_has_theme_json() does not cache its return value between each test.
-if ( ! defined( 'WP_RUN_CORE_TESTS' ) ) {
-	define( 'WP_RUN_CORE_TESTS', true );
-}
-
 // Require composer dependencies.
 require_once dirname( __DIR__ ) . '/vendor/autoload.php';
 


### PR DESCRIPTION
A [recent update in Core ](https://core.trac.wordpress.org/changeset/59086)caused the php tests to fail. 

I asked about it here: https://core.trac.wordpress.org/ticket/61530#comment:54

I got an answer here: https://core.trac.wordpress.org/ticket/61530#comment:55


Removing the `WP_RUN_CORE_TESTS` constant added in https://github.com/WordPress/gutenberg/pull/51950 will negate the check for `IMPORTER_PLUGIN_FOR_TESTS`, which is required for Core tests, but not Gutenberg (right now)



## Testing Instructions

Stare at the PHP tests in CI and will for them to pass. 🤞🏻 