### PR TITLE
Update/replace edit button with enter on selection

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { dragHandle, trash, edit } from '@wordpress/icons';
+import { dragHandle, trash } from '@wordpress/icons';
 import { Button, ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as blocksStore } from '@wordpress/blocks';
@@ -15,7 +15,6 @@ import BlockDraggable from '../block-draggable';
 import BlockMover from '../block-mover';
 import Shuffle from '../block-toolbar/shuffle';
 import NavigableToolbar from '../navigable-toolbar';
-import { unlock } from '../../lock-unlock';
 
 export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 	const selected = useSelect(
@@ -74,12 +73,9 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 		isPrevBlockTemplatePart,
 		canRemove,
 		canMove,
-		setIsInserterOpened,
 	} = selected;
 
-	const { removeBlock, __unstableSetEditorMode, resetZoomLevel } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { removeBlock } = useDispatch( blockEditorStore );
 
 	const showBlockDraggable = canMove && ! isBlockTemplatePart;
 
@@ -121,23 +117,6 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 			) }
 			{ canMove && canRemove && (
 				<Shuffle clientId={ clientId } as={ ToolbarButton } />
-			) }
-
-			{ ! isBlockTemplatePart && (
-				<ToolbarButton
-					className="zoom-out-toolbar-button"
-					icon={ edit }
-					label={ __( 'Edit' ) }
-					onClick={ () => {
-						// Setting may be undefined.
-						if ( typeof setIsInserterOpened === 'function' ) {
-							setIsInserterOpened( false );
-						}
-						__unstableSetEditorMode( 'edit' );
-						resetZoomLevel();
-						__unstableContentRef.current?.focus();
-					} }
-				/>
 			) }
 
 			{ canRemove && ! isBlockTemplatePart && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes edit button from zoom out mode toolbar and replaces it with an enter keypress on the selected block while in zoom out mode.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too --> Fixes #65746. Also, currently pressing Enter on the selected block will add a paragraph block, which does not seem like the intended behavior in this view.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds condition to existing `useSelectedBlockEventHandlers` Enter keypress to exit zoom out if an enter keypress on selected block in zoom out mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Enter Zoom Out Mode via the header zoom out button
- Tab to editor canvas
- Use arrow keys to move block selection
- Edit button on the navigation item should be gone
- Press Enter
- Should exit zoom out and return to default editing experience with current block still selected

## Screenshots or screencast <!-- if applicable -->
**Before**

https://github.com/user-attachments/assets/8856a82d-c7a5-4eee-8a02-8408854759a5 

**After**

https://github.com/user-attachments/assets/ff1a09cb-1e3d-4389-83ff-3a90e52c8f51 





