### PR TITLE
Leverage scheduler.yield in splitTask when available

### DIFF
--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -64,7 +64,7 @@ export const splitTask =
 	typeof window.scheduler.yield === 'function'
 		? window.scheduler.yield.bind( window.scheduler )
 		: () => {
-				return new Promise( async ( resolve ) => {
+				return new Promise( ( resolve ) => {
 					setTimeout( resolve, 0 );
 				} );
 		  };

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -24,8 +24,8 @@ interface Flusher {
 
 declare global {
 	interface Window {
-		scheduler: {
-			readonly yield: () => Promise<void>;
+		scheduler?: {
+			readonly yield?: () => Promise< void >;
 		};
 	}
 }

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -62,7 +62,7 @@ export const splitTask =
 	null !== window.scheduler &&
 	'yield' in window.scheduler &&
 	typeof window.scheduler.yield === 'function'
-		? window.scheduler.yield
+		? window.scheduler.yield.bind( window.scheduler )
 		: () => {
 				return new Promise( async ( resolve ) => {
 					setTimeout( resolve, 0 );

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -57,11 +57,7 @@ const afterNextFrame = ( callback: () => void ) => {
  * @return Promise
  */
 export const splitTask =
-	'scheduler' in window &&
-	typeof window.scheduler === 'object' &&
-	null !== window.scheduler &&
-	'yield' in window.scheduler &&
-	typeof window.scheduler.yield === 'function'
+	typeof window.scheduler?.yield === 'function'
 		? window.scheduler.yield.bind( window.scheduler )
 		: () => {
 				return new Promise( ( resolve ) => {

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -25,7 +25,7 @@ interface Flusher {
 declare global {
 	interface Window {
 		scheduler: {
-			readonly yield: () => void;
+			readonly yield: () => Promise<void>;
 		};
 	}
 }

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -49,19 +49,17 @@ const afterNextFrame = ( callback: () => void ) => {
  * @return Promise
  */
 export const splitTask = () => {
+	if (
+		'scheduler' in window &&
+		typeof window.scheduler === 'object' &&
+		null !== window.scheduler &&
+		'yield' in window.scheduler &&
+		typeof window.scheduler.yield === 'function'
+	) {
+		return window.scheduler.yield();
+	}
 	return new Promise( async ( resolve ) => {
-		if (
-			'scheduler' in window &&
-			typeof window.scheduler === 'object' &&
-			null !== window.scheduler &&
-			'yield' in window.scheduler &&
-			typeof window.scheduler.yield === 'function'
-		) {
-			await window.scheduler.yield();
-			resolve( undefined );
-		} else {
-			setTimeout( resolve, 0 );
-		}
+		setTimeout( resolve, 0 );
 	} );
 };
 

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -49,9 +49,19 @@ const afterNextFrame = ( callback: () => void ) => {
  * @return Promise
  */
 export const splitTask = () => {
-	return new Promise( ( resolve ) => {
-		// TODO: Use scheduler.yield() when available.
-		setTimeout( resolve, 0 );
+	return new Promise( async ( resolve ) => {
+		if (
+			'scheduler' in window &&
+			typeof window.scheduler === 'object' &&
+			null !== window.scheduler &&
+			'yield' in window.scheduler &&
+			typeof window.scheduler.yield === 'function'
+		) {
+			await window.scheduler.yield();
+			resolve( undefined );
+		} else {
+			setTimeout( resolve, 0 );
+		}
 	} );
 };
 

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -62,9 +62,7 @@ export const splitTask =
 	null !== window.scheduler &&
 	'yield' in window.scheduler &&
 	typeof window.scheduler.yield === 'function'
-		? () => {
-				return window.scheduler.yield();
-		  }
+		? window.scheduler.yield
 		: () => {
 				return new Promise( async ( resolve ) => {
 					setTimeout( resolve, 0 );

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -22,6 +22,14 @@ interface Flusher {
 	readonly dispose: () => void;
 }
 
+declare global {
+	interface Window {
+		scheduler: {
+			readonly yield: () => void;
+		};
+	}
+}
+
 /**
  * Executes a callback function after the next frame is rendered.
  *
@@ -48,20 +56,20 @@ const afterNextFrame = ( callback: () => void ) => {
  *
  * @return Promise
  */
-export const splitTask = () => {
-	if (
-		'scheduler' in window &&
-		typeof window.scheduler === 'object' &&
-		null !== window.scheduler &&
-		'yield' in window.scheduler &&
-		typeof window.scheduler.yield === 'function'
-	) {
-		return window.scheduler.yield();
-	}
-	return new Promise( async ( resolve ) => {
-		setTimeout( resolve, 0 );
-	} );
-};
+export const splitTask =
+	'scheduler' in window &&
+	typeof window.scheduler === 'object' &&
+	null !== window.scheduler &&
+	'yield' in window.scheduler &&
+	typeof window.scheduler.yield === 'function'
+		? () => {
+				return window.scheduler.yield();
+		  }
+		: () => {
+				return new Promise( async ( resolve ) => {
+					setTimeout( resolve, 0 );
+				} );
+		  };
 
 /**
  * Creates a Flusher object that can be used to flush computed values and notify listeners.


### PR DESCRIPTION
Fixes #64483.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->



Use `scheduler.yield()` in the `splitTask()` function in `@wordpress/interactivity` when available. Otherwise, continue to fall back to using `setTimeout` as currently.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In https://github.com/WordPress/gutenberg/pull/58227 a `yieldToMain()` function was introduced to break up long hydration tasks when a document is initialized by the Interactivity API. At the time, this function was implemented using `setTimeout()` as [shown](https://web.dev/articles/optimize-long-tasks#async-await) in the [Optimize long tasks](https://web.dev/articles/optimize-long-tasks) article on web.dev. That article also [describes](https://web.dev/articles/optimize-long-tasks#scheduler-dot-yield) a more performant mechanism in [`scheduler.yield()`](https://developer.mozilla.org/en-US/docs/Web/API/Scheduler/yield) which would be coming at a later date. That date is now in Chromium browsers ([caniuse](https://caniuse.com/mdn-api_scheduler_yield)). 

In https://github.com/WordPress/gutenberg/pull/62665 the `yieldToMain()` function was renamed to `splitTask()` and was then exported by the `@wordpress/interactivity` package for extensions to leverage (e.g. in [Async Actions](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/#async-actions)).

On a post that contains 38 interactive blocks (36 of which are Image blocks with lightboxes) the performance benefits of using `scheduler.yield()` in the following two traces (both run with 6x CPU slowdown on a HP Dragonfly Elite Chromebook):

1. Scripting time is reduced by 21%.
2. Painting time is reduced by 36%.
3. Idle time is reduced by 57% as is seen in the elimination of gaps in the flame chart.
4. Hydration completes before the `load` event.

### Splitting tasks with `setTimeout()`

See [trace.cafe](https://trace.cafe/t/oDgkQh4P1n).

![Screenshot 2024-10-09 16 49 03](https://github.com/user-attachments/assets/9d98545b-9cb6-4351-9c0d-3aabf89ba7d8)

![image](https://github.com/user-attachments/assets/0db1ca14-72ad-47d3-b950-db55dfff4df9)

### Splitting tasks with `scheduler.yield()`

See [trace.cafe](https://trace.cafe/t/3bGJrURUly)

![Screenshot 2024-10-09 16 49 09](https://github.com/user-attachments/assets/e0b83c44-8895-4003-b9ad-4a350c76d925)

![image](https://github.com/user-attachments/assets/bf0a1958-36b3-4edb-8f81-14d4fe41a989)

## Additional Observation

When `scheduler.yield()` is used, I see a 99ms long task caused by `flushAfterPaintEffects`:

![image](https://github.com/user-attachments/assets/8d0db04f-37b4-4051-8c50-091549d2a1ce)

When `setTimeout()` is used, these tasks are split up (where the black outlines indicate instances of  `flushAfterPaintEffects`):

![image](https://github.com/user-attachments/assets/26b4604f-2244-40ab-91bd-a325241d48c6)

This appears to be due to the fact that `flushAfterPaintEffects` itself is scheduled for execution using a timer, meaning that when `scheduler.yield()` is used, the pending paint effects are allowed to bunch up for one single call. This is [part of Preact](https://github.com/preactjs/preact/blob/b5bdcefaa610178cce29ff0d109a036228ef1a2e/hooks/src/index.js#L441-L457), and perhaps that long task can be addressed upstream by introducing `scheduler.yield()` there as well (cf. https://github.com/facebook/react/pull/27069).