### PR TITLE
Query Loop: Fix isControlAllowed and isTemplate combined logic

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -123,21 +123,23 @@ export default function QueryInspectorControls( props ) {
 	const showInheritControl =
 		isTemplate && isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
-		( ! inherit && isControlAllowed( allowedControls, 'postType' ) ) ||
-		! isTemplate;
+		! inherit &&
+		! isTemplate &&
+		isControlAllowed( allowedControls, 'postType' );
 	const postTypeControlLabel = __( 'Post type' );
 	const postTypeControlHelp = __(
 		'Select the type of content to display: posts, pages, or custom post types.'
 	);
 	const showColumnsControl = false;
 	const showOrderControl =
-		( ! inherit && isControlAllowed( allowedControls, 'order' ) ) ||
-		! isTemplate;
+		! inherit &&
+		! isTemplate &&
+		isControlAllowed( allowedControls, 'order' );
 	const showStickyControl =
-		( ! inherit &&
-			showSticky &&
-			isControlAllowed( allowedControls, 'sticky' ) ) ||
-		( showSticky && ! isTemplate );
+		! inherit &&
+		! isTemplate &&
+		showSticky &&
+		isControlAllowed( allowedControls, 'sticky' );
 	const showSettingsPanel =
 		showInheritControl ||
 		showPostTypeControl ||

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -123,21 +123,16 @@ export default function QueryInspectorControls( props ) {
 	const showInheritControl =
 		isTemplate && isControlAllowed( allowedControls, 'inherit' );
 	const showPostTypeControl =
-		! inherit &&
-		! isTemplate &&
-		isControlAllowed( allowedControls, 'postType' );
+		! inherit && isControlAllowed( allowedControls, 'postType' );
 	const postTypeControlLabel = __( 'Post type' );
 	const postTypeControlHelp = __(
 		'Select the type of content to display: posts, pages, or custom post types.'
 	);
 	const showColumnsControl = false;
 	const showOrderControl =
-		! inherit &&
-		! isTemplate &&
-		isControlAllowed( allowedControls, 'order' );
+		! inherit && isControlAllowed( allowedControls, 'order' );
 	const showStickyControl =
 		! inherit &&
-		! isTemplate &&
 		showSticky &&
 		isControlAllowed( allowedControls, 'sticky' );
 	const showSettingsPanel =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This fixes the logic for showing the `allowedControls` for the Query Loop block in combination with the new `isTemplate` check from https://github.com/WordPress/gutenberg/pull/65067.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/WordPress/gutenberg/issues/65902.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Previously, the `isTemplate` check was considered separately from the `isControlAllowed` check, and now with this PR, the logic is combined. This wasn't an intentional change to the logic, so this is a pure bug fix.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

These are taken from the testing instructions in https://github.com/WordPress/gutenberg/issues/65902:

Create a new block variation using this snippet:

```
registerBlockVariation(
	'core/query',
	{
		name: 'testing-allowed-controls',
		title: __( 'Testing Allowed Controls' ),
		category: 'theme',
		keywords: [],
		scope: [ 'inserter' ],
		attributes: {
			namespace: 'testing-allowed-controls',
		},
		allowedControls: [],
		innerBlocks: [],
		isActive: [ 'namespace' ],
	}
);
```

Go to 3 block editors:

- Site Editor > Templates > Index
- Site Editor > Templates > Single Posts
- Posts > Add New, or edit an existing post (e.g. "Sample Page")

Add the `Testing Allowed Controls` query block variation into the block editor content via the inserter. Choose any inner blocks template.

Check the available controls in the block options panel (right sidebar), and ensure that no controls are available on single posts or pages.

## Screenshots or screencast <!-- if applicable -->

| Site Editor > Sample Page on trunk | Site Editor > Sample Page on this PR |
| ------ | ------- |
| ![image](https://github.com/user-attachments/assets/2425fdb1-9a54-4e34-bd51-0439f436e760) | ![image](https://github.com/user-attachments/assets/7a65cd91-9030-4e35-82b1-341b595c24c9) |


