### PR TITLE
Fix: Shadow styles are not removed from ServerSideRender when skipBlockSupportAttributes is true

### DIFF
--- a/packages/server-side-render/src/server-side-render.js
+++ b/packages/server-side-render/src/server-side-render.js
@@ -28,6 +28,7 @@ export function removeBlockSupportAttributes( attributes ) {
 	const {
 		backgroundColor,
 		borderColor,
+		boxShadow,
 		fontFamily,
 		fontSize,
 		gradient,
@@ -36,7 +37,7 @@ export function removeBlockSupportAttributes( attributes ) {
 		...restAttributes
 	} = attributes;
 
-	const { border, color, elements, spacing, typography, ...restStyles } =
+	const { border, color, elements, shadow, spacing, typography, ...restStyles } =
 		attributes?.style || EMPTY_OBJECT;
 
 	return {

--- a/packages/server-side-render/src/test/index.js
+++ b/packages/server-side-render/src/test/index.js
@@ -84,6 +84,7 @@ describe( 'rendererPath', () => {
 			removeBlockSupportAttributes( {
 				backgroundColor: 'foreground',
 				borderColor: 'foreground',
+				boxShadow: 'sharp',
 				fontFamily: 'system-font',
 				fontSize: 'small',
 				gradient: 'vivid-cyan-blue-to-vivid-purple',
@@ -107,6 +108,7 @@ describe( 'rendererPath', () => {
 							},
 						},
 					},
+					shadow: 'var:preset|shadow|sharp',
 					spacing: {
 						margin: {
 							top: '10px',


### PR DESCRIPTION
Include "shadow" in removed block support attributes within server-side-render (#65882)

Resolves issue where `skipBlockSupportAttributes` was not working for blocks with "shadow" support.
