### PR TITLE
Fix : Paragraph appender layout shift

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -158,6 +158,15 @@
 	}
 }
 
+// Prevent appender layout shift when default placeholder is clicked and replaced with insertDefaultBlock( undefined, rootClientId );
+.is-root-container.wp-block-post-content-is-layout-flow .block-list-appender {
+
+	p.block-editor-default-block-appender__content {
+		margin-block-start: 0;
+		margin-block-end: 0;
+	}
+}
+
 .block-editor-default-block-appender__content {
 	cursor: text;
 }

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -24,6 +24,11 @@
 	.block-editor-default-block-appender__content {
 		// Set the opacity of the initial block appender to the same as placeholder text in an empty Paragraph block.
 		opacity: 0.62;
+
+		// The following prevent user agent styles from applying margins to the appender's inner paragraph.
+		// Prevents Layout shift in the editor when single post's content block's inner block content width is unset.
+		margin-block-start: 0;
+		margin-block-end: 0;
 	}
 
 	// In "constrained" layout containers, the first and last paragraphs have their margins zeroed out.
@@ -155,15 +160,6 @@
 	.block-editor-inserter__toggle.components-button.has-icon,
 	.block-list-appender__toggle {
 		display: flex;
-	}
-}
-
-// Prevent appender layout shift when default placeholder is clicked and replaced with insertDefaultBlock( undefined, rootClientId );
-.is-root-container.wp-block-post-content-is-layout-flow .block-list-appender {
-
-	p.block-editor-default-block-appender__content {
-		margin-block-start: 0;
-		margin-block-end: 0;
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Adds a style that targets `block-editor-default-block-appender__content` placeholder
- The style sets `margin-block-start` & `margin-block-end` to `0`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/65969
- The style `margin-block-start` & `margin-block-end` are set as `1em` w.r.t styles associated to the `p` tag
- When `Type / to choose a block` is clicked, the following function is executed, which causes the layout shift due to `replacement` of several elements and their style.
```
const onAppend = () => {
	insertDefaultBlock( undefined, rootClientId );
	startTyping();
};
```

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- The style added here ensure the `layout of the content` in the `editor` does not shift when `onClick` is triggered