### PR TITLE
Editor: Consistent external media pre-publish image/button sizes

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -98,8 +98,8 @@ function Image( { clientId, alt, url } ) {
 			animate={ { opacity: 1 } }
 			exit={ { opacity: 0, scale: 0 } }
 			style={ {
-				width: '36px',
-				height: '36px',
+				width: '32px',
+				height: '32px',
 				objectFit: 'cover',
 				borderRadius: '2px',
 				cursor: 'pointer',
@@ -256,7 +256,7 @@ export default function MaybeUploadMediaPanel() {
 					<Spinner />
 				) : (
 					<Button
-						__next40pxDefaultSize
+						size="compact"
 						variant="primary"
 						onClick={ uploadImages }
 					>


### PR DESCRIPTION
## What?
Fix the sizes of the external media pre-publish image/button sizes. Currently, the images and the button aren't the same size.

## Why?
For better consistency.

## How?
Using a compact size button (32px) and updating preview images to be 32px as well.

## Testing Instructions
* Start a post
* Insert some Openverse media in it
* Go to publish the post.
* Verify image and button sizes in the pre-publish panel are the same.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|---|---|
|<img width="286" alt="Screenshot 2024-09-26 at 12 08 24" src="https://github.com/user-attachments/assets/35fd3907-cba0-42af-994c-e98f7e165656">|<img width="285" alt="Screenshot 2024-09-26 at 12 08 44" src="https://github.com/user-attachments/assets/761b8fa5-1ae8-41a0-ba14-005d41313901">|




