### PR TITLE
Interactivity: Update preact packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7260,10 +7260,27 @@
 			"integrity": "sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==",
 			"dev": true
 		},
+		"node_modules/@preact/signals": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.3.0.tgz",
+			"integrity": "sha512-EOMeg42SlLS72dhoq6Vjq08havnLseWmPQ8A0YsgIAqMgWgx7V1a39+Pxo6i7SY5NwJtH4849JogFq3M67AzWg==",
+			"license": "MIT",
+			"dependencies": {
+				"@preact/signals-core": "^1.7.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			},
+			"peerDependencies": {
+				"preact": "10.x"
+			}
+		},
 		"node_modules/@preact/signals-core": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.4.0.tgz",
-			"integrity": "sha512-5iYoZBhELLIhUQceZI7sDTQWPb+xcVSn2qk8T/aNl/VMh+A4AiPX9YRSh4XO7fZ6pncrVxl1Iln82poVqYVbbw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/@preact/signals-core/-/signals-core-1.8.0.tgz",
+			"integrity": "sha512-OBvUsRZqNmjzCZXWLxkZfhcgT+Fk8DDcT/8vD6a1xhDemodyy87UJRJfASMuSD8FaAIeGgGm85ydXhm7lr4fyA==",
+			"license": "MIT",
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
@@ -42094,6 +42111,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/preact": {
+			"version": "10.24.2",
+			"resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
+			"integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/preact"
+			}
+		},
 		"node_modules/prebuild-install": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -55663,8 +55690,8 @@
 			"version": "6.9.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@preact/signals": "^1.2.2",
-				"preact": "^10.19.3"
+				"@preact/signals": "^1.3.0",
+				"preact": "^10.24.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -55682,30 +55709,6 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"packages/interactivity/node_modules/@preact/signals": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@preact/signals/-/signals-1.2.2.tgz",
-			"integrity": "sha512-ColCqdo4cRP18bAuIR4Oik5rDpiyFtPIJIygaYPMEAwTnl4buWkBOflGBSzhYyPyJfKpkwlekrvK+1pzQ2ldWw==",
-			"dependencies": {
-				"@preact/signals-core": "^1.4.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
-			},
-			"peerDependencies": {
-				"preact": "10.x"
-			}
-		},
-		"packages/interactivity/node_modules/preact": {
-			"version": "10.19.3",
-			"resolved": "https://registry.npmjs.org/preact/-/preact-10.19.3.tgz",
-			"integrity": "sha512-nHHTeFVBTHRGxJXKkKu5hT8C/YWBkPso4/Gad6xuj5dbptt9iF9NZr9pHbPhBrnT2klheu7mHTxTZ/LjwJiEiQ==",
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/preact"
 			}
 		},
 		"packages/interface": {

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Upgrade preact libraries [#66008](https://github.com/WordPress/gutenberg/pull/66008).
+
 ### Bug Fixes
 
 -   Fix an issue where "default" could not be used as a directive suffix ([#65815](https://github.com/WordPress/gutenberg/pull/65815)).

--- a/packages/interactivity/package.json
+++ b/packages/interactivity/package.json
@@ -31,8 +31,8 @@
 		"./debug": "./build-module/debug.js"
 	},
 	"dependencies": {
-		"@preact/signals": "^1.2.2",
-		"preact": "^10.19.3"
+		"@preact/signals": "^1.3.0",
+		"preact": "^10.24.2"
 	},
 	"publishConfig": {
 		"access": "public"

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -67,9 +67,9 @@ export const splitTask = () => {
  * @param notify  The function that notifies listeners when the value is flushed.
  * @return The Flusher object with `flush` and `dispose` properties.
  */
-function createFlusher( compute: () => unknown, notify: () => void ): Flusher {
+function createFlusher( compute: () => void, notify: () => void ): Flusher {
 	let flush: () => void = () => undefined;
-	const dispose = effect( function ( this: any ) {
+	const dispose = effect( function ( this: any ): void {
 		flush = this.c.bind( this );
 		this.x = compute;
 		this.c = notify;

--- a/packages/interactivity/src/vdom.ts
+++ b/packages/interactivity/src/vdom.ts
@@ -161,7 +161,6 @@ export function toVdom( root: Node ): Array< ComponentChild > {
 			}, {} );
 		}
 
-		// @ts-expect-error Fixed in upcoming preact release https://github.com/preactjs/preact/pull/4334
 		if ( localName === 'template' ) {
 			props.content = [
 				...( elementNode as HTMLTemplateElement ).content.childNodes,


### PR DESCRIPTION
## What?

- [@preact/signals@1.3.0](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals%401.3.0)
- [@preact/signals-core@1.5.0](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals-core%401.5.0)
- [@preact/signals-core@1.6.0](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals-core%401.6.0)
- [@preact/signals-core@1.7.0](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals-core%401.7.0)
- [@preact/signals-core@1.8.0](https://github.com/preactjs/signals/releases/tag/%40preact%2Fsignals-core%401.8.0)
- [10.19.4](https://github.com/preactjs/preact/releases/tag/10.19.4)
- [10.19.5](https://github.com/preactjs/preact/releases/tag/10.19.5)
- [10.19.6](https://github.com/preactjs/preact/releases/tag/10.19.6)
- [10.19.7](https://github.com/preactjs/preact/releases/tag/10.19.7)
- [10.20.0](https://github.com/preactjs/preact/releases/tag/10.20.0)
- [10.20.1](https://github.com/preactjs/preact/releases/tag/10.20.1)
- [10.20.2](https://github.com/preactjs/preact/releases/tag/10.20.2)
- [10.21.0](https://github.com/preactjs/preact/releases/tag/10.21.0)
- [10.22.0](https://github.com/preactjs/preact/releases/tag/10.22.0)
- [10.22.1](https://github.com/preactjs/preact/releases/tag/10.22.1)
- [10.23.0](https://github.com/preactjs/preact/releases/tag/10.23.0)
- [10.23.1](https://github.com/preactjs/preact/releases/tag/10.23.1)
- [10.23.2](https://github.com/preactjs/preact/releases/tag/10.23.2)
- [10.24.0](https://github.com/preactjs/preact/releases/tag/10.24.0)
- [10.24.1](https://github.com/preactjs/preact/releases/tag/10.24.1)
- [10.24.2](https://github.com/preactjs/preact/releases/tag/10.24.2)

[Full preact changelog](https://github.com/preactjs/preact/compare/10.19.4...10.24.2)

## Why?

These dependencies are essential for Interactivity API and continue to improve.

## How?

Update.

## Testing Instructions

End to end tests on CI are likely sufficient.

