### PR TITLE
Fix Parent Check Condition in `buildTermsTree`

### DIFF
--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -14,14 +14,16 @@ export function buildTermsTree( flatTerms ) {
 	const flatTermsWithParentAndChildren = flatTerms.map( ( term ) => {
 		return {
 			children: [],
-			parent: null,
+			parent: undefined,
 			...term,
 		};
 	} );
 
 	// All terms should have a `parent` because we're about to index them by it.
 	if (
-		flatTermsWithParentAndChildren.some( ( { parent } ) => parent === null )
+		flatTermsWithParentAndChildren.some(
+			( { parent } ) => parent === undefined
+		)
 	) {
 		return flatTermsWithParentAndChildren;
 	}

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -22,7 +22,7 @@ export function buildTermsTree( flatTerms ) {
 	// All terms should have a `parent` because we're about to index them by it.
 	if (
 		flatTermsWithParentAndChildren.some(
-			( { parent } ) => parent === undefined
+			( { parent } ) => parent === undefined || parent === null
 		)
 	) {
 		return flatTermsWithParentAndChildren;

--- a/packages/editor/src/utils/terms.js
+++ b/packages/editor/src/utils/terms.js
@@ -22,7 +22,7 @@ export function buildTermsTree( flatTerms ) {
 	// All terms should have a `parent` because we're about to index them by it.
 	if (
 		flatTermsWithParentAndChildren.some(
-			( { parent } ) => parent === undefined || parent === null
+			( { parent } ) => parent === undefined
 		)
 	) {
 		return flatTermsWithParentAndChildren;

--- a/packages/editor/src/utils/test/terms.js
+++ b/packages/editor/src/utils/test/terms.js
@@ -4,14 +4,14 @@
 import { buildTermsTree } from '../terms';
 
 describe( 'buildTermsTree()', () => {
-	it( 'Should return same array as input with null parent and empty children added if parent is never specified.', () => {
+	it( 'Should return same array as input with undefined parent and empty children added if parent is never specified.', () => {
 		const input = Object.freeze( [
 			{ id: 2232, dummy: true },
 			{ id: 2245, dummy: true },
 		] );
 		const output = Object.freeze( [
-			{ id: 2232, parent: null, children: [], dummy: true },
-			{ id: 2245, parent: null, children: [], dummy: true },
+			{ id: 2232, parent: undefined, children: [], dummy: true },
+			{ id: 2245, parent: undefined, children: [], dummy: true },
 		] );
 		const termsTreem = buildTermsTree( input );
 		expect( termsTreem ).toEqual( output );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The buildTermsTree function skips the process of converting terms into a tree structure if all terms in the passed array have no parent. Previously, this condition was determined by checking if `parent === null`, but it failed to evaluate correctly when parent was undefined. We will modify it to handle both null and undefined correctly.

## Why?

fix: #65704.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Check `parent === undefiend`

## Testing Instructions

Try #65704.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
