### PR TITLE
Avoid a useless redirect with site title and home link blocks

### DIFF
--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -154,7 +154,7 @@ function render_block_core_home_link( $attributes, $content, $block ) {
 	return sprintf(
 		'<li %1$s><a class="wp-block-home-link__content wp-block-navigation-item__content" href="%2$s" rel="home"%3$s>%4$s</a></li>',
 		block_core_home_link_build_li_wrapper_attributes( $block->context ),
-		esc_url( home_url() ),
+		esc_url( home_url( '/' ) ),
 		$aria_current,
 		wp_kses_post( $attributes['label'] )
 	);

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -36,7 +36,7 @@ function render_block_core_site_title( $attributes ) {
 
 		$site_title = sprintf(
 			'<a href="%1$s" target="%2$s" rel="home"%3$s>%4$s</a>',
-			esc_url( home_url() ),
+			esc_url( home_url( '/' ) ),
 			esc_attr( $link_target ),
 			$aria_current,
 			esc_html( $site_title )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #65670 

## Why?
Avoid a redirect caused by the link in the site title block when WordPress is installed in a sufolder or on multisite with sites in folder.

## How?
Use `home_url( '/' ) instead of `home_url()`

## Testing Instructions
1. Install WordPress in a subfolder
2. Create a page and insert the site title block
3. View the page on frontend
4. Open the browser tools to observe that there will be no redirect.
5. Check the link proposed by the site title block is `https://mysite.com/wordpress/` instead of `https://mysite.com/wordpress` in the current stable version. 
6. Click on the link and observe that there is no 301 redirect