### PR TITLE
Fix layout shift on zoom out in post/page editor.

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -21,6 +21,13 @@
 	margin-left: calc(-1 * (#{$prev-container-width} - #{$container-width}) / 2);
 }
 
+// Avoid collapsing margins causing a layout shift when invoking zooming.
+.block-editor-iframe__body,
+.editor-visual-editor__post-title-wrapper {
+	border-top: 0.1em solid transparent;
+	border-bottom: 0.1em solid transparent;
+}
+
 .block-editor-iframe__html {
 	border: 0 solid $gray-300;
 	transform-origin: top center;


### PR DESCRIPTION
## What?

When zooming in or out in the post or page editors, or the site editor with "Show template" off, there's a very noticable jump and layout shift:

![zoom jump](https://github.com/user-attachments/assets/a8a50598-0afb-4d9d-b451-df5e442e3cd5)

This layout shift is caused by collapsing margins, both on the `body` element of the editing canvas itself, and on the margins applied to the post title wrapper.

By adding a thin invisible border, we prevent margin collapsing, and thus, prevent the layout shift from happening:

![after](https://github.com/user-attachments/assets/11dff1ec-7981-4dfb-af74-4f22d533aed2)

## Testing Instructions

Test zooming in and out in post, page editors, or site editor with "Show template" turned off.