### PR TITLE
consistent with block-development-examples data-basics-59c8f8

### DIFF
--- a/docs/how-to-guides/data-basics/1-data-basics-setup.md
+++ b/docs/how-to-guides/data-basics/1-data-basics-setup.md
@@ -10,7 +10,7 @@ We'll do all the development inside of a WordPress plugin. Let's start by creati
 
 -   my-first-gutenberg-app.php – to create a new admin page
 -   src/index.js – for our JavaScript application
--   style.css – for the minimal stylesheet
+-   src/style.css – for the minimal stylesheet
 -   package.json – for the build process
 
 Go ahead and create these files using the following snippets:
@@ -36,7 +36,7 @@ window.addEventListener(
 );
 ```
 
-**style.css:**
+**src/style.css:**
 
 ```css
 .toplevel_page_my-first-gutenberg-app #wpcontent {
@@ -149,7 +149,7 @@ function load_custom_wp_admin_scripts( $hook ) {
 	// Load our style.css.
 	wp_register_style(
 		'my-first-gutenberg-app',
-		plugins_url( 'style.css', __FILE__ ),
+		plugins_url( 'build/style-index.css', __FILE__ ),
 		array(),
 		$asset_file['version']
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The PR make Dev document match with [block-development-examples data-basics-59c8f8](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/data-basics-59c8f8)

## Why?
Mismatches between Dev document and Finished example makes confusing. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
