### PR TITLE
Use consistent canvas frame spacing on device preview and zoom out

### DIFF
--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -43,11 +43,9 @@ export default function useResizeCanvas( deviceType ) {
 		return deviceWidth < actualWidth ? deviceWidth : actualWidth;
 	};
 
-	const marginValue = () => ( window.innerHeight < 800 ? 36 : 64 );
-
 	const contentInlineStyles = ( device ) => {
 		const height = device === 'Mobile' ? '768px' : '1024px';
-		const marginVertical = marginValue() + 'px';
+		const marginVertical = '40px';
 		const marginHorizontal = 'auto';
 
 		switch ( device ) {

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -341,7 +341,7 @@ function VisualEditor( {
 		isZoomedOut && ! isTabletViewport
 			? {
 					scale: 'default',
-					frameSize: '48px',
+					frameSize: '40px',
 			  }
 			: {};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The zoom out frame spacing was set to `48px`, while the preview frame for responsive views is set to `36px` and `64px` based on viewport. Instead let's just keep it the same value (`40px`) so that there is less variance when switching between each of these. 


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Trigger zoom out.
2. Trigger device previews.
3. See consistent frame spacing between the editor header and the preview. 

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/459ba15c-a44e-4a79-bc98-dbc39d67af14



