### PR TITLE
Storybook: Add stub doc on existing colors.

### DIFF
--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -1,0 +1,104 @@
+import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
+
+<Meta title="Tokens/Color" name="page" />
+
+# Color
+
+This document outlines the default color set of the WordPress component system as it ships. The page is a work in progress. 
+
+
+## Gray Tones
+
+<ColorPalette>
+	<ColorItem
+		title="Black"
+		subtitle="Pure black. For UI, use Gray 900"
+		colors={{
+			'$black': '#000',
+		}}
+	/>
+	<ColorItem
+		title="Gray 900"
+		subtitle="Default text/icon color."
+		colors={{
+			'$gray-900': '#1e1e1e',
+		}}
+	/>
+	<ColorItem
+		title="Gray 800"
+		subtitle=""
+		colors={{
+			'$gray-800': '#2f2f2f',
+		}}
+	/>
+	<ColorItem
+		title="Gray 700"
+		subtitle="Meets 4.6:1 text contrast against white."
+		colors={{
+			'$gray-700': '#757575',
+		}}
+	/>
+	<ColorItem
+		title="Gray 600"
+		subtitle="Meets 3:1 UI or large text contrast against white."
+		colors={{
+			'$gray-600': '#949494',
+		}}
+	/>
+	<ColorItem
+		title="Gray 400"
+		subtitle=""
+		colors={{
+			'$gray-400': '#ccc',
+		}}
+	/>
+	<ColorItem
+		title="Gray 300"
+		subtitle="Used for most borders on white."
+		colors={{
+			'$gray-300': '#ddd',
+		}}
+	/>
+	<ColorItem
+		title="Gray 200"
+		subtitle="Used sparingly for light borders on white."
+		colors={{
+			'$gray-200': '#e0e0e0',
+		}}
+	/>
+	<ColorItem
+		title="Gray 100"
+		subtitle=""
+		colors={{
+			'$gray-100': '#f0f0f0',
+		}}
+	/>
+	<ColorItem
+		title="White"
+		subtitle="Used for light gray backgrounds."
+		colors={{
+			'$white': '#fff',
+		}}
+	/>
+</ColorPalette>
+
+
+
+## Other
+
+<ColorPalette>
+	<ColorItem
+		title="Alert colors"
+		subtitle=""
+		colors={{
+			'Alert Yellow': '#f0b849',
+			'Alert Red': '#cc1818',
+			'Alert Green': '#4ab866',
+		}}
+	/>
+</ColorPalette>
+
+
+
+
+

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -6,85 +6,26 @@ import { Meta, ColorPalette, ColorItem } from '@storybook/blocks';
 
 This document outlines the default color set of the WordPress component system as it ships. The page is a work in progress. 
 
-
-## Gray Tones
+## Colors
 
 <ColorPalette>
 	<ColorItem
-		title="Black"
-		subtitle="Pure black. For UI, use Gray 900"
+		title="Gray Tones"
+		subtitle=""
 		colors={{
 			'$black': '#000',
-		}}
-	/>
-	<ColorItem
-		title="Gray 900"
-		subtitle="Default text/icon color."
-		colors={{
 			'$gray-900': '#1e1e1e',
-		}}
-	/>
-	<ColorItem
-		title="Gray 800"
-		subtitle=""
-		colors={{
 			'$gray-800': '#2f2f2f',
-		}}
-	/>
-	<ColorItem
-		title="Gray 700"
-		subtitle="Meets 4.5:1 text contrast against white."
-		colors={{
 			'$gray-700': '#757575',
-		}}
-	/>
-	<ColorItem
-		title="Gray 600"
-		subtitle="Meets 3:1 UI or large text contrast against white."
-		colors={{
 			'$gray-600': '#949494',
-		}}
-	/>
-	<ColorItem
-		title="Gray 400"
-		subtitle=""
-		colors={{
 			'$gray-400': '#ccc',
-		}}
-	/>
-	<ColorItem
-		title="Gray 300"
-		subtitle="Used for most borders on white."
-		colors={{
 			'$gray-300': '#ddd',
-		}}
-	/>
-	<ColorItem
-		title="Gray 200"
-		subtitle="Used sparingly for light borders on white."
-		colors={{
 			'$gray-200': '#e0e0e0',
-		}}
-	/>
-	<ColorItem
-		title="Gray 100"
-		subtitle=""
-		colors={{
 			'$gray-100': '#f0f0f0',
-		}}
-	/>
-	<ColorItem
-		title="White"
-		subtitle="Used for light gray backgrounds."
-		colors={{
 			'$white': '#fff',
 		}}
 	/>
 </ColorPalette>
