### PR TITLE
Fix components coding standards in Zoom Out Toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -203,7 +203,7 @@
 	}
 
 	// Make the spacing consistent between controls.
-	.components-button {
+	.zoom-out-toolbar-button {
 		height: $button-size-next-default-40px;
 	}
 }


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/63994#issuecomment-2391109041

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoids targetting `components-*` classes.

Addresses review in https://github.com/WordPress/gutenberg/pull/63994#issuecomment-2391109041

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/63994#issuecomment-2391109041

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

I read this line from the review:

> In this specific case, you should be able to achieve the same effect by setting the __next40pxDefaultSize prop on the affected Button components — no need to apply any external CSS at all. Soon we will switch all instances of Button to have a height of 40px by default.

But this PR still uses CSS to apply the "next" button size. 

Why?

Because AFAIK, we can't do this via props as the components utilising the buttons are shared with other toolbars and I want to avoid prop drilling.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- On `trunk` activate Zoom Out and select a section.
- Notice positioning and spacing of buttons in Zoom Out toolbar
- Switch to this branch
- Do the same
- They should look identical

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before

<img width="131" alt="before" src="https://github.com/user-attachments/assets/2a0f5a82-3b4b-4de5-80b8-158b95497927">

#### After

<img width="152" alt="after" src="https://github.com/user-attachments/assets/dbcb3357-8cf7-4ea2-97d8-8ba656041621">

