### PR TITLE
Edit Site: Fix `useLink` prop mutation

### DIFF
--- a/packages/edit-site/src/components/routes/link.js
+++ b/packages/edit-site/src/components/routes/link.js
@@ -33,14 +33,17 @@ export function useLink( params, state, shouldReplace = false ) {
 		...Object.keys( currentArgs )
 	);
 
+	let extraParams = {};
 	if ( isPreviewingTheme() ) {
-		params = {
-			...params,
+		extraParams = {
 			wp_theme_preview: currentlyPreviewingTheme(),
 		};
 	}
 
-	const newUrl = addQueryArgs( currentUrlWithoutArgs, params );
+	const newUrl = addQueryArgs( currentUrlWithoutArgs, {
+		...params,
+		...extraParams,
+	} );
 
 	return {
 		href: newUrl,


### PR DESCRIPTION
## What?
Currently, we're mutating a prop in the `useLink` hook in the site editor. This PR refactors to remove that mutation.

## Why?
Mutating props is [not recommended](https://react.dev/reference/rules/components-and-hooks-must-be-pure#props) as it could lead to unexpected consequences.

Also, this resolves an ESLint error when using React Compiler:
```
gutenberg/packages/edit-site/src/components/routes/link.js
[2]   37:3  error  Mutating component props or hook arguments is not allowed. Consider using a local variable instead  react-compiler/react-compiler
```

See #61788 for more details. 

## How?
We're using an extra object to avoid the mutation. 

## Testing Instructions
Verify test instructions for #50030 still pass.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None