### PR TITLE
Comments Pagination Numbers: Add block example

### DIFF
--- a/packages/block-library/src/comments-pagination-numbers/index.js
+++ b/packages/block-library/src/comments-pagination-numbers/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

Adds block example definition for the Comments Pagination Numbers block.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

- Adds an example to the Comments Pagination Numbers block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm block example displays for the Comments Pagination Numbers block.
3. Insert a Comments block, select it, then click the quick inserter
4. In the insert popover, select Browse All to open the main inserter, then search for Comments Pagination Numbers
5. Confirm the example displays in the preview for the Comments Pagination Numbers block.


## Screenshots or screencast <!-- if applicable -->
<img width="420" alt="Screenshot 2024-09-25 at 4 10 10 pm" src="https://github.com/user-attachments/assets/8fc35a57-a897-44b1-8ba8-a6704ee157b2">
<img width="679" alt="Screenshot 2024-09-25 at 4 09 41 pm" src="https://github.com/user-attachments/assets/cecfb529-dcb1-47f1-bdff-c3b992d8baf4">

