### PR TITLE
List view: fix miscolored icons

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -44,6 +44,11 @@
 
 		svg {
 			fill: currentColor;
+			// Optimizate for high contrast modes.
+			// See also https://blogs.windows.com/msedgedev/2020/09/17/styling-for-windows-high-contrast-with-new-standards-for-forced-colors/.
+			@media (forced-colors: active) {
+				fill: CanvasText;
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -41,6 +41,10 @@
 		&:hover {
 			color: var(--wp-admin-theme-color);
 		}
+
+		svg {
+			fill: currentColor;
+		}
 	}
 
 	&:not(.is-selected) .block-editor-list-view-block-select-button {


### PR DESCRIPTION
Fixes #65697

## What?

This PR fixes the icon color inconsistency (chevron, sticky, lock) in the List view.

## Why?

As of #65361, the list view button has been replaced with the `a` element instead of the `Button` component. This means that the following styles no longer apply:

https://github.com/WordPress/gutenberg/blob/3155ab7fff75f4204faaa5bb621811f492905dc6/packages/components/src/button/style.scss#L373

## How?

Considering the possibility that new icons may be added to list view buttons in the future, I added `fill:currentColor` to all SVGs in the list view buttons. This selector should be equivalent to the previous `.components-button svg`.

## Testing Instructions

- Insert a Group block. Apply the anchor, sticky position, and block lock.
- Select the block and check the icon color.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/6b0f88c0-8b19-4e8b-85bb-ee3a0a3fc264) | ![after](https://github.com/user-attachments/assets/af5d3335-3eef-4fc4-bd51-175c3f73e279) |

