### PR TITLE
Update README.md

### DIFF
--- a/packages/interactivity-router/README.md
+++ b/packages/interactivity-router/README.md
@@ -80,7 +80,7 @@ Example:
      <li><a href="/post-2">Post 2</a></li>
      <li><a href="/post-3">Post 3</a></li>
   </ul>
-  <a data-wp-on--click="actions.navigate" href="/page/2">
+  <a data-wp-on--click="actions.navigate" href="/page/2">Page 2</a>
 </div>
 ```
 


### PR DESCRIPTION
added link text and closing `</a>` anchor HTML element tag to HTML example line: 83

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
adding closing open HTML tag

## Why?
To assist new users who might be inexperienced with code syntax by limiting unexpected code errors when copy/pasting from examples provided

## How?
ensuring example is a valid HTML code fragment

before:

```html
<div data-wp-interactive="myblock" data-wp-router-region="main-list">
  <ul>
     <li><a href="/post-1">Post 1</a></li>
     <li><a href="/post-2">Post 2</a></li>
     <li><a href="/post-3">Post 3</a></li>
  </ul>
  <a data-wp-on--click="actions.navigate" href="/page/2">
</div>
```
after:

```html
<div data-wp-interactive="myblock" data-wp-router-region="main-list">
  <ul>
     <li><a href="/post-1">Post 1</a></li>
     <li><a href="/post-2">Post 2</a></li>
     <li><a href="/post-3">Post 3</a></li>
  </ul>
  <a data-wp-on--click="actions.navigate" href="/page/2">Page 2</a>
</div>
```
