### PR TITLE
Use custom name in block sidebar if available (retaining block type information)

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -76,13 +76,16 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 								sprintf(
 									// translators:  1: Custom block name. 2: Block title.
 									_x(
-										'%1$s <badge>%2$s</badge>',
+										'<span>%1$s</span> <badge>%2$s</badge>',
 										'block label'
 									),
 									name,
 									title
 								),
 								{
+									span: (
+										<span className="block-editor-block-card__name" />
+									),
 									badge: <Badge />,
 								}
 						  )

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -11,16 +11,21 @@ import {
 	Button,
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { __, _x, isRTL, sprintf } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
 
 function BlockCard( { title, icon, description, blockType, className, name } ) {
 	if ( blockType ) {
@@ -67,11 +72,19 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 			<VStack spacing={ 1 }>
 				<h2 className="block-editor-block-card__title">
 					{ name?.length
-						? sprintf(
-								// translators:  1: Custom block name. 2: Block title.
-								_x( '%1$s (%2$s)', 'block label' ),
-								name,
-								title
+						? createInterpolateElement(
+								sprintf(
+									// translators:  1: Custom block name. 2: Block title.
+									_x(
+										'%1$s <badge>%2$s</badge>',
+										'block label'
+									),
+									name,
+									title
+								),
+								{
+									badge: <Badge />,
+								}
 						  )
 						: title }
 				</h2>

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -7,6 +7,9 @@
 
 .block-editor-block-card__title {
 	font-weight: 500;
+	display: flex;
+	align-items: center;
+	gap: 0 $grid-unit-10;
 
 	&.block-editor-block-card__title {
 		font-size: $default-font-size;
@@ -27,3 +30,4 @@
 .block-editor-block-card.is-synced .block-editor-block-icon {
 	color: var(--wp-block-synced-color);
 }
+

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -9,7 +9,8 @@
 	font-weight: 500;
 	display: flex;
 	align-items: center;
-	gap: 0 $grid-unit-10;
+	flex-wrap: wrap;
+	gap: #{$grid-unit-10 / 2} $grid-unit-10;
 
 	&.block-editor-block-card__title {
 		font-size: $default-font-size;

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -10,7 +10,7 @@
 	display: flex;
 	align-items: center;
 	flex-wrap: wrap;
-	gap: #{$grid-unit-10 / 2} $grid-unit-10;
+	gap: calc($grid-unit-10 / 2) $grid-unit-10;
 
 	&.block-editor-block-card__title {
 		font-size: $default-font-size;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

~Removes the block's name (e.g. `Group`) from the inspector controls if a custom name is defined.~

Use custom name (e.g. "My cool block") in block sidebar details panel if defined and include a "badge" to retain information about the original block type (e.g. `Group`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Suggested by @richtabor in https://github.com/WordPress/gutenberg/pull/65398#issuecomment-2368853179.

Discussion in this PR has evolved the concept somewhat.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Create x2 Group blocks
- Rename the first Group block with a custom name.
- Check that only the custom name/block name is shown in the block's inspector controls based on whether the block has/hasn't a custom name.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="630" alt="Screen Shot 2024-12-16 at 11 23 14" src="https://github.com/user-attachments/assets/95015790-1617-4a9c-85ec-b587db1ef48e" />

<img width="743" alt="Screen Shot 2024-12-16 at 11 23 02" src="https://github.com/user-attachments/assets/a04f80d6-c704-466a-bd1f-4ff94d17d151" />

