### PR TITLE
Temp disable test for Classic Block Media issue

### DIFF
--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -39,7 +39,8 @@ test.describe( 'Classic', () => {
 		await expect.poll( editor.getEditedPostContent ).toBe( 'test' );
 	} );
 
-	// Broken upstream in Core.
+	// Reinitiate once this ticket is fixed:
+	// https://core.trac.wordpress.org/ticket/60666
 	// eslint-disable-next-line playwright/no-skipped-test
 	test.skip( 'should insert media, convert to blocks, and undo in one step', async ( {
 		editor,

--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -39,7 +39,9 @@ test.describe( 'Classic', () => {
 		await expect.poll( editor.getEditedPostContent ).toBe( 'test' );
 	} );
 
-	test( 'should insert media, convert to blocks, and undo in one step', async ( {
+	// Broken upstream in Core.
+	// eslint-disable-next-line playwright/no-skipped-test
+	test.skip( 'should insert media, convert to blocks, and undo in one step', async ( {
 		editor,
 		mediaUtils,
 		page,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A [change in WP Core](https://core.trac.wordpress.org/ticket/60666#comment:25) is causing all Gutenberg repo e2e tests to fail. This PR temporarily proposes skipping that test to get the CI pipeline back in order.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We need to be able to merge PRs whilst we wait on a fix in Core.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`.skip` the test.

https://github.com/WordPress/gutenberg/blob/f5378f6f63445b305728a1c44cfb6b4662fc19a2/test/e2e/specs/editor/blocks/classic.spec.js#L42

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This test should pass `editor/blocks/classic.spec.js:42:2`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
