### PR TITLE
DatePicker: Use compact button size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Enhancements
 
 -   `MenuGroup`: Simplify the MenuGroup styles within dropdown menus. ([#65561](https://github.com/WordPress/gutenberg/pull/65561)).
+-   `DatePicker`: Use compact button size. ([#65653](https://github.com/WordPress/gutenberg/pull/65653)).
 
 ## 28.8.0 (2024-09-19)
 

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -125,6 +125,7 @@ export function DatePicker( {
 							)
 						);
 					} }
+					size="compact"
 				/>
 				<NavigatorHeading level={ 3 }>
 					<strong>
@@ -150,6 +151,7 @@ export function DatePicker( {
 							)
 						);
 					} }
+					size="compact"
 				/>
 			</Navigator>
 			<Calendar


### PR DESCRIPTION
## What?
This PR updates the `DatePicker` to use `compact` size for the Prev and Next buttons.

## Why?
In #65018 we're replacing the size violations, but that applies only to components outside the `@wordpress/components` package. Here, we're updating the button sizes within a `@wordpress/components` to match the sizing guidelines.

## How?
We're making the prev / next buttons compact.

My understanding is that icon buttons should be compact (32px) and not 40px (nor the 36px that they are now). Can you verify that's the case @WordPress/gutenberg-design?

## Testing Instructions
* Test the "Prev" and "Next" buttons of the DatePicker make sense and look/work well with the compact sizing:
  * In Storybook: `/?path=/story/components-datepicker--default`
  * In the post editor by selecting a publish date.  

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|---|---|
|![Screenshot 2024-09-25 at 17 36 51](https://github.com/user-attachments/assets/a0971c49-68bf-44f8-9127-72c1a037fdc6)|![Screenshot 2024-09-25 at 17 34 11](https://github.com/user-attachments/assets/3aa9677b-c602-498a-92df-66c4cd5f5709)|



