### PR TITLE
Zoom out: e2e test - zoomed out mode zooms the canvas

### DIFF
--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -22,11 +22,18 @@ test.describe( 'Zoom Out', () => {
 		editor,
 	} ) => {
 		await page.getByLabel( 'Zoom Out' ).click();
-		const frame = editor.canvas.locator( 'html' );
-		await expect( frame ).toHaveCSS(
+		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
+		const html = editor.canvas.locator( 'html' );
+
+		//Check that the html is scaled
+		await expect( html ).toHaveCSS(
 			'transform',
 			'matrix(0.75, 0, 0, 0.75, 0, 0)'
 		);
-		await page.pause();
+		const iframeRect = await iframe.boundingBox();
+		const htmlRect = await html.boundingBox();
+
+		//Check that the iframe is larger than the html
+		expect( iframeRect.width ).toBeGreaterThan( htmlRect.width );
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -35,5 +35,22 @@ test.describe( 'Zoom Out', () => {
 
 		//Check that the iframe is larger than the html
 		expect( iframeRect.width ).toBeGreaterThan( htmlRect.width );
+
+		//Check that the zoomed out content has a frame around it
+		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
+
+		//We use border to separate the content from the frame so we need
+		//to check that that is present too, since boundingBox()
+		//includes the border to calculate the position
+		const borderWidths = await html.evaluate( ( el ) => {
+			const styles = window.getComputedStyle( el );
+			return {
+				top: parseFloat( styles.borderTopWidth ),
+				right: parseFloat( styles.borderRightWidth ),
+				bottom: parseFloat( styles.borderBottomWidth ),
+				left: parseFloat( styles.borderLeftWidth ),
+			};
+		} );
+		expect( htmlRect.y + borderWidths.top ).toBeGreaterThan( iframeRect.y );
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -28,7 +28,7 @@ test.describe( 'Zoom Out', () => {
 		// Check that the html is scaled.
 		await expect( html ).toHaveCSS(
 			'transform',
-			'matrix(0.75, 0, 0, 0.75, 0, 0)'
+			'matrix(0.67, 0, 0, 0.67, 0, 0)'
 		);
 		const iframeRect = await iframe.boundingBox();
 		const htmlRect = await html.boundingBox();
@@ -38,19 +38,5 @@ test.describe( 'Zoom Out', () => {
 
 		// Check that the zoomed out content has a frame around it.
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
-
-		// We use border to separate the content from the frame so we need
-		// to check that that is present too, since boundingBox()
-		// includes the border to calculate the position.
-		const borderWidths = await html.evaluate( ( el ) => {
-			const styles = window.getComputedStyle( el );
-			return {
-				top: parseFloat( styles.borderTopWidth ),
-				right: parseFloat( styles.borderRightWidth ),
-				bottom: parseFloat( styles.borderBottomWidth ),
-				left: parseFloat( styles.borderLeftWidth ),
-			};
-		} );
-		expect( htmlRect.y + borderWidths.top ).toBeGreaterThan( iframeRect.y );
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -25,7 +25,7 @@ test.describe( 'Zoom Out', () => {
 		const iframe = page.locator( 'iframe[name="editor-canvas"]' );
 		const html = editor.canvas.locator( 'html' );
 
-		//Check that the html is scaled
+		// Check that the html is scaled.
 		await expect( html ).toHaveCSS(
 			'transform',
 			'matrix(0.75, 0, 0, 0.75, 0, 0)'
@@ -33,15 +33,15 @@ test.describe( 'Zoom Out', () => {
 		const iframeRect = await iframe.boundingBox();
 		const htmlRect = await html.boundingBox();
 
-		//Check that the iframe is larger than the html
+		// Check that the iframe is larger than the html.
 		expect( iframeRect.width ).toBeGreaterThan( htmlRect.width );
 
-		//Check that the zoomed out content has a frame around it
+		// Check that the zoomed out content has a frame around it.
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
 
-		//We use border to separate the content from the frame so we need
-		//to check that that is present too, since boundingBox()
-		//includes the border to calculate the position
+		// We use border to separate the content from the frame so we need
+		// to check that that is present too, since boundingBox()
+		// includes the border to calculate the position.
 		const borderWidths = await html.evaluate( ( el ) => {
 			const styles = window.getComputedStyle( el );
 			return {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -17,12 +17,16 @@ test.describe( 'Zoom Out', () => {
 		await editor.canvas.locator( 'body' ).click();
 	} );
 
-	test( 'Entering zoomed out mode zooms the canvas', async ( { page } ) => {
+	test( 'Entering zoomed out mode zooms the canvas', async ( {
+		page,
+		editor,
+	} ) => {
 		await page.getByLabel( 'Zoom Out' ).click();
-		await expect(
-			page
-				.canvas
-				.locator( 'html' )
-		).toHaveCSS( 'transform', 'matrix(0.75, 0, 0, 0.75, 0, 0)' );
+		const frame = editor.canvas.locator( 'html' );
+		await expect( frame ).toHaveCSS(
+			'transform',
+			'matrix(0.75, 0, 0, 0.75, 0, 0)'
+		);
+		await page.pause();
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -37,6 +37,11 @@ test.describe( 'Zoom Out', () => {
 		expect( iframeRect.width ).toBeGreaterThan( htmlRect.width );
 
 		// Check that the zoomed out content has a frame around it.
+		const paddingTop = await html.evaluate( ( element ) => {
+			const paddingValue = window.getComputedStyle( element ).paddingTop;
+			return parseFloat( paddingValue );
+		} );
+		expect( htmlRect.y + paddingTop ).toBeGreaterThan( iframeRect.y );
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -3,65 +3,26 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-// The test is flaky and fails almost consistently.
-// See: https://github.com/WordPress/gutenberg/issues/61806.
-// eslint-disable-next-line playwright/no-skipped-test
-test.describe.skip( 'Zoom Out', () => {
+test.describe( 'Zoom Out', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'emptytheme' );
-	} );
-
-	test.beforeEach( async ( { admin, editor, page } ) => {
-		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
-
-		const zoomedOutCheckbox = page.getByLabel(
-			'Enable zoomed out view when selecting a pattern category in the main inserter.'
-		);
-
-		await zoomedOutCheckbox.setChecked( true );
-		await expect( zoomedOutCheckbox ).toBeChecked();
-		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
-
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
-	} );
-
-	test.afterEach( async ( { admin, page } ) => {
-		await admin.visitAdminPage( 'admin.php', 'page=gutenberg-experiments' );
-		const zoomedOutCheckbox = page.getByLabel(
-			'Enable zoomed out view when selecting a pattern category in the main inserter.'
-		);
-		await zoomedOutCheckbox.setChecked( false );
-		await expect( zoomedOutCheckbox ).not.toBeChecked();
-		await page.getByRole( 'button', { name: 'Save Changes' } ).click();
+		await requestUtils.activateTheme( 'twentytwentyfour' );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'Clicking on inserter while on zoom-out should open the patterns tab on the inserter', async ( {
-		page,
-	} ) => {
-		// Trigger zoom out on Global Styles because there the inserter is not open.
-		await page.getByRole( 'button', { name: 'Styles' } ).click();
-		await page.getByRole( 'button', { name: 'Browse styles' } ).click();
+	test.beforeEach( async ( { admin, editor } ) => {
+		await admin.visitSiteEditor();
+		await editor.canvas.locator( 'body' ).click();
+	} );
 
-		// select the 1st pattern
-		await page
-			.frameLocator( 'iframe[name="editor-canvas"]' )
-			.locator( 'header' )
-			.click();
-
-		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 3 );
-		await page.getByLabel( 'Add pattern' ).first().click();
-		await expect( page.getByLabel( 'Add pattern' ) ).toHaveCount( 2 );
-
+	test( 'Entering zoomed out mode zooms the canvas', async ( { page } ) => {
+		await page.getByLabel( 'Zoom Out' ).click();
 		await expect(
 			page
-				.locator( '#tabs-2-allPatterns-view div' )
-				.filter( { hasText: 'All' } )
-				.nth( 1 )
-		).toBeVisible();
+				.frameLocator( 'iframe[name="editor-canvas"]' )
+				.locator( 'html' )
+		).toHaveCSS( 'transform', 'matrix(0.75, 0, 0, 0.75, 0, 0)' );
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -21,7 +21,7 @@ test.describe( 'Zoom Out', () => {
 		await page.getByLabel( 'Zoom Out' ).click();
 		await expect(
 			page
-				.frameLocator( 'iframe[name="editor-canvas"]' )
+				.canvas
 				.locator( 'html' )
 		).toHaveCSS( 'transform', 'matrix(0.75, 0, 0, 0.75, 0, 0)' );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of https://github.com/WordPress/gutenberg/issues/65797

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We didn't have any e2e tests for zoom out mode

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This one removes the skip for zoom out mode tests and replaces the outdated test with a new one. I will follow up with more PRs from the list in Part of https://github.com/WordPress/gutenberg/issues/65797

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `npm run test:e2e -- site-editor/zoom-out.spec.js` and the tests should pass

