### PR TITLE
Fixed zoom out mode when switching to code editor

### DIFF
--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -13,14 +13,16 @@ import { store as preferencesStore } from '@wordpress/preferences';
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
 
 const ZoomOutToggle = () => {
-	const { isZoomOut, showIconLabels } = useSelect( ( select ) => ( {
+	const { isZoomOut, showIconLabels, mode } = useSelect( ( select ) => ( {
 		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
 		showIconLabels: select( preferencesStore ).get(
 			'core',
 			'showIconLabels'
 		),
+		mode: unlock( select( editorStore ) ).getEditorMode(),
 	} ) );
 
 	const { resetZoomLevel, setZoomLevel, __unstableSetEditorMode } = unlock(
@@ -35,6 +37,11 @@ const ZoomOutToggle = () => {
 		}
 		__unstableSetEditorMode( isZoomOut ? 'edit' : 'zoom-out' );
 	};
+
+	if ( 'text' === mode ) {
+		resetZoomLevel();
+		__unstableSetEditorMode( 'edit' );
+	}
 
 	return (
 		<Button


### PR DESCRIPTION
## What?
Part of - https://github.com/WordPress/gutenberg/issues/65783

## Why?
Solve - https://github.com/WordPress/gutenberg/issues/65783

## Testing Instructions

Enable zoomed-out view (tested in post editor):

- Enable zoomed-out view (tested in post editor.
- Switch to code editor.
- Exit code editor.
- Note zoom-out button is not active.

## Screenshots or screencast <!-- if applicable -->
[Posts ‹ gutenberg — WordPress.webm](https://github.com/user-attachments/assets/4d4b6a8f-5dfc-409e-b7ae-2aaeeb59747b)
