### PR TITLE
Fix duotone on parallax/repeated featured image cover blocks

### DIFF
--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -45,13 +45,15 @@ function render_block_core_cover( $attributes, $content ) {
 			return $content;
 		}
 
+		$current_thumbnail_id = get_post_thumbnail_id();
+
 		$processor = new WP_HTML_Tag_Processor( '<div></div>' );
 		$processor->next_tag();
 
-		$current_caption = get_the_post_thumbnail_caption();
-		if ( $current_caption ) {
+		$current_alt = trim( strip_tags( get_post_meta( $current_thumbnail_id, '_wp_attachment_image_alt', true ) ) );
+		if ( $current_alt ) {
 			$processor->set_attribute( 'role', 'img' );
-			$processor->set_attribute( 'aria-label', $current_caption );
+			$processor->set_attribute( 'aria-label', $current_alt );
 		}
 
 		$processor->add_class( 'wp-block-cover__image-background' );

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -57,6 +57,7 @@ function render_block_core_cover( $attributes, $content ) {
 		}
 
 		$processor->add_class( 'wp-block-cover__image-background' );
+		$processor->add_class( 'wp-image-' . $current_thumbnail_id );
 		if ( $attributes['hasParallax'] ) {
 			$processor->add_class( 'has-parallax' );
 		}

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -62,7 +62,11 @@ function render_block_core_cover( $attributes, $content ) {
 			$processor->add_class( 'is-repeated' );
 		}
 
-		$styles = 'background-position:' . isset( $object_position ) ? $object_position : '50% 50%' . ';';
+		$background_position = '50% 50%';
+		if ( isset( $object_position ) ) {
+			$background_position = $object_position;
+		}
+		$styles = 'background-position:' . $background_position . ';';
 		if ( $current_featured_image ) {
 			$styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 		}

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -48,18 +48,18 @@ function render_block_core_cover( $attributes, $content ) {
 		$processor = new WP_HTML_Tag_Processor( '<div></div>' );
 		$processor->next_tag();
 
+		$current_caption = get_the_post_thumbnail_caption();
+		if ( $current_caption ) {
+			$processor->set_attribute( 'role', 'img' );
+			$processor->set_attribute( 'aria-label', $current_caption );
+		}
+
 		$processor->add_class( 'wp-block-cover__image-background' );
 		if ( $attributes['hasParallax'] ) {
 			$processor->add_class( 'has-parallax' );
 		}
 		if ( $attributes['isRepeated'] ) {
 			$processor->add_class( 'is-repeated' );
-		}
-
-		$current_caption = get_the_post_thumbnail_caption();
-		if ( $current_caption ) {
-			$processor->set_attribute( 'role', 'img' );
-			$processor->set_attribute( 'aria-label', $current_caption );
 		}
 
 		$styles = 'background-position:' . isset( $object_position ) ? $object_position : '50% 50%' . ';';

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -62,10 +62,8 @@ function render_block_core_cover( $attributes, $content ) {
 			$processor->add_class( 'is-repeated' );
 		}
 
-		$styles = 'background-position:' . ( $object_position ?? '50% 50%' ) . ';';
-		if ( $current_featured_image ) {
-			$styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
-		}
+		$styles  = 'background-position:' . ( $object_position ?? '50% 50%' ) . ';';
+		$styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 		$processor->set_attribute( 'style', $styles );
 
 		$image = $processor->get_updated_html();

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -20,9 +20,9 @@ function render_block_core_cover( $attributes, $content ) {
 		return $content;
 	}
 
-	if ( isset( $attributes['focalPoint'] ) ) {
-		$object_position = round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%';
-	}
+	$object_position = isset( $attributes['focalPoint'] )
+		? round( $attributes['focalPoint']['x'] * 100 ) . '% ' . round( $attributes['focalPoint']['y'] * 100 ) . '%'
+		: null;
 
 	if ( ! ( $attributes['hasParallax'] || $attributes['isRepeated'] ) ) {
 		$attr = array(
@@ -30,9 +30,9 @@ function render_block_core_cover( $attributes, $content ) {
 			'data-object-fit' => 'cover',
 		);
 
-		if ( isset( $object_position ) ) {
+		if ( $object_position ) {
 			$attr['data-object-position'] = $object_position;
-			$attr['style']                = 'object-position: ' . $object_position . ';';
+			$attr['style']                = 'object-position:' . $object_position . ';';
 		}
 
 		$image = get_the_post_thumbnail( null, 'post-thumbnail', $attr );
@@ -62,11 +62,7 @@ function render_block_core_cover( $attributes, $content ) {
 			$processor->add_class( 'is-repeated' );
 		}
 
-		$background_position = '50% 50%';
-		if ( isset( $object_position ) ) {
-			$background_position = $object_position;
-		}
-		$styles = 'background-position:' . $background_position . ';';
+		$styles = 'background-position:' . ( $object_position ?? '50% 50%' ) . ';';
 		if ( $current_featured_image ) {
 			$styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 		}

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -62,9 +62,9 @@ function render_block_core_cover( $attributes, $content ) {
 			$processor->set_attribute( 'aria-label', $current_caption );
 		}
 
-		$styles = 'background-image: url(' . esc_url( $current_featured_image ) . ');';
-		if ( isset( $object_position ) ) {
-			$styles .= 'background-position: ' . $object_position . ';';
+		$styles = 'background-position:' . isset( $object_position ) ? $object_position : '50% 50%' . ';';
+		if ( $current_featured_image ) {
+			$styles .= 'background-image:url(' . esc_url( $current_featured_image ) . ');';
 		}
 		$processor->set_attribute( 'style', $styles );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates the cover block to render a `<div>` background when using featured images.

The best way to review this is to compare with the [cover block's `save` function](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/cover/save.js#L127-L146) as the newly added code should mirror that when a featured image is used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #50828 

Cover blocks using featured images didn't pick up duotone because they weren't using an element for the featured image.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Generate a `<div>` instead of setting `background-image` for cover blocks using featured images.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

```html
<!-- wp:query {"queryId":9,"query":{"perPage":12,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false,"taxQuery":null,"parents":[],"format":[]}} -->
<div class="wp-block-query"><!-- wp:post-template -->
<!-- wp:cover {"useFeaturedImage":true,"hasParallax":true,"dimRatio":0,"isUserOverlayColor":true,"isDark":false,"style":{"color":{"duotone":"var:preset|duotone|grayscale"}}} -->
<div class="wp-block-cover is-light has-parallax"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-0 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->
<p class="has-text-align-center has-large-font-size"></p>
<!-- /wp:paragraph --></div></div>
<!-- /wp:cover -->
<!-- /wp:post-template --></div>
<!-- /wp:query -->
```

1. Create some posts that have featured images.
2. Insert above content or add the following structure.
   - Query loop block
     - Cover block
       - Enable featured image
       - Enable parallax (also try repeat)
       - Enable duotone filter
4. Save and view the page to confirm that the featured images cover blocks show the duotone effect.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

### Before

![Screen Shot 2024-10-07 at 16 09 32](https://github.com/user-attachments/assets/d61c0975-3f22-445d-a238-ecc1cbbe9818)

### After

![Screen Shot 2024-10-07 at 16 09 13](https://github.com/user-attachments/assets/bb13d249-386d-49d4-b771-241d4d7b50cb)