### PR TITLE
e2e: fix Block Visibility test

### DIFF
--- a/test/e2e/specs/editor/various/block-visibility.spec.js
+++ b/test/e2e/specs/editor/various/block-visibility.spec.js
@@ -48,7 +48,7 @@ test.describe( 'Block Visibility', () => {
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
 			.getByRole( 'searchbox', {
-				name: 'Search for blocks and patterns',
+				name: 'Search',
 			} )
 			.fill( 'Heading' );
 
@@ -89,7 +89,7 @@ test.describe( 'Block Visibility', () => {
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
 			.getByRole( 'searchbox', {
-				name: 'Search for blocks and patterns',
+				name: 'Search',
 			} )
 			.fill( 'Heading' );
 


### PR DESCRIPTION
## What?

The E2E tests for the Block Visibility reference a search field labeled "Search for blocks and patterns" to search for blocks. However, as of #65458, that label was changed to "Search".

At the time CI was performed in #65458, there were probably no e2e tests for block visibility yet.

## Testing Instructions

I'm currently checking whether it passes the e2e test.