### PR TITLE
Buttons: add box-sizing:border-box rule

### DIFF
--- a/packages/block-library/src/buttons/style.scss
+++ b/packages/block-library/src/buttons/style.scss
@@ -2,6 +2,8 @@
 $blocks-block__margin: 0.5em;
 
 .wp-block-buttons {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
 
 	&.is-vertical {
 		flex-direction: column;


### PR DESCRIPTION
Related to #63538

## What?

This PR applies `box-sizing: border-box` to the Buttons block, so that its size when padding and background color are applied will match that of other blocks.

## Why?

As mentioned in #43465, I think this rule is necessary for `wp-block-`-based blocks that support padding.

However, some users may prefer to fit the buttons inside to the container width instead of the wrapper block. Please let me know your thoughts.

## Testing Instructions

Insert a Buttons block and apply padding, border and background color to it.

## Screenshots or screencast <!-- if applicable -->

Below are screenshots of Twenty Twenty-Five:

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/aace7764-d2d4-470f-988f-e5947e23afbc) | ![after](https://github.com/user-attachments/assets/ccc194a8-a3d5-4468-8d29-ec2c8c47fca0) |

> [!NOTE]
> I consider adding `box-sizing` an enhancement rather than a bug fix, but I am wondering whether this should be backported to WP 6.7. 
> By the way, Twenty Twenty-Five should not be affected by this change ([Search results by `"<!-- wp:buttons"`](https://github.com/search?q=repo%3AWordPress%2Ftwentytwentyfive%20%22%3C!--%20wp%3Abuttons%22&type=code)).