### PR TITLE
Focus first section root block if no selected block and tabbing to zoom out canvas

### DIFF
--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -23,6 +23,7 @@ export default function useTabNav() {
 		hasMultiSelection,
 		getSelectedBlockClientId,
 		getBlockCount,
+		getBlockOrder,
 		getLastFocus,
 		getSectionRootClientId,
 		isZoomOut,
@@ -54,9 +55,21 @@ export default function useTabNav() {
 		}
 		// In "compose" mode without a selected ID, we want to place focus on the section root when tabbing to the canvas.
 		else if ( __unstableGetEditorMode() === 'zoom-out' && isZoomOut() ) {
-			container.current
-				.querySelector( `[data-block="${ getSectionRootClientId() }"]` )
-				.focus();
+			const sectionRootClientId = getSectionRootClientId();
+			const sectionBlocks = getBlockOrder( sectionRootClientId );
+
+			// If we have section within the section root, focus the first one.
+			if ( sectionBlocks.length ) {
+				container.current
+					.querySelector( `[data-block="${ sectionBlocks[ 0 ] }"]` )
+					.focus();
+			}
+			// If we don't have any section blocks, focus the section root.
+			else {
+				container.current
+					.querySelector( `[data-block="${ sectionRootClientId }"]` )
+					.focus();
+			}
 		} else {
 			const canvasElement =
 				container.current.ownerDocument === event.target.ownerDocument

--- a/packages/block-editor/src/components/writing-flow/use-tab-nav.js
+++ b/packages/block-editor/src/components/writing-flow/use-tab-nav.js
@@ -19,10 +19,16 @@ export default function useTabNav() {
 	const focusCaptureBeforeRef = useRef();
 	const focusCaptureAfterRef = useRef();
 
-	const { hasMultiSelection, getSelectedBlockClientId, getBlockCount } =
-		useSelect( blockEditorStore );
+	const {
+		hasMultiSelection,
+		getSelectedBlockClientId,
+		getBlockCount,
+		getLastFocus,
+		getSectionRootClientId,
+		isZoomOut,
+		__unstableGetEditorMode,
+	} = unlock( useSelect( blockEditorStore ) );
 	const { setLastFocus } = unlock( useDispatch( blockEditorStore ) );
-	const { getLastFocus } = unlock( useSelect( blockEditorStore ) );
 
 	// Reference that holds the a flag for enabling or disabling
 	// capturing on the focus capture elements.
@@ -45,6 +51,12 @@ export default function useTabNav() {
 					)
 					.focus();
 			}
+		}
+		// In "compose" mode without a selected ID, we want to place focus on the section root when tabbing to the canvas.
+		else if ( __unstableGetEditorMode() === 'zoom-out' && isZoomOut() ) {
+			container.current
+				.querySelector( `[data-block="${ getSectionRootClientId() }"]` )
+				.focus();
 		} else {
 			const canvasElement =
 				container.current.ownerDocument === event.target.ownerDocument
@@ -61,7 +73,6 @@ export default function useTabNav() {
 				const next = isBefore
 					? tabbables[ 0 ]
 					: tabbables[ tabbables.length - 1 ];
-
 				next.focus();
 			}
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/65830

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
No visible or useful focus when tabbing to the canvas in zoom out mode without a block selection.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
On tab nav focus capture, if in zoom out, focus the first block of the section root. This will also cause it to be selected. If there are no section blocks, focus the section root wrapper instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Reload full site editor
- Tab to zoom out button in header
- Press enter to initialize zoom out
- Tab to canvas
- Focus should be on section root

## Screenshots or screencast <!-- if applicable -->




https://github.com/user-attachments/assets/f6470ed0-9994-44e8-817a-b1460d9e58b9


