### PR TITLE
File block: Allow content only editing

### DIFF
--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -16,7 +16,8 @@
 			"role": "local"
 		},
 		"href": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"fileId": {
 			"type": "string",
@@ -27,13 +28,15 @@
 		"fileName": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "a:not([download])"
+			"selector": "a:not([download])",
+			"role": "content"
 		},
 		"textLinkHref": {
 			"type": "string",
 			"source": "attribute",
 			"selector": "a:not([download])",
-			"attribute": "href"
+			"attribute": "href",
+			"role": "content"
 		},
 		"textLinkTarget": {
 			"type": "string",
@@ -48,7 +51,8 @@
 		"downloadButtonText": {
 			"type": "rich-text",
 			"source": "rich-text",
-			"selector": "a[download]"
+			"selector": "a[download]",
+			"role": "content"
 		},
 		"displayPreview": {
 			"type": "boolean"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See https://github.com/WordPress/gutenberg/issues/65778

Allows contentOnly editing in the file block.

## How?
Adds `role: content` to the file block attributes. I've tried to match other media blocks like image with the attributes that receive the content role.

## Testing Instructions
1. Open a template in the Site Editor
2. Insert a file block in one of the sections
3. Switch to Write mode
4. Try editing the file block

## Screenshots or screencast <!-- if applicable -->
#### Before
https://github.com/user-attachments/assets/1bf9a631-575b-413e-9b7e-e18e574c9c80

#### After
https://github.com/user-attachments/assets/0b9d6ac1-f3be-41ac-9fe6-70e3154c5098



