### PR TITLE
Top Toolbar: Show document bar when no block is selected even if block tools are expanded

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -58,7 +58,7 @@ function Header( {
 		isPublishSidebarOpened,
 		showIconLabels,
 		hasFixedToolbar,
-		isBlockSelected,
+		hasBlockSelection,
 		isNestedEntity,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
@@ -75,7 +75,7 @@ function Header( {
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
-			isBlockSelected:
+			hasBlockSelection:
 				!! select( blockEditorStore ).getBlockSelectionStart(),
 			isNestedEntity:
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
@@ -90,7 +90,7 @@ function Header( {
 		useState( true );
 
 	const hasCenter =
-		( ! isBlockSelected || isBlockToolsCollapsed ) &&
+		( ! hasBlockSelection || isBlockToolsCollapsed ) &&
 		! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 	/*

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { useMediaQuery, useViewportMatch } from '@wordpress/compose';
 import { __unstableMotion as motion } from '@wordpress/components';
@@ -52,12 +53,13 @@ function Header( {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
+		postType,
 		isTextEditor,
 		isPublishSidebarOpened,
 		showIconLabels,
 		hasFixedToolbar,
+		isBlockSelected,
 		isNestedEntity,
-		postType,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -73,6 +75,8 @@ function Header( {
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
 			hasFixedToolbar: getPreference( 'core', 'fixedToolbar' ),
+			isBlockSelected:
+				!! select( blockEditorStore ).getBlockSelectionStart(),
 			isNestedEntity:
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
 		};
@@ -85,7 +89,9 @@ function Header( {
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
 
-	const hasCenter = isBlockToolsCollapsed && ! isTooNarrowForDocumentBar;
+	const hasCenter =
+		( ! isBlockSelected || isBlockToolsCollapsed ) &&
+		! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 	/*
 	 * The edit-post-header classname is only kept for backward compatability


### PR DESCRIPTION
## What?
Fixes #65824

Fixes an issue where the Document Bar isn't present when clicking 'Edit Original' on a synced pattern while Top Toolbar mode is activated.

## Why?
The Document Bar usually hides when block tools are expanded if there's not enough space in the top bar.

When navigating to a pattern, the Block Tools are still considered expanded from the post being edited, even though they're not shown at all due to no block being selected.

## How?
The fix is to show the document bar when there's no block selected, as in this case there won't be any block tools shown.

## Testing Instructions
1. Swith on Top Toolbar mode
2. Insert a synced pattern
3. Click 'Edit Original' from the toolbar
4. Observe the Document Bar and Back button should be present

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="893" alt="Screenshot 2024-10-02 at 7 02 57 pm" src="https://github.com/user-attachments/assets/6b214bcf-d654-42a0-9552-d06dadd81514">

#### After
<img width="896" alt="Screenshot 2024-10-02 at 7 02 32 pm" src="https://github.com/user-attachments/assets/e6ec74b8-6d47-4f9e-8a2d-dd1be3821c42">
