### PR TITLE
Simplify logical expression in `InitPatternModal`

### DIFF
--- a/packages/edit-post/src/components/init-pattern-modal/index.js
+++ b/packages/edit-post/src/components/init-pattern-modal/index.js
@@ -27,8 +27,8 @@ export default function InitPatternModal() {
 			isNewPost: isCleanNewPost(),
 		};
 	}, [] );
-	const [ isModalOpen, setIsModalOpen ] = useState( () =>
-		isNewPost && postType === 'wp_block' ? true : false
+	const [ isModalOpen, setIsModalOpen ] = useState(
+		() => isNewPost && postType === 'wp_block'
 	);
 
 	if ( postType !== 'wp_block' || ! isNewPost ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I was catching up with GH and [noticed](https://github.com/WordPress/gutenberg/pull/65734) this logical expression that can be simplified.  `InitPatternModal` should still render when we're creating a new pattern.


