### PR TITLE
Fix zoom out not persisting while switching between editor and code editor

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -306,11 +306,13 @@ function Iframe( {
 			_src,
 			() => {
 				URL.revokeObjectURL( _src );
-				resetZoomLevel();
-				__unstableSetEditorMode( 'edit' );
+				if ( isZoomedOut ) {
+					resetZoomLevel();
+					__unstableSetEditorMode( 'edit' );
+				}
 			},
 		];
-	}, [ html, resetZoomLevel, __unstableSetEditorMode ] );
+	}, [ html, resetZoomLevel, __unstableSetEditorMode, isZoomedOut ] );
 
 	useEffect( () => cleanup, [ cleanup ] );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -22,7 +22,7 @@ import {
 	useDisabled,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -31,7 +31,6 @@ import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
 import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
 
 function bubbleEvent( event, Constructor, frame ) {
 	const init = {};
@@ -131,9 +130,6 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
-	const { resetZoomLevel, __unstableSetEditorMode } = unlock(
-		useDispatch( blockEditorStore )
-	);
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -302,17 +298,8 @@ function Iframe( {
 		const _src = URL.createObjectURL(
 			new window.Blob( [ html ], { type: 'text/html' } )
 		);
-		return [
-			_src,
-			() => {
-				URL.revokeObjectURL( _src );
-				if ( isZoomedOut ) {
-					resetZoomLevel();
-					__unstableSetEditorMode( 'edit' );
-				}
-			},
-		];
-	}, [ html, resetZoomLevel, __unstableSetEditorMode, isZoomedOut ] );
+		return [ _src, () => URL.revokeObjectURL( _src ) ];
+	}, [ html ] );
 
 	useEffect( () => cleanup, [ cleanup ] );
 

--- a/packages/editor/src/components/text-editor/index.js
+++ b/packages/editor/src/components/text-editor/index.js
@@ -6,6 +6,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useEffect, useRef } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -13,6 +14,7 @@ import { useEffect, useRef } from '@wordpress/element';
 import { store as editorStore } from '../../store';
 import PostTextEditor from '../post-text-editor';
 import PostTitleRaw from '../post-title/post-title-raw';
+import { unlock } from '../../lock-unlock';
 
 export default function TextEditor( { autoFocus = false } ) {
 	const { switchEditorMode } = useDispatch( editorStore );
@@ -26,13 +28,20 @@ export default function TextEditor( { autoFocus = false } ) {
 		};
 	}, [] );
 
+	const { resetZoomLevel, __unstableSetEditorMode } = unlock(
+		useDispatch( blockEditorStore )
+	);
+
 	const titleRef = useRef();
 	useEffect( () => {
+		resetZoomLevel();
+		__unstableSetEditorMode( 'edit' );
+
 		if ( autoFocus ) {
 			return;
 		}
 		titleRef?.current?.focus();
-	}, [ autoFocus ] );
+	}, [ autoFocus, resetZoomLevel, __unstableSetEditorMode ] );
 
 	return (
 		<div className="editor-text-editor">


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes the issue where zoom out isn't persisting while switching between 
* editor and code editor
* templates

Closes: #65783

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When the editor is switched, component gets destroyed and the value of `prevContainerWidthRef.current` is set to undefined.

The hook doesn't set the value because it is in ZoomedOut mode.

```
useEffect( () => {
	if ( ! isZoomedOut ) {
		prevContainerWidthRef.current = containerWidth;
	}
}, [ containerWidth, isZoomedOut ] );
```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Enter to zoom out mode
2. switch to code editor and exit code editor
3. Now, it should get back to zoom out mode
4. It should work the same when templates are switched while in zoom out mode.

## Screenshots or screencast <!-- if applicable -->

![zoom-out-fix](https://github.com/user-attachments/assets/73686c84-f7da-4b17-a47f-fbb418c54b45)

