### PR TITLE
Fixed Style Label Appears Twice in Sidebar in tablet view

### DIFF
--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -19,6 +19,7 @@
 	background: $white;
 	padding-right: $grid-unit-15; // Reduced padding to account for close buttons.
 	gap: $grid-unit-10; // Always ensure space between contents and close buttons.
+	display: none;
 
 	.interface-complementary-area-header__title {
 		margin: 0;
@@ -35,5 +36,9 @@
 		@include break-medium() {
 			display: flex;
 		}
+	}
+
+	@include break-medium() {
+		display: flex;
 	}
 }


### PR DESCRIPTION
## What?
Solve https://github.com/WordPress/gutenberg/issues/66050

## Why?
Part of https://github.com/WordPress/gutenberg/issues/66050

## How?
By adding the CSS to the sidebar header.

## Testing Instructions
1. Open the Gutenberg editor.
2. In the top-right corner, click on the "Style" button to open the style section in the sidebar.
3. Switch to the laptop responsive view.
     - Observe that the "Style" label appears only once in the style section of the sidebar.
4. Now, switch the responsive view to tablet mode.
5. Open the style section in the sidebar.
     - Note: "Style" label appears only once in the style section of the sidebar.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/523b9dc7-6a62-46bd-b654-a24a5cfb08df