### PR TITLE
Query Pagination Numbers: Add block example

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/index.js
+++ b/packages/block-library/src/query-pagination-numbers/index.js
@@ -16,6 +16,7 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/query-pagination/index.js
+++ b/packages/block-library/src/query-pagination/index.js
@@ -20,7 +20,6 @@ export const settings = {
 	edit,
 	save,
 	deprecated,
-	example: {},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707
Related: https://github.com/WordPress/gutenberg/pull/65430

## What?

- Adds block example definition for the **Query Pagination Numbers** block.
- Removes recent addition of example for Query Pagination block
    - This makes the Query Pagination blocks consistent with the Comments pagination blocks
    - There are some difficulties providing examples for blocks that rely on Posts and Comments in block context. 
    - Displaying the lower level blocks means they can be clicked to open their respective block types under Global Styles
    - It's arguable that duplicating the examples in the Style Book (to include the parent Query Pagination example) provides added value. It can be revisited in a future follow-up if desired.

## Why?

The Style Book is being iterated on and part of that effort is to ensure the desired blocks are shown there. Currently, this is dependent on blocks having an example defined.

## How?

- Adds an example to the Query Pagination Numbers block.
- Removes the example from the Query Pagination block.

## Testing Instructions

1. Navigate to the Style Book, (Appearance > Editor > Styles > Style Book icon) and switch to the "Theme" tab.
2. Confirm block example displays for the Query Pagination Numbers block.
3. Confirm block example Query Pagination block **does not display.**
4. Insert a Query Loop block, select it, then click the quick inserter.
5. In the insert popover, select Browse All to open the main inserter, then search for Numbers
6. Confirm the example displays in the preview for the Page Numbers but not the Pagination block.


## Screenshots or screencast <!-- if applicable -->
<img width="425" alt="Screenshot 2024-09-25 at 4 50 59 pm" src="https://github.com/user-attachments/assets/b8d2cf3b-35f6-46a5-991b-ad2c85bf93ff">

https://github.com/user-attachments/assets/7f8c76fb-3d3f-419d-b8ec-e179aed240c7


