### PR TITLE
LinkControl: Fix unneeded `props` prop

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -421,7 +421,6 @@ function LinkControl( {
 									</InputControlSuffixWrapper>
 								)
 							}
-							props
 						/>
 					</div>
 					{ errorMessage && (


### PR DESCRIPTION
Follow-up to #65158

## What?

Removes an unnecessary `props` prop in the LinkControl that was added [by mistake](https://github.com/WordPress/gutenberg/pull/65158/files#r1774012288).

## Testing Instructions

Insert a Paragraph block, select a string range and try to add a link. The link popover should work as expected.