### PR TITLE
Fix vertical tab focus style

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -231,13 +231,6 @@ $block-inserter-tabs-height: 44px;
 		margin-top: auto;
 	}
 
-	// Temporarily disable the component's indicator animation.
-	// TODO: remove in favor of using the native component's styles and behavior,
-	// see https://github.com/WordPress/gutenberg/pull/62879#issuecomment-2219720582
-	&[aria-orientation="vertical"]::after {
-		content: none;
-	}
-
 	.block-editor-inserter__category-tab {
 		// Account for the icon on the right so that it's visually balanced.
 		padding: $grid-unit-10 $grid-unit-05 $grid-unit-10 $grid-unit-15;

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -156,10 +156,6 @@ export const Tab = styled( Ariakit.Tab )`
 		&::after {
 			content: '';
 			position: absolute;
-			top: ${ space( 3 ) };
-			right: ${ space( 3 ) };
-			bottom: ${ space( 3 ) };
-			left: ${ space( 3 ) };
 			pointer-events: none;
 
 			// Draw the indicator.
@@ -185,10 +181,24 @@ export const Tab = styled( Ariakit.Tab )`
 		min-height: ${ space(
 			10
 		) }; // Avoid fixed height to allow for long strings that go in multiple lines.
+
+		&::after {
+			top: ${ space( 0.5 ) };
+			right: ${ space( 0.5 ) };
+			bottom: ${ space( 0.5 ) };
+			left: ${ space( 0.5 ) };
+		}
 	}
 
 	[aria-orientation='horizontal'] & {
 		justify-content: center;
+
+		&::after {
+			top: ${ space( 3 ) };
+			right: ${ space( 3 ) };
+			bottom: ${ space( 3 ) };
+			left: ${ space( 3 ) };
+		}
 	}
 `;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/65863

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Focus ring is inset instead of wrapping the tab.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Differentiate between focus style on vertical and horizontal tabs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Go to the Preferences Pane
- Go to the tabs
- Use the arrow keys to move between the tabs
- Blue focus ring is inset from the gray indicator


## Screenshots or screencast <!-- if applicable -->
**Before**
![Focus ring on preferences tabs is not aligned with background indicator](https://github.com/user-attachments/assets/3ef0ec1a-3d90-4ad4-a933-d4a5d4370aa2)

**After**
<img width="1004" alt="Focus ring on preferences tabs is aligned with background indicator" src="https://github.com/user-attachments/assets/d2b82f52-ebd2-4d4c-b909-abb15673f0eb">



