### PR TITLE
Zoom out: fix scaling issues

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -21,8 +21,14 @@
 	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
 	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
 	$prev-container-width: var(--wp-block-editor-iframe-zoom-out-prev-container-width);
+	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+	$max-width: 750px;
 
 	transform: scale(#{$scale});
+
+	&.is-default-scale {
+		transform: scale( calc( ( min( #{$container-width}, #{$max-width} ) - 2 * #{$frame-size} ) / #{$prev-container-width} ) );
+	}
 
 	background-color: $gray-300;
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -21,14 +21,8 @@
 	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
 	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
 	$prev-container-width: var(--wp-block-editor-iframe-zoom-out-prev-container-width);
-	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-	$max-width: 750px;
 
 	transform: scale(#{$scale});
-
-	&.is-default-scale {
-		transform: scale( calc( ( min( #{$container-width}, #{$max-width} ) - 2 * #{$frame-size} ) / #{$prev-container-width} ) );
-	}
 
 	background-color: $gray-300;
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -32,11 +32,11 @@
 	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
 	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
 	margin-bottom: calc(-1 * #{$total-height});
-
-	&::before,
-	&::after {
-		height: calc(#{$frame-size} / #{$scale});
-	}
+	// Add the top/bottom frame size. We use scaling to account for the left/right, as
+	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+	// of the content.
+	padding-top: calc(#{$frame-size} / #{$scale});
+	padding-bottom: calc(#{$frame-size} / #{$scale});
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -29,7 +29,7 @@
 	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 	// so we need to adjust the height of the content to match the scale by using negative margins.
 	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-	$total-frame-height: calc(2 * #{$frame-size});
+	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
 	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
 	margin-bottom: calc(-1 * #{$total-height});
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,9 +3,16 @@
 }
 
 .block-editor-iframe__html {
-	border: 0 solid $gray-300;
 	transform-origin: top center;
 	@include editor-canvas-resize-animation;
+	&::before,
+	&::after {
+		content: "";
+		display: block;
+		height: 0;
+		background-color: $gray-300;
+		@include editor-canvas-resize-animation;
+	}
 }
 
 .block-editor-iframe__html.is-zoomed-out {
@@ -19,14 +26,17 @@
 
 	background-color: $gray-300;
 
-	padding: calc(#{$frame-size} / #{$scale}) 0;
-
 	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 	// so we need to adjust the height of the content to match the scale by using negative margins.
 	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
 	$total-frame-height: calc(2 * #{$frame-size});
 	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
 	margin-bottom: calc(-1 * #{$total-height});
+
+	&::before,
+	&::after {
+		height: calc(#{$frame-size} / #{$scale});
+	}
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -5,14 +5,6 @@
 .block-editor-iframe__html {
 	transform-origin: top center;
 	@include editor-canvas-resize-animation;
-	&::before,
-	&::after {
-		content: "";
-		display: block;
-		height: 0;
-		background-color: $gray-300;
-		@include editor-canvas-resize-animation;
-	}
 }
 
 .block-editor-iframe__html.is-zoomed-out {

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -305,13 +305,14 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 
-		if ( scale === 'default' ) {
-			iframeDocument.documentElement.classList.add( 'is-default-scale' );
-		}
-
+		const maxWidth = 750;
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scale
+			scale === 'default'
+				? ( Math.min( containerWidth, maxWidth ) -
+						parseInt( frameSize ) * 2 ) /
+						prevContainerWidthRef.current
+				: scale
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
@@ -354,9 +355,6 @@ function Iframe( {
 			);
 			iframeDocument.documentElement.style.removeProperty(
 				'--wp-block-editor-iframe-zoom-out-prev-container-width'
-			);
-			iframeDocument.documentElement.classList.remove(
-				'is-default-scale'
 			);
 		};
 	}, [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -309,7 +309,8 @@ function Iframe( {
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
 			scale === 'default'
-				? Math.min( containerWidth, maxWidth ) /
+				? ( Math.min( containerWidth, maxWidth ) -
+						parseInt( frameSize ) * 2 ) /
 						prevContainerWidthRef.current
 				: scale
 		);

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -306,6 +306,9 @@ function Iframe( {
 		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 
 		const maxWidth = 750;
+		// This scaling calculation has to happen within the JS because CSS calc() can
+		// only divide and multiply by a unitless value. I.e. calc( 100px / 2 ) is valid
+		// but calc( 100px / 2px ) is not.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
 			scale === 'default'

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -305,14 +305,13 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 
-		const maxWidth = 750;
+		if ( scale === 'default' ) {
+			iframeDocument.documentElement.classList.add( 'is-default-scale' );
+		}
+
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scale === 'default'
-				? ( Math.min( containerWidth, maxWidth ) -
-						parseInt( frameSize ) * 2 ) /
-						prevContainerWidthRef.current
-				: scale
+			scale
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
@@ -355,6 +354,9 @@ function Iframe( {
 			);
 			iframeDocument.documentElement.style.removeProperty(
 				'--wp-block-editor-iframe-zoom-out-prev-container-width'
+			);
+			iframeDocument.documentElement.classList.remove(
+				'is-default-scale'
 			);
 		};
 	}, [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -317,9 +317,11 @@ function Iframe( {
 						prevContainerWidthRef.current
 				: scale
 		);
+
+		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			typeof frameSize === 'number' ? `${ frameSize }px` : frameSize
+			`${ frameSize }px`
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -100,6 +100,7 @@ function useBubbleEvents( iframeDocument ) {
 		};
 	} );
 }
+
 function Iframe( {
 	contentRef,
 	children,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -100,7 +100,6 @@ function useBubbleEvents( iframeDocument ) {
 		};
 	} );
 }
-
 function Iframe( {
 	contentRef,
 	children,
@@ -321,7 +320,7 @@ function Iframe( {
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ frameSize }px`
+			typeof frameSize === 'number' ? `${ frameSize }px` : frameSize
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',

--- a/packages/block-editor/src/components/iframe/style.scss
+++ b/packages/block-editor/src/components/iframe/style.scss
@@ -12,5 +12,6 @@
 	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
 	$prev-container-width: var(--wp-block-editor-iframe-zoom-out-prev-container-width, 100vw);
 	width: $prev-container-width;
+	// This is to offset the movement of the iframe when we open sidebars
 	margin-left: calc(-1 * (#{$prev-container-width} - #{$container-width}) / 2);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Closes https://github.com/WordPress/gutenberg/issues/65757. 

As @stokesman discovered in https://github.com/WordPress/gutenberg/pull/65814/, we need to account for the frame size in the scaling in order to prevent reflows of the content. This PR takes that idea in a slightly different direction.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The trunk implementation uses a `border` applied to the iframe to offset it from the edges of the frame. Applying the border causes a reflow of content because the border is included in the width of the html element.

Margin and padding both cause the same problem as they are on the inside of the iframe. And the `box-sizing` property also doesn't work because we're working within the iframe.

We need the iframe to be full width of the canvas to be able to scroll anywhere in the zoomed out canvas area and avoid double scrollbars. Because of this, any offsetting needs to be done within the iframe.

The fix then, is to apply the frame size into the scaling calculation for the width. When we scale the canvas, we need to make sure it scales far enough that it _also_ includes the frame size offset. This means we can remove the border (no reflowing) and preserve a frame offset.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- For the top and bottom frame, use `padding` as it seems to work across browsers (unlike `margin`) and makes more sense contextually (unlike `border` or pseudo-elements).
- For the left and right of the frame, include the `frameSize` in the calculation for `scale` so that none of the `padding`/`margin`/`border` are included in the width calculation.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow @stokesman's testing procedure from #65814.

> 1. Observe the actual width of the canvas `html` element
> 2. Engage zoom-out
> 3. Verify the width is the same as before
> 
> Using Chrome’s dev tools the `Computed` tab will show the width as if it were not scaled so it’s handy for this. Though if you have the `html` element selected during the transition to zoom out, it may fail to update completely so deselecting and reselecting `html` element is recommended.

Visually, this means that content will not reflow when zoom out is engaged.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
