### PR TITLE
Try zooming out when selecting the patterns tab in the inserter 

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -289,7 +289,7 @@ function InserterMenu(
 	);
 
 	const handleZoomOut = ( newSelectedTab ) => {
-		if ( isZoomOutMode && newSelectedTab !== 'patterns' ) {
+		if ( isZoomOutMode && newSelectedTab === 'blocks' ) {
 			resetZoomLevel();
 			__unstableSetEditorMode( 'edit' );
 		} else if ( ! isZoomOutMode && newSelectedTab === 'patterns' ) {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -17,7 +17,7 @@ import {
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDebouncedInput } from '@wordpress/compose';
-import { useSelect } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,6 +32,7 @@ import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import { store as blockEditorStore } from '../../store';
 import TabbedSidebar from '../tabbed-sidebar';
+import { unlock } from '../../lock-unlock';
 
 const NOOP = () => {};
 function InserterMenu(
@@ -283,7 +284,22 @@ function InserterMenu(
 		showMediaPanel,
 	] );
 
+	const { resetZoomLevel, setZoomLevel, __unstableSetEditorMode } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
+	const handleZoomOut = ( newSelectedTab ) => {
+		if ( isZoomOutMode && newSelectedTab !== 'patterns' ) {
+			resetZoomLevel();
+			__unstableSetEditorMode( 'edit' );
+		} else if ( ! isZoomOutMode && newSelectedTab === 'patterns' ) {
+			setZoomLevel( 50 );
+			__unstableSetEditorMode( 'zoom-out' );
+		}
+	};
+
 	const handleSetSelectedTab = ( value ) => {
+		handleZoomOut( value );
 		// If no longer on patterns tab remove the category setting.
 		if ( value !== 'patterns' ) {
 			setSelectedPatternCategory( null );

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -17,7 +17,7 @@ import {
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useDebouncedInput } from '@wordpress/compose';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -32,7 +32,7 @@ import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
 import { store as blockEditorStore } from '../../store';
 import TabbedSidebar from '../tabbed-sidebar';
-import { unlock } from '../../lock-unlock';
+import { useZoomOut } from '../../hooks/use-zoom-out';
 
 const NOOP = () => {};
 function InserterMenu(
@@ -77,6 +77,10 @@ function InserterMenu(
 		}
 	}
 	const [ selectedTab, setSelectedTab ] = useState( getInitialTab() );
+
+	const shouldUseZoomOut =
+		selectedTab === 'patterns' || selectedTab === 'media';
+	useZoomOut( shouldUseZoomOut );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {
@@ -284,22 +288,7 @@ function InserterMenu(
 		showMediaPanel,
 	] );
 
-	const { resetZoomLevel, setZoomLevel, __unstableSetEditorMode } = unlock(
-		useDispatch( blockEditorStore )
-	);
-
-	const handleZoomOut = ( newSelectedTab ) => {
-		if ( isZoomOutMode && newSelectedTab === 'blocks' ) {
-			resetZoomLevel();
-			__unstableSetEditorMode( 'edit' );
-		} else if ( ! isZoomOutMode && newSelectedTab === 'patterns' ) {
-			setZoomLevel( 50 );
-			__unstableSetEditorMode( 'zoom-out' );
-		}
-	};
-
 	const handleSetSelectedTab = ( value ) => {
-		handleZoomOut( value );
 		// If no longer on patterns tab remove the category setting.
 		if ( value !== 'patterns' ) {
 			setSelectedPatternCategory( null );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65749

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Now that the zoom out view is easy to exit, automagically engaging it when patterns are about to be inserted seems a better idea. We have had this before, disabled it and now we're bringing it back.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the Inserter's menu we add a handler that deals with zoom out depending on what tab is selected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the site editor
- In a template
- Open the inserter from the plus button in the rop left corner
- Then click on patterns tab
- _The canvas should enter zoom out view and if you click selection should work as in zoom out mode (only sections can be selected)_
- _Switching to blocks ~or media tabs~ tab (only) exits the zoom out view and mode_
- In non-zoom out, only switching to `Patterns` will active Zoom Out. Media does nothing.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->



https://github.com/user-attachments/assets/16bb0be3-882c-463f-bf66-b95ac3a5af81




Co-authored-by: draganescu <andraganescu@git.wordpress.org>
Co-authored-by: getdave <get_dave@git.wordpress.org>
Co-authored-by: richtabor <richtabor@git.wordpress.org>
Co-authored-by: jeryj <jeryj@git.wordpress.org>