### PR TITLE
Storybook: allow for case-agnostic filtering of icons

### DIFF
--- a/packages/icons/src/icon/stories/index.story.js
+++ b/packages/icons/src/icon/stories/index.story.js
@@ -47,7 +47,7 @@ const LibraryExample = () => {
 	const filteredIcons = filter.length
 		? Object.fromEntries(
 				Object.entries( availableIcons ).filter( ( [ name ] ) =>
-					name.includes( filter )
+					name.toLowerCase().includes( filter.toLowerCase() )
 				)
 		  )
 		: availableIcons;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Allows for case-agnostic filtering of icons in Storybook.

## Why?

At the moment, some filtering searches do not return expected results.

## How?

This change converts both the icon name and the filter input to lowercase before performing the inclusion check. This way, the filtering becomes case-insensitive.

## Testing Instructions

1. Run `npm run storybook:dev`
2. Go to the Icons page
3. Filter the icon list using a few terms and ensure all matching icons are returned.

## Screenshots <!-- if applicable -->

Before | After
--|--
<img width="302" alt="image" src="https://github.com/user-attachments/assets/e2bef91a-54ed-4f17-91cb-2f50b711a250"> | <img width="316" alt="image" src="https://github.com/user-attachments/assets/e684cdfc-0109-424e-b85e-9bb2d9d04ed5">
