### PR TITLE
Latest Comments: Add border block support

### DIFF
--- a/packages/block-library/src/editor.scss
+++ b/packages/block-library/src/editor.scss
@@ -22,6 +22,7 @@
 @import "./group/editor.scss";
 @import "./html/editor.scss";
 @import "./image/editor.scss";
+@import "./latest-comments/editor.scss";
 @import "./latest-posts/editor.scss";
 @import "./media-text/editor.scss";
 @import "./more/editor.scss";

--- a/packages/block-library/src/latest-comments/block.json
+++ b/packages/block-library/src/latest-comments/block.json
@@ -58,6 +58,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-latest-comments-editor",

--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -33,6 +33,7 @@ export default function LatestComments( { attributes, setAttributes } ) {
 		style: {
 			...attributes?.style,
 			spacing: undefined,
+			border: undefined,
 		},
 	};
 

--- a/packages/block-library/src/latest-comments/editor.scss
+++ b/packages/block-library/src/latest-comments/editor.scss
@@ -1,11 +1,17 @@
 // Higher specificity - target list via wrapper.
 .wp-block-latest-comments .wp-block-latest-comments {
-	// Remove left spacing. Higher specificity required to
+	// Remove spacing. Higher specificity required to
 	// override default wp-block layout styles in the Post/Site editor.
-	padding-left: 0;
+	padding: 0;
 	// These styles prevent duplicate borders in the Latest Comments block caused by
 	// server-side rendering injecting additional styles in the editor. They ensure
 	// consistent appearance in the editor while avoiding conflicts with frontend styles.
 	border: none;
 	border-radius: inherit;
+}
+
+// Reset margin for inner elements of the server-side rendered block
+// to avoid extra spacing introduced in the editor
+ol.wp-block-latest-comments {
+	margin: 0;
 }

--- a/packages/block-library/src/latest-comments/editor.scss
+++ b/packages/block-library/src/latest-comments/editor.scss
@@ -1,0 +1,11 @@
+// Higher specificity - target list via wrapper.
+.wp-block-latest-comments .wp-block-latest-comments {
+	// Remove left spacing. Higher specificity required to
+	// override default wp-block layout styles in the Post/Site editor.
+	padding-left: 0;
+	// These styles prevent duplicate borders in the Latest Comments block caused by
+	// server-side rendering injecting additional styles in the editor. They ensure
+	// consistent appearance in the editor while avoiding conflicts with frontend styles.
+	border: none;
+	border-radius: inherit;
+}

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -3,11 +3,12 @@ ol.wp-block-latest-comments {
 	// Removes left spacing in Customizer Widgets screen.
 	// Due to low specificity this will be safely overridden
 	// by default wp-block layout styles in the Post/Site editor
-	margin-left: 0;
-
+	margin: 0;
+	padding: 30px 30px 10px 30px;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
+
 
 // Following styles leverage :where so that typography block support styles and
 // global styles apply when necessary.
@@ -31,7 +32,6 @@ ol.wp-block-latest-comments {
 	// Remove left spacing. Higher specificity required to
 	// override default wp-block layout styles in the Post/Site editor.
 	// The following styles are to prevent duplicate spacing and border for the latest comments.
-	padding-left: 0;
 	border: none;
 	border-radius: inherit;
 }

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -9,7 +9,6 @@ ol.wp-block-latest-comments {
 	box-sizing: border-box;
 }
 
-
 // Following styles leverage :where so that typography block support styles and
 // global styles apply when necessary.
 :where(.wp-block-latest-comments:not([style*="line-height"] .wp-block-latest-comments__comment)) {

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -3,8 +3,7 @@ ol.wp-block-latest-comments {
 	// Removes left spacing in Customizer Widgets screen.
 	// Due to low specificity this will be safely overridden
 	// by default wp-block layout styles in the Post/Site editor
-	margin: 0;
-	padding: 30px 30px 10px 30px;
+	margin-left: 0;
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
@@ -31,9 +30,10 @@ ol.wp-block-latest-comments {
 .wp-block-latest-comments .wp-block-latest-comments {
 	// Remove left spacing. Higher specificity required to
 	// override default wp-block layout styles in the Post/Site editor.
-	// The following styles are to prevent duplicate spacing and border for the latest comments.
+	// The following styles are to prevent duplicate border for the latest comments.
 	border: none;
 	border-radius: inherit;
+	box-sizing: border-box;
 }
 
 .wp-block-latest-comments__comment {

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -30,7 +30,10 @@ ol.wp-block-latest-comments {
 .wp-block-latest-comments .wp-block-latest-comments {
 	// Remove left spacing. Higher specificity required to
 	// override default wp-block layout styles in the Post/Site editor.
+	// The following styles are to prevent duplicate spacing and border for the latest comments.
 	padding-left: 0;
+	border: none;
+	border-radius: inherit;
 }
 
 .wp-block-latest-comments__comment {

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -4,6 +4,7 @@ ol.wp-block-latest-comments {
 	// Due to low specificity this will be safely overridden
 	// by default wp-block layout styles in the Post/Site editor
 	margin-left: 0;
+
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
 }
@@ -30,6 +31,7 @@ ol.wp-block-latest-comments {
 .wp-block-latest-comments .wp-block-latest-comments {
 	// Remove left spacing. Higher specificity required to
 	// override default wp-block layout styles in the Post/Site editor.
+	padding-left: 0;
 	// The following styles are to prevent duplicate border for the latest comments.
 	border: none;
 	border-radius: inherit;

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -1,3 +1,8 @@
+.wp-block-latest-comments {
+	// This block has customizable border, border-box makes that more predictable.
+	box-sizing: border-box;
+}
+
 // Lower specificity - target list element.
 ol.wp-block-latest-comments {
 	// Removes left spacing in Customizer Widgets screen.
@@ -34,7 +39,6 @@ ol.wp-block-latest-comments {
 	// The following styles are to prevent duplicate border for the latest comments.
 	border: none;
 	border-radius: inherit;
-	box-sizing: border-box;
 }
 
 .wp-block-latest-comments__comment {

--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -31,16 +31,6 @@ ol.wp-block-latest-comments {
 	}
 }
 
-// Higher specificity - target list via wrapper.
-.wp-block-latest-comments .wp-block-latest-comments {
-	// Remove left spacing. Higher specificity required to
-	// override default wp-block layout styles in the Post/Site editor.
-	padding-left: 0;
-	// The following styles are to prevent duplicate border for the latest comments.
-	border: none;
-	border-radius: inherit;
-}
-
 .wp-block-latest-comments__comment {
 	list-style: none;
 	margin-bottom: 1em;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Add border block support to the Latest Comments block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Latest Comments` block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that ` Latest Comments` block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add ` Latest Comments` block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend
- Since padding style has been moved from style.scss to editor.scss, please activate TT1 theme and check any padding are applied to the latest comments block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
In Frontend:
![frontend](https://github.com/user-attachments/assets/6c2d5977-09d8-43b6-a501-750b2ec57be7)

In Backend:
![backend1](https://github.com/user-attachments/assets/186fd684-1b0a-4777-9b55-936f075814ac)

