### PR TITLE
Tests: Add unit tests for image rendering

### DIFF
--- a/phpunit/blocks/render-block-image-test.php
+++ b/phpunit/blocks/render-block-image-test.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Image block rendering tests.
+ *
+ * @package WordPress
+ * @subpackage Blocks
+ */
+
+/**
+ * Tests for the Image block.
+ *
+ * @group blocks
+ */
+class Tests_Blocks_Render_Image extends WP_UnitTestCase {
+	/**
+	 * @covers ::render_block_core_image
+	 */
+	public function test_should_render_block_core_image_when_src_is_defined() {
+		$attributes    = array();
+		$content       = '<figure class="wp-block-image"><img src="http://' . WP_TESTS_DOMAIN . '/wp-content/uploads/2021/04/canola.jpg" aria-label="test render"/></figure>';
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:image -->'
+		);
+		$parsed_block  = $parsed_blocks[0];
+		$block         = new WP_Block( $parsed_block );
+
+		$rendered_block = gutenberg_render_block_core_image( $attributes, $content, $block );
+		$this->assertStringContainsString( 'aria-label="test render"', $rendered_block );
+	}
+
+	/**
+	 * @covers ::render_block_core_image
+	 */
+	public function test_should_not_render_block_core_image_when_src_is_not_defined() {
+		$attributes    = array();
+		$content       = '<figure class="wp-block-image"><img /></figure>';
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:image -->'
+		);
+		$parsed_block  = $parsed_blocks[0];
+		$block         = new WP_Block( $parsed_block );
+
+		$rendered_block = gutenberg_render_block_core_image( $attributes, $content, $block );
+		$this->assertEquals( '', $rendered_block );
+	}
+
+	/**
+	 * @covers ::render_block_core_image
+	 */
+	public function test_should_not_render_block_core_image_when_src_is_empty_string() {
+		$attributes    = array();
+		$content       = '<figure class="wp-block-image"><img src=""/></figure>';
+		$parsed_blocks = parse_blocks(
+			'<!-- wp:image -->'
+		);
+		$parsed_block  = $parsed_blocks[0];
+		$block         = new WP_Block( $parsed_block );
+
+		$rendered_block = gutenberg_render_block_core_image( $attributes, $content, $block );
+		$this->assertEquals( '', $rendered_block );
+	}
+}


### PR DESCRIPTION
## What?
In this pull request I'm adding a first suite of unit tests to ensure the image is rendered (or not rendered) appropriately. This can be use as a reference to add lightbox tests or other changes made in the PHP rendering in the future.

## Why?
It will help cover different use cases, especially related to block bindings, and ensure changes won't break the user experience. For example [this one](https://github.com/WordPress/gutenberg/pull/66004).

## How?
I added a new file in the blocks unit tests and followed the patterns there.

## Testing Instructions
The new unit tests should pass.

I also checked that removing [this conditional](https://github.com/WordPress/gutenberg/blob/e4af6b69f25c25da40ac48839fe122f62825aaa7/packages/block-library/src/image/index.php#L27-L29) in the image rendering the tests fail.
