### PR TITLE
WIP: Components :update `re-resizable` library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26631,11 +26631,6 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
-		"node_modules/fast-memoize": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
-		},
 		"node_modules/fast-uri": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
@@ -43034,18 +43029,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/re-resizable": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
-			"integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
-			"dependencies": {
-				"fast-memoize": "^2.5.1"
-			},
-			"peerDependencies": {
-				"react": "^16.13.1 || ^17.0.0",
-				"react-dom": "^16.13.1 || ^17.0.0"
-			}
-		},
 		"node_modules/react": {
 			"version": "18.3.1",
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -53214,7 +53197,7 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
+				"re-resizable": "^6.10.0",
 				"react-colorful": "^5.3.1",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
@@ -53279,6 +53262,16 @@
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
 			"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+		},
+		"packages/components/node_modules/re-resizable": {
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.10.0.tgz",
+			"integrity": "sha512-hysSK0xmA5nz24HBVztlk4yCqCLCvS32E6ZpWxVKop9x3tqCa4yAj1++facrmkOf62JsJHjmjABdKxXofYioCw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.13.1 || ^17.0.0 || ^18.0.0",
+				"react-dom": "^16.13.1 || ^17.0.0 || ^18.0.0"
+			}
 		},
 		"packages/components/node_modules/uuid": {
 			"version": "8.3.2",
@@ -68273,7 +68266,7 @@
 				"is-plain-object": "^5.0.0",
 				"memize": "^2.1.0",
 				"path-to-regexp": "^6.2.1",
-				"re-resizable": "^6.4.0",
+				"re-resizable": "^6.10.0",
 				"react-colorful": "^5.3.1",
 				"remove-accents": "^0.5.0",
 				"uuid": "^9.0.1"
@@ -68313,6 +68306,11 @@
 					"version": "6.2.2",
 					"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
 					"integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw=="
+				},
+				"re-resizable": {
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.10.0.tgz",
+					"integrity": "sha512-hysSK0xmA5nz24HBVztlk4yCqCLCvS32E6ZpWxVKop9x3tqCa4yAj1++facrmkOf62JsJHjmjABdKxXofYioCw=="
 				},
 				"uuid": {
 					"version": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
@@ -77093,11 +77091,6 @@
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
-		},
-		"fast-memoize": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
-			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw=="
 		},
 		"fast-uri": {
 			"version": "3.0.1",
@@ -89445,14 +89438,6 @@
 					"dev": true,
 					"optional": true
 				}
-			}
-		},
-		"re-resizable": {
-			"version": "6.9.0",
-			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.0.tgz",
-			"integrity": "sha512-3cUDG81ylyqI0Pdgle/RHwwRYq0ORZzsUaySOCO8IbEtNyaRtrIHYm/jMQ5pjcNiKCxR3vsSymIQZHwJq4gg2Q==",
-			"requires": {
-				"fast-memoize": "^2.5.1"
 			}
 		},
 		"react": {

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 -   `MenuGroup`: Simplify the MenuGroup styles within dropdown menus. ([#65561](https://github.com/WordPress/gutenberg/pull/65561)).
 
+### Internal
+
+-   Update `re-resizable` dependency to 6.10.0 ([#65637](https://github.com/WordPress/gutenberg/pull/65637)).
+
 ## 28.8.0 (2024-09-19)
 
 ### Bug Fixes

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,7 +72,7 @@
 		"is-plain-object": "^5.0.0",
 		"memize": "^2.1.0",
 		"path-to-regexp": "^6.2.1",
-		"re-resizable": "^6.4.0",
+		"re-resizable": "^6.10.0",
 		"react-colorful": "^5.3.1",
 		"remove-accents": "^0.5.0",
 		"uuid": "^9.0.1"

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -87,6 +87,17 @@ const HANDLE_STYLES = {
 	bottomLeft: HANDLE_STYLES_OVERRIDES,
 };
 
+const DEFAULT_ENABLE = {
+	top: false,
+	right: false,
+	bottom: false,
+	left: false,
+	topRight: false,
+	bottomRight: false,
+	bottomLeft: false,
+	topLeft: false,
+};
+
 type ResizableBoxProps = ResizableProps & {
 	children: ReactNode;
 	showHandle?: boolean;
@@ -101,6 +112,7 @@ function UnforwardedResizableBox(
 		showHandle = true,
 		__experimentalShowTooltip: showTooltip = false,
 		__experimentalTooltipProps: tooltipProps = {},
+		enable,
 		...props
 	}: ResizableBoxProps,
 	ref: ForwardedRef< Resizable >
@@ -115,6 +127,7 @@ function UnforwardedResizableBox(
 			handleClasses={ HANDLE_CLASSES }
 			handleStyles={ HANDLE_STYLES }
 			ref={ ref }
+			enable={ { ...DEFAULT_ENABLE, ...enable } }
 			{ ...props }
 		>
 			{ children }


### PR DESCRIPTION
## What?

This PR updates the `re-resizable` library used in the `Resizablebox` component from version `6.4.0` to version `6.10.0`.

- [re-resizable changelog](https://github.com/bokuweb/re-resizable/blob/master/CHANGELOG.md)
- [Diff between re-resizable 6.4.0 and 6.10.0](https://github.com/bokuweb/re-resizable/compare/v6.4.0...6.10.0)

## Why?

Gutenberg may render focusable buttons via the `handleComponent` prop to make the resizer focusable and resizable by keyboard events.

These buttons are rendered together after their `children`, which causes a mismatch between the visually expected tab order and the actual tab order.

## How?

I submitted https://github.com/bokuweb/re-resizable/pull/827 to fix this issue. This PR was merged and released as version `6.10.0`. By updating to this version, the tab order will match the visual order.

## Testing Instructions

- Gutenberg uses the `ResizableBox component` with focusable resize handles in the following three places. Please make sure that the tab order and visual order match in these places:
  - Site Editor View Mode
  - Patterns Editor
  - Post Meta Box (Enable custom fields in the post editor)
  - Judging from the CHANGELOG, no breaking changes should have been added on the library side.
- Make sure that the behavior of `ResizableBox` that does not use the `handleComponent` prop, such as the Image block and Site Logo block, remains unchanged.

## Screenshots or screencast <!-- if applicable -->
