### PR TITLE
Use standard button variations for the Post featured image UI.

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -173,46 +173,51 @@ function PostFeaturedImage( {
 						allowedTypes={ ALLOWED_MEDIA_TYPES }
 						modalClass="editor-post-featured-image__media-modal"
 						render={ ( { open } ) => (
-							<div className="editor-post-featured-image__container">
-								<Button
-									__next40pxDefaultSize
-									ref={ toggleRef }
-									className={
-										! featuredImageId
-											? 'editor-post-featured-image__toggle'
-											: 'editor-post-featured-image__preview'
-									}
-									onClick={ open }
-									aria-label={
-										! featuredImageId
-											? null
-											: __(
-													'Edit or replace the featured image'
-											  )
-									}
-									aria-describedby={
-										! featuredImageId
-											? null
-											: `editor-post-featured-image-${ featuredImageId }-describedby`
-									}
-									aria-haspopup="dialog"
-									disabled={ isLoading }
-									accessibleWhenDisabled
-								>
-									{ !! featuredImageId && media && (
-										<img
-											className="editor-post-featured-image__preview-image"
-											src={ mediaSourceUrl }
-											alt={ getImageDescription( media ) }
-										/>
-									) }
-									{ isLoading && <Spinner /> }
-									{ ! featuredImageId &&
-										! isLoading &&
-										( postType?.labels
-											?.set_featured_image ||
-											DEFAULT_SET_FEATURE_IMAGE_LABEL ) }
-								</Button>
+							<>
+								<div className="editor-post-featured-image__container">
+									<Button
+										__next40pxDefaultSize
+										ref={ toggleRef }
+										className={
+											! featuredImageId
+												? 'editor-post-featured-image__toggle'
+												: 'editor-post-featured-image__preview'
+										}
+										onClick={ open }
+										aria-label={
+											! featuredImageId
+												? null
+												: __(
+														'Edit or replace the featured image'
+												  )
+										}
+										aria-describedby={
+											! featuredImageId
+												? null
+												: `editor-post-featured-image-${ featuredImageId }-describedby`
+										}
+										aria-haspopup="dialog"
+										disabled={ isLoading }
+										accessibleWhenDisabled
+									>
+										{ !! featuredImageId && media && (
+											<img
+												className="editor-post-featured-image__preview-image"
+												src={ mediaSourceUrl }
+												alt={ getImageDescription(
+													media
+												) }
+											/>
+										) }
+										{ isLoading && <Spinner /> }
+										{ ! featuredImageId &&
+											! isLoading &&
+											( postType?.labels
+												?.set_featured_image ||
+												DEFAULT_SET_FEATURE_IMAGE_LABEL ) }
+									</Button>
+									<DropZone onFilesDrop={ onDropFiles } />
+								</div>
 								{ !! featuredImageId && (
 									<HStack className="editor-post-featured-image__actions">
 										<Button
@@ -220,6 +225,7 @@ function PostFeaturedImage( {
 											className="editor-post-featured-image__action"
 											onClick={ open }
 											aria-haspopup="dialog"
+											variant="secondary"
 										>
 											{ __( 'Replace' ) }
 										</Button>
@@ -230,13 +236,14 @@ function PostFeaturedImage( {
 												onRemoveImage();
 												toggleRef.current.focus();
 											} }
+											variant="secondary"
+											isDestructive
 										>
 											{ __( 'Remove' ) }
 										</Button>
 									</HStack>
 								) }
-								<DropZone onFilesDrop={ onDropFiles } />
-							</div>
+							</>
 						) }
 						value={ featuredImageId }
 					/>

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -5,21 +5,13 @@
 		position: absolute;
 		top: 50%;
 		left: 50%;
-		margin-top: -9px;
-		margin-left: -9px;
+		margin: 0;
+		transform: translate(-50%, -50%);
 	}
 }
 
 .editor-post-featured-image__container {
 	position: relative;
-
-	&:hover,
-	&:focus,
-	&:focus-within {
-		.editor-post-featured-image__actions {
-			opacity: 1;
-		}
-	}
 
 	.components-drop-zone__content {
 		border-radius: $radius-small;
@@ -72,17 +64,10 @@
 }
 
 .editor-post-featured-image__actions {
-	@include reduce-motion("transition");
-	bottom: 0;
-	opacity: 0; // Use opacity instead of visibility so that the buttons remain in the tab order.
-	padding: $grid-unit-10;
-	position: absolute;
-	transition: opacity 50ms ease-out;
+	padding: $grid-unit-10 0;
 }
 
 .editor-post-featured-image__action {
-	backdrop-filter: blur(16px) saturate(180%);
-	background: rgba(255, 255, 255, 0.75);
 	flex-grow: 1;
 	justify-content: center;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Addresses part of https://github.com/WordPress/gutenberg/issues/62743

## What?
<!-- In a few words, what is the PR actually doing? -->
Custom implementations and styling aren't great for the reasons explained in https://github.com/WordPress/gutenberg/issues/62743.
This PR aims to use default button variants for the Post featured image buttons 'Replace' and 'Remove'.

Also, as reported several times, controls that appear and disappear are a problem for accessibility and should be avoided.

Lastly, controls for destructive actions in WordPress should be red.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- WordPress does have a library of reusable UI components. Using ad-hoc implementations and styling defeats the purpose of a reusable components library.
- Consistency is key to provide a cohesive user experience.
- Ad-hoc implementations increase maintenance cost and should be avoided.
- Appearing-disappearing controls should be avoided.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Uses default secondary buttons with the 'destructive` red color for the 'Remove' button.
- Moves the buttons out of the image preview.
- Makes the buttons always visible (when an image is set).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Screenshots before and after:

![Screenshot 2024-09-30 at 16 38 50](https://github.com/user-attachments/assets/ac64d157-2075-41ed-a4ae-01c60a2a3ff2)


