### PR TITLE
Zoom out: e2e for vertical toolbar appearance

### DIFF
--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -69,9 +69,11 @@ test.describe( 'Zoom Out', () => {
 		const firstPatternRect = await firstPattern.boundingBox();
 
 		//Check that the toolbar is vertically aligned to the pattern and to the left
-		expect( toolbarRect.y ).toEqual( firstPatternRect.y );
-		expect( toolbarRect.x + toolbarRect.width ).toEqual(
-			firstPatternRect.x
+		expect( Math.round( toolbarRect.y ) ).toEqual(
+			Math.round( firstPatternRect.y )
 		);
+		expect(
+			Math.round( toolbarRect.x ) + Math.round( toolbarRect.width )
+		).toEqual( Math.round( firstPatternRect.x ) );
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -44,4 +44,22 @@ test.describe( 'Zoom Out', () => {
 		expect( htmlRect.y + paddingTop ).toBeGreaterThan( iframeRect.y );
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
 	} );
+
+	test( 'When in zoom out, a vertical toolbar appears for sections', async ( {
+		page,
+		editor,
+	} ) => {
+		await page.getByLabel( 'Zoom Out' ).click();
+
+		//Click on the first pattern of the theme
+		await editor.canvas
+			.locator( 'div' )
+			.filter( { hasText: 'A commitment to innovation' } )
+			.nth( 1 )
+			.click();
+
+		await expect(
+			page.getByRole( 'toolbar', { name: 'Block tools' } )
+		).toBeVisible();
+	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -51,15 +51,27 @@ test.describe( 'Zoom Out', () => {
 	} ) => {
 		await page.getByLabel( 'Zoom Out' ).click();
 
-		//Click on the first pattern of the theme
-		await editor.canvas
+		const firstPattern = editor.canvas
 			.locator( 'div' )
 			.filter( { hasText: 'A commitment to innovation' } )
-			.nth( 1 )
-			.click();
+			.nth( 1 );
 
-		await expect(
-			page.getByRole( 'toolbar', { name: 'Block tools' } )
-		).toBeVisible();
+		//Click on the first pattern of the theme
+		await firstPattern.click();
+
+		const toolbar = page.getByRole( 'toolbar', {
+			name: 'Block tools',
+		} );
+
+		await expect( toolbar ).toBeVisible();
+
+		const toolbarRect = await toolbar.boundingBox();
+		const firstPatternRect = await firstPattern.boundingBox();
+
+		//Check that the toolbar is vertically aligned to the pattern and to the left
+		expect( toolbarRect.y ).toEqual( firstPatternRect.y );
+		expect( toolbarRect.x + toolbarRect.width ).toEqual(
+			firstPatternRect.x
+		);
 	} );
 } );


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of https://github.com/WordPress/gutenberg/issues/65797
Right now based on top of https://github.com/WordPress/gutenberg/pull/65943 until it gets merged

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We didn't have any e2e tests for zoom out mode

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Checks if the vertical toolbar appears for a selected section on zoom out and checks that it's aligned correctly to the side of the section

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Run `npm run test:e2e -- site-editor/zoom-out.spec.js` and the tests should pass