### PR TITLE
Inserter: Fix Block visibility manager

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1542,8 +1542,8 @@ export function getTemplateLock( state, rootClientId ) {
 
 /**
  * Determines if the given block type is visible in the inserter.
- * Note that this is different than whenter a block is allowed to be inserted.
- * In some case, the block is not allowed in a given position but
+ * Note that this is different than whether a block is allowed to be inserted.
+ * In some cases, the block is not allowed in a given position but
  * it should still be visible in the inserter to be able to add it
  * to a different position.
  *

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1581,8 +1581,13 @@ const isBlockVisibleInTheInserter = ( state, blockNameOrType ) => {
 
 	// If parent blocks are not visible, child blocks should be hidden too.
 	if ( !! blockType.parent?.length ) {
-		return blockType.parent.some( ( name ) =>
-			isBlockVisibleInTheInserter( state, name )
+		return blockType.parent.some(
+			( name ) =>
+				isBlockVisibleInTheInserter( state, name ) ||
+				// Exception for blocks with post-content parent,
+				// the root level is often consider as "core/post-content".
+				// This exception should only apply to the post editor ideally though.
+				name === 'core/post-content'
 		);
 	}
 	return true;

--- a/test/e2e/specs/editor/various/allowed-patterns.spec.js
+++ b/test/e2e/specs/editor/various/allowed-patterns.spec.js
@@ -54,7 +54,7 @@ test.describe( 'Allowed Patterns', () => {
 			);
 		} );
 
-		test( 'should show all patterns even if not allowed', async ( {
+		test( 'should hide patterns with only hidden blocks', async ( {
 			admin,
 			page,
 		} ) => {
@@ -77,11 +77,7 @@ test.describe( 'Allowed Patterns', () => {
 				page
 					.getByRole( 'listbox', { name: 'Block patterns' } )
 					.getByRole( 'option' )
-			).toHaveText( [
-				'Test: Single heading',
-				'Test: Single paragraph',
-				'Test: Paragraph inside group',
-			] );
+			).toHaveText( [ 'Test: Single heading' ] );
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes #65687 

## What?

In #65490 we changed a bit how the inserter works by avoiding any initial block type filtering and only upon insertion figuring out what things can or can't be allowed in a given position and also try to guess a more suitable position.

The problem is that in some situations (block visibility managed, allowed blocks settings), it doesn't really make sense to show the blocks at all. So this PR separate the `canInsertBlock` selector into two:

 - One about visibility of the block
 - One about the possibility to insert the block in a given position.

**Note**

- For child blocks, I elected for now to keep them in the inserter. The reason is that there's value in that, for instance, if you're within a nested block within a column, it's handy to be able to click "column" block to insert a new column in the parent's columns block. We can revise/tweak that behavior if it's deemed too problematic.

- Note that the PR applies the fix to the pattern inserter too.

## Testing Instructions

1- Open the post inserter
2- Go to preferences > blocks and remove the "heading" block
3- Open the inserter and notice the block is not visible anymore and any block that uses the block is not either.
