### PR TITLE
Adds envelope icon

### DIFF
--- a/packages/icons/CHANGELOG.md
+++ b/packages/icons/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features
 
+-   Add new `envelope` icon.
+
 -   Add new `bell` and `bell-unread` icons.
 
 ## 10.7.0 (2024-09-05)

--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -79,6 +79,7 @@ export { default as drawerLeft } from './library/drawer-left';
 export { default as drawerRight } from './library/drawer-right';
 export { default as download } from './library/download';
 export { default as edit } from './library/edit';
+export { default as envelope } from './library/envelope';
 export { default as external } from './library/external';
 export { default as file } from './library/file';
 export { default as filter } from './library/filter';

--- a/packages/icons/src/library/envelope.js
+++ b/packages/icons/src/library/envelope.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+const envelope = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M3 7c0-1.1.9-2 2-2h14a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7Zm2-.5h14c.3 0 .5.2.5.5v1L12 13.5 4.5 7.9V7c0-.3.2-.5.5-.5Zm-.5 3.3V17c0 .3.2.5.5.5h14c.3 0 .5-.2.5-.5V9.8L12 15.4 4.5 9.8Z"
+		/>
+	</SVG>
+);
+
+export default envelope;


### PR DESCRIPTION
## What?

Add an icon for an envelope

## Why?
Context: https://github.com/WordPress/gutenberg/issues/65531

This icon is widely recognized and helps users quickly identify email-related functions, such as accessing and managing newsletters and interacting with mail interfaces. Its inclusion provides a clear visual representation of these types of communication, which is currently lacking in WordPress.

## Screenshots 

<img width="184" alt="mail-icon_individual" src="https://github.com/user-attachments/assets/82c1f0e5-d622-492a-9ba4-f6c48a1409ba">

## Testing Instructions

- Run Storybook locally npm run storybook:dev
- Open the icon library http://localhost:50240/?path=/story/icons-icon--library
- Search for the `envelope` icon

## References
https://www.figma.com/design/e4tLacmlPuZV47l7901FEs/WordPress-Design-Library?node-id=100489-5216&node-type=frame&t=2IvEe1dEb69GvAMV-11