### PR TITLE
Zoom Out: When double clicking a template while zoomed out , reset zoom level instead of showing dialog

### DIFF
--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -32,6 +32,7 @@ import { usesContextKey } from './components/rich-text/format-edit';
 import { ExperimentalBlockCanvas } from './components/block-canvas';
 import { getDuotoneFilter } from './components/duotone/utils';
 import { useFlashEditableBlocks } from './components/use-flash-editable-blocks';
+import { useZoomOutModeExit } from './components/block-list/use-block-props/use-zoom-out-mode-exit';
 import {
 	selectBlockPatternsKey,
 	reusableBlocksSelectKey,
@@ -78,6 +79,7 @@ lock( privateApis, {
 	TextAlignmentControl,
 	usesContextKey,
 	useFlashEditableBlocks,
+	useZoomOutModeExit,
 	globalStylesDataKey,
 	globalStylesLinksDataKey,
 	selectBlockPatternsKey,

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -48,6 +48,7 @@ const {
 	useLayoutStyles,
 	ExperimentalBlockCanvas: BlockCanvas,
 	useFlashEditableBlocks,
+	useZoomOutModeExit,
 } = unlock( blockEditorPrivateApis );
 
 /**
@@ -335,6 +336,7 @@ function VisualEditor( {
 		useSelectNearestEditableBlock( {
 			isEnabled: renderingMode === 'template-locked',
 		} ),
+		useZoomOutModeExit(),
 	] );
 
 	const zoomOutProps =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65505

When double clicking areas of a template while zoomed out (i.e. while template preview is switched on while editing a page or post), reset zoom level instead of showing a dialog.

Props to @PARTHVATALIYA for the original work on this fix over in https://github.com/WordPress/gutenberg/pull/65565 🙇 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While zoomed out, the idea in #65505 is that it'll feel more intuitive to cancel out of zoom out mode when double clicking areas of the template, rather than showing the dialog to switch to editing the template. As the issue described, when double clicking outside of the content area, the desire appears to be to get out of zoom out mode as the first priority.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

<!--

Because the Edit Template Blocks Notification component is what's already handling double click in this case, it seemed natural to me to co-locate the logic with that component, so it's in one place where we either show the notification, or reset the zoom level. Happy for feedback, though, if folks feel like there's a better place for this.

In terms of the logic, I mostly just copied how the Zoom Out Toggle works here: https://github.com/WordPress/gutenberg/blob/1def0f6b4ddab54e49629837ff557c2a117815e8/packages/editor/src/components/zoom-out-toggle/index.js#L17
-->

* Try to re-use the existing `useZoomOutModeExit` hook, and attach it to the editor canvas so that double clicks on the canvas will result in deactivating the zoom out mode.
* Update the `EditTemplateBlocksNotification` component so that it only handles a double click event if the `event.defaultPrevented` has not be set yet.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open up a post in the post editor
2. Switch on template preview
3. Click Zoom Out at the top of the post editor
4. Double click on part of the template (on trunk this will show the prompt to switch to template editing mode, with this PR applied, it should deactivate zoom out mode)
5. Repeat the above from the site editor while editing a page. The Zoom Out mode should deactivate when clicking on headers or footers or the page title.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Post editor:

https://github.com/user-attachments/assets/de111a3e-282d-4861-915d-8dc041fc37e7

Editing a page in the site editor:

https://github.com/user-attachments/assets/69fe00d3-6ba2-4b17-8854-dabfe5c7a5e8



