### PR TITLE
SearchControl: Fix rest props mutation

### DIFF
--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -67,7 +67,7 @@ function UnforwardedSearchControl(
 ) {
 	// @ts-expect-error The `disabled` prop is not yet supported in the SearchControl component.
 	// Work with the design team (@WordPress/gutenberg-design) if you need this feature.
-	delete restProps.disabled;
+	const { disabled, ...filteredRestProps } = restProps;
 
 	const searchRef = useRef< HTMLInputElement >( null );
 	const instanceId = useInstanceId(
@@ -117,7 +117,7 @@ function UnforwardedSearchControl(
 						/>
 					</SuffixItemWrapper>
 				}
-				{ ...restProps }
+				{ ...filteredRestProps }
 			/>
 		</ContextSystemProvider>
 	);


### PR DESCRIPTION
## What?
Currently, we're mutating a rest props object in the `SearchControl` component. This PR refactors to remove that mutation.

## Why?
By mutating a rest props object, we could easily be mutating props themselves, and mutating props is [not recommended](https://react.dev/reference/rules/components-and-hooks-must-be-pure#props) as it could lead to unexpected consequences.

Also, this resolves an ESLint error when using React Compiler:
```
/gutenberg/packages/components/src/search-control/index.tsx
70:9  error  Mutating component props or hook arguments is not allowed. Consider using a local variable instead  react-compiler/react-compiler
```

See #61788 for more details. 

## How?
We're using an extra rest props call to avoid the mutation. 

I believe no CHANGELOG is necessary in this PR. 

## Testing Instructions
Test `SearchControl` in Storybook and verify there are no regressions.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None