### PR TITLE
Improve pattern rendering performance in the inserter

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/index.js
+++ b/packages/block-editor/src/components/block-patterns-list/index.js
@@ -221,9 +221,8 @@ function BlockPatternsList(
 			aria-label={ label }
 			ref={ ref }
 		>
-			{ blockPatterns.map( ( pattern ) => {
-				const isShown = shownPatterns.includes( pattern );
-				return isShown ? (
+			{ shownPatterns.map( ( pattern ) => {
+				return (
 					<BlockPattern
 						key={ pattern.name }
 						id={ pattern.name }
@@ -235,10 +234,11 @@ function BlockPatternsList(
 						showTooltip={ showTitlesAsTooltip }
 						category={ category }
 					/>
-				) : (
-					<BlockPatternPlaceholder key={ pattern.name } />
 				);
 			} ) }
+			{ shownPatterns.length < blockPatterns.length && (
+				<BlockPatternPlaceholder />
+			) }
 			{ pagingProps && <BlockPatternsPaging { ...pagingProps } /> }
 		</Composite>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

fixes: #65920

It fixes the re-rendering by directly rendering the `shownPatterns` instead of conditionally rendering all `blockPatterns`
Even this triggers a re-render, but since a pattern preview is memoized, it doesn't cause pattern to render again.

**Before:**

![patterns-render](https://github.com/user-attachments/assets/7fc1c3ad-3f9d-4a0d-b6e7-8171330fc2e4)

**After:**

![patterns-render-fix](https://github.com/user-attachments/assets/2b4c470b-b0de-41c9-a014-4fdee26875b5)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


1. Open editor
2. Open pattern menu
3. Click on block in the editor and observe patterns are not re-rendered

