### PR TITLE
Global Styles: fix screens crashing on exit animation

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -14,6 +14,7 @@ import {
 	FlexItem,
 	ToggleControl,
 } from '@wordpress/components';
+import { usePrevious } from '@wordpress/compose';
 import { moreVertical } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 
@@ -35,10 +36,24 @@ function FontSize() {
 	const [ isRenameDialogOpen, setIsRenameDialogOpen ] = useState( false );
 
 	const {
-		params: { origin, slug },
+		params: { origin: originParam, slug: slugParam },
 		goBack,
 		goTo,
 	} = useNavigator();
+
+	// When the screen animates out, the params become undefined. The following
+	// code retains the previous value around, to avoid the screen from crashing
+	// or removing its contents during the animation.
+	const previousOrigin = usePrevious( originParam );
+	const previousSlug = usePrevious( slugParam );
+	const origin =
+		previousOrigin !== undefined && originParam === undefined
+			? previousOrigin
+			: originParam;
+	const slug =
+		previousSlug !== undefined && slugParam === undefined
+			? previousSlug
+			: slugParam;
 
 	const [ fontSizes, setFontSizes ] = useGlobalSetting(
 		'typography.fontSizes'

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -27,6 +27,7 @@ import {
 	Modal,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
+import { usePrevious } from '@wordpress/compose';
 import { __, sprintf } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import {
@@ -73,9 +74,24 @@ const presetShadowMenuItems = [
 
 export default function ShadowsEditPanel() {
 	const {
-		params: { category, slug },
+		params: { category: categoryParam, slug: slugParam },
 		goTo,
 	} = useNavigator();
+
+	// When the screen animates out, the params become undefined. The following
+	// code retains the previous value around, to avoid the screen from crashing
+	// or removing its contents during the animation.
+	const previousCategory = usePrevious( categoryParam );
+	const previousSlug = usePrevious( slugParam );
+	const category =
+		previousCategory !== undefined && categoryParam === undefined
+			? previousCategory
+			: categoryParam;
+	const slug =
+		previousSlug !== undefined && slugParam === undefined
+			? previousSlug
+			: slugParam;
+
 	const [ shadows, setShadows ] = useGlobalSetting(
 		`shadow.presets.${ category }`
 	);


### PR DESCRIPTION
Temporary fix for #65711
Alternative to #65765
Related to #64777

## What?

This PR fixes a critical error that occurs when returning to the previous screen from the shadow presets panel or the font presets panel.

## Why?

@t-hamano found that the problem was caused by https://github.com/WordPress/gutenberg/pull/64777.

From [this comment](https://github.com/WordPress/gutenberg/issues/65711#issuecomment-2380625635):

> The cause of this problem is likely that in the component where the crash occurs, some logic relies on URL parameters, namely `useNavigator`.
> 
> For example, in the Shadows panel, `category` and `slug` are taken from URL parameters [here](https://github.com/WordPress/gutenberg/blob/faa6968936e8d996acafb8fd846d3ca08dad7088/packages/edit-site/src/components/global-styles/shadows-edit-panel.js#L75-L78).
> 
> However, when we return from this panel, the URL parameters have already been changed to new ones, so all parameters are `undefined`. The panel crashes because parameters are not expected to be `undefined`.

## How?

Keep around the previous values of the params when they become undefined during an exit animation, as part of the suggestion in [this comment](https://github.com/WordPress/gutenberg/issues/65711#issuecomment-2383603543).

## Testing Instructions

- Open the site editor > global styles > Shadows > Choose one of the presets > click the Back button
- Open the site editor > global styles > Typography > Font size presets > Choose one of the presets > click the Back button

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/60cf99b5-e269-4865-b821-bc01e9f93d30

