### PR TITLE
Always preview style variations using desktop device type

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -14,8 +14,9 @@ import ScreenHeader from './header';
 import SidebarNavigationScreenGlobalStylesContent from '../sidebar-navigation-screen-global-styles/content';
 
 function ScreenStyleVariations() {
-	// Move to zoom out mode when this component is mounted
-	// and back to the previous mode when unmounted.
+	// Style Variations should only be previewed in with
+	// - a "zoomed out" editor
+	// - "Desktop" device preview
 	const { setDeviceType } = useDispatch( editorStore );
 	useZoomOut();
 	setDeviceType( 'desktop' );

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -4,6 +4,8 @@
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useZoomOut } from '@wordpress/block-editor';
+import { useDispatch } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -14,7 +16,9 @@ import SidebarNavigationScreenGlobalStylesContent from '../sidebar-navigation-sc
 function ScreenStyleVariations() {
 	// Move to zoom out mode when this component is mounted
 	// and back to the previous mode when unmounted.
+	const { setDeviceType } = useDispatch( editorStore );
 	useZoomOut();
+	setDeviceType( 'desktop' );
 
 	return (
 		<>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65991


Fixes the style variations preview when a device type is set, whcih currently zooms out the preview of small viewports.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The device viewports are already small, scaling them out results in an unuseable UI.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Reset the device type when browse styles is invoked and the variation route is loaded. Always use the desktop device type to preview style variations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

0. Using a theme that has style variations (e.g. TT4)
1. In a template
2. Set the device preview using the drop down in the left part of the editor header to mobile
3. Go to Global styles using the black and white icon 
4. Click on Browse styles
5. _Notice the device type is desktop and the scaling is applied to that in the canvas_

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/73dc2589-0d46-4e18-886d-3aeccfe2e865


