### PR TITLE
Block Bindings: Open the stable editor APIs

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -839,6 +839,38 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/url-popover/README.md>
 
+### useBlockBindingsUtils
+
+Retrieves the existing utils to update the block `bindings` metadata.
+
+_Usage_
+
+```js
+import { useBlockBindingsUtils } from '@wordpress/block-editor';
+const { updateBlockBindings, removeAllBlockBindings } = useBlockBindingsUtils();
+
+updateBlockBindings( {
+	url: {
+		source: 'core/post-meta',
+		args: {
+			key: 'url_custom_field',
+		},
+	},
+	alt: {
+		source: 'core/post-meta',
+		args: {
+			key: 'text_custom_field',
+		},
+	},
+} );
+
+removeAllBlockBindings();
+```
+
+_Returns_
+
+-   `?WPBlockBindingsUtils`: Object containing the block bindings utils.
+
 ### useBlockCommands
 
 Undocumented declaration.

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -841,7 +841,12 @@ _Related_
 
 ### useBlockBindingsUtils
 
-Retrieves the existing utils to update the block `bindings` metadata.
+Retrieves the existing utils needed to update the block `bindings` metadata. They can be used to create, modify, or remove connections from the existing block attributes.
+
+It contains the following utils:
+
+-   `updateBlockBindings`: Updates the value of the bindings connected to block attributes. It can be used to remove a specific binding by setting the value to `undefined`.
+-   `removeAllBlockBindings`: Removes the bindings property of the `metadata` attribute.
 
 _Usage_
 
@@ -849,6 +854,7 @@ _Usage_
 import { useBlockBindingsUtils } from '@wordpress/block-editor';
 const { updateBlockBindings, removeAllBlockBindings } = useBlockBindingsUtils();
 
