### PR TITLE
Revert "Temp disable test for Classic Block Media issue."

### DIFF
--- a/test/e2e/specs/editor/blocks/classic.spec.js
+++ b/test/e2e/specs/editor/blocks/classic.spec.js
@@ -39,10 +39,7 @@ test.describe( 'Classic', () => {
 		await expect.poll( editor.getEditedPostContent ).toBe( 'test' );
 	} );
 
-	// Reinitiate once this ticket is fixed:
-	// https://core.trac.wordpress.org/ticket/60666
-	// eslint-disable-next-line playwright/no-skipped-test
-	test.skip( 'should insert media, convert to blocks, and undo in one step', async ( {
+	test( 'should insert media, convert to blocks, and undo in one step', async ( {
 		editor,
 		mediaUtils,
 		page,


### PR DESCRIPTION
This reverts commit 8477a6184055c3c8a62c77af354826645dcaf351.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reverts and follow up to #65793.

## Why?

The commit causing the broken tests has been reverted in WordPress-Develop [r59156](https://core.trac.wordpress.org/changeset/59156)

## How?

`git revert`

## Testing Instructions

N/A: Just wait for the tests to pass on this PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
