### PR TITLE
Fix: pattern rendering issue

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -78,6 +78,7 @@ export default function DataviewsPatterns() {
 	const categoryId = categoryIdFromURL || PATTERN_DEFAULT_CATEGORY;
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const previousCategoryId = usePrevious( categoryId );
+	const previouspostType = usePrevious( type );
 	const viewSyncStatus = view.filters?.find(
 		( { field } ) => field === 'sync-status'
 	)?.value;
@@ -121,10 +122,10 @@ export default function DataviewsPatterns() {
 
 	// Reset the page number when the category changes.
 	useEffect( () => {
-		if ( previousCategoryId !== categoryId ) {
+		if ( previousCategoryId !== categoryId || previouspostType !== type ) {
 			setView( ( prevView ) => ( { ...prevView, page: 1 } ) );
 		}
-	}, [ categoryId, previousCategoryId ] );
+	}, [ categoryId, previousCategoryId, previouspostType, type ] );
 	const { data, paginationInfo } = useMemo( () => {
 		// Search is managed server-side as well as filters for patterns.
 		// However, the author filter in template parts is done client-side.

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -78,7 +78,7 @@ export default function DataviewsPatterns() {
 	const categoryId = categoryIdFromURL || PATTERN_DEFAULT_CATEGORY;
 	const [ view, setView ] = useState( DEFAULT_VIEW );
 	const previousCategoryId = usePrevious( categoryId );
-	const previouspostType = usePrevious( type );
+	const previousPostType = usePrevious( type );
 	const viewSyncStatus = view.filters?.find(
 		( { field } ) => field === 'sync-status'
 	)?.value;
@@ -122,10 +122,10 @@ export default function DataviewsPatterns() {
 
 	// Reset the page number when the category changes.
 	useEffect( () => {
-		if ( previousCategoryId !== categoryId || previouspostType !== type ) {
+		if ( previousCategoryId !== categoryId || previousPostType !== type ) {
 			setView( ( prevView ) => ( { ...prevView, page: 1 } ) );
 		}
-	}, [ categoryId, previousCategoryId, previouspostType, type ] );
+	}, [ categoryId, previousCategoryId, previousPostType, type ] );
 	const { data, paginationInfo } = useMemo( () => {
 		// Search is managed server-side as well as filters for patterns.
 		// However, the author filter in template parts is done client-side.


### PR DESCRIPTION
## What?
part of https://github.com/WordPress/gutenberg/issues/66009

## Why?
Fixes:-  https://github.com/WordPress/gutenberg/issues/66009

## How?
I’ve tracked down the issue and identified that it occurs because the page is not reset to page 1 when switching tabs. This happens due to the condition failure in the file [index.js#L124](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/page-patterns/index.js#L124). When switching tabs between wp_block post type and wp_template_part, neither has a category, so the categoryId defaults to PATTERN_DEFAULT_CATEGORY. As a result, both the previous and current categories are the same, causing the condition to fail.  I have added a condition using the same logic for the post type, which resolves the issue

## Testing Instructions
1.  Log into your test site.
2. Go to Appearance > Editor
3. In the Design menu, select Patterns. By default, the template parts have 5 templates showing
4. In the "View options", set the Layout to Grid. 
5. Go into all patterns.
6. Navigate the next page using the pagination at the bottom of the editor.
7. Select the all template parts tab
8. Patterns should render after switching to All template parts tab.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/5e94bd7d-dc45-4aed-b317-3434a22c6034