+// Update url and alt attributes.
 updateBlockBindings( {
 	url: {
 		source: 'core/post-meta',
@@ -864,6 +870,10 @@ updateBlockBindings( {
 	},
 } );
 
+// Remove binding from url attribute.
+updateBlockBindings( { url: undefined } );
+
+// Remove bindings from all attributes.
 removeAllBlockBindings();
 ```
 

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -20,7 +20,7 @@ import {
 	removeFormat,
 } from '@wordpress/rich-text';
 import { Popover } from '@wordpress/components';
-import { store as blocksStore } from '@wordpress/blocks';
+import { getBlockBindingsSource } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -39,7 +39,6 @@ import FormatEdit from './format-edit';
 import { getAllowedFormats } from './utils';
 import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
-import { unlock } from '../../lock-unlock';
 import { canBindBlock } from '../../hooks/use-bindings-attributes';
 import BlockContext from '../block-context';
 
@@ -175,7 +174,6 @@ export function RichTextWrapper(
 			}
 
 			const relatedBinding = blockBindings[ identifier ];
-			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
 			const blockBindingsSource = getBlockBindingsSource(
 				relatedBinding.source
 			);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { privateApis as blocksPrivateApis } from '@wordpress/blocks';
+import {
+	getBlockBindingsSource,
+	getBlockBindingsSources,
+} from '@wordpress/blocks';
 import {
 	__experimentalItemGroup as ItemGroup,
 	__experimentalItem as Item,
@@ -47,7 +50,6 @@ const useToolsPanelDropdownMenuProps = () => {
 };
 
 function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
-	const { getBlockBindingsSources } = unlock( blocksPrivateApis );
 	const registeredSources = getBlockBindingsSources();
 	const { updateBlockBindings } = useBlockBindingsUtils();
 	const currentKey = binding?.args?.key;
@@ -96,8 +98,7 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 
 function BlockBindingsAttribute( { attribute, binding, fieldsList } ) {
 	const { source: sourceName, args } = binding || {};
-	const sourceProps =
-		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
+	const sourceProps = getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
 	return (
 		<VStack className="block-editor-bindings__item" spacing={ 0 }>
@@ -200,7 +201,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 			if ( ! bindableAttributes || bindableAttributes.length === 0 ) {
 				return EMPTY_OBJECT;
 			}
-			const { getBlockBindingsSources } = unlock( blocksPrivateApis );
 			const registeredSources = getBlockBindingsSources();
 			Object.entries( registeredSources ).forEach(
 				( [ sourceName, { getFieldsList, usesContext } ] ) => {

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -201,7 +201,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 		const _setAttributes = useCallback(
 			( nextAttributes ) => {
-				registry.batch( ( select, dispatch ) => {
+				registry.batch( () => {
 					if ( ! blockBindings ) {
 						setAttributes( nextAttributes );
 						return;

--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -201,7 +201,7 @@ export const withBlockBindingSupport = createHigherOrderComponent(
 
 		const _setAttributes = useCallback(
 			( nextAttributes ) => {
-				registry.batch( () => {
+				registry.batch( ( select, dispatch ) => {
 					if ( ! blockBindings ) {
 						setAttributes( nextAttributes );
 						return;

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -47,7 +47,6 @@ import { PrivatePublishDateTimePicker } from './components/publish-date-time-pic
 import useSpacingSizes from './components/spacing-sizes-control/hooks/use-spacing-sizes';
 import useBlockDisplayTitle from './components/block-title/use-block-display-title';
 import TabbedSidebar from './components/tabbed-sidebar';
-import { useBlockBindingsUtils } from './utils/block-bindings';
 
 /**
  * Private @wordpress/block-editor APIs.
@@ -92,6 +91,5 @@ lock( privateApis, {
 	useBlockDisplayTitle,
 	__unstableBlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
-	useBlockBindingsUtils,
 	sectionRootClientIdKey,
 } );

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -13,6 +13,43 @@ function isObjectEmpty( object ) {
 	return ! object || Object.keys( object ).length === 0;
 }
 
+/**
+ * Contains utils to update the block `bindings` metadata.
+ *
+ * @typedef {Object} WPBlockBindingsUtils
+ *
+ * @property {Function} updateBlockBindings    Updates the value of the bindings connected to block attributes.
+ * @property {Function} removeAllBlockBindings Removes the bindings property of the `metadata` attribute.
+ */
+
+/**
+ * Retrieves the existing utils to update the block `bindings` metadata.
+ *
+ * @return {?WPBlockBindingsUtils} Object containing the block bindings utils.
+ *
+ * @example
+ * ```js
+ * import { useBlockBindingsUtils } from '@wordpress/block-editor'
+ * const { updateBlockBindings, removeAllBlockBindings } = useBlockBindingsUtils();
+ *
+ * updateBlockBindings( {
+ *     url: {
+ *         source: 'core/post-meta',
+ *         args: {
+ *             key: 'url_custom_field',
+ *         },
+ * 	   },
+ *     alt: {
+ *         source: 'core/post-meta',
+ *         args: {
+ *             key: 'text_custom_field',
+ *         },
+ * 	   }
+ * } );
+ *
+ * removeAllBlockBindings();
+ * ```
+ */
 export function useBlockBindingsUtils() {
 	const { clientId } = useBlockEditContext();
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -44,13 +44,13 @@ function isObjectEmpty( object ) {
  *         args: {
  *             key: 'url_custom_field',
  *         },
- * 	   },
+ *     },
  *     alt: {
  *         source: 'core/post-meta',
  *         args: {
  *             key: 'text_custom_field',
  *         },
- * 	   }
+ *     },
  * } );
  *
  * // Remove binding from url attribute.

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -23,7 +23,12 @@ function isObjectEmpty( object ) {
  */
 
 /**
- * Retrieves the existing utils to update the block `bindings` metadata.
+ * Retrieves the existing utils needed to update the block `bindings` metadata.
+ * They can be used to create, modify, or remove connections from the existing block attributes.
+ *
+ * It contains the following utils:
+ * - `updateBlockBindings`: Updates the value of the bindings connected to block attributes. It can be used to remove a specific binding by setting the value to `undefined`.
+ * - `removeAllBlockBindings`: Removes the bindings property of the `metadata` attribute.
  *
  * @return {?WPBlockBindingsUtils} Object containing the block bindings utils.
  *
@@ -32,6 +37,7 @@ function isObjectEmpty( object ) {
  * import { useBlockBindingsUtils } from '@wordpress/block-editor'
  * const { updateBlockBindings, removeAllBlockBindings } = useBlockBindingsUtils();
  *
+ * // Update url and alt attributes.
  * updateBlockBindings( {
  *     url: {
  *         source: 'core/post-meta',
@@ -47,6 +53,10 @@ function isObjectEmpty( object ) {
  * 	   }
  * } );
  *
+ * // Remove binding from url attribute.
+ * updateBlockBindings( { url: undefined } );
+ *
+ * // Remove bindings from all attributes.
  * removeAllBlockBindings();
  * ```
  */

--- a/packages/block-editor/src/utils/index.js
+++ b/packages/block-editor/src/utils/index.js
@@ -1,2 +1,3 @@
 export { default as transformStyles } from './transform-styles';
 export { default as getPxFromCssUnit } from './get-px-from-css-unit';
+export { useBlockBindingsUtils } from './block-bindings';

--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -32,7 +32,7 @@ import {
 	InnerBlocks,
 } from '@wordpress/block-editor';
 import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
-import { store as blocksStore } from '@wordpress/blocks';
+import { getBlockBindingsSource } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -196,7 +196,6 @@ function ReusableBlockEdit( {
 		( select ) => {
 			const { getBlocks, getSettings, getBlockEditingMode } =
 				select( blockEditorStore );
-			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
 			// For editing link to the site editor if the theme and user permissions support it.
 			return {
 				innerBlocks: getBlocks( patternClientId ),

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -9,7 +9,6 @@ import clsx from 'clsx';
 import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
-import { unlock } from '../lock-unlock';
 
 /**
  * WordPress dependencies
@@ -45,7 +44,7 @@ import {
 	createBlock,
 	cloneBlock,
 	getDefaultBlockName,
-	store as blocksStore,
+	getBlockBindingsSource,
 } from '@wordpress/blocks';
 import { useMergeRefs, useRefEffect } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -240,9 +239,9 @@ function ButtonEdit( props ) {
 				return {};
 			}
 
-			const blockBindingsSource = unlock(
-				select( blocksStore )
-			).getBlockBindingsSource( metadata?.bindings?.url?.source );
+			const blockBindingsSource = getBlockBindingsSource(
+				metadata?.bindings?.url?.source
+			);
 
 			return {
 				lockUrlControls:

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { isBlobURL, createBlobURL } from '@wordpress/blob';
-import { store as blocksStore, createBlock } from '@wordpress/blocks';
+import { createBlock, getBlockBindingsSource } from '@wordpress/blocks';
 import { Placeholder } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import {
@@ -28,7 +28,6 @@ import { useResizeObserver } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import { unlock } from '../lock-unlock';
 import { useUploadMediaFromBlobURL } from '../utils/hooks';
 import Image from './image';
 import { isValidFileType } from './utils';
@@ -372,9 +371,9 @@ export function ImageEdit( {
 				return {};
 			}
 
-			const blockBindingsSource = unlock(
-				select( blocksStore )
-			).getBlockBindingsSource( metadata?.bindings?.url?.source );
+			const blockBindingsSource = getBlockBindingsSource(
+				metadata?.bindings?.url?.source
+			);
 
 			return {
 				lockUrlControls:

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -34,7 +34,7 @@ import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { getFilename } from '@wordpress/url';
-import { switchToBlockType, store as blocksStore } from '@wordpress/blocks';
+import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
 import { crop, overlayText, upload } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -476,7 +476,6 @@ export default function Image( {
 			if ( ! isSingleSelected ) {
 				return {};
 			}
-			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
 			const {
 				url: urlBinding,
 				alt: altBinding,

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -526,8 +526,8 @@ registerBlockBindingsSource( {
 	name: 'plugin/my-custom-source',
 	label: _x( 'My Custom Source', 'block bindings source' ),
 	usesContext: [ 'postType' ],
-	getValues: () => getSourceValues(),
-	setValues: () => updateMyCustomValuesInBatch(),
+	getValues: getSourceValues,
+	setValues: updateMyCustomValuesInBatch,
 	canUserEditValue: () => true,
 } );
 ```

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -536,11 +536,11 @@ _Parameters_
 
 -   _source_ `Object`: Properties of the source to be registered.
 -   _source.name_ `string`: The unique and machine-readable name.
--   _source.label_ `[string]`: Human-readable label.
--   _source.usesContext_ `[Array]`: Array of context needed by the source only in the editor.
--   _source.getValues_ `[Function]`: Function to get the values from the source.
--   _source.setValues_ `[Function]`: Function to update multiple values connected to the source.
--   _source.canUserEditValue_ `[Function]`: Function to determine if the user can edit the value.
+-   _source.label_ `[string]`: Human-readable label. Optional when it is defined in the server.
+-   _source.usesContext_ `[Array]`: Optional array of context needed by the source only in the editor.
+-   _source.getValues_ `[Function]`: Optional function to get the values from the source.
+-   _source.setValues_ `[Function]`: Optional function to update multiple values connected to the source.
+-   _source.canUserEditValue_ `[Function]`: Optional function to determine if the user can edit the value.
 
 ### registerBlockCollection
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -117,7 +117,7 @@ _Returns_
 
 ### getBlockBindingsSource
 
-Returns a registered block bindings source.
+Returns a registered block bindings source by its name.
 
 _Parameters_
 
@@ -845,7 +845,7 @@ _Returns_
 
 ### unregisterBlockBindingsSource
 
-Unregisters a block bindings source
+Unregisters a block bindings source by providing its name.
 
 _Usage_
 

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -115,6 +115,26 @@ _Returns_
 
 -   `string[]`: The attribute names that have the provided role.
 
+### getBlockBindingsSource
+
+Returns a registered block bindings source.
+
+_Parameters_
+
+-   _name_ `string`: Block bindings source name.
+
+_Returns_
+
+-   `?Object`: Block bindings source.
+
+### getBlockBindingsSources
+
+Returns all registered block bindings sources.
+
+_Returns_
+
+-   `Array`: Block bindings sources.
+
 ### getBlockContent
 
 Given a block object, returns the Block's Inner HTML markup.
@@ -492,6 +512,36 @@ _Returns_
 
 -   `Array`: A list of blocks.
 
+### registerBlockBindingsSource
+
+Registers a new block bindings source with an object defining its behavior. Once registered, the source is available to be connected to the supported block attributes.
+
+_Usage_
+
+```js
+import { _x } from '@wordpress/i18n';
+import { registerBlockBindingsSource } from '@wordpress/blocks';
+
+registerBlockBindingsSource( {
+	name: 'plugin/my-custom-source',
+	label: _x( 'My Custom Source', 'block bindings source' ),
+	usesContext: [ 'postType' ],
+	getValues: () => getSourceValues(),
+	setValues: () => updateMyCustomValuesInBatch(),
+	canUserEditValue: () => true,
+} );
+```
+
+_Parameters_
+
+-   _source_ `Object`: Properties of the source to be registered.
+-   _source.name_ `string`: The unique and machine-readable name.
+-   _source.label_ `[string]`: Human-readable label.
+-   _source.usesContext_ `[Array]`: Array of context needed by the source only in the editor.
+-   _source.getValues_ `[Function]`: Function to get the values from the source.
+-   _source.setValues_ `[Function]`: Function to update multiple values connected to the source.
+-   _source.canUserEditValue_ `[Function]`: Function to determine if the user can edit the value.
+
 ### registerBlockCollection
 
 Registers a new block collection to group blocks in the same namespace in the inserter.
@@ -792,6 +842,22 @@ _Parameters_
 _Returns_
 
 -   `Array`: Updated Block list.
+
+### unregisterBlockBindingsSource
+
+Unregisters a block bindings source
+
+_Usage_
+
+```js
+import { unregisterBlockBindingsSource } from '@wordpress/blocks';
+
+unregisterBlockBindingsSource( 'plugin/my-custom-source' );
+```
+
+_Parameters_
+
+-   _name_ `string`: The name of the block bindings source to unregister.
 
 ### unregisterBlockStyle
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -2,12 +2,6 @@
  * Internal dependencies
  */
 import { lock } from '../lock-unlock';
-import {
-	registerBlockBindingsSource,
-	unregisterBlockBindingsSource,
-	getBlockBindingsSource,
-	getBlockBindingsSources,
-} from './registration';
 import { isUnmodifiedBlockContent } from './utils';
 
 // The blocktype is the most important concept within the block API. It defines
@@ -147,6 +141,10 @@ export {
 	unregisterBlockStyle,
 	registerBlockVariation,
 	unregisterBlockVariation,
+	registerBlockBindingsSource,
+	unregisterBlockBindingsSource,
+	getBlockBindingsSource,
+	getBlockBindingsSources,
 } from './registration';
 export {
 	isUnmodifiedBlock,
@@ -179,10 +177,4 @@ export {
 } from './constants';
 
 export const privateApis = {};
-lock( privateApis, {
-	registerBlockBindingsSource,
-	unregisterBlockBindingsSource,
-	getBlockBindingsSource,
-	getBlockBindingsSources,
-	isUnmodifiedBlockContent,
-} );
+lock( privateApis, { isUnmodifiedBlockContent } );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -784,8 +784,8 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  *     name: 'plugin/my-custom-source',
  *     label: _x( 'My Custom Source', 'block bindings source' ),
  *     usesContext: [ 'postType' ],
- *     getValues: () => getSourceValues(),
- *     setValues: () => updateMyCustomValuesInBatch(),
+ *     getValues: getSourceValues,
+ *     setValues: updateMyCustomValuesInBatch,
  *     canUserEditValue: () => true,
  * } );
  * ```

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -774,7 +774,6 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  * @param {Function} [source.getValues]        Function to get the values from the source.
  * @param {Function} [source.setValues]        Function to update multiple values connected to the source.
  * @param {Function} [source.canUserEditValue] Function to determine if the user can edit the value.
- * @param {Function} [source.getFieldsList]    Function to get the lists of fields to expose in the connections panel.
  *
  * @example
  * ```js
@@ -784,6 +783,7 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  * registerBlockBindingsSource( {
  *     name: 'plugin/my-custom-source',
  *     label: _x( 'My Custom Source', 'block bindings source' ),
+ *     usesContext: [ 'postType' ],
  *     getValues: () => getSourceValues(),
  *     setValues: () => updateMyCustomValuesInBatch(),
  *     canUserEditValue: () => true,

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -903,7 +903,7 @@ export const registerBlockBindingsSource = ( source ) => {
 };
 
 /**
- * Unregisters a block bindings source
+ * Unregisters a block bindings source by providing its name.
  *
  * @param {string} name The name of the block bindings source to unregister.
  *
@@ -924,7 +924,7 @@ export function unregisterBlockBindingsSource( name ) {
 }
 
 /**
- * Returns a registered block bindings source.
+ * Returns a registered block bindings source by its name.
  *
  * @param {string} name Block bindings source name.
  *

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -769,11 +769,11 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  *
  * @param {Object}   source                    Properties of the source to be registered.
  * @param {string}   source.name               The unique and machine-readable name.
- * @param {string}   [source.label]            Human-readable label.
- * @param {Array}    [source.usesContext]      Array of context needed by the source only in the editor.
- * @param {Function} [source.getValues]        Function to get the values from the source.
- * @param {Function} [source.setValues]        Function to update multiple values connected to the source.
- * @param {Function} [source.canUserEditValue] Function to determine if the user can edit the value.
+ * @param {string}   [source.label]            Human-readable label. Optional when it is defined in the server.
+ * @param {Array}    [source.usesContext]      Optional array of context needed by the source only in the editor.
+ * @param {Function} [source.getValues]        Optional function to get the values from the source.
+ * @param {Function} [source.setValues]        Optional function to update multiple values connected to the source.
+ * @param {Function} [source.canUserEditValue] Optional function to determine if the user can edit the value.
  *
  * @example
  * ```js

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -393,6 +393,13 @@ function getMergedUsesContext( existingUsesContext = [], newUsesContext = [] ) {
 export function blockBindingsSources( state = {}, action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_BINDINGS_SOURCE':
+			// Only open this API in Gutenberg and for `core/post-meta` for the moment.
+			let getFieldsList;
+			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+				getFieldsList = action.getFieldsList;
+			} else if ( action.name === 'core/post-meta' ) {
+				getFieldsList = action.getFieldsList;
+			}
 			return {
 				...state,
 				[ action.name ]: {
@@ -407,7 +414,7 @@ export function blockBindingsSources( state = {}, action ) {
 					// Only set `canUserEditValue` if `setValues` is also defined.
 					canUserEditValue:
 						action.setValues && action.canUserEditValue,
-					getFieldsList: action.getFieldsList,
+					getFieldsList,
 				},
 			};
 		case 'ADD_BOOTSTRAPPED_BLOCK_BINDINGS_SOURCE':

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -1,10 +1,4 @@
-const { unlock } =
-	wp.privateApis.__dangerousOptInToUnstableAPIsOnlyForCoreModules(
-		'I acknowledge private features are not for use in themes or plugins and doing so will break in the next version of WordPress.',
-		'@wordpress/blocks'
-	);
-
-const { registerBlockBindingsSource } = unlock( wp.blocks.privateApis );
+const { registerBlockBindingsSource } = wp.blocks;
 const { fieldsList } = window.testingBindings || {};
 
 const getValues = ( { bindings } ) => {

--- a/packages/editor/src/bindings/api.js
+++ b/packages/editor/src/bindings/api.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import {
-	privateApis as blocksPrivateApis,
 	store as blocksStore,
+	registerBlockBindingsSource,
 } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 
@@ -25,7 +25,6 @@ import { unlock } from '../lock-unlock';
  * ```
  */
 export function registerCoreBlockBindingsSources() {
-	const { registerBlockBindingsSource } = unlock( blocksPrivateApis );
 	registerBlockBindingsSource( patternOverrides );
 	registerBlockBindingsSource( postMeta );
 }

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -6,7 +6,7 @@ import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditingMode } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { store as blocksStore } from '@wordpress/blocks';
+import { getBlockBindingsSource } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -58,7 +58,6 @@ function ControlsWithStoreSubscription( props ) {
 	const blockEditingMode = useBlockEditingMode();
 	const { hasPatternOverridesSource, isEditingSyncedPattern } = useSelect(
 		( select ) => {
-			const { getBlockBindingsSource } = unlock( select( blocksStore ) );
 			const { getCurrentPostType, getEditedPostAttribute } =
 				select( editorStore );
 

--- a/packages/patterns/src/components/pattern-overrides-controls.js
+++ b/packages/patterns/src/components/pattern-overrides-controls.js
@@ -4,7 +4,7 @@
 import { useState, useId } from '@wordpress/element';
 import {
 	InspectorControls,
-	privateApis as blockEditorPrivateApis,
+	useBlockBindingsUtils,
 } from '@wordpress/block-editor';
 import { BaseControl, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -17,9 +17,6 @@ import {
 	AllowOverridesModal,
 	DisallowOverridesModal,
 } from './allow-overrides-modal';
-import { unlock } from '../lock-unlock';
-
-const { useBlockBindingsUtils } = unlock( blockEditorPrivateApis );
 
 function PatternOverridesControls( {
 	attributes,


### PR DESCRIPTION
This PR is built on top of https://github.com/WordPress/gutenberg/pull/65710 because it shouldn't be merged until that one is done.

## What?
In this pull request, I propose opening the block bindings editor APIs that I personally consider stable because they have been used privately for a whole release cycle now. This covers:

### Block bindings utils
It exposes a `useBlockBindingsUtils` hook that returns the helpers to modify the `metadata.bindings` attribute. Right now, it includes:

- `updateBlockBindings`: This works similarly to `updateBlockAttributes`. It can be used to create/remove specific connections.
- `removeAllBlockBindings`: This is used to remove all connections existing in a block.

These utils are being used by the UI to connect to post meta and by pattern overrides. They can be helpful to let other sources build their own UI if wanted.

### Registration API
It exposes the following functions:
- `registerBlockBindingsSource`: to register a source in the client (more on this later).
- `unregisterBlockBindingsSource`: to unregister an existing source.
- `getBlockBindingsSource`: to get a specific registered source and its properties.
- `getBlockBindingsSources`: to get all the registered sources in the client.
 
They are based on other registration APIs like block types, block variations, or block collections.

### Source properties
Each registered source in the client can include the following properties:
- `name`: The unique and machine-readable name.
- `label`: Human-readable label.
- `usesContext`: Array of context needed by the source only in the editor.
- `getValues`: Function to get the values from the source. It receives `select`, `context`, and the block `bindings` created for that specific source. It must return an object with `attribute: value`. Similar to `getBlockAttributes`.
- `setValues`: Function to update multiple values connected to the source. It receives `select`, `dispatch`, `context`, and the block `bindings` created for that specific source, including the new value. Similar to `updateBlockAttributes`.
- `canUserEditValue`: Function to let the editor know if the block attribute connected should be editable or not. It receives `select`, `context`, and the source arguments.

They all include proper testing, and there are JSDocs, but **they need to be documented better**.

Apart from that, there is the `getFieldsList` property that remains private for 6.7 and only works for `core/post-meta` BUT it is open if Gutenberg is active. This one is not mature enough and this way, it will allow us to gather feedback and iterate on it safely.

## Why?
Opening the editor APIs was a common demand for block bindings and it empowers what extenders can build with it. Additionally, I believe the APIs we are exposing should be safe.

## How?
* Export the functions as non-private APIs.
* Remove all the `unlock` where these functions were called.
* Add a check in the reducer to ensure `getFieldsList` can only be used for post meta or when Gutenberg plugin is active.

## Testing Instructions
These APIs are covered in the block-bindings tests. So they should pass.
