### PR TITLE
Prevent footnote from affecting line height

### DIFF
--- a/packages/block-library/src/footnotes/style.scss
+++ b/packages/block-library/src/footnotes/style.scss
@@ -19,3 +19,9 @@ a[data-fn].fn::after {
 	text-indent: 0;
 	float: left;
 }
+
+sup[data-fn].fn {
+	vertical-align: baseline;
+	position: relative;
+	top: -0.4em;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Fixes issue https://github.com/WordPress/gutenberg/issues/65800
- Prevents footnote from affecting line-height of the text.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Adding Footnotes to a Paragraph block was changing the line height of that specific line, resulting in uneven line height for the Paragraph.


## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Added styles targeted to footnote element to adjust the line height.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Create a page or post
2. Add a Paragraph block
3. Add a footnote to any line from the Paragraph block toolbar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1736bddf-1075-4d31-b8c6-9d189809694b

