### PR TITLE
Composite: make items tabbable if active element gets removed

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 -   `ToggleGroupControl`: Fix arrow key navigation in RTL ([#65735](https://github.com/WordPress/gutenberg/pull/65735)).
 -   `ToggleGroupControl`: indicator doesn't jump around when the layout around it changes ([#65175](https://github.com/WordPress/gutenberg/pull/65175)).
 -   `Composite`: fix legacy support for the store prop ([#65821](https://github.com/WordPress/gutenberg/pull/65821)).
+-   `Composite`: make items tabbable if active element gets removed ([#65720](https://github.com/WordPress/gutenberg/pull/65720)).
 
 ### Deprecations
 

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -26,5 +26,23 @@ export const CompositeItem = forwardRef<
 	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
-	return <Ariakit.CompositeItem store={ store } { ...props } ref={ ref } />;
+	// If the active item is not connected, Composite may end up in a state
+	// where none of the items are tabbable. In this case, we force all items to
+	// be tabbable, so that as soon as an item received focus, it becomes active
+	// and Composite goes back to working as expected.
+	const tabbable = Ariakit.useStoreState( store, ( state ) => {
+		return (
+			state?.activeId !== null &&
+			! store?.item( state?.activeId )?.element?.isConnected
+		);
+	} );
+
+	return (
+		<Ariakit.CompositeItem
+			store={ store }
+			tabbable={ tabbable }
+			{ ...props }
+			ref={ ref }
+		/>
+	);
 } );

--- a/packages/components/src/composite/test/index.tsx
+++ b/packages/components/src/composite/test/index.tsx
@@ -69,7 +69,7 @@ function RemoveItemTest( props: ComponentProps< typeof Composite > ) {
 }
 
 describe( 'Composite', () => {
-	it( 'should remain focussable even when there is no elements in the DOM associated with the currently active ID', async () => {
+	it( 'should remain focusable even when there are no elements in the DOM associated with the currently active ID', async () => {
 		await renderAndValidate( <RemoveItemTest /> );
 
 		const toggleButton = screen.getByRole( 'button', {

--- a/packages/components/src/composite/test/index.tsx
+++ b/packages/components/src/composite/test/index.tsx
@@ -1,0 +1,123 @@
+/**
+ * External dependencies
+ */
+import { queryByAttribute, render, screen } from '@testing-library/react';
+import { click, press, waitFor } from '@ariakit/test';
+import type { ComponentProps } from 'react';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { Composite } from '..';
+
+// This is necessary because of how Ariakit calculates page up and
+// page down. Without this, nothing has a height, and so paging up
+// and down doesn't behave as expected in tests.
+
+let clientHeightSpy: jest.SpiedGetter<
+	typeof HTMLElement.prototype.clientHeight
+>;
+
+beforeAll( () => {
+	clientHeightSpy = jest
+		.spyOn( HTMLElement.prototype, 'clientHeight', 'get' )
+		.mockImplementation( function getClientHeight( this: HTMLElement ) {
+			if ( this.tagName === 'BODY' ) {
+				return window.outerHeight;
+			}
+			return 50;
+		} );
+} );
+
+afterAll( () => {
+	clientHeightSpy?.mockRestore();
+} );
+
+async function renderAndValidate( ...args: Parameters< typeof render > ) {
+	const view = render( ...args );
+	await waitFor( () => {
+		const activeButton = queryByAttribute(
+			'data-active-item',
+			view.baseElement,
+			'true'
+		);
+		expect( activeButton ).not.toBeNull();
+	} );
+	return view;
+}
+
+function RemoveItemTest( props: ComponentProps< typeof Composite > ) {
+	const [ showThirdItem, setShowThirdItem ] = useState( true );
+	return (
+		<>
+			<button>Focus trap before composite</button>
+			<Composite { ...props }>
+				<Composite.Item>Item 1</Composite.Item>
+				<Composite.Item>Item 2</Composite.Item>
+				{ showThirdItem && <Composite.Item>Item 3</Composite.Item> }
+			</Composite>
+			<button onClick={ () => setShowThirdItem( ( value ) => ! value ) }>
+				Toggle third item
+			</button>
+		</>
+	);
+}
+
+describe( 'Composite', () => {
+	it( 'should remain focussable even when there is no elements in the DOM associated with the currently active ID', async () => {
+		await renderAndValidate( <RemoveItemTest /> );
+
+		const toggleButton = screen.getByRole( 'button', {
+			name: 'Toggle third item',
+		} );
+
+		await press.Tab();
+		await press.Tab();
+
+		expect(
+			screen.getByRole( 'button', { name: 'Item 1' } )
+		).toHaveFocus();
+
+		await press.ArrowRight();
+		await press.ArrowRight();
+
+		expect(
+			screen.getByRole( 'button', { name: 'Item 3' } )
+		).toHaveFocus();
+
+		await click( toggleButton );
+
+		expect(
+			screen.queryByRole( 'button', { name: 'Item 3' } )
+		).not.toBeInTheDocument();
+
+		await press.ShiftTab();
+
+		expect(
+			screen.getByRole( 'button', { name: 'Item 2' } )
+		).toHaveFocus();
+
+		await click( toggleButton );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Item 3' } )
+		).toBeVisible();
+
+		await press.ShiftTab();
+
+		expect(
+			screen.getByRole( 'button', { name: 'Item 2' } )
+		).toHaveFocus();
+
+		await press.ArrowRight();
+
+		expect(
+			screen.getByRole( 'button', { name: 'Item 3' } )
+		).toHaveFocus();
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

May fix https://github.com/WordPress/gutenberg/issues/65283

This PR tweaks the behavior of the `Composite` component so that the composite widget can continue to receive keyboard focus even when its active ID doesn't correspond to an element rendered in the DOM.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The fact that `Composite` can end up in a situation where the whole widget is not focusable is bad for assistive technology, and we should try to fix it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Following [a suggestion](https://github.com/ariakit/ariakit/issues/4129) from the Ariakit maintainers, this PR makes all composite items tabbable if the element associated with the active ID is not connected to the store.

In this case, when the focus is moved back to the composite widget, the items will be able to receive focus. As soon as one item receives focus, all composite items will stop being tabbable and revert back to the standard behavior of a composite widget.

## Review suggestions

Review commit-by-commit. The actual fix is applied in the first commit. The rest of the commits are accessories to the main fix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In Storybook:
- Load the "Remove active item" example
- Focus the composite widget, and with the arrow keys move focus on the third item
- Tab to the "Toggle third item button" and click it
- Tab back to the composite widget: the second item should receive focus and become active
- Moving arrow keys should work as expected in the composite widget

<details>

<summary>Edit: it looks like the UI has changed and it's impossible to reproduce the bug in the editor as of now</summary>

In the editor:
- Follow the testing instructions indicated in https://github.com/WordPress/gutenberg/issues/65283
- When clicking the "randomize colors" button, tab back to the color palette.
- The last item in the palette should receive keyboard focus
- Moving arrow keys should work as expected in the composite widget

</details>

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/d7535e1c-d70e-4ee2-a7e3-bbdadeec1e32" /> | <video src="https://github.com/user-attachments/assets/d91a8172-e2d8-460f-967d-cc9b65bff417" /> |


