### PR TITLE
Feat: Moves size settings to inspector controls.

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -8,7 +8,6 @@ import clsx from 'clsx';
  */
 import { useEffect, useRef } from '@wordpress/element';
 import {
-	BlockControls,
 	useInnerBlocksProps,
 	useBlockProps,
 	InspectorControls,
@@ -20,16 +19,12 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
-	MenuGroup,
-	MenuItem,
 	PanelBody,
 	ToggleControl,
-	ToolbarDropdownMenu,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { check } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
 const sizeOptions = [
@@ -119,10 +114,6 @@ export function SocialLinksEdit( props ) {
 		renderAppender: hasAnySelected && InnerBlocks.ButtonBlockAppender,
 	} );
 
-	const POPOVER_PROPS = {
-		position: 'bottom right',
-	};
-
 	const colorSettings = [
 		{
 			// Use custom attribute as fallback to prevent loss of named color selection when
@@ -163,43 +154,6 @@ export function SocialLinksEdit( props ) {
 
 	return (
 		<>
-			<BlockControls group="other">
-				<ToolbarDropdownMenu
-					label={ __( 'Size' ) }
-					text={ __( 'Size' ) }
-					icon={ null }
-					popoverProps={ POPOVER_PROPS }
-				>
-					{ ( { onClose } ) => (
-						<MenuGroup>
-							{ sizeOptions.map( ( entry ) => {
-								return (
-									<MenuItem
-										icon={
-											( size === entry.value ||
-												( ! size &&
-													entry.value ===
-														'has-normal-icon-size' ) ) &&
-											check
-										}
-										isSelected={ size === entry.value }
-										key={ entry.value }
-										onClick={ () => {
-											setAttributes( {
-												size: entry.value,
-											} );
-										} }
-										onClose={ onClose }
-										role="menuitemradio"
-									>
-										{ entry.name }
-									</MenuItem>
-								);
-							} ) }
-						</MenuGroup>
-					) }
-				</ToolbarDropdownMenu>
-			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<ToggleGroupControl

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -18,20 +18,15 @@ import {
 	__experimentalUseMultipleOriginColorsAndGradients as useMultipleOriginColorsAndGradients,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import {
-	PanelBody,
-	ToggleControl,
-	__experimentalToggleGroupControl as ToggleGroupControl,
-	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-} from '@wordpress/components';
+import { PanelBody, ToggleControl, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
 const sizeOptions = [
-	{ name: __( 'Small' ), value: 'has-small-icon-size' },
-	{ name: __( 'Normal' ), value: 'has-normal-icon-size' },
-	{ name: __( 'Large' ), value: 'has-large-icon-size' },
-	{ name: __( 'Huge' ), value: 'has-huge-icon-size' },
+	{ label: __( 'Small' ), value: 'has-small-icon-size' },
+	{ label: __( 'Normal' ), value: 'has-normal-icon-size' },
+	{ label: __( 'Large' ), value: 'has-large-icon-size' },
+	{ label: __( 'Huge' ), value: 'has-huge-icon-size' },
 ];
 
 export function SocialLinksEdit( props ) {
@@ -156,29 +151,19 @@ export function SocialLinksEdit( props ) {
 		<>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
-					<ToggleGroupControl
+					<SelectControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
+						help={ __( 'Choose the size of the Social Icons.' ) }
 						label={ __( 'Size' ) }
-						value={ size ?? 'has-normal-icon-size' }
 						onChange={ ( entry ) => {
 							setAttributes( {
 								size: entry,
 							} );
 						} }
-						isBlock
-						help={ __( 'Choose the size of the Social Icons.' ) }
-					>
-						{ sizeOptions.map( ( entry ) => {
-							return (
-								<ToggleGroupControlOption
-									key={ entry.value }
-									value={ entry.value }
-									label={ entry.name }
-								/>
-							);
-						} ) }
-					</ToggleGroupControl>
+						value={ size ?? 'has-normal-icon-size' }
+						options={ sizeOptions }
+					/>
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Open links in new tab' ) }

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -25,6 +25,8 @@ import {
 	PanelBody,
 	ToggleControl,
 	ToolbarDropdownMenu,
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
@@ -200,6 +202,29 @@ export function SocialLinksEdit( props ) {
 			</BlockControls>
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						label={ __( 'Size' ) }
+						value={ size ?? 'has-normal-icon-size' }
+						onChange={ ( entry ) => {
+							setAttributes( {
+								size: entry,
+							} );
+						} }
+						isBlock
+						help={ __( 'Choose the size of the Social Icons.' ) }
+					>
+						{ sizeOptions.map( ( entry ) => {
+							return (
+								<ToggleGroupControlOption
+									key={ entry.value }
+									value={ entry.value }
+									label={ entry.name }
+								/>
+							);
+						} ) }
+					</ToggleGroupControl>
 					<ToggleControl
 						__nextHasNoMarginBottom
 						label={ __( 'Open links in new tab' ) }


### PR DESCRIPTION
## What?
Fixes: #65647 

## Why?
The Social Icons block has a 'size' setting that is placed in a toolbar dropdown menu labeled 'Size', but in other blocks it is there in inspector controls.

## How?
This PR moves the size settings to inspector controls.

## Testing Instructions
1. Add the Social Icons Block.
2. Size settings should be available in the inspector controls panel instead on block toolbar. 

## Screenshots or screencast 

https://github.com/user-attachments/assets/f623fa21-a5f9-4e71-bb65-41eb9ce4d3a2
