### PR TITLE
"Upload media" post publish panel: update button and thumbnail sizes

### DIFF
--- a/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
+++ b/packages/editor/src/components/post-publish-panel/maybe-upload-media.js
@@ -98,8 +98,8 @@ function Image( { clientId, alt, url } ) {
 			animate={ { opacity: 1 } }
 			exit={ { opacity: 0, scale: 0 } }
 			style={ {
-				width: '36px',
-				height: '36px',
+				height: '32px',
+				aspectRatio: '1',
 				objectFit: 'cover',
 				borderRadius: '2px',
 				cursor: 'pointer',
@@ -256,7 +256,7 @@ export default function MaybeUploadMediaPanel() {
 					<Spinner />
 				) : (
 					<Button
-						__next40pxDefaultSize
+						size="compact"
 						variant="primary"
 						onClick={ uploadImages }
 					>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Iterate on the button sizing changes from https://github.com/WordPress/gutenberg/pull/65083#discussion_r1746075019, by tweaking the "Update" button size from `40px` to `32px` and updating the thumbnail sizes accordingly

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

UI polish

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Setting `size="compact"` on the `Button`, and manually updating the thumbnail styles

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Install the TT4 or TT5 theme
- Create a new draft post
- Insert a pattern that includes one or more images
- Click the "Publish" button in the top bar
- In the sidebar that opens, check the "Suggestion: external media" panel
- Both the 'Upload' button and the image thumbnails should be 32px tall

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
|  ![Screenshot 2024-09-26 at 11 15 40](https://github.com/user-attachments/assets/59a70a69-9ec4-468a-8504-5ff2d745689e) | ![Screenshot 2024-09-26 at 11 09 45](https://github.com/user-attachments/assets/5393a255-e30c-47ef-ad08-1de5870ffe74) |

And a bonus version simulating enough thumbnails to cause the button to wrap to a new line:

![Screenshot 2024-09-26 at 11 14 15](https://github.com/user-attachments/assets/f554a9b3-7b91-41db-8f75-aa5061d968ff)

   