### PR TITLE
Composite: fix legacy implementation passing store prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `Navigator`: fix `isInitial` logic ([#65527](https://github.com/WordPress/gutenberg/pull/65527)).
 -   `ToggleGroupControl`: Fix arrow key navigation in RTL ([#65735](https://github.com/WordPress/gutenberg/pull/65735)).
 -   `ToggleGroupControl`: indicator doesn't jump around when the layout around it changes ([#65175](https://github.com/WordPress/gutenberg/pull/65175)).
+-   `Composite`: fix legacy support for the store prop ([#65821](https://github.com/WordPress/gutenberg/pull/65821)).
 
 ### Deprecations
 

--- a/packages/components/src/composite/group-label.tsx
+++ b/packages/components/src/composite/group-label.tsx
@@ -20,11 +20,12 @@ export const CompositeGroupLabel = forwardRef<
 	WordPressComponentProps< CompositeGroupLabelProps, 'div', false >
 >( function CompositeGroupLabel( props, ref ) {
 	const context = useCompositeContext();
+	// @ts-expect-error The store prop in undocumented and only used by the
+	// legacy compat layer.
+	const storeViaProps = props.store as Ariakit.CompositeStore;
+	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+
 	return (
-		<Ariakit.CompositeGroupLabel
-			store={ context.store as Ariakit.CompositeStore }
-			{ ...props }
-			ref={ ref }
-		/>
+		<Ariakit.CompositeGroupLabel store={ store } { ...props } ref={ ref } />
 	);
 } );

--- a/packages/components/src/composite/group-label.tsx
+++ b/packages/components/src/composite/group-label.tsx
@@ -20,8 +20,10 @@ export const CompositeGroupLabel = forwardRef<
 	WordPressComponentProps< CompositeGroupLabelProps, 'div', false >
 >( function CompositeGroupLabel( props, ref ) {
 	const context = useCompositeContext();
-	// @ts-expect-error The store prop in undocumented and only used by the
-	// legacy compat layer.
+
+	// @ts-expect-error The store prop is undocumented and only used by the
+	// legacy compat layer. The `store` prop is documented, but its type is
+	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return (

--- a/packages/components/src/composite/group-label.tsx
+++ b/packages/components/src/composite/group-label.tsx
@@ -22,8 +22,7 @@ export const CompositeGroupLabel = forwardRef<
 	const context = useCompositeContext();
 	// @ts-expect-error The store prop in undocumented and only used by the
 	// legacy compat layer.
-	const storeViaProps = props.store as Ariakit.CompositeStore;
-	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return (
 		<Ariakit.CompositeGroupLabel store={ store } { ...props } ref={ ref } />

--- a/packages/components/src/composite/group.tsx
+++ b/packages/components/src/composite/group.tsx
@@ -20,8 +20,10 @@ export const CompositeGroup = forwardRef<
 	WordPressComponentProps< CompositeGroupProps, 'div', false >
 >( function CompositeGroup( props, ref ) {
 	const context = useCompositeContext();
-	// @ts-expect-error The store prop in undocumented and only used by the
-	// legacy compat layer.
+
+	// @ts-expect-error The store prop is undocumented and only used by the
+	// legacy compat layer. The `store` prop is documented, but its type is
+	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;

--- a/packages/components/src/composite/group.tsx
+++ b/packages/components/src/composite/group.tsx
@@ -22,8 +22,7 @@ export const CompositeGroup = forwardRef<
 	const context = useCompositeContext();
 	// @ts-expect-error The store prop in undocumented and only used by the
 	// legacy compat layer.
-	const storeViaProps = props.store as Ariakit.CompositeStore;
-	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/group.tsx
+++ b/packages/components/src/composite/group.tsx
@@ -20,11 +20,10 @@ export const CompositeGroup = forwardRef<
 	WordPressComponentProps< CompositeGroupProps, 'div', false >
 >( function CompositeGroup( props, ref ) {
 	const context = useCompositeContext();
-	return (
-		<Ariakit.CompositeGroup
-			store={ context.store as Ariakit.CompositeStore }
-			{ ...props }
-			ref={ ref }
-		/>
-	);
+	// @ts-expect-error The store prop in undocumented and only used by the
+	// legacy compat layer.
+	const storeViaProps = props.store as Ariakit.CompositeStore;
+	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+
+	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/hover.tsx
+++ b/packages/components/src/composite/hover.tsx
@@ -22,8 +22,7 @@ export const CompositeHover = forwardRef<
 	const context = useCompositeContext();
 	// @ts-expect-error The store prop in undocumented and only used by the
 	// legacy compat layer.
-	const storeViaProps = props.store as Ariakit.CompositeStore;
-	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/hover.tsx
+++ b/packages/components/src/composite/hover.tsx
@@ -20,11 +20,10 @@ export const CompositeHover = forwardRef<
 	WordPressComponentProps< CompositeHoverProps, 'div', false >
 >( function CompositeHover( props, ref ) {
 	const context = useCompositeContext();
-	return (
-		<Ariakit.CompositeHover
-			store={ context.store as Ariakit.CompositeStore }
-			{ ...props }
-			ref={ ref }
-		/>
-	);
+	// @ts-expect-error The store prop in undocumented and only used by the
+	// legacy compat layer.
+	const storeViaProps = props.store as Ariakit.CompositeStore;
+	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+
+	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/hover.tsx
+++ b/packages/components/src/composite/hover.tsx
@@ -20,8 +20,10 @@ export const CompositeHover = forwardRef<
 	WordPressComponentProps< CompositeHoverProps, 'div', false >
 >( function CompositeHover( props, ref ) {
 	const context = useCompositeContext();
-	// @ts-expect-error The store prop in undocumented and only used by the
-	// legacy compat layer.
+
+	// @ts-expect-error The store prop is undocumented and only used by the
+	// legacy compat layer. The `store` prop is documented, but its type is
+	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeGroup store={ store } { ...props } ref={ ref } />;

--- a/packages/components/src/composite/index.tsx
+++ b/packages/components/src/composite/index.tsx
@@ -73,7 +73,10 @@ export const Composite = Object.assign(
 		},
 		ref
 	) {
-		const store = Ariakit.useCompositeStore( {
+		// @ts-expect-error The store prop is undocumented and only used by the
+		// legacy compat layer.
+		const storeProp = props.store as Ariakit.CompositeStore;
+		const internalStore = Ariakit.useCompositeStore( {
 			activeId,
 			defaultActiveId,
 			setActiveId,
@@ -84,6 +87,8 @@ export const Composite = Object.assign(
 			orientation,
 			rtl,
 		} );
+
+		const store = storeProp ?? internalStore;
 
 		const contextValue = useMemo(
 			() => ( {

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -21,8 +21,9 @@ export const CompositeItem = forwardRef<
 >( function CompositeItem( props, ref ) {
 	const context = useCompositeContext();
 
-	// @ts-expect-error The store prop in undocumented and only used by the
-	// legacy compat layer.
+	// @ts-expect-error The store prop is undocumented and only used by the
+	// legacy compat layer. The `store` prop is documented, but its type is
+	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeItem store={ store } { ...props } ref={ ref } />;

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -23,8 +23,7 @@ export const CompositeItem = forwardRef<
 
 	// @ts-expect-error The store prop in undocumented and only used by the
 	// legacy compat layer.
-	const storeViaProps = props.store as Ariakit.CompositeStore;
-	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeItem store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/item.tsx
+++ b/packages/components/src/composite/item.tsx
@@ -20,11 +20,11 @@ export const CompositeItem = forwardRef<
 	WordPressComponentProps< CompositeItemProps, 'button', false >
 >( function CompositeItem( props, ref ) {
 	const context = useCompositeContext();
-	return (
-		<Ariakit.CompositeItem
-			store={ context.store as Ariakit.CompositeStore }
-			{ ...props }
-			ref={ ref }
-		/>
-	);
+
+	// @ts-expect-error The store prop in undocumented and only used by the
+	// legacy compat layer.
+	const storeViaProps = props.store as Ariakit.CompositeStore;
+	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+
+	return <Ariakit.CompositeItem store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/row.tsx
+++ b/packages/components/src/composite/row.tsx
@@ -21,8 +21,9 @@ export const CompositeRow = forwardRef<
 >( function CompositeRow( props, ref ) {
 	const context = useCompositeContext();
 
-	// @ts-expect-error The store prop in undocumented and only used by the
-	// legacy compat layer.
+	// @ts-expect-error The store prop is undocumented and only used by the
+	// legacy compat layer. The `store` prop is documented, but its type is
+	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;

--- a/packages/components/src/composite/row.tsx
+++ b/packages/components/src/composite/row.tsx
@@ -23,8 +23,7 @@ export const CompositeRow = forwardRef<
 
 	// @ts-expect-error The store prop in undocumented and only used by the
 	// legacy compat layer.
-	const storeViaProps = props.store as Ariakit.CompositeStore;
-	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/row.tsx
+++ b/packages/components/src/composite/row.tsx
@@ -20,11 +20,11 @@ export const CompositeRow = forwardRef<
 	WordPressComponentProps< CompositeRowProps, 'div', false >
 >( function CompositeRow( props, ref ) {
 	const context = useCompositeContext();
-	return (
-		<Ariakit.CompositeRow
-			store={ context.store as Ariakit.CompositeStore }
-			{ ...props }
-			ref={ ref }
-		/>
-	);
+
+	// @ts-expect-error The store prop in undocumented and only used by the
+	// legacy compat layer.
+	const storeViaProps = props.store as Ariakit.CompositeStore;
+	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+
+	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/typeahead.tsx
+++ b/packages/components/src/composite/typeahead.tsx
@@ -21,8 +21,9 @@ export const CompositeTypeahead = forwardRef<
 >( function CompositeTypeahead( props, ref ) {
 	const context = useCompositeContext();
 
-	// @ts-expect-error The store prop in undocumented and only used by the
-	// legacy compat layer.
+	// @ts-expect-error The store prop is undocumented and only used by the
+	// legacy compat layer. The `store` prop is documented, but its type is
+	// obfuscated to discourage its use outside of the component's internals.
 	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;

--- a/packages/components/src/composite/typeahead.tsx
+++ b/packages/components/src/composite/typeahead.tsx
@@ -20,11 +20,11 @@ export const CompositeTypeahead = forwardRef<
 	WordPressComponentProps< CompositeTypeaheadProps, 'div', false >
 >( function CompositeTypeahead( props, ref ) {
 	const context = useCompositeContext();
-	return (
-		<Ariakit.CompositeTypeahead
-			store={ context.store as Ariakit.CompositeStore }
-			{ ...props }
-			ref={ ref }
-		/>
-	);
+
+	// @ts-expect-error The store prop in undocumented and only used by the
+	// legacy compat layer.
+	const storeViaProps = props.store as Ariakit.CompositeStore;
+	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+
+	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;
 } );

--- a/packages/components/src/composite/typeahead.tsx
+++ b/packages/components/src/composite/typeahead.tsx
@@ -23,8 +23,7 @@ export const CompositeTypeahead = forwardRef<
 
 	// @ts-expect-error The store prop in undocumented and only used by the
 	// legacy compat layer.
-	const storeViaProps = props.store as Ariakit.CompositeStore;
-	const store = storeViaProps ?? ( context.store as Ariakit.CompositeStore );
+	const store = ( props.store ?? context.store ) as Ariakit.CompositeStore;
 
 	return <Ariakit.CompositeRow store={ store } { ...props } ref={ ref } />;
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from #65720

Fix internal implementation of `Composite` to make it work better with legacy usages

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This fixes a big that could cause `Composite` to stop working as expected when used via its legacy, unstable exports

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By explicitly grabbing the `store` prop and explicitly prioritizing it against the store read from internal context.

This is necessary because of how the legacy implementation of `Composite` works, which allows folks to pass a `state` prop to the old version of the component, which we needed to "translate" to passing a `store` prop in our legacy compat layer.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- All tests should pass
- The legacy Storybook examples of Composite should continue to work
- Make a change in `Composite.Item` that relies on the `store` logic (like the one applied in https://github.com/WordPress/gutenberg/pull/65720). On `trunk`, the change has a chance to break the `CompositeItem` legacy component, because it's not using the right `store`. This PR makes sure that, if the legacy implementation is passing a `store` via props, that store will be used instead.