### PR TITLE
Stabilize the Experimental block supports property

### DIFF
--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -160,15 +160,17 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 		return null;
 	}
 
+	const defaultBorderControls = 
+		getBlockSupport( name, [ BORDER_SUPPORT_KEY, '__experimentalDefaultControls' ] ) ||
+		getBlockSupport( name, [ BORDER_SUPPORT_KEY, 'defaultControls' ] );
+
+	const defaultShadowControls = 
+		getBlockSupport( name, [ SHADOW_SUPPORT_KEY, '__experimentalDefaultControls' ] ) ||
+		getBlockSupport( name, [ SHADOW_SUPPORT_KEY, 'defaultControls' ] );
+
 	const defaultControls = {
-		...getBlockSupport( name, [
-			BORDER_SUPPORT_KEY,
-			'__experimentalDefaultControls',
-		] ),
-		...getBlockSupport( name, [
-			SHADOW_SUPPORT_KEY,
-			'__experimentalDefaultControls',
-		] ),
+		...defaultBorderControls,
+		...defaultShadowControls,
 	};
 
 	return (

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -288,10 +288,9 @@ export function ColorEdit( { clientId, name, setAttributes, settings } ) {
 		return null;
 	}
 
-	const defaultControls = getBlockSupport( name, [
-		COLOR_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultControls = 
+		getBlockSupport( name, [ COLOR_SUPPORT_KEY, '__experimentalDefaultControls' ] ) ||
+		getBlockSupport( name, [ COLOR_SUPPORT_KEY, 'defaultControls' ] );
 
 	const enableContrastChecking =
 		Platform.OS === 'web' &&

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -86,19 +86,18 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 		return null;
 	}
 
-	const defaultDimensionsControls = getBlockSupport( name, [
-		DIMENSIONS_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
-	const defaultSpacingControls = getBlockSupport( name, [
-		SPACING_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultDimensionsControls = 
+		getBlockSupport( name, [ DIMENSIONS_SUPPORT_KEY, '__experimentalDefaultControls' ] ) ||
+		getBlockSupport( name, [ DIMENSIONS_SUPPORT_KEY, 'defaultControls' ] );
+
+	const defaultSpacingControls = 
+		getBlockSupport( name, [ SPACING_SUPPORT_KEY, '__experimentalDefaultControls' ] ) ||
+		getBlockSupport( name, [ SPACING_SUPPORT_KEY, 'defaultControls' ] );
+
 	const defaultControls = {
 		...defaultDimensionsControls,
 		...defaultSpacingControls,
 	};
-
 	return (
 		<>
 			<StylesDimensionsPanel

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -131,10 +131,9 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 		return null;
 	}
 
-	const defaultControls = getBlockSupport( name, [
-		TYPOGRAPHY_SUPPORT_KEY,
-		'__experimentalDefaultControls',
-	] );
+	const defaultControls = 
+		getBlockSupport( name, [ TYPOGRAPHY_SUPPORT_KEY, '__experimentalDefaultControls' ] ) ||
+		getBlockSupport( name, [ TYPOGRAPHY_SUPPORT_KEY, 'defaultControls' ] );
 
 	return (
 		<StylesTypographyPanel


### PR DESCRIPTION
## What?
Split from https://github.com/WordPress/gutenberg/issues/64314

## Why?
The __experimentalDefaultControls property developers can choose which settings are displayed by default in the Editor for each block support. The `__experimental` prefix removed and now make it easier for third-party developers to confidently use this `defaultControls` property. Also, falling back to the __experimental prefix if available.

`__experimentalDefaultControls → defaultControls`

I have added the supports for those hooks:

- Color
- Typography
- Spacing
- Border 

Now both are workable `__experimentalDefaultControls` & `defaultControls`

## Testing Instructions
1. Open block.json file or area.
2. If you have already used for block support `__experimentalDefaultControls` instead of we can use it `defaultControls` only.
3. Block support default controls now managing by using this `defaultControls` property

Note: Here we need to update the WP core blocks' block.json files to use the non __experimental prefixes.