### PR TITLE
Fix focus loss when deleting selected block in zoom out mode

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -135,6 +135,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 						}
 						__unstableSetEditorMode( 'edit' );
 						resetZoomLevel();
+						__unstableContentRef.current?.focus();
 					} }
 				/>
 			) }

--- a/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-toolbar.js
@@ -135,7 +135,6 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 						}
 						__unstableSetEditorMode( 'edit' );
 						resetZoomLevel();
-						__unstableContentRef.current?.focus();
 					} }
 				/>
 			) }
@@ -147,6 +146,7 @@ export default function ZoomOutToolbar( { clientId, __unstableContentRef } ) {
 					label={ __( 'Delete' ) }
 					onClick={ () => {
 						removeBlock( clientId );
+						__unstableContentRef.current?.focus();
 					} }
 				/>
 			) }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/65762
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Moves focus to the block canvas when deleting a block via the zoom out toolbar

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Focus loss is bad.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
`__unstableContentRef.current?.focus();` when deleting the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Enter zoom out mode via header
- Navigate to block canvas
- When a section block is selected, move focus to the block's zoom out toolbar
- Move focus to Delete
- Press Enter
- Focus should be on the canvas

## Screenshots or screencast <!-- if applicable -->
