### PR TITLE
Media Library: Expose filters dropdown for individual images, such as with the Image block

### DIFF
--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -71,6 +71,46 @@ const getFeaturedImageMediaFrame = () => {
 };
 
 /**
+ * Prepares the Single Image toolbars and frames.
+ *
+ * @return {window.wp.media.view.MediaFrame.Select} The default media workflow.
+ */
+const getSingleImageMediaFrame = () => {
+	const { wp } = window;
+
+	// Extend the default Select frame, and use the same `createStates` method as in core,
+	// but with the addition of `filterable: 'uploaded'` to the Library state, so that
+	// the user can filter the media library by uploaded images.
+	return wp.media.view.MediaFrame.Select.extend( {
+		/**
+		 * Create the default states on the frame.
+		 */
+		createStates() {
+			const options = this.options;
+
+			if ( this.options.states ) {
+				return;
+			}
+
+			// Add the default states.
+			this.states.add( [
+				// Main states.
+				new wp.media.controller.Library( {
+					library: wp.media.query( options.library ),
+					multiple: options.multiple,
+					title: options.title,
+					priority: 20,
+					filterable: 'uploaded', // Allow filtering by uploaded images.
+				} ),
+				new wp.media.controller.EditImage( {
+					model: options.editImage,
+				} ),
+			] );
+		},
+	} );
+};
+
+/**
  * Prepares the Gallery toolbars and frames.
  *
  * @return {window.wp.media.view.MediaFrame.Post} The default media workflow.
@@ -324,6 +364,47 @@ class MediaUpload extends Component {
 		};
 	}
 
+	/**
+	 * Initializes the Media Library requirements for the single image flow.
+	 *
+	 * @return {void}
+	 */
+	buildAndSetSingleImageFrame() {
+		const { wp } = window;
+		const {
+			allowedTypes,
+			multiple = false,
+			title = __( 'Select or Upload Media' ),
+			value,
+		} = this.props;
+
+		const frameConfig = {
+			title,
+			multiple,
+		};
+		if ( !! allowedTypes ) {
+			frameConfig.library = { type: allowedTypes };
+		}
+
+		// If a frame already exists, remove it.
+		if ( this.frame ) {
+			this.frame.remove();
+		}
+
+		const singleImageFrame = getSingleImageMediaFrame();
+		const attachments = getAttachmentsCollection( value );
+		const selection = new wp.media.model.Selection( attachments.models, {
+			props: attachments.props.toJSON(),
+		} );
+		this.frame = new singleImageFrame( {
+			mimeType: allowedTypes,
+			multiple,
+			selection,
+			...frameConfig,
+		} );
+		wp.media.frame = this.frame;
+	}
+
 	componentWillUnmount() {
 		this.frame?.remove();
 	}
@@ -424,27 +505,15 @@ class MediaUpload extends Component {
 
 	openModal() {
 		const {
-			allowedTypes,
 			gallery = false,
 			unstableFeaturedImageFlow = false,
 			modalClass,
-			multiple = false,
-			title = __( 'Select or Upload Media' ),
 		} = this.props;
-		const { wp } = window;
 
 		if ( gallery ) {
 			this.buildAndSetGalleryFrame();
 		} else {
-			const frameConfig = {
-				title,
-				multiple,
-			};
-			if ( !! allowedTypes ) {
-				frameConfig.library = { type: allowedTypes };
-			}
-
-			this.frame = wp.media( frameConfig );
+			this.buildAndSetSingleImageFrame();
 		}
 
 		if ( modalClass ) {

--- a/packages/media-utils/src/components/media-upload/index.js
+++ b/packages/media-utils/src/components/media-upload/index.js
@@ -71,16 +71,16 @@ const getFeaturedImageMediaFrame = () => {
 };
 
 /**
- * Prepares the Single Image toolbars and frames.
+ * Prepares the default frame for selecting a single media item.
  *
  * @return {window.wp.media.view.MediaFrame.Select} The default media workflow.
  */
-const getSingleImageMediaFrame = () => {
+const getSingleMediaFrame = () => {
 	const { wp } = window;
 
 	// Extend the default Select frame, and use the same `createStates` method as in core,
 	// but with the addition of `filterable: 'uploaded'` to the Library state, so that
-	// the user can filter the media library by uploaded images.
+	// the user can filter the media library by uploaded media.
 	return wp.media.view.MediaFrame.Select.extend( {
 		/**
 		 * Create the default states on the frame.
@@ -369,7 +369,7 @@ class MediaUpload extends Component {
 	 *
 	 * @return {void}
 	 */
-	buildAndSetSingleImageFrame() {
+	buildAndSetSingleMediaFrame() {
 		const { wp } = window;
 		const {
 			allowedTypes,
@@ -391,7 +391,7 @@ class MediaUpload extends Component {
 			this.frame.remove();
 		}
 
-		const singleImageFrame = getSingleImageMediaFrame();
+		const singleImageFrame = getSingleMediaFrame();
 		const attachments = getAttachmentsCollection( value );
 		const selection = new wp.media.model.Selection( attachments.models, {
 			props: attachments.props.toJSON(),
@@ -513,7 +513,7 @@ class MediaUpload extends Component {
 		if ( gallery ) {
 			this.buildAndSetGalleryFrame();
 		} else {
-			this.buildAndSetSingleImageFrame();
+			this.buildAndSetSingleMediaFrame();
 		}
 
 		if ( modalClass ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/12753

Expose the Filters dropdown within the media library modal that's used by the Image block (the default state for the `MediaUpload` component).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As reported in #12753, it's useful for folks to be able to filter by unattached images, etc, as folks can currently do via the modal for the Gallery block. This PR essentially gets parity between the Image and Gallery blocks when it comes to the filters available from the media library.

Note as reported in #12753, there is likely still some behaviour here that could be buggy. For example, this needs to be investigated:

> Worth noting here that some work would need to be done to ensure Gutenberg added images are properly seen as attached.
> Right now, you can have an image in a Gutenberg post or page but the status in WP Admin > Media will still show unattached.

This still occurs with this PR:

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/52009ad0-6712-42ca-88e8-6d41ac18593d">

However if I upload an image directly to a post within Gutenberg, it is attached correctly:

<img width="1277" alt="image" src="https://github.com/user-attachments/assets/c75d468a-e535-4d94-a2ba-ccfbe44f3762">

So, while reviewing this PR, keep that in mind when looking at the filters. If that issue feels like a blocker, we can pause this PR for now while investigating the above issue. It might need a little further investigation so that attaching images to a post only happens when we believe it's likely what the user intended 🤔 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Update the `MediaUpload` component so that when selecting single image media, the Select media frame is configured to use the `filterable` option of `'uploaded'`. To achieve this, the proposal here is to extend `wp.media.view.MediaFrame.Select`, in a similar way to how the featured image frame currently works. We then override `createStates`, using the same code as in core, only with `filterable` added in to switch on the filters.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open up the post editor
2. Add an image block
3. Browse the media library from the block
4. Notice that with this PR applied the filter dropdown is now available

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="449" alt="image" src="https://github.com/user-attachments/assets/e21c265a-5e36-4e09-9048-ec88ae609426"> | <img width="373" alt="image" src="https://github.com/user-attachments/assets/f378f971-961d-4e2e-b5ec-8b8ca1f8a474"> |

https://github.com/user-attachments/assets/6b891c0b-7d6b-4bbb-8e17-c0aa066ad51a