### PR TITLE
Button: Move to stricter lint rule for 40px size adherence

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -322,6 +322,7 @@ module.exports = {
 						'BorderBoxControl',
 						'BorderControl',
 						'BoxControl',
+						'Button',
 						'ComboboxControl',
 						'CustomSelectControl',
 						'DimensionControl',
@@ -352,14 +353,6 @@ module.exports = {
 						message:
 							'FormFileUpload should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
 					},
-					// Temporary rules until all existing components have the `__next40pxDefaultSize` prop.
-					...[ 'Button' ].map( ( componentName ) => ( {
-						// Not strict. Allows pre-existing __next40pxDefaultSize={ false } usage until they are all manually updated.
-						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"])):not(:has(JSXAttribute[name.name="size"]))`,
-						message:
-							componentName +
-							' should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
-					} ) ),
 				],
 			},
 		},

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -344,7 +344,7 @@ module.exports = {
 						selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__next40pxDefaultSize"][value.expression.value!=false])):not(:has(JSXAttribute[name.name="size"][value.value!="default"]))`,
 						message:
 							componentName +
-							' should have the `__next40pxDefaultSize` prop to opt-in to the new default size.',
+							' should have the `__next40pxDefaultSize` prop when using the default size.',
 					} ) ),
 					{
 						// Falsy `__next40pxDefaultSize` without a `render` prop.

--- a/packages/editor/src/components/post-template/classic-theme.js
+++ b/packages/editor/src/components/post-template/classic-theme.js
@@ -177,8 +177,7 @@ function PostTemplateDropdownContent( { onClose } ) {
 			{ canEdit && onNavigateToEntityRecord && (
 				<p>
 					<Button
-						// TODO: Switch to `true` (40px size) if possible
-						__next40pxDefaultSize={ false }
+						__next40pxDefaultSize
 						variant="link"
 						onClick={ () => {
 							onNavigateToEntityRecord( {


### PR DESCRIPTION
Closes #65018
Closes #63871

## What?

Moves `Button` to the stricter lint rule for adherence to the 40px default size.

Also fixes the last remaining violation.

## Testing Instructions

✅ `npm run lint:js -- --quiet` passes
