### PR TITLE
Site Editor: Prepare route registration by refactoring the site editor router

### DIFF
--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -20,7 +20,7 @@ import { unlock } from '../../lock-unlock';
 import { useCommonCommands } from '../../hooks/commands/use-common-commands';
 import { useEditModeCommands } from '../../hooks/commands/use-edit-mode-commands';
 import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
-import useLayoutAreas from '../layout/router';
+import useActiveRoute from '../layout/router';
 import useSetCommandContext from '../../hooks/commands/use-set-command-context';
 import { useRegisterSiteEditorRoutes } from '../site-editor-routes';
 
@@ -34,7 +34,7 @@ function AppLayout() {
 	useCommonCommands();
 	useSetCommandContext();
 	useRegisterSiteEditorRoutes();
-	const route = useLayoutAreas();
+	const route = useActiveRoute();
 
 	return <Layout route={ route } />;
 }

--- a/packages/edit-site/src/components/app/index.js
+++ b/packages/edit-site/src/components/app/index.js
@@ -22,6 +22,7 @@ import { useEditModeCommands } from '../../hooks/commands/use-edit-mode-commands
 import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 import useLayoutAreas from '../layout/router';
 import useSetCommandContext from '../../hooks/commands/use-set-command-context';
+import { useRegisterSiteEditorRoutes } from '../site-editor-routes';
 
 const { RouterProvider } = unlock( routerPrivateApis );
 const { GlobalStylesProvider } = unlock( editorPrivateApis );
