### PR TITLE
Docs: env: Expand examples of path syntax

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -499,7 +499,7 @@ Several types of strings can be passed into the `core`, `plugins`, `themes`, and
 | ----------------- | -------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
 | Relative path     | `.<path>\|~<path>`                           | `"./a/directory"`, `"../a/directory"`, `"~/a/directory"`                                                                           |
 | Absolute path     | `/<path>\|<letter>:\<path>`                  | `"/a/directory"`, `"C:\\a\\directory"`                                                                                             |
-| GitHub repository | `<owner>/<repo>[#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, if no branch is provided wp-env will fall back to the repos default branch |
+| GitHub repository | `<owner>/<repo>[/<path>][#<ref>]`                     | `"WordPress/WordPress"`, `"WordPress/gutenberg#trunk"`, `WordPress/themes/my-theme#my-branch`; if no branch is provided wp-env will fall back to the repo's default branch |
 | SSH repository    | `ssh://user@host/<owner>/<repo>.git[#<ref>]` | `"ssh://git@github.com/WordPress/WordPress.git"`                                                                                   |
 | ZIP File          | `http[s]://<host>/<path>.zip`                | `"https://wordpress.org/wordpress-5.4-beta2.zip"`                                                                                  |
 


### PR DESCRIPTION
GitHub repository syntax (e.g. `WordPress/gutenberg#branch`) supports specifying a subpath, but this is not clear. Expand the documentation accordingly: `WordPress/themes/my-theme#my-branch`.