### PR TITLE
Navigation block: Use `apply_block_hooks_to_content()`

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1499,6 +1499,12 @@ function block_core_navigation_mock_parsed_block( $inner_blocks, $post ) {
  */
 function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
 	$mock_navigation_block = block_core_navigation_mock_parsed_block( $inner_blocks, $post );
+
+	if ( function_exists( 'apply_block_hooks_to_content' ) ) {
+		$mock_navigation_block_markup = serialize_block( $mock_navigation_block );
+		return apply_block_hooks_to_content( $mock_navigation_block_markup, $post, 'insert_hooked_blocks' );
+	}
+
 	$hooked_blocks         = get_hooked_blocks();
 	$before_block_visitor  = null;
 	$after_block_visitor   = null;

--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -1505,9 +1505,9 @@ function block_core_navigation_insert_hooked_blocks( $inner_blocks, $post ) {
 		return apply_block_hooks_to_content( $mock_navigation_block_markup, $post, 'insert_hooked_blocks' );
 	}
 
-	$hooked_blocks         = get_hooked_blocks();
-	$before_block_visitor  = null;
-	$after_block_visitor   = null;
+	$hooked_blocks        = get_hooked_blocks();
+	$before_block_visitor = null;
+	$after_block_visitor  = null;
 
 	if ( ! empty( $hooked_blocks ) || has_filter( 'hooked_block_types' ) ) {
 		$before_block_visitor = make_before_block_visitor( $hooked_blocks, $post, 'insert_hooked_blocks' );


### PR DESCRIPTION
## What?
In the Navigation block, use `apply_block_hooks_to_content` (introduced in WP 6.6), if available.

## Why?
This is part of a centralization effort, i.e. to make `apply_block_hooks_to_content` the canonical entrypoint for applying the Block Hooks logic to a given piece of block markup. The same change has already been applied to the relevant call sites of Block Hooks logic in Core, see https://github.com/WordPress/wordpress-develop/pull/7220.

**This is particularly relevant for https://github.com/WordPress/wordpress-develop/pull/7443, which will ensure that `apply_block_hooks_to_content` respects a hooked block's `"multiple": false` setting.** In other words, the present PR is required to make sure that a hooked block isn't inserted more than once into a Navigation menu if it has `"multiple": false` set.

## How?
By checking if `apply_block_hooks_to_content` exists, and if it does, by invoking it instead of the more indirect sequence of `make_before_block_visitor`/`make_after_block_visitor`, followed by `traverse_and_serialize_block`.

## Testing Instructions
Verify that hooked blocks insertion into the Navigation menu works as before. For more detailed testing instructions, refer to https://github.com/WordPress/gutenberg/pull/57754.