### PR TITLE
Zoom out: Reset zoom out level when device type is changed

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -28,6 +28,7 @@ import { ActionItem } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import PostPreviewButton from '../post-preview-button';
+import { unlock } from '../../lock-unlock';
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 	const { deviceType, homeUrl, isTemplate, isViewable, showIconLabels } =
@@ -46,10 +47,12 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		}, [] );
 	const { setDeviceType } = useDispatch( editorStore );
 	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
+	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
 		setDeviceType( newDeviceType );
 		__unstableSetEditorMode( 'edit' );
+		resetZoomLevel();
 	};
 
 	const isMobile = useViewportMatch( 'medium', '<' );


### PR DESCRIPTION
Related to #65411

## What?

To fix #65411, a fix was made in #65444 to handle zoom out mode when the device preview changes. However, in trunk, changing the device preview does not disable the zoom out mode.

## Why?

My guess is that it has to do with the zoom out level introduced by #65482.

## How?

Add `resetZoomLevel()`.

## Testing Instructions

Follow the testing instructions in #65444.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/fd52111f-3d66-4714-8df0-4857bb526415


### After

https://github.com/user-attachments/assets/293dca6d-6fd6-447b-9d9e-2f6bf3af7323


