### PR TITLE
`PaletteEdit`: dedupe palette element slugs

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `PaletteEdit`: dedupe palette element slugs ([#65772](https://github.com/WordPress/gutenberg/pull/65772)).
 -   `Tabs`: fix skipping indication animation glitch ([#65878](https://github.com/WordPress/gutenberg/pull/65878)).
 
 ## 28.9.0 (2024-10-03)

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -73,16 +73,13 @@ function NameInput( { value, onChange, label }: NameInputProps ) {
 /*
  * Deduplicates the slugs of the provided elements.
  */
-export function deduplicateElementSlugs(
-	elements: PaletteElement[] | undefined
-) {
-	if ( ! elements ) {
-		return;
-	}
-	const slugCounts = {};
-	const updatedElements = elements.map( ( element: PaletteElement ) => ( {
+export function deduplicateElementSlugs< T extends PaletteElement >(
+	elements: T[]
+): T[] {
+	const slugCounts: { [ slug: string ]: number } = {};
+	const updatedElements = elements.map( ( element: T ) => ( {
 		...element,
-	} ) );
+	} ) ) as T[];
 
 	updatedElements.forEach( ( element, index ) => {
 		const { slug } = element;
@@ -306,9 +303,11 @@ function PaletteEditListView< T extends Color | Gradient >( {
 		elementsReferenceRef.current = elements;
 	}, [ elements ] );
 
-	const debounceOnChange = useDebounce( ( updatedElements ) => {
-		onChange( deduplicateElementSlugs( updatedElements ) );
-	}, 100 );
+	const debounceOnChange = useDebounce(
+		( updatedElements: T[] ) =>
+			onChange( deduplicateElementSlugs( updatedElements ) ),
+		100
+	);
 
 	return (
 		<VStack spacing={ 3 }>

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -70,6 +70,32 @@ function NameInput( { value, onChange, label }: NameInputProps ) {
 	);
 }
 
+/*
+ * Deduplicates the slugs of the provided elements.
+ */
+export function deduplicateElementSlugs(
+	elements: PaletteElement[] | undefined
+) {
+	if ( ! elements ) {
+		return;
+	}
+	const slugCounts = {};
+	const updatedElements = elements.map( ( element: PaletteElement ) => ( {
+		...element,
+	} ) );
+
+	updatedElements.forEach( ( element, index ) => {
+		const { slug } = element;
+		slugCounts[ slug ] = ( slugCounts[ slug ] || 0 ) + 1;
+
+		if ( slugCounts[ slug ] > 1 ) {
+			element.slug = `${ slug }-${ index }`;
+		}
+	} );
+
+	return updatedElements;
+}
+
 /**
  * Returns a name and slug for a palette item. The name takes the format "Color + id".
  * To ensure there are no duplicate ids, this function checks all slugs.
@@ -280,7 +306,9 @@ function PaletteEditListView< T extends Color | Gradient >( {
 		elementsReferenceRef.current = elements;
 	}, [ elements ] );
 
-	const debounceOnChange = useDebounce( onChange, 100 );
+	const debounceOnChange = useDebounce( ( updatedElements ) => {
+		onChange( deduplicateElementSlugs( updatedElements ) );
+	}, 100 );
 
 	return (
 		<VStack spacing={ 3 }>

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -49,7 +49,6 @@ import { kebabCase } from '../utils/strings';
 import type {
 	Color,
 	ColorPickerPopoverProps,
-	Gradient,
 	NameInputProps,
 	OptionProps,
 	PaletteEditListViewProps,
@@ -132,7 +131,7 @@ export function getNameAndSlugForPosition(
 	};
 }
 
-function ColorPickerPopover< T extends Color | Gradient >( {
+function ColorPickerPopover< T extends PaletteElement >( {
 	isGradient,
 	element,
 	onChange,
@@ -190,7 +189,7 @@ function ColorPickerPopover< T extends Color | Gradient >( {
 	);
 }
 
-function Option< T extends Color | Gradient >( {
+function Option< T extends PaletteElement >( {
 	canOnlyChangeValues,
 	element,
 	onChange,
@@ -288,7 +287,7 @@ function Option< T extends Color | Gradient >( {
 	);
 }
 
-function PaletteEditListView< T extends Color | Gradient >( {
+function PaletteEditListView< T extends PaletteElement >( {
 	elements,
 	onChange,
 	canOnlyChangeValues,

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -77,14 +77,14 @@ export function deduplicateElementSlugs< T extends PaletteElement >(
 ) {
 	const slugCounts: { [ slug: string ]: number } = {};
 
-	return elements.map( ( element, index ) => {
+	return elements.map( ( element ) => {
 		let newSlug: string | undefined;
 
 		const { slug } = element;
 		slugCounts[ slug ] = ( slugCounts[ slug ] || 0 ) + 1;
 
 		if ( slugCounts[ slug ] > 1 ) {
-			newSlug = `${ slug }-${ index }`;
+			newSlug = `${ slug }-${ slugCounts[ slug ] - 1 }`;
 		}
 
 		return { ...element, slug: newSlug ?? slug };

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -74,22 +74,21 @@ function NameInput( { value, onChange, label }: NameInputProps ) {
  */
 export function deduplicateElementSlugs< T extends PaletteElement >(
 	elements: T[]
-): T[] {
+) {
 	const slugCounts: { [ slug: string ]: number } = {};
-	const updatedElements = elements.map( ( element: T ) => ( {
-		...element,
-	} ) ) as T[];
 
-	updatedElements.forEach( ( element, index ) => {
+	return elements.map( ( element, index ) => {
+		let newSlug: string | undefined;
+
 		const { slug } = element;
 		slugCounts[ slug ] = ( slugCounts[ slug ] || 0 ) + 1;
 
 		if ( slugCounts[ slug ] > 1 ) {
-			element.slug = `${ slug }-${ index }`;
+			newSlug = `${ slug }-${ index }`;
 		}
-	} );
 
-	return updatedElements;
+		return { ...element, slug: newSlug ?? slug };
+	} );
 }
 
 /**

--- a/packages/components/src/palette-edit/test/index.tsx
+++ b/packages/components/src/palette-edit/test/index.tsx
@@ -7,7 +7,10 @@ import { click, type, press } from '@ariakit/test';
 /**
  * Internal dependencies
  */
-import PaletteEdit, { getNameAndSlugForPosition } from '..';
+import PaletteEdit, {
+	getNameAndSlugForPosition,
+	deduplicateElementSlugs,
+} from '..';
 import type { PaletteElement } from '../types';
 
 const noop = () => {};
@@ -94,6 +97,52 @@ describe( 'getNameAndSlugForPosition', () => {
 			name: 'Color 151',
 			slug: 'test-color-151',
 		} );
+	} );
+} );
+
+describe( 'deduplicateElementSlugs', () => {
+	it( 'should not change the slugs if they are unique', () => {
+		const elements: PaletteElement[] = [
+			{
+				slug: 'test-color-1',
+				color: '#ffffff',
+				name: 'Test Color 1',
+			},
+			{
+				slug: 'test-color-2',
+				color: '#1a4548',
+				name: 'Test Color 2',
+			},
+		];
+
+		expect( deduplicateElementSlugs( elements ) ).toEqual( elements );
+	} );
+	it( 'should change the slugs if they are not unique', () => {
+		const elements: PaletteElement[] = [
+			{
+				slug: 'test-color-1',
+				color: '#ffffff',
+				name: 'Test Color 1',
+			},
+			{
+				slug: 'test-color-1',
+				color: '#1a4548',
+				name: 'Test Color 2',
+			},
+		];
+
+		expect( deduplicateElementSlugs( elements ) ).toEqual( [
+			{
+				slug: 'test-color-1',
+				color: '#ffffff',
+				name: 'Test Color 1',
+			},
+			{
+				slug: 'test-color-1-1',
+				color: '#1a4548',
+				name: 'Test Color 2',
+			},
+		] );
 	} );
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Part of https://github.com/WordPress/gutenberg/issues/43197

First pass at deduping palette slugs

## Why?
The color palette uses the palette item name to generate a slug. So, `Test 1` will be `custom-test-1`.

If there are identical names, the slugs would normally be the same. Slugs should be unique identifiers so they can be correctly applied as CSS vars.

## How?
When updating palette item names, check for duplicate slugs. If duplicates are found, update those slugs.

## Testing Instructions

In _Site Editor > Global Styles > Colors > Palette_ create multiple custom colors and gradients.

Give all or some of each the same name. 

Save and try to apply your custom colors in the editor.

They should work in the front and backend.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Given a series of duplicate names:

<img width="267" alt="Screenshot 2024-10-01 at 4 44 13 pm" src="https://github.com/user-attachments/assets/3054c746-4a3c-4ef3-9fd6-7b87f6f942dd">

The custom palette is still operable due to unique slugs:

https://github.com/user-attachments/assets/617cf731-e39d-487c-bd27-8113af143092

Which are saved to global styles and output in the frontend

<img width="269" alt="Screenshot 2024-10-01 at 4 45 59 pm" src="https://github.com/user-attachments/assets/31154dd7-5c86-47eb-a6e0-48d51dc0301d">


