### PR TITLE
Fix moving block popover when zoomed out

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -180,8 +180,16 @@ function BlockPopoverInbetween( {
 		const observer = new window.MutationObserver( forcePopoverRecompute );
 		observer.observe( previousElement, { attributes: true } );
 
+		const zoomedOutObserver = new window.MutationObserver(
+			forcePopoverRecompute
+		);
+		zoomedOutObserver.observe( previousElement.closest( 'html' ), {
+			attributes: true,
+		} );
+
 		return () => {
 			observer.disconnect();
+			zoomedOutObserver.disconnect();
 		};
 	}, [ previousElement ] );
 
@@ -192,8 +200,16 @@ function BlockPopoverInbetween( {
 		const observer = new window.MutationObserver( forcePopoverRecompute );
 		observer.observe( nextElement, { attributes: true } );
 
+		const zoomedOutObserver = new window.MutationObserver(
+			forcePopoverRecompute
+		);
+		zoomedOutObserver.observe( nextElement.closest( 'html' ), {
+			attributes: true,
+		} );
+
 		return () => {
 			observer.disconnect();
+			zoomedOutObserver.disconnect();
 		};
 	}, [ nextElement ] );
 

--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -69,8 +69,16 @@ function BlockPopover(
 		);
 		observer.observe( selectedElement, { attributes: true } );
 
+		const zoomedOutObserver = new window.MutationObserver(
+			forceRecomputePopoverDimensions
+		);
+		zoomedOutObserver.observe( selectedElement.closest( 'html' ), {
+			attributes: true,
+		} );
+
 		return () => {
 			observer.disconnect();
+			zoomedOutObserver.disconnect();
 		};
 	}, [ selectedElement ] );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65188

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The anchor of block popover for both the toolbar and the inserter only recomputes if the slection has any transform, but when zoomed out the whole container is transformed and the anchor of the block popover remains behind.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added more observers 🤷🏻 
I am thinking we could have some sort of event to subscribe to?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a template
2. Select a block
3. Enable zoom out
4. Notice the block toolbar and inserters
5. Open inserters
6. _Notice the blcok toolbar and inserters are still anchored to selection_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0c5b636e-9095-4acb-8462-f4edfaf685c2



