### PR TITLE
Make zoom transition smoother

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -37,7 +37,7 @@
 }
 
 @mixin editor-canvas-resize-animation() {
-	transition: all 0.4s cubic-bezier(0.65, 0, 0.45, 1);
+	transition: all 0.4s cubic-bezier(0.46, 0.03, 0.52, 0.96);
 	@include reduce-motion("transition");
 }
 

--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -37,7 +37,7 @@
 }
 
 @mixin editor-canvas-resize-animation() {
-	transition: all 0.5s cubic-bezier(0.65, 0, 0.45, 1);
+	transition: all 0.4s cubic-bezier(0.65, 0, 0.45, 1);
 	@include reduce-motion("transition");
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A minor adjustment to make the transition fit better with general transition speed across the experience. 

### Before 

https://github.com/user-attachments/assets/0fdfe6b3-0cc8-4a1c-aced-3c827e4cb430


### After 

https://github.com/user-attachments/assets/52d9bb9f-8d3e-41a9-a471-a79e41e238f6

