### PR TITLE
add: wp-env start --disable-port-mapping option

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added a --disable-port-mapping option to `wp-env start` that removes the port mappings from wp-env containers. 
+
 ## 10.9.0 (2024-10-03)
 
 ## 10.8.0 (2024-09-19)

--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -281,15 +281,25 @@ first install, use the '--update' flag to download updates to mapped sources and
 to re-apply WordPress configuration options.
 
 Options:
-  --debug    Enable debug output.                     [boolean] [default: false]
-  --update   Download source updates and apply WordPress configuration.
+  --help                  Show help                                    [boolean]
+  --debug                 Enable debug output.        [boolean] [default: false]
+  --version               Show version number                          [boolean]
+  --update                Download source updates and apply WordPress
+                          configuration.              [boolean] [default: false]
+  --xdebug                Enables Xdebug. If not passed, Xdebug is turned off.
+                          If no modes are set, uses "debug". You may set
+                          multiple Xdebug modes by passing them in a
+                          comma-separated list: `--xdebug=develop,coverage`. See
+                          https://xdebug.org/docs/all_settings#mode for
+                          information about Xdebug modes.               [string]
+  --scripts               Execute any configured lifecycle scripts.
+                                                       [boolean] [default: true]
+  --disable-port-mapping  Do not expose container ports to the host. This is
+                          useful when you are running multiple instances of
+                          wp-env and intend to access them via a reverse proxy
+                          sidecar. The WordPress instance will listen on the
+                          default port 80 within the Docker network.
                                                       [boolean] [default: false]
