### PR TITLE
Flattens icon and reduces its weight

### DIFF
--- a/packages/icons/src/library/square.js
+++ b/packages/icons/src/library/square.js
@@ -4,13 +4,11 @@
 import { SVG, Path } from '@wordpress/primitives';
 
 const square = (
-	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
-			fill="none"
-			d="M5.75 12.75V18.25H11.25M12.75 5.75H18.25V11.25"
-			stroke="currentColor"
-			strokeWidth="1.5"
-			strokeLinecap="square"
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M17.5 6.5h-4.75V5H19v6.25h-1.5V6.5ZM5 12.75h1.5v4.75h4.75V19H5v-6.25Z"
 		/>
 	</SVG>
 );


### PR DESCRIPTION
## What?
The current code for the square icon introduced [here](https://github.com/WordPress/gutenberg/pull/65183/) included a fixed `strokeWidth="1.5"` and other unecessary tags like `strokeLinecap="square"`. When pasted on Figma, the icon displays a width of `1px` instead of `1.5px`, by flattening we'll have a consistent line weight.

This PR flattens the icon and also reduces its weight.

## Testing Instructions
- Run Storybook locally npm run storybook:dev
- Open the icon library http://localhost:50240/?path=/story/icons-icon--library
- Search for the `square` icon

## Screenshots 
 
Here is the icon in context before and after:

![image](https://github.com/user-attachments/assets/a9686d6f-f385-4427-a3a6-c44a0910e319)
