### PR TITLE
Add `isVisible` option to fields within DataForm

### DIFF
--- a/packages/dataviews/src/components/dataform-combined-edit/index.tsx
+++ b/packages/dataviews/src/components/dataform-combined-edit/index.tsx
@@ -12,6 +12,7 @@ import {
  * Internal dependencies
  */
 import type { DataFormCombinedEditProps, NormalizedField } from '../../types';
+import FormFieldVisibility from '../form-field-visibility';
 
 function Header( { title }: { title: string } ) {
 	return (
@@ -41,13 +42,15 @@ function DataFormCombinedEdit< Item >( {
 		);
 	const children = visibleChildren.map( ( child ) => {
 		return (
-			<div className="dataforms-combined-edit__field" key={ child.id }>
-				<child.Edit
-					data={ data }
-					field={ child }
-					onChange={ onChange }
-				/>
-			</div>
+			<FormFieldVisibility key={ child.id } data={ data } field={ child }>
+				<div className="dataforms-combined-edit__field">
+					<child.Edit
+						data={ data }
+						field={ child }
+						onChange={ onChange }
+					/>
+				</div>
+			</FormFieldVisibility>
 		);
 	} );
 

--- a/packages/dataviews/src/components/dataform-field-visibility/index.tsx
+++ b/packages/dataviews/src/components/dataform-field-visibility/index.tsx
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField } from '../../types';
+
+type DataFormFieldVisibilityProps< Item > = React.PropsWithChildren< {
+	field: NormalizedField< Item >;
+	data: Item;
+} >;
+
+export default function DataFormFieldVisibility< Item >( {
+	data,
+	field,
+	children,
+}: DataFormFieldVisibilityProps< Item > ) {
+	const dependencies = field.dependencies
+		? field.dependencies.map( ( dep ) => data[ dep ] )
+		: [ field?.getValue( { item: data } ) ];
+	const isVisible = useMemo( () => {
+		if ( field.isVisible ) {
+			return field.isVisible( data );
+		}
+		return true;
+	}, [ field.isVisible, ...dependencies ] );
+
+	if ( ! isVisible ) {
+		return null;
+	}
+	return children;
+}

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -1,13 +1,25 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import DataForm from '../index';
-import type { CombinedFormField } from '../../../types';
+import type { CombinedFormField, Field } from '../../../types';
+
+type SamplePost = {
+	title: string;
+	order: number;
+	author: number;
+	status: string;
+	reviewer: string;
+	date: string;
+	birthdate: string;
+	sampleField?: string;
+	password?: string;
+};
 
 const meta = {
 	title: 'DataViews/DataForm',
@@ -19,6 +31,22 @@ const meta = {
 				'Chooses the layout of the form. "regular" is the default layout.',
 			options: [ 'regular', 'panel' ],
 		},
+		sampleFieldType: {
+			name: 'Sample Field Type',
+			control: { type: 'select' },
+			description: 'Chooses the type of the sample field.',
+			options: [ 'text', 'integer', 'datetime' ],
+		},
+		additionalSampleFieldDependency: {
+			name: 'Additional Sample Field Dependency',
+			control: { type: 'select' },
+			description:
+				'Choose an additional dependency of the sample field for visiblity.',
+			options: [ 'order', 'author', 'status' ],
+		},
+	},
+	args: {
+		sampleFieldType: 'text',
 	},
 };
 export default meta;
@@ -75,16 +103,47 @@ const fields = [
 		elements: [
 			{ value: 'draft', label: 'Draft' },
 			{ value: 'published', label: 'Published' },
+			{ value: 'private', label: 'Private' },
 		],
 	},
 	{
 		id: 'password',
 		label: 'Password',
 		type: 'text' as const,
+		isVisible: ( item: SamplePost ) => {
+			return item.status !== 'private';
+		},
+		dependencies: [ 'status' ],
 	},
-];
+] as Field< SamplePost >[];
 
