### PR TITLE
Exit zoom out when mode is changed

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -36,7 +36,7 @@ function ToolSelector( props, ref ) {
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { __unstableSetEditorMode } = unlock(
+	const { resetZoomLevel, __unstableSetEditorMode } = unlock(
 		useDispatch( blockEditorStore )
 	);
 
@@ -67,7 +67,10 @@ function ToolSelector( props, ref ) {
 							value={
 								mode === 'navigation' ? 'navigation' : 'edit'
 							}
-							onSelect={ __unstableSetEditorMode }
+							onSelect={ ( newMode ) => {
+								resetZoomLevel();
+								__unstableSetEditorMode( newMode );
+							} }
 							choices={ [
 								{
 									value: 'navigation',


### PR DESCRIPTION
Fixes #65901

## What?

Disables zoom out mode when editor mode is changed.

## Why?

Currently zoom out doesn't work properly when the editor mode is changed.

NOTE: This is a fix specifically for WP 6.7. Whether the zoom out feature should be treated as a "mode" in itself and where to expose this feature is still a topic for discussion in #65856.

## How?

Exit zoom out mode via `resetZoomLevel()` when mode is changed.

## Testing Instructions

- Enable zoom out mode.
- Open the tools dropdown and select Write mode.
- The zoom out mode should be exited.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/86cf9546-153a-40a0-a256-e139bc76c52a


