### PR TITLE
Global style revisions: remove unnecessary `goTo` navigation call

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -72,7 +72,6 @@ function ScreenRevisions() {
 	);
 
 	const onCloseRevisions = () => {
-		goTo( '/' ); // Return to global styles main panel.
 		const canvasContainerView =
 			editorCanvasContainerView === 'global-styles-revisions:style-book'
 				? 'style-book'


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How? Why?

Partly addresses https://github.com/WordPress/gutenberg/issues/65794

Remove `goTo()` call in the `onBack` callback for the ScreenHeader since`Navigator.BackButton` already has default back behaviour.


## Testing Instructions

Head over to Global styles revisions. 
Check that the header back button returns to the root styles panel.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/bf4c6b69-89bf-4c2c-8541-a9b8fd0948cb





