### PR TITLE
List all active fonts in the typography section

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -25,6 +25,19 @@ import { unlock } from '../../lock-unlock';
 
 const { useGlobalSetting } = unlock( blockEditorPrivateApis );
 
+/**
+ * Maps the fonts with the source, if available.
+ *
+ * @param {Array}  fonts  The fonts to map.
+ * @param {string} source The source of the fonts.
+ * @return {Array} The mapped fonts.
+ */
+function mapFontsWithSource( fonts, source ) {
+	return fonts
+		? fonts.map( ( f ) => setUIValuesNeeded( f, { source } ) )
+		: [];
+}
+
 function FontFamilies() {
 	const { baseCustomFonts, modalTabOpen, setModalTabOpen } =
 		useContext( FontLibraryContext );
@@ -34,16 +47,8 @@ function FontFamilies() {
 		undefined,
 		'base'
 	);
-	const themeFonts = fontFamilies?.theme
-		? fontFamilies.theme.map( ( f ) =>
-				setUIValuesNeeded( f, { source: 'theme' } )
-		  )
-		: [];
-	const customFonts = fontFamilies?.custom
-		? fontFamilies.custom.map( ( f ) =>
-				setUIValuesNeeded( f, { source: 'custom' } )
-		  )
-		: [];
+	const themeFonts = mapFontsWithSource( fontFamilies?.theme, 'theme' );
+	const customFonts = mapFontsWithSource( fontFamilies?.custom, 'custom' );
 	const activeFonts = [ ...themeFonts, ...customFonts ].sort( ( a, b ) =>
 		a.name.localeCompare( b.name )
 	);

--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -35,16 +35,18 @@ function FontFamilies() {
 		'base'
 	);
 	const themeFonts = fontFamilies?.theme
-		? fontFamilies.theme
-				.map( ( f ) => setUIValuesNeeded( f, { source: 'theme' } ) )
-				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
+		? fontFamilies.theme.map( ( f ) =>
+				setUIValuesNeeded( f, { source: 'theme' } )
+		  )
 		: [];
 	const customFonts = fontFamilies?.custom
-		? fontFamilies.custom
-				.map( ( f ) => setUIValuesNeeded( f, { source: 'custom' } ) )
-				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
+		? fontFamilies.custom.map( ( f ) =>
+				setUIValuesNeeded( f, { source: 'custom' } )
+		  )
 		: [];
-	const activeFonts = [ ...themeFonts, ...customFonts ];
+	const activeFonts = [ ...themeFonts, ...customFonts ].sort( ( a, b ) =>
+		a.name.localeCompare( b.name )
+	);
 	const hasFonts = 0 < activeFonts.length;
 	const hasInstalledFonts =
 		hasFonts ||

--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -44,8 +44,8 @@ function FontFamilies() {
 				.map( ( f ) => setUIValuesNeeded( f, { source: 'custom' } ) )
 				.sort( ( a, b ) => a.name.localeCompare( b.name ) )
 		: [];
-	const hasFonts = 0 < customFonts.length || 0 < themeFonts.length;
-
+	const activeFonts = [ ...themeFonts, ...customFonts ];
+	const hasFonts = 0 < activeFonts.length;
 	const hasInstalledFonts =
 		hasFonts ||
 		baseFontFamilies?.theme?.length > 0 ||
@@ -61,11 +61,11 @@ function FontFamilies() {
 			) }
 
 			<VStack spacing={ 4 }>
-				{ [ ...themeFonts, ...customFonts ].length > 0 && (
+				{ activeFonts.length > 0 && (
 					<>
 						<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 						<ItemGroup size="large" isBordered isSeparated>
-							{ themeFonts.map( ( font ) => (
+							{ activeFonts.map( ( font ) => (
 								<FontFamilyItem
 									key={ font.slug }
 									font={ font }


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/65805

## What?
List all active fonts in the typography section

## Why?

## How?
Listing both theme and custom fonts.

## Testing Instructions
See https://github.com/WordPress/gutenberg/issues/65805


