### PR TITLE
Filter UI: Remove popover max height

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/style.scss
+++ b/packages/dataviews/src/components/dataviews-filters/style.scss
@@ -160,7 +160,6 @@
 }
 
 .dataviews-filters__search-widget-listbox {
-	max-height: $grid-unit * 23;
 	padding: $grid-unit-05;
 	overflow: auto;
 }


### PR DESCRIPTION
## What?
Remove `max-height` on the filter popover UI.

## Why?
The value is a little aggressive, leading to status being clipped in the pages data view:

<img width="293" alt="Screenshot 2024-10-02 at 16 33 47" src="https://github.com/user-attachments/assets/ec3a62c7-8265-4f36-be54-ab8c1d7f6cae">


## How?
By removing the `max-height` style the height of the popover will be governed by the underlying component, which already handles potential visibility issues caused by the viewport size:


https://github.com/user-attachments/assets/8a615461-1bcd-478f-a748-4a0376e0f09c



## Testing Instructions
1. Open the Pages data view
2. Add a Status filter
3. Observe the popover no longer scrolls and that all options are visible

