### PR TITLE
Try: Add welcome guide for zoom out mode

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -71,5 +71,8 @@ export async function visitSiteEditor(
 			welcomeGuidePage: false,
 			welcomeGuideTemplate: false,
 		} );
+		await this.editor.setPreferences( 'core', {
+			welcomeGuideZoomOut: false,
+		} );
 	}
 }

--- a/packages/e2e-test-utils-playwright/src/editor/set-preferences.ts
+++ b/packages/e2e-test-utils-playwright/src/editor/set-preferences.ts
@@ -4,6 +4,7 @@
 import type { Editor } from './index';
 
 type PreferencesContext =
+	| 'core'
 	| 'core/edit-post'
 	| 'core/edit-site'
 	| 'core/customize-widgets';

--- a/packages/e2e-test-utils/src/site-editor.js
+++ b/packages/e2e-test-utils/src/site-editor.js
@@ -33,6 +33,10 @@ export async function disableSiteEditorWelcomeGuide() {
 		window.wp.data
 			.dispatch( 'core/preferences' )
 			.set( 'core/edit-site', 'welcomeGuideTemplate', false );
+
+		window.wp.data
+			.dispatch( 'core/preferences' )
+			.set( 'core', 'welcomeGuideZoomOut', false );
 	} );
 }
 

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -72,6 +72,7 @@ export function initializeEditor(
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
+		welcomeGuideZoomOut: true,
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -80,6 +80,7 @@ export function initializeEditor( id, settings ) {
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		welcomeGuideZoomOut: true,
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -73,6 +73,7 @@ export function initializePostsDashboard( id, settings ) {
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		welcomeGuideZoomOut: true,
 	} );
 
 	dispatch( editSiteStore ).updateSettings( settings );

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -13,6 +13,7 @@ import { TEMPLATE_POST_TYPE } from '../../store/constants';
 import EditorInterface from '../editor-interface';
 import { ExperimentalEditorProvider } from '../provider';
 import Sidebar from '../sidebar';
+import WelcomeGuide from '../welcome-guide';
 
 function Editor( {
 	postType,
@@ -71,6 +72,7 @@ function Editor( {
 					initialEdits={ initialEdits }
 					useSubRegistry={ false }
 				>
+					<WelcomeGuide />
 					<EditorInterface { ...props }>
 						{ extraContent }
 					</EditorInterface>

--- a/packages/editor/src/components/welcome-guide/index.js
+++ b/packages/editor/src/components/welcome-guide/index.js
@@ -1,0 +1,28 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+/**
+ * Internal dependencies
+ */
+import WelcomeGuideZoomOut from './zoom-out';
+import { unlock } from '../../lock-unlock';
+
+export default function WelcomeGuide() {
+	const { isActive, isZoomOut } = useSelect( ( select ) => {
+		const { get } = select( preferencesStore );
+		return {
+			isActive: get( 'core', 'welcomeGuideZoomOut' ),
+			isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
+		};
+	}, [] );
+
+	if ( ! isActive || ! isZoomOut ) {
+		return null;
+	}
+
+	return <WelcomeGuideZoomOut />;
+}

--- a/packages/editor/src/components/welcome-guide/style.scss
+++ b/packages/editor/src/components/welcome-guide/style.scss
@@ -1,0 +1,27 @@
+.editor-welcome-guide {
+	width: 312px;
+}
+
+.editor-welcome-guide__image {
+	margin: 0 0 $grid-unit-20;
+	> img {
+		display: block;
+		max-width: 100%;
+		object-fit: cover;
+	}
+}
+
+.editor-welcome-guide__heading {
+	font-family: $default-font;
+	font-size: 24px;
+	line-height: 1.4;
+	margin: $grid-unit-20 0 $grid-unit-20 0;
+	padding: 0 $grid-unit-40;
+}
+
+.editor-welcome-guide__text {
+	font-size: $default-font-size;
+	line-height: 1.4;
+	margin: 0 0 $grid-unit-20 0;
+	padding: 0 $grid-unit-40;
+}

--- a/packages/editor/src/components/welcome-guide/zoom-out.js
+++ b/packages/editor/src/components/welcome-guide/zoom-out.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { Guide } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { store as preferencesStore } from '@wordpress/preferences';
+
+export default function WelcomeGuideZoomOut() {
+	const isActive = useSelect( ( select ) => {
+		const { get } = select( preferencesStore );
+		return get( 'core', 'welcomeGuideZoomOut' );
+	}, [] );
+	const { set } = useDispatch( preferencesStore );
+	return (
+		<Guide
+			className="editor-welcome-guide"
+			contentLabel={ __( 'Welcome to the Zoom Out view' ) }
+			finishButtonText={ __( 'Continue' ) }
+			onFinish={ () => set( 'core', 'welcomeGuideZoomOut', ! isActive ) }
+			pages={ [
+				{
+					image: (
+						<picture className="editor-welcome-guide__image">
+							<source
+								srcSet="https://s.w.org/images/block-editor/welcome-template-editor.svg"
+								media="(prefers-reduced-motion: reduce)"
+							/>
+							<img
+								src="https://s.w.org/images/block-editor/welcome-template-editor.gif"
+								width="312"
+								height="240"
+								alt={ __( 'Zoom Out view' ) }
+							/>
+						</picture>
+					),
+					content: (
+						<>
+							<h1 className="editor-welcome-guide__heading">
+								{ __( 'Welcome to the Zoom Out view' ) }
+							</h1>
+							<p className="editor-welcome-guide__text">
+								{ __(
+									'The Zoom Out view simplifies your editing experience by allowing you to create and edit at the pattern level rather than focusing on individual blocks.'
+								) }
+							</p>
+						</>
+					),
+				},
+			] }
+		/>
+	);
+}

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -56,3 +56,4 @@
 @import "./components/table-of-contents/style.scss";
 @import "./components/text-editor/style.scss";
 @import "./components/visual-editor/style.scss";
+@import "./components/welcome-guide/style.scss";


### PR DESCRIPTION
Partially resolves #65856

## What?

This PR adds a welcome guide to let users know what the zoom out mode introduced in WP 6.7 means.

![image](https://github.com/user-attachments/assets/660adb70-d485-45ef-987b-d4cf6d3f4abd)

> [!NOTE]
> The image has not been created yet, so it's reused from other welcome guides. If it makes sense to move forward with this PR, I would appreciate your help in creating the images.

## Why?

Zoom out mode is a new feature coming to WP 6.7. However, with just a button labeled "Zoom out," it's hard for users to understand what this mode does.

We've often shown welcome guides for new/important features. Below are screenshots of all the welcome guides:

<details><summary>Block Editor</summary>

![block-editor](https://github.com/user-attachments/assets/7ecbe238-d298-4aa9-8bff-024bfae4466b)

</details> 

<details><summary>Template Editor</summary>

![template-editor](https://github.com/user-attachments/assets/72fedeec-37ab-4002-aad8-9cbcee9372f4)

</details> 

<details><summary>Site Editor</summary>

![site-editor](https://github.com/user-attachments/assets/cc0cca6c-eb54-4dfe-b52b-f6e6c07ddf75)

</details> 

<details><summary>Global Styles</summary>

![global-styles](https://github.com/user-attachments/assets/d52680f0-c8e1-44f6-8a48-289e00fe8e01)

</details> 

<details><summary>Widget Editor</summary>

![widget-editor](https://github.com/user-attachments/assets/2d287529-b349-4a29-9095-4d4bce4fa627)

</details> 

<details><summary>Pages Screen</summary>

![edit-page](https://github.com/user-attachments/assets/bb760c7b-61bc-4e28-9442-ba088817f4e8)

</details> 

## How?

Show a welcome guide when the user enters zoom out mode for the first time.

Please note that this setting is saved in `core`, not `core/edit-post` or `edit-site`.

## Testing Instructions

- Create a new user and log in as that user. Or run the following code to initialize all welcome guides:
  ```javascript
  // Enable Zoom out welcome guide
  wp.data.dispatch('core/preferences').set('core', 'welcomeGuideZoomOut', true);
  // Enable Block editor welcome guide
  wp.data.dispatch('core/preferences').set('core/edit-post', 'welcomeGuide', true);
  wp.data.dispatch('core/preferences').set('core/edit-site', 'welcomeGuide', true);
  // Enable Styles welcome guide
  wp.data.dispatch('core/preferences').set('core/edit-site', 'welcomeGuideStyles', true);
  // Enable Pages welcome guide
  wp.data.dispatch('core/preferences').set('core/edit-post', 'welcomeGuidePage', true);
  // Enable Template welcome guide
  wp.data.dispatch('core/preferences').set('core/edit-post', 'welcomeGuideTemplate', true);
  ```
- Go to the post editor.
- Click the zoom out button.
- The welcome guide should appear.
- Go to the site editor and click the zoom out button.
- The welcome guide should NOT appear.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f9f317f4-5e3c-43bc-8d80-3e608a69e0d4