### PR TITLE
Issue templates: add new issue type option

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a bug with the WordPress block editor or Gutenberg plugin
 labels: ['[Type] Bug']
+type: 'Bug'
 body:
     - type: markdown
       attributes:

--- a/.github/ISSUE_TEMPLATE/Bug_report_mobile.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report_mobile.md
@@ -2,6 +2,7 @@
 name: Bug report (Mobile)
 about: Report a bug with the mobile app version of Gutenberg
 labels: Mobile App - i.e. Android or iOS
+type: 'Bug'
 
 ---
 
@@ -40,7 +41,7 @@ Please list the steps needed to reproduce the bug. For example:
 ## Screenshots or screen recording (optional)
 <!--
 If possible, please upload a screenshot or screen recording which demonstrates
-the bug. 
+the bug.
 -->
 
 ## WordPress information

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -2,6 +2,7 @@
 name: Feature request
 about: Propose an idea for a feature or an enhancement
 labels: "[Type] Enhancement"
+type: 'Enhancement'
 
 ---
 


### PR DESCRIPTION
## What?

This new option was added as part of this set of changes to GitHub issues:
https://github.blog/changelog/2024-10-01-evolving-github-issues-public-preview/

## Why?

It will prove useful to sort issues using the new "Type" option displayed in the GitHub issue sidebar.

## How?

This new template field is supported as of this issue:
https://github.com/orgs/community/discussions/139933

## Testing Instructions

Not much to test here, since this PR will need to be merged before we can test by creating a new issue. 

### Testing Instructions for Keyboard

See above.

## Screenshots or screencast

<img width="351" alt="image" src="https://github.com/user-attachments/assets/d940a404-4c4c-49d7-bf2f-d97760266b08">

