### PR TITLE
Update Zoom Out for document width parity

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -32,7 +32,6 @@
 	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
 	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
 	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-	$prev-container-width: var(--wp-block-editor-iframe-zoom-out-prev-container-width);
 
 	transform: scale(#{$scale});
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -48,6 +48,7 @@
 	$total-frame-height: calc(2 * #{$frame-size});
 	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
 	margin-bottom: calc(-1 * #{$total-height});
+	margin-inline: calc(-1 * #{$frame-size} / #{$scale});
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -40,15 +40,15 @@
 
 	// Firefox and Safari don't render margin-bottom here and margin-bottom is needed for Chrome
 	// layout, so we use border matching the background instead of margins.
-	border: calc(#{$frame-size} / #{$scale}) solid $gray-300;
+	border: $frame-size solid $gray-300;
 
 	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 	// so we need to adjust the height of the content to match the scale by using negative margins.
 	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-	$total-frame-height: calc(2 * #{$frame-size});
+	$total-frame-height: calc(2 * (#{$scale} * #{$frame-size}));
 	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
 	margin-bottom: calc(-1 * #{$total-height});
-	margin-inline: calc(-1 * #{$frame-size} / #{$scale});
+	margin-inline: calc(-1 * #{$frame-size});
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -307,10 +307,10 @@ function Iframe( {
 
 		const maxWidth = 750;
 		const frameSizeIsNumber = typeof frameSize === 'number';
-		// The added space from `frameSize` has to be factored in for accurate scale calculation,
-		// but if `frameSize` can’t be treated as a pixel value it’s left out. Accounting for other
-		// units (e.g. rem or %) would be complicated. Usage in core is pixels only. If we can
-		// formally type `frameSize` as number (of pixels) the conditionals here can be obviated.
+		// `frameSize` has to be factored into default scale calculation because it narrows the
+		// content width. If it’s a non-pixel value it’s still applied in the style but can’t be
+		// directly factored into the scale. A consumer could pass a `scale` that has factored in
+		// their non-pixel `frameSize` if they need to. Core relies only on pixel values.
 		let frameWidth = 0;
 		if ( frameSizeIsNumber || frameSize.endsWith( 'px' ) ) {
 			frameWidth =

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -344,10 +344,6 @@ function Iframe( {
 			'--wp-block-editor-iframe-zoom-out-container-width',
 			`${ containerWidth }px`
 		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-prev-container-width',
-			`${ prevContainerWidthRef.current }px`
-		);
 
 		return () => {
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
@@ -366,9 +362,6 @@ function Iframe( {
 			);
 			iframeDocument.documentElement.style.removeProperty(
 				'--wp-block-editor-iframe-zoom-out-container-width'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-prev-container-width'
 			);
 		};
 	}, [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -317,15 +317,18 @@ function Iframe( {
 				2 * ( frameSizeIsNumber ? frameSize : parseInt( frameSize ) );
 		}
 		const usedWidth = Math.min( containerWidth, maxWidth ) - frameWidth;
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale',
+		const usedScale =
 			scale === 'default'
 				? usedWidth / prevContainerWidthRef.current
-				: scale
+				: scale;
+		const integerFrameSize = Math.round( frameWidth / 2 / usedScale );
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scale',
+			usedScale
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			frameSizeIsNumber ? `${ frameSize }px` : frameSize
+			frameWidth !== 0 ? `${ integerFrameSize }px` : frameSize
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -307,10 +307,10 @@ function Iframe( {
 
 		const maxWidth = 750;
 		const frameSizeIsNumber = typeof frameSize === 'number';
-		// The added space from `frameSize` has to be accounted for in scale calculation.
-		// This just punts in case `frameSize` can’t be treated as a pixel value. It’d
-		// probably be good to formally type `frameSize` as number and treat it as pixels.
-		// Core usage is pixels only and supporting any unit would be complicated.
+		// The added space from `frameSize` has to be factored in for accurate scale calculation,
+		// but if `frameSize` can’t be treated as a pixel value it’s left out. Accounting for other
+		// units (e.g. rem or %) would be complicated. Usage in core is pixels only. If we can
+		// formally type `frameSize` as number (of pixels) the conditionals here can be obviated.
 		let frameWidth = 0;
 		if ( frameSizeIsNumber || frameSize.endsWith( 'px' ) ) {
 			frameWidth =

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -306,16 +306,26 @@ function Iframe( {
 		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 
 		const maxWidth = 750;
+		const frameSizeIsNumber = frameSize === 'number';
+		// The added space from `frameSize` has to be accounted for in scale calculation.
+		// This just punts in case `frameSize` can’t be treated as a pixel value. It’d
+		// probably be good to formally type `frameSize` as number and treat it as pixels.
+		// Core usage is pixels only and supporting any unit would be complicated.
+		let frameWidth = 0;
+		if ( frameSizeIsNumber || frameSize.endsWith( 'px' ) ) {
+			frameWidth =
+				2 * ( frameSizeIsNumber ? frameSize : parseInt( frameSize ) );
+		}
+		const usedWidth = Math.min( containerWidth, maxWidth ) - frameWidth;
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
 			scale === 'default'
-				? Math.min( containerWidth, maxWidth ) /
-						prevContainerWidthRef.current
+				? usedWidth / prevContainerWidthRef.current
 				: scale
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			typeof frameSize === 'number' ? `${ frameSize }px` : frameSize
+			frameSizeIsNumber ? `${ frameSize }px` : frameSize
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -328,7 +328,9 @@ function Iframe( {
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			frameWidth !== 0 ? `${ integerFrameSize }px` : frameSize
+			frameWidth !== 0
+				? `${ integerFrameSize }px`
+				: `calc( ${ frameSize } / ${ usedScale } )`
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -306,7 +306,7 @@ function Iframe( {
 		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 
 		const maxWidth = 750;
-		const frameSizeIsNumber = frameSize === 'number';
+		const frameSizeIsNumber = typeof frameSize === 'number';
 		// The added space from `frameSize` has to be accounted for in scale calculation.
 		// This just punts in case `frameSize` can’t be treated as a pixel value. It’d
 		// probably be good to formally type `frameSize` as number and treat it as pixels.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Updating zoom out so its scaling/styling preserves document width.

## Why?
Document width is off due to lack of accounting for the added space around canvas.

Resolves #65757 #63519

## How?
- Subtracts the frame spacing width from the width used to calculate scale
- Adds negative margins to widen the document by the amount its contents are narrowed by
- Rounds the spacing value used for `border` and `margin-inline` to avoid sub-pixel document widths

## Testing Instructions
1. Observe the actual width of the canvas `html` element
2. Engage zoom-out
3. Verify the width is the same as before

Using Chrome’s dev tools the `Computed` tab will show the width as if it were not scaled so it’s handy for this. Though if you have the `html` element selected during the transition to zoom out, it may fail to update completely so deselecting and reselecting `html` element is recommended.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/c3045434-b825-4ad1-b6cd-aa00ed1fa4a1

