### PR TITLE
Fix aria-checked attribute not set for plugin settings buttons in Options dropdown

### DIFF
--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -35,6 +35,13 @@ function ComplementaryAreaToggle( {
 		<ComponentToUse
 			icon={ selectedIcon && isSelected ? selectedIcon : icon }
 			aria-controls={ identifier.replace( '/', ':' ) }
+			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
+			aria-checked={
+				props.role === 'menuitemcheckbox' ||
+				props.role === 'menuitemradio'
+					? isSelected
+					: undefined
+			}
 			onClick={ () => {
 				if ( isSelected ) {
 					disableComplementaryArea( scope );

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -10,6 +10,25 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { store as interfaceStore } from '../../store';
 import complementaryAreaContext from '../complementary-area-context';
 
+/**
+ * Whether the role supports checked state.
+ *
+ * @param {HTMLElement['role']} role Role.
+ * @return {boolean} Whether the role supports checked state.
+ * @see https://www.w3.org/TR/wai-aria-1.1/#aria-checked
+ */
+function roleSupportsCheckedState( role ) {
+	return [
+		'checkbox',
+		'option',
+		'radio',
+		'switch',
+		'menuitemcheckbox',
+		'menuitemradio',
+		'treeitem',
+	].includes( role );
+}
+
 function ComplementaryAreaToggle( {
 	as = Button,
 	scope,
@@ -37,10 +56,7 @@ function ComplementaryAreaToggle( {
 			aria-controls={ identifier.replace( '/', ':' ) }
 			// Make sure aria-checked matches spec https://www.w3.org/TR/wai-aria-1.1/#aria-checked
 			aria-checked={
-				props.role === 'menuitemcheckbox' ||
-				props.role === 'menuitemradio'
-					? isSelected
-					: undefined
+				roleSupportsCheckedState( props.role ) ? isSelected : undefined
 			}
 			onClick={ () => {
 				if ( isSelected ) {

--- a/packages/interface/src/components/complementary-area-toggle/index.js
+++ b/packages/interface/src/components/complementary-area-toggle/index.js
@@ -13,7 +13,7 @@ import complementaryAreaContext from '../complementary-area-context';
 /**
  * Whether the role supports checked state.
  *
- * @param {HTMLElement['role']} role Role.
+ * @param {import('react').AriaRole} role Role.
  * @return {boolean} Whether the role supports checked state.
  * @see https://www.w3.org/TR/wai-aria-1.1/#aria-checked
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
It fixes the a11y issue with plugin buttons in the options menu in the post editor where there is no indication of whether the plugin sidebar is already open or not.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes #65666 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It updates `ComplementaryAreaToggle` to pass `aria-checked` if the role is set to `menuitemcheckbox` or `menuitemradio`

## Testing Instructions
- Install a plugin that adds a plugin menu/sidebar, e.g. Jetpack
- Click on the options menu (3 dots)
- Inspect the plugin settings button
- Confirm that `aria-checked` attribute is set correctly

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/36fbf2d8-3aa3-4a3e-b8ba-3c4fed0b012b)

