### PR TITLE
Global Styles: fix overflow caused by RangeControl tooltip

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `PaletteEdit`: dedupe palette element slugs ([#65772](https://github.com/WordPress/gutenberg/pull/65772)).
+-   `RangeControl`: do not tooltip contents to the DOM when not shown ([#65875](https://github.com/WordPress/gutenberg/pull/65875)).
 -   `Tabs`: fix skipping indication animation glitch ([#65878](https://github.com/WordPress/gutenberg/pull/65878)).
 
 ## 28.9.0 (2024-10-03)

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -57,7 +57,10 @@ const wrapperMargin = ( { marks, __nextHasNoMarginBottom }: WrapperProps ) => {
 	return '';
 };
 
-export const Wrapper = styled.div< WrapperProps >`
+export const Wrapper = styled( 'div', {
+	shouldForwardProp: ( prop: string ) =>
+		! [ 'color', '__nextHasNoMarginBottom', 'marks' ].includes( prop ),
+} )< WrapperProps >`
 	display: block;
 	flex: 1;
 	position: relative;

--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -261,9 +261,20 @@ export const InputRange = styled.input`
 `;
 
 const tooltipShow = ( { show }: TooltipProps ) => {
-	return css( {
-		opacity: show ? 1 : 0,
-	} );
+	return css`
+		display: ${ show ? 'inline-block' : 'none' };
+		opacity: ${ show ? 1 : 0 };
+
+		@media not ( prefers-reduced-motion ) {
+			transition:
+				opacity 120ms ease,
+				display 120ms ease allow-discrete;
+		}
+
+		@starting-style {
+			opacity: 0;
+		}
+	`;
 };
 
 const tooltipPosition = ( { position }: TooltipProps ) => {
@@ -284,10 +295,8 @@ export const Tooltip = styled.span< TooltipProps >`
 	background: rgba( 0, 0, 0, 0.8 );
 	border-radius: ${ CONFIG.radiusSmall };
 	color: white;
-	display: inline-block;
 	font-size: 12px;
 	min-width: 32px;
-	opacity: 0;
 	padding: 4px 8px;
 	pointer-events: none;
 	position: absolute;
@@ -295,11 +304,8 @@ export const Tooltip = styled.span< TooltipProps >`
 	user-select: none;
 	line-height: 1.4;
 
-	@media not ( prefers-reduced-motion ) {
-		transition: opacity 120ms ease;
-	}
-
 	${ tooltipShow };
+
 	${ tooltipPosition };
 	${ rtl(
 		{ transform: 'translateX(-50%)' },

--- a/packages/components/src/range-control/tooltip.tsx
+++ b/packages/components/src/range-control/tooltip.tsx
@@ -40,7 +40,7 @@ export default function SimpleTooltip(
 	return (
 		<Tooltip
 			{ ...restProps }
-			aria-hidden={ show }
+			aria-hidden="false"
 			className={ classes }
 			position={ position }
 			show={ show }

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -197,7 +197,11 @@ function FontSize() {
 				</HStack>
 
 				<View>
-					<Spacer paddingX={ 4 }>
+					<Spacer
+						paddingX={ 4 }
+						marginBottom={ 0 }
+						paddingBottom={ 6 }
+					>
 						<VStack spacing={ 4 }>
 							<FlexItem>
 								<FontSizePreview fontSize={ fontSize } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65825

This PR fixes an involuntary overflow in the font size screen, in the Global Styles sidebar

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixing a visual glitch

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

As @ciampo and @t-hamano debugged in #65825, the cause for the overflow is the `RangeControl`'s tooltip.

The tooltip is a custom implementation (context for this decision can be found in https://github.com/WordPress/gutenberg/pull/19916 and https://github.com/WordPress/gutenberg/pull/23006).

This PR applies two separate fixes:

- it sets the tooltip to `display: none` when hidden. This seems safe because the tooltip already has a `aria-hidden` attribute set, and because it only replicates the same information that assistive technology can parse from the native `input` element. We can still animate the tooltip thanks to the recent [`@starting-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/@starting-style) and [`allow-discrete`](https://developer.mozilla.org/en-US/docs/Web/CSS/transition-behavior) CSS apis, which should work in most browsers (and can be considered as progressive enhancement);
- It uses padding instead of margin for the bottom part of the screen, which removes the overflow when the tooltip is shown

> [!NOTE]
> `RangeControl` can clearly benefit from some love. We should see if we can use the `Tooltip` component, instead of a custom implementation. And potentially remove a lot of code, given the advancements in CSS styling of native inputs. Obviously not in scope for this PR. And potentially, we could just look at overhauling the whole set of slider-related components (see https://github.com/WordPress/gutenberg/issues/40507)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow instructions in #65825 — the overflow bug should be gone.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/d2cd33c0-c839-4b6b-a732-753c89d4d0fe

