### PR TITLE
Post Terms: Remove unnecessary 'get_the_terms' call

### DIFF
--- a/packages/block-library/src/post-terms/index.php
+++ b/packages/block-library/src/post-terms/index.php
@@ -24,11 +24,6 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		return '';
 	}
 
-	$post_terms = get_the_terms( $block->context['postId'], $attributes['term'] );
-	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
-		return '';
-	}
-
 	$classes = array( 'taxonomy-' . $attributes['term'] );
 	if ( isset( $attributes['textAlign'] ) ) {
 		$classes[] = 'has-text-align-' . $attributes['textAlign'];
@@ -59,7 +54,7 @@ function render_block_core_post_terms( $attributes, $content, $block ) {
 		wp_kses_post( $suffix )
 	);
 
-	if ( is_wp_error( $post_terms ) ) {
+	if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## What?
PR updates the Post Terms render callback and removes unnecessary `get_the_terms` call.

## Why?
The post terms are retrieved, but values are never used for rendering. The [`get_the_term_list`](https://developer.wordpress.org/reference/functions/get_the_term_list/) handles the markup and internally calls the `get_the_terms` function.

## Testing Instructions
1. Open a post or page.
2. Insert a Post Term block - Tags or Categories.
3. Preview the post. Confirm it renders nothing.
4. Assign a term to a post and preview it again.
5. Confirm the correct term list is rendered.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-04 at 05 44 27](https://github.com/user-attachments/assets/dde2dc0b-646d-4f45-b90f-9efb13a6e2bf)
