### PR TITLE
SearchControl: Deprecate onClose prop

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,10 @@
 -   `RangeControl`: do not tooltip contents to the DOM when not shown ([#65875](https://github.com/WordPress/gutenberg/pull/65875)).
 -   `Tabs`: fix skipping indication animation glitch ([#65878](https://github.com/WordPress/gutenberg/pull/65878)).
 
+### Deprecations
+
+-   `SearchControl`: Soft deprecate `onClose` prop ([#65988](https://github.com/WordPress/gutenberg/pull/65988)).
+
 ### Enhancements
 
 -   `Tabs`: revamped vertical orientation styles ([#65387](https://github.com/WordPress/gutenberg/pull/65387)).

--- a/packages/components/src/search-control/README.md
+++ b/packages/components/src/search-control/README.md
@@ -76,6 +76,8 @@ A function that receives the value of the input.
 
 #### onClose
 
+_Note: this prop is deprecated._
+
 When an `onClose` callback is provided, the search control will render a close button that will trigger the given callback.
 
 Use this if you want the button to trigger your own logic to close the search field entirely, rather than just clearing the input value.

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -33,10 +33,8 @@ function SuffixItem( {
 	}
 
 	if ( onClose ) {
-		deprecated( 'onClose function prop', {
-			since: '6.7',
-			version: '',
-			plugin: 'wp.components.SearchControl',
+		deprecated( '`onClose` prop in wp.components.SearchControl', {
+			since: '6.8',
 		} );
 	}
 

--- a/packages/components/src/search-control/index.tsx
+++ b/packages/components/src/search-control/index.tsx
@@ -10,6 +10,7 @@ import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import { Icon, search, closeSmall } from '@wordpress/icons';
 import { forwardRef, useMemo, useRef } from '@wordpress/element';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -29,6 +30,14 @@ function SuffixItem( {
 }: SuffixItemProps ) {
 	if ( ! onClose && ! value ) {
 		return <Icon icon={ search } />;
+	}
+
+	if ( onClose ) {
+		deprecated( 'onClose function prop', {
+			since: '6.7',
+			version: '',
+			plugin: 'wp.components.SearchControl',
+		} );
 	}
 
 	const onReset = () => {

--- a/packages/components/src/search-control/stories/index.story.tsx
+++ b/packages/components/src/search-control/stories/index.story.tsx
@@ -50,20 +50,3 @@ Default.args = {
 	help: 'Help text to explain the input.',
 	__nextHasNoMarginBottom: true,
 };
-
-/**
- * _Note: this prop is deprecated._
- *
- * When an `onClose` callback is provided, the search control will render a close button
- * that will trigger the given callback.
- *
- * Use this if you want the button to trigger your own logic to close the search field entirely,
- * rather than just clearing the input value.
- */
-export const WithOnClose = Template.bind( {} );
-WithOnClose.args = {
-	...Default.args,
-};
-WithOnClose.argTypes = {
-	onClose: { action: 'onClose' },
-};

--- a/packages/components/src/search-control/stories/index.story.tsx
+++ b/packages/components/src/search-control/stories/index.story.tsx
@@ -52,6 +52,8 @@ Default.args = {
 };
 
 /**
+ * _Note: this prop is deprecated._
+ *
  * When an `onClose` callback is provided, the search control will render a close button
  * that will trigger the given callback.
  *

--- a/packages/components/src/search-control/test/index.tsx
+++ b/packages/components/src/search-control/test/index.tsx
@@ -79,7 +79,9 @@ describe( 'SearchControl', () => {
 				<Component onChange={ onChangeSpy } onClose={ onCloseSpy } />
 			);
 
-			expect( console ).toHaveWarned();
+			expect( console ).toHaveWarnedWith(
+				'`onClose` prop in wp.components.SearchControl is deprecated since version 6.8.'
+			);
 			expect(
 				screen.queryByRole( 'button', { name: 'Close search' } )
 			).toBeVisible();

--- a/packages/components/src/search-control/test/index.tsx
+++ b/packages/components/src/search-control/test/index.tsx
@@ -72,13 +72,14 @@ describe( 'SearchControl', () => {
 			expect( onChangeSpy ).toHaveBeenLastCalledWith( '' );
 		} );
 
-		it( 'should should render a Close button (instead of Reset) when onClose function is provided', async () => {
+		it( 'should render a Close button (instead of Reset) when onClose function is provided', async () => {
 			const onChangeSpy = jest.fn();
 			const onCloseSpy = jest.fn();
 			render(
 				<Component onChange={ onChangeSpy } onClose={ onCloseSpy } />
 			);
 
+			expect( console ).toHaveWarned();
 			expect(
 				screen.queryByRole( 'button', { name: 'Close search' } )
 			).toBeVisible();

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -42,6 +42,7 @@ export type SearchControlProps = Pick< InputControlProps, 'help' | 'value' > & {
 	 * rather than just clearing the input value.
 	 *
 	 * @deprecated
+	 * @ignore
 	 */
 	onClose?: () => void;
 	/** @ignore */

--- a/packages/components/src/search-control/types.ts
+++ b/packages/components/src/search-control/types.ts
@@ -40,6 +40,8 @@ export type SearchControlProps = Pick< InputControlProps, 'help' | 'value' > & {
 	 *
 	 * Use this if you want the button to trigger your own logic to close the search field entirely,
 	 * rather than just clearing the input value.
+	 *
+	 * @deprecated
 	 */
 	onClose?: () => void;
 	/** @ignore */


### PR DESCRIPTION
## What?
- Add `@deprecated` for `onClose` function prop for `SearchControl component`
- Update `README.md`, `JSDoc` and `StoryBook` with `_Note: this prop is deprecated._`
- When `onClose` prop is provided, execute `deprecated` from `@wordpress/deprecated`
- Update `test` to expect `console.warn` when `onClose` is provided + fix `should should` typo

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/65334
> The onClose prop is not used anymore in the Gutenberg app
> The prop itself is causing confusion to consumers (https://github.com/WordPress/gutenberg/issues/64921),

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- `Soft Deprecates` the `onClose` prop
- Add `deprecation` notice in the `SearchControl's docs`
- Execute `deprecated` when `onClose` is provided
- Add `test` to expect `deprecation warning`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Clone the branch into the `plugins` directory of your `WordPress` installation
```
git clone https://github.com/Vrishabhsk/gutenberg/tree/update/deprecate-onClose
```
- Build the files
```
cd gutenberg && npm install & npm build
```
- Activate the `Gutenberg`plugin via the `Plugins Admin Page`.
- Create a custom block
```
npx @wordpress/create-block@latest demo --variant=dynamic
```
- Modify the `edit.js` to use `SelectControl` component
```
export default function Edit() {
	return (
		<p {...useBlockProps()}>
			<h1>Shut up</h1>
			<InspectorControls>
				<PanelBody title="Form Settings" initialOpen={false}>
					<PanelRow>
						<SearchControl
							label={__("Search posts")}
							onChange={(val) => {}}
						/>
					</PanelRow>
				</PanelBody>
			</InspectorControls>
		</p>
	);
}
```
- To test the deprecated log, use the following snippet : [`Deprecated Hook`](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-deprecated/#hook)