### PR TITLE
Stabilize typography block support keys

### DIFF
--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -20,16 +20,16 @@ function gutenberg_register_typography_support( $block_type ) {
 		return;
 	}
 
-	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
+	$has_font_family_support     = $typography_supports['fontFamily'] ?? $typography_supports['__experimentalFontFamily'] ?? false;
 	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
-	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
-	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
-	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_font_style_support      = $typography_supports['fontStyle'] ?? $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['fontWeight'] ?? $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['letterSpacing'] ?? $typography_supports['__experimentalLetterSpacing'] ?? false;
 	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
 	$has_text_align_support      = $typography_supports['textAlign'] ?? false;
 	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
-	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
-	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_text_decoration_support = $typography_supports['textDecoration'] ?? $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['textTransform'] ?? $typography_supports['__experimentalTextTransform'] ?? false;
 	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	$has_typography_support = $has_font_family_support
@@ -91,16 +91,16 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 		return array();
 	}
 
-	$has_font_family_support     = $typography_supports['__experimentalFontFamily'] ?? false;
+	$has_font_family_support     = $typography_supports['fontFamily'] ?? $typography_supports['__experimentalFontFamily'] ?? false;
 	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
-	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
-	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
-	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_font_style_support      = $typography_supports['fontStyle'] ?? $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['fontWeight'] ?? $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['letterSpacing'] ?? $typography_supports['__experimentalLetterSpacing'] ?? false;
 	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
 	$has_text_align_support      = $typography_supports['textAlign'] ?? false;
 	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
-	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
-	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_text_decoration_support = $typography_supports['textDecoration'] ?? $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['textTransform'] ?? $typography_supports['__experimentalTextTransform'] ?? false;
 	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	// Whether to skip individual block support features.
