### PR TITLE
Block Bindings: Allow custom components block bindings UI

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -203,20 +203,15 @@ export function RichTextWrapper(
 
 			const { getBlockAttributes } = select( blockEditorStore );
 			const blockAttributes = getBlockAttributes( clientId );
-			const fieldsList = blockBindingsSource?.getFieldsList?.( {
-				select,
-				context: blockBindingsContext,
-			} );
-			const bindingKey =
-				fieldsList?.[ relatedBinding?.args?.key ]?.label ??
-				blockBindingsSource?.label;
+			const bindingLabel =
+				relatedBinding?.label ?? blockBindingsSource?.label;
 
 			const _bindingsPlaceholder = _disableBoundBlock
-				? bindingKey
+				? bindingLabel
 				: sprintf(
 						/* translators: %s: connected field label or source label */
 						__( 'Add %s' ),
-						bindingKey
+						bindingLabel
 				  );
 			const _bindingsLabel = _disableBoundBlock
 				? relatedBinding?.args?.key || blockBindingsSource?.label

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -204,7 +204,12 @@ export function RichTextWrapper(
 			const { getBlockAttributes } = select( blockEditorStore );
 			const blockAttributes = getBlockAttributes( clientId );
 			const bindingLabel =
-				relatedBinding?.label ?? blockBindingsSource?.label;
+				blockBindingsSource?.getBindingLabel?.( {
+					select,
+					context: blockBindingsContext,
+					attribute: identifier,
+					binding: relatedBinding,
+				} ) ?? blockBindingsSource?.label;
 
 			const _bindingsPlaceholder = _disableBoundBlock
 				? bindingLabel
@@ -228,7 +233,14 @@ export function RichTextWrapper(
 				bindingsLabel: _bindingsLabel,
 			};
 		},
-		[ blockBindings, identifier, blockName, blockContext, adjustedValue ]
+		[
+			blockBindings,
+			identifier,
+			clientId,
+			blockName,
+			blockContext,
+			adjustedValue,
+		]
 	);
 
 	const shouldDisableEditing = readOnly || disableBoundBlock;

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -96,8 +96,8 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 	);
 }
 
-function BlockBindingsAttribute( { attribute, binding, fieldsList } ) {
-	const { source: sourceName, args } = binding || {};
+function BlockBindingsAttribute( { attribute, binding } ) {
+	const { source: sourceName, label: bindingLabel } = binding || {};
 	const sourceProps = getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
 	return (
@@ -111,16 +111,14 @@ function BlockBindingsAttribute( { attribute, binding, fieldsList } ) {
 				>
 					{ isSourceInvalid
 						? __( 'Invalid source' )
-						: fieldsList?.[ sourceName ]?.[ args?.key ]?.label ||
-						  sourceProps?.label ||
-						  sourceName }
+						: bindingLabel || sourceProps?.label || sourceName }
 				</Text>
 			) }
 		</VStack>
 	);
 }
 
