### PR TITLE
Editor: Prevent wrapping text when showing icon labels in header

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -130,6 +130,7 @@
 		// ... and display labels.
 		&::after {
 			content: attr(aria-label);
+			white-space: nowrap;
 		}
 		&[aria-disabled="true"] {
 			background-color: transparent;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/65491

## What?

Prevents wrapping text for editor header buttons when `showIconLabels` is set to `true`.

## Why?

Preventing wrapping keeps these buttons in line with others within the header and arguably more readable. 

See https://github.com/WordPress/gutenberg/issues/65491 for more details.

## How?

Adds `white-space: nowrap` for buttons within the editor's header while the show icon labels preference is enabled.

## Testing Instructions

1. Open editor and enable the show button text labels preference under Accessibility.
    <img width="350" alt="Screenshot 2024-10-11 at 3 59 44 pm" src="https://github.com/user-attachments/assets/69604281-fa7d-48df-8f5a-f1ff4eea26ba">
2. Confirm that the "Zoom out" button in the editor's header does not wrap at any viewport.
3. For bonus points, switch languages or add pinned plugin sidebars and confirm no wrapping occurs.

<details>
<summary>Test snippet to add pinned plugin</summary>

Paste the following into dev tools:

```js
(function (wp, React) {
    var el = React.createElement;
    var registerPlugin = wp.plugins.registerPlugin;
    var PluginSidebar = wp.editor.PluginSidebar;
    var __ = wp.i18n.__;

    const SimplePluginSidebar = () => {
        return el(
            PluginSidebar,
            {
                name: 'simple-plugin-sidebar',
                title: __('My Simple Sidebar'),
                icon: 'smiley',
            },
            el('p', null, __('This is a simple plugin sidebar.'))
        );
    };

    // Register the plugin
    registerPlugin('simple-plugin-sidebar', {
        render: SimplePluginSidebar,
    });
})(window.wp, window.React);
```

</details>

## Screenshots or screencast <!-- if applicable -->

Before: 
<img width="1289" alt="Screenshot 2024-10-11 at 3 38 14 pm" src="https://github.com/user-attachments/assets/df588e7a-7a03-4e9e-9def-764b81f10843">

After: 
<img width="1288" alt="Screenshot 2024-10-11 at 3 38 34 pm" src="https://github.com/user-attachments/assets/71e9021e-56d3-40b7-83ee-7deea8046ff0">



