### PR TITLE
Fix: Don't render image when `src` attribute is empty

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -24,7 +24,7 @@ function render_block_core_image( $attributes, $content, $block ) {
 
 	$p = new WP_HTML_Tag_Processor( $content );
 
-	if ( ! $p->next_tag( 'img' ) || null === $p->get_attribute( 'src' ) ) {
+	if ( ! $p->next_tag( 'img' ) || ! $p->get_attribute( 'src' ) ) {
 		return '';
 	}
 


### PR DESCRIPTION
## What?
In [this old pull request](https://github.com/WordPress/gutenberg/pull/45220), a check was introduced to not render the image when the `src` attribute is not defined. Following the same logic, I believe the image shouldn't render when the attribute is an empty string. This could be the case when that attribute is connected to an empty custom field through block bindings, for example.

## Why?
When the image src is an empty string, this is the resulting HTML in `trunk`

```html
<figure class="wp-block-image"><img decoding="async" src="" alt=""></figure>
```

Following the same reasoning of the original PR: "According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img), the img element must have src attribute, so I believe this is incorrect markup."

> The src attribute is required, and contains the path to the image you want to embed.

For that reason, I think it is better to not render the image.

## How?
I'm just changing the conditional to not render the image when the attribute is falsy, not only null.

## Testing Instructions
1. Register a custom field with an empty value by default.
```
	register_meta(
		'post',
		'empty_field',
		array(
			'label'          => 'Empty Field',
			'show_in_rest' => true,
			'single'       => true,
			'type'         => 'string',
			'default'      => '',
		)
	);
```
2. Go to a page and insert an image.
3. Connect the image src to the empty field. Go to the block settings -> Attributes -> Click three dots -> Select URL -> Connect it to a custom field.
4. Go to the frontend and check that the HTML doesn't include the empty img.