-function ReadOnlyBlockBindingsPanelItems( { bindings, fieldsList } ) {
+function ReadOnlyBlockBindingsPanelItems( { bindings } ) {
 	return (
 		<>
 			{ Object.entries( bindings ).map( ( [ attribute, binding ] ) => (
@@ -128,7 +126,6 @@ function ReadOnlyBlockBindingsPanelItems( { bindings, fieldsList } ) {
 					<BlockBindingsAttribute
 						attribute={ attribute }
 						binding={ binding }
-						fieldsList={ fieldsList }
 					/>
 				</Item>
 			) ) }
@@ -168,7 +165,6 @@ function EditableBlockBindingsPanelItems( {
 									<BlockBindingsAttribute
 										attribute={ attribute }
 										binding={ binding }
-										fieldsList={ fieldsList }
 									/>
 								</Item>
 							}

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -66,24 +66,17 @@ function BlockBindingsPanelDropdown( { attribute, binding } ) {
 						}
 					}
 
-					const SourceComponent = render;
-					const ChildComponent = (
-						<SourceComponent
-							context={ context }
-							binding={ binding }
-							attribute={ attribute }
-						/>
-					);
-
-					// Check if the ChildComponent renders something that is valid and not null.
+					// Render the source component first to be able to check if it is null.
 					// TODO: Look for a better way to do this.
-					const renderedChild = ChildComponent.type(
-						ChildComponent.props
-					);
+					const SourceComponent = render( {
+						context,
+						attribute,
+						binding,
+					} );
 
 					return (
 						<>
-							{ renderedChild && (
+							{ SourceComponent && (
 								<DropdownMenuV2
 									key={ sourceName }
 									// TODO: Review mobile version.
@@ -98,7 +91,7 @@ function BlockBindingsPanelDropdown( { attribute, binding } ) {
 										</DropdownMenuV2.Item>
 									}
 								>
-									{ cloneElement( ChildComponent ) }
+									{ cloneElement( SourceComponent ) }
 								</DropdownMenuV2>
 							) }
 						</>

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -120,7 +120,7 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 				context[ key ] = blockContext[ key ];
 			}
 		}
-		const _bindingsLabel = sourceProps?.getBindingLabel( {
+		const _bindingsLabel = sourceProps?.getBindingLabel?.( {
 			select,
 			context,
 			attribute,

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -104,9 +104,30 @@ function BlockBindingsPanelDropdown( { attribute, binding } ) {
 }
 
 function BlockBindingsAttribute( { attribute, binding } ) {
-	const { source: sourceName, label: bindingLabel } = binding || {};
+	const blockContext = useContext( BlockContext );
+	const { source: sourceName } = binding || {};
 	const sourceProps = getBlockBindingsSource( sourceName );
 	const isSourceInvalid = ! sourceProps;
+	const bindingLabel = useSelect( ( select ) => {
+		if ( isSourceInvalid ) {
+			return;
+		}
+		// TODO: Explore if it makes sense to get the context in the parent component.
+		const { usesContext } = sourceProps;
+		const context = {};
+		if ( usesContext?.length ) {
+			for ( const key of usesContext ) {
+				context[ key ] = blockContext[ key ];
+			}
+		}
+		const _bindingsLabel = sourceProps?.getBindingLabel( {
+			select,
+			context,
+			attribute,
+			binding,
+		} );
+		return _bindingsLabel || sourceProps?.label || sourceName;
+	} );
 	return (
 		<VStack className="block-editor-bindings__item" spacing={ 0 }>
 			<Text truncate>{ attribute }</Text>
@@ -116,9 +137,7 @@ function BlockBindingsAttribute( { attribute, binding } ) {
 					variant={ ! isSourceInvalid && 'muted' }
 					isDestructive={ isSourceInvalid }
 				>
-					{ isSourceInvalid
-						? __( 'Invalid source' )
-						: bindingLabel || sourceProps?.label || sourceName }
+					{ isSourceInvalid ? __( 'Invalid source' ) : bindingLabel }
 				</Text>
 			) }
 		</VStack>

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { useDispatch, useRegistry } from '@wordpress/data';
 
 /**
@@ -8,6 +9,9 @@ import { useDispatch, useRegistry } from '@wordpress/data';
  */
 import { store as blockEditorStore } from '../store';
 import { useBlockEditContext } from '../components/block-edit';
+import { unlock } from '../lock-unlock';
+
+const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 function isObjectEmpty( object ) {
 	return ! object || Object.keys( object ).length === 0;
@@ -142,5 +146,82 @@ export function useBlockBindingsUtils() {
 		} );
 	};
 
-	return { updateBlockBindings, removeAllBlockBindings };
+	/**
+	 * Component to list the fields that can be connected.
+	 * This allows other sources to reuse the UI created for "Post Meta".
+	 *
+	 * @param {Object} props           Props needed to render the component.
+	 * @param {Object} props.fields    List of fields to include in the dropdown. Each field is an object with a label and a value.
+	 * @param {string} props.attribute Attribute that is being updated.
+	 * @param {Object} [props.binding] Optional object containing the current binding for that attribute if exist.
+	 *
+	 * @example
+	 * ```js
+	 * import { useBlockBindingsUtils } from '@wordpress/block-editor'
+	 *
+	 * const { FieldsList } = useBlockBindingsUtils();
+	 * registerBlockBindingsSource( {
+	 *     name: 'core/custom-source',
+	 *     label: 'Custom Source',
+	 *     getValues: () => {},
+	 *     render: ( { attribute, binding }) => {
+	 *         const fields = {
+	 * 		       field_1: {
+	 * 			       label: 'Field 1 Label',
+	 * 			       value: 'Field 1 Value',
+	 * 		       },
+	 * 		       field_2: {
+	 * 			       label: 'Field 2 Label',
+	 * 			       value: 'Field 2 Value',
+	 * 		       },
+	 *         };
+	 *         return (
+	 *             <FieldsList
+	 *                 fields={ fields }
+	 *                 attribute={ attribute }
+	 *                 binding={ binding }
+	 *             />
+	 *         );
+	 *     } );
+	 * } );
+	 * ```
+	 *
+	 * @return {Function} Component to list the fields that can be connected.
+	 */
+	const FieldsList = ( { fields, attribute, binding } ) => {
+		if ( ! Object.keys( fields || {} ).length ) {
+			return null;
+		}
+
+		return (
+			<DropdownMenuV2.Group>
+				{ Object.entries( fields ).map( ( [ key, args ] ) => (
+					<DropdownMenuV2.RadioItem
+						key={ key }
+						onChange={ () =>
+							updateBlockBindings( {
+								[ attribute ]: {
+									label: fields[ key ].label,
+									source: 'core/post-meta',
+									args: { key },
+								},
+							} )
+						}
+						name={ attribute + '-binding' }
+						value={ key }
+						checked={ key === binding?.args?.key }
+					>
+						<DropdownMenuV2.ItemLabel>
+							{ args?.label }
+						</DropdownMenuV2.ItemLabel>
+						<DropdownMenuV2.ItemHelpText>
+							{ args?.value }
+						</DropdownMenuV2.ItemHelpText>
+					</DropdownMenuV2.RadioItem>
+				) ) }
+			</DropdownMenuV2.Group>
+		);
+	};
+
+	return { updateBlockBindings, removeAllBlockBindings, FieldsList };
 }

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -150,10 +150,11 @@ export function useBlockBindingsUtils() {
 	 * Component to list the fields that can be connected.
 	 * This allows other sources to reuse the UI created for "Post Meta".
 	 *
-	 * @param {Object} props           Props needed to render the component.
-	 * @param {Object} props.fields    List of fields to include in the dropdown. Each field is an object with a label and a value.
-	 * @param {string} props.attribute Attribute that is being updated.
-	 * @param {Object} [props.binding] Optional object containing the current binding for that attribute if exist.
+	 * @param {Object} props                  Props needed to render the component.
+	 * @param {Object} props.fields           List of fields to include in the dropdown. Each field is an object with a label and a value.
+	 * @param {string} props.source           Name of the source that triggers the component.
+	 * @param {string} props.attribute        Attribute that is being updated.
+	 * @param {Object} [props.currentBinding] Optional object containing the current binding for that attribute if it exists.
 	 *
 	 * @example
 	 * ```js
@@ -178,8 +179,9 @@ export function useBlockBindingsUtils() {
 	 *         return (
 	 *             <FieldsList
 	 *                 fields={ fields }
+	 *                 source="core/custom-source"
 	 *                 attribute={ attribute }
-	 *                 binding={ binding }
+	 *                 currentBinding={ binding }
 	 *             />
 	 *         );
 	 *     } );
@@ -188,7 +190,7 @@ export function useBlockBindingsUtils() {
 	 *
 	 * @return {Function} Component to list the fields that can be connected.
 	 */
-	const FieldsList = ( { fields, attribute, binding } ) => {
+	const FieldsList = ( { fields, source, attribute, currentBinding } ) => {
 		if ( ! Object.keys( fields || {} ).length ) {
 			return null;
 		}
@@ -201,15 +203,14 @@ export function useBlockBindingsUtils() {
 						onChange={ () =>
 							updateBlockBindings( {
 								[ attribute ]: {
-									label: fields[ key ].label,
-									source: 'core/post-meta',
+									source,
 									args: { key },
 								},
 							} )
 						}
 						name={ attribute + '-binding' }
 						value={ key }
-						checked={ key === binding?.args?.key }
+						checked={ key === currentBinding?.args?.key }
 					>
 						<DropdownMenuV2.ItemLabel>
 							{ args?.label }

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -800,7 +800,7 @@ export const registerBlockBindingsSource = ( source ) => {
 		getValues,
 		setValues,
 		canUserEditValue,
-		getFieldsList,
+		render,
 	} = source;
 
 	const existingSource = unlock(
@@ -894,10 +894,10 @@ export const registerBlockBindingsSource = ( source ) => {
 		return;
 	}
 
-	// Check the `getFieldsList` property is correct.
-	if ( getFieldsList && typeof getFieldsList !== 'function' ) {
+	// Check the `render` property is correct.
+	if ( render && typeof render !== 'function' ) {
 		// eslint-disable-next-line no-console
-		warning( 'Block bindings source getFieldsList must be a function.' );
+		warning( 'Block bindings source render must be a function.' );
 		return;
 	}
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -801,6 +801,7 @@ export const registerBlockBindingsSource = ( source ) => {
 		setValues,
 		canUserEditValue,
 		render,
+		getBindingLabel,
 	} = source;
 
 	const existingSource = unlock(
@@ -896,8 +897,13 @@ export const registerBlockBindingsSource = ( source ) => {
 
 	// Check the `render` property is correct.
 	if ( render && typeof render !== 'function' ) {
-		// eslint-disable-next-line no-console
 		warning( 'Block bindings source render must be a function.' );
+		return;
+	}
+
+	// Check the `getBindingLabel` property is correct.
+	if ( getBindingLabel && typeof getBindingLabel !== 'function' ) {
+		warning( 'Block bindings source getBindingLabel must be a function.' );
 		return;
 	}
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1643,15 +1643,15 @@ describe( 'blocks', () => {
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
 
-		// Check the `getFieldsList` callback is correct.
-		it( 'should reject invalid getFieldsList callback', () => {
+		// Check the `render` callback is correct.
+		it( 'should reject invalid render callback', () => {
 			registerBlockBindingsSource( {
 				name: 'core/testing',
 				label: 'testing',
-				getFieldsList: 'should be a function',
+				render: 'should be a function',
 			} );
 			expect( console ).toHaveWarnedWith(
-				'Block bindings source getFieldsList must be a function.'
+				'Block bindings source render must be a function.'
 			);
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
@@ -1664,8 +1664,8 @@ describe( 'blocks', () => {
 				getValues: () => 'value',
 				setValues: () => 'new values',
 				canUserEditValue: () => true,
-				getFieldsList: () => {
-					return { field: 'value' };
+				render: () => {
+					return <div>Test</div>;
 				},
 			};
 			registerBlockBindingsSource( {
@@ -1688,7 +1688,7 @@ describe( 'blocks', () => {
 			expect( source.getValues ).toBeUndefined();
 			expect( source.setValues ).toBeUndefined();
 			expect( source.canUserEditValue ).toBeUndefined();
-			expect( source.getFieldsList ).toBeUndefined();
+			expect( source.render ).toBeUndefined();
 			unregisterBlockBindingsSource( 'core/valid-source' );
 		} );
 

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1656,6 +1656,19 @@ describe( 'blocks', () => {
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
 
+		// Check the `getBindingLabel` callback is correct.
+		it( 'should reject invalid getBindingLabel callback', () => {
+			registerBlockBindingsSource( {
+				name: 'core/testing',
+				label: 'testing',
+				getBindingLabel: 'should be a function',
+			} );
+			expect( console ).toHaveWarnedWith(
+				'Block bindings source getBindingLabel must be a function.'
+			);
+			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
+		} );
+
 		// Check correct sources are registered as expected.
 		it( 'should register a valid source', () => {
 			const sourceProperties = {
@@ -1667,6 +1680,7 @@ describe( 'blocks', () => {
 				render: () => {
 					return <div>Test</div>;
 				},
+				getBindingLabel: () => 'Label',
 			};
 			registerBlockBindingsSource( {
 				name: 'core/valid-source',

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -56,6 +56,7 @@ export function addBlockBindingsSource( source ) {
 		setValues: source.setValues,
 		canUserEditValue: source.canUserEditValue,
 		render: source.render,
+		getBindingLabel: source.getBindingLabel,
 	};
 }
 

--- a/packages/blocks/src/store/private-actions.js
+++ b/packages/blocks/src/store/private-actions.js
@@ -55,7 +55,7 @@ export function addBlockBindingsSource( source ) {
 		getValues: source.getValues,
 		setValues: source.setValues,
 		canUserEditValue: source.canUserEditValue,
-		getFieldsList: source.getFieldsList,
+		render: source.render,
 	};
 }
 

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -408,6 +408,7 @@ export function blockBindingsSources( state = {}, action ) {
 					canUserEditValue:
 						action.setValues && action.canUserEditValue,
 					render: action.render,
+					getBindingLabel: action.getBindingLabel,
 				},
 			};
 		case 'ADD_BOOTSTRAPPED_BLOCK_BINDINGS_SOURCE':

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -393,13 +393,6 @@ function getMergedUsesContext( existingUsesContext = [], newUsesContext = [] ) {
 export function blockBindingsSources( state = {}, action ) {
 	switch ( action.type ) {
 		case 'ADD_BLOCK_BINDINGS_SOURCE':
-			// Only open this API in Gutenberg and for `core/post-meta` for the moment.
-			let getFieldsList;
-			if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-				getFieldsList = action.getFieldsList;
-			} else if ( action.name === 'core/post-meta' ) {
-				getFieldsList = action.getFieldsList;
-			}
 			return {
 				...state,
 				[ action.name ]: {
@@ -414,7 +407,7 @@ export function blockBindingsSources( state = {}, action ) {
 					// Only set `canUserEditValue` if `setValues` is also defined.
 					canUserEditValue:
 						action.setValues && action.canUserEditValue,
-					getFieldsList,
+					render: action.render,
 				},
 			};
 		case 'ADD_BOOTSTRAPPED_BLOCK_BINDINGS_SOURCE':

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -38,7 +38,8 @@ function gutenberg_test_block_bindings_registration() {
 		plugins_url( 'block-bindings/index.js', __FILE__ ),
 		array(
 			'wp-blocks',
-			'wp-private-apis',
+			'wp-block-editor',
+			'wp-element',
 		),
 		filemtime( plugin_dir_path( __FILE__ ) . 'block-bindings/index.js' ),
 		true
@@ -49,7 +50,7 @@ function gutenberg_test_block_bindings_registration() {
 		'gutenberg-test-block-bindings',
 		'testingBindings',
 		array(
-			'fieldsList' => $fields_list,
+			'fields' => $fields_list,
 		)
 	);
 

--- a/packages/e2e-tests/plugins/block-bindings/index.js
+++ b/packages/e2e-tests/plugins/block-bindings/index.js
@@ -1,10 +1,12 @@
 const { registerBlockBindingsSource } = wp.blocks;
-const { fieldsList } = window.testingBindings || {};
+const { useBlockBindingsUtils } = wp.blockEditor;
+const { createElement } = wp.element;
+const { fields } = window.testingBindings || {};
 
 const getValues = ( { bindings } ) => {
 	const newValues = {};
 	for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
-		newValues[ attributeName ] = fieldsList[ source.args.key ]?.value;
+		newValues[ attributeName ] = fields[ source.args.key ]?.value;
 	}
 	return newValues;
 };
@@ -23,7 +25,18 @@ registerBlockBindingsSource( {
 	getValues,
 	setValues,
 	canUserEditValue: () => true,
-	getFieldsList: () => fieldsList,
+	render: function TestingComponent( { attribute, binding } ) {
+		const { FieldsList } = useBlockBindingsUtils();
+		return createElement( FieldsList, {
+			fields,
+			source: 'testing/complete-source',
+			attribute,
+			currentBinding: binding,
+		} );
+	},
+	getBindingLabel: ( { binding } ) => {
+		return fields[ binding?.args?.key ]?.label;
+	},
 } );
 
 registerBlockBindingsSource( {

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -173,4 +173,8 @@ export default {
 			/>
 		);
 	},
+	getBindingLabel( { select, context, binding } ) {
+		const metaFields = getPostMetaFields( select, context );
+		return metaFields?.[ binding.args.key ]?.label || binding.args.key;
+	},
 };

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -161,6 +161,7 @@ export default {
 						onChange={ () =>
 							updateBlockBindings( {
 								[ attribute ]: {
+									label: fields[ key ].label,
 									source: 'core/post-meta',
 									args: { key },
 								},

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -165,6 +165,10 @@ export default {
 			[ context ]
 		);
 
+		if ( ! fields ) {
+			return null;
+		}
+
 		return (
 			<FieldsList
 				fields={ fields }

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -3,7 +3,7 @@
  */
 import { useBlockBindingsUtils } from '@wordpress/block-editor';
 import { store as coreDataStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
+import { createSelector, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -36,42 +36,56 @@ import { unlock } from '../lock-unlock';
  * }
  * ```
  */
-function getPostMetaFields( select, context ) {
-	const { getEditedEntityRecord } = select( coreDataStore );
-	const { getRegisteredPostMeta } = unlock( select( coreDataStore ) );
+const getPostMetaFields = createSelector(
+	( select, context ) => {
+		const { getEditedEntityRecord } = select( coreDataStore );
+		const { getRegisteredPostMeta } = unlock( select( coreDataStore ) );
 
-	let entityMetaValues;
-	// Try to get the current entity meta values.
-	if ( context?.postType && context?.postId ) {
-		entityMetaValues = getEditedEntityRecord(
-			'postType',
-			context?.postType,
-			context?.postId
-		).meta;
-	}
-
-	const registeredFields = getRegisteredPostMeta( context?.postType );
-	const metaFields = {};
-	Object.entries( registeredFields || {} ).forEach( ( [ key, props ] ) => {
-		// Don't include footnotes or private fields.
-		if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
-			metaFields[ key ] = {
-				label: props.title || key,
-				value:
-					// When using the entity value, an empty string IS a valid value.
-					entityMetaValues?.[ key ] ??
-					// When using the default, an empty string IS NOT a valid value.
-					( props.default || undefined ),
-			};
+		let entityMetaValues;
+		// Try to get the current entity meta values.
+		if ( context?.postType && context?.postId ) {
+			entityMetaValues = getEditedEntityRecord(
+				'postType',
+				context?.postType,
+				context?.postId
+			).meta;
 		}
-	} );
 
-	if ( ! Object.keys( metaFields || {} ).length ) {
-		return null;
-	}
+		const registeredFields = getRegisteredPostMeta( context?.postType );
+		const metaFields = {};
+		Object.entries( registeredFields || {} ).forEach(
+			( [ key, props ] ) => {
+				// Don't include footnotes or private fields.
+				if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
+					metaFields[ key ] = {
+						label: props.title || key,
+						value:
+							// When using the entity value, an empty string IS a valid value.
+							entityMetaValues?.[ key ] ??
+							// When using the default, an empty string IS NOT a valid value.
+							( props.default || undefined ),
+					};
+				}
+			}
+		);
 
-	return metaFields;
-}
+		if ( ! Object.keys( metaFields || {} ).length ) {
+			return null;
+		}
+
+		return metaFields;
+	},
+	( select, context ) => [
+		select( coreDataStore ).getEditedEntityRecord(
+			'postType',
+			context.postType,
+			context.postId
+		).meta,
+		unlock( select( coreDataStore ) ).getRegisteredPostMeta(
+			context.postType
+		),
+	]
+);
 
 export default {
 	name: 'core/post-meta',
@@ -144,10 +158,12 @@ export default {
 	},
 	render: function PostMetaComponent( { context, attribute, binding } ) {
 		const { FieldsList } = useBlockBindingsUtils();
-		// TODO: Fix useSelect warning.
-		const fields = useSelect( ( select ) => {
-			return getPostMetaFields( select, context );
-		} );
+		const fields = useSelect(
+			( select ) => {
+				return getPostMetaFields( select, context );
+			},
+			[ context ]
+		);
 
 		return (
 			<FieldsList

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -168,8 +168,9 @@ export default {
 		return (
 			<FieldsList
 				fields={ fields }
+				source="core/post-meta"
 				attribute={ attribute }
-				binding={ binding }
+				currentBinding={ binding }
 			/>
 		);
 	},

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useBlockBindingsUtils } from '@wordpress/block-editor';
-import { privateApis as componentsPrivateApis } from '@wordpress/components';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 
@@ -11,8 +10,6 @@ import { useSelect } from '@wordpress/data';
  */
 import { store as editorStore } from '../store';
 import { unlock } from '../lock-unlock';
-
-const { DropdownMenuV2 } = unlock( componentsPrivateApis );
 
 /**
  * Gets a list of post meta fields with their values and labels
@@ -146,40 +143,18 @@ export default {
 		return true;
 	},
 	render: function PostMetaComponent( { context, attribute, binding } ) {
-		const { updateBlockBindings } = useBlockBindingsUtils();
+		const { FieldsList } = useBlockBindingsUtils();
 		// TODO: Fix useSelect warning.
 		const fields = useSelect( ( select ) => {
 			return getPostMetaFields( select, context );
 		} );
-		const currentKey = binding?.args?.key;
 
 		return (
-			<DropdownMenuV2.Group>
-				{ Object.entries( fields ).map( ( [ key, args ] ) => (
-					<DropdownMenuV2.RadioItem
-						key={ key }
-						onChange={ () =>
-							updateBlockBindings( {
-								[ attribute ]: {
-									label: fields[ key ].label,
-									source: 'core/post-meta',
-									args: { key },
-								},
-							} )
-						}
-						name={ attribute + '-binding' }
-						value={ key }
-						checked={ key === currentKey }
-					>
-						<DropdownMenuV2.ItemLabel>
-							{ args?.label }
-						</DropdownMenuV2.ItemLabel>
-						<DropdownMenuV2.ItemHelpText>
-							{ args?.value }
-						</DropdownMenuV2.ItemHelpText>
-					</DropdownMenuV2.RadioItem>
-				) ) }
-			</DropdownMenuV2.Group>
+			<FieldsList
+				fields={ fields }
+				attribute={ attribute }
+				binding={ binding }
+			/>
 		);
 	},
 };

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -757,7 +757,7 @@ test.describe( 'Registered sources', () => {
 		} );
 	} );
 
-	test.describe( 'getFieldsList', () => {
+	test.describe( 'render', () => {
 		test( 'should be possible to update attribute value through bindings UI', async ( {
 			editor,
 			page,
@@ -772,6 +772,9 @@ test.describe( 'Registered sources', () => {
 				} )
 				.click();
 			await page.getByRole( 'button', { name: 'content' } ).click();
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
 			await page
 				.getByRole( 'menuitemradio' )
 				.filter( { hasText: 'Text Field Label' } )
@@ -908,6 +911,9 @@ test.describe( 'Registered sources', () => {
 				},
 			} );
 			await page.getByRole( 'button', { name: 'content' } ).click();
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
 			const textField = page
 				.getByRole( 'menuitemradio' )
 				.filter( { hasText: 'Text Field Label' } );
@@ -1096,7 +1102,7 @@ test.describe( 'Registered sources', () => {
 				'Add Empty Field Label'
 			);
 		} );
-		test( 'should show source label when value is empty, cannot edit, and `getFieldsList` is undefined', async ( {
+		test( 'should show source label when value is empty, cannot edit, and `render` is undefined', async ( {
 			editor,
 		} ) => {
 			await editor.insertBlock( {

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -164,6 +164,9 @@ test.describe( 'Post Meta source', () => {
 				} );
 				await contentBinding.click();
 				await page
+					.getByRole( 'menuitem', { name: 'Post Meta' } )
+					.click();
+				await page
 					.getByRole( 'menuitemradio' )
 					.filter( { hasText: 'Movie field label' } )
 					.click();
@@ -195,6 +198,9 @@ test.describe( 'Post Meta source', () => {
 				} );
 				await contentBinding.click();
 				await page
+					.getByRole( 'menuitem', { name: 'Post Meta' } )
+					.click();
+				await page
 					.getByRole( 'menuitemradio' )
 					.filter( { hasText: 'field_without_label_or_default' } )
 					.click();
@@ -220,6 +226,9 @@ test.describe( 'Post Meta source', () => {
 					.getByRole( 'button', {
 						name: 'content',
 					} )
+					.click();
+				await page
+					.getByRole( 'menuitem', { name: 'Post Meta' } )
 					.click();
 			} );
 
@@ -314,20 +323,19 @@ test.describe( 'Post Meta source', () => {
 					name: 'content',
 				} )
 				.click();
+			// Check post meta dropdown is not available.
+			await expect(
+				page.getByRole( 'menuitem', { name: 'Post Meta' } )
+			).toBeHidden();
+
 			// Check the fields registered by other sources are there.
+			await page
+				.getByRole( 'menuitem', { name: 'Complete Source' } )
+				.click();
 			const customSourceField = page
 				.getByRole( 'menuitemradio' )
 				.filter( { hasText: 'Text Field Label' } );
 			await expect( customSourceField ).toBeVisible();
-			// Check the post meta fields are not visible.
-			const globalField = page
-				.getByRole( 'menuitemradio' )
-				.filter( { hasText: 'text_custom_field' } );
-			await expect( globalField ).toBeHidden();
-			const movieField = page
-				.getByRole( 'menuitemradio' )
-				.filter( { hasText: 'Movie field label' } );
-			await expect( movieField ).toBeHidden();
 		} );
 		test( 'should show the key in attributes connected to post meta', async ( {
 			editor,
@@ -542,6 +550,7 @@ test.describe( 'Post Meta source', () => {
 					name: 'content',
 				} )
 				.click();
+			await page.getByRole( 'menuitem', { name: 'Post Meta' } ).click();
 			const movieField = page
 				.getByRole( 'menuitemradio' )
 				.filter( { hasText: 'Movie field label' } );


### PR DESCRIPTION
## What?
In this pull request, I'm exploring how extending the block bindings UI could look like. Introducing a basic UI that can be iterated later. Everything is up for debate, and I am still thinking about the different possibilities. I just made something up to trigger the conversations. I'd love to know more opinions if the path of these APIs is good or it should be discarded.


This is one possibility I was considering, and it basically consists of the following:
- Remove the existing `getFieldsList` API. I am not convinced about how it works right now, and it is limited to the post meta UI.
- Add a `render` property that lets sources decide what to show in the dropdown.
- Expose a `FieldsList` component, which allows sources to reuse the UI used for post meta.
- Add a `getBindingLabel` property. This is used in two places so far, in the Attributes panel and in the Rich Text placeholder when the value is empty. (This was previously relying on the `getFieldsList` API.

| ![Screenshot 2024-10-09 at 15 27 21](https://github.com/user-attachments/assets/a56108fd-5806-4eaf-9177-360b901fbade) | ![Screenshot 2024-10-09 at 15 27 12](https://github.com/user-attachments/assets/3f2de9cb-0d18-4102-935c-dbb7273dc21a) |
|----------|----------|

With those mechanisms, sources should be able to introduce the UI they need in an "easy" way. These are a couple of examples, WooCommerce using the same UI as Post Meta, and a Custom Source using a custom component.

_You can find the code examples at the end of this post._

https://github.com/user-attachments/assets/ece84cd4-c15f-4d17-81fe-651157c425bc

As you can see, the idea is to include in the dropdown only the sources that have defined a `render` property and, if all of them return `null`, don't show the dropdown at all.

In a follow-up pull request, I plan to explore a "default" UI for sources that don't need anything custom. For example, sources registered in the server.

## Why?
Extending the UI has been a common demand of block bindings user, and I believe we need to explore how it could be shaped.

## Testing Instructions
This should be covered by e2e tests, which have been updated to these changes.

If you want to test it manually, you can register new sources similar to the examples shared below.

## Code examples

#### WooCommerce source registration

```js
// This should be fetched from the API.
const fields = {
	product_title: {
		label: 'Product Title',
		value: 'Cool Socks',
	},
	product_price: {
		label: 'Product Price',
		value: '$9.99',
	},
};

const wooSource = {
	name: 'core/woocommerce',
	label: 'WooCommerce',
	getValues( { select, clientId, context, bindings } ) {
		const newValues = {};
		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
			// Use the value, the field label, or the field key.
			const fieldKey = source.args.key;
			const { value: fieldValue, label: fieldLabel } =
				fields?.[ fieldKey ] || {};
			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
		}
		return newValues;
	},
	setValues( { select, dispatch, clientId, bindings } ) {
		console.log( 'edit woo' );
	},
	canUserEditValue: () => true,
	render( { context, attribute, binding } ) {
		const { FieldsList } = useBlockBindingsUtils();
		return (
			<FieldsList
				fields={ fields }
				source={ 'core/woocommerce' }
				attribute={ attribute }
				currentBinding={ binding }
			/>
		);
	},
	getBindingLabel( { select, context, attribute, binding } ) {
		return fields?.[ binding.args.key ]?.label || binding.args.key;
	},
};

...

registerBlockBindingsSource( wooSource );

```

#### Custom source registration

```js
const customSource = {
	name: 'core/custom-source',
	label: 'Custom Source',
	getValues: () => {
		return 'Custom Source';
	},
	render: () => {
		return (
			<div style={ { padding: '20px' } }>This is a custom component</div>
		);
	},
};

...

registerBlockBindingsSource( customSource );

```
