### PR TITLE
Openverse: prevent multiple insertions during upload

### DIFF
--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -193,7 +193,6 @@ export function MediaPreview( { media, onClick, category } ) {
 									},
 								} );
 
-								// TODO: Move to a new onSuccess callback as part of #61447.
 								createSuccessNotice(
 									__( 'Image uploaded and inserted.' ),
 									{ type: 'snackbar', id: 'inserter-notice' }

--- a/packages/block-editor/src/components/inserter/media-tab/media-preview.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-preview.js
@@ -20,7 +20,7 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { useMemo, useCallback, useState, useRef } from '@wordpress/element';
+import { useMemo, useCallback, useState } from '@wordpress/element';
 import { cloneBlock } from '@wordpress/blocks';
 import { moreVertical, external } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -127,14 +127,13 @@ export function MediaPreview( { media, onClick, category } ) {
 		useState( false );
 	const [ isHovered, setIsHovered ] = useState( false );
 	const [ isInserting, setIsInserting ] = useState( false );
-	const hasInsertedBlock = useRef( false );
 	const [ block, preview ] = useMemo(
 		() => getBlockAndPreviewFromMedia( media, category.mediaType ),
 		[ media, category.mediaType ]
 	);
 	const { createErrorNotice, createSuccessNotice } =
 		useDispatch( noticesStore );
-	const { getSettings } = useSelect( blockEditorStore );
+	const { getSettings, getBlock } = useSelect( blockEditorStore );
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
 
 	const onMediaInsert = useCallback(
@@ -183,7 +182,7 @@ export function MediaPreview( { media, onClick, category } ) {
 								return;
 							}
 
-							if ( ! hasInsertedBlock.current ) {
+							if ( ! getBlock( clonedBlock.clientId ) ) {
 								// Ensure the block is only inserted once.
 								onClick( {
 									...clonedBlock,
@@ -199,8 +198,6 @@ export function MediaPreview( { media, onClick, category } ) {
 									__( 'Image uploaded and inserted.' ),
 									{ type: 'snackbar', id: 'inserter-notice' }
 								);
-
-								hasInsertedBlock.current = true;
 							} else {
 								// For subsequent calls, update the existing block.
 								updateBlockAttributes( clonedBlock.clientId, {
@@ -234,6 +231,7 @@ export function MediaPreview( { media, onClick, category } ) {
 			createSuccessNotice,
 			updateBlockAttributes,
 			createErrorNotice,
+			getBlock,
 		]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When adding an Openverse image from the inserter, `mediaUpload()` is called to upload the image to the media library.

Inserting the block onto the canvas happens in the `onFileChange` callback.

This callback can theoretically be called multiple times, especially in the future.

The block should only be inserted once though, and on subsequent invocations it should just update the existing block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

I noticed this while working on client-side media processing, see https://github.com/swissspidy/media-experiments/issues/693 and #61447

There, the `onFileChange` callback can be fired dozens of times, which caused the block to be inserted over and over again.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses a `ref` to check whether the block has already been inserted or not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Activate the Media Experiments plugin
2. Insert an Openverse image through the media inserter
3. Verify that it's only added to the canvas once and not multiple times

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->
