### PR TITLE
Avoid errors when a fontSize preset is not available

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -36,7 +36,6 @@ function FontSize() {
 
 	const {
 		params: { origin, slug },
-		goBack,
 		goTo,
 	} = useNavigator();
 
@@ -127,7 +126,7 @@ function FontSize() {
 		if ( ! fontSize ) {
 			goTo( '/typography/font-sizes/' );
 		}
-	}, [ fontSize, goBack ] );
+	}, [ fontSize, goTo ] );
 
 	// Avoid rendering if the font size is not available.
 	if ( ! fontSize ) {

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -15,7 +15,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { moreVertical } from '@wordpress/icons';
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -54,10 +54,10 @@ function FontSize() {
 
 	// Whether the font size is fluid. If not defined, use the global fluid value of the theme.
 	const isFluid =
-		fontSize.fluid !== undefined ? !! fontSize.fluid : !! globalFluid;
+		fontSize?.fluid !== undefined ? !! fontSize.fluid : !! globalFluid;
 
 	// Whether custom fluid values are used.
-	const isCustomFluid = typeof fontSize.fluid === 'object';
+	const isCustomFluid = typeof fontSize?.fluid === 'object';
 
 	const handleNameChange = ( value ) => {
 		updateFontSize( 'name', value );
@@ -107,9 +107,6 @@ function FontSize() {
 	};
 
 	const handleRemoveFontSize = () => {
-		// Navigate to the font sizes list.
-		goBack();
-
 		const newFontSizes = sizes.filter( ( size ) => size.slug !== slug );
 		setFontSizes( {
 			...fontSizes,
@@ -124,6 +121,18 @@ function FontSize() {
 	const toggleRenameDialog = () => {
 		setIsRenameDialogOpen( ! isRenameDialogOpen );
 	};
+
+	// Navigate to the font sizes list if the font size is not available.
+	useEffect( () => {
+		if ( ! fontSize ) {
+			goTo( '/typography/font-sizes/' );
+		}
+	}, [ fontSize, goBack ] );
+
+	// Avoid rendering if the font size is not available.
+	if ( ! fontSize ) {
+		return null;
+	}
 
 	return (
 		<>

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -124,7 +124,7 @@ function FontSize() {
 	// Navigate to the font sizes list if the font size is not available.
 	useEffect( () => {
 		if ( ! fontSize ) {
-			goTo( '/typography/font-sizes/' );
+			goTo( '/typography/font-sizes/', { isBack: true } );
 		}
 	}, [ fontSize, goTo ] );
 


### PR DESCRIPTION
## What?
Avoid errors when a fontSize preset is not available

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/65774

## How?
- use ? optional chain operator when a property may be undefined.
- Navigate to typograpjy

## Testing Instructions
1. Activate TT4
2. Create a custom preset.
3. Reset global styles
Expected result: you should be directed to the typography -> font size presets screen.


## Screenshots or screencast <!-- if applicable -->
