### PR TITLE
InspectorControls: Try prop to bypass BaseControl margin

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -17,6 +17,7 @@
 	}
 
 	// Reset unwanted margin-bottom from being applied to BaseControls within certain components.
+	.block-editor-inspector-controls__no-base-control-margin,
 	.components-focal-point-picker-control,
 	.components-query-controls,
 	.components-range-control {

--- a/packages/block-editor/src/components/inspector-controls/fill.js
+++ b/packages/block-editor/src/components/inspector-controls/fill.js
@@ -22,6 +22,7 @@ export default function InspectorControlsFill( {
 	children,
 	group = 'default',
 	__experimentalGroup,
+	__nextNoBaseControlMargin = false,
 	resetAllFilter,
 } ) {
 	if ( __experimentalGroup ) {
@@ -53,7 +54,15 @@ export default function InspectorControlsFill( {
 					return (
 						<ToolsPanelInspectorControl
 							fillProps={ fillProps }
-							children={ children }
+							children={
+								__nextNoBaseControlMargin ? (
+									<div className="block-editor-inspector-controls__no-base-control-margin">
+										{ children }
+									</div>
+								) : (
+									children
+								)
+							}
 							resetAllFilter={ resetAllFilter }
 						/>
 					);

--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -31,7 +31,6 @@
 @import "./nextpage/editor.scss";
 @import "./page-list/editor.scss";
 @import "./paragraph/editor.scss";
-@import "./post-author/editor.scss";
 @import "./post-excerpt/editor.scss";
 @import "./pullquote/editor.scss";
 @import "./rss/editor.scss";

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -99,12 +99,9 @@ function PostAuthorEdit( {
 
 	return (
 		<>
-			<InspectorControls>
+			<InspectorControls __nextNoBaseControlMargin>
 				<PanelBody title={ __( 'Settings' ) }>
-					<VStack
-						spacing={ 4 }
-						className="wp-block-post-author__inspector-settings"
-					>
+					<VStack spacing={ 4 }>
 						{ showAuthorControl &&
 							( ( showCombobox && (
 								<ComboboxControl

--- a/packages/block-library/src/post-author/editor.scss
+++ b/packages/block-library/src/post-author/editor.scss
@@ -1,7 +1,0 @@
-.wp-block-post-author__inspector-settings {
-	// Counteract the margin added by the block inspector.
-	.components-base-control,
-	.components-base-control:last-child {
-		margin-bottom: 0;
-	}
-}


### PR DESCRIPTION
Part of #65191

## What?

Adds a `__nextNoBaseControlMargin` opt-in prop to bypass `BaseControl` bottom margins added by Block Inspector CSS.

### TODO

- [ ] What happens in Grid slots like ToolsPanel?
- [ ] How to manage spacing when there are multiple sibling fills?
- [ ] CSS implications of adding/removing a wrapper div

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
