### PR TITLE
Zoom layout shift: Alternate fix.

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -27,8 +27,10 @@
 	@include editor-canvas-resize-animation;
 
 	// Applying flex here prevents the body element, and title inside, from margin-collapse.
-	display: flex;
-	flex-direction: column;
+	body {
+		display: flex;
+		flex-direction: column;
+	}
 }
 
 .block-editor-iframe__html.is-zoomed-out {

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -27,10 +27,8 @@
 	@include editor-canvas-resize-animation;
 
 	// Applying flex here prevents the body element, and title inside, from margin-collapse.
-	body {
-		display: flex;
-		flex-direction: column;
-	}
+	display: flex;
+	flex-direction: column;
 }
 
 .block-editor-iframe__html.is-zoomed-out {
@@ -57,6 +55,8 @@
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+		display: flex;
+		flex-direction: column;
 
 		> .is-root-container:not(.wp-block-post-content) {
 			flex: 1;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -25,6 +25,10 @@
 	border: 0 solid $gray-300;
 	transform-origin: top center;
 	@include editor-canvas-resize-animation;
+
+	// Applying flex here prevents the body element, and title inside, from margin-collapse.
+	display: flex;
+	flex-direction: column;
 }
 
 .block-editor-iframe__html.is-zoomed-out {
@@ -51,8 +55,6 @@
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
-		display: flex;
-		flex-direction: column;
 
 		> .is-root-container:not(.wp-block-post-content) {
 			flex: 1;


### PR DESCRIPTION
## What?

Alternative to #65915. Uses flex to prevent margin collapse instead of borders.

![layout shift](https://github.com/user-attachments/assets/d229a044-6790-4438-8a4e-480c2b04b86a)

## Why?

The body and title elements have margin collapsing in the shift from zoomed in to zoomed out, causing a jarring zoom experience in the post editor.

This PR fixes it by applying flex rules to the canvas container always, not just when zoomed in. Abs position, flex, grid, borders, and floats are the options we have to prevent margin collapsing.