### PR TITLE
Update PHP block support code in lib/block-supports/border.php to use…

### DIFF
--- a/lib/block-supports/border.php
+++ b/lib/block-supports/border.php
@@ -17,7 +17,7 @@ function gutenberg_register_border_support( $block_type ) {
 		$block_type->attributes = array();
 	}
 
-	if ( block_has_support( $block_type, array( '__experimentalBorder' ) ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
+	if ( block_has_support( $block_type, array( 'border', '__experimentalBorder' ) ) && ! array_key_exists( 'style', $block_type->attributes ) ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
 		);
@@ -52,7 +52,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'radius' ) &&
 		isset( $block_attributes['style']['border']['radius'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'radius' )
+		(! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'radius' ) ||
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'radius' ))
 	) {
 		$border_radius = $block_attributes['style']['border']['radius'];
 
@@ -67,7 +68,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		gutenberg_has_border_feature_support( $block_type, 'style' ) &&
 		isset( $block_attributes['style']['border']['style'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' )
+		( ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' ) ||
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'style' ) )
 	) {
 		$border_block_styles['style'] = $block_attributes['style']['border']['style'];
 	}
@@ -76,7 +78,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	if (
 		$has_border_width_support &&
 		isset( $block_attributes['style']['border']['width'] ) &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' )
+		( ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ||
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'width' ) )
 	) {
 		$border_width = $block_attributes['style']['border']['width'];
 
@@ -91,7 +94,8 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 	// Border color.
 	if (
 		$has_border_color_support &&
-		! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' )
+		( ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ||
+		! wp_should_skip_block_supports_serialization( $block_type, 'border', 'color' ) )
 	) {
 		$preset_border_color          = array_key_exists( 'borderColor', $block_attributes ) ? "var:preset|color|{$block_attributes['borderColor']}" : null;
 		$custom_border_color          = $block_attributes['style']['border']['color'] ?? null;
@@ -103,9 +107,9 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 		foreach ( array( 'top', 'right', 'bottom', 'left' ) as $side ) {
 			$border                       = $block_attributes['style']['border'][ $side ] ?? null;
 			$border_side_values           = array(
-				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'width' ) ? $border['width'] : null,
-				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'color' ) ? $border['color'] : null,
-				'style' => isset( $border['style'] ) && ! wp_should_skip_block_supports_serialization( $block_type, '__experimentalBorder', 'style' ) ? $border['style'] : null,
+				'width' => isset( $border['width'] ) && ! wp_should_skip_block_supports_serialization( $block_type, 'border', 'width' )  ? $border['width'] : null,
+				'color' => isset( $border['color'] ) && ! wp_should_skip_block_supports_serialization( $block_type, 'border', 'color' ) ? $border['color'] : null,
+				'style' => isset( $border['style'] ) && ! wp_should_skip_block_supports_serialization( $block_type, 'border', 'style' ) ? $border['style'] : null,
 			);
 			$border_block_styles[ $side ] = $border_side_values;
 		}
@@ -143,7 +147,7 @@ function gutenberg_apply_border_support( $block_type, $block_attributes ) {
 function gutenberg_has_border_feature_support( $block_type, $feature, $default_value = false ) {
 	// Check if all border support features have been opted into via `"__experimentalBorder": true`.
 	if ( $block_type instanceof WP_Block_Type ) {
-		$block_type_supports_border = $block_type->supports['__experimentalBorder'] ?? $default_value;
+		$block_type_supports_border = $block_type->supports['border'] ?? $block_type->supports['__experimentalBorder'] ?? $default_value;
 		if ( true === $block_type_supports_border ) {
 			return true;
 		}
@@ -151,7 +155,8 @@ function gutenberg_has_border_feature_support( $block_type, $feature, $default_v
 
 	// Check if the specific feature has been opted into individually
 	// via nested flag under `__experimentalBorder`.
-	return block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default_value );
+	return block_has_support( $block_type, array( '__experimentalBorder', $feature ), $default_value )
+	|| block_has_support( $block_type, array( 'border', $feature ), $default_value );
 }
 
 // Register the block support.


### PR DESCRIPTION
… the non __experimental prefix

## What?
Updating php code to work both '--experimental' and non '--experimental ' prefix.

## Why?

Borrowing from the format of https://github.com/WordPress/gutenberg/issues/63001, this issue outlines the tasks needed to stabilize the __experimentalBorder support. Doing so will make it easier for third-party extenders to confidently build custom blocks that provide border support and modify existing blocks with this support.

## How?
Updating PHP block support code in lib/block-supports/border.php to use the non __experimental prefix, falling back to the __experimental prefix if available.

## Testing Instructions
1. Open a post or page.
2. Apply border to any of the section in the post/ page/ template.
3. Border functionality will work fine even after updating the code with non experimental prefixes.

NOTE: This PR is only handling the PHP block support  code updation for non experimental prefix.

