### PR TITLE
Fixed: zoom out can hide the scrollbar

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -242,7 +242,7 @@ function Iframe( {
 	const isZoomedOut = scale !== 1;
 
 	useEffect( () => {
-		if ( ! isZoomedOut ) {
+		if ( isZoomedOut ) {
 			prevContainerWidthRef.current = containerWidth;
 		}
 	}, [ containerWidth, isZoomedOut ] );


### PR DESCRIPTION
## What?

fixes the issue of scrollbar gets hidden when block inserter sidebar is open while zoomout view is enabled 

Closes https://github.com/WordPress/gutenberg/issues/65595

## Why?
This PR fixes the issue of scrollbar gets hidden when block inserter sidebar is open while zoomout view is enabled 

## How?
When zoomout view is enabled we maintain the prevContainerWidthRef.current = containerWidth in the iframe.

## Testing Instructions
- Zoom out
- Open a sidebar

## Screenshots or screencast <!-- if applicable -->
[issue-65595.webm](https://github.com/user-attachments/assets/9f08a91a-3704-4c35-b067-86818bf3d416)