### PR TITLE
Limit zoom out toggle to specific post types

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -57,15 +57,18 @@ function Header( {
 		showIconLabels,
 		hasFixedToolbar,
 		isNestedEntity,
+		postType,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
 			getEditorMode,
 			getEditorSettings,
+			getCurrentPostType,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
 		} = select( editorStore );
 
 		return {
+			postType: getCurrentPostType(),
 			isTextEditor: getEditorMode() === 'text',
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
@@ -74,6 +77,10 @@ function Header( {
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
 		};
 	}, [] );
+
+	const canBeZoomedOut = [ 'post', 'page', 'wp_template' ].includes(
+		postType
+	);
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
@@ -135,7 +142,9 @@ function Header( {
 					<PostSavedState forceIsDirty={ forceIsDirty } />
 				) }
 
-				{ isEditorIframed && isWideViewport && <ZoomOutToggle /> }
+				{ canBeZoomedOut && isEditorIframed && isWideViewport && (
+					<ZoomOutToggle />
+				) }
 
 				<PreviewDropdown
 					forceIsAutosaveable={ forceIsDirty }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #61044

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

> It doesn't make sense - for now - to engage zoom out mode when we're editing a template part or a single pattern. In these situations the detailed focused editing of a small amount of content makes no use of a bird's eye view.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Hardcodes the post types we want the mode to be available for and does not render the affordance to access it for the others.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a template that has a header and a footer
2. _The zoom out toggle should render in the header_
3. Select a header
4. Select edit from the block toolbar
5. _The zoom out toggle should not render in the header_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/979e0549-93f9-47ff-ae5a-ba73aa921ca3


