### PR TITLE
Global styles: improve Navigator usage in typography panel

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -158,7 +158,6 @@ function FontSize() {
 							__( 'Manage the font size %s.' ),
 							fontSize.name
 						) }
-						onBack={ () => goTo( '/typography/font-sizes/' ) }
 					/>
 					{ origin === 'custom' && (
 						<FlexItem>

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-size.js
@@ -36,7 +36,7 @@ function FontSize() {
 
 	const {
 		params: { origin, slug },
-		goTo,
+		goBack,
 	} = useNavigator();
 
 	const [ fontSizes, setFontSizes ] = useGlobalSetting(
@@ -53,10 +53,10 @@ function FontSize() {
 
 	// Navigate to the font sizes list if the font size is not available.
 	useEffect( () => {
-		if ( ! fontSize ) {
-			goTo( '/typography/font-sizes/', { isBack: true } );
+		if ( !! slug && ! fontSize ) {
+			goBack();
 		}
-	}, [ fontSize, goTo ] );
+	}, [ slug, fontSize, goBack ] );
 
 	if ( ! origin || ! slug || ! fontSize ) {
 		return null;

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes-count.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes-count.js
@@ -24,7 +24,7 @@ function FontSizes() {
 			</HStack>
 			<ItemGroup isBordered isSeparated>
 				<NavigationButtonAsItem
-					path="/typography/font-sizes/"
+					path="/typography/font-sizes"
 					aria-label={ __( 'Edit font size presets' ) }
 				>
 					<HStack direction="row">

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -302,7 +302,7 @@ function GlobalStylesUI() {
 				<ScreenTypography />
 			</GlobalStylesNavigationScreen>
 
-			<GlobalStylesNavigationScreen path="/typography/font-sizes/">
+			<GlobalStylesNavigationScreen path="/typography/font-sizes">
 				<FontSizes />
 			</GlobalStylesNavigationScreen>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #65794
Follow up to #65791

This PR improves the usage of the `Navigator` component in the Font Size screen in the Global Styles

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There are a few areas in the font size presets screen where `Navigator` is not being used as expected:

- `goTo` is being used instead of `goBack`, and it's there to "hide" a bug where `goTo` is being called twice inside a `useEffect`
- `goTo` is being called unnecessarily when the user clicks on the "back" button, and is hiding a bug caused by a wrongly formatted screen path

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- added an extra check on the `slug`, so that the check inside the `useEffect` only passes once and thus allows us to use `goBack` instead of `goTo`
- remove trailing slash from the font size screen's `path`, which allows `Navigator` to navigate back to the correct screen without the need for the extra `goTo`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the site editor, open the global styles sidebar
- Navigate to typography > font size presets
  - [ ] Clicking the back button behaves as expected and goes back to the root screen
- Navigate again to typography > font size presets
- Click on a theme preset:
  - [ ] Make changes and then reset global styles. The changes should be reset, but the screen shouldn't change and the user can continue to make changes as needed;
  - [ ] Clicking the back button behaves as expected and goes back to the font size presets screen;
- Create a custom preset, and click on it:
  - [ ] Make changes and then reset global styles. A navigation back to the font size presets screen should be triggered, since the preset doesn't exist anymore;
- Create another custom preset, and click on it:
  - [ ] Clicking the back button behaves as expected and goes back to the font size presets screen;

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/6f60ae99-2c76-4b54-918f-8b764e786f62

