### PR TITLE
Block Bindings: Fix editing protected custom fields in block bindings

### DIFF
--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -55,9 +55,10 @@ function gutenberg_test_block_bindings_registration() {
 		'post',
 		'_protected_field',
 		array(
-			'type'    => 'string',
-			'single'  => true,
-			'default' => 'protected field value',
+			'type'         => 'string',
+			'show_in_rest' => true,
+			'single'       => true,
+			'default'      => 'protected field value',
 		)
 	);
 	register_meta(

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -114,14 +114,9 @@ export default {
 			return false;
 		}
 
-		// Check that the custom field is not protected and available in the REST API.
+		const fieldValue = getPostMetaFields( registry, context )?.[ args.key ]
+			?.value;
 		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
-		const fieldValue = registry
-			.select( coreDataStore )
-			.getEntityRecord( 'postType', postType, context?.postId )?.meta?.[
-			args.key
-		];
-
 		if ( fieldValue === undefined ) {
 			return false;
 		}

--- a/test/e2e/specs/editor/various/block-bindings.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings.spec.js
@@ -2390,6 +2390,33 @@ test.describe( 'Block bindings', () => {
 					previewPage.locator( '#image-alt-binding img' )
 				).toHaveAttribute( 'alt', 'new value' );
 			} );
+
+			test( 'should not be possible to edit the value of the protected custom fields', async ( {
+				editor,
+			} ) => {
+				await editor.insertBlock( {
+					name: 'core/paragraph',
+					attributes: {
+						content: 'paragraph default content',
+						metadata: {
+							bindings: {
+								content: {
+									source: 'core/post-meta',
+									args: { key: '_protected_field' },
+								},
+							},
+						},
+					},
+				} );
+				const paragraphBlock = editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} );
+
+				await expect( paragraphBlock ).toHaveAttribute(
+					'contenteditable',
+					'false'
+				);
+			} );
 		} );
 	} );
 


### PR DESCRIPTION
## What?
Prevent editing protected fields.

This is built on top of https://github.com/WordPress/gutenberg/pull/65659

## Why?
The same way protected fields can be selected through the UI, I believe that if they are connected through the attributes, they shouldn't be editable.

## How?
I'm reusing the `getPostMetaFields` that checks the protected fields.

Additionally, I'm adding an e2e test to cover this.

## Testing Instructions
1. Register a protected custom field: `_protected_field`.
```
	register_meta(
		'post',
		'_protected_field',
		array(
			'label'          => 'Protected field',
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
		)
	);
```
2. Connect a paragraph to this protected field.
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/post-meta","args":{"key":"_protected_field"}}}}} -->
<p>Default content</p>
<!-- /wp:paragraph -->
```
3. Check that it is not editable.