### PR TITLE
Update tools menus with Write / Design order

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -71,6 +71,16 @@ function ToolSelector( props, ref ) {
 							onSelect={ __unstableSetEditorMode }
 							choices={ [
 								{
+									value: 'navigation',
+									label: (
+										<>
+											<Icon icon={ editIcon } />
+											{ __( 'Write' ) }
+										</>
+									),
+									info: __( 'Focus on content.' ),
+								},
+								{
 									value: 'edit',
 									label: (
 										<>
@@ -78,19 +88,7 @@ function ToolSelector( props, ref ) {
 											{ __( 'Design' ) }
 										</>
 									),
-									info: __(
-										'Full control over layout and styling.'
-									),
-								},
-								{
-									value: 'navigation',
-									label: (
-										<>
-											<Icon icon={ editIcon } />
-											{ __( 'Edit' ) }
-										</>
-									),
-									info: __( 'Focus on content.' ),
+									info: __( 'Edit layout and styles.' ),
 								},
 							] }
 						/>

--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -95,7 +95,7 @@ function ToolSelector( props, ref ) {
 					</NavigableMenu>
 					<div className="block-editor-tool-selector__help">
 						{ __(
-							'Tools provide different interactions for selecting, navigating, and editing blocks. Toggle between select and edit by pressing Escape and Enter.'
+							'Tools provide different sets of interactions for blocks. Toggle between simplified content tools (Write) and advanced visual editing tools (Design).'
 						) }
 					</div>
 				</>


### PR DESCRIPTION
Closes #65663 

The "Write" descriptor might feel a bit off in the context of template or page editing, but perhaps we can make it contextual on whether "visible template" is on or off.