### PR TITLE
`ToggleGroupControl`: clean up animation logic

### DIFF
--- a/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/toggle-group-control/test/__snapshots__/index.tsx.snap
@@ -61,7 +61,7 @@ exports[`ToggleGroupControl controlled should render correctly with icons 1`] = 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-8.is-animation-enabled::before {
+  .emotion-8[data-indicator-animated]::before {
     transition-property: transform,border-radius;
     transition-duration: 0.2s;
     transition-timing-function: ease-out;
@@ -426,7 +426,7 @@ exports[`ToggleGroupControl controlled should render correctly with text options
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-8.is-animation-enabled::before {
+  .emotion-8[data-indicator-animated]::before {
     transition-property: transform,border-radius;
     transition-duration: 0.2s;
     transition-timing-function: ease-out;
@@ -695,7 +695,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with icons 1`] 
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-8.is-animation-enabled::before {
+  .emotion-8[data-indicator-animated]::before {
     transition-property: transform,border-radius;
     transition-duration: 0.2s;
     transition-timing-function: ease-out;
@@ -1054,7 +1054,7 @@ exports[`ToggleGroupControl uncontrolled should render correctly with text optio
 }
 
 @media not ( prefers-reduced-motion ) {
-  .emotion-8.is-animation-enabled::before {
+  .emotion-8[data-indicator-animated]::before {
     transition-property: transform,border-radius;
     transition-duration: 0.2s;
     transition-timing-function: ease-out;

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -58,7 +58,7 @@ function useAnimatedOffsetRect(
 	rect: ElementOffsetRect,
 	{
 		prefix = 'subelement',
-		attribute = `${ prefix }-animated`,
+		dataAttribute = `${ prefix }-animated`,
 		transitionEndFilter = () => true,
 	}: {
 		/**
@@ -69,10 +69,13 @@ function useAnimatedOffsetRect(
 		prefix?: string;
 		/**
 		 * The name of the data attribute used to indicate that the animation is in
-		 * progress.
+		 * progress. The `data-` prefix is added automatically.
+		 *
+		 * For example, if `dataAttribute` is `indicator-animated`, the attribute will
+		 * be `data-indicator-animated`.
 		 * @default `${ prefix }-animated`
 		 */
-		attribute?: string;
+		dataAttribute?: string;
 		/**
 		 * A function that is called with the transition event and returns a boolean
 		 * indicating whether the animation should be stopped. The default is a function
@@ -101,19 +104,19 @@ function useAnimatedOffsetRect(
 	useOnValueUpdate( rect.element, ( { previousValue } ) => {
 		// Only enable the animation when moving from one element to another.
 		if ( rect.element && previousValue ) {
-			container?.setAttribute( `data-${ attribute }`, '' );
+			container?.setAttribute( `data-${ dataAttribute }`, '' );
 		}
 	} );
 	useLayoutEffect( () => {
 		function onTransitionEnd( event: TransitionEvent ) {
 			if ( transitionEndFilter( event ) ) {
-				container?.removeAttribute( `data-${ attribute }` );
+				container?.removeAttribute( `data-${ dataAttribute }` );
 			}
 		}
 		container?.addEventListener( 'transitionend', onTransitionEnd );
 		return () =>
 			container?.removeEventListener( 'transitionend', onTransitionEnd );
-	}, [ attribute, container, transitionEndFilter ] );
+	}, [ dataAttribute, container, transitionEndFilter ] );
 }
 
 function UnconnectedToggleGroupControl(
@@ -148,7 +151,7 @@ function UnconnectedToggleGroupControl(
 	);
 	useAnimatedOffsetRect( controlElement, selectedRect, {
 		prefix: 'selected',
-		attribute: 'indicator-animated',
+		dataAttribute: 'indicator-animated',
 		transitionEndFilter: ( event ) => event.pseudoElement === '::before',
 	} );
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -59,7 +59,7 @@ function useAnimatedOffsetRect(
 	{
 		prefix = 'subelement',
 		attribute = `${ prefix }-animated`,
-		transitionEndFilter,
+		transitionEndFilter = () => true,
 	}: {
 		/**
 		 * The prefix used for the CSS variables, e.g. if `prefix` is `selected`, the
@@ -75,11 +75,12 @@ function useAnimatedOffsetRect(
 		attribute?: string;
 		/**
 		 * A function that is called with the transition event and returns a boolean
-		 * indicating whether the animation should be stopped. The default is to
-		 * always stop the animation.
+		 * indicating whether the animation should be stopped. The default is a function
+		 * that always returns `true`.
 		 *
 		 * For example, if the animated element is the `::before` pseudo-element, the
 		 * function can be written as `( event ) => event.pseudoElement === '::before'`.
+		 * @default () => true
 		 */
 		transitionEndFilter?: ( event: TransitionEvent ) => boolean;
 	} = {}
@@ -105,7 +106,7 @@ function useAnimatedOffsetRect(
 	} );
 	useLayoutEffect( () => {
 		function onTransitionEnd( event: TransitionEvent ) {
-			if ( transitionEndFilter?.( event ) ?? true ) {
+			if ( transitionEndFilter( event ) ) {
 				container?.removeAttribute( `data-${ attribute }` );
 			}
 		}

--- a/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
+++ b/packages/components/src/toggle-group-control/toggle-group-control/styles.ts
@@ -28,7 +28,7 @@ export const toggleGroupControl = ( {
 	${ ! isDeselectable && enclosingBorders( isBlock ) }
 
 	@media not ( prefers-reduced-motion ) {
-		&.is-animation-enabled::before {
+		&[data-indicator-animated]::before {
 			transition-property: transform, border-radius;
 			transition-duration: 0.2s;
 			transition-timing-function: ease-out;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Misc. cleanups and improvements of the `useSubelementAnimation` (now renamed to `useAnimatedOffsetRect`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve clarity and also to later hoist and reuse the same utility in `Tabs.Tablist`. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Functionally, the implementation is unchanged. However, I made the following improvements:

- Various renames.
- API now takes the rect in instead of creating it. This will enable its later use in `TabList`, where the rect is used for other purposes.
- Switched from CSS class to data attribute. Class was fine, but this way it should be a bit more resilient to potential React reconciliation conflicts.
- Improved docs with more details and better clarity.
- Parent (now "container") extracted from options and made mandatory (though nullable) so that users can't miss it (I made this mistake myself recently and it caused a bug). It doesn't default to the overflow parent of the subelement anymore either.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check that the ToggleGroupControl animation still works as expected, both in Storybook and in Gutenberg instances.

## Demo

https://github.com/user-attachments/assets/331307db-b61b-4628-9228-236cd11b62f7

