### PR TITLE
Tweak entity save panel button

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -131,8 +131,18 @@ export function EntitiesSavedStatesExtensible( {
 				<FlexItem
 					isBlock
 					as={ Button }
+					variant="secondary"
+					size="compact"
+					onClick={ dismissPanel }
+				>
+					{ __( 'Cancel' ) }
+				</FlexItem>
+				<FlexItem
+					isBlock
+					as={ Button }
 					ref={ saveButtonRef }
 					variant="primary"
+					size="compact"
 					disabled={ ! saveEnabled }
 					accessibleWhenDisabled
 					onClick={ () =>
@@ -146,14 +156,6 @@ export function EntitiesSavedStatesExtensible( {
 					className="editor-entities-saved-states__save-button"
 				>
 					{ saveLabel }
-				</FlexItem>
-				<FlexItem
-					isBlock
-					as={ Button }
-					variant="secondary"
-					onClick={ dismissPanel }
-				>
-					{ __( 'Cancel' ) }
 				</FlexItem>
 			</Flex>
 

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -1,8 +1,8 @@
 .entities-saved-states__panel-header {
 	box-sizing: border-box;
 	background: $white;
-	padding-left: $grid-unit-10;
-	padding-right: $grid-unit-10;
+	padding-left: $grid-unit-20;
+	padding-right: $grid-unit-20;
 	height: $header-height;
 	border-bottom: $border-width solid $gray-300;
 }


### PR DESCRIPTION
Related to #65317

## What?

This PR makes three changes to the entity save panels for the global styles:

- Swap button positions
- Change button size from 36px to 32px.
- Align outer padding of buttons with the pre-publish panel in the post editor.

## Why?

In #65317, the position of the pre-publish buttons was reversed:

![post-editor](https://github.com/user-attachments/assets/19481ed7-3ce6-412b-b6c9-f339e291911d)

The entity save panel buttons in the site editor are in the opposite position to this, which is a bit confusing.

## How?

I've adjusted it so that it has the exact same layout as the pre-publish button.

## Testing Instructions

- Update the global styles.
- Click the Save button.
- The Cancel button should have focus.
- Click the Cancel button.
- The Save button should have focus.

### Testing Instructions for Keyboard

Test the same steps using only the keyboard.

## Screenshots or screencast <!-- if applicable -->

### Before

![before](https://github.com/user-attachments/assets/17ff4875-29cf-4ad2-9336-29e05fa8ca2f)

### After

![after](https://github.com/user-attachments/assets/40ee0c4d-bdd1-4965-be9e-ab8ec6174a58)
