### PR TITLE
Use correct label in PHP Backport documentation

### DIFF
--- a/docs/contributors/code/back-merging-to-wp-core.md
+++ b/docs/contributors/code/back-merging-to-wp-core.md
@@ -31,7 +31,7 @@ There are however certain exceptions to that rule. PRs with the following criter
 
 -   Does not contain changes to PHP code.
 -   Has label `Backport from WordPress Core` - this code is already in WP Core and is being synchronized back to Gutenberg.
--   Has label `Backport to WordPress Core` - this code has already been synchronized to WP Core.
+-   Has label `Backported to WordPress Core` - this code has already been synchronized to WP Core.
 
 ## Further Reading
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Uses correct label in the PHP Backporting documentation


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because details matter...

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Corrects label from `Backport to WP Core` to `Backported to WP Core` (past tense).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Read words.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
<img width="1566" alt="Screen Shot 2024-10-07 at 11 06 10" src="https://github.com/user-attachments/assets/78bd0e73-c876-4af8-adfd-e5b01ce77a71">


