### PR TITLE
Tooltip: do not add the `aria-describedby` attribute to the anchor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -147,6 +147,60 @@ const restrictedSyntaxComponents = [
 		message:
 			'`disabled` used without the `accessibleWhenDisabled` prop. Disabling a control without maintaining focusability can cause accessibility issues, by hiding their presence from screen reader users, or preventing focus from returning to a trigger element. (Ignore this error if you truly mean to disable.)',
 	},
+	// Rules to find tooltip usage that needs reviewing.
+	{
+		// All tooltips
+		selector: `JSXOpeningElement[name.name="Tooltip"]`,
+		message:
+			'Tooltip needs to have its anchor checked to make sure it has an accessible description if needed',
+	},
+	...[
+		'Tooltip',
+		'ToolbarButton',
+		'ToolbarDropdownMenu',
+		'DropdownMenu',
+	].map( ( componentName ) => ( {
+		selector: `JSXOpeningElement[name.name="${ componentName }"]:not(:has(JSXAttribute[name.name="__nextHasNoMarginBottom"]))`,
+		message:
+			componentName +
+			' needs to have its anchor checked to make sure it has an accessible description if needed.',
+	} ) ),
+	{
+		// All Button s with a `label` and no explicit `showTooltip={false}` (includes the ones with no children)
+		selector: `JSXOpeningElement[name.name="Button"]:not(:has(JSXAttribute[name.name="showTooltip"][value.expression.value!=true])):has(JSXAttribute[name.name="label"])`,
+		message:
+			'Button needs to be checked to make sure it has an accessible description if needed',
+	},
+	{
+		// All Button s with a `shortcut`
+		selector: `JSXOpeningElement[name.name="Button"]:has(JSXAttribute[name.name="shortcut"])`,
+		message:
+			'Button needs to be checked to make sure it has an accessible description if needed',
+	},
+	{
+		// All Buttons with a description prop
+		selector: `JSXOpeningElement[name.name="Button"]:has(JSXAttribute[name.name="description"])`,
+		message:
+			'Button needs to be checked to make sure it has an accessible description if needed',
+	},
+	{
+		// All Buttons with a describedBy prop
+		selector: `JSXOpeningElement[name.name="Button"]:has(JSXAttribute[name.name="describedBy"])`,
+		message:
+			'Button needs to be checked to make sure it has an accessible description if needed',
+	},
+	{
+		// All Buttons with a aria-describedby prop
+		selector: `JSXOpeningElement[name.name="Button"]:has(JSXAttribute[name.name="aria-describedby"])`,
+		message:
+			'Button needs to be checked to make sure it has an accessible description if needed',
+	},
+	{
+		// All Buttons with a aria-label prop
+		selector: `JSXOpeningElement[name.name="Button"]:has(JSXAttribute[name.name="aria-label"])`,
+		message:
+			'Button needs to be checked to make sure it has an accessible description if needed',
+	},
 ];
 
 module.exports = {

--- a/packages/components/src/tooltip/index.tsx
+++ b/packages/components/src/tooltip/index.tsx
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import * as Ariakit from '@ariakit/react';
-import { useStoreState } from '@ariakit/react';
 import clsx from 'clsx';
 
 /**
@@ -14,7 +13,6 @@ import {
 	useContext,
 	createContext,
 	forwardRef,
-	cloneElement,
 } from '@wordpress/element';
 import deprecated from '@wordpress/deprecated';
 
@@ -94,7 +92,6 @@ function UnforwardedTooltip(
 		placement: computedPlacement,
 		showTimeout: delay,
 	} );
-	const mounted = useStoreState( tooltipStore, 'mounted' );
 
 	if ( isNestedInTooltip ) {
 		return isOnlyChild ? (
@@ -104,31 +101,12 @@ function UnforwardedTooltip(
 		);
 	}
 
-	// TODO: this is a temporary workaround to minimize the effects of the
-	// Ariakit upgrade. Ariakit doesn't pass the `aria-describedby` prop to
-	// the tooltip anchor anymore since 0.4.0, so we need to add it manually.
-	// The `aria-describedby` attribute is added only if the anchor doesn't have
-	// one already, and if the tooltip text is not the same as the anchor's
-	// `aria-label`
-	// See: https://github.com/WordPress/gutenberg/pull/64066
-	// See: https://github.com/WordPress/gutenberg/pull/65989
-	function addDescribedById( element: React.ReactElement ) {
-		return describedById &&
-			mounted &&
-			element.props[ 'aria-describedby' ] === undefined &&
-			element.props[ 'aria-label' ] !== text
-			? cloneElement( element, { 'aria-describedby': describedById } )
-			: element;
-	}
-
 	return (
 		<TooltipInternalContext.Provider value={ CONTEXT_VALUE }>
 			<Ariakit.TooltipAnchor
 				onClick={ hideOnClick ? tooltipStore.hide : undefined }
 				store={ tooltipStore }
-				render={
-					isOnlyChild ? addDescribedById( children ) : undefined
-				}
+				render={ isOnlyChild ? children : undefined }
 				ref={ ref }
 			>
 				{ isOnlyChild ? undefined : children }

--- a/packages/components/src/tooltip/test/index.tsx
+++ b/packages/components/src/tooltip/test/index.tsx
@@ -64,36 +64,6 @@ describe( 'Tooltip', () => {
 			expectTooltipToBeHidden();
 		} );
 
-		it( 'should associate the tooltip text with its anchor via the accessible description when visible', async () => {
-			render( <Tooltip { ...props } /> );
-
-			// The anchor can not be found by querying for its description,
-			// since that is present only when the tooltip is visible
-			expect(
-				screen.queryByRole( 'button', { description: 'tooltip text' } )
-			).not.toBeInTheDocument();
-
-			// Hover the anchor. The tooltip shows and its text is used to describe
-			// the tooltip anchor
-			await hover(
-				screen.getByRole( 'button', {
-					name: 'Tooltip anchor',
-				} )
-			);
-			expect(
-				await screen.findByRole( 'button', {
-					description: 'tooltip text',
-				} )
-			).toBeInTheDocument();
-
-			// Hover outside of the anchor, tooltip should hide
-			await hoverOutside();
-			await waitExpectTooltipToHide();
-			expect(
-				screen.queryByRole( 'button', { description: 'tooltip text' } )
-			).not.toBeInTheDocument();
-		} );
-
 		it( 'should not leak Tooltip props to the tooltip anchor', () => {
 			render(
 				<Tooltip data-foo>
@@ -489,9 +459,7 @@ describe( 'Tooltip', () => {
 				screen.queryByRole( 'tooltip', { name: 'Inner tooltip' } )
 			).not.toBeInTheDocument();
 			expect(
-				screen.getByRole( 'button', {
-					description: 'Outer tooltip',
-				} )
+				screen.getByRole( 'tooltip', { name: 'Outer tooltip' } )
 			).toBeVisible();
 
 			// Hover outside of the anchor, tooltip should hide
@@ -514,84 +482,6 @@ describe( 'Tooltip', () => {
 			expect(
 				screen.getByRole( 'button', { name: 'Anchor' } )
 			).not.toHaveClass( 'components-tooltip' );
-		} );
-	} );
-
-	describe( 'aria-describedby', () => {
-		it( "should not override the anchor's aria-describedby attribute if specified", async () => {
-			render(
-				<>
-					<Tooltip { ...props }>
-						<button aria-describedby="tooltip-test-description">
-							Tooltip anchor
-						</button>
-					</Tooltip>
-					{ /* eslint-disable-next-line no-restricted-syntax */ }
-					<p id="tooltip-test-description">Tooltip description</p>
-					<button>focus trap outside</button>
-				</>
-			);
-
-			expect(
-				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-			).toHaveAccessibleDescription( 'Tooltip description' );
-
-			// Focus the anchor, tooltip should show
-			await press.Tab();
-			expect(
-				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-			).toHaveFocus();
-			await waitExpectTooltipToShow();
-
-			// The anchors should retain its previous accessible description,
-			// since the tooltip shouldn't override it.
-			expect(
-				screen.getByRole( 'button', { name: 'Tooltip anchor' } )
-			).toHaveAccessibleDescription( 'Tooltip description' );
-
-			// Focus the other button, tooltip should hide
-			await press.Tab();
-			expect(
-				screen.getByRole( 'button', { name: 'focus trap outside' } )
-			).toHaveFocus();
-			await waitExpectTooltipToHide();
-		} );
-
-		it( "should not add the aria-describedby attribute to the anchor if the tooltip text matches the anchor's aria-label", async () => {
-			render(
-				<>
-					<Tooltip { ...props }>
-						<button aria-label={ props.text }>
-							Tooltip anchor
-						</button>
-					</Tooltip>
-					<button>focus trap outside</button>
-				</>
-			);
-
-			expect(
-				screen.getByRole( 'button', { name: props.text } )
-			).not.toHaveAccessibleDescription();
-
-			// Focus the anchor, tooltip should show
-			await press.Tab();
-			expect(
-				screen.getByRole( 'button', { name: props.text } )
-			).toHaveFocus();
-			await waitExpectTooltipToShow();
-
-			// The anchor shouldn't have an aria-describedby prop
-			// because its aria-label matches the tooltip text.
-			expect(
-				screen.getByRole( 'button', { name: props.text } )
-			).not.toHaveAccessibleDescription();
-
-			// Focus the other button, tooltip should hide
-			await press.Tab();
-			expect(
-				screen.getByRole( 'button', { name: 'focus trap outside' } )
-			).toHaveFocus();
-			await waitExpectTooltipToHide();
 		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

With the changes from this PR, the `Tooltip` component does not add the `aria-describedby` attribute to its anchor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/issues/65888 (and many other places), the `Tooltip` component currently can add the `aria-describedby` attribute to its anchor, thus providing an accessible description for the anchor element.

This approach is problematic for a few reasons:

- it can provide redundant information in case the anchor already had an accessible description, or a label that was informative enough (this was in part mitigated in https://github.com/WordPress/gutenberg/pull/65989);
- the accessible description is only available when the tooltip is visible, meaning that it can change dynamically — which can be disruptive to assistive technology users.

It was therefore decided that tooltips should be assumed to be decorative only, and that **anchors using a tooltip should make sure they have an accessible label and description regardless of potential tooltips.**

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Deleting code. The underlying `ariakit` component already doesn't add the `aria-describedby` attribute.

### TODO
 - [ ] Create a list of components that need reviewing
 - [ ] Create accessibility guidelines
 - [ ] Divide and conquer

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

For any tooltip usage, make sure that when the tooltip is shown, there are no changes to the `aria-describedby` attribute on the anchor.