### PR TITLE
Navigator: mark experimental exports as deprecated

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 -   `__experimentalBorderControl` can now be imported as a stable `BorderControl` ([#65475](https://github.com/WordPress/gutenberg/pull/65475)).
 -   `__experimentalBorderBoxControl` can now be imported as a stable `BorderBoxControl` ([#65586](https://github.com/WordPress/gutenberg/pull/65586)).
+-   `__experimentalNavigator*` components can now be imported as a stable `Navigator`. Similarly, the `__experimentalUseNavigator` hook can be imported as a stable `useNavigator` ([#65802](https://github.com/WordPress/gutenberg/pull/65802)).
 
 ### Enhancements
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -129,15 +129,21 @@ export { default as __experimentalNavigationGroup } from './navigation/group';
 export { default as __experimentalNavigationItem } from './navigation/item';
 export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
+	/** @deprecated Import `Navigator` instead. */
 	NavigatorProvider as __experimentalNavigatorProvider,
+	/** @deprecated Import `Navigator` instead. */
 	NavigatorScreen as __experimentalNavigatorScreen,
+	/** @deprecated Import `Navigator` instead. */
 	NavigatorButton as __experimentalNavigatorButton,
+	/** @deprecated Import `Navigator` instead. */
 	NavigatorBackButton as __experimentalNavigatorBackButton,
+	/** @deprecated Import `Navigator` instead. */
 	NavigatorToParentButton as __experimentalNavigatorToParentButton,
 } from './navigator/legacy';
 export {
 	Navigator,
 	useNavigator,
+	/** @deprecated Import `Navigator` instead. */
 	useNavigator as __experimentalUseNavigator,
 } from './navigator';
 export { default as Notice } from './notice';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -131,19 +131,19 @@ export { default as __experimentalNavigationMenu } from './navigation/menu';
 export {
 	/** @deprecated Import `Navigator` instead. */
 	NavigatorProvider as __experimentalNavigatorProvider,
-	/** @deprecated Import `Navigator` instead. */
+	/** @deprecated Import `Navigator` and use `Navigator.Screen` instead. */
 	NavigatorScreen as __experimentalNavigatorScreen,
-	/** @deprecated Import `Navigator` instead. */
+	/** @deprecated Import `Navigator` and use `Navigator.Button` instead. */
 	NavigatorButton as __experimentalNavigatorButton,
-	/** @deprecated Import `Navigator` instead. */
+	/** @deprecated Import `Navigator` and use `Navigator.BackButton` instead. */
 	NavigatorBackButton as __experimentalNavigatorBackButton,
-	/** @deprecated Import `Navigator` instead. */
+	/** @deprecated Import `Navigator` and use `Navigator.BackButton` instead. */
 	NavigatorToParentButton as __experimentalNavigatorToParentButton,
 } from './navigator/legacy';
 export {
 	Navigator,
 	useNavigator,
-	/** @deprecated Import `Navigator` instead. */
+	/** @deprecated Import `useNavigator` instead. */
 	useNavigator as __experimentalUseNavigator,
 } from './navigator';
 export { default as Notice } from './notice';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #59418

This PR marks the following exports from `@wordpress/components` as deprecated: `__experimentalNavigatorProvider`, `__experimentalNavigatorScreen`, `__experimentalNavigatorButton`, `__experimentalNavigatorBackButton`, `__experimentalNavigatorToParentButton` and `__experimentalUseNavigator`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `Navigator` is not exported also as a stable API. The stable export should be preferred over the `__experimental` one.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Following the passive deprecation strategy highlighted in https://github.com/WordPress/gutenberg/issues/61099

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure there are no usages left of the deprecated components in the codebase
- Make sure that the `@deprecated` JSDoc tag is applied and shows as expected on the deprecated exports
- No runtime changes