### PR TITLE
Embed Block: Set width for embed in group block

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -13,6 +13,11 @@
 	}
 }
 
+// When inside a group block, make sure the embed is not collapsed.
+.wp-block-group .wp-block-embed {
+	width: 100%;
+}
+
 // Supply a min-width when inside a cover block, to prevent it from collapsing.
 .wp-block-cover .wp-block-embed {
 	min-width: 320px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR sets a `width: 100%` CSS rule for embed blocks within group block. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes: #65741 
Video embeds (or even all embeds `responsive: true` attribute) are collapsing in both the editor and on the frontend when embedded (😉 ) into Row/Stack blocks.

While I haven't been able to identify the root cause precisely, it seems that because the `embed` block, when in responsive mode, rely on a container to define its height/width and the group block does not provide size related styles, embed collapses.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By setting `width: 100%` for `.wp-block-group .wp-block-embed`. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. In a block editor, add a Stack block
2. add a youtube or vimeo embed block into the Stack block
3. Check if the video preview is rendered correctly
4. Publish, check the content
5. Repeat 1-4 for Post, Page, and Side editor

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A

## Screenshots or screencast <!-- if applicable -->

Before: 
<img width="500" alt="Screenshot 2024-10-02 at 19 53 27" src="https://github.com/user-attachments/assets/770a2097-aafa-459f-8cc1-3bce7e3c5833">
<img width="500" alt="Screenshot 2024-10-02 at 19 53 01" src="https://github.com/user-attachments/assets/541625ef-d710-4d01-91f7-306a76199dab">

After:
<img width="500" alt="Screenshot 2024-10-02 at 20 21 53" src="https://github.com/user-attachments/assets/f3b8cf0f-9231-421b-b8b3-8d9a596b9a1c">
<img width="500" alt="Screenshot 2024-10-02 at 20 22 26" src="https://github.com/user-attachments/assets/72fca802-5980-47e0-a564-95dce27d4905">

