### PR TITLE
Docs: Remove PHPDoc for non-existing parameter

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -13,9 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Overrides the REST controller for the `wp_global_styles` post type.
  *
- * @param array  $args      Array of arguments for registering a post type.
+ * @param array $args Array of arguments for registering a post type.
  *                          See the register_post_type() function for accepted arguments.
- * @param string $post_type Post type key.
  *
  * @return array Array of arguments for registering a post type.
  */


### PR DESCRIPTION
## What?
The function `gutenberg_override_global_styles_endpoint` only has a `$args` parameter, so we should remove the PHPDoc for the non-existing `$post_type` parameter.