-
-
-
-## Other
 
 <ColorPalette>
 	<ColorItem
@@ -98,7 +39,14 @@ This document outlines the default color set of the WordPress component system a
 	/>
 </ColorPalette>
 
+## Contrast
 
+Ensure proper contrast is met between text, icons, UI, and backgrounds. Text needs to meet a 4.5:1 ratio to meet AA standards, while large text (16px+) and UI elements (borders, etc.) need to meet a 3:1 ratio. In this section is a list of tokens you can use to meet these criteria.
 
+Against a white background:
 
+* **Gray 700**\
+Lightest gray you can use and meet 4.5:1 text contrast.
 
+* **Gray 600**\
+Lightest gray you can use and meet 3:1 UI contrast.

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -33,7 +33,7 @@ This document outlines the default color set of the WordPress component system a
 	/>
 	<ColorItem
 		title="Gray 700"
-		subtitle="Meets 4.6:1 text contrast against white."
+		subtitle="Meets 4.5:1 text contrast against white."
 		colors={{
 			'$gray-700': '#757575',
 		}}

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -10,10 +10,20 @@ This document outlines the default color set of the WordPress component system a
 
 <ColorPalette>
 	<ColorItem
-		title="Gray Tones"
+		title="Black & White"
 		subtitle=""
 		colors={{
 			'$black': '#000',
+			'$white': '#fff',
+		}}
+	/>
+</ColorPalette>
+
+<ColorPalette>
+	<ColorItem
+		title="Gray Tones"
+		subtitle=""
+		colors={{
 			'$gray-900': '#1e1e1e',
 			'$gray-800': '#2f2f2f',
 			'$gray-700': '#757575',
@@ -22,7 +32,6 @@ This document outlines the default color set of the WordPress component system a
 			'$gray-300': '#ddd',
 			'$gray-200': '#e0e0e0',
 			'$gray-100': '#f0f0f0',
-			'$white': '#fff',
 		}}
 	/>
 </ColorPalette>

--- a/storybook/stories/tokens/color.mdx
+++ b/storybook/stories/tokens/color.mdx
@@ -32,9 +32,9 @@ This document outlines the default color set of the WordPress component system a
 		title="Alert colors"
 		subtitle=""
 		colors={{
-			'Alert Yellow': '#f0b849',
-			'Alert Red': '#cc1818',
-			'Alert Green': '#4ab866',
+			'$alert-yellow': '#f0b849',
+			'$alert-red': '#cc1818',
+			'$alert-green': '#4ab866',
 		}}
 	/>
 </ColorPalette>


### PR DESCRIPTION
## What?

Adds a first stub file for a new Storybook document on the colors that exist in [base styles](https://github.com/WordPress/gutenberg/blob/trunk/packages/base-styles/_colors.scss).

![2024-10-09 12 10 02 localhost c91af00f1d2a](https://github.com/user-attachments/assets/4b844b03-e8f8-45e0-a7db-054ace8d2520)

## Why?

You shouldn't have to look in an SCSS file to find the existing colors documented,

## Testing Instructions

Check out the branch, and run storybook: `npm run storybook:dev`, then browse to Tokens > Color
