### PR TITLE
Edit Mode: Prevent editable text selection on first click

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -70,7 +70,6 @@ export function PrivateBlockToolbar( {
 		hasParentPattern,
 		hasContentOnlyLocking,
 		showShuffleButton,
-		showSlots,
 		showGroupButtons,
 		showLockButtons,
 		showSwitchSectionStyleButton,
@@ -148,7 +147,6 @@ export function PrivateBlockToolbar( {
 			hasParentPattern: _hasParentPattern,
 			hasContentOnlyLocking: _hasTemplateLock,
 			showShuffleButton: _isZoomOut,
-			showSlots: ! _isZoomOut,
 			showGroupButtons: ! _isZoomOut,
 			showLockButtons: ! _isZoomOut,
 			showSwitchSectionStyleButton: _isZoomOut,
@@ -239,7 +237,7 @@ export function PrivateBlockToolbar( {
 				{ showSwitchSectionStyleButton && (
 					<SwitchSectionStyle clientId={ blockClientIds[ 0 ] } />
 				) }
-				{ shouldShowVisualToolbar && showSlots && (
+				{ shouldShowVisualToolbar && (
 					<>
 						<BlockControls.Slot
 							group="parent"

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -63,6 +63,7 @@ export default function BlockTools( {
 } ) {
 	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode, isDragging } =
 		useSelect( selector, [] );
+
 	const isMatch = useShortcutEventMatch();
 	const {
 		getBlocksByClientId,

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -63,7 +63,6 @@ export default function BlockTools( {
 } ) {
 	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode, isDragging } =
 		useSelect( selector, [] );
-
 	const isMatch = useShortcutEventMatch();
 	const {
 		getBlocksByClientId,

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -15,24 +15,29 @@ import { unlock } from '../../lock-unlock';
 function ZoomOutModeInserters() {
 	const [ isReady, setIsReady ] = useState( false );
 	const {
-		hasSelection,
+		selectedSectionClientId,
 		blockOrder,
 		setInserterIsOpened,
 		sectionRootClientId,
-		selectedBlockClientId,
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
 			getBlockOrder,
-			getSelectionStart,
 			getSelectedBlockClientId,
 			getSectionRootClientId,
+			isSectionBlock,
+			getParentSectionBlock,
 		} = unlock( select( blockEditorStore ) );
 
 		const root = getSectionRootClientId();
+		const selectionBlockClientId = getSelectedBlockClientId();
+		const _selectedSectionClientId =
+			! selectionBlockClientId || isSectionBlock( selectionBlockClientId )
+				? selectionBlockClientId
+				: getParentSectionBlock( selectionBlockClientId );
 
 		return {
-			hasSelection: !! getSelectionStart().clientId,
+			selectedSectionClientId: _selectedSectionClientId,
 			blockOrder: getBlockOrder( root ),
 			sectionRootClientId: root,
 			setInserterIsOpened:
@@ -54,13 +59,13 @@ function ZoomOutModeInserters() {
 		};
 	}, [] );
 
-	if ( ! isReady || ! hasSelection ) {
+	if ( ! isReady || ! selectedSectionClientId ) {
 		return null;
 	}
 
-	const previousClientId = selectedBlockClientId;
+	const previousClientId = selectedSectionClientId;
 	const index = blockOrder.findIndex(
-		( clientId ) => selectedBlockClientId === clientId
+		( clientId ) => selectedSectionClientId === clientId
 	);
 	const nextClientId = blockOrder[ index + 1 ];
 

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -73,13 +73,11 @@ function UncontrolledInnerBlocks( props ) {
 		layout,
 		name,
 		blockType,
-		parentLock,
 		defaultLayout,
 	} = props;
 
 	useNestedSettingsUpdate(
 		clientId,
-		parentLock,
 		allowedBlocks,
 		prioritizedInserterBlocks,
 		defaultBlock,
@@ -196,7 +194,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const {
 				getBlockName,
 				isZoomOut,
-				getTemplateLock,
 				getBlockRootClientId,
 				getBlockEditingMode,
 				getBlockSettings,
@@ -239,7 +236,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				),
 				name: blockName,
 				blockType: getBlockType( blockName ),
-				parentLock: getTemplateLock( parentClientId ),
 				parentClientId,
 				isDropZoneDisabled: _isDropZoneDisabled,
 				defaultLayout,
@@ -251,7 +247,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		__experimentalCaptureToolbars,
 		name,
 		blockType,
-		parentLock,
 		parentClientId,
 		isDropZoneDisabled,
 		defaultLayout,
@@ -278,7 +273,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 		layout,
 		name,
 		blockType,
-		parentLock,
 		defaultLayout,
 		...options,
 	};

--- a/packages/block-editor/src/components/inner-blocks/index.native.js
+++ b/packages/block-editor/src/components/inner-blocks/index.native.js
@@ -105,13 +105,11 @@ function UncontrolledInnerBlocks( props ) {
 
 	const context = useBlockContext( clientId );
 
-	const { nestingLevel, parentLock } = useSelect(
+	const { nestingLevel } = useSelect(
 		( select ) => {
-			const { getBlockParents, getTemplateLock, getBlockRootClientId } =
-				select( blockEditorStore );
+			const { getBlockParents } = select( blockEditorStore );
 			return {
 				nestingLevel: getBlockParents( clientId )?.length,
-				parentLock: getTemplateLock( getBlockRootClientId( clientId ) ),
 			};
 		},
 		[ clientId ]
@@ -119,7 +117,6 @@ function UncontrolledInnerBlocks( props ) {
 
 	useNestedSettingsUpdate(
 		clientId,
-		parentLock,
 		allowedBlocks,
 		prioritizedInserterBlocks,
 		defaultBlock,

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -41,7 +41,6 @@ function useShallowMemo( value ) {
  * came from props.
  *
  * @param {string}               clientId                   The client ID of the block to update.
- * @param {string}               parentLock
  * @param {string[]}             allowedBlocks              An array of block names which are permitted
  *                                                          in inner blocks.
  * @param {string[]}             prioritizedInserterBlocks  Block names and/or block variations to be prioritized in the inserter, in the format {blockName}/{variationName}.
@@ -63,7 +62,6 @@ function useShallowMemo( value ) {
  */
 export default function useNestedSettingsUpdate(
 	clientId,
-	parentLock,
 	allowedBlocks,
 	prioritizedInserterBlocks,
 	defaultBlock,
@@ -90,16 +88,11 @@ export default function useNestedSettingsUpdate(
 		prioritizedInserterBlocks
 	);
 
-	const _templateLock =
-		templateLock === undefined || parentLock === 'contentOnly'
-			? parentLock
-			: templateLock;
-
 	useLayoutEffect( () => {
 		const newSettings = {
 			allowedBlocks: _allowedBlocks,
 			prioritizedInserterBlocks: _prioritizedInserterBlocks,
-			templateLock: _templateLock,
+			templateLock,
 		};
 
 		// These values are not defined for RN, so only include them if they
@@ -176,7 +169,7 @@ export default function useNestedSettingsUpdate(
 		clientId,
 		_allowedBlocks,
 		_prioritizedInserterBlocks,
-		_templateLock,
+		templateLock,
 		defaultBlock,
 		directInsert,
 		__experimentalDefaultBlock,

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -15,8 +15,8 @@ import {
 	getBlockName,
 	getTemplateLock,
 	getClientIdsWithDescendants,
-	isNavigationMode,
 	getBlockRootClientId,
+	__unstableGetEditorMode,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -507,7 +507,10 @@ export function isSectionBlock( state, clientId ) {
 	return (
 		getBlockName( state, clientId ) === 'core/block' ||
 		getTemplateLock( state, clientId ) === 'contentOnly' ||
-		( isNavigationMode( state ) && sectionClientIds.includes( clientId ) )
+		( [ 'navigation', 'zoom-out' ].includes(
+			__unstableGetEditorMode( state )
+		) &&
+			sectionClientIds.includes( clientId ) )
 	);
 }
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -507,9 +507,8 @@ export function isSectionBlock( state, clientId ) {
 	return (
 		getBlockName( state, clientId ) === 'core/block' ||
 		getTemplateLock( state, clientId ) === 'contentOnly' ||
-		( [ 'navigation', 'zoom-out' ].includes(
-			__unstableGetEditorMode( state )
-		) &&
+		( ( __unstableGetEditorMode( state ) === 'navigation' ||
+			isZoomOut( state ) ) &&
 			sectionClientIds.includes( clientId ) )
 	);
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -17,6 +17,7 @@ import {
 	getClientIdsWithDescendants,
 	getBlockRootClientId,
 	__unstableGetEditorMode,
+	getBlockListSettings,
 } from './selectors';
 import {
 	checkAllowListRecursive,
@@ -506,7 +507,10 @@ export function isSectionBlock( state, clientId ) {
 	const sectionClientIds = getBlockOrder( state, sectionRootClientId );
 	return (
 		getBlockName( state, clientId ) === 'core/block' ||
-		getTemplateLock( state, clientId ) === 'contentOnly' ||
+		// This is different than getTemplateLock
+		// because children of sections are not sections automatically.
+		getBlockListSettings( state, clientId )?.templateLock ===
+			'contentOnly' ||
 		( ( __unstableGetEditorMode( state ) === 'navigation' ||
 			isZoomOut( state ) ) &&
 			sectionClientIds.includes( clientId ) )

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2250,8 +2250,6 @@ function getDerivedBlockEditingModesForTree(
 	isNavMode = false,
 	treeClientId = ''
 ) {
-	const isZoomedOut =
-		state?.zoomLevel < 100 || state?.zoomLevel === 'auto-scaled';
 	const derivedBlockEditingModes = new Map();
 
 	// When there are sections, the majority of blocks are disabled,
@@ -2267,7 +2265,7 @@ function getDerivedBlockEditingModesForTree(
 
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
-		if ( isZoomedOut || isNavMode ) {
+		if ( isNavMode ) {
 			// If the root block is the section root set its editing mode to contentOnly.
 			if ( clientId === sectionRootClientId ) {
 				derivedBlockEditingModes.set( clientId, 'contentOnly' );
@@ -2289,7 +2287,6 @@ function getDerivedBlockEditingModesForTree(
 			// disabled.
 			// If the tree root is not in a section, set its editing mode to disabled.
 			if (
-				isZoomedOut ||
 				! findParentInClientIdsList( state, clientId, sectionClientIds )
 			) {
 				derivedBlockEditingModes.set( clientId, 'disabled' );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1571,7 +1571,17 @@ export function getTemplateLock( state, rootClientId ) {
 		return state.settings.templateLock ?? false;
 	}
 
-	return getBlockListSettings( state, rootClientId )?.templateLock ?? false;
+	const currentLock = getBlockListSettings(
+		state,
+		rootClientId
+	)?.templateLock;
+	if ( currentLock !== undefined ) {
+		return currentLock;
+	}
+	return getTemplateLock(
+		state,
+		getBlockRootClientId( state, rootClientId )
+	);
 }
 
 /**
@@ -2954,7 +2964,7 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 		return true;
 	}
 
-	// In navigation mode, the block overlay is active when the block is not
+	// For sections, the block overlay is active when the block is not
 	// selected (and doesn't contain a selected child). The same behavior is
 	// also enabled in all modes for blocks that have controlled children
 	// (reusable block, template part, navigation), unless explicitly disabled

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -41,6 +41,7 @@ import {
 	isSectionBlock,
 	getParentSectionBlock,
 	isZoomOut,
+	getSectionRootClientId,
 } from './private-selectors';
 
 /**

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2976,7 +2976,8 @@ export function __unstableHasActiveBlockOverlayActive( state, clientId ) {
 	);
 	const shouldEnableIfUnselected = blockSupportDisable
 		? false
-		: areInnerBlocksControlled( state, clientId );
+		: areInnerBlocksControlled( state, clientId ) &&
+		  clientId !== getSectionRootClientId( state, clientId );
 
 	return (
 		shouldEnableIfUnselected &&

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3828,28 +3828,45 @@ describe( 'selectors', () => {
 
 		it( 'should return false if the specified clientId was not found', () => {
 			const state = {
-				settings: { templateLock: 'all' },
+				settings: {},
 				blockListSettings: {
 					chicken: {
 						templateLock: 'insert',
 					},
+					ribs: {},
+				},
+				blocks: {
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							ribs: '',
+						} )
+					),
 				},
 			};
 
 			expect( getTemplateLock( state, 'ribs' ) ).toBe( false );
 		} );
 
-		it( 'should return false if template lock was not set on the specified block', () => {
+		it( 'should return the parent lock if the specified clientId was not found', () => {
 			const state = {
 				settings: { templateLock: 'all' },
 				blockListSettings: {
 					chicken: {
-						test: 'tes1t',
+						templateLock: 'insert',
 					},
+				},
+				blocks: {
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							ribs: '',
+						} )
+					),
 				},
 			};
 
-			expect( getTemplateLock( state, 'chicken' ) ).toBe( false );
+			expect( getTemplateLock( state, 'ribs' ) ).toBe( 'all' );
 		} );
 
 		it( 'should return the template lock for the specified clientId', () => {
@@ -3859,6 +3876,14 @@ describe( 'selectors', () => {
 					chicken: {
 						templateLock: 'insert',
 					},
+				},
+				blocks: {
+					parents: new Map(
+						Object.entries( {
+							chicken: '',
+							ribs: '',
+						} )
+					),
 				},
 			};
 

--- a/test/e2e/specs/editor/various/content-only-lock.spec.js
+++ b/test/e2e/specs/editor/various/content-only-lock.spec.js
@@ -24,6 +24,13 @@ test.describe( 'Content-only lock', () => {
 <!-- /wp:group -->` );
 
 		await pageUtils.pressKeys( 'secondary+M' );
+
+		// First click selects the section.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.click();
+
+		// Second click selects the content.
 		await editor.canvas
 			.locator( 'role=document[name="Block: Paragraph"i]' )
 			.click();
@@ -50,9 +57,18 @@ test.describe( 'Content-only lock', () => {
 <!-- /wp:group -->` );
 
 		await pageUtils.pressKeys( 'secondary+M' );
+
+		// First click selects the section.
+		await editor.canvas
+			.locator( 'role=document[name="Block: Group"i]' )
+			.first()
+			.click();
+
+		// Second click selects the content.
 		await editor.canvas
 			.locator( 'role=document[name="Block: Paragraph"i]' )
 			.click();
+
 		await page.keyboard.type( ' WP' );
 		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{


### PR DESCRIPTION
Related #65298 and #64197 

## What?

This PR starts the unification of "zoom-out" interaction model with the interaction model of "edit" tool/mode. 
So it does the following in both modes:

 - Click on the section block (anywhere in the section block), selects the section block and highlights content blocks.
 - From there you can click again on content blocks to edit them.

For me, it does test well in both modes but would appreciate more 👀 to confirm that this behavior looks good and whether I missed some nuances. 

Closes https://github.com/WordPress/gutenberg/issues/65736

## Testing Instructions

1- Insert some patterns in the post editor.
2- Enable zoom-out
3- Notice that you click sections to select them
4- Then you can click content blocks to edit text
5- Do the same test in "edit" mode. 
