### PR TITLE
Comment Date: Add block example

### DIFF
--- a/packages/block-library/src/comment-date/index.js
+++ b/packages/block-library/src/comment-date/index.js
@@ -18,6 +18,7 @@ export const settings = {
 	icon,
 	edit,
 	deprecated,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds block example definition for the Comment Date block.

Note: Without a `commentId` supplied via block context the block will only render `Comment Date` text rather than a date. This is how it works for existing previews on things like the parent Comments block. This PR at least allows the Style Book to display what styling the date string would ultimately receive.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

- Adds an example to the Comment Date block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm block example displays for the Comment Date block.
3. Insert a Comments block, select the Comments Template then click the quick inserter.
4. In the insert popover, select Browse All to open the main inserter, then search for Comment Date
5. Confirm the example displays in the preview for the Comment Date block.


## Screenshots or screencast <!-- if applicable -->

<img width="431" alt="Screenshot 2024-09-25 at 3 36 44 pm" src="https://github.com/user-attachments/assets/be5d4907-64cc-4f77-87c7-436640589c88">
<img width="679" alt="Screenshot 2024-09-25 at 3 37 21 pm" src="https://github.com/user-attachments/assets/5e3e253e-f31b-4d18-80f6-fc88fae83c80">
