### PR TITLE
Block bindings: Prevent register editor sources before server sources.

### DIFF
--- a/packages/blocks/package.json
+++ b/packages/blocks/package.json
@@ -36,6 +36,7 @@
 		"@wordpress/data": "file:../data",
 		"@wordpress/deprecated": "file:../deprecated",
 		"@wordpress/dom": "file:../dom",
+		"@wordpress/dom-ready": "file:../dom-ready",
 		"@wordpress/element": "file:../element",
 		"@wordpress/hooks": "file:../hooks",
 		"@wordpress/html-entities": "file:../html-entities",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #66031


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

`registerBlockBindingsSource` ([link here](https://github.com/WordPress/gutenberg/blob/ced4f8ca1204fb1737faf44f46e1d27aa78d966e/packages/blocks/src/api/registration.js#L795)) is being executed by 3rd party developers before `bootstrapBlockBindingsSourcesFromServer` happen.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By using `domReady`, we force the function to be executed and the end of the

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Follow the instructions in #66031. Which are:

 - Create a custom source on the server.
 - Create the same custom source on the editor without a label (which should be already provided by the server function).
 - Check that the bound value is working as expected on the editor (showing what it should show, and editable).

