### PR TITLE
Fix zoom reflow by replacing border with padding

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -19,9 +19,7 @@
 
 	background-color: $gray-300;
 
-	// Firefox and Safari don't render margin-bottom here and margin-bottom is needed for Chrome
-	// layout, so we use border matching the background instead of margins.
-	border: calc(#{$frame-size} / #{$scale}) solid $gray-300;
+	padding: calc(#{$frame-size} / #{$scale}) 0;
 
 	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 	// so we need to adjust the height of the content to match the scale by using negative margins.


### PR DESCRIPTION
## What?
Fixes #65757 by removing the applied border and applying padding instead. 

## Screenshots or screencast
### Before 

As seen in FireFox: 

https://github.com/user-attachments/assets/5b255566-db95-4e7a-bbef-105126da5fb8


### After

https://github.com/user-attachments/assets/5623161d-2cb7-4a30-86cc-2a25544f84fb


