### PR TITLE
Comment Pagination: Add previous and next link block examples

### DIFF
--- a/packages/block-library/src/comments-pagination-next/block.json
+++ b/packages/block-library/src/comments-pagination-next/block.json
@@ -12,6 +12,11 @@
 			"type": "string"
 		}
 	},
+	"example": {
+		"attributes": {
+			"label": "Comments Next Page"
+		}
+	},
 	"usesContext": [ "postId", "comments/paginationArrow" ],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/comments-pagination-previous/block.json
+++ b/packages/block-library/src/comments-pagination-previous/block.json
@@ -12,6 +12,11 @@
 			"type": "string"
 		}
 	},
+	"example": {
+		"attributes": {
+			"label": "Comments Previous Page"
+		}
+	},
 	"usesContext": [ "postId", "comments/paginationArrow" ],
 	"supports": {
 		"reusable": false,


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds block example definitions for the Comment Pagination Previous/Next blocks.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

- Adds an example to the Comment Pagination Previous block.
- Adds an example to the Comment Pagination Next block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm block examples display for both the Comment Pagination Previous and Next blocks.
3. Insert a Comments block, select it, then click the quick inserter.
4. In the insert popover, select Browse All to open the main inserter, then search for Comment Pagination
5. Confirm the example displays in the preview for the Comment Pagination Previous/Next blocks


## Screenshots or screencast <!-- if applicable -->
<img width="460" alt="Screenshot 2024-09-25 at 4 05 59 pm" src="https://github.com/user-attachments/assets/a20f8571-5e54-4ff7-a784-8054b07361f6">
<img width="686" alt="Screenshot 2024-09-25 at 4 05 38 pm" src="https://github.com/user-attachments/assets/80e1f7f1-3753-4adf-99fd-5f9cddec0f13">
<img width="675" alt="Screenshot 2024-09-25 at 4 05 32 pm" src="https://github.com/user-attachments/assets/6e709b14-78f8-4b7d-9a99-9222eafbabe6">
