### PR TITLE
Social Links: Fix block appender size

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -101,19 +101,10 @@
 .wp-block-social-links .block-list-appender {
 	position: static; // display inline.
 
-	.block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-10 - 2px;
-	}
-}
-
-.wp-block-social-links {
-	&.has-small-icon-size .block-editor-button-block-appender.components-button.components-button {
+	.block-editor-button-block-appender {
+		height: 1.5em;
+		width: 1.5em;
+		font-size: inherit;
 		padding: 0;
-	}
-	&.has-large-icon-size .block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-20 - 2px;
-	}
-	&.has-huge-icon-size .block-editor-button-block-appender.components-button.components-button {
-		padding: $grid-unit-30 - 1px;
 	}
 }


### PR DESCRIPTION
Fixes #65766
Related to #64877

## What?

This PR fixes two issues with the social link block:

- The inserter is not square.
- When you increase the icon size, the plus sign becomes invisible.

| Icon size | Before | After |
|--------|--------|--------|
| Small | ![image](https://github.com/user-attachments/assets/12b426e3-9efe-4d09-b7cb-2291656217ab)| ![image](https://github.com/user-attachments/assets/cf9256c4-ed4b-41e0-a537-d7d72ef1a013)|
| Normal | ![image](https://github.com/user-attachments/assets/0f871cca-760a-4f2a-98cb-2b610a4e99b5)| ![image](https://github.com/user-attachments/assets/feb31933-63ff-4a5e-9b46-df702ac68899)|
| Large | ![image](https://github.com/user-attachments/assets/8a23ed9f-4fb3-4469-849c-a53ffbf81a9c)| ![image](https://github.com/user-attachments/assets/210228af-6b29-4394-a335-980629ff9bf1)|
| Huge | ![image](https://github.com/user-attachments/assets/ca0d394f-0b32-4726-9fb1-3801b8548c29) | ![image](https://github.com/user-attachments/assets/a9968d53-92a6-406f-b6ad-5a5fd60af386) | 

## Why?

#65225 applied a new 40px default size to inserter buttons. This makes the component's CSS specificity higher and overrides `height:auto`:

![height](https://github.com/user-attachments/assets/3015c497-2429-4f9d-ab86-ffe14a4815c4)

## How?

Instead of relying on padding to determine the size of the button, I give the inserter button an explicit width and height in em units. This ensures that the inserter will always be the same size as the icon, even if a custom size is needed in the future:

https://github.com/user-attachments/assets/024f4fcb-4b9b-4c3e-babc-f1d60ba62c30

## Testing Instructions

- Insert a Social Links block.
- When you change the icon size, the inserter button should be the same as the icon and square.
- It should also display correctly if you enable the "Show text" option or change the block style.