### PR TITLE
Post Content: Fix display of block support styles

### DIFF
--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -25,6 +25,7 @@ import { useMemo } from '@wordpress/element';
 import { useCanEditEntity } from '../utils/hooks';
 
 function ReadOnlyContent( {
+	parentLayout,
 	layoutClassNames,
 	userCanEdit,
 	postType,
@@ -43,6 +44,7 @@ function ReadOnlyContent( {
 	const blockPreviewProps = useBlockPreview( {
 		blocks,
 		props: blockProps,
+		layout: parentLayout,
 	} );
 
 	if ( userCanEdit ) {
@@ -120,6 +122,7 @@ function Content( props ) {
 		<EditableContent { ...props } />
 	) : (
 		<ReadOnlyContent
+			parentLayout={ props.parentLayout }
 			layoutClassNames={ layoutClassNames }
 			userCanEdit={ userCanEdit }
 			postType={ postType }
@@ -165,6 +168,7 @@ function RecursionError() {
 export default function PostContentEdit( {
 	context,
 	__unstableLayoutClassNames: layoutClassNames,
+	__unstableParentLayout: parentLayout,
 } ) {
 	const { postId: contextPostId, postType: contextPostType } = context;
 	const hasAlreadyRendered = useHasRecursion( contextPostId );
@@ -178,6 +182,7 @@ export default function PostContentEdit( {
 			{ contextPostId && contextPostType ? (
 				<Content
 					context={ context }
+					parentLayout={ parentLayout }
 					layoutClassNames={ layoutClassNames }
 				/>
 			) : (

--- a/packages/block-library/src/post-content/edit.js
+++ b/packages/block-library/src/post-content/edit.js
@@ -8,13 +8,17 @@ import {
 	RecursionProvider,
 	useHasRecursion,
 	Warning,
+	__experimentalUseBlockPreview as useBlockPreview,
 } from '@wordpress/block-editor';
+import { parse } from '@wordpress/blocks';
 import {
 	useEntityProp,
 	useEntityBlockEditor,
 	store as coreStore,
 } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
@@ -33,7 +37,27 @@ function ReadOnlyContent( {
 		postId
 	);
 	const blockProps = useBlockProps( { className: layoutClassNames } );
-	return content?.protected && ! userCanEdit ? (
+	const blocks = useMemo( () => {
+		return content?.raw ? parse( content.raw ) : [];
+	}, [ content?.raw ] );
+	const blockPreviewProps = useBlockPreview( {
+		blocks,
+		props: blockProps,
+	} );
+
+	if ( userCanEdit ) {
+		/*
+		 * Rendering the block preview using the raw content blocks allows for
+		 * block support styles to be generated and applied by the editor.
+		 *
+		 * The preview using the raw blocks can only be presented to users with
+		 * edit permissions for the post to prevent potential exposure of private
+		 * block content.
+		 */
+		return <div { ...blockPreviewProps }></div>;
+	}
+
+	return content?.protected ? (
 		<div { ...blockProps }>
 			<Warning>{ __( 'This content is password protected.' ) }</Warning>
 		</div>


### PR DESCRIPTION
Fixes:
- https://github.com/WordPress/gutenberg/issues/65644

Revisits approach from:
- https://github.com/WordPress/gutenberg/pull/35863

## What?

Renders actual blocks for Post Content previews when the user can edit the post being previewed. This allows the editors block support hooks to do their job and render additional styles as needed.

Props to @andrewserong for the approach.

## Why?

Currently, the Post Content block renders read-only content via a REST API call. The server side rendered content returned via that request lacks additional stylesheets normally enqueued by block supports. This results in element, layout, and block style variation styles all missing when viewing Query loops containing Post Content previews.


## How?

https://github.com/WordPress/gutenberg/pull/35863 was originally blocked due to concern around potentially exposing private block data if the raw block data was rendered. This PR takes a ever-so-slightly different approach in that it will only render the raw blocks instead of server side rendered HTML when the user has access to edit the post in question.

My understanding is that plugins providing visibility control over blocks within a page, still allow any user with rights to edit a particular page to edit those visibility or access-controller blocks e.g. change them, alter the user capabilities required for their display etc. In other words, the access control there is primarily for the frontend. (happy to be corrected here 🙂)

If a post is password protected and a user doesn't have edit permissions for that post, the original warning is still displayed in place of the post's content.

## Testing Instructions

Using TT5:

1. Create a post and add some content including a nested block with custom layout e.g. Row or Grid block
2. Select a container block and apply a section style provided via TT5
3. Add a paragraph containing a link to the content and apply a custom link color to that block
4. Save and publish the post
5. Switch to the Site Editor and edit the home template
6. Confirm that the query loop in that template renders the post content appropriately.

<details>
<summary>Example block content to test with if it helps</summary>


```html
<!-- wp:group {"className":"is-style-section-4","style":{"spacing":{"padding":{"right":"var:preset|spacing|40","left":"var:preset|spacing|40","top":"var:preset|spacing|40","bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group is-style-section-4" style="padding-top:var(--wp--preset--spacing--40);padding-right:var(--wp--preset--spacing--40);padding-bottom:var(--wp--preset--spacing--40);padding-left:var(--wp--preset--spacing--40)"><!-- wp:group {"style":{"layout":{"columnSpan":1,"rowSpan":1}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
<div class="wp-block-group"><!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#29c8f8"}}}}} -->
<p class="has-link-color">Welcome to <a href="http://www.wordpress.org">WordPress</a>. This is your first post. Edit or delete it, then start writing! Welcome to WordPress. </p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"style":{"elements":{"link":{"color":{"text":"#3ee732"}}}}} -->
<p class="has-link-color">Welcome to WordPress. This is your first post. Edit or delete it, then start writing! Welcome to <a href="http://wordpress.org">WordPress</a>. </p>
<!-- /wp:paragraph --></div>
<!-- /wp:group -->

<!-- wp:buttons {"style":{"layout":{"columnSpan":2,"rowSpan":1}},"layout":{"type":"flex","justifyContent":"center"}} -->
<div class="wp-block-buttons"><!-- wp:button -->
<div class="wp-block-button"><a class="wp-block-button__link wp-element-button">Button</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group -->

<!-- wp:image {"sizeSlug":"full","linkDestination":"none"} -->
<figure class="wp-block-image size-full"><img/></figure>
<!-- /wp:image --></div>
<!-- /wp:group -->
```
</details>

## Screenshots or screencast <!-- if applicable -->



| Post | Before | After |
|---|---|---|
| <img width="1320" alt="Screenshot 2024-10-09 at 6 41 33 pm" src="https://github.com/user-attachments/assets/cd968d8b-8340-4ccc-864d-dc7664419a0d"> | <img width="1625" alt="Screenshot 2024-10-09 at 6 41 17 pm" src="https://github.com/user-attachments/assets/2a5082ad-f989-45cf-a901-f900784c6f97"> | <img width="1629" alt="Screenshot 2024-10-10 at 3 00 10 pm" src="https://github.com/user-attachments/assets/b4e03742-0265-4299-bc3a-04d479dca8c9"> |



