### PR TITLE
BorderControl: Use `__next40pxDefaultSize` prop for Reset button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,7 @@
 -   `DatePicker`: Use compact button size. ([#65653](https://github.com/WordPress/gutenberg/pull/65653)).
 -   `Navigator`: add support for exit animation ([#64777](https://github.com/WordPress/gutenberg/pull/64777)).
 -   `Guide`: Update finish button to use the new default size ([#65680](https://github.com/WordPress/gutenberg/pull/65680)).
+-   `BorderControl`: Use `__next40pxDefaultSize` prop for Reset button ([#65682](https://github.com/WordPress/gutenberg/pull/65682)).
 
 ## 28.8.0 (2024-09-19)
 

--- a/packages/components/src/border-control/border-control-dropdown/component.tsx
+++ b/packages/components/src/border-control/border-control-dropdown/component.tsx
@@ -237,6 +237,7 @@ const BorderControlDropdown = (
 							onReset();
 							onClose();
 						} }
+						__next40pxDefaultSize
 					>
 						{ __( 'Reset' ) }
 					</Button>

--- a/packages/components/src/border-control/styles.ts
+++ b/packages/components/src/border-control/styles.ts
@@ -156,7 +156,6 @@ export const resetButton = css`
 		border-top: ${ CONFIG.borderWidth } solid ${ COLORS.gray[ 400 ] };
 		border-top-left-radius: 0;
 		border-top-right-radius: 0;
-		height: 40px;
 	}
 `;
 


### PR DESCRIPTION
## What?
This PR updates the "Reset" button of the `BorderControl` component to use the new 40px default size.

## Why?
Discovered as I was auditing button sizes as part of reviewing #65018.

## How?
We're adding the `__next40pxDefaultSize` prop to the "Reset" button. The button was already set to `40px` through CSS, but we no longer need that style override when we can just opt in with the `__next40pxDefaultSize` prop.

## Testing Instructions
* Open Storybook: `/?path=/story/components-experimental-bordercontrol--default`
* Pick a color.
* Verify the "Reset" button is still the right size (40px).

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-09-26 at 18 24 28](https://github.com/user-attachments/assets/591d90fe-dece-4bdf-b32b-1e79a052c6e6)



