### PR TITLE
Editor Canvas: Tweak close button

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -125,7 +125,7 @@ function EditorCanvasContainer( {
 					>
 						{ shouldShowCloseButton && (
 							<Button
-								__next40pxDefaultSize
+								size="compact"
 								className="edit-site-editor-canvas-container__close-button"
 								icon={ closeSmall }
 								label={ closeButtonLabel || __( 'Close' ) }

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -29,7 +29,7 @@
 .edit-site-editor-canvas-container__close-button {
 	position: absolute;
 	right: $grid-unit-10;
-	top: math.div($grid-unit-60 - $button-size, 2); // ( tab height - button size ) / 2
+	top: $grid-unit-10;
 	z-index: 1;
 	background: $white;
 }


### PR DESCRIPTION
## What?

On the Revision and Style Book canvases, especially on the Style Book canvas, the close button feels very large and the positioning seems slightly incorrect.

## How?

- Change the button size to 32px.
- In the Stylebook canvas, make sure the button is exactly vertically centered on the tab.

## Screenshots or screencast <!-- if applicable -->

### Revisions

Having a close button on the revision canvas seems a bit odd to me, but maybe this can be considered in a follow-up.

#### Before

![image](https://github.com/user-attachments/assets/d1093283-12d8-4f75-822d-86ab3f990757)

#### After

![image](https://github.com/user-attachments/assets/82bdb2ed-3220-46f0-9d9f-bf1a44b95642)

### Style Book

#### Before

![image](https://github.com/user-attachments/assets/f6187098-359a-47c2-849c-ba4d545b33d8)

#### After

![image](https://github.com/user-attachments/assets/34f2924c-48d5-4405-8a87-8744d2649e2e)

