### PR TITLE
Tooltip: add aria-describedby to anchor only if not redundant

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Tooltip`: add `aria-describedby` to the anchor only if not redundant ([#65989](https://github.com/WordPress/gutenberg/pull/65989)).
 -   `PaletteEdit`: dedupe palette element slugs ([#65772](https://github.com/WordPress/gutenberg/pull/65772)).
 -   `RangeControl`: do not tooltip contents to the DOM when not shown ([#65875](https://github.com/WordPress/gutenberg/pull/65875)).
 -   `Tabs`: fix skipping indication animation glitch ([#65878](https://github.com/WordPress/gutenberg/pull/65878)).

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -107,9 +107,16 @@ function UnforwardedTooltip(
 	// TODO: this is a temporary workaround to minimize the effects of the
 	// Ariakit upgrade. Ariakit doesn't pass the `aria-describedby` prop to
 	// the tooltip anchor anymore since 0.4.0, so we need to add it manually.
+	// The `aria-describedby` attribute is added only if the anchor doesn't have
+	// one already, and if the tooltip text is not the same as the anchor's
+	// `aria-label`
 	// See: https://github.com/WordPress/gutenberg/pull/64066
+	// See: https://github.com/WordPress/gutenberg/pull/65989
 	function addDescribedById( element: React.ReactElement ) {
-		return describedById && mounted
+		return describedById &&
+			mounted &&
+			element.props[ 'aria-describedby' ] === undefined &&
+			element.props[ 'aria-label' ] !== text
 			? cloneElement( element, { 'aria-describedby': describedById } )
 			: element;
 	}

--- a/packages/components/src/tooltip/stories/index.story.tsx
+++ b/packages/components/src/tooltip/stories/index.story.tsx
@@ -36,17 +36,6 @@ const meta: Meta< typeof Tooltip > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
-	decorators: [
-		( Story ) => {
-			return (
-				<>
-					{ /* eslint-disable-next-line no-restricted-syntax */ }
-					<p id="test-description">Button description</p>
-					<Story />
-				</>
-			);
-		},
-	],
 };
 export default meta;
 
@@ -84,20 +73,4 @@ Nested.args = {
 		</Tooltip>
 	),
 	text: 'Outer tooltip text',
-};
-
-export const AlreadyWithDescription: StoryFn< typeof Tooltip > = Template.bind(
-	{}
-);
-AlreadyWithDescription.args = {
-	children: (
-		<button aria-describedby="test-description">Tooltip Anchor</button>
-	),
-	text: 'Tooltip Text',
-};
-
-export const SameLabel: StoryFn< typeof Tooltip > = Template.bind( {} );
-SameLabel.args = {
-	children: <button aria-label="Button label">Tooltip Anchor</button>,
-	text: 'Button label',
 };

--- a/packages/components/src/tooltip/stories/index.story.tsx
+++ b/packages/components/src/tooltip/stories/index.story.tsx
@@ -36,6 +36,16 @@ const meta: Meta< typeof Tooltip > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
+	decorators: [
+		( Story ) => {
+			return (
+				<>
+					<p id="test-description">Button's description</p>
+					<Story />
+				</>
+			);
+		},
+	],
 };
 export default meta;
 
@@ -73,4 +83,20 @@ Nested.args = {
 		</Tooltip>
 	),
 	text: 'Outer tooltip text',
+};
+
+export const AlreadyWithDescription: StoryFn< typeof Tooltip > = Template.bind(
+	{}
+);
+AlreadyWithDescription.args = {
+	children: (
+		<button aria-describedby="test-description">Tooltip Anchor</button>
+	),
+	text: 'Tooltip Text',
+};
+
+export const SameLabel: StoryFn< typeof Tooltip > = Template.bind( {} );
+SameLabel.args = {
+	children: <button aria-label="Button label">Tooltip Anchor</button>,
+	text: 'Button label',
 };

--- a/packages/components/src/tooltip/stories/index.story.tsx
+++ b/packages/components/src/tooltip/stories/index.story.tsx
@@ -40,7 +40,8 @@ const meta: Meta< typeof Tooltip > = {
 		( Story ) => {
 			return (
 				<>
-					<p id="test-description">Button's description</p>
+					{ /* eslint-disable-next-line no-restricted-syntax */ }
+					<p id="test-description">Button description</p>
 					<Story />
 				</>
 			);

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -516,4 +516,82 @@ describe( 'Tooltip', () => {
 			).not.toHaveClass( 'components-tooltip' );
 		} );
 	} );
+
+	describe( 'aria-describedby', () => {
+		it( "should not override the anchor's aria-describedby attribute if specified", async () => {
+			render(
+				<>
+					<Tooltip { ...props }>
+						<button aria-describedby="tooltip-test-description">
+							Tooltip anchor
+						</button>
+					</Tooltip>
+					{ /* eslint-disable-next-line no-restricted-syntax */ }
+					<p id="tooltip-test-description">Tooltip description</p>
+					<button>focus trap outside</button>
+				</>
+			);
+
+			expect(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			).toHaveAccessibleDescription( 'Tooltip description' );
+
+			// Focus the anchor, tooltip should show
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			).toHaveFocus();
+			await waitExpectTooltipToShow();
+
+			// The anchors should retain its previous accessible description,
+			// since the tooltip shouldn't override it.
+			expect(
+				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
+			).toHaveAccessibleDescription( 'Tooltip description' );
+
+			// Focus the other button, tooltip should hide
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', { name: 'focus trap outside' } )
+			).toHaveFocus();
+			await waitExpectTooltipToHide();
+		} );
+
+		it( "should not add the aria-describedby attribute to the anchor if the tooltip text matches the anchor's aria-label", async () => {
+			render(
+				<>
+					<Tooltip { ...props }>
+						<button aria-label={ props.text }>
+							Tooltip anchor
+						</button>
+					</Tooltip>
+					<button>focus trap outside</button>
+				</>
+			);
+
+			expect(
+				screen.getByRole( 'button', { name: props.text } )
+			).not.toHaveAccessibleDescription();
+
+			// Focus the anchor, tooltip should show
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', { name: props.text } )
+			).toHaveFocus();
+			await waitExpectTooltipToShow();
+
+			// The anchor shouldn't have an aria-describedby prop
+			// because its aria-label matches the tooltip text.
+			expect(
+				screen.getByRole( 'button', { name: props.text } )
+			).not.toHaveAccessibleDescription();
+
+			// Focus the other button, tooltip should hide
+			await press.Tab();
+			expect(
+				screen.getByRole( 'button', { name: 'focus trap outside' } )
+			).toHaveFocus();
+			await waitExpectTooltipToHide();
+		} );
+	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #65888

This PR makes changes to the `Tooltip` component so that the `aria-describedby` attribute gets added more conservatively

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in  #65888, the way `Tooltip` adds an `aria-describedby` attribute can disrupt assistive technology users:

- the tooltip is displayed dynamically, which means that the accessible description is only available when the tooltip is visible;
- the tooltip's description can override an existing description;
- the tooltip's description can be unnecessary if it's a copy of the accessible label;
- in general, tooltips should not be a mean of adding an accessible description (although this drawback is not in the scope of this PR)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Implementing @t-hamano 's [suggestion](https://github.com/WordPress/gutenberg/issues/65888#issuecomment-2395827508): the `Tooltip` component checks that there isn't a `aria-describedby` attribute already defined, and that the tooltip text is different from the anchor's accessible label.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure that a tooltip anchor has an explicit `aria-describedby` attribute. Inspecting the anchor, make sure that the `aria-describedby` attribute doesn't change when the tooltip is shown.
- Make sure that a tooltip anchor has an explicit `aria-label` attribute, and that the tooltip text is the same as the anchor's `aria-label`. Inspecting the anchor, make sure that the `aria-describedby` attribute is not added to the anchor when the tooltip is shown.

I've added a couple of temporary Storybook examples to help with testing in isolation.


In the editor, you can test this by:
- inserting a block
- moving focus to the block toolbar
- inspect the `button` responsible for triggering the "options" dropdown (the last one in the toolbar)
- notice how, with the changes from this PR applied, when the button receives focus and the tooltip shows, the button does _not_ get an `aria-describedby` attribute added for the tooltip

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0126844d-6611-41ce-b97a-ec2b3b5dd928
