### PR TITLE
Global styles: leave screen if current shadow entry gets deleted

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -81,7 +81,7 @@ export default function ShadowsEditPanel() {
 	);
 
 	useEffect( () => {
-		const currentShadow = shadows?.find(
+		const hasCurrentShadow = shadows?.some(
 			( shadow ) => shadow.slug === slug
 		);
 		// If the shadow being edited doesn't exist anymore in the global styles setting, navigate back
@@ -92,7 +92,7 @@ export default function ShadowsEditPanel() {
 		//
 		// The check on the slug is necessary to prevent a double back navigation when the user triggers
 		// a backward navigation by interacting with the screen's UI.
-		if ( !! slug && ! currentShadow ) {
+		if ( !! slug && ! hasCurrentShadow ) {
 			goBack();
 		}
 	}, [ shadows, slug, goBack ] );

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -79,18 +79,23 @@ export default function ShadowsEditPanel() {
 	const [ shadows, setShadows ] = useGlobalSetting(
 		`shadow.presets.${ category }`
 	);
-	const currentShadow = shadows?.find( ( shadow ) => shadow.slug === slug );
 
 	useEffect( () => {
+		const currentShadow = shadows?.find(
+			( shadow ) => shadow.slug === slug
+		);
 		// If the shadow being edited doesn't exist anymore in the global styles setting, navigate back
 		// to prevent the user from editing a non-existent shadow entry.
 		// This can happen, for example:
 		// - when the user deletes the shadow
 		// - when the user resets the styles while editing a custom shadow
-		if ( ! currentShadow ) {
+		//
+		// The check on the slug is necessary to prevent a double back navigation when the user triggers
+		// a backward navigation by interacting with the screen's UI.
+		if ( !! slug && ! currentShadow ) {
 			goBack();
 		}
-	}, [ currentShadow, goBack ] );
+	}, [ shadows, slug, goBack ] );
 
 	const [ baseShadows ] = useGlobalSetting(
 		`shadow.presets.${ category }`,

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -35,7 +35,7 @@ import {
 	reset,
 	moreVertical,
 } from '@wordpress/icons';
-import { useState, useMemo } from '@wordpress/element';
+import { useState, useMemo, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -73,12 +73,25 @@ const presetShadowMenuItems = [
 
 export default function ShadowsEditPanel() {
 	const {
+		goBack,
 		params: { category, slug },
-		goTo,
 	} = useNavigator();
 	const [ shadows, setShadows ] = useGlobalSetting(
 		`shadow.presets.${ category }`
 	);
+	const currentShadow = shadows?.find( ( shadow ) => shadow.slug === slug );
+
+	useEffect( () => {
+		// If the shadow being edited doesn't exist anymore in the global styles setting, navigate back
+		// to prevent the user from editing a non-existent shadow entry.
+		// This can happen, for example:
+		// - when the user deletes the shadow
+		// - when the user resets the styles while editing a custom shadow
+		if ( ! currentShadow ) {
+			goBack();
+		}
+	}, [ currentShadow, goBack ] );
+
 	const [ baseShadows ] = useGlobalSetting(
 		`shadow.presets.${ category }`,
 		undefined,
@@ -123,9 +136,7 @@ export default function ShadowsEditPanel() {
 	};
 
 	const handleShadowDelete = () => {
-		const updatedShadows = shadows.filter( ( s ) => s.slug !== slug );
-		setShadows( updatedShadows );
-		goTo( `/shadows` );
+		setShadows( shadows.filter( ( s ) => s.slug !== slug ) );
 	};
 
 	const handleShadowRename = ( newName ) => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65930

This PR prevents the Global Styles "shadow edit" screen from crashing when a user resets the styles while on the screen and editing a custom shadow preset.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Bug fix

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The bug was caused by the fact that the user would be allowed to edit a stale shadow preset, after it had been removed from the global styles.

This PR checks for the current screen shadow to actually exist — and if it doesn't, it navigates back to the parent screen, where all up-to-date shadows are listed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Make sure that the bug flagged in #65930 can't be replicated on this PR.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a0cc3a68-34f6-46f9-a0c2-e5bcac1d3882