-  --xdebug   Enables Xdebug. If not passed, Xdebug is turned off. If no modes
-             are set, uses "debug". You may set multiple Xdebug modes by passing
-             them in a comma-separated list: `--xdebug=develop,coverage`. See
-             https://xdebug.org/docs/all_settings#mode for information about
-             Xdebug modes.                                              [string]
-  --scripts  Execute any configured lifecycle scripts. [boolean] [default: true]
 ```
 
 ### `wp-env stop`

--- a/packages/env/lib/cli.js
+++ b/packages/env/lib/cli.js
@@ -144,6 +144,12 @@ module.exports = function cli() {
 				describe: 'Execute any configured lifecycle scripts.',
 				default: true,
 			} );
+			args.option( 'disable-port-mapping', {
+				type: 'boolean',
+				describe:
+					'Do not expose container ports to the host. This is useful when you are running multiple instances of wp-env and intend to access them via a reverse proxy sidecar. The WordPress instance will listen on the default port 80 within the Docker network.',
+				default: false,
+			} );
 		},
 		withSpinner( env.start )
 	);

--- a/packages/env/lib/commands/start.js
+++ b/packages/env/lib/commands/start.js
@@ -43,11 +43,12 @@ const CONFIG_CACHE_KEY = 'config_checksum';
  * Starts the development server.
  *
  * @param {Object}  options
- * @param {Object}  options.spinner A CLI spinner which indicates progress.
- * @param {boolean} options.update  If true, update sources.
- * @param {string}  options.xdebug  The Xdebug mode to set.
- * @param {boolean} options.scripts Indicates whether or not lifecycle scripts should be executed.
- * @param {boolean} options.debug   True if debug mode is enabled.
+ * @param {Object}  options.spinner            A CLI spinner which indicates progress.
+ * @param {boolean} options.update             If true, update sources.
+ * @param {string}  options.xdebug             The Xdebug mode to set.
+ * @param {boolean} options.scripts            Indicates whether or not lifecycle scripts should be executed.
+ * @param {boolean} options.debug              True if debug mode is enabled.
+ * @param {boolean} options.disablePortMapping True if the container ports should not be exposed to the host.
  */
 module.exports = async function start( {
 	spinner,
@@ -55,6 +56,7 @@ module.exports = async function start( {
 	xdebug,
 	scripts,
 	debug,
+	disablePortMapping,
 } ) {
 	spinner.text = 'Reading configuration.';
 	await checkForLegacyInstall( spinner );
@@ -63,6 +65,7 @@ module.exports = async function start( {
 		spinner,
 		debug,
 		xdebug,
+		disablePortMapping,
 		writeChanges: true,
 	} );
 

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -30,6 +30,7 @@ const postProcessConfig = require( './post-process-config' );
  * @property {Object.<string, string>}              lifecycleScripts        Any lifecycle scripts that we might need to execute.
  * @property {Object.<string, WPEnvironmentConfig>} env                     Specific config for different environments.
  * @property {boolean}                              debug                   True if debug mode is enabled.
+ * @property {boolean}                              disablePortMapping      True if the container ports should not be exposed to the host.
  */
 
 /**

--- a/packages/env/lib/config/parse-config.js
+++ b/packages/env/lib/config/parse-config.js
@@ -428,6 +428,7 @@ async function parseEnvironmentConfig(
 		switch ( key ) {
 			case 'testsPort':
 			case 'lifecycleScripts':
+			case 'disablePortMapping':
 			case 'env': {
 				if ( options.rootConfig ) {
 					continue;

--- a/packages/env/lib/init-config.js
+++ b/packages/env/lib/init-config.js
@@ -23,20 +23,22 @@ const buildDockerComposeConfig = require( './build-docker-compose-config' );
  * ~/.wp-env/Dockerfile.
  *
  * @param {Object}  options
- * @param {Object}  options.spinner      A CLI spinner which indicates progress.
- * @param {boolean} options.debug        True if debug mode is enabled.
- * @param {string}  options.xdebug       The Xdebug mode to set. Defaults to "off".
- * @param {boolean} options.writeChanges If true, writes the parsed config to the
- *                                       required docker files like docker-compose
- *                                       and Dockerfile. By default, this is false
- *                                       and only the `start` command writes any
- *                                       changes.
+ * @param {Object}  options.spinner            A CLI spinner which indicates progress.
+ * @param {boolean} options.debug              True if debug mode is enabled.
+ * @param {string}  options.xdebug             The Xdebug mode to set. Defaults to "off".
+ * @param {boolean} options.disablePortMapping True if the container ports should not be exposed to the host.
+ * @param {boolean} options.writeChanges       If true, writes the parsed config to the
+ *                                             required docker files like docker-compose
+ *                                             and Dockerfile. By default, this is false
+ *                                             and only the `start` command writes any
+ *                                             changes.
  * @return {WPConfig} The-env config object.
  */
 module.exports = async function initConfig( {
 	spinner,
 	debug,
 	xdebug = 'off',
+	disablePortMapping = false,
 	writeChanges = false,
 } ) {
 	const config = await loadConfig( path.resolve( '.' ) );
@@ -46,6 +48,9 @@ module.exports = async function initConfig( {
 	// config has changed when only the xdebug param has changed. This is needed
 	// so that Docker will rebuild the image whenever the xdebug flag changes.
 	config.xdebug = xdebug;
+
+	// Ditto for disablePortMapping.
+	config.disablePortMapping = disablePortMapping;
 
 	const dockerComposeConfig = buildDockerComposeConfig( config );
 

--- a/packages/env/lib/test/build-docker-compose-config.js
+++ b/packages/env/lib/test/build-docker-compose-config.js
@@ -131,4 +131,51 @@ describe( 'buildDockerComposeConfig', () => {
 		expect( dockerConfig.volumes.wordpress ).toBe( undefined );
 		expect( dockerConfig.volumes[ 'tests-wordpress' ] ).toBe( undefined );
 	} );
+
+	it( 'should not have port mappings if disablePortMapping is specified', () => {
+		const envConfig = {
+			...CONFIG,
+			mysqlPort: 3306,
+		};
+
+		const dockerConfig = buildDockerComposeConfig( {
+			workDirectoryPath: '/path',
+			disablePortMapping: true,
+			env: { development: envConfig, tests: envConfig },
+		} );
+
+		expect( dockerConfig.services.wordpress.ports ).toBe( undefined );
+		expect( dockerConfig.services[ 'tests-wordpress' ].ports ).toBe(
+			undefined
+		);
+		expect( dockerConfig.services.mysql.ports ).toBe( undefined );
+		expect( dockerConfig.services[ 'tests-mysql' ].ports ).toBe(
+			undefined
+		);
+	} );
+
+	it( 'should have port mappings if disablePortMapping is not specified', () => {
+		const envConfig = {
+			...CONFIG,
+			mysqlPort: 3306,
+		};
+
+		const dockerConfig = buildDockerComposeConfig( {
+			workDirectoryPath: '/path',
+			env: { development: envConfig, tests: envConfig },
+		} );
+
+		expect( dockerConfig.services.wordpress.ports ).toEqual( [
+			'${WP_ENV_PORT:-8888}:80',
+		] );
+		expect( dockerConfig.services[ 'tests-wordpress' ].ports ).toEqual( [
+			'${WP_ENV_TESTS_PORT:-8888}:80',
+		] );
+		expect( dockerConfig.services.mysql.ports ).toEqual( [
+			'${WP_ENV_MYSQL_PORT:-3306}:3306',
+		] );
+		expect( dockerConfig.services[ 'tests-mysql' ].ports ).toEqual( [
+			'${WP_ENV_TESTS_MYSQL_PORT:-3306}:3306',
+		] );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adding a `--disable-port-mapping` option to the `wp-env start` CLI command that causes the wp-env container to not have any exposed ports.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There's currently no way to have multiple instances of `wp-env` stacks running locally all on port 80/443. This becomes a problem if we want to run containers that are accessed by a reverse proxy sidecar, or for example, the [built in DNS functionality of Orbstack](https://docs.orbstack.dev/docker/domains#custom).

Note that these services generally expose the endpoints at a hostname that does not allow configuration of alternate ports. Combined with the WordPress automatic port redirection, it ends up with an incompatible situation with the reverse proxy listening on port 80/443 but the user agent getting redirected to the customised port.

It's also problematic when we have other services running on port 80/443, but still want to be able to run our `wp-env` stack on those ports. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Simply removes the `ports` configuration from all the containers if the flag is passed in.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run `wp-env start --disable-port-mapping`
2. Run `docker ps` and you should see the wp-env stack without any ports forwarded.
3. Run `wp-env start`
4. Run `docker ps` and you should see the expected ports being forwarded.
