### PR TITLE
Revert "Fix zoom reflow by replacing border with padding"

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -19,7 +19,9 @@
 
 	background-color: $gray-300;
 
-	padding: calc(#{$frame-size} / #{$scale}) 0;
+	// Firefox and Safari don't render margin-bottom here and margin-bottom is needed for Chrome
+	// layout, so we use border matching the background instead of margins.
+	border: calc(#{$frame-size} / #{$scale}) solid $gray-300;
 
 	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 	// so we need to adjust the height of the content to match the scale by using negative margins.


### PR DESCRIPTION
Reverts WordPress/gutenberg#66012

It fixes the intended issue, but breaks the padding around the canvas. Opening this revert if we need it, but we may not yet.