### PR TITLE
Block Bindings: Add `@since` tag in bindings apis JSDocs

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -881,6 +881,10 @@ _Returns_
 
 -   `?WPBlockBindingsUtils`: Object containing the block bindings utils.
 
+_Changelog_
+
+`6.7.0` Introduced in WordPress core.
+
 ### useBlockCommands
 
 Undocumented declaration.

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -30,6 +30,8 @@ function isObjectEmpty( object ) {
  * - `updateBlockBindings`: Updates the value of the bindings connected to block attributes. It can be used to remove a specific binding by setting the value to `undefined`.
  * - `removeAllBlockBindings`: Removes the bindings property of the `metadata` attribute.
  *
+ * @since 6.7.0 Introduced in WordPress core.
+ *
  * @return {?WPBlockBindingsUtils} Object containing the block bindings utils.
  *
  * @example

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -127,6 +127,10 @@ _Returns_
 
 -   `?Object`: Block bindings source.
 
+_Changelog_
+
+`6.7.0` Introduced in WordPress core.
+
 ### getBlockBindingsSources
 
 Returns all registered block bindings sources.
@@ -134,6 +138,10 @@ Returns all registered block bindings sources.
 _Returns_
 
 -   `Array`: Block bindings sources.
+
+_Changelog_
+
+`6.7.0` Introduced in WordPress core.
 
 ### getBlockContent
 
@@ -542,6 +550,10 @@ _Parameters_
 -   _source.setValues_ `[Function]`: Optional function to update multiple values connected to the source.
 -   _source.canUserEditValue_ `[Function]`: Optional function to determine if the user can edit the value.
 
+_Changelog_
+
+`6.7.0` Introduced in WordPress core.
+
 ### registerBlockCollection
 
 Registers a new block collection to group blocks in the same namespace in the inserter.
@@ -858,6 +870,10 @@ unregisterBlockBindingsSource( 'plugin/my-custom-source' );
 _Parameters_
 
 -   _name_ `string`: The name of the block bindings source to unregister.
+
+_Changelog_
+
+`6.7.0` Introduced in WordPress core.
 
 ### unregisterBlockStyle
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -767,6 +767,8 @@ export const unregisterBlockVariation = ( blockName, variationName ) => {
  * behavior. Once registered, the source is available to be connected
  * to the supported block attributes.
  *
+ * @since 6.7.0 Introduced in WordPress core.
+ *
  * @param {Object}   source                    Properties of the source to be registered.
  * @param {string}   source.name               The unique and machine-readable name.
  * @param {string}   [source.label]            Human-readable label. Optional when it is defined in the server.
@@ -905,6 +907,8 @@ export const registerBlockBindingsSource = ( source ) => {
 /**
  * Unregisters a block bindings source by providing its name.
  *
+ * @since 6.7.0 Introduced in WordPress core.
+ *
  * @param {string} name The name of the block bindings source to unregister.
  *
  * @example
@@ -926,6 +930,8 @@ export function unregisterBlockBindingsSource( name ) {
 /**
  * Returns a registered block bindings source by its name.
  *
+ * @since 6.7.0 Introduced in WordPress core.
+ *
  * @param {string} name Block bindings source name.
  *
  * @return {?Object} Block bindings source.
@@ -936,6 +942,8 @@ export function getBlockBindingsSource( name ) {
 
 /**
  * Returns all registered block bindings sources.
+ *
+ * @since 6.7.0 Introduced in WordPress core.
  *
  * @return {Array} Block bindings sources.
  */


### PR DESCRIPTION
## What?
As suggested [here](https://github.com/WordPress/gutenberg/pull/65713#issuecomment-2384813308), I'm exploring how it would look like introducing the `@since` tag to the exposed bindings APIs.
 
## Why?
It could help track which APIs are available in each release.

## How?
I just added the `@since` tag and generated the docs.

## Testing Instructions
Nothing should be affected. Tests should pass.