### PR TITLE
Edit Post: Remove unnecessary effect in `InitPatternModal`

### DIFF
--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -11,12 +11,11 @@ import {
 	ToggleControl,
 	TextControl,
 } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
 
 export default function InitPatternModal() {
 	const { editPost } = useDispatch( editorStore );
-	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ syncType, setSyncType ] = useState( undefined );
 	const [ title, setTitle ] = useState( '' );
 
@@ -28,14 +27,9 @@ export default function InitPatternModal() {
 			isNewPost: isCleanNewPost(),
 		};
 	}, [] );
-
-	useEffect( () => {
-		if ( isNewPost && postType === 'wp_block' ) {
-			setIsModalOpen( true );
-		}
-		// We only want the modal to open when the page is first loaded.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
+	const [ isModalOpen, setIsModalOpen ] = useState( () =>
+		isNewPost && postType === 'wp_block' ? true : false
+	);
 
 	if ( postType !== 'wp_block' || ! isNewPost ) {
 		return null;


### PR DESCRIPTION
## What?
This PR removes the unnecessary `useEffect` from `InitPatternModal` and replaces it with conditional lazy state init.

## Why?
We're allowing the React Compiler to work with this component - previously it was returning this due to our `eslint-ignore`:

```
37:3  error  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-compiler/react-compiler
```

We're also saving an extra rerender. 

See #61788.

## How?
We're removing the `useEffect` call and moving the conditional logic to lazy state initialization.

## Testing Instructions
* Open `/wp-admin/post-new.php?post_type=wp_block`
* Verify the popup appears immediately.
* Open `/wp-admin/post-new.php`
* Verify no popup appears.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-09-30 at 12 35 35](https://github.com/user-attachments/assets/fa7d74dc-ff77-4b7e-9f47-ea50a8e142f4)
