### PR TITLE
Restores setting zoom out mode to useZoomOut hook

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1077,11 +1077,11 @@ _Parameters_
 
 ### useZoomOut
 
-A hook used to set the zoomed out view, invoking the hook sets the mode.
+A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
 
 _Parameters_
 
--   _zoomOut_ `boolean`: If we should zoom out or not.
+-   _zoomOut_ `boolean`: If we should enter into zoomOut mode or not
 
 ### Warning
 

--- a/test/e2e/specs/editor/various/parsing-patterns.spec.js
+++ b/test/e2e/specs/editor/various/parsing-patterns.spec.js
@@ -36,6 +36,14 @@ test.describe( 'Parsing patterns', () => {
 				],
 			} );
 		} );
+
+		// Exit zoom out mode and select the inner buttons block to ensure
+		// the correct insertion point is selected.
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await editor.selectBlocks(
+			editor.canvas.locator( 'role=document[name="Block: Button"i]' )
+		);
+
 		await page.fill(
 			'role=region[name="Block Library"i] >> role=searchbox[name="Search"i]',
 			'whitespace'
@@ -43,7 +51,7 @@ test.describe( 'Parsing patterns', () => {
 		await page
 			.locator( 'role=option[name="Pattern with top-level whitespace"i]' )
 			.click();
-		expect( await editor.getBlocks() ).toMatchObject( [
+		await expect.poll( editor.getBlocks ).toMatchObject( [
 			{
 				name: 'core/buttons',
 				innerBlocks: [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
The useZoomOut hook was only setting zoom level, not entering the zoom out mode, which gets it into odd scenarios.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The bug on trunk:
- Open Inserter
- Open Patterns Tab
- Select something on canvas
- Bug one: (it will be in the normal editing mode, not zoom out)
- Unset Zoom Out via header button
- Click Zoom Out button in header again
- Enters Zoom out for real
- Close Inserter
- Bug 2: In zoom out mode while on full canvas

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Revert useZoomOut mode to when it also handled setting and unsetting the mode
- Add setZoomLevel to be handled when entering/exiting zoom out mode
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open Inserter
- Open Patterns Tab
- Select something on canvas
- Unset Zoom Out via header button
- Click Zoom Out button in header again
- Enters Zoom out for real
- Close Inserter

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
**Before**
https://github.com/user-attachments/assets/dad48d4b-8b56-4d91-bc9e-515f0c5b579b

**After**
https://github.com/user-attachments/assets/39f08ead-22dc-4c46-b034-fa9385f3e5f1