### PR TITLE
Connected/synced blocks: show backdrop across all

### DIFF
--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -27,7 +27,7 @@
 }
 
 .block-editor-block-switcher__toggle-text {
-	margin-left: $grid-unit-10;
+	margin-left: $grid-unit-15;
 
 	// Account for double label when show-text-buttons is set.
 	.show-icon-labels & {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -37,15 +37,20 @@
 		border-right: $border-width solid $gray-300;
 	}
 
+	&.is-synced,
 	&.is-connected {
-		.block-editor-block-switcher .components-button::before {
+		.block-editor-block-switcher .components-button::after {
+			content: "";
+			display: block;
+			position: absolute;
+			left: 2px;
+			height: $grid-unit-40;
+			width: $grid-unit-40;
+			z-index: -1;
 			background: color-mix(in srgb, var(--wp-block-synced-color) 10%, transparent);
 			border-radius: $radius-small;
 		}
-	}
 
-	&.is-synced,
-	&.is-connected {
 		.block-editor-block-switcher .components-button .block-editor-block-icon {
 			color: var(--wp-block-synced-color);
 		}


### PR DESCRIPTION
## What?

Followup to #65233. Show the connected block "backdrop" across synced blocks as well. Before:

![Screenshot 2024-10-07 at 14 09 59](https://github.com/user-attachments/assets/ba6dfe6d-4052-4b51-ba36-62e34fb473ec)

![Screenshot 2024-10-07 at 14 10 12](https://github.com/user-attachments/assets/33f027b8-47de-452f-b27c-ab7db73c5372)

After:

![Screenshot 2024-10-07 at 14 10 03](https://github.com/user-attachments/assets/2c470f90-cfc2-488c-8856-76c9ffcb3115)


## Why?

The main purpose of the backdrop is to provide further differentiation between standard blocks and special blocks. Whether synced or connected to data sources, both types are "special", and differentiating further between the two may not be worth it.

## Testing Instructions

Test connected, default, and synced blocks, be sure to test the focus style which should be unchanged. An easy way to test a connected block is to drop this in your functions.php:

```
// Random image source
register_meta(
	'post',
	'random_image',
	array(
		'show_in_rest'      => true,
		'single'            => true,
		'type'              => 'string',
		'sanitize_callback' => 'esc_url_raw',
		'default'           => get_theme_file_uri( 'https://picsum.photos/seed/picsum/600/400' )
	)
);
```

Then go add the random_image source to your Image block.