@@ -451,8 +451,8 @@ function gutenberg_get_computed_fluid_typography_value( $args = array() ) {
  * @since 6.6.0 Deprecated bool argument $should_use_fluid_typography.
  * @since 6.7.0 Font size presets can enable fluid typography individually, even if it’s disabled globally.
  *
- * @param array $preset       {
- *     Required. fontSizes preset value as seen in theme.json.
+ * @param array      $preset       {
+ *          Required. fontSizes preset value as seen in theme.json.
  *
  *     @type string           $name Name of the font size preset.
  *     @type string           $slug Kebab-case unique identifier for the font size preset.

--- a/lib/block-supports/typography.php
+++ b/lib/block-supports/typography.php
@@ -22,14 +22,14 @@ function gutenberg_register_typography_support( $block_type ) {
 
 	$has_font_family_support     = $typography_supports['fontFamily'] ?? $typography_supports['__experimentalFontFamily'] ?? false;
 	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
-	$has_font_style_support      = $typography_supports['fontStyle'] ?? $typography_supports['__experimentalFontStyle'] ?? false;
-	$has_font_weight_support     = $typography_supports['fontWeight'] ?? $typography_supports['__experimentalFontWeight'] ?? false;
-	$has_letter_spacing_support  = $typography_supports['letterSpacing'] ?? $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
 	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
 	$has_text_align_support      = $typography_supports['textAlign'] ?? false;
 	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
-	$has_text_decoration_support = $typography_supports['textDecoration'] ?? $typography_supports['__experimentalTextDecoration'] ?? false;
-	$has_text_transform_support  = $typography_supports['textTransform'] ?? $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
 	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	$has_typography_support = $has_font_family_support
@@ -93,14 +93,14 @@ function gutenberg_apply_typography_support( $block_type, $block_attributes ) {
 
 	$has_font_family_support     = $typography_supports['fontFamily'] ?? $typography_supports['__experimentalFontFamily'] ?? false;
 	$has_font_size_support       = $typography_supports['fontSize'] ?? false;
-	$has_font_style_support      = $typography_supports['fontStyle'] ?? $typography_supports['__experimentalFontStyle'] ?? false;
-	$has_font_weight_support     = $typography_supports['fontWeight'] ?? $typography_supports['__experimentalFontWeight'] ?? false;
-	$has_letter_spacing_support  = $typography_supports['letterSpacing'] ?? $typography_supports['__experimentalLetterSpacing'] ?? false;
+	$has_font_style_support      = $typography_supports['__experimentalFontStyle'] ?? false;
+	$has_font_weight_support     = $typography_supports['__experimentalFontWeight'] ?? false;
+	$has_letter_spacing_support  = $typography_supports['__experimentalLetterSpacing'] ?? false;
 	$has_line_height_support     = $typography_supports['lineHeight'] ?? false;
 	$has_text_align_support      = $typography_supports['textAlign'] ?? false;
 	$has_text_columns_support    = $typography_supports['textColumns'] ?? false;
-	$has_text_decoration_support = $typography_supports['textDecoration'] ?? $typography_supports['__experimentalTextDecoration'] ?? false;
-	$has_text_transform_support  = $typography_supports['textTransform'] ?? $typography_supports['__experimentalTextTransform'] ?? false;
+	$has_text_decoration_support = $typography_supports['__experimentalTextDecoration'] ?? false;
+	$has_text_transform_support  = $typography_supports['__experimentalTextTransform'] ?? false;
 	$has_writing_mode_support    = $typography_supports['__experimentalWritingMode'] ?? false;
 
 	// Whether to skip individual block support features.

--- a/packages/block-editor/src/hooks/font-family.js
+++ b/packages/block-editor/src/hooks/font-family.js
@@ -13,7 +13,7 @@ import { shouldSkipSerialization } from './utils';
 import { TYPOGRAPHY_SUPPORT_KEY } from './typography';
 import { unlock } from '../lock-unlock';
 
-export const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';
+export const FONT_FAMILY_SUPPORT_KEY = 'typography.fontFamily' ? 'typography.fontFamily' : 'typography.__experimentalFontFamily';
 const { kebabCase } = unlock( componentsPrivateApis );
 
 /**

--- a/packages/block-editor/src/hooks/supports.js
+++ b/packages/block-editor/src/hooks/supports.js
@@ -9,17 +9,17 @@ const ALIGN_WIDE_SUPPORT_KEY = 'alignWide';
 const BORDER_SUPPORT_KEY = '__experimentalBorder';
 const COLOR_SUPPORT_KEY = 'color';
 const CUSTOM_CLASS_NAME_SUPPORT_KEY = 'customClassName';
-const FONT_FAMILY_SUPPORT_KEY = 'typography.__experimentalFontFamily';
+const FONT_FAMILY_SUPPORT_KEY = 'typography.fontFamily' ? 'typography.fontFamily' : 'typography.__experimentalFontFamily';
 const FONT_SIZE_SUPPORT_KEY = 'typography.fontSize';
 const LINE_HEIGHT_SUPPORT_KEY = 'typography.lineHeight';
 /**
  * Key within block settings' support array indicating support for font style.
  */
-const FONT_STYLE_SUPPORT_KEY = 'typography.__experimentalFontStyle';
+const FONT_STYLE_SUPPORT_KEY = 'typography.fontStyle' ? 'typography.fontStyle' : 'typography.__experimentalFontStyle';
 /**
  * Key within block settings' support array indicating support for font weight.
  */
-const FONT_WEIGHT_SUPPORT_KEY = 'typography.__experimentalFontWeight';
+const FONT_WEIGHT_SUPPORT_KEY = 'typography.fontWeight' ? 'typography.fontWeight' : 'typography.__experimentalFontWeight';
 /**
  * Key within block settings' supports array indicating support for text
  * align e.g. settings found in `block.json`.
@@ -34,7 +34,7 @@ const TEXT_COLUMNS_SUPPORT_KEY = 'typography.textColumns';
  * Key within block settings' supports array indicating support for text
  * decorations e.g. settings found in `block.json`.
  */
-const TEXT_DECORATION_SUPPORT_KEY = 'typography.__experimentalTextDecoration';
+const TEXT_DECORATION_SUPPORT_KEY = 'typography.textDecoration' ? 'typography.textDecoration' : 'typography.__experimentalTextDecoration';
 /**
  * Key within block settings' supports array indicating support for writing mode
  * e.g. settings found in `block.json`.
@@ -44,13 +44,13 @@ const WRITING_MODE_SUPPORT_KEY = 'typography.__experimentalWritingMode';
  * Key within block settings' supports array indicating support for text
  * transforms e.g. settings found in `block.json`.
  */
-const TEXT_TRANSFORM_SUPPORT_KEY = 'typography.__experimentalTextTransform';
+const TEXT_TRANSFORM_SUPPORT_KEY = 'typography.textTransform' ? 'typography.textTransform' : 'typography.__experimentalTextTransform';
 
 /**
  * Key within block settings' supports array indicating support for letter-spacing
  * e.g. settings found in `block.json`.
  */
-const LETTER_SPACING_SUPPORT_KEY = 'typography.__experimentalLetterSpacing';
+const LETTER_SPACING_SUPPORT_KEY = 'typography.letterSpacing' ? 'typography.letterSpacing' : 'typography.__experimentalLetterSpacing';
 const LAYOUT_SUPPORT_KEY = 'layout';
 const TYPOGRAPHY_SUPPORT_KEYS = [
 	LINE_HEIGHT_SUPPORT_KEY,

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -46,17 +46,11 @@
 			"fontSize": true,
 			"__experimentalFontFamily": true,
 			"lineHeight": true,
-			"fontFamily": true,
 			"__experimentalFontStyle": true,
-    		"fontStyle": true,
 			"__experimentalFontWeight": true,
-			"fontWeight": true,
 			"__experimentalLetterSpacing": true,
-			"letterSpacing": true,
 			"__experimentalTextTransform": true,
-			"textTransform": true,
 			"__experimentalTextDecoration": true,
-			"textDecoration": true,
 			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true

--- a/packages/block-library/src/verse/block.json
+++ b/packages/block-library/src/verse/block.json
@@ -46,11 +46,17 @@
 			"fontSize": true,
 			"__experimentalFontFamily": true,
 			"lineHeight": true,
+			"fontFamily": true,
 			"__experimentalFontStyle": true,
+    		"fontStyle": true,
 			"__experimentalFontWeight": true,
+			"fontWeight": true,
 			"__experimentalLetterSpacing": true,
+			"letterSpacing": true,
 			"__experimentalTextTransform": true,
+			"textTransform": true,
 			"__experimentalTextDecoration": true,
+			"textDecoration": true,
 			"__experimentalWritingMode": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -183,7 +183,7 @@ export const __EXPERIMENTAL_STYLE_PROPERTY = {
 	},
 	fontFamily: {
 		value: [ 'typography', 'fontFamily' ],
-		support: [ 'typography', '__experimentalFontFamily' ],
+		support: [ 'typography', 'fontFamily' ],
 		useEngine: true,
 	},
 	fontSize: {


### PR DESCRIPTION
## What?
Split from [#63001](https://github.com/WordPress/gutenberg/issues/63001)

## Why?
This issue tracks progress towards stabilizing the typography block support with backward compatibility
Stabilized the following typography block supports:

__experimentalFontFamily → fontFamily

### Testing Instructions 
Open block.json file or area.
If you have already used it for block support __experimentalFontFamily instead we can use it fontFamily only. Similar to other block supports as well.

Note: Here we need to update the WP core blocks' block.json files to use the non __experimental prefixes.

## Screenshots or screencast <!-- if applicable -->