-export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
+export const Default = ( {
+	type,
+	sampleFieldType = 'text',
+	additionalSampleFieldDependency,
+}: {
+	type: 'panel' | 'regular';
+	sampleFieldType: 'text' | 'integer' | 'datetime';
+	additionalSampleFieldDependency?: keyof SamplePost;
+} ) => {
+	const visibileFields = useMemo( () => {
+		const dependencies = [ 'sampleField' ];
+		if ( additionalSampleFieldDependency ) {
+			dependencies.push( additionalSampleFieldDependency );
+		}
+		return [
+			...fields,
+			{
+				id: 'sampleField',
+				label: 'Sample Field',
+				type: sampleFieldType,
+				isVisible: ( item: SamplePost ) => {
+					return item.order < 3 && item.sampleField !== 'hide';
+				},
+				dependencies,
+			},
+		] as Field< SamplePost >[];
+	}, [ sampleFieldType, additionalSampleFieldDependency ] );
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
 		order: 2,
@@ -98,19 +157,21 @@ export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
 	const form = {
 		fields: [
 			'title',
+			'sampleField',
 			'order',
 			'author',
 			'reviewer',
 			'status',
+			'password',
 			'date',
 			'birthdate',
 		],
 	};
 
 	return (
-		<DataForm
+		<DataForm< SamplePost >
 			data={ post }
-			fields={ fields }
+			fields={ visibileFields }
 			form={ {
 				...form,
 				type,

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -37,13 +37,6 @@ const meta = {
 			description: 'Chooses the type of the sample field.',
 			options: [ 'text', 'integer', 'datetime' ],
 		},
-		additionalSampleFieldDependency: {
-			name: 'Additional Sample Field Dependency',
-			control: { type: 'select' },
-			description:
-				'Choose an additional dependency of the sample field for visiblity.',
-			options: [ 'order', 'author', 'status' ],
-		},
 	},
 	args: {
 		sampleFieldType: 'text',
@@ -113,24 +106,17 @@ const fields = [
 		isVisible: ( item: SamplePost ) => {
 			return item.status !== 'private';
 		},
-		dependencies: [ 'status' ],
 	},
 ] as Field< SamplePost >[];
 
 export const Default = ( {
 	type,
 	sampleFieldType = 'text',
-	additionalSampleFieldDependency,
 }: {
 	type: 'panel' | 'regular';
 	sampleFieldType: 'text' | 'integer' | 'datetime';
-	additionalSampleFieldDependency?: keyof SamplePost;
 } ) => {
 	const visibileFields = useMemo( () => {
-		const dependencies = [ 'sampleField' ];
-		if ( additionalSampleFieldDependency ) {
-			dependencies.push( additionalSampleFieldDependency );
-		}
 		return [
 			...fields,
 			{
@@ -140,10 +126,9 @@ export const Default = ( {
 				isVisible: ( item: SamplePost ) => {
 					return item.order < 3 && item.sampleField !== 'hide';
 				},
-				dependencies,
 			},
 		] as Field< SamplePost >[];
-	}, [ sampleFieldType, additionalSampleFieldDependency ] );
+	}, [ sampleFieldType ] );
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
 		order: 2,

--- a/packages/dataviews/src/components/dataform/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataform/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -17,7 +17,6 @@ type SamplePost = {
 	reviewer: string;
 	date: string;
 	birthdate: string;
-	sampleField?: string;
 	password?: string;
 };
 
@@ -31,15 +30,6 @@ const meta = {
 				'Chooses the layout of the form. "regular" is the default layout.',
 			options: [ 'regular', 'panel' ],
 		},
-		sampleFieldType: {
-			name: 'Sample Field Type',
-			control: { type: 'select' },
-			description: 'Chooses the type of the sample field.',
-			options: [ 'text', 'integer', 'datetime' ],
-		},
-	},
-	args: {
-		sampleFieldType: 'text',
 	},
 };
 export default meta;
@@ -109,26 +99,7 @@ const fields = [
 	},
 ] as Field< SamplePost >[];
 
-export const Default = ( {
-	type,
-	sampleFieldType = 'text',
-}: {
-	type: 'panel' | 'regular';
-	sampleFieldType: 'text' | 'integer' | 'datetime';
-} ) => {
-	const visibileFields = useMemo( () => {
-		return [
-			...fields,
-			{
-				id: 'sampleField',
-				label: 'Sample Field',
-				type: sampleFieldType,
-				isVisible: ( item: SamplePost ) => {
-					return item.order < 3 && item.sampleField !== 'hide';
-				},
-			},
-		] as Field< SamplePost >[];
-	}, [ sampleFieldType ] );
+export const Default = ( { type }: { type: 'panel' | 'regular' } ) => {
 	const [ post, setPost ] = useState( {
 		title: 'Hello, World!',
 		order: 2,
@@ -142,7 +113,6 @@ export const Default = ( {
 	const form = {
 		fields: [
 			'title',
-			'sampleField',
 			'order',
 			'author',
 			'reviewer',
@@ -156,7 +126,7 @@ export const Default = ( {
 	return (
 		<DataForm< SamplePost >
 			data={ post }
-			fields={ visibileFields }
+			fields={ fields }
 			form={ {
 				...form,
 				type,

--- a/packages/dataviews/src/components/form-field-visibility/index.tsx
+++ b/packages/dataviews/src/components/form-field-visibility/index.tsx
@@ -8,25 +8,22 @@ import { useMemo } from '@wordpress/element';
  */
 import type { NormalizedField } from '../../types';
 
-type DataFormFieldVisibilityProps< Item > = React.PropsWithChildren< {
+type FormFieldVisibilityProps< Item > = React.PropsWithChildren< {
 	field: NormalizedField< Item >;
 	data: Item;
 } >;
 
-export default function DataFormFieldVisibility< Item >( {
+export default function FormFieldVisibility< Item >( {
 	data,
 	field,
 	children,
-}: DataFormFieldVisibilityProps< Item > ) {
-	const dependencies = field.dependencies
-		? field.dependencies.map( ( dep ) => data[ dep ] )
-		: [ field?.getValue( { item: data } ) ];
+}: FormFieldVisibilityProps< Item > ) {
 	const isVisible = useMemo( () => {
 		if ( field.isVisible ) {
 			return field.isVisible( data );
 		}
 		return true;
-	}, [ field.isVisible, ...dependencies ] );
+	}, [ field.isVisible, data ] );
 
 	if ( ! isVisible ) {
 		return null;

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -19,6 +19,7 @@ import { closeSmall } from '@wordpress/icons';
 import { normalizeFields } from '../../normalize-fields';
 import { getVisibleFields } from '../get-visible-fields';
 import type { DataFormProps, NormalizedField } from '../../types';
+import DataFormFieldVisibility from '../../components/dataform-field-visibility';
 
 interface FormFieldProps< Item > {
 	data: Item;
@@ -156,12 +157,17 @@ export default function FormPanel< Item >( {
 		<VStack spacing={ 2 }>
 			{ visibleFields.map( ( field ) => {
 				return (
-					<FormField
+					<DataFormFieldVisibility
 						key={ field.id }
 						data={ data }
 						field={ field }
-						onChange={ onChange }
-					/>
+					>
+						<FormField
+							data={ data }
+							field={ field }
+							onChange={ onChange }
+						/>
+					</DataFormFieldVisibility>
 				);
 			} ) }
 		</VStack>

--- a/packages/dataviews/src/dataforms-layouts/panel/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/panel/index.tsx
@@ -19,7 +19,7 @@ import { closeSmall } from '@wordpress/icons';
 import { normalizeFields } from '../../normalize-fields';
 import { getVisibleFields } from '../get-visible-fields';
 import type { DataFormProps, NormalizedField } from '../../types';
-import DataFormFieldVisibility from '../../components/dataform-field-visibility';
+import FormFieldVisibility from '../../components/form-field-visibility';
 
 interface FormFieldProps< Item > {
 	data: Item;
@@ -157,7 +157,7 @@ export default function FormPanel< Item >( {
 		<VStack spacing={ 2 }>
 			{ visibleFields.map( ( field ) => {
 				return (
-					<DataFormFieldVisibility
+					<FormFieldVisibility
 						key={ field.id }
 						data={ data }
 						field={ field }
@@ -167,7 +167,7 @@ export default function FormPanel< Item >( {
 							field={ field }
 							onChange={ onChange }
 						/>
-					</DataFormFieldVisibility>
+					</FormFieldVisibility>
 				);
 			} ) }
 		</VStack>

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -10,7 +10,7 @@ import { useMemo } from '@wordpress/element';
 import { normalizeFields } from '../../normalize-fields';
 import { getVisibleFields } from '../get-visible-fields';
 import type { DataFormProps } from '../../types';
-import DataFormFieldVisibility from '../../components/dataform-field-visibility';
+import FormFieldVisibility from '../../components/form-field-visibility';
 
 export default function FormRegular< Item >( {
 	data,
@@ -34,7 +34,7 @@ export default function FormRegular< Item >( {
 		<VStack spacing={ 4 }>
 			{ visibleFields.map( ( field ) => {
 				return (
-					<DataFormFieldVisibility
+					<FormFieldVisibility
 						key={ field.id }
 						data={ data }
 						field={ field }
@@ -44,7 +44,7 @@ export default function FormRegular< Item >( {
 							field={ field }
 							onChange={ onChange }
 						/>
-					</DataFormFieldVisibility>
+					</FormFieldVisibility>
 				);
 			} ) }
 		</VStack>

--- a/packages/dataviews/src/dataforms-layouts/regular/index.tsx
+++ b/packages/dataviews/src/dataforms-layouts/regular/index.tsx
@@ -10,6 +10,7 @@ import { useMemo } from '@wordpress/element';
 import { normalizeFields } from '../../normalize-fields';
 import { getVisibleFields } from '../get-visible-fields';
 import type { DataFormProps } from '../../types';
+import DataFormFieldVisibility from '../../components/dataform-field-visibility';
 
 export default function FormRegular< Item >( {
 	data,
@@ -33,12 +34,17 @@ export default function FormRegular< Item >( {
 		<VStack spacing={ 4 }>
 			{ visibleFields.map( ( field ) => {
 				return (
-					<field.Edit
+					<DataFormFieldVisibility
 						key={ field.id }
 						data={ data }
 						field={ field }
-						onChange={ onChange }
-					/>
+					>
+						<field.Edit
+							data={ data }
+							field={ field }
+							onChange={ onChange }
+						/>
+					</DataFormFieldVisibility>
 				);
 			} ) }
 		</VStack>

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -129,11 +129,6 @@ export type Field< Item > = {
 	isVisible?: ( item: Item ) => boolean;
 
 	/**
-	 * Dependency list for triggering isVisible.
-	 */
-	dependencies?: Array< keyof Item >;
-
-	/**
 	 * Whether the field is sortable.
 	 */
 	enableSorting?: boolean;

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -124,7 +124,7 @@ export type Field< Item > = {
 	isValid?: ( item: Item, context?: ValidationContext ) => boolean;
 
 	/**
-	 * Callback used to display the field.
+	 * Callback used to decide if a field should be displayed.
 	 */
 	isVisible?: ( item: Item ) => boolean;
 

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -124,6 +124,16 @@ export type Field< Item > = {
 	isValid?: ( item: Item, context?: ValidationContext ) => boolean;
 
 	/**
+	 * Callback used to display the field.
+	 */
+	isVisible?: ( item: Item ) => boolean;
+
+	/**
+	 * Dependency list for triggering isVisible.
+	 */
+	dependencies?: Array< keyof Item >;
+
+	/**
 	 * Whether the field is sortable.
 	 */
 	enableSorting?: boolean;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This adds the `isVisible` callback to the field type for determining if a field should be visible within DataForms.
~~It also adds a `dependency` array option that gets used by the `isVisible` callback. By default it only listens to the field value for changes.~~

## Why?

This solves the problem for dynamically showing/hiding fields within the form that depend specific field values. For example we want to hide the password field when the post status is set to `private`, but display it otherwise. Instead of filtering the `form.fields` list at the top level, this allows us to handle this on a per field level.

## How?

It adds a `isVisible` callback that passes the data being edited. It should return a boolean.
~~In addition, there is a dependency array, that works similar as the dependency array passed to `useMemo` or `useEffect` calls. It takes a list of keys that the `isVisible` function may depend on.~~

In the case of the `password` field, it depends on the `status` field. So it would take `dependency: [ 'status' ]` and the `isVisible` function will only be run if `status` changes.

## Testing Instructions
1. Run storybook `npm run storybook:dev`
2. Go to the DataViews > DataForm storybook
3. Switch the status to `private` in the sample data form and notice how the password field disappears

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
