### PR TITLE
Revert "Pattern block: Ensure consistent editing of overrides in Write Mode (#65408)"

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -684,21 +684,3 @@ export function getClosestAllowedInsertionPointForPattern(
 export function getInsertionPoint( state ) {
 	return state.insertionPoint;
 }
-
-/**
- * Retrieves the number of parent pattern blocks.
- *
- * @param {Object} state    Global application state.
- * @param {string} clientId The block client ID.
- *
- * @return {number} The number of parent pattern blocks.
- */
-export function getParentPatternCount( state, clientId ) {
-	const parents = getBlockParents( state, clientId );
-	return parents.reduce( ( count, parent ) => {
-		if ( getBlockName( state, parent ) === 'core/block' ) {
-			return count + 1;
-		}
-		return count;
-	}, 0 );
-}

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -40,7 +40,6 @@ import {
 	getSectionRootClientId,
 	isSectionBlock,
 	getParentSectionBlock,
-	getParentPatternCount,
 } from './private-selectors';
 
 /**
@@ -2971,43 +2970,6 @@ export const getBlockEditingMode = createRegistrySelector(
 			// rootClientId, but the default rootClientId is actually `''`.
 			if ( clientId === null ) {
 				clientId = '';
-			}
-
-			// Handle pattern blocks (core/block) and the content of those blocks.
-			const parentPatternCount = getParentPatternCount( state, clientId );
-
-			// Make the outer pattern block content only mode.
-			if (
-				getBlockName( state, clientId ) === 'core/block' &&
-				parentPatternCount === 0
-			) {
-				return 'contentOnly';
-			}
-
-			if ( parentPatternCount > 0 ) {
-				// Disable nested patterns.
-				if ( parentPatternCount > 1 ) {
-					return 'disabled';
-				}
-
-				// Disable pattern content editing in zoom-out mode.
-				const _isZoomOut =
-					__unstableGetEditorMode( state ) === 'zoom-out';
-				if ( _isZoomOut ) {
-					return 'disabled';
-				}
-
-				// If the block has a binding of any kind, allow content only editing.
-				const attributes = getBlockAttributes( state, clientId );
-				if (
-					Object.keys( attributes?.metadata?.bindings ?? {} )
-						?.length > 0
-				) {
-					return 'contentOnly';
-				}
-
-				// Otherwise, the block is part of the pattern source and should not be editable.
-				return 'disabled';
 			}
 
 			// In zoom-out mode, override the behavior set by

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -428,6 +428,7 @@ describe( 'private selectors', () => {
 							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
 						],
 					] ),
+
 					order: new Map( [
 						[
 							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
@@ -442,7 +443,6 @@ describe( 'private selectors', () => {
 						],
 						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 					] ),
-					byClientId: new Map( [] ),
 				},
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],
@@ -495,7 +495,6 @@ describe( 'private selectors', () => {
 						],
 						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 					] ),
-					byClientId: new Map( [] ),
 				},
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3079,7 +3079,7 @@ describe( 'selectors', () => {
 					byClientId: new Map(
 						Object.entries( {
 							block1: { name: 'core/test-block-ancestor' },
-							block2: { name: 'core/group' },
+							block2: { name: 'core/block' },
 							block3: { name: 'core/test-block-parent' },
 						} )
 					),
@@ -4667,115 +4667,5 @@ describe( 'getBlockEditingMode', () => {
 				'9b9c5c3f-2e46-4f02-9e14-9fed515b958s'
 			)
 		).toBe( 'disabled' );
-	} );
-
-	describe( 'pattern blocks', () => {
-		const patternBlockState = {
-			settings: {},
-			blocks: {
-				byClientId: new Map(
-					Object.entries( {
-						'pattern-a': { name: 'core/block' },
-						'pattern-b': { name: 'core/block' },
-						'heading-a': { name: 'core/heading' },
-						'paragraph-a': { name: 'core/paragraph' },
-						'paragraph-b': { name: 'core/paragraph' },
-					} )
-				),
-				order: new Map(
-					Object.entries( {
-						'': [ 'pattern-a' ],
-						'pattern-a': [
-							'heading-a',
-							'paragraph-a',
-							'pattern-b',
-						],
-						'pattern-b': [ 'paragraph-b' ],
-					} )
-				),
-				parents: new Map(
-					Object.entries( {
-						'paragraph-b': 'pattern-b',
-						'pattern-b': 'pattern-a',
-						'paragraph-a': 'pattern-a',
-						'heading-a': 'pattern-a',
-						'pattern-a': '',
-					} )
-				),
-				blockListSettings: {
-					'pattern-a': {},
-					'pattern-b': {},
-				},
-				attributes: new Map(
-					Object.entries( {
-						'paragraph-a': {
-							metadata: {
-								bindings: {
-									__default: {
-										source: 'core/pattern-overrides',
-									},
-								},
-							},
-						},
-						'paragraph-b': {
-							metadata: {
-								bindings: {
-									__default: {
-										source: 'core/pattern-overrides',
-									},
-								},
-							},
-						},
-					} )
-				),
-			},
-		};
-
-		it( 'should return contentOnly for the outer pattern block', () => {
-			expect(
-				getBlockEditingMode( patternBlockState, 'pattern-a' )
-			).toBe( 'contentOnly' );
-		} );
-
-		it( 'should return contentOnly for blocks with bindings in the outer pattern', () => {
-			expect(
-				getBlockEditingMode( patternBlockState, 'paragraph-a' )
-			).toBe( 'contentOnly' );
-		} );
-
-		it( 'should return disabled for unbound blocks', () => {
-			expect(
-				getBlockEditingMode( patternBlockState, 'heading-a' )
-			).toBe( 'disabled' );
-		} );
-
-		it( 'should return disabled for the nested pattern', () => {
-			expect(
-				getBlockEditingMode( patternBlockState, 'pattern-a' )
-			).toBe( 'contentOnly' );
-		} );
-
-		it( 'should return disabled for blocks with bindings in the nested pattern', () => {
-			expect(
-				getBlockEditingMode( patternBlockState, 'paragraph-b' )
-			).toBe( 'disabled' );
-		} );
-
-		it( 'should disable all inner blocks of the outer pattern in zoom out mode with the outer pattern in content only mode', () => {
-			const state = {
-				...patternBlockState,
-				editorMode: 'zoom-out',
-			};
-			expect( getBlockEditingMode( state, 'pattern-a' ) ).toBe(
-				'contentOnly'
-			);
-			[ 'paragraph-a', 'paragraph-b', 'heading-a', 'pattern-b' ].forEach(
-				( block ) => {
-					expect( getBlockEditingMode( state, block ) ).toBe(
-						'disabled'
-					);
-				}
-			);
-		} );
 	} );
 } );


### PR DESCRIPTION
This reverts commit ace97353e22183c395fa9abd903fe3a19fe73826.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Reverts #65408 due to the performance regression mentioned in https://github.com/WordPress/gutenberg/pull/65408#issuecomment-2399607190.

The plan would be to follow up with the same changes but with optimizations that avoid the performance impact.