### PR TITLE
Block Bindings: Use `registry` instead of `select` in `canUserEditValue`

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -188,7 +188,7 @@ export function RichTextWrapper(
 
 			const _disableBoundBlock =
 				! blockBindingsSource?.canUserEditValue?.( {
-					select,
+					registry,
 					context: blockBindingsContext,
 					args: relatedBinding.args,
 				} );

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -48,7 +48,7 @@ import {
 	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,
@@ -190,6 +190,7 @@ function ButtonEdit( props ) {
 	const colorProps = useColorProps( attributes );
 	const spacingProps = useSpacingProps( attributes );
 	const shadowProps = useShadowProps( attributes );
+	const registry = useRegistry();
 	const ref = useRef();
 	const richTextRef = useRef();
 	const blockProps = useBlockProps( {
@@ -248,7 +249,7 @@ function ButtonEdit( props ) {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
 					! blockBindingsSource?.canUserEditValue?.( {
-						select,
+						registry,
 						context,
 						args: metadata?.bindings?.url?.args,
 					} ),

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -9,7 +9,7 @@ import clsx from 'clsx';
 import { isBlobURL, createBlobURL } from '@wordpress/blob';
 import { store as blocksStore, createBlock } from '@wordpress/blocks';
 import { Placeholder } from '@wordpress/components';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect, useRegistry } from '@wordpress/data';
 import {
 	BlockIcon,
 	useBlockProps,
@@ -113,6 +113,7 @@ export function ImageEdit( {
 
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
 
+	const registry = useRegistry();
 	const containerRef = useRef();
 	// Only observe the max width from the parent container when the parent layout is not flex nor grid.
 	// This won't work for them because the container width changes with the image.
@@ -380,7 +381,7 @@ export function ImageEdit( {
 				lockUrlControls:
 					!! metadata?.bindings?.url &&
 					! blockBindingsSource?.canUserEditValue?.( {
-						select,
+						registry,
 						context,
 						args: metadata?.bindings?.url?.args,
 					} ),

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -17,7 +17,7 @@ import {
 	Placeholder,
 } from '@wordpress/components';
 import { useViewportMatch } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import {
 	BlockControls,
 	InspectorControls,
@@ -134,6 +134,7 @@ export default function Image( {
 	const numericWidth = width ? parseInt( width, 10 ) : undefined;
 	const numericHeight = height ? parseInt( height, 10 ) : undefined;
 
+	const registry = useRegistry();
 	const imageRef = useRef();
 	const { allowResize = true } = context;
 	const { getBlock, getSettings } = useSelect( blockEditorStore );
@@ -496,7 +497,7 @@ export default function Image( {
 				lockUrlControls:
 					!! urlBinding &&
 					! urlBindingSource?.canUserEditValue?.( {
-						select,
+						registry,
 						context,
 						args: urlBinding?.args,
 					} ),
@@ -511,7 +512,7 @@ export default function Image( {
 				lockAltControls:
 					!! altBinding &&
 					! altBindingSource?.canUserEditValue?.( {
-						select,
+						registry,
 						context,
 						args: altBinding?.args,
 					} ),
@@ -525,7 +526,7 @@ export default function Image( {
 				lockTitleControls:
 					!! titleBinding &&
 					! titleBindingSource?.canUserEditValue?.( {
-						select,
+						registry,
 						context,
 						args: titleBinding?.args,
 					} ),

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -99,14 +99,15 @@ export default {
 				meta: newMeta,
 			} );
 	},
-	canUserEditValue( { select, context, args } ) {
+	canUserEditValue( { registry, context, args } ) {
 		// Lock editing in query loop.
 		if ( context?.query || context?.queryId ) {
 			return false;
 		}
 
 		const postType =
-			context?.postType || select( editorStore ).getCurrentPostType();
+			context?.postType ||
+			registry.select( editorStore ).getCurrentPostType();
 
 		// Check that editing is happening in the post editor and not a template.
 		if ( postType === 'wp_template' ) {
@@ -115,28 +116,31 @@ export default {
 
 		// Check that the custom field is not protected and available in the REST API.
 		// Empty string or `false` could be a valid value, so we need to check if the field value is undefined.
-		const fieldValue = select( coreDataStore ).getEntityRecord(
-			'postType',
-			postType,
-			context?.postId
-		)?.meta?.[ args.key ];
+		const fieldValue = registry
+			.select( coreDataStore )
+			.getEntityRecord( 'postType', postType, context?.postId )?.meta?.[
+			args.key
+		];
 
 		if ( fieldValue === undefined ) {
 			return false;
 		}
 		// Check that custom fields metabox is not enabled.
-		const areCustomFieldsEnabled =
-			select( editorStore ).getEditorSettings().enableCustomFields;
+		const areCustomFieldsEnabled = registry
+			.select( editorStore )
+			.getEditorSettings().enableCustomFields;
 		if ( areCustomFieldsEnabled ) {
 			return false;
 		}
 
 		// Check that the user has the capability to edit post meta.
-		const canUserEdit = select( coreDataStore ).canUser( 'update', {
-			kind: 'postType',
-			name: context?.postType,
-			id: context?.postId,
-		} );
+		const canUserEdit = registry
+			.select( coreDataStore )
+			.canUser( 'update', {
+				kind: 'postType',
+				name: context?.postType,
+				id: context?.postId,
+			} );
 		if ( ! canUserEdit ) {
 			return false;
 		}


### PR DESCRIPTION
## What?
In this pull request, I explore the possibility of passing `registry` as a prop to `canUserEditValue` instead of just `select`.

I'm marking it as a `bug` because it will help solve [this issue](https://github.com/WordPress/gutenberg/pull/65658).

## Why?
It helps keeping consistency between other APIs like `getValues`, `setValues`, or `getFieldsList`. This also helps in cases where we want to reuse functions among those APIs. You can find an example in [this pull request](https://github.com/WordPress/gutenberg/pull/65658), where I am reusing `getPostMetaFields`.

## How?
I'm just passing `registry` and doing `registry.select` instead of `select`.

## Testing Instructions
Everything should keep working and e2e should pass.
