### PR TITLE
Block bindings: Improve performance by memo postypes slug.

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -182,6 +182,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					postTypes: getPostTypes( { per_page: -1 } ),
 				};
 			}, [] );
+		const postTypesSlugs = useMemo( () => {
+			return postTypes?.map( ( entity ) => entity.slug ) || [];
+		}, [ postTypes ] );
+
 		const shouldRenderTemplate = !! template && mode !== 'post-only';
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
@@ -194,11 +198,6 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					postContext.postType = 'post';
 				} else if ( post.slug.split( '-' )[ 0 ] === 'single' ) {
 					// If the slug is single-{postType}, infer the post type from the slug.
-					const postTypesSlugs = useMemo( () => {
-						return (
-							postTypes?.map( ( entity ) => entity.slug ) || []
-						);
-					}, [] );
 					const match = post.slug.match(
 						`^single-(${ postTypesSlugs.join( '|' ) })(?:-.+)?$`
 					);

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -194,8 +194,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					postContext.postType = 'post';
 				} else if ( post.slug.split( '-' )[ 0 ] === 'single' ) {
 					// If the slug is single-{postType}, infer the post type from the slug.
-					const postTypesSlugs =
-						postTypes?.map( ( entity ) => entity.slug ) || [];
+					const postTypesSlugs = useMemo( () => {
+						return (
+							postTypes?.map( ( entity ) => entity.slug ) || []
+						);
+					}, [] );
 					const match = post.slug.match(
 						`^single-(${ postTypesSlugs.join( '|' ) })(?:-.+)?$`
 					);

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -224,9 +224,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			shouldRenderTemplate,
 			post.id,
 			post.type,
+			post.slug,
+			postTypesSlugs,
 			rootLevelPost.type,
 			rootLevelPost.slug,
-			postTypes,
 		] );
 		const { id, type } = rootLevelPost;
 		const blockEditorSettings = useBlockEditorSettings(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Improve the perfomance of the postTypesSlugs by memoizing it.

trunk:
<img width="374" alt="trunk" src="https://github.com/user-attachments/assets/0e0a2d76-f2a5-4f3a-8b80-7e4ebd54f9a2">

PR:
<img width="388" alt="Screenshot 2024-09-27 at 14 19 19" src="https://github.com/user-attachments/assets/38ba7879-8853-4c89-8f33-3502ddd2764f">

