### PR TITLE
Post Terms: Fix fatal error when 'get_the_term_list' returns 'WP_Error'

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -51,13 +51,19 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		$suffix = '<span class="wp-block-post-terms__suffix">' . $attributes['suffix'] . '</span>' . $suffix;
 	}
 
-	return get_the_term_list(
+	$post_terms = get_the_term_list(
 		$block->context['postId'],
 		$attributes['term'],
 		wp_kses_post( $prefix ),
 		'<span class="wp-block-post-terms__separator">' . esc_html( $separator ) . '</span>',
 		wp_kses_post( $suffix )
 	);
+
+	if ( is_wp_error( $post_terms ) ) {
+		return false;
+	}
+
+	return $post_terms;
 }
 
 /**

--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -60,7 +60,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 	);
 
 	if ( is_wp_error( $post_terms ) ) {
-		return false;
+		return '';
 	}
 
 	return $post_terms;


### PR DESCRIPTION
## What?
update the `core/post-term` `render_block_core_post_terms` function to handle `WP_Error` and not throw a fatal error.

## Why?
fixes https://github.com/WordPress/gutenberg/issues/65832

## How?
- store `get_the_term_list` as a separate variable and check if it's `WP_Error` then simply return false otherwise return actual output.

## Testing Instructions
- Add the `Terms List` block to the post.
- make `get_the_term_list` to return `WP_Error`.
- on the front end, you will not see any fatal error. 


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/87c6cbed-beff-4a3c-8b09-8d8f9476b5da

