### PR TITLE
Add Inline Quotation Format

### DIFF
--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -15,6 +15,7 @@ import { keyboard } from './keyboard';
 import { unknown } from './unknown';
 import { language } from './language';
 import { nonBreakingSpace } from './non-breaking-space';
+import { quotation } from './quotation';
 
 export default [
 	bold,
@@ -31,4 +32,5 @@ export default [
 	unknown,
 	language,
 	nonBreakingSpace,
+	quotation,
 ];

--- a/packages/format-library/src/quotation/index.js
+++ b/packages/format-library/src/quotation/index.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { toggleFormat } from '@wordpress/rich-text';
+import {
+	RichTextToolbarButton,
+	RichTextShortcut,
+} from '@wordpress/block-editor';
+import { quote as quoteIcon } from '@wordpress/icons';
+
+const name = 'core/quotation';
+const title = __( 'Inline Quotation' );
+
+export const quotation = {
+	name,
+	title,
+	tagName: 'q',
+	className: null,
+	edit( { isActive, value, onChange, onFocus } ) {
+		function onToggle() {
+			onChange( toggleFormat( value, { type: name, title } ) );
+		}
+
+		function onClick() {
+			onToggle();
+			onFocus();
+		}
+
+		return (
+			<>
+				<RichTextShortcut
+					type="access"
+					character="q"
+					onUse={ onToggle }
+				/>
+				<RichTextToolbarButton
+					icon={ quoteIcon }
+					title={ title }
+					onClick={ onClick }
+					isActive={ isActive }
+					role="menuitemcheckbox"
+				/>
+			</>
+		);
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds an quotation format to support for short inline quotations using the `<q>` tag.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allowing inline quotes for better content structuring and WCAG compliance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR introduces a new format type `core/quotation` with a corresponding toolbar button and keyboard shortcut.

## Testing Instructions
1. Open a post or page in the Gutenberg editor.
2. Select a portion of text.
3. Click the quotation button in the toolbar to apply the inline quotation format.
4. Verify that the inline quote text is wrapped in a `<q>` tag and is correctly rendered in the editor and in the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Open a post or page in the Gutenberg editor.
2. Select some text within a paragraph block using the keyboard.
3. Press `Ctrl+Option+q` (on Apple devices) or `Shift+Alt+q` (on non-Apple devices) to apply the inline quotation format.
4. Verify that the selected text is wrapped in a `<q>` tag.
5. Press `Ctrl+Option+q` (on Apple devices) or `Shift+Alt+q` (on non-Apple devices) again to remove the inline quotation format.
6. Ensure that the format is applied and removed correctly using only the keyboard.

## Screenshots or screencast <!-- if applicable -->
![image](https://github.com/user-attachments/assets/c3051456-a8a2-4772-8522-b7512d6aa38a)
