### PR TITLE
Rename wp_register_block_template() to register_block_template()

### DIFF
--- a/backport-changelog/6.7/7543.md
+++ b/backport-changelog/6.7/7543.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7543
+
+* https://github.com/WordPress/gutenberg/pull/65958

--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -27,7 +27,7 @@ if ( ! function_exists( 'register_block_template' ) ) {
 	}
 }
 
-if ( ! function_exists( 'wp_unregister_block_template' ) ) {
+if ( ! function_exists( 'unregister_block_template' ) ) {
 	/**
 	 * Unregister a template.
 	 *
@@ -35,7 +35,7 @@ if ( ! function_exists( 'wp_unregister_block_template' ) ) {
 	 * @return WP_Block_Template|WP_Error The unregistered template object on success, WP_Error object on failure or if
 	 *                                    the template doesn't exist.
 	 */
-	function wp_unregister_block_template( $template_name ) {
+	function unregister_block_template( $template_name ) {
 		return WP_Block_Templates_Registry::get_instance()->unregister( $template_name );
 	}
 }

--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -5,7 +5,7 @@
  * @package gutenberg
  */
 
-if ( ! function_exists( 'wp_register_block_template' ) ) {
+if ( ! function_exists( 'register_block_template' ) ) {
 	/**
 	 * Register a template.
 	 *
@@ -22,7 +22,7 @@ if ( ! function_exists( 'wp_register_block_template' ) ) {
 	 * }
 	 * @return WP_Block_Template|WP_Error The registered template object on success, WP_Error object on failure.
 	 */
-	function wp_register_block_template( $template_name, $args = array() ) {
+	function register_block_template( $template_name, $args = array() ) {
 		return WP_Block_Templates_Registry::get_instance()->register( $template_name, $args );
 	}
 }

--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -39,3 +39,46 @@ if ( ! function_exists( 'unregister_block_template' ) ) {
 		return WP_Block_Templates_Registry::get_instance()->unregister( $template_name );
 	}
 }
+
+if ( ! function_exists( 'wp_register_block_template' ) ) {
+	/**
+	 * Register a template.
+	 *
+	 * @deprecated 19.4.0 wp_register_block_template is deprecated. Please use register_block_template instead.
+	 *
+	 * @param string       $template_name Template name in the form of `plugin_uri//template_name`.
+	 * @param array|string $args {
+	 *     Optional. Array or string of arguments for registering a block template.
+	 *
+	 *     @type string   $title       Optional. Title of the template as it will be shown in the Site Editor
+	 *                                 and other UI elements.
+	 *     @type string   $description Optional. Description of the template as it will be shown in the Site
+	 *                                 Editor.
+	 *     @type string   $content     Optional. Default content of the template that will be used when the
+	 *                                 template is rendered or edited in the editor.
+	 *     @type string[] $post_types  Optional. Array of post types to which the template should be available.
+	 *     @type string   $plugin      Uri of the plugin that registers the template.
+	 * }
+	 * @return WP_Block_Template|WP_Error The registered template object on success, WP_Error object on failure.
+	 */
+	function wp_register_block_template( $template_name, $args = array() ) {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 19.4.0', 'register_block_template' );
+		register_block_template( $template_name, $args );
+	}
+}
+
+if ( ! function_exists( 'wp_unregister_block_template' ) ) {
+	/**
+	 * Unregister a template.
+	 *
+	 * @deprecated 19.4.0 wp_unregister_block_template is deprecated. Please use unregister_block_template instead.
+	 *
+	 * @param string $template_name Template name in the form of `plugin_uri//template_name`.
+	 * @return WP_Block_Template|WP_Error The unregistered template object on success, WP_Error object on failure or if
+	 *                                    the template doesn't exist.
+	 */
+	function wp_unregister_block_template( $template_name ) {
+		_deprecated_function( __FUNCTION__, 'Gutenberg 19.4.0', 'unregister_block_template' );
+		return unregister_block_template( $template_name );
+	}
+}

--- a/packages/e2e-tests/plugins/block-template-registration.php
+++ b/packages/e2e-tests/plugins/block-template-registration.php
@@ -11,7 +11,7 @@ add_action(
 	'init',
 	function () {
 		// Custom template used by most tests.
-		wp_register_block_template(
+		register_block_template(
 			'gutenberg//plugin-template',
 			array(
 				'title'       => 'Plugin Template',
@@ -28,7 +28,7 @@ add_action(
 		);
 
 		// Custom template overridden by the theme.
-		wp_register_block_template(
+		register_block_template(
 			'gutenberg//custom-template',
 			array(
 				'title'       => 'Custom Template (overridden by the theme)',
@@ -39,7 +39,7 @@ add_action(
 		);
 
 		// Custom template used to test unregistration.
-		wp_register_block_template(
+		register_block_template(
 			'gutenberg//plugin-unregistered-template',
 			array(
 				'title'       => 'Plugin Unregistered Template',
@@ -50,7 +50,7 @@ add_action(
 		wp_unregister_block_template( 'gutenberg//plugin-unregistered-template' );
 
 		// Custom template used to test overriding default WP templates.
-		wp_register_block_template(
+		register_block_template(
 			'gutenberg//page',
 			array(
 				'title'       => 'Plugin Page Template',
@@ -60,7 +60,7 @@ add_action(
 		);
 
 		// Custom template used to test overriding default WP templates which can be created by the user.
-		wp_register_block_template(
+		register_block_template(
 			'gutenberg//author-admin',
 			array(
 				'title'       => 'Plugin Author Template',

--- a/packages/e2e-tests/plugins/block-template-registration.php
+++ b/packages/e2e-tests/plugins/block-template-registration.php
@@ -47,7 +47,7 @@ add_action(
 				'content'     => '<!-- wp:template-part {"slug":"header","tagName":"header"} /--><!-- wp:group {"tagName":"main","layout":{"inherit":true}} --><main class="wp-block-group"><!-- wp:paragraph --><p>This is a plugin-registered template that is also unregistered.</p><!-- /wp:paragraph --></main><!-- /wp:group -->',
 			)
 		);
-		wp_unregister_block_template( 'gutenberg//plugin-unregistered-template' );
+		unregister_block_template( 'gutenberg//plugin-unregistered-template' );
 
 		// Custom template used to test overriding default WP templates.
 		register_block_template(

--- a/phpunit/block-template-test.php
+++ b/phpunit/block-template-test.php
@@ -11,7 +11,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 	public function test_get_block_templates_from_registry() {
 		$template_name = 'test-plugin//test-template';
 
-		wp_register_block_template( $template_name );
+		register_block_template( $template_name );
 
 		$templates = get_block_templates();
 
@@ -26,7 +26,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 			'title' => 'Test Template',
 		);
 
-		wp_register_block_template( $template_name, $args );
+		register_block_template( $template_name, $args );
 
 		$template = get_block_template( 'block-theme//test-template' );
 

--- a/phpunit/block-template-test.php
+++ b/phpunit/block-template-test.php
@@ -17,7 +17,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( $template_name, $templates );
 
-		wp_unregister_block_template( $template_name );
+		unregister_block_template( $template_name );
 	}
 
 	public function test_get_block_template_from_registry() {
@@ -32,6 +32,6 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		$this->assertEquals( 'Test Template', $template->title );
 
-		wp_unregister_block_template( $template_name );
+		unregister_block_template( $template_name );
 	}
 }

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -32,7 +32,7 @@ class Gutenberg_REST_Templates_Controller_6_7_Test extends WP_Test_REST_Controll
 			'post_types'  => array( 'post', 'page' ),
 		);
 
-		wp_register_block_template( $template_name, $args );
+		register_block_template( $template_name, $args );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/test-plugin//test-template' );
 		$response = rest_get_server()->dispatch( $request );

--- a/phpunit/class-gutenberg-rest-templates-controller-test.php
+++ b/phpunit/class-gutenberg-rest-templates-controller-test.php
@@ -52,7 +52,7 @@ class Gutenberg_REST_Templates_Controller_6_7_Test extends WP_Test_REST_Controll
 		$this->assertSame( 'Test Template', $data['title']['rendered'], 'Template title mismatch.' );
 		$this->assertSame( 'test-plugin', $data['plugin'], 'Plugin name mismatch.' );
 
-		wp_unregister_block_template( $template_name );
+		unregister_block_template( $template_name );
 
 		$request  = new WP_REST_Request( 'GET', '/wp/v2/templates/test-plugin//test-template' );
 		$response = rest_get_server()->dispatch( $request );


### PR DESCRIPTION
## What?
As discussed in https://github.com/WordPress/gutenberg/pull/61577, we want to remove the `wp_` prefix from `wp_register_block_template()` and `wp_unregister_block_template()`.

Backport PR in core: https://github.com/WordPress/wordpress-develop/pull/7543.

## Why?
To keep it consistent with other functions like `register_block_type`, `register_block_pattern` and `register_block_style`.

## How?

This PR directly replaces the old functions with the new ones, it doesn't deprecate them. Given that they were not shipped in WordPress core my understanding is that we don't need to keep backwards compatibility. But please, correct me if I'm wrong.

## Testing Instructions

1. Add this code to an existing plugin or in a code snippet using the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/):

```PHP
add_action(
	'init',
	function () {
		register_block_template(
			'gutenberg//plugin-template',
			array(
				'title'       => 'Plugin Template',
				'description' => 'A template registered by a plugin.',
				'content'     => '<!-- wp:template-part {"slug":"header","tagName":"header"} /--><!-- wp:group {"tagName":"main","layout":{"inherit":true}} --><main class="wp-block-group"><!-- wp:paragraph --><p>This is a plugin-registered template.</p><!-- /wp:paragraph --></main><!-- /wp:group -->',
			)
		);
		add_action(
			'category_template_hierarchy',
			function () {
				return array( 'plugin-template' );
			}
		);
	}
);
```
2. Go to a post category in the frontend (ie: `/category/test-category/`) and verify the _Plugin Template_ contents are rendered.
3. Go to Appearance > Editor > Templates and verify the `Plugin Template` appears with the correct title and description.
4. Make some edits to the template. Verify they are applied in the frontend.
5. Revert the edits and verify edits are reverted in the frontend as well.
6. Edit the previous code snippet adding these lines:
```PHP
		unregister_block_template( 'gutenberg//plugin-template' );
```
7. Verify the template no longer appears under Appearance > Editor > Templates and going to a post category in the frontend doesn't render it either.