### PR TITLE
Zoom layout shift: second alternate fix.

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -1,5 +1,6 @@
 .block-editor-iframe__body {
 	position: relative;
+	border-top: 0.01px solid transparent;
 }
 
 .block-editor-iframe__html {
@@ -32,8 +33,6 @@
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
-		display: flex;
-		flex-direction: column;
 
 		> .is-root-container:not(.wp-block-post-content) {
 			flex: 1;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -1,6 +1,6 @@
 .block-editor-iframe__body {
 	position: relative;
-	border-top: 0.01px solid transparent;
+	border: 0.01px solid transparent;
 }
 
 .block-editor-iframe__html {


### PR DESCRIPTION
## What?

Alternative to #65915, and #65967. Removes flex from the zoomed out body element, replaces with a transparent border to prevent margin collapsing from causing a layout shift:

![test2](https://github.com/user-attachments/assets/1fe0ff21-34b6-467c-8edc-c6b3970dfd27)

## Testing Instructions

Go to the post editor, zoom out. There should be no layout shift.