### PR TITLE
Block Bindings UI: Decode HTML entities in Block Bindings UI label

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -15,6 +15,7 @@ import {
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useContext, Fragment } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
@@ -99,6 +100,11 @@ function BlockBindingsAttribute( { attribute, binding, fieldsList } ) {
 	const sourceProps =
 		unlock( blocksPrivateApis ).getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
+	const sourceLabel = isSourceInvalid
+		? __( 'Invalid source' )
+		: fieldsList?.[ sourceName ]?.[ args?.key ]?.label ||
+		  sourceProps?.label ||
+		  sourceName;
 	return (
 		<VStack className="block-editor-bindings__item" spacing={ 0 }>
 			<Text truncate>{ attribute }</Text>
@@ -108,11 +114,7 @@ function BlockBindingsAttribute( { attribute, binding, fieldsList } ) {
 					variant={ ! isSourceInvalid && 'muted' }
 					isDestructive={ isSourceInvalid }
 				>
-					{ isSourceInvalid
-						? __( 'Invalid source' )
-						: fieldsList?.[ sourceName ]?.[ args?.key ]?.label ||
-						  sourceProps?.label ||
-						  sourceName }
+					{ decodeEntities( sourceLabel ) }
 				</Text>
 			) }
 		</VStack>


### PR DESCRIPTION
## What?

The Twenty Twenty-Five theme [uses a block binding to display copy text in the footer](https://github.com/WordPress/twentytwentyfive/blob/dab66613aff7fd1d171450d6bc1f303b57cc7d59/functions.php#L146). I noticed that the HTML entities for this label were not displaying correctly.

## Testing Instructions

- Download Twenty Twenty-Five from [the GitHub repository](https://github.com/WordPress/twentytwentyfive) and activate it.
- Click the copy text in the footer template.
- Check the Attributes panel.

If you want to test other HTML entities, use code like the one below:

```php
register_block_bindings_source(
	'test/html-entities',
	array(
		'label'              => '&amp; &#8240; &cent;',
		'get_value_callback' => '__return_null',
	)
);
```

```html
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"test/html-entities"}}}} -->
<p></p>
<!-- /wp:paragraph -->
```

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/4ad48c74-12ee-45fe-9c96-547a0b589796)

### After

![image](https://github.com/user-attachments/assets/ccba30ba-ccaf-4278-81fd-7722a867f500)

