### PR TITLE
Block Bindings: Only pass `usesContext` properties to editor APIs

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -117,7 +117,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 		// used purposely here to ensure `boundAttributes` is updated whenever
 		// there are attribute updates.
 		// `source.getValues` may also call a selector via `registry.select`.
-		const updatedContext = { ...context };
+		const updatedContext = {};
 		const boundAttributes = useSelect( () => {
 			if ( ! blockBindings ) {
 				return;
@@ -285,7 +285,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 					{ ...props }
 					attributes={ { ...props.attributes, ...boundAttributes } }
 					setAttributes={ _setAttributes }
-					context={ updatedContext }
+					context={ { ...context, ...updatedContext } }
 				/>
 			</>
 		);


### PR DESCRIPTION
## What?
As suggested [here](https://github.com/WordPress/gutenberg/pull/65618#discussion_r1775077099), I'm exploring changing the context passed to the editor APIs to only include the properties defined in `usesContext` and not the rest from `props.context`. 

## Why?
It helps keeping consistency with other APIs like `getFieldsList` that only receives the properties defined in `usesContext`, and it makes sense to only include those.

## How?
I'm just not initializing the `updatedContext` variable with the properties from `props.context`.

## Testing Instructions
Everything should keep working as expected, and e2e tests should pass.
