### PR TITLE
Enhancement : Add filter in core/page-list block

### DIFF
--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -278,7 +278,7 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 		 * @param WP_Block $block      The parsed block.
 		 */
 		apply_filters(
-			'block_core_page_list_get_pages_args',
+			'block_core_page_list_pages_query_args',
 			array(
 				'sort_column' => 'menu_order,post_title',
 				'order'       => 'asc',

--- a/packages/block-library/src/page-list/index.php
+++ b/packages/block-library/src/page-list/index.php
@@ -266,11 +266,30 @@ function render_block_core_page_list( $attributes, $content, $block ) {
 	$is_nested      = $attributes['isNested'];
 
 	$all_pages = get_pages(
-		array(
-			'sort_column' => 'menu_order,post_title',
-			'order'       => 'asc',
+		/**
+		 * Filters the arguments for the `core/page-list` get_poges() Query.
+		 *
+		 * @see get_pages()
+		 *
+		 * @since 6.8.0
+		 *
+		 * @param array    $args       An array of arguments to query the pages array.
+		 * @param array    $attributes The block attributes.
+		 * @param WP_Block $block      The parsed block.
+		 */
+		apply_filters(
+			'block_core_page_list_get_pages_args',
+			array(
+				'sort_column' => 'menu_order,post_title',
+				'order'       => 'asc',
+			),
+			$attributes,
+			$block
 		)
 	);
+
+	// If the get_pages() function returns false, set it to an empty array.
+	$all_pages = is_array( $all_pages ) ? $all_pages : array();
 
 	// If there are no pages, there is nothing to show.
 	if ( empty( $all_pages ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Allow filtering of the `query args` for the `get_pages` query used in `core/page-list` block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/65897
> Currently the core/page-list block doesn't provide any filters for modifying the pages query. The user has to either use the get_pages_query_args or get_pages filters, should they want to filter the query. However, targeting the correct get_pages() call is difficult as the filters are not aware of in which context they are used - in a block or some other place.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- The user can add a filter to modify the `query args` as follows : 
```
function modify_query_args ( $args, $attributes, $block ) {
	$args['sort_column'] = 'menu_order';
	return $args;
}

add_filter( 'block_core_page_list_pages_query_args', 'modify_query_args', 10, 3 );
``` 