### PR TITLE
MediaPlaceholder: Use InputControl in URL popover

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/content.scss
+++ b/packages/block-editor/src/components/media-placeholder/content.scss
@@ -1,5 +1,5 @@
 .block-editor-media-placeholder__url-input-form {
-	min-width: 200px;
+	min-width: 260px;
 
 	@include break-small() {
 		width: 300px;

--- a/packages/block-editor/src/components/media-placeholder/content.scss
+++ b/packages/block-editor/src/components/media-placeholder/content.scss
@@ -1,25 +1,9 @@
 .block-editor-media-placeholder__url-input-form {
-	display: flex;
+	min-width: 200px;
 
-	// Selector requires a lot of specificity to override base styles.
-	input[type="url"].block-editor-media-placeholder__url-input-field {
-		width: 100%;
-		min-width: 200px;
-
-		@include break-small() {
-			width: 300px;
-		}
-
-		flex-grow: 1;
-		border: none;
-		border-radius: 0;
-		margin: 2px;
-
+	@include break-small() {
+		width: 300px;
 	}
-}
-
-.block-editor-media-placeholder__url-input-submit-button {
-	flex-shrink: 1;
 }
 
 .block-editor-media-placeholder__cancel-button.is-link {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -11,6 +11,8 @@ import {
 	FormFileUpload,
 	Placeholder,
 	DropZone,
+	__experimentalInputControl as InputControl,
+	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 	withFilters,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -42,21 +44,23 @@ const InsertFromURLPopover = ( {
 			className="block-editor-media-placeholder__url-input-form"
 			onSubmit={ onSubmit }
 		>
-			<input
-				className="block-editor-media-placeholder__url-input-field"
-				type="text"
-				aria-label={ __( 'URL' ) }
+			<InputControl
+				__next40pxDefaultSize
+				label={ __( 'URL' ) }
+				hideLabelFromVision
 				placeholder={ __( 'Paste or type URL' ) }
 				onChange={ onChange }
 				value={ src }
-			/>
-			<Button
-				// TODO: Switch to `true` (40px size) if possible
-				__next40pxDefaultSize={ false }
-				className="block-editor-media-placeholder__url-input-submit-button"
-				icon={ keyboardReturn }
-				label={ __( 'Apply' ) }
-				type="submit"
+				suffix={
+					<InputControlSuffixWrapper variant="control">
+						<Button
+							size="small"
+							icon={ keyboardReturn }
+							label={ __( 'Apply' ) }
+							type="submit"
+						/>
+					</InputControlSuffixWrapper>
+				}
 			/>
 		</form>
 	</URLPopover>
@@ -165,10 +169,6 @@ export function MediaPlaceholder( {
 			( allowedType ) =>
 				allowedType === 'image' || allowedType.startsWith( 'image/' )
 		);
-	};
-
-	const onChangeSrc = ( event ) => {
-		setSrc( event.target.value );
 	};
 
 	const onFilesUpload = ( files ) => {
@@ -407,7 +407,7 @@ export function MediaPlaceholder( {
 			onSelectURL && (
 				<URLSelectionUI
 					src={ src }
-					onChangeSrc={ onChangeSrc }
+					onChangeSrc={ setSrc }
 					onSelectURL={ onSelectURL }
 				/>
 			)


### PR DESCRIPTION
Follow-up to #64709

## What?

Replaces the raw `input` in the MediaPlaceholder URL popover with an InputControl, and move the submit button to the suffix slot like the other similar UI patterns.

## Why?

Easier and more consistent styling, as well as UI pattern consolidation among all the URL input controls.

## Testing Instructions

Add an Image block. The "Insert from URL" flow should work as expected.

## Screenshots or screencast <!-- if applicable -->

### Desktop

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/78ae8fec-0292-4f8c-9dc7-985ff82099c2" alt="MediaPlaceholder URL popover, before" width="652">|<img src="https://github.com/user-attachments/assets/d3302d40-9a90-4a4c-8809-c94d7067650f" alt="MediaPlaceholder URL popover, after" width="652">|

### Mobile

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/e3384c91-96d9-4c7c-b030-7c9ffacca0b0" alt="MediaPlaceholder URL popover (mobile), before" width="343">|<img src="https://github.com/user-attachments/assets/6b240c6b-6380-468d-8ac1-456caf8aef36" alt="MediaPlaceholder URL popover (mobile), after" width="343">|
