### PR TITLE
Block Editor: Cleanup `AutoBlockPreview` render memoization of `BlockList`

### DIFF
--- a/packages/block-editor/src/components/block-preview/auto.js
+++ b/packages/block-editor/src/components/block-preview/auto.js
@@ -15,7 +15,7 @@ import EditorStyles from '../editor-styles';
 import { store } from '../../store';
 
 // This is used to avoid rendering the block list if the sizes change.
-let MemoizedBlockList;
+const MemoizedBlockList = memo( BlockList );
 
 const MAX_HEIGHT = 2000;
 const EMPTY_ADDITIONAL_STYLES = [];
@@ -54,9 +54,6 @@ function ScaledBlockPreview( {
 
 		return styles;
 	}, [ styles, additionalStyles ] );
-
-	// Initialize on render instead of module top level, to avoid circular dependency issues.
-	MemoizedBlockList = MemoizedBlockList || memo( BlockList );
 
 	const scale = containerWidth / viewportWidth;
 	const aspectRatio = contentHeight


### PR DESCRIPTION
## What?
Cleans up the circular dependency fix from #22425 that appears to be unnecessary today.

## Why?
It is no longer necessary - the [dependency graph in question](https://github.com/WordPress/gutenberg/pull/22425#issuecomment-2404743689) no longer exists. 

Also, it will resolve one of the errors reported by the React Compiler (see #61788).

## How?
Just move the memorization to the top level of the module.

## Testing Instructions
* Verify all checks are green.
* Smoke test previewing and inserting patterns with all different inserters.
* Install [`CircularDependencyPlugin`](https://www.npmjs.com/package/circular-dependency-plugin) as part of the dev webpack config, add it as a plugin, and verify it reports no errors.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None