### PR TITLE
Color variables, update 4.6 to 4.5. One line code change typo fix. Easy.

### DIFF
--- a/packages/base-styles/_colors.scss
+++ b/packages/base-styles/_colors.scss
@@ -8,7 +8,7 @@
 $black: #000;			// Use only when you truly need pure black. For UI, use $gray-900.
 $gray-900: #1e1e1e;
 $gray-800: #2f2f2f;
-$gray-700: #757575;		// Meets 4.6:1 text contrast against white.
+$gray-700: #757575;		// Meets 4.5:1 text contrast against white.
 $gray-600: #949494;		// Meets 3:1 UI or large text contrast against white.
 $gray-400: #ccc;
 $gray-300: #ddd;		// Used for most borders.


### PR DESCRIPTION
## What?

Noticed a tiny typo in a code comment in the base styles. It's 4.5:1 contrast ratio, not 4.6. 