### PR TITLE
Remove the verb Toggle from the Block Inserter button.

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -322,7 +322,7 @@ function InserterMenu(
 					onSelect={ handleSetSelectedTab }
 					onClose={ onClose }
 					selectedTab={ selectedTab }
-					closeButtonLabel={ __( 'Close block inserter' ) }
+					closeButtonLabel={ __( 'Close Block Inserter' ) }
 					tabs={ [
 						{
 							name: 'blocks',

--- a/packages/e2e-test-utils/src/inserter.js
+++ b/packages/e2e-test-utils/src/inserter.js
@@ -49,12 +49,12 @@ async function isGlobalInserterOpen() {
 		return !! document.querySelector(
 			'.edit-post-header [aria-label="Add block"].is-pressed,' +
 				'.edit-site-header-edit-mode [aria-label="Add block"].is-pressed,' +
-				'.edit-post-header [aria-label="Toggle block inserter"].is-pressed,' +
-				'.edit-site-header [aria-label="Toggle block inserter"].is-pressed,' +
-				'.edit-widgets-header [aria-label="Toggle block inserter"].is-pressed,' +
+				'.edit-post-header [aria-label="Block Inserter"].is-pressed,' +
+				'.edit-site-header [aria-label="Block Inserter"].is-pressed,' +
+				'.edit-widgets-header [aria-label="Block Inserter"].is-pressed,' +
 				'.edit-widgets-header [aria-label="Add block"].is-pressed,' +
 				'.edit-site-header-edit-mode__inserter-toggle.is-pressed,' +
-				'.editor-header [aria-label="Toggle block inserter"].is-pressed'
+				'.editor-header [aria-label="Block Inserter"].is-pressed'
 		);
 	} );
 }
@@ -68,10 +68,10 @@ export async function toggleGlobalBlockInserter() {
 		'.editor-document-tools__inserter-toggle,' +
 			'.edit-post-header [aria-label="Add block"],' +
 			'.edit-site-header [aria-label="Add block"],' +
-			'.edit-post-header [aria-label="Toggle block inserter"],' +
-			'.edit-site-header [aria-label="Toggle block inserter"],' +
+			'.edit-post-header [aria-label="Block Inserter"],' +
+			'.edit-site-header [aria-label="Block Inserter"],' +
 			'.edit-widgets-header [aria-label="Add block"],' +
-			'.edit-widgets-header [aria-label="Toggle block inserter"],' +
+			'.edit-widgets-header [aria-label="Block Inserter"],' +
 			'.edit-site-header-edit-mode__inserter-toggle'
 	);
 }

--- a/packages/edit-widgets/src/components/header/document-tools/index.js
+++ b/packages/edit-widgets/src/components/header/document-tools/index.js
@@ -72,7 +72,7 @@ function DocumentTools() {
 				/* translators: button label text should, if possible, be under 16
 					characters. */
 				label={ _x(
-					'Toggle block inserter',
+					'Block Inserter',
 					'Generic label for block inserter button'
 				) }
 				size="compact"

--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -47,7 +47,7 @@ export default function InserterSidebar() {
 					__next40pxDefaultSize
 					icon={ close }
 					onClick={ closeInserter }
-					label={ __( 'Close block inserter' ) }
+					label={ __( 'Close Block Inserter' ) }
 				/>
 			</TagName>
 			<div className="edit-widgets-layout__inserter-panel-content">

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -96,7 +96,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 
 	/* translators: button label text should, if possible, be under 16 characters. */
 	const longLabel = _x(
-		'Toggle block inserter',
+		'Block Inserter',
 		'Generic label for block inserter button'
 	);
 	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -33,10 +33,8 @@ test.describe( 'Columns', () => {
 			.first()
 			.click();
 
-		// Toggle Block inserter
-		await page
-			.locator( 'role=button[name="Toggle block inserter"i]' )
-			.click();
+		// Block Inserter
+		await page.locator( 'role=button[name="Block Inserter"i]' ).click();
 
 		// Verify Column
 		const inserterOptions = page.locator(

--- a/test/e2e/specs/editor/blocks/group.spec.js
+++ b/test/e2e/specs/editor/blocks/group.spec.js
@@ -14,7 +14,7 @@ test.describe( 'Group', () => {
 	} ) => {
 		// Search for the group block and insert it.
 		const inserterButton = page.locator(
-			'role=button[name="Toggle block inserter"i]'
+			'role=button[name="Block Inserter"i]'
 		);
 
 		await inserterButton.click();

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -438,6 +438,7 @@ test.describe( 'Image', () => {
 		async function openMediaTab() {
 			const blockInserter = page.getByRole( 'button', {
 				name: 'Block Inserter',
+				exact: true,
 			} );
 			const isClosed =
 				( await blockInserter.getAttribute( 'aria-pressed' ) ) ===

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -437,7 +437,7 @@ test.describe( 'Image', () => {
 
 		async function openMediaTab() {
 			const blockInserter = page.getByRole( 'button', {
-				name: 'Toggle block inserter',
+				name: 'Block Inserter',
 			} );
 			const isClosed =
 				( await blockInserter.getAttribute( 'aria-pressed' ) ) ===

--- a/test/e2e/specs/editor/plugins/allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/allowed-blocks.spec.js
@@ -20,7 +20,9 @@ test.describe( 'Allowed Blocks Filter', () => {
 		page,
 	} ) => {
 		// The paragraph block is available.
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		const searchbox = page
 			.getByRole( 'region', { name: 'Block Library' } )

--- a/test/e2e/specs/editor/plugins/allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/allowed-blocks.spec.js
@@ -20,9 +20,7 @@ test.describe( 'Allowed Blocks Filter', () => {
 		page,
 	} ) => {
 		// The paragraph block is available.
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		const searchbox = page
 			.getByRole( 'region', { name: 'Block Library' } )

--- a/test/e2e/specs/editor/plugins/block-directory.spec.js
+++ b/test/e2e/specs/editor/plugins/block-directory.spec.js
@@ -122,7 +122,7 @@ test.describe( 'Block Directory', () => {
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -209,7 +209,7 @@ test.describe( 'Block Directory', () => {
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {

--- a/test/e2e/specs/editor/plugins/block-directory.spec.js
+++ b/test/e2e/specs/editor/plugins/block-directory.spec.js
@@ -122,7 +122,7 @@ test.describe( 'Block Directory', () => {
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -209,7 +209,7 @@ test.describe( 'Block Directory', () => {
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {

--- a/test/e2e/specs/editor/plugins/block-icons.spec.js
+++ b/test/e2e/specs/editor/plugins/block-icons.spec.js
@@ -26,7 +26,7 @@ test.describe( 'Block Icons', () => {
 	test( 'Block with svg icon', async ( { editor, page } ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -60,7 +60,7 @@ test.describe( 'Block Icons', () => {
 	test( 'Block with dash icon', async ( { editor, page } ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -100,7 +100,7 @@ test.describe( 'Block Icons', () => {
 	test( 'Block with function icon', async ( { editor, page } ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -137,7 +137,7 @@ test.describe( 'Block Icons', () => {
 	} ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -185,7 +185,7 @@ test.describe( 'Block Icons', () => {
 	} ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {

--- a/test/e2e/specs/editor/plugins/block-icons.spec.js
+++ b/test/e2e/specs/editor/plugins/block-icons.spec.js
@@ -26,7 +26,7 @@ test.describe( 'Block Icons', () => {
 	test( 'Block with svg icon', async ( { editor, page } ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -60,7 +60,7 @@ test.describe( 'Block Icons', () => {
 	test( 'Block with dash icon', async ( { editor, page } ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -100,7 +100,7 @@ test.describe( 'Block Icons', () => {
 	test( 'Block with function icon', async ( { editor, page } ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -137,7 +137,7 @@ test.describe( 'Block Icons', () => {
 	} ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {
@@ -185,7 +185,7 @@ test.describe( 'Block Icons', () => {
 	} ) => {
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		const blockLibrary = page.getByRole( 'region', {

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -21,9 +21,7 @@ test.describe( 'Block variations', () => {
 	test( 'Search for the overridden default Quote block', async ( {
 		page,
 	} ) => {
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
@@ -62,9 +60,7 @@ test.describe( 'Block variations', () => {
 	test( 'Search for the Paragraph block with 2 additional variations', async ( {
 		page,
 	} ) => {
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )

--- a/test/e2e/specs/editor/plugins/block-variations.spec.js
+++ b/test/e2e/specs/editor/plugins/block-variations.spec.js
@@ -21,7 +21,9 @@ test.describe( 'Block variations', () => {
 	test( 'Search for the overridden default Quote block', async ( {
 		page,
 	} ) => {
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
@@ -60,7 +62,9 @@ test.describe( 'Block variations', () => {
 	test( 'Search for the Paragraph block with 2 additional variations', async ( {
 		page,
 	} ) => {
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Child Blocks', () => {
 	test( 'are hidden from the global block inserter', async ( { page } ) => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } );
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',
 		} );
@@ -47,7 +47,7 @@ test.describe( 'Child Blocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',
@@ -85,7 +85,7 @@ test.describe( 'Child Blocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',

--- a/test/e2e/specs/editor/plugins/child-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/child-blocks.spec.js
@@ -19,7 +19,7 @@ test.describe( 'Child Blocks', () => {
 	test( 'are hidden from the global block inserter', async ( { page } ) => {
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter' } );
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',
 		} );
@@ -47,7 +47,7 @@ test.describe( 'Child Blocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter' } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',
@@ -85,7 +85,7 @@ test.describe( 'Child Blocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter' } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -45,7 +45,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',
@@ -92,7 +92,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',

--- a/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
+++ b/test/e2e/specs/editor/plugins/inner-blocks-allowed-blocks.spec.js
@@ -45,7 +45,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter' } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',
@@ -92,7 +92,7 @@ test.describe( 'Allowed Blocks Setting on InnerBlocks', () => {
 
 		const blockInserter = page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } );
+			.getByRole( 'button', { name: 'Block Inserter' } );
 		const blockLibrary = page
 			.getByRole( 'region', {
 				name: 'Block Library',

--- a/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
+++ b/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
@@ -60,7 +60,9 @@ test.describe( 'Preventing Pattern Recursion (server)', () => {
 		editor,
 	} ) => {
 		// Click the Block Inserter button
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 		// Click the Patterns tab
 		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
 		// Click the Uncategorized tab

--- a/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
+++ b/test/e2e/specs/editor/plugins/pattern-recursion.spec.js
@@ -59,10 +59,8 @@ test.describe( 'Preventing Pattern Recursion (server)', () => {
 		page,
 		editor,
 	} ) => {
-		// Click the Toggle block inserter button
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		// Click the Block Inserter button
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 		// Click the Patterns tab
 		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
 		// Click the Uncategorized tab

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -208,7 +208,7 @@ test.describe( 'Post-type locking', () => {
 			await expect(
 				page
 					.getByRole( 'toolbar', { name: 'Document tools' } )
-					.getByRole( 'button', { name: 'Toggle block inserter' } )
+					.getByRole( 'button', { name: 'Block Inserter' } )
 			).toBeEnabled();
 
 			await editor.insertBlock( { name: 'core/list' } );

--- a/test/e2e/specs/editor/plugins/post-type-locking.spec.js
+++ b/test/e2e/specs/editor/plugins/post-type-locking.spec.js
@@ -208,7 +208,10 @@ test.describe( 'Post-type locking', () => {
 			await expect(
 				page
 					.getByRole( 'toolbar', { name: 'Document tools' } )
-					.getByRole( 'button', { name: 'Block Inserter' } )
+					.getByRole( 'button', {
+						name: 'Block Inserter',
+						exact: true,
+					} )
 			).toBeEnabled();
 
 			await editor.insertBlock( { name: 'core/list' } );

--- a/test/e2e/specs/editor/plugins/register-block-type-hooks.spec.js
+++ b/test/e2e/specs/editor/plugins/register-block-type-hooks.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Register block type hooks', () => {
 	} );
 
 	test( 'has a custom category for Paragraph block', async ( { page } ) => {
-		await page.click( 'role=button[name="Toggle block inserter"i]' );
+		await page.click( 'role=button[name="Block Inserter"i]' );
 
 		expect(
 			page.locator(

--- a/test/e2e/specs/editor/various/a11y.spec.js
+++ b/test/e2e/specs/editor/various/a11y.spec.js
@@ -40,10 +40,10 @@ test.describe( 'a11y (@firefox, @webkit)', () => {
 
 		// This test assumes the Editor is not in Fullscreen mode. Check the
 		// first tabbable element within the 'Editor top bar' region is the
-		// 'Toggle block inserter' button.
+		// 'Block Inserter' button.
 		await pageUtils.pressKeys( 'Tab' );
 		await expect(
-			page.locator( 'role=button[name=/Toggle block inserter/i]' )
+			page.locator( 'role=button[name=/Block Inserter/i]' )
 		).toBeFocused();
 	} );
 

--- a/test/e2e/specs/editor/various/adding-patterns.spec.js
+++ b/test/e2e/specs/editor/various/adding-patterns.spec.js
@@ -9,7 +9,7 @@ test.describe( 'adding patterns', () => {
 	} );
 
 	test( 'should insert a block pattern', async ( { page, editor } ) => {
-		await page.getByLabel( 'Toggle block inserter' ).click();
+		await page.getByLabel( 'Block Inserter' ).click();
 
 		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
 		await page.fill(

--- a/test/e2e/specs/editor/various/allowed-patterns.spec.js
+++ b/test/e2e/specs/editor/various/allowed-patterns.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Allowed Patterns', () => {
 		await admin.createNewPost();
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 
 		await page
@@ -61,7 +61,7 @@ test.describe( 'Allowed Patterns', () => {
 			await admin.createNewPost();
 			await page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Block Inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 
 			await page

--- a/test/e2e/specs/editor/various/allowed-patterns.spec.js
+++ b/test/e2e/specs/editor/various/allowed-patterns.spec.js
@@ -18,7 +18,7 @@ test.describe( 'Allowed Patterns', () => {
 		await admin.createNewPost();
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 
 		await page
@@ -61,7 +61,7 @@ test.describe( 'Allowed Patterns', () => {
 			await admin.createNewPost();
 			await page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Toggle block inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter' } )
 				.click();
 
 			await page

--- a/test/e2e/specs/editor/various/block-visibility.spec.js
+++ b/test/e2e/specs/editor/various/block-visibility.spec.js
@@ -42,9 +42,7 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
 			.getByRole( 'searchbox', {
@@ -59,9 +57,7 @@ test.describe( 'Block Visibility', () => {
 			'Heading block should not be visible'
 		).toBeHidden();
 
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		// Show heading block again.
 		await BlockVisibilityUtils.openBlockVisibilityManager();
@@ -83,9 +79,7 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
 			.getByRole( 'searchbox', {
@@ -117,9 +111,7 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		await expect(
 			page
@@ -128,9 +120,7 @@ test.describe( 'Block Visibility', () => {
 			'Media category should not be visible'
 		).toBeHidden();
 
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		// Show Media category blocks again.
 		await BlockVisibilityUtils.openBlockVisibilityManager();
@@ -152,9 +142,7 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 
 		await expect(
 			page

--- a/test/e2e/specs/editor/various/block-visibility.spec.js
+++ b/test/e2e/specs/editor/various/block-visibility.spec.js
@@ -42,7 +42,9 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
 			.getByRole( 'searchbox', {
@@ -57,7 +59,9 @@ test.describe( 'Block Visibility', () => {
 			'Heading block should not be visible'
 		).toBeHidden();
 
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		// Show heading block again.
 		await BlockVisibilityUtils.openBlockVisibilityManager();
@@ -79,7 +83,9 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 		await page
 			.getByRole( 'region', { name: 'Block Library' } )
 			.getByRole( 'searchbox', {
@@ -111,7 +117,9 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		await expect(
 			page
@@ -120,7 +128,9 @@ test.describe( 'Block Visibility', () => {
 			'Media category should not be visible'
 		).toBeHidden();
 
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		// Show Media category blocks again.
 		await BlockVisibilityUtils.openBlockVisibilityManager();
@@ -142,7 +152,9 @@ test.describe( 'Block Visibility', () => {
 			} )
 			.getByRole( 'button', { name: 'Close' } )
 			.click();
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 
 		await expect(
 			page

--- a/test/e2e/specs/editor/various/editor-modes.spec.js
+++ b/test/e2e/specs/editor/various/editor-modes.spec.js
@@ -115,7 +115,7 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Block Inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 		).toBeDisabled();
 
 		// Go back to the visual editor.

--- a/test/e2e/specs/editor/various/editor-modes.spec.js
+++ b/test/e2e/specs/editor/various/editor-modes.spec.js
@@ -115,7 +115,7 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 		await expect(
 			page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Toggle block inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter' } )
 		).toBeDisabled();
 
 		// Go back to the visual editor.

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -72,7 +72,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		);
 
 		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
 		);
 
 		await page.fill(
@@ -135,7 +135,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		);
 
 		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
 		);
 
 		await page.fill(
@@ -191,7 +191,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		);
 
 		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
 		);
 
 		const PATTERN_NAME = 'Standard';
@@ -283,7 +283,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		// Insert a synced pattern.
 		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
 		);
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
@@ -347,7 +347,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		);
 
 		await page.click(
-			'role=region[name="Editor top bar"i] >> role=button[name="Toggle block inserter"i]'
+			'role=region[name="Editor top bar"i] >> role=button[name="Block Inserter"i]'
 		);
 
 		const PATTERN_NAME = 'Standard';
@@ -389,7 +389,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await admin.createNewPost();
 
 		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
+			name: 'Block Inserter',
 		} );
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',
@@ -503,7 +503,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await editor.selectBlocks( paragraphBlock );
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
@@ -624,7 +624,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await admin.createNewPost();
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 		await page.getByRole( 'option', { name: 'More', exact: true } ).click();
 
@@ -646,7 +646,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await admin.createNewPost();
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
@@ -674,7 +674,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 			await page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Toggle block inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter' } )
 				.click();
 			await page
 				.getByRole( 'listbox', { name: 'Media' } )
@@ -726,7 +726,7 @@ test.describe( 'insert media from inserter', () => {
 	} ) => {
 		await admin.createNewPost();
 
-		await page.getByLabel( 'Toggle block inserter' ).click();
+		await page.getByLabel( 'Block Inserter' ).click();
 		await page.getByRole( 'tab', { name: 'Media' } ).click();
 		await page.getByRole( 'tab', { name: 'Images' } ).click();
 		await page.getByLabel( uploadedMedia.title.raw ).click();

--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -390,6 +390,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 		const inserterButton = page.getByRole( 'button', {
 			name: 'Block Inserter',
+			exact: true,
 		} );
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',
@@ -503,7 +504,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await editor.selectBlocks( paragraphBlock );
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
@@ -624,7 +625,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await admin.createNewPost();
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 		await page.getByRole( 'option', { name: 'More', exact: true } ).click();
 
@@ -646,7 +647,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 		await admin.createNewPost();
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 		await page
 			.getByRole( 'listbox', { name: 'Text' } )
@@ -674,7 +675,7 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 
 			await page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Block Inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 			await page
 				.getByRole( 'listbox', { name: 'Media' } )

--- a/test/e2e/specs/editor/various/parsing-patterns.spec.js
+++ b/test/e2e/specs/editor/various/parsing-patterns.spec.js
@@ -15,7 +15,7 @@ test.describe( 'Parsing patterns', () => {
 			innerBlocks: [ { name: 'core/button', attributes: { text: 'a' } } ],
 		} );
 		await page.keyboard.press( 'ArrowDown' );
-		await page.getByLabel( 'Toggle block inserter' ).click();
+		await page.getByLabel( 'Block Inserter' ).click();
 
 		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
 		await page.evaluate( () => {

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -495,7 +495,9 @@ test.describe( 'Synced pattern', () => {
 			attributes: { ref: id },
 		} );
 
-		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+		await page
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+			.click();
 		await page
 			.getByRole( 'searchbox', {
 				name: 'Search',

--- a/test/e2e/specs/editor/various/patterns.spec.js
+++ b/test/e2e/specs/editor/various/patterns.spec.js
@@ -63,7 +63,7 @@ test.describe( 'Unsynced pattern', () => {
 
 		// Check that the new pattern is available in the inserter and that it gets inserted as
 		// a plain paragraph block.
-		await page.getByLabel( 'Toggle block inserter' ).click();
+		await page.getByLabel( 'Block Inserter' ).click();
 		await page
 			.getByRole( 'tab', {
 				name: 'Patterns',
@@ -166,7 +166,7 @@ test.describe( 'Synced pattern', () => {
 		).toBe( true );
 
 		// Check that the new pattern is available in the inserter.
-		await page.getByLabel( 'Toggle block inserter' ).click();
+		await page.getByLabel( 'Block Inserter' ).click();
 		await page
 			.getByRole( 'tab', {
 				name: 'Patterns',
@@ -495,9 +495,7 @@ test.describe( 'Synced pattern', () => {
 			attributes: { ref: id },
 		} );
 
-		await page
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
-			.click();
+		await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 		await page
 			.getByRole( 'searchbox', {
 				name: 'Search',

--- a/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
+++ b/test/e2e/specs/editor/various/shortcut-focus-toolbar.spec.js
@@ -201,11 +201,11 @@ class ToolbarUtils {
 		this.pageUtils = pageUtils;
 
 		this.documentToolbarButton = this.page.getByRole( 'button', {
-			name: 'Toggle block inserter',
+			name: 'Block Inserter',
 			exact: true,
 		} );
 		this.documentToolbarTooltip = this.page.locator(
-			'text=Toggle block inserter'
+			'text=Block Inserter'
 		);
 		this.blockToolbarParagraphButton = this.page.getByRole( 'button', {
 			name: 'Paragraph',

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -318,7 +318,7 @@ async function draftNewPage( page ) {
 // Create a Group block with 2 nested Group blocks.
 async function addPageContent( editor, page ) {
 	const inserterButton = page.locator(
-		'role=button[name="Toggle block inserter"i]'
+		'role=button[name="Block Inserter"i]'
 	);
 	await inserterButton.click();
 	await page.type( 'role=searchbox[name="Search"i]', 'Group' );

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -36,7 +36,7 @@ async function addPageContent( editor, page ) {
 		.fill( 'Lorem ipsum dolor sit amet' );
 
 	// Insert into Page Content using global inserter.
-	await page.getByRole( 'button', { name: 'Toggle block inserter' } ).click();
+	await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
 	await page.getByRole( 'option', { name: 'Heading', exact: true } ).click();
 	await editor.canvas
 		.getByRole( 'document', {

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -36,7 +36,9 @@ async function addPageContent( editor, page ) {
 		.fill( 'Lorem ipsum dolor sit amet' );
 
 	// Insert into Page Content using global inserter.
-	await page.getByRole( 'button', { name: 'Block Inserter' } ).click();
+	await page
+		.getByRole( 'button', { name: 'Block Inserter', exact: true } )
+		.click();
 	await page.getByRole( 'option', { name: 'Heading', exact: true } ).click();
 	await editor.canvas
 		.getByRole( 'document', {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -44,6 +44,7 @@ test.describe( 'Site Editor Inserter', () => {
 	} ) => {
 		const inserterButton = page.getByRole( 'button', {
 			name: 'Block Inserter',
+			exact: true,
 		} );
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -24,13 +24,13 @@ test.describe( 'Site Editor Inserter', () => {
 	test( 'inserter toggle button should toggle global inserter', async ( {
 		page,
 	} ) => {
-		await page.click( 'role=button[name="Toggle block inserter"i]' );
+		await page.click( 'role=button[name="Block Inserter"i]' );
 
 		// Visibility check
 		await expect(
 			page.locator( 'role=searchbox[name="Search"i]' )
 		).toBeVisible();
-		await page.click( 'role=button[name="Toggle block inserter"i]' );
+		await page.click( 'role=button[name="Block Inserter"i]' );
 		//Hidden State check
 		await expect(
 			page.locator( 'role=searchbox[name="Search"i]' )
@@ -43,7 +43,7 @@ test.describe( 'Site Editor Inserter', () => {
 		editor,
 	} ) => {
 		const inserterButton = page.getByRole( 'button', {
-			name: 'Toggle block inserter',
+			name: 'Block Inserter',
 		} );
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -29,7 +29,7 @@ test.describe( 'Style Book', () => {
 
 	test( 'should disable toolbar buttons when open', async ( { page } ) => {
 		await expect(
-			page.locator( 'role=button[name="Toggle block inserter"i]' )
+			page.locator( 'role=button[name="Block Inserter"i]' )
 		).toBeDisabled();
 		await expect(
 			page.locator( 'role=button[name="Tools"i]' )

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -56,7 +56,7 @@ test.describe( 'Widgets screen', () => {
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Block Inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 			.click();
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',
@@ -698,7 +698,7 @@ class WidgetsScreen {
 		if ( await blockLibrary.isHidden() ) {
 			await this.#page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Block Inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter', exact: true } )
 				.click();
 		}
 

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -56,7 +56,7 @@ test.describe( 'Widgets screen', () => {
 
 		await page
 			.getByRole( 'toolbar', { name: 'Document tools' } )
-			.getByRole( 'button', { name: 'Toggle block inserter' } )
+			.getByRole( 'button', { name: 'Block Inserter' } )
 			.click();
 		const blockLibrary = page.getByRole( 'region', {
 			name: 'Block Library',
@@ -698,7 +698,7 @@ class WidgetsScreen {
 		if ( await blockLibrary.isHidden() ) {
 			await this.#page
 				.getByRole( 'toolbar', { name: 'Document tools' } )
-				.getByRole( 'button', { name: 'Toggle block inserter' } )
+				.getByRole( 'button', { name: 'Block Inserter' } )
 				.click();
 		}
 

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -368,9 +368,11 @@ test.describe( 'Post Editor Performance', () => {
 			// Go to the test page.
 			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
-			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Block Inserter',
-			} );
+			const globalInserterToggle = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', {
+					name: 'Block Inserter',
+				} );
 
 			const samples = 10;
 			const throwaway = 1;
@@ -424,9 +426,11 @@ test.describe( 'Post Editor Performance', () => {
 			// Go to the test page.
 			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
-			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Block Inserter',
-			} );
+			const globalInserterToggle = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', {
+					name: 'Block Inserter',
+				} );
 			// Open Inserter.
 			await globalInserterToggle.click();
 
@@ -483,9 +487,11 @@ test.describe( 'Post Editor Performance', () => {
 			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
 
-			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Block Inserter',
-			} );
+			const globalInserterToggle = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', {
+					name: 'Block Inserter',
+				} );
 			const paragraphBlockItem = page.locator(
 				'.block-editor-inserter__menu .editor-block-list-item-paragraph'
 			);
@@ -535,9 +541,11 @@ test.describe( 'Post Editor Performance', () => {
 		test( 'Run the test', async ( { page, admin, perfUtils } ) => {
 			await admin.createNewPost();
 			await perfUtils.disableAutosave();
-			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Block Inserter',
-			} );
+			const globalInserterToggle = page
+				.getByRole( 'region', { name: 'Editor top bar' } )
+				.getByRole( 'button', {
+					name: 'Block Inserter',
+				} );
 
 			const testPatterns = [
 				{

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -370,7 +370,6 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
-				exact: true,
 			} );
 
 			const samples = 10;
@@ -427,7 +426,6 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
-				exact: true,
 			} );
 			// Open Inserter.
 			await globalInserterToggle.click();
@@ -487,7 +485,6 @@ test.describe( 'Post Editor Performance', () => {
 
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
-				exact: true,
 			} );
 			const paragraphBlockItem = page.locator(
 				'.block-editor-inserter__menu .editor-block-list-item-paragraph'
@@ -540,7 +537,6 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
-				exact: true,
 			} );
 
 			const testPatterns = [

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -369,7 +369,7 @@ test.describe( 'Post Editor Performance', () => {
 			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Toggle block inserter',
+				name: 'Block Inserter',
 			} );
 
 			const samples = 10;
@@ -425,7 +425,7 @@ test.describe( 'Post Editor Performance', () => {
 			await admin.editPost( draftId );
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Toggle block inserter',
+				name: 'Block Inserter',
 			} );
 			// Open Inserter.
 			await globalInserterToggle.click();
@@ -484,7 +484,7 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 
 			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Toggle block inserter',
+				name: 'Block Inserter',
 			} );
 			const paragraphBlockItem = page.locator(
 				'.block-editor-inserter__menu .editor-block-list-item-paragraph'
@@ -536,7 +536,7 @@ test.describe( 'Post Editor Performance', () => {
 			await admin.createNewPost();
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
-				name: 'Toggle block inserter',
+				name: 'Block Inserter',
 			} );
 
 			const testPatterns = [

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -370,6 +370,7 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
+				exact: true,
 			} );
 
 			const samples = 10;
@@ -426,6 +427,7 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
+				exact: true,
 			} );
 			// Open Inserter.
 			await globalInserterToggle.click();
@@ -485,6 +487,7 @@ test.describe( 'Post Editor Performance', () => {
 
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
+				exact: true,
 			} );
 			const paragraphBlockItem = page.locator(
 				'.block-editor-inserter__menu .editor-block-list-item-paragraph'
@@ -537,6 +540,7 @@ test.describe( 'Post Editor Performance', () => {
 			await perfUtils.disableAutosave();
 			const globalInserterToggle = page.getByRole( 'button', {
 				name: 'Block Inserter',
+				exact: true,
 			} );
 
 			const testPatterns = [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Addresses part of https://github.com/WordPress/gutenberg/issues/61483

## What?
<!-- In a few words, what is the PR actually doing? -->
- The verb 'toggle' isn't well translatable in many languages and should not be used.
- WordPress features should be title case, much like 'List View', 'Document Overview', and many other ones.

Note: I'd still like the 'Block Inserter' to be renamed because the current name is too technical and the tool isn't just inseerting blocks any longer. However, this is a first step to make the name better translatable and avoid the verb 'toggle'.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Better usability and localization.
- Consistency

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Chagees all the strings 'Toggle block inserter` to 'Block Inserter'.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Edit a post.
- Hover or focus the block inserter button. 
- Observe the tooltip is 'Block Inserter', title case.
- Check the same think in the Site Editor and in the Widgets editor.
- Make sure there are no occurrences of the string 'Toggle block inserter' aanywhere in the codebase.
- Check the tests pass.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
