### PR TITLE
Fix overflow in patterns filter container

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -158,7 +158,7 @@ export function PatternsFilter( {
 								value={ patternSyncFilter }
 							/>
 						</MenuGroup>
-						<div className="block-editor-tool-selector__help">
+						<div className="block-editor-inserter__patterns-category-filters__help">
 							{ createInterpolateElement(
 								__(
 									'Patterns are available from the <Link>WordPress.org Pattern Directory</Link>, bundled in the active theme, or created by users on this site. Only patterns created on this site can be synced.'

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -260,6 +260,13 @@ $block-inserter-tabs-height: 44px;
 	margin-top: $grid-unit-30;
 }
 
+.block-editor-inserter__patterns-category-filters__help {
+	padding: $grid-unit-20;
+	border-top: $border-width solid $gray-300;
+	color: $gray-700;
+	min-width: 280px;
+}
+
 .block-editor-inserter__media-list,
 .block-editor-block-patterns-list {
 	overflow-y: auto;

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -1,4 +1,8 @@
 .block-editor-tool-selector__help {
+	margin-top: $grid-unit-10;
+	margin-left: -$grid-unit-10;
+	margin-right: -$grid-unit-10;
+	margin-bottom: -$grid-unit-10;
 	padding: $grid-unit-20;
 	border-top: $border-width solid $gray-300;
 	color: $gray-700;

--- a/packages/block-editor/src/components/tool-selector/style.scss
+++ b/packages/block-editor/src/components/tool-selector/style.scss
@@ -1,8 +1,4 @@
 .block-editor-tool-selector__help {
-	margin-top: $grid-unit-10;
-	margin-left: -$grid-unit-10;
-	margin-right: -$grid-unit-10;
-	margin-bottom: -$grid-unit-10;
 	padding: $grid-unit-20;
 	border-top: $border-width solid $gray-300;
 	color: $gray-700;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This fixes overflow in patterns filter by removing the negative margins.


| Before | After |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/937bb1e6-c6ac-4f93-a925-61db175ad78c"/> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/6a58fb61-b71c-4e38-8748-8adc72524260"> |
| <img width="286" alt="image" src="https://github.com/user-attachments/assets/7c1afb38-933b-474c-b25c-9afeaca62fe8"> | <img width="304" alt="image" src="https://github.com/user-attachments/assets/67232ba6-5fbf-4fad-881d-c84fdc9b7bb7"> |
| <img width="289" alt="image" src="https://github.com/user-attachments/assets/09495633-6557-44bd-ad08-371fa6996454"> | <img width="304" alt="image" src="https://github.com/user-attachments/assets/8f13728a-3680-4e20-8148-a7d58d297cb2"> |

@richtabor It increases the spacing in case of tools menu, but they are now aligned with the icons. May be reduce the container padding here?

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In editor, click `+` -> Patterns -> Filter and verify it has no scrollbars
2. In the editor click Tools menu and verify the spacing.
