### PR TITLE
Group: fix padding select

### DIFF
--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -24,7 +24,7 @@
 // hack a progressive enhancement.
 /* stylelint-disable -- Stylelint is disabled to allow the hack to work. */
 _::-webkit-full-page-media, _:future, :root .block-editor-block-list__layout::selection,
-_::-webkit-full-page-media, _:future, :root .has-multi-selection .block-editor-block-list__layout::selection {
+_::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .block-editor-block-list__layout::selection {
 	background-color: transparent;
 }
 /* stylelint-enable */

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -47,20 +47,21 @@ export function useWritingFlow() {
 			useRefEffect(
 				( node ) => {
 					node.tabIndex = 0;
-					node.contentEditable = false;
+					node.dataset.hasMultiSelection = hasMultiSelection;
 
 					if ( ! hasMultiSelection ) {
-						return;
+						return () => {
+							delete node.dataset.hasMultiSelection;
+						};
 					}
 
-					node.classList.add( 'has-multi-selection' );
 					node.setAttribute(
 						'aria-label',
 						__( 'Multiple selected blocks' )
 					);
 
 					return () => {
-						node.classList.remove( 'has-multi-selection' );
+						delete node.dataset.hasMultiSelection;
 						node.removeAttribute( 'aria-label' );
 					};
 				},

--- a/packages/block-editor/src/components/writing-flow/index.js
+++ b/packages/block-editor/src/components/writing-flow/index.js
@@ -47,6 +47,7 @@ export function useWritingFlow() {
 			useRefEffect(
 				( node ) => {
 					node.tabIndex = 0;
+					node.contentEditable = false;
 
 					if ( ! hasMultiSelection ) {
 						return;

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -11,7 +11,7 @@
 
 	user-select: none;
 
-	> * {
+	> *:not(.wp-block-group) {
 		user-select: all;
 	}
 }

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -8,6 +8,12 @@
 		left: 0;
 		right: 0;
 	}
+
+	user-select: none;
+
+	> * {
+		user-select: all;
+	}
 }
 
 // Place block list appender in the same place content will appear.

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -12,7 +12,7 @@
 	user-select: none;
 
 	> *:not(.wp-block-group) {
-		user-select: all;
+		user-select: initial;
 	}
 }
 

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -8,12 +8,14 @@
 		left: 0;
 		right: 0;
 	}
+}
 
+:where(.wp-block-group:not(.has-child-selected) > *) {
+	user-select: initial;
+}
+
+:where(.wp-block-group:not(.has-child-selected)) {
 	user-select: none;
-
-	> *:not(.wp-block-group) {
-		user-select: initial;
-	}
 }
 
 // Place block list appender in the same place content will appear.

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -12,13 +12,13 @@
 
 // Reset user select, but the next rule should take precedence for nested
 // groups.
-:where(.wp-block-group:not(.has-child-selected) > *) {
+:where([contenteditable]:not([contenteditable="true"]) .wp-block-group > *) {
 	user-select: initial;
 }
 
-// When no child is selected, prevent children from capturing the selection,
-// which happens when the group is flex and children inlined.
-:where(.wp-block-group:not(.has-child-selected)) {
+// When we are not multi-selecting, prevent children from capturing the
+// selection, which happens when the group is flex and children inlined.
+:where([contenteditable]:not([contenteditable="true"]) .wp-block-group) {
 	user-select: none;
 }
 

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -10,10 +10,14 @@
 	}
 }
 
+// Reset user select, but the next rule should take precedence for nested
+// groups.
 :where(.wp-block-group:not(.has-child-selected) > *) {
 	user-select: initial;
 }
 
+// When no child is selected, prevent children from capturing the selection,
+// which happens when the group is flex and children inlined.
 :where(.wp-block-group:not(.has-child-selected)) {
 	user-select: none;
 }

--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -12,13 +12,13 @@
 
 // Reset user select, but the next rule should take precedence for nested
 // groups.
-:where([contenteditable]:not([contenteditable="true"]) .wp-block-group > *) {
+:where([data-has-multi-selection]:not([contenteditable="true"]) .wp-block-group > *) {
 	user-select: initial;
 }
 
 // When we are not multi-selecting, prevent children from capturing the
 // selection, which happens when the group is flex and children inlined.
-:where([contenteditable]:not([contenteditable="true"]) .wp-block-group) {
+:where([data-has-multi-selection]:not([contenteditable="true"]) .wp-block-group) {
 	user-select: none;
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes clicking on group padding for flex layout.

The cause: https://codepen.io/iseulde/pen/OJKNWOz

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Clicking on the padding of a group with flex layout causes selection to be captured by a nested rich text block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use `user-select: none` to prevent selection on group blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Example from below:

```html
<!-- wp:group {"metadata":{"name":"Team members","categories":["about"],"patternName":"twentytwentyfour/team-4-col"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->
<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size">Meet our team</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"align":"center"} -->
<p class="has-text-align-center">Our comprehensive suite of professionals caters to a diverse team, ranging from seasoned architects to renowned engineers.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
