### PR TITLE
ToggleGroupControl: Fix arrow key navigation in RTL

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   `ToolsPanel`: atomic one-step state update when (un)registering panels ([#65564](https://github.com/WordPress/gutenberg/pull/65564)).
 -   `Navigator`: fix `isInitial` logic ([#65527](https://github.com/WordPress/gutenberg/pull/65527)).
+-   `ToggleGroupControl`: Fix arrow key navigation in RTL ([#65735](https://github.com/WordPress/gutenberg/pull/65735)).
 
 ### Deprecations
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -10,6 +10,7 @@ import { useStoreState } from '@ariakit/react';
  */
 import { useInstanceId } from '@wordpress/compose';
 import { forwardRef, useMemo } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -65,6 +66,7 @@ function UnforwardedToggleGroupControlAsRadioGroup(
 		defaultValue,
 		value,
 		setValue: wrappedOnChangeProp,
+		rtl: isRTL(),
 	} );
 
 	const selectedValue = useStoreState( radio, 'value' );


### PR DESCRIPTION
Reported in https://github.com/WordPress/gutenberg/issues/64963#issuecomment-2342603496

## What?

Fixes arrow key navigation when ToggleGroupControl is in RTL mode.

### Testing Instructions for Keyboard

See default Storybook story for ToggleGroupControl and toggle it to RTL mode in the toolbar. Test that arrow key navigation works as expected.


https://github.com/user-attachments/assets/35cdec00-d38c-4801-acff-c119317d955d

