### PR TITLE
Fix output buffering for cross-origin isolation

### DIFF
--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -237,15 +237,10 @@ function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 
 	ob_start(
 		function ( string $output, ?int $phase ) use ( $coep ): string {
-			// Only send the header when the buffer is not being cleaned.
-			if ( ( $phase & PHP_OUTPUT_HANDLER_CLEAN ) === 0 ) {
-				header( 'Cross-Origin-Opener-Policy: same-origin' );
-				header( "Cross-Origin-Embedder-Policy: $coep" );
+			header( 'Cross-Origin-Opener-Policy: same-origin' );
+			header( "Cross-Origin-Embedder-Policy: $coep" );
 
-				$output = gutenberg_add_crossorigin_attributes( $output );
-			}
-
-			return $output;
+			return gutenberg_add_crossorigin_attributes( $output );
 		}
 	);
 }

--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -254,7 +254,7 @@ function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	$coep = $is_safari ? 'require-corp' : 'credentialless';
 
 	ob_start(
-		function ( string $output, ?int $phase ) use ( $coep ): string {
+		function ( string $output ) use ( $coep ): string {
 			header( 'Cross-Origin-Opener-Policy: same-origin' );
 			header( "Cross-Origin-Embedder-Policy: $coep" );
 

--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -187,6 +187,24 @@ function gutenberg_rest_get_attachment_filesize( array $post ): ?int {
 }
 
 /**
+ * Filters the list of rewrite rules formatted for output to an .htaccess file.
+ *
+ * Adds support for serving wasm-vips locally.
+ *
+ * @param string $rules mod_rewrite Rewrite rules formatted for .htaccess.
+ * @return string Filtered rewrite rules.
+ */
+function gutenberg_filter_mod_rewrite_rules( string $rules ): string {
+	$rules .= "\n# BEGIN Gutenberg client-side media processing experiment\n" .
+				"AddType application/wasm wasm\n" .
+				"# END Gutenberg client-side media processing experiment\n";
+
+	return $rules;
+}
+
+add_filter( 'mod_rewrite_rules', 'gutenberg_filter_mod_rewrite_rules' );
+
+/**
  * Enables cross-origin isolation in the block editor.
  *
  * Required for enabling SharedArrayBuffer for WebAssembly-based


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a quick follow-up to #64650 with two simple fixes:

1. Ensures the HTTP headers for cross-origin isolation are correctly sent in the output buffer callback
2. Adds some hardening to ensure wasm files are served with the correct mime type (if not already done by the host anyway)
	* Actual wasm files will be added in follow-up PRs.

Note: this is only applicable when the client-side media processing experiment is enabled.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #61447

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

N/A

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
