### PR TITLE
Block Editor: use shallow memo for prioritized inserter blocks

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useLayoutEffect, useMemo, useState } from '@wordpress/element';
+import { useLayoutEffect, useState } from '@wordpress/element';
 import { useRegistry } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import isShallowEqual from '@wordpress/is-shallow-equal';
@@ -77,10 +77,7 @@ export default function useNestedSettingsUpdate(
 	// otherwise if the arrays change length but the first elements are equal the comparison,
 	// does not works as expected.
 	const _allowedBlocks = useShallowMemo( allowedBlocks );
-
-	const _prioritizedInserterBlocks = useMemo(
-		() => prioritizedInserterBlocks,
-		// eslint-disable-next-line react-hooks/exhaustive-deps
+	const _prioritizedInserterBlocks = useShallowMemo(
 		prioritizedInserterBlocks
 	);
 

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -16,12 +16,21 @@ import { getLayoutType } from '../../layouts';
 
 const pendingSettingsUpdates = new WeakMap();
 
+// Creates a memoizing caching function that remembers the last value and keeps returning it
+// as long as the new values are shallowly equal. Helps keep dependencies stable.
+function createShallowMemo() {
+	let value;
+	return ( newValue ) => {
+		if ( value === undefined || ! isShallowEqual( value, newValue ) ) {
+			value = newValue;
+		}
+		return value;
+	};
+}
+
 function useShallowMemo( value ) {
-	const [ prevValue, setPrevValue ] = useState( value );
-	if ( ! isShallowEqual( prevValue, value ) ) {
-		setPrevValue( value );
-	}
-	return prevValue;
+	const [ memo ] = useState( createShallowMemo );
+	return memo( value );
 }
 
 /**


### PR DESCRIPTION
## What?
This PR updates the prioritized inserter blocks prop to utilize the `useShallowMemo` utility, which considers array length changes. 

## Why?
This was initially motivated by resolving an error for React Compiler (see https://github.com/WordPress/gutenberg/pull/61788):

```
  83:3  error  React Compiler has skipped optimizing this component because one or more React ESLint rules were disabled. React Compiler only works when your components follow all the rules of React, disabling them may result in unexpected or incorrect behavior  react-compiler/react-compiler
```

But then, while researching why it was there in the first place, I noticed @ellatrix introduced the memoization in #30311 to reduce extra updates without a stable reference. @jorgefilipecosta took it a step further in #53943 to consider array length changes, but the fix wasn't considered for #50510, which introduced a similar practice for prioritized inserter blocks. 

So, in this PR, we're making the same improvement for `prioritizedInserterBlocks` while getting rid of the extra `eslint-ignore` directive.

## How?
We're utilizing `useShallowMemo` for `prioritizedInserterBlocks`.

## Testing Instructions
* Insert a "Navigation" block.
* Click the inserter inside the "Navigation" block.
* Click "Add block" at the bottom.
* Verify the "Page Link" and "Custom Link" appear first, followed by the rest of the allowed blocks.
* Verify all tests pass.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-09-30 at 13 35 44](https://github.com/user-attachments/assets/219108c5-8de7-4d01-ad0b-57fb83c66f29)
