### PR TITLE
Query Loop: Fix query type indicator

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -211,7 +211,7 @@ export default function QueryInspectorControls( props ) {
 							label={ __( 'Query type' ) }
 							isBlock
 							onChange={ ( value ) => {
-								setQuery( { inherit: !! value } );
+								setQuery( { inherit: value === 'default' } );
 							} }
 							help={
 								inherit
@@ -222,14 +222,14 @@ export default function QueryInspectorControls( props ) {
 											'Display a list of posts or custom post types based on specific criteria.'
 									  )
 							}
-							value={ !! inherit }
+							value={ !! inherit ? 'default' : 'custom' }
 						>
 							<ToggleGroupControlOption
-								value
+								value="default"
 								label={ __( 'Default' ) }
 							/>
 							<ToggleGroupControlOption
-								value={ false }
+								value="custom"
 								label={ __( 'Custom' ) }
 							/>
 						</ToggleGroupControl>


### PR DESCRIPTION
Related to #65175

## What?

This PR ensures that the query type indicator is displayed correctly in the Query Loop block.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c47b0c71-a655-454b-a002-159580c8e2c6) | ![image](https://github.com/user-attachments/assets/838534a3-5ccb-46cb-bec7-67cb3a734f41)| 

## Why?

I noticed that when the "Custom" option is selected, all of the CSS variables for positioning and sizing are zero:

![image](https://github.com/user-attachments/assets/d386dcf6-f098-45a6-8af3-13715389fd4c)

I suspect this is because the values ​​are boolean, which is [not a allowed type for the `value` prop](https://github.com/WordPress/gutenberg/blob/18fdd2537564195d1492e16836d0a621283ad9b1/packages/components/src/toggle-group-control/types.ts#L20).

## How?

I set the `inherit` block attribute, which is a boolean value, to be processed as string values `"default"`​, `"custom"` in the `ToggleGroupControl` component. bThis seems to work correctly.

## Testing Instructions

- Open the site editor and select the "All Archives" template.
- Click the Query Loop block.
- Change the "Query type" option.