### PR TITLE
Code block: set LTR direction for RTL languages

### DIFF
--- a/packages/block-library/src/code/editor.scss
+++ b/packages/block-library/src/code/editor.scss
@@ -1,7 +1,3 @@
 .wp-block-code code {
 	background: none;
-	/*!rtl:begin:ignore*/
-	direction: ltr;
-	text-align: left;
-	/*!rtl:end:ignore*/
 }

--- a/packages/block-library/src/code/editor.scss
+++ b/packages/block-library/src/code/editor.scss
@@ -1,3 +1,7 @@
 .wp-block-code code {
 	background: none;
+	/*!rtl:begin:ignore*/
+	direction: ltr;
+	text-align: left;
+	/*!rtl:end:ignore*/
 }

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -9,5 +9,9 @@
 		font-family: inherit;
 		overflow-wrap: break-word;
 		white-space: pre-wrap;
+		/*!rtl:begin:ignore*/
+		direction: ltr;
+		text-align: left;
+		/*!rtl:end:ignore*/
 	}
 }

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -9,9 +9,10 @@
 		font-family: inherit;
 		overflow-wrap: break-word;
 		white-space: pre-wrap;
+		// Set direction and avoid inheriting alignment from a parent element.
 		/*!rtl:begin:ignore*/
 		direction: ltr;
-		text-align: left;
+		text-align: initial;
 		/*!rtl:end:ignore*/
 	}
 }


### PR DESCRIPTION
Fixes #65890

## Testing Instructions
1. Set your site language to a right-to-left language (and set your profile language to match the site).
2. Go to the post editor.
3. Add a Code block and insert some code.
4. Save changes.
5. View the direction and alignment both in the editor and on the front.