### PR TITLE
Block Directory: Fix downloadable block item alignment

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -71,6 +71,7 @@
 	}
 
 	.is-installing & {
+    // Adding an extra 6px to avoid the UI from jumping when the rating bar gets hidden
 		margin-right: $grid-unit-20 + 6px;
 	}
 }

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -71,7 +71,7 @@
 	}
 
 	.is-installing & {
-    // Adding an extra 6px to avoid the UI from jumping when the rating bar gets hidden
+		// Adding an extra 6px to avoid the UI from jumping when the rating bar gets hidden
 		margin-right: $grid-unit-20 + 6px;
 	}
 }

--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -69,6 +69,10 @@
 		align-items: center;
 		justify-content: center;
 	}
+
+	.is-installing & {
+		margin-right: $grid-unit-20 + 6px;
+	}
 }
 
 .block-directory-block-ratings {


### PR DESCRIPTION
## What?
Fixes an alignment issue while installing custom block plugins from the block directory.

## Why?
Just fixing a bug that I encountered while reviewing https://github.com/WordPress/gutenberg/pull/65467#pullrequestreview-2328638598.

## How?
We're adding some margin to the block icon's top element while installing. The reason is that while installing, we're hiding the rating bar, which is a bit wider (6px) than the icon container. When the rating bar is removed, it makes the icon container smaller, and that makes the rest of the content jump a bit. By adding those `6px` when installing the block, we keep the consistency.

Ideally, this would refactor the markup, maybe keep more of the block icon, and make a better "installing" state, but this is work for another PR. For now, I'm just fixing a bug so it gets into WP 6.7.

## Testing Instructions
* Start a new post.
* Open the main inserter.
* Search for "Custom Block"
* Install a couple of blocks from the block directory.
* Verify the alignment issue is no more.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|---|---|
|<video src="https://github.com/user-attachments/assets/08717c00-454a-4342-ba80-570b69bd9640" />|<video src="https://github.com/user-attachments/assets/9f3e4a9d-8427-4616-b9a5-d5313fa7c9a1" />|
