### PR TITLE
Global styles: improve navigation logic for revisions screen

### DIFF
--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -1,13 +1,7 @@
 /**
  * WordPress dependencies
  */
-import {
-	FlexItem,
-	FlexBlock,
-	Flex,
-	Button,
-	useNavigator,
-} from '@wordpress/components';
+import { FlexItem, FlexBlock, Flex, Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { styles, seen, backup } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';

--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -86,21 +86,17 @@ export default function GlobalStylesSidebar() {
 	}, [ shouldClearCanvasContainerView ] );
 
 	const { setIsListViewOpened } = useDispatch( editorStore );
-	const { goTo } = useNavigator();
 
 	const toggleRevisions = () => {
 		setIsListViewOpened( false );
 		if ( isRevisionsStyleBookOpened ) {
-			goTo( '/' );
 			setEditorCanvasContainerView( 'style-book' );
 			return;
 		}
 		if ( isRevisionsOpened ) {
-			goTo( '/' );
 			setEditorCanvasContainerView( undefined );
 			return;
 		}
-		goTo( '/revisions' );
 
 		if ( isStyleBookOpened ) {
 			setEditorCanvasContainerView(

--- a/packages/edit-site/src/components/global-styles/screen-revisions/index.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/index.js
@@ -3,7 +3,6 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import {
-	useNavigator,
 	__experimentalConfirmDialog as ConfirmDialog,
 	Spinner,
 } from '@wordpress/components';
@@ -33,7 +32,6 @@ const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 const PAGE_SIZE = 10;
 
 function ScreenRevisions() {
-	const { goTo } = useNavigator();
 	const { user: currentEditorGlobalStyles, setUserConfig } =
 		useContext( GlobalStylesContext );
 	const { blocks, editorCanvasContainerView } = useSelect(
@@ -71,6 +69,8 @@ function ScreenRevisions() {
 		currentEditorGlobalStyles
 	);
 
+	// The actual code that triggers the revisions screen to navigate back
+	// to the home screen in in `packages/edit-site/src/components/global-styles/ui.js`.
 	const onCloseRevisions = () => {
 		const canvasContainerView =
 			editorCanvasContainerView === 'global-styles-revisions:style-book'
@@ -84,15 +84,6 @@ function ScreenRevisions() {
 		setIsLoadingRevisionWithUnsavedChanges( false );
 		onCloseRevisions();
 	};
-
-	useEffect( () => {
-		if (
-			! editorCanvasContainerView ||
-			! editorCanvasContainerView.startsWith( 'global-styles-revisions' )
-		) {
-			goTo( '/' ); // Return to global styles main panel.
-		}
-	}, [ editorCanvasContainerView ] );
 
 	useEffect( () => {
 		if ( ! isLoading && revisions.length ) {

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -253,7 +253,9 @@ function GlobalStylesEditorCanvasContainerLink() {
 		switch ( editorCanvasContainerView ) {
 			case 'global-styles-revisions':
 			case 'global-styles-revisions:style-book':
-				goTo( '/revisions' );
+				if ( ! isRevisionsOpen ) {
+					goTo( '/revisions' );
+				}
 				break;
 			case 'global-styles-css':
 				goTo( '/css' );
@@ -267,7 +269,14 @@ function GlobalStylesEditorCanvasContainerLink() {
 				 * browsing global styles panel.
 				 */
 				if ( isRevisionsOpen ) {
-					goTo( '/' );
+					goTo( '/', { isBack: true } );
+				}
+				break;
+			default:
+				// In general, if the revision screen is in view but the
+				// `editorCanvasContainerView` is not a revision view, close it.
+				if ( isRevisionsOpen ) {
+					goTo( '/', { isBack: true } );
 				}
 				break;
 		}

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -258,6 +258,14 @@ function GlobalStylesEditorCanvasContainerLink() {
 			case 'global-styles-css':
 				goTo( '/css' );
 				break;
+			// The stand-alone style book is open
+			// and the revisions panel is open,
+			// close the revisions panel.
+			// Otherwise keep the style book open while
+			// browsing global styles panel.
+			//
+			// Falling through as it matches the default scenario.
+			case 'style-book':
 			default:
 				// In general, if the revision screen is in view but the
 				// `editorCanvasContainerView` is not a revision view, close it.

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -260,21 +260,12 @@ function GlobalStylesEditorCanvasContainerLink() {
 			case 'global-styles-css':
 				goTo( '/css' );
 				break;
-			case 'style-book':
-				/*
-				 * The stand-alone style book is open
-				 * and the revisions panel is open,
-				 * close the revisions panel.
-				 * Otherwise keep the style book open while
-				 * browsing global styles panel.
-				 */
-				if ( isRevisionsOpen ) {
-					goTo( '/', { isBack: true } );
-				}
-				break;
 			default:
 				// In general, if the revision screen is in view but the
 				// `editorCanvasContainerView` is not a revision view, close it.
+				// This also includes the scenario when the stand-alone style
+				// book is open, in which case we want the user to close the
+				// revisions screen and browse global styles.
 				if ( isRevisionsOpen ) {
 					goTo( '/', { isBack: true } );
 				}

--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -70,10 +70,8 @@ function GlobalStylesActionMenu() {
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
-	const { goTo } = useNavigator();
 	const loadCustomCSS = () => {
 		setEditorCanvasContainerView( 'global-styles-css' );
-		goTo( '/css' );
 	};
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/65794

Tweak the code in the global styles sidebar, improving the logic around navigating to and away from the revisions screen.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Navigating to/from the revisions screen wasn't always triggering the correct animation, and sometimes the exit animation was playing twice.

> [!NOTE]
> Navigating _to_ the revisions screen can still trigger a double animation, but I believe this is caused by how the screen itself handles data fetching updates via a mix of data store selectors and internal state, which causes the component to re-render and potentially re-trigger the CSS entry animation. This PR doesn't aim at improving that aspect — to improve it, we should probably refactor the revisions screen's internal code more substantially, similarly to the work that @jsnajdr did in https://github.com/WordPress/gutenberg/pull/65564

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Since the button that shows/hides the screen is actually outside of `Navigator`, it can't use `Navigator.Button` or `useNavigator` directly. Instead, interacting with the button changes a value in the data store, and then code in the global styles sidebar react to those changes to programmatically navigate to a new screen.

This PR removes any similar logic in the revisions screen itself and moves any needed logic to the file hosting the root `Navigator` component, next to where other similar logic is.

This PR also add the `isBack` flag when navigating to the home screen, which makes the animation more aligned with the user's expectations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the site editor, open the global styles sidebar;
- Interact with the revisions screen:
  - Open and close the screen by clicking on the icon button in the global styles sidebar header;
    - [ ] When toggling the revisions screen _off_, the screen leaves with a backwards animation (on `trunk`, it navigates forward)
  - Navigate back to the home screen by clicking the back button in the revisions screen's header;
- As explained above, the double navigation that can happen when navigating _to_ the revisions screen already exists on `trunk`, and fixing it is out of the scope of this PR.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
|  <video src="https://github.com/user-attachments/assets/7de59332-0b88-4241-b111-016f798c25df" /> | <video src="https://github.com/user-attachments/assets/14f371fc-be0f-4082-94b0-05ed8b3d6968" /> |


