### PR TITLE
Block Bindings: Fix showing bindings field values in theme templates

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -188,12 +188,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			const postContext = {};
 			// If it is a template, try to inherit the post type from the slug.
 			if ( post.type === 'wp_template' ) {
-				const themeSlug = post.slug;
-				if ( themeSlug === 'page' ) {
+				if ( post.slug === 'page' ) {
 					postContext.postType = 'page';
-				} else if ( themeSlug === 'single' ) {
+				} else if ( post.slug === 'single' ) {
 					postContext.postType = 'post';
-				} else if ( themeSlug.split( '-' )[ 0 ] === 'single' ) {
+				} else if ( post.slug.split( '-' )[ 0 ] === 'single' ) {
 					// If the slug is single-{postType}, infer the post type from the slug.
 					const postTypesSlugs =
 						postTypes?.map( ( entity ) => entity.slug ) || [];

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -188,24 +188,21 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			const postContext = {};
 			// If it is a template, try to inherit the post type from the slug.
 			if ( post.type === 'wp_template' ) {
-				const [ kind ] = post.slug.split( '-' );
-				switch ( kind ) {
-					case 'page':
-						if ( ! post.is_custom ) {
-							postContext.postType = 'page';
-						}
-						break;
-					case 'single':
-						// Infer the post type from the slug.
-						const postTypesSlugs =
-							postTypes?.map( ( entity ) => entity.slug ) || [];
-						const match = post.slug.match(
-							`^single-(${ postTypesSlugs.join( '|' ) })(?:-.+)?$`
-						);
-						if ( match ) {
-							postContext.postType = match[ 1 ];
-						}
-						break;
+				const themeSlug = post.slug;
+				if ( themeSlug === 'page' ) {
+					postContext.postType = 'page';
+				} else if ( themeSlug === 'single' ) {
+					postContext.postType = 'post';
+				} else if ( themeSlug.split( '-' )[ 0 ] === 'single' ) {
+					// If the slug is single-{postType}, infer the post type from the slug.
+					const postTypesSlugs =
+						postTypes?.map( ( entity ) => entity.slug ) || [];
+					const match = post.slug.match(
+						`^single-(${ postTypesSlugs.join( '|' ) })(?:-.+)?$`
+					);
+					if ( match ) {
+						postContext.postType = match[ 1 ];
+					}
 				}
 			} else if (
 				! NON_CONTEXTUAL_POST_TYPES.includes( rootLevelPost.type ) ||

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -188,27 +188,24 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			const postContext = {};
 			// If it is a template, try to inherit the post type from the slug.
 			if ( post.type === 'wp_template' ) {
-				if ( ! post.is_custom ) {
-					const [ kind ] = post.slug.split( '-' );
-					switch ( kind ) {
-						case 'page':
+				const [ kind ] = post.slug.split( '-' );
+				switch ( kind ) {
+					case 'page':
+						if ( ! post.is_custom ) {
 							postContext.postType = 'page';
-							break;
-						case 'single':
-							// Infer the post type from the slug.
-							const postTypesSlugs =
-								postTypes?.map( ( entity ) => entity.slug ) ||
-								[];
-							const match = post.slug.match(
-								`^single-(${ postTypesSlugs.join(
-									'|'
-								) })(?:-.+)?$`
-							);
-							if ( match ) {
-								postContext.postType = match[ 1 ];
-							}
-							break;
-					}
+						}
+						break;
+					case 'single':
+						// Infer the post type from the slug.
+						const postTypesSlugs =
+							postTypes?.map( ( entity ) => entity.slug ) || [];
+						const match = post.slug.match(
+							`^single-(${ postTypesSlugs.join( '|' ) })(?:-.+)?$`
+						);
+						if ( match ) {
+							postContext.postType = match[ 1 ];
+						}
+						break;
 				}
 			} else if (
 				! NON_CONTEXTUAL_POST_TYPES.includes( rootLevelPost.type ) ||


### PR DESCRIPTION
## What?
While working on adding [this test](https://github.com/WordPress/gutenberg/pull/65526/files#diff-169d4acdecb966fa33b188dcf2bfa92aca9f3ac66c188a4b8facbd45b5e806dcR62), I realized that connected blocks in CPT templates like `single-movie` weren't showing the default values. When you create a single-movie template from the editor, it works as expected. However, when you directly create a `single-movie.html` in your theme, it doesn't.

This pull request aims to solve that.

## Why?
It should work for theme files as well.

## How?
After triaging it, it seems that `single-movie.html` is treated as a custom template, even if it is specific to movies. For that reason, I've change the conditional to not rely on `post.is_custom` and directly check the slug. That conditional was there to cover use cases like `page-custom-template`. With the new code, it directly checks that the theme slug **matches** "page", while previously it was checking the theme slug **starts with** "page". 

## Testing Instructions
This one is hard to test manually because you need a CPT theme template like `single-movie.html` and cannot be created through the editor UI. It will be covered by [this automated test](https://github.com/WordPress/gutenberg/pull/65526/files#diff-169d4acdecb966fa33b188dcf2bfa92aca9f3ac66c188a4b8facbd45b5e806dcR62), among others, in the future.

Basically, you would need to:
1. Register a custom field for a "movie" CPT:
register_meta(
		'post',
		'movie_title',
		array(
			'label'          => 'Movie Title',
			'object_subtype' => 'movie',
			'show_in_rest' => true,
			'single'       => true,
			'type'         => 'string',
			'default'	   => 'Default movie title',
		)
	);
2. Create a `single-movie.html` file in your theme.
3. Go to your single movie template and add a paragraph connected to that field.
4. Check that it shows the default value instead of the key.
