### PR TITLE
Post editor: Fix "typewriter" spacing style application

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -84,7 +84,7 @@ const DESIGN_POST_TYPES = [
 	'wp_navigation',
 ];
 
-function useEditorStyles( withPaddingAppender ) {
+function useEditorStyles( ...additionalStyles ) {
 	const { hasThemeStyleSupport, editorSettings } = useSelect( ( select ) => {
 		return {
 			hasThemeStyleSupport:
@@ -92,6 +92,8 @@ function useEditorStyles( withPaddingAppender ) {
 			editorSettings: select( editorStore ).getEditorSettings(),
 		};
 	}, [] );
+
+	const addedStyles = additionalStyles.join( '\n' );
 
 	// Compute the default styles.
 	return useMemo( () => {
@@ -129,15 +131,8 @@ function useEditorStyles( withPaddingAppender ) {
 			? editorSettings.styles ?? []
 			: defaultEditorStyles;
 
-		// Add a space for the typewriter effect. When typing in the last block,
-		// there needs to be room to scroll up.
-		if ( withPaddingAppender ) {
-			return [
-				...baseStyles,
-				{
-					css: ':root :where(.editor-styles-wrapper)::after {content: ""; display: block; height: 40vh;}',
-				},
-			];
+		if ( addedStyles ) {
+			return [ ...baseStyles, { css: addedStyles } ];
 		}
 
 		return baseStyles;
@@ -146,7 +141,7 @@ function useEditorStyles( withPaddingAppender ) {
 		editorSettings.disableLayoutStyles,
 		editorSettings.styles,
 		hasThemeStyleSupport,
-		withPaddingAppender,
+		addedStyles,
 	] );
 }
 
@@ -449,7 +444,9 @@ function Layout( {
 		},
 		[ currentPostType, isEditingTemplate, settings.supportsTemplateMode ]
 	);
-	const paddingAppenderRef = usePaddingAppender( enablePaddingAppender );
+	const [ paddingAppenderRef, paddingStyle ] = usePaddingAppender(
+		enablePaddingAppender
+	);
 
 	// Set the right context for the command palette
 	const commandContext = hasBlockSelected
@@ -465,7 +462,7 @@ function Layout( {
 		} ),
 		[ settings, onNavigateToEntityRecord, onNavigateToPreviousEntityRecord ]
 	);
-	const styles = useEditorStyles( enablePaddingAppender );
+	const styles = useEditorStyles( paddingStyle );
 
 	// We need to add the show-icon-labels class to the body element so it is applied to modals.
 	if ( showIconLabels ) {

--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -6,24 +6,12 @@ import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 
-export function usePaddingAppender() {
+export function usePaddingAppender( enabled ) {
 	const registry = useRegistry();
 	return useRefEffect(
 		( node ) => {
 			function onMouseDown( event ) {
 				if ( event.target !== node ) {
-					return;
-				}
-
-				const { ownerDocument } = node;
-				const { defaultView } = ownerDocument;
-
-				const pseudoHeight = defaultView.parseInt(
-					defaultView.getComputedStyle( node, ':after' ).height,
-					10
-				);
-
-				if ( ! pseudoHeight ) {
 					return;
 				}
 
@@ -57,11 +45,13 @@ export function usePaddingAppender() {
 					insertDefaultBlock();
 				}
 			}
-			node.addEventListener( 'mousedown', onMouseDown );
-			return () => {
-				node.removeEventListener( 'mousedown', onMouseDown );
-			};
+			if ( enabled ) {
+				node.addEventListener( 'mousedown', onMouseDown );
+				return () => {
+					node.removeEventListener( 'mousedown', onMouseDown );
+				};
+			}
 		},
-		[ registry ]
+		[ enabled, registry ]
 	);
 }

--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -6,9 +6,14 @@ import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { isUnmodifiedDefaultBlock } from '@wordpress/blocks';
 
+// Ruleset to add space for the typewriter effect. When typing in the last
+// block, there needs to be room to scroll up.
+const CSS =
+	':root :where(.editor-styles-wrapper)::after {content: ""; display: block; height: 40vh;}';
+
 export function usePaddingAppender( enabled ) {
 	const registry = useRegistry();
-	return useRefEffect(
+	const effect = useRefEffect(
 		( node ) => {
 			function onMouseDown( event ) {
 				if ( event.target !== node ) {
@@ -45,13 +50,12 @@ export function usePaddingAppender( enabled ) {
 					insertDefaultBlock();
 				}
 			}
-			if ( enabled ) {
-				node.addEventListener( 'mousedown', onMouseDown );
-				return () => {
-					node.removeEventListener( 'mousedown', onMouseDown );
-				};
-			}
+			node.addEventListener( 'mousedown', onMouseDown );
+			return () => {
+				node.removeEventListener( 'mousedown', onMouseDown );
+			};
 		},
-		[ enabled, registry ]
+		[ registry ]
 	);
+	return enabled ? [ effect, CSS ] : [];
 }


### PR DESCRIPTION
## What?
Fixes a bug where the "typewriter" space below the post content is showing up when not intended:
- When the "Show template" option is checked
- When Zoom Out is engaged

Also this makes `usePaddingAppender` contain its concerns and support disabling it. Follows up on #64992.

## Why?
To fix a bug and improve code quality.

Currently, the hook is always active in the Post editor but doesn’t have an effect in some contexts (e.g. template editing, or focused editing of template parts or patterns). It returns early in those contexts by actively testing whether its associated styling is applied in the document. Such testing is potentially brittle and unnecessary because the same conditions that omit the styling can be used to inactivate the hook.

Besides that its associated styling and the conditions for applying it are in a separate hook that ideally doesn’t own those concerns.

## How?
- Adds a parameter to control whether `usePaddingAppender` is enabled
- Extracts the conditions for applying the styles from the `useEditorStyles` hook and uses them to control whether the `usePaddingAppender` is enabled
- Makes `usePaddingAppender` own and return its styles
- Makes `useEditorStyles` accept additional styles so it can generically handle the style from `usePaddingAppender`

## Testing Instructions
1. Open the Post editor
2. Make sure that clicking below the post content adds a default block or focuses the last one if it‘s already inserted.

### Screen recording
This shows how on trunk the space gets added below the template when the template is set to show.

https://github.com/user-attachments/assets/071bc2ee-cba9-4c94-8b16-33059eb67a38

