### PR TITLE
Guide: Update finish button to use the new default size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -17,6 +17,7 @@
 -   `MenuGroup`: Simplify the MenuGroup styles within dropdown menus. ([#65561](https://github.com/WordPress/gutenberg/pull/65561)).
 -   `DatePicker`: Use compact button size. ([#65653](https://github.com/WordPress/gutenberg/pull/65653)).
 -   `Navigator`: add support for exit animation ([#64777](https://github.com/WordPress/gutenberg/pull/64777)).
+-   `Guide`: Update finish button to use the new default size ([#65680](https://github.com/WordPress/gutenberg/pull/65680)).
 
 ## 28.8.0 (2024-09-19)
 

--- a/packages/components/src/guide/index.tsx
+++ b/packages/components/src/guide/index.tsx
@@ -164,6 +164,7 @@ function Guide( {
 							className="components-guide__finish-button"
 							variant="primary"
 							onClick={ onFinish }
+							__next40pxDefaultSize
 						>
 							{ finishButtonText }
 						</Button>


### PR DESCRIPTION
## What?
This PR updates the "Finish" button of the Guide component to use the new 40px default size.

## Why?
Discovered as I was auditing button sizes as part of reviewing #65018.

## How?
We're adding the `__next40pxDefaultSize` prop to the "Finish" button. The rest of the buttons already used that size, so we're just making all buttons consistent now. 

## Testing Instructions
* Open Storybook: `/?path=/docs/components-guide--docs`
* Open the guide.
* Go to the last step.
* Verify the "Finish" button is the same size as the "Previous" button (40px).

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|---|---|
|![Screenshot 2024-09-26 at 17 35 48](https://github.com/user-attachments/assets/c0d5385d-9a99-430f-bca5-36e2e9f639f4)|![Screenshot 2024-09-26 at 17 35 26](https://github.com/user-attachments/assets/bef1e756-0813-4e99-9ec7-0948bbd8b414)|