@@ -32,6 +33,7 @@ function AppLayout() {
 	useEditModeCommands();
 	useCommonCommands();
 	useSetCommandContext();
+	useRegisterSiteEditorRoutes();
 	const route = useLayoutAreas();
 
 	return <Layout route={ route } />;

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -68,7 +68,7 @@ export default function Layout( { route } ) {
 	const isEditorLoading = useIsSiteEditorLoading();
 	const [ isResizableFrameOversized, setIsResizableFrameOversized ] =
 		useState( false );
-	const { key: routeKey, areas, widths } = route;
+	const { name: routeKey, areas, widths } = route;
 	const animationRef = useMovingAnimation( {
 		triggerAnimationOnChange: canvasMode,
 	} );

--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -70,7 +70,7 @@ export default function Layout( { route } ) {
 		useState( false );
 	const { key: routeKey, areas, widths } = route;
 	const animationRef = useMovingAnimation( {
-		triggerAnimationOnChange: canvasMode + '__' + routeKey,
+		triggerAnimationOnChange: canvasMode,
 	} );
 
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
@@ -61,24 +61,26 @@ function useRedirectOldPaths() {
 	}, [ history, params ] );
 }
 
-export default function useLayoutAreas() {
+export default function useActiveRoute() {
 	const { params } = useLocation();
 	useRedirectOldPaths();
 	const routes = useSelect( ( select ) => {
 		return unlock( select( editSiteStore ) ).getRoutes();
 	}, [] );
-	const matchedRoute = routes.find( ( route ) => route.match( params ) );
-	if ( ! matchedRoute ) {
-		return {
-			key: 404,
-			areas: {},
-			widths: {},
-		};
-	}
+	return useMemo( () => {
+		const matchedRoute = routes.find( ( route ) => route.match( params ) );
+		if ( ! matchedRoute ) {
+			return {
+				key: 404,
+				areas: {},
+				widths: {},
+			};
+		}
 
-	return {
-		key: matchedRoute.name,
-		areas: matchedRoute.areas,
-		widths: matchedRoute.widths,
-	};
+		return {
+			key: matchedRoute.name,
+			areas: matchedRoute.areas,
+			widths: matchedRoute.widths,
+		};
+	}, [ routes, params ] );
 }

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -78,7 +78,7 @@ export default function useActiveRoute() {
 		}
 
 		return {
-			key: matchedRoute.name,
+			name: matchedRoute.name,
 			areas: matchedRoute.areas,
 			widths: matchedRoute.widths,
 		};

--- a/packages/edit-site/src/components/layout/router.js
+++ b/packages/edit-site/src/components/layout/router.js
@@ -2,31 +2,19 @@
  * WordPress dependencies
  */
 import { privateApis as routerPrivateApis } from '@wordpress/router';
-import { __ } from '@wordpress/i18n';
 import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
-import Editor from '../editor';
-import PostList from '../post-list';
-import PagePatterns from '../page-patterns';
-import PageTemplates from '../page-templates';
-import SidebarNavigationScreen from '../sidebar-navigation-screen';
-import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
-import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
-import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
-import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
-import SidebarNavigationScreenPatterns from '../sidebar-navigation-screen-patterns';
-import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
-import DataViewsSidebarContent from '../sidebar-dataviews';
 import {
 	NAVIGATION_POST_TYPE,
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	TEMPLATE_POST_TYPE,
 } from '../../utils/constants';
-import { PostEdit } from '../post-edit';
+import { store as editSiteStore } from '../../store';
 
 const { useLocation, useHistory } = unlock( routerPrivateApis );
 
@@ -75,127 +63,22 @@ function useRedirectOldPaths() {
 
 export default function useLayoutAreas() {
 	const { params } = useLocation();
-	const { postType, postId, path, layout, isCustom, canvas, quickEdit } =
-		params;
-	const hasEditCanvasMode = canvas === 'edit';
 	useRedirectOldPaths();
-
-	// Page list
-	if ( postType === 'page' ) {
-		const isListLayout = layout === 'list' || ! layout;
-		const showQuickEdit = quickEdit && ! isListLayout;
+	const routes = useSelect( ( select ) => {
+		return unlock( select( editSiteStore ) ).getRoutes();
+	}, [] );
+	const matchedRoute = routes.find( ( route ) => route.match( params ) );
+	if ( ! matchedRoute ) {
 		return {
-			key: 'pages',
-			areas: {
-				sidebar: (
-					<SidebarNavigationScreen
-						title={ __( 'Pages' ) }
-						backPath={ {} }
-						content={ <DataViewsSidebarContent /> }
-					/>
-				),
-				content: <PostList postType={ postType } />,
-				preview: ! showQuickEdit &&
-					( isListLayout || hasEditCanvasMode ) && <Editor />,
-				mobile: hasEditCanvasMode ? (
-					<Editor />
-				) : (
-					<PostList postType={ postType } />
-				),
-				edit: showQuickEdit && (
-					<PostEdit postType={ postType } postId={ postId } />
-				),
-			},
-			widths: {
-				content: isListLayout ? 380 : undefined,
-				edit: showQuickEdit ? 380 : undefined,
-			},
+			key: 404,
+			areas: {},
+			widths: {},
 		};
 	}
 
-	// Templates
-	if ( postType === TEMPLATE_POST_TYPE ) {
-		const isListLayout = isCustom !== 'true' && layout === 'list';
-		return {
-			key: 'templates',
-			areas: {
-				sidebar: (
-					<SidebarNavigationScreenTemplatesBrowse backPath={ {} } />
-				),
-				content: <PageTemplates />,
-				preview: ( isListLayout || hasEditCanvasMode ) && <Editor />,
-				mobile: hasEditCanvasMode ? <Editor /> : <PageTemplates />,
-			},
-			widths: {
-				content: isListLayout ? 380 : undefined,
-			},
-		};
-	}
-
-	// Patterns
-	if (
-		[ TEMPLATE_PART_POST_TYPE, PATTERN_TYPES.user ].includes( postType )
-	) {
-		return {
-			key: 'patterns',
-			areas: {
-				sidebar: <SidebarNavigationScreenPatterns backPath={ {} } />,
-				content: <PagePatterns />,
-				mobile: hasEditCanvasMode ? <Editor /> : <PagePatterns />,
-				preview: hasEditCanvasMode && <Editor />,
-			},
-		};
-	}
-
-	// Styles
-	if ( path === '/wp_global_styles' ) {
-		return {
-			key: 'styles',
-			areas: {
-				sidebar: (
-					<SidebarNavigationScreenGlobalStyles backPath={ {} } />
-				),
-				preview: <Editor />,
-				mobile: hasEditCanvasMode && <Editor />,
-			},
-		};
-	}
-
-	// Navigation
-	if ( postType === NAVIGATION_POST_TYPE ) {
-		if ( postId ) {
-			return {
-				key: 'navigation',
-				areas: {
-					sidebar: (
-						<SidebarNavigationScreenNavigationMenu
-							backPath={ { postType: NAVIGATION_POST_TYPE } }
-						/>
-					),
-					preview: <Editor />,
-					mobile: hasEditCanvasMode && <Editor />,
-				},
-			};
-		}
-		return {
-			key: 'navigation',
-			areas: {
-				sidebar: (
-					<SidebarNavigationScreenNavigationMenus backPath={ {} } />
-				),
-				preview: <Editor />,
-				mobile: hasEditCanvasMode && <Editor />,
-			},
-		};
-	}
-
-	// Fallback shows the home page preview
 	return {
-		key: 'default',
-		areas: {
-			sidebar: <SidebarNavigationScreenMain />,
-			preview: <Editor />,
-			mobile: hasEditCanvasMode && <Editor />,
-		},
+		key: matchedRoute.name,
+		areas: matchedRoute.areas,
+		widths: matchedRoute.widths,
 	};
 }

--- a/packages/edit-site/src/components/posts-app/index.js
+++ b/packages/edit-site/src/components/posts-app/index.js
@@ -12,7 +12,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
  */
 import useInitEditedEntityFromURL from '../sync-state-with-url/use-init-edited-entity-from-url';
 import Layout from '../layout';
-import useLayoutAreas from './router';
+import useActiveRoute from './router';
 import { unlock } from '../../lock-unlock';
 
 const { RouterProvider } = unlock( routerPrivateApis );
@@ -21,7 +21,7 @@ const { GlobalStylesProvider } = unlock( editorPrivateApis );
 function PostsLayout() {
 	// This ensures the edited entity id and type are initialized properly.
 	useInitEditedEntityFromURL();
-	const route = useLayoutAreas();
+	const route = useActiveRoute();
 	return <Layout route={ route } />;
 }
 

--- a/packages/edit-site/src/components/posts-app/router.js
+++ b/packages/edit-site/src/components/posts-app/router.js
@@ -17,7 +17,7 @@ import PostList from '../post-list';
 
 const { useLocation } = unlock( routerPrivateApis );
 
-export default function useLayoutAreas() {
+export default function useActiveRoute() {
 	const { params = {} } = useLocation();
 	const { postType, layout, canvas } = params;
 	const labels = useSelect(
@@ -31,7 +31,7 @@ export default function useLayoutAreas() {
 	if ( [ 'post' ].includes( postType ) ) {
 		const isListLayout = layout === 'list' || ! layout;
 		return {
-			key: 'posts-list',
+			name: 'posts-list',
 			areas: {
 				sidebar: (
 					<SidebarNavigationScreen
@@ -59,7 +59,7 @@ export default function useLayoutAreas() {
 
 	// Fallback shows the home page preview
 	return {
-		key: 'default',
+		name: 'default',
 		areas: {
 			sidebar: <SidebarNavigationScreenMain />,
 			preview: <Editor isPostsList />,

--- a/packages/edit-site/src/components/site-editor-routes/home-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/home-edit.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import Editor from '../editor';
+import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
+
+export const homeEditRoute = {
+	name: 'home-edit',
+	match: ( params ) => {
+		return params.canvas === 'edit';
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenMain />,
+		preview: <Editor />,
+		mobile: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/home-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/home-view.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import Editor from '../editor';
+import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
+
+export const homeViewRoute = {
+	name: 'home-view',
+	match: ( params ) => {
+		return params.canvas !== 'edit';
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenMain />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/index.js
+++ b/packages/edit-site/src/components/site-editor-routes/index.js
@@ -54,7 +54,7 @@ export function useRegisterSiteEditorRoutes() {
 	const { registerRoute } = unlock( useDispatch( siteEditorStore ) );
 	useEffect( () => {
 		registry.batch( () => {
-			routes.map( registerRoute );
+			routes.forEach( registerRoute );
 		} );
 	}, [ registry, registerRoute ] );
 }

--- a/packages/edit-site/src/components/site-editor-routes/index.js
+++ b/packages/edit-site/src/components/site-editor-routes/index.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useRegistry, useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as siteEditorStore } from '../../store';
+import { homeViewRoute } from './home-view';
+import { homeEditRoute } from './home-edit';
+import { navigationViewRoute } from './navigation-view';
+import { navigationEditRoute } from './navigation-edit';
+import { navigationItemEditRoute } from './navigation-item-edit';
+import { navigationItemViewRoute } from './navigation-item-view';
+import { stylesEditRoute } from './styles-edit';
+import { stylesViewRoute } from './styles-view';
+import { patternsEditRoute } from './patterns-edit';
+import { patternsViewRoute } from './patterns-view';
+import { templatesEditRoute } from './templates-edit';
+import { templatesListViewRoute } from './templates-list-view';
+import { templatesViewRoute } from './templates-view';
+import { pagesViewRoute } from './pages-view';
+import { pagesEditRoute } from './pages-edit';
+import { pagesListViewRoute } from './pages-list-view';
+import { pagesListViewQuickEditRoute } from './pages-list-view-quick-edit';
+import { pagesViewQuickEditRoute } from './pages-view-quick-edit';
+
+const routes = [
+	pagesListViewQuickEditRoute,
+	pagesListViewRoute,
+	pagesViewQuickEditRoute,
+	pagesViewRoute,
+	pagesEditRoute,
+	templatesEditRoute,
+	templatesListViewRoute,
+	templatesViewRoute,
+	patternsViewRoute,
+	patternsEditRoute,
+	stylesViewRoute,
+	stylesEditRoute,
+	navigationItemViewRoute,
+	navigationItemEditRoute,
+	navigationViewRoute,
+	navigationEditRoute,
+	homeViewRoute,
+	homeEditRoute,
+];
+
+export function useRegisterSiteEditorRoutes() {
+	const registry = useRegistry();
+	const { registerRoute } = unlock( useDispatch( siteEditorStore ) );
+	useEffect( () => {
+		registry.batch( () => {
+			routes.map( registerRoute );
+		} );
+	}, [ registry, registerRoute ] );
+}

--- a/packages/edit-site/src/components/site-editor-routes/navigation-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-edit.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+import Editor from '../editor';
+import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
+
+export const navigationEditRoute = {
+	name: 'navigation-edit',
+	match: ( params ) => {
+		return (
+			params.postType === NAVIGATION_POST_TYPE &&
+			! params.postId &&
+			params.canvas === 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenNavigationMenus backPath={ {} } />,
+		preview: <Editor />,
+		mobile: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item-edit.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+import Editor from '../editor';
+import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
+
+export const navigationItemEditRoute = {
+	name: 'navigation-item-edit',
+	match: ( params ) => {
+		return (
+			params.postType === NAVIGATION_POST_TYPE &&
+			!! params.postId &&
+			params.canvas === 'edit'
+		);
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreenNavigationMenu
+				backPath={ { postType: NAVIGATION_POST_TYPE } }
+			/>
+		),
+		preview: <Editor />,
+		mobile: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/navigation-item-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-item-view.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+import Editor from '../editor';
+import SidebarNavigationScreenNavigationMenu from '../sidebar-navigation-screen-navigation-menu';
+
+export const navigationItemViewRoute = {
+	name: 'navigation-item-view',
+	match: ( params ) => {
+		return (
+			params.postType === NAVIGATION_POST_TYPE &&
+			!! params.postId &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreenNavigationMenu
+				backPath={ { postType: NAVIGATION_POST_TYPE } }
+			/>
+		),
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/navigation-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/navigation-view.js
@@ -1,0 +1,21 @@
+/**
+ * Internal dependencies
+ */
+import { NAVIGATION_POST_TYPE } from '../../utils/constants';
+import Editor from '../editor';
+import SidebarNavigationScreenNavigationMenus from '../sidebar-navigation-screen-navigation-menus';
+
+export const navigationViewRoute = {
+	name: 'navigation-view',
+	match: ( params ) => {
+		return (
+			params.postType === NAVIGATION_POST_TYPE &&
+			! params.postId &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenNavigationMenus backPath={ {} } />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/pages-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-edit.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import PostList from '../post-list';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import Editor from '../editor';
+
+function PageList() {
+	return <PostList postType="page" />;
+}
+
+export const pagesEditRoute = {
+	name: 'pages-edit',
+	match: ( params ) => {
+		return params.postType === 'page' && params.canvas === 'edit';
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreen
+				title={ __( 'Pages' ) }
+				backPath={ {} }
+				content={ <DataViewsSidebarContent /> }
+			/>
+		),
+		content: <PageList />,
+		mobile: <Editor />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/pages-list-view-quick-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-list-view-quick-edit.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import PostList from '../post-list';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import { unlock } from '../../lock-unlock';
+import { PostEdit } from '../post-edit';
+import Editor from '../editor';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function PageList() {
+	return <PostList postType="page" />;
+}
+
+function PageQuickEdit() {
+	const { params } = useLocation();
+	return <PostEdit postType="page" postId={ params.postId } />;
+}
+
+export const pagesListViewQuickEditRoute = {
+	name: 'pages-list-view-quick-edit',
+	match: ( params ) => {
+		return (
+			params.isCustom !== 'true' &&
+			( params.layout ?? 'list' ) === 'list' &&
+			!! params.quickEdit &&
+			params.postType === 'page' &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreen
+				title={ __( 'Pages' ) }
+				backPath={ {} }
+				content={ <DataViewsSidebarContent /> }
+			/>
+		),
+		content: <PageList />,
+		mobile: <PageList />,
+		preview: <Editor />,
+		edit: <PageQuickEdit />,
+	},
+	width: {
+		content: 380,
+		edit: 380,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/pages-list-view-quick-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-list-view-quick-edit.js
@@ -49,7 +49,7 @@ export const pagesListViewQuickEditRoute = {
 		preview: <Editor />,
 		edit: <PageQuickEdit />,
 	},
-	width: {
+	widths: {
 		content: 380,
 		edit: 380,
 	},

--- a/packages/edit-site/src/components/site-editor-routes/pages-list-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-list-view.js
@@ -38,7 +38,7 @@ export const pagesListViewRoute = {
 		preview: <Editor />,
 		mobile: <PageList />,
 	},
-	width: {
+	widths: {
 		content: 380,
 	},
 };

--- a/packages/edit-site/src/components/site-editor-routes/pages-list-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-list-view.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import PostList from '../post-list';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import Editor from '../editor';
+
+function PageList() {
+	return <PostList postType="page" />;
+}
+
+export const pagesListViewRoute = {
+	name: 'pages-list-view',
+	match: ( params ) => {
+		return (
+			params.isCustom !== 'true' &&
+			( params.layout ?? 'list' ) === 'list' &&
+			! params.quickEdit &&
+			params.postType === 'page' &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreen
+				title={ __( 'Pages' ) }
+				backPath={ {} }
+				content={ <DataViewsSidebarContent /> }
+			/>
+		),
+		content: <PageList />,
+		preview: <Editor />,
+		mobile: <PageList />,
+	},
+	width: {
+		content: 380,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/pages-view-quick-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-view-quick-edit.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
+ * Internal dependencies
+ */
+import PostList from '../post-list';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+import { unlock } from '../../lock-unlock';
+import { PostEdit } from '../post-edit';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function PageList() {
+	return <PostList postType="page" />;
+}
+
+function PageQuickEdit() {
+	const { params } = useLocation();
+	return <PostEdit postType="page" postId={ params.postId } />;
+}
+
+export const pagesViewQuickEditRoute = {
+	name: 'pages-view-quick-edit',
+	match: ( params ) => {
+		return (
+			( params.isCustom === 'true' ||
+				( params.layout ?? 'list' ) !== 'list' ) &&
+			!! params.quickEdit &&
+			params.postType === 'page' &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreen
+				title={ __( 'Pages' ) }
+				backPath={ {} }
+				content={ <DataViewsSidebarContent /> }
+			/>
+		),
+		content: <PageList />,
+		mobile: <PageList />,
+		edit: <PageQuickEdit />,
+	},
+	width: {
+		edit: 380,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/pages-view-quick-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-view-quick-edit.js
@@ -47,7 +47,7 @@ export const pagesViewQuickEditRoute = {
 		mobile: <PageList />,
 		edit: <PageQuickEdit />,
 	},
-	width: {
+	widths: {
 		edit: 380,
 	},
 };

--- a/packages/edit-site/src/components/site-editor-routes/pages-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages-view.js
@@ -1,0 +1,39 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import PostList from '../post-list';
+import DataViewsSidebarContent from '../sidebar-dataviews';
+import SidebarNavigationScreen from '../sidebar-navigation-screen';
+
+function PageList() {
+	return <PostList postType="page" />;
+}
+
+export const pagesViewRoute = {
+	name: 'pages-view',
+	match: ( params ) => {
+		return (
+			( params.isCustom === 'true' ||
+				( params.layout ?? 'list' ) !== 'list' ) &&
+			! params.quickEdit &&
+			params.postType === 'page' &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: (
+			<SidebarNavigationScreen
+				title={ __( 'Pages' ) }
+				backPath={ {} }
+				content={ <DataViewsSidebarContent /> }
+			/>
+		),
+		content: <PageList />,
+		mobile: <PageList />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/patterns-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/patterns-edit.js
@@ -1,0 +1,24 @@
+/**
+ * Internal dependencies
+ */
+import Editor from '../editor';
+import SidebarNavigationScreenPatterns from '../sidebar-navigation-screen-patterns';
+import PagePatterns from '../page-patterns';
+import { PATTERN_TYPES, TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
+
+export const patternsEditRoute = {
+	name: 'patterns-edit',
+	match: ( params ) => {
+		return (
+			[ TEMPLATE_PART_POST_TYPE, PATTERN_TYPES.user ].includes(
+				params.postType
+			) && params.canvas === 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenPatterns backPath={ {} } />,
+		content: <PagePatterns />,
+		mobile: <Editor />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/patterns-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/patterns-view.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import SidebarNavigationScreenPatterns from '../sidebar-navigation-screen-patterns';
+import PagePatterns from '../page-patterns';
+import { PATTERN_TYPES, TEMPLATE_PART_POST_TYPE } from '../../utils/constants';
+
+export const patternsViewRoute = {
+	name: 'patterns-view',
+	match: ( params ) => {
+		return (
+			[ TEMPLATE_PART_POST_TYPE, PATTERN_TYPES.user ].includes(
+				params.postType
+			) && params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenPatterns backPath={ {} } />,
+		content: <PagePatterns />,
+		mobile: <PagePatterns />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/styles-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles-edit.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import Editor from '../editor';
+import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
+
+export const stylesEditRoute = {
+	name: 'styles-edit',
+	match: ( params ) => {
+		return params.path === '/wp_global_styles' && params.canvas === 'edit';
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenGlobalStyles backPath={ {} } />,
+		preview: <Editor />,
+		mobile: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/styles-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles-view.js
@@ -1,0 +1,16 @@
+/**
+ * Internal dependencies
+ */
+import Editor from '../editor';
+import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
+
+export const stylesViewRoute = {
+	name: 'styles-view',
+	match: ( params ) => {
+		return params.path === '/wp_global_styles' && params.canvas !== 'edit';
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenGlobalStyles backPath={ {} } />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/templates-edit.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates-edit.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import PageTemplates from '../page-templates';
+import Editor from '../editor';
+import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
+
+export const templatesEditRoute = {
+	name: 'templates-edit',
+	match: ( params ) => {
+		return (
+			params.postType === TEMPLATE_POST_TYPE && params.canvas === 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenTemplatesBrowse backPath={ {} } />,
+		content: <PageTemplates />,
+		mobile: <Editor />,
+		preview: <Editor />,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/templates-list-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates-list-view.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import PageTemplates from '../page-templates';
+import Editor from '../editor';
+import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
+
+export const templatesListViewRoute = {
+	name: 'templates-list-view',
+	match: ( params ) => {
+		return (
+			params.isCustom !== 'true' &&
+			params.layout === 'list' &&
+			params.postType === TEMPLATE_POST_TYPE &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenTemplatesBrowse backPath={ {} } />,
+		content: <PageTemplates />,
+		mobile: <PageTemplates />,
+		preview: <Editor />,
+	},
+	widths: {
+		content: 380,
+	},
+};

--- a/packages/edit-site/src/components/site-editor-routes/templates-view.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates-view.js
@@ -1,0 +1,22 @@
+/**
+ * Internal dependencies
+ */
+import { TEMPLATE_POST_TYPE } from '../../utils/constants';
+import PageTemplates from '../page-templates';
+import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
+
+export const templatesViewRoute = {
+	name: 'templates-view',
+	match: ( params ) => {
+		return (
+			( params.isCustom === 'true' || params.layout !== 'list' ) &&
+			params.postType === TEMPLATE_POST_TYPE &&
+			params.canvas !== 'edit'
+		);
+	},
+	areas: {
+		sidebar: <SidebarNavigationScreenTemplatesBrowse backPath={ {} } />,
+		content: <PageTemplates />,
+		mobile: <PageTemplates />,
+	},
+};

--- a/packages/edit-site/src/store/private-actions.js
+++ b/packages/edit-site/src/store/private-actions.js
@@ -93,3 +93,10 @@ export const setEditorCanvasContainerView =
 			view,
 		} );
 	};
+
+export function registerRoute( route ) {
+	return {
+		type: 'REGISTER_ROUTE',
+		route,
+	};
+}

--- a/packages/edit-site/src/store/private-selectors.js
+++ b/packages/edit-site/src/store/private-selectors.js
@@ -19,3 +19,7 @@ export function getCanvasMode( state ) {
 export function getEditorCanvasContainerView( state ) {
 	return state.editorCanvasContainerView;
 }
+
+export function getRoutes( state ) {
+	return state.routes;
+}

--- a/packages/edit-site/src/store/reducer.js
+++ b/packages/edit-site/src/store/reducer.js
@@ -98,10 +98,20 @@ function editorCanvasContainerView( state = undefined, action ) {
 	return state;
 }
 
+function routes( state = [], action ) {
+	switch ( action.type ) {
+		case 'REGISTER_ROUTE':
+			return [ ...state, action.route ];
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	settings,
 	editedPost,
 	saveViewPanel,
 	canvasMode,
 	editorCanvasContainerView,
+	routes,
 } );


### PR DESCRIPTION
## What?

For a long time, people have been asking about an API to register pages and routes into the site editor. We're not ready yet to open such API because there are unknowns like: How to expand this API later to the full admin... That said, the current PR makes a huge progress towards that by adding an internal registration API and refactor the existing routes to use it.

## How?

A route object would be something like:

```
const myRoute = {
   name: "Name of the route",
   match: (params)=> boolean // function to see if the current url params match the current route
   areas: {
   },
   widths: {
   }
}
```

**Note**

This PR is not entirely ready, there are still some transitions to improve and we need to do some good testing and debugging. 

## Testing Instructions

Navigate everywhere in the site editor. 