### PR TITLE
Composite: add "With Tooltip" storybook example

### DIFF
--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -377,19 +377,13 @@ export const WithTooltips: StoryObj< typeof Composite > = {
 		children: (
 			<>
 				<Tooltip text="Tooltip one">
-					<Composite.Item render={ <button /> }>
-						Item one
-					</Composite.Item>
+					<Composite.Item>Item one</Composite.Item>
 				</Tooltip>
 				<Tooltip text="Tooltip two">
-					<Composite.Item render={ <button /> }>
-						Item two
-					</Composite.Item>
+					<Composite.Item>Item two</Composite.Item>
 				</Tooltip>
 				<Tooltip text="Tooltip three">
-					<Composite.Item render={ <button /> }>
-						Item three
-					</Composite.Item>
+					<Composite.Item>Item three</Composite.Item>
 				</Tooltip>
 			</>
 		),

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -13,6 +13,7 @@ import { useContext, useMemo } from '@wordpress/element';
  */
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { Composite } from '..';
+import { Tooltip } from '../../tooltip';
 
 const meta: Meta< typeof Composite > = {
 	title: 'Components/Composite',
@@ -351,5 +352,52 @@ const Fill = ( { children } ) => {
 				},
 			},
 		},
+	},
+};
+
+/**
+ * Combining the `Tooltip` and `Composite` component has a few caveats.
+ * For example, the following code won't work as expected:
+ *
+ * ```jsx
+ * <Composite.Item
+ *   render={
+ *   <Tooltip text="Tooltip">
+ *     <button>Button</button>
+ *   </Tooltip>
+ * ```
+ *
+ * Take a look at this story's source code to see how to correctly compose
+ * these two components.
+ */
+export const WithTooltips: StoryObj< typeof Composite > = {
+	...Default,
+	args: {
+		...Default.args,
+		children: (
+			<>
+				<Tooltip text="Tooltip one">
+					<Composite.Item render={ <button /> }>
+						Item one
+					</Composite.Item>
+				</Tooltip>
+				<Composite.Item
+					render={ ( props ) => (
+						<Tooltip text="Tooltip two">
+							<button { ...props }>Item two</button>
+						</Tooltip>
+					) }
+				/>
+				<Composite.Item
+					render={ ( props ) => (
+						<Tooltip text="Tooltip three">
+							<button { ...props } />
+						</Tooltip>
+					) }
+				>
+					Item three
+				</Composite.Item>
+			</>
+		),
 	},
 };

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -14,7 +14,6 @@ import { useContext, useMemo } from '@wordpress/element';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { Composite } from '..';
 import { Tooltip } from '../../tooltip';
-import Button from '../../button';
 
 const meta: Meta< typeof Composite > = {
 	title: 'Components/Composite',
@@ -390,9 +389,7 @@ export const WithTooltips: StoryObj< typeof Composite > = {
 					<Composite.Item>Item two</Composite.Item>
 				</Tooltip>
 				<Tooltip text="Tooltip three">
-					<Composite.Item render={ <Button /> }>
-						Item three
-					</Composite.Item>
+					<Composite.Item>Item three</Composite.Item>
 				</Tooltip>
 			</>
 		),

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -14,6 +14,7 @@ import { useContext, useMemo } from '@wordpress/element';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { Composite } from '..';
 import { Tooltip } from '../../tooltip';
+import Button from '../../button';
 
 const meta: Meta< typeof Composite > = {
 	title: 'Components/Composite',
@@ -389,7 +390,9 @@ export const WithTooltips: StoryObj< typeof Composite > = {
 					<Composite.Item>Item two</Composite.Item>
 				</Tooltip>
 				<Tooltip text="Tooltip three">
-					<Composite.Item>Item three</Composite.Item>
+					<Composite.Item render={ <Button /> }>
+						Item three
+					</Composite.Item>
 				</Tooltip>
 			</>
 		),

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -381,22 +381,16 @@ export const WithTooltips: StoryObj< typeof Composite > = {
 						Item one
 					</Composite.Item>
 				</Tooltip>
-				<Composite.Item
-					render={ ( props ) => (
-						<Tooltip text="Tooltip two">
-							<button { ...props }>Item two</button>
-						</Tooltip>
-					) }
-				/>
-				<Composite.Item
-					render={ ( props ) => (
-						<Tooltip text="Tooltip three">
-							<button { ...props } />
-						</Tooltip>
-					) }
-				>
-					Item three
-				</Composite.Item>
+				<Tooltip text="Tooltip two">
+					<Composite.Item render={ <button /> }>
+						Item two
+					</Composite.Item>
+				</Tooltip>
+				<Tooltip text="Tooltip three">
+					<Composite.Item render={ <button /> }>
+						Item three
+					</Composite.Item>
+				</Tooltip>
 			</>
 		),
 	},

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -356,19 +356,25 @@ const Fill = ( { children } ) => {
 };
 
 /**
- * Combining the `Tooltip` and `Composite` component has a few caveats.
- * For example, the following code won't work as expected:
+ * Combining the `Tooltip` and `Composite` component has a few caveats. And while there are a few ways to compose these two components, our recommendation is to render `Composite.Item` as a child of `Tooltip`.
  *
  * ```jsx
+ * // 🔴 Does not work
  * <Composite.Item
  *   render={
- *   <Tooltip text="Tooltip">
- *     <button>Button</button>
- *   </Tooltip>
- * ```
+ *     <Tooltip text="Tooltip">
+ *       <button>Item</button>
+ *     </Tooltip>
+ *   }
+ * />
  *
- * Take a look at this story's source code to see how to correctly compose
- * these two components.
+ * // 🟢 Good
+ * <Tooltip text="Tooltip one">
+ *   <Composite.Item>
+ *     Item one
+ *   </Composite.Item>
+ * </Tooltip>
+ * ```
  */
 export const WithTooltips: StoryObj< typeof Composite > = {
 	...Default,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65615

Add a Storybook example to illustrate how to correctly compose `Tooltip` and `Composite`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Composite the two components is not trivial, such an example can be of help to consumers of the library

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added a new Storybook example following the suggestions from #65615

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Load the new Storybook example
- Make sure that composite and tooltip functionality work as expected

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/478244ea-c1e1-4cce-a03f-ffb7b0f4f514

