### PR TITLE
Global styles: font size panel crashing when navigating back

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -37,7 +37,6 @@ function FontSize() {
 	const {
 		params: { origin, slug },
 		goBack,
-		goTo,
 	} = useNavigator();
 
 	const [ fontSizes, setFontSizes ] = useGlobalSetting(
@@ -45,6 +44,10 @@ function FontSize() {
 	);
 
 	const [ globalFluid ] = useGlobalSetting( 'typography.fluid' );
+
+	if ( ! origin || ! slug ) {
+		return;
+	}
 
 	// Get the font sizes from the origin, default to empty array.
 	const sizes = fontSizes[ origin ] ?? [];
@@ -151,7 +154,6 @@ function FontSize() {
 							__( 'Manage the font size %s.' ),
 							fontSize.name
 						) }
-						onBack={ () => goTo( '/typography/font-sizes/' ) }
 					/>
 					{ origin === 'custom' && (
 						<FlexItem>

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -37,6 +37,7 @@ function FontSize() {
 	const {
 		params: { origin, slug },
 		goBack,
+		goTo,
 	} = useNavigator();
 
 	const [ fontSizes, setFontSizes ] = useGlobalSetting(
@@ -154,6 +155,7 @@ function FontSize() {
 							__( 'Manage the font size %s.' ),
 							fontSize.name
 						) }
+						onBack={ () => goTo( '/typography/font-sizes/' ) }
 					/>
 					{ origin === 'custom' && (
 						<FlexItem>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? How?

When navigating back from the font sizes panel, the origin and slug navigation params are not available and the editor crashes.

 Let's return early if we can't find them.


## Testing Instructions

1. Head to the site editor
2. Open Global styles > Typography > Font sizes 
3. Select a font size
4. Navigate back to the font sizes panel
5. Nothing should crash!


## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/cbc6fee2-7fa8-4464-83aa-266576234a5c



### After

https://github.com/user-attachments/assets/ce0106b7-537a-4c09-a9aa-3738f7b1ffc3

