### PR TITLE
Navigator: fix README heading hierarchy

### DIFF
--- a/packages/components/src/navigator/README.md
+++ b/packages/components/src/navigator/README.md
@@ -70,6 +70,8 @@ The children elements.
 
 #### `Navigator.Screen`
 
+##### Props
+
 ###### `path`: `string`
 
 The screen's path, matched against the current path stored in the navigator.
@@ -94,7 +96,9 @@ The children elements.
 
 -   Required: Yes
 
-##### `Navigator.Button`
+#### `Navigator.Button`
+
+##### Props
 
 ###### `path`: `string`
 
@@ -119,7 +123,9 @@ The children elements.
 
 `Navigator.Button` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
 
-##### `Navigator.BackButton`
+#### `Navigator.BackButton`
+
+##### Props
 
 ###### `children`: `string`
 
@@ -131,9 +137,11 @@ The children elements.
 
 `Navigator.BackButton` also inherits all of the [`Button` props](/packages/components/src/button/README.md#props), except for `href` and `target`.
 
-###### `useNavigator`
+#### `useNavigator`
 
 You can retrieve a `navigator` instance by using the `useNavigator` hook.
+
+##### Props
 
 The `navigator` instance has a few properties:
 


### PR DESCRIPTION
As noted in https://github.com/WordPress/gutenberg/pull/64613#discussion_r1781774570

Fix the heading hierarchy in the `Navigator` README file, and add missing `Props` sub-headings.