### PR TITLE
HierarchicalTermSelector: remove unnecessary tab focus

### DIFF
--- a/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/hierarchical-term-selector.js
@@ -417,7 +417,6 @@ export function HierarchicalTermSelector( { slug } ) {
 			) }
 			<div
 				className="editor-post-taxonomies__hierarchical-terms-list"
-				tabIndex="0"
 				role="group"
 				aria-label={ groupLabel }
 			>


### PR DESCRIPTION
Fixes [#65894](https://github.com/WordPress/gutenberg/issues/65894)

## What?

This PR removes the unnecessary tab focus that exists in the `HierarchicalTermSelector` component.

## Why?

See #65894 to see where this component is used and why tabIndex is not needed.

## Testing Instructions

### Testing Instructions for Keyboard

- Open the post editor.
- Open the post sidebar.
- Use the tab key to focus the Categories panel.
- Press enter to open the Categories panel.
- Press the tab key to focus the search field, if present.
- Press tab. The first checkbox will get focus and your screen reader should announce it as "Categories  grouping {categoryName} check box  checked."

## Screenshots or screencast <!-- if applicable -->

The video below shows how a screen reader reads the test steps as they are performed.

https://github.com/user-attachments/assets/db59dfc5-03f1-4b33-a137-739c87bf0a2f


