### PR TITLE
Customize widgets, edit post: refactor Button to new sizes

### DIFF
--- a/packages/customize-widgets/src/components/error-boundary/index.js
+++ b/packages/customize-widgets/src/components/error-boundary/index.js
@@ -11,12 +11,7 @@ import { doAction } from '@wordpress/hooks';
 function CopyButton( { text, children } ) {
 	const ref = useCopyToClipboard( text );
 	return (
-		<Button
-			// TODO: Switch to `true` (40px size) if possible
-			__next40pxDefaultSize={ false }
-			variant="secondary"
-			ref={ ref }
-		>
+		<Button size="compact" variant="secondary" ref={ ref }>
 			{ children }
 		</Button>
 	);

--- a/packages/customize-widgets/src/components/inserter/index.js
+++ b/packages/customize-widgets/src/components/inserter/index.js
@@ -37,8 +37,7 @@ function Inserter( { setIsOpened } ) {
 					{ __( 'Add a block' ) }
 				</h2>
 				<Button
-					// TODO: Switch to `true` (40px size) if possible
-					__next40pxDefaultSize={ false }
+					size="small"
 					className="customize-widgets-layout__inserter-panel-header-close-button"
 					icon={ closeSmall }
 					onClick={ () => setIsOpened( false ) }

--- a/packages/customize-widgets/src/components/inserter/index.js
+++ b/packages/customize-widgets/src/components/inserter/index.js
@@ -38,7 +38,6 @@ function Inserter( { setIsOpened } ) {
 				</h2>
 				<Button
 					size="small"
-					className="customize-widgets-layout__inserter-panel-header-close-button"
 					icon={ closeSmall }
 					onClick={ () => setIsOpened( false ) }
 					aria-label={ __( 'Close inserter' ) }

--- a/packages/customize-widgets/src/components/welcome-guide/index.js
+++ b/packages/customize-widgets/src/components/welcome-guide/index.js
@@ -43,7 +43,6 @@ export default function WelcomeGuide( { sidebar } ) {
 					  ) }
 			</p>
 			<Button
-				className="customize-widgets-welcome-guide__button"
 				size="compact"
 				variant="primary"
 				onClick={ () =>

--- a/packages/customize-widgets/src/components/welcome-guide/index.js
+++ b/packages/customize-widgets/src/components/welcome-guide/index.js
@@ -43,8 +43,7 @@ export default function WelcomeGuide( { sidebar } ) {
 					  ) }
 			</p>
 			<Button
-				// TODO: Switch to `true` (40px size) if possible
-				__next40pxDefaultSize={ false }
+				__next40pxDefaultSize
 				className="customize-widgets-welcome-guide__button"
 				variant="primary"
 				onClick={ () =>

--- a/packages/customize-widgets/src/components/welcome-guide/index.js
+++ b/packages/customize-widgets/src/components/welcome-guide/index.js
@@ -43,8 +43,8 @@ export default function WelcomeGuide( { sidebar } ) {
 					  ) }
 			</p>
 			<Button
-				__next40pxDefaultSize
 				className="customize-widgets-welcome-guide__button"
+				size="compact"
 				variant="primary"
 				onClick={ () =>
 					toggle( 'core/customize-widgets', 'welcomeGuide' )

--- a/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
+++ b/packages/edit-post/src/components/back-button/fullscreen-mode-close.js
@@ -91,8 +91,7 @@ function FullscreenModeClose( { showTooltip, icon, href, initialPost } ) {
 	return (
 		<motion.div whileHover="expand">
 			<Button
-				// TODO: Switch to `true` (40px size) if possible
-				__next40pxDefaultSize={ false }
+				__next40pxDefaultSize
 				className={ classes }
 				href={ buttonHref }
 				label={ buttonLabel }

--- a/packages/edit-post/src/components/back-button/test/__snapshots__/fullscreen-mode-close.js.snap
+++ b/packages/edit-post/src/components/back-button/test/__snapshots__/fullscreen-mode-close.js.snap
@@ -5,7 +5,7 @@ exports[`FullscreenModeClose when in full screen mode should display a default s
   <div>
     <a
       aria-label="Back"
-      class="components-button edit-post-fullscreen-mode-close"
+      class="components-button edit-post-fullscreen-mode-close is-next-40px-default-size"
       href="edit.php?"
     >
       <svg

--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -82,8 +82,7 @@ export default function InitPatternModal() {
 							/>
 							<HStack justify="right">
 								<Button
-									// TODO: Switch to `true` (40px size) if possible
-									__next40pxDefaultSize={ false }
+									__next40pxDefaultSize
 									variant="primary"
 									type="submit"
 									disabled={ ! title }

--- a/packages/edit-post/src/components/preferences-modal/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/enable-custom-fields.js
@@ -39,8 +39,7 @@ export function CustomFieldsConfirmation( { willEnable } ) {
 				) }
 			</p>
 			<Button
-				// TODO: Switch to `true` (40px size) if possible
-				__next40pxDefaultSize={ false }
+				__next40pxDefaultSize
 				className="edit-post-preferences-modal__custom-fields-confirmation-button"
 				variant="secondary"
 				isBusy={ isReloading }

--- a/packages/edit-post/src/components/preferences-modal/enable-custom-fields.js
+++ b/packages/edit-post/src/components/preferences-modal/enable-custom-fields.js
@@ -40,7 +40,6 @@ export function CustomFieldsConfirmation( { willEnable } ) {
 			</p>
 			<Button
 				__next40pxDefaultSize
-				className="edit-post-preferences-modal__custom-fields-confirmation-button"
 				variant="secondary"
 				isBusy={ isReloading }
 				accessibleWhenDisabled

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
@@ -97,7 +97,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
       A page reload is required for this change. Make sure your content is saved before reloading.
     </p>
     <button
-      class="components-button edit-post-preferences-modal__custom-fields-confirmation-button is-next-40px-default-size is-secondary"
+      class="components-button is-next-40px-default-size is-secondary"
       type="button"
     >
       Show & Reload Page
@@ -300,7 +300,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
       A page reload is required for this change. Make sure your content is saved before reloading.
     </p>
     <button
-      class="components-button edit-post-preferences-modal__custom-fields-confirmation-button is-next-40px-default-size is-secondary"
+      class="components-button is-next-40px-default-size is-secondary"
       type="button"
     >
       Hide & Reload Page

--- a/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
+++ b/packages/edit-post/src/components/preferences-modal/test/__snapshots__/enable-custom-fields.js.snap
@@ -97,7 +97,7 @@ exports[`EnableCustomFieldsOption renders a checked checkbox and a confirmation 
       A page reload is required for this change. Make sure your content is saved before reloading.
     </p>
     <button
-      class="components-button edit-post-preferences-modal__custom-fields-confirmation-button is-secondary"
+      class="components-button edit-post-preferences-modal__custom-fields-confirmation-button is-next-40px-default-size is-secondary"
       type="button"
     >
       Show & Reload Page
@@ -300,7 +300,7 @@ exports[`EnableCustomFieldsOption renders an unchecked checkbox and a confirmati
       A page reload is required for this change. Make sure your content is saved before reloading.
     </p>
     <button
-      class="components-button edit-post-preferences-modal__custom-fields-confirmation-button is-secondary"
+      class="components-button edit-post-preferences-modal__custom-fields-confirmation-button is-next-40px-default-size is-secondary"
       type="button"
     >
       Hide & Reload Page


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #65018

Migrate some of the existing usages of `Button` to the new 40px sizing

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #65018

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By either setting `__next40pxDefaultSize` to `true`, or by applying a different `size`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

See individual comments
