### PR TITLE
Experiment: Expanded `contentOnly` / write mode List block editing

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -75,6 +75,7 @@ function UncontrolledInnerBlocks( props ) {
 		blockType,
 		parentLock,
 		defaultLayout,
+		contentOnlyInsertion,
 	} = props;
 
 	useNestedSettingsUpdate(
@@ -89,7 +90,8 @@ function UncontrolledInnerBlocks( props ) {
 		templateLock,
 		captureToolbars,
 		orientation,
-		layout
+		layout,
+		contentOnlyInsertion
 	);
 
 	useInnerBlockTemplateSync(

--- a/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
+++ b/packages/block-editor/src/components/inner-blocks/use-nested-settings-update.js
@@ -51,6 +51,7 @@ function useShallowMemo( value ) {
  * @param {string}               orientation                The direction in which the block
  *                                                          should face.
  * @param {Object}               layout                     The layout object for the block container.
+ * @param {?boolean}             contentOnlyInsertion       Whether inner blocks can be inserted in content only mode.
  */
 export default function useNestedSettingsUpdate(
 	clientId,
@@ -64,7 +65,8 @@ export default function useNestedSettingsUpdate(
 	templateLock,
 	captureToolbars,
 	orientation,
-	layout
+	layout,
+	contentOnlyInsertion
 ) {
 	// Instead of adding a useSelect mapping here, please add to the useSelect
 	// mapping in InnerBlocks! Every subscription impacts performance.
@@ -145,6 +147,10 @@ export default function useNestedSettingsUpdate(
 				alternative: '`boolean` values',
 				since: '6.5',
 			} );
+		}
+
+		if ( contentOnlyInsertion !== undefined ) {
+			newSettings.contentOnlyInsertion = contentOnlyInsertion;
 		}
 
 		// Batch updates to block list settings to avoid triggering cascading renders

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1623,8 +1623,14 @@ const canInsertBlockTypeUnmemoized = (
 		blockType = getBlockType( blockName );
 	}
 
-	const isLocked = !! getTemplateLock( state, rootClientId );
-	if ( isLocked ) {
+	const parentBlockListSettings = getBlockListSettings( state, rootClientId );
+	const templateLock = getTemplateLock( state, rootClientId );
+	const allowsContentOnlyInsertion =
+		templateLock === 'contentOnly' &&
+		!! parentBlockListSettings?.contentOnlyInsertion;
+
+	const isLocked = !! templateLock;
+	if ( isLocked && ! allowsContentOnlyInsertion ) {
 		return false;
 	}
 
@@ -1636,8 +1642,6 @@ const canInsertBlockTypeUnmemoized = (
 	if ( getBlockEditingMode( state, rootClientId ?? '' ) === 'disabled' ) {
 		return false;
 	}
-
-	const parentBlockListSettings = getBlockListSettings( state, rootClientId );
 
 	// The parent block doesn't have settings indicating it doesn't support
 	// inner blocks, return false.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1635,7 +1635,7 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const _isSectionBlock = !! isSectionBlock( state, rootClientId );
-	if ( _isSectionBlock ) {
+	if ( _isSectionBlock && ! allowsContentOnlyInsertion ) {
 		return false;
 	}
 
@@ -1784,12 +1784,17 @@ export function canRemoveBlock( state, clientId ) {
 	}
 
 	const rootClientId = getBlockRootClientId( state, clientId );
-	if ( getTemplateLock( state, rootClientId ) ) {
+	const templateLock = getTemplateLock( state, rootClientId );
+	const parentBlockListSettings = getBlockListSettings( state, rootClientId );
+	const allowsContentOnlyInsertion =
+		templateLock === 'contentOnly' &&
+		!! parentBlockListSettings?.contentOnlyInsertion;
+	if ( templateLock && ! allowsContentOnlyInsertion ) {
 		return false;
 	}
 
 	const isBlockWithinSection = !! getParentSectionBlock( state, clientId );
-	if ( isBlockWithinSection ) {
+	if ( isBlockWithinSection && ! allowsContentOnlyInsertion ) {
 		return false;
 	}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1635,7 +1635,9 @@ const canInsertBlockTypeUnmemoized = (
 	}
 
 	const _isSectionBlock = !! isSectionBlock( state, rootClientId );
-	if ( _isSectionBlock && ! allowsContentOnlyInsertion ) {
+	const allowSectionInsertion =
+		!! parentBlockListSettings?.contentOnlyInsertion;
+	if ( _isSectionBlock && ! allowSectionInsertion ) {
 		return false;
 	}
 
@@ -1794,7 +1796,9 @@ export function canRemoveBlock( state, clientId ) {
 	}
 
 	const isBlockWithinSection = !! getParentSectionBlock( state, clientId );
-	if ( isBlockWithinSection && ! allowsContentOnlyInsertion ) {
+	const allowSectionInsertion =
+		!! parentBlockListSettings?.contentOnlyInsertion;
+	if ( isBlockWithinSection && ! allowSectionInsertion ) {
 		return false;
 	}
 

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -79,6 +79,7 @@ export default function ListItemEdit( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		renderAppender: false,
 		__unstableDisableDropZone: true,
+		contentOnlyInsertion: true,
 	} );
 	const useEnterRef = useEnter( { content, clientId } );
 	const useSpaceRef = useSpace( clientId );

--- a/packages/block-library/src/list/edit.js
+++ b/packages/block-library/src/list/edit.js
@@ -139,6 +139,7 @@ export default function Edit( { attributes, setAttributes, clientId, style } ) {
 			renderAppender: false,
 		} ),
 		__experimentalCaptureToolbars: true,
+		contentOnlyInsertion: true,
 	} );
 	useMigrateOnLoad( attributes, clientId );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
See #65778

Experiments with allowing list items to be added/removed and outdented/indented in content only mode

## How?
Adds a `contentOnlyInsertion `property to `useInnerBlocksProps`.  (maybe `allowContentOnlyInsertion` is a better name) 

When this is present, it bypasses some of the usual logic for blocks in the `canInsertBlockTypes` and `canRemoveBlock` selectors.

## Notes

- At the moment this works ok for list as it has a limited subset of inner block types, but for other blocks like `quote` that accept any inner block type, we might want to limit what can be inserted in contentOnly mode. Perhaps an option is an API like `allowContentOnlyInsertion: [ 'core/paragraph' ]`, or specify `directInsert` in contentOnly mode.
- There might be some writing flow oddities to consider. I think I noticed a few, but I need to write them down
- When you have a list nested in another list, the 'section' (or content only locked parent) content panel should probably only show the parent-most list, at the moment it'll show the nested one too, but they look like siblings:
<img width="265" alt="Screenshot 2024-10-02 at 5 20 40 pm" src="https://github.com/user-attachments/assets/9589f25d-bef8-4d8c-a10d-5dff283b33b9">

- Similarly List View should probably be flattened
- Is `useInnerBlocksProps` the right place to declare this or should it be in the block.json? With `useInnerBlocksProps` it can at least be made private to start with.

## Testing Instructions
1. Open a template like Blog Homepage in the site editor
2. Add a List in the middle of one of the sections/patterns
3. Switch to write mode an try editing the List

Also try with contentOnly locked group, here's a code snippet that can be pasted into a code editor:
```html
<!-- wp:group {"templateLock":"contentOnly","layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>1<!-- wp:list -->
<ul class="wp-block-list"><!-- wp:list-item -->
<li>2</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>3</li>
<!-- /wp:list-item -->
<!-- wp:list-item -->
<li>4</li>
<!-- /wp:list-item --></ul>
<!-- /wp:list --></div>
<!-- /wp:group -->
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8ba8b946-3ab8-4217-b5bf-c5c010960831


