### PR TITLE
Hide grid visualizer when grid is template locked or block editing mode is not default

### DIFF
--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -10,7 +10,6 @@ import { useSelect } from '@wordpress/data';
  */
 import { GridVisualizer, useGridLayoutSync } from '../components/grid';
 import { store as blockEditorStore } from '../store';
-import { unlock } from '../lock-unlock';
 
 function GridLayoutSync( props ) {
 	useGridLayoutSync( props );
@@ -24,7 +23,7 @@ function GridTools( { clientId, layout } ) {
 				isDraggingBlocks,
 				getTemplateLock,
 				getBlockEditingMode,
-			} = unlock( select( blockEditorStore ) );
+			} = select( blockEditorStore );
 
 			// These calls are purposely ordered from least expensive to most expensive.
 			// Hides the visualizer in cases where the user is not or cannot interact with it.

--- a/packages/block-editor/src/hooks/grid-visualizer.js
+++ b/packages/block-editor/src/hooks/grid-visualizer.js
@@ -10,26 +10,41 @@ import { useSelect } from '@wordpress/data';
  */
 import { GridVisualizer, useGridLayoutSync } from '../components/grid';
 import { store as blockEditorStore } from '../store';
+import { unlock } from '../lock-unlock';
 
 function GridLayoutSync( props ) {
 	useGridLayoutSync( props );
 }
 
 function GridTools( { clientId, layout } ) {
-	const { isSelected, isDragging } = useSelect( ( select ) => {
-		const { isBlockSelected, isDraggingBlocks } =
-			select( blockEditorStore );
+	const isVisible = useSelect(
+		( select ) => {
+			const {
+				isBlockSelected,
+				isDraggingBlocks,
+				getTemplateLock,
+				getBlockEditingMode,
+			} = unlock( select( blockEditorStore ) );
 
-		return {
-			isSelected: isBlockSelected( clientId ),
-			isDragging: isDraggingBlocks(),
-		};
-	} );
+			// These calls are purposely ordered from least expensive to most expensive.
+			// Hides the visualizer in cases where the user is not or cannot interact with it.
+			if (
+				( ! isDraggingBlocks() && ! isBlockSelected( clientId ) ) ||
+				getTemplateLock( clientId ) ||
+				getBlockEditingMode( clientId ) !== 'default'
+			) {
+				return false;
+			}
+
+			return true;
+		},
+		[ clientId ]
+	);
 
 	return (
 		<>
 			<GridLayoutSync clientId={ clientId } />
-			{ ( isSelected || isDragging ) && (
+			{ isVisible && (
 				<GridVisualizer clientId={ clientId } parentLayout={ layout } />
 			) }
 		</>

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -16,7 +16,7 @@ import {
 	GridItemResizer,
 	GridItemMovers,
 } from '../components/grid';
-
+import { unlock } from '../lock-unlock';
 // Used for generating the instance ID
 const LAYOUT_CHILD_BLOCK_PROPS_REFERENCE = {};
 
@@ -175,9 +175,54 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 		isManualPlacement,
 	} = parentLayout;
 
-	const rootClientId = useSelect(
+	if ( parentLayoutType !== 'grid' ) {
+		return null;
+	}
+
+	return (
+		<GridTools
+			clientId={ clientId }
+			style={ style }
+			setAttributes={ setAttributes }
+			allowSizingOnChildren={ allowSizingOnChildren }
+			isManualPlacement={ isManualPlacement }
+			parentLayout={ parentLayout }
+		/>
+	);
+}
+
+function GridTools( {
+	clientId,
+	style,
+	setAttributes,
+	allowSizingOnChildren,
+	isManualPlacement,
+	parentLayout,
+} ) {
+	const { rootClientId, isVisible } = useSelect(
 		( select ) => {
-			return select( blockEditorStore ).getBlockRootClientId( clientId );
+			const {
+				getBlockRootClientId,
+				getBlockEditingMode,
+				getTemplateLock,
+			} = unlock( select( blockEditorStore ) );
+
+			const _rootClientId = getBlockRootClientId( clientId );
+
+			if (
+				getTemplateLock( _rootClientId ) ||
+				getBlockEditingMode( _rootClientId ) !== 'default'
+			) {
+				return {
+					rootClientId: _rootClientId,
+					isVisible: false,
+				};
+			}
+
+			return {
+				rootClientId: _rootClientId,
+				isVisible: true,
+			};
 		},
 		[ clientId ]
 	);
@@ -185,7 +230,7 @@ function ChildLayoutControlsPure( { clientId, style, setAttributes } ) {
 	// Use useState() instead of useRef() so that GridItemResizer updates when ref is set.
 	const [ resizerBounds, setResizerBounds ] = useState();
 
-	if ( parentLayoutType !== 'grid' ) {
+	if ( ! isVisible ) {
 		return null;
 	}
 

--- a/packages/block-editor/src/hooks/layout-child.js
+++ b/packages/block-editor/src/hooks/layout-child.js
@@ -16,7 +16,7 @@ import {
 	GridItemResizer,
 	GridItemMovers,
 } from '../components/grid';
-import { unlock } from '../lock-unlock';
+
 // Used for generating the instance ID
 const LAYOUT_CHILD_BLOCK_PROPS_REFERENCE = {};
 
@@ -205,7 +205,7 @@ function GridTools( {
 				getBlockRootClientId,
 				getBlockEditingMode,
 				getTemplateLock,
-			} = unlock( select( blockEditorStore ) );
+			} = select( blockEditorStore );
 
 			const _rootClientId = getBlockRootClientId( clientId );
 


### PR DESCRIPTION
## What?
Fixes #65974

The grid visualizer doesn't work so well in zoomed out mode, but it also doesn't have much of a purpose, so in this PR it's being hidden. The PR does so by hiding the visualizer whenever the grid block is template locked or has a non-default block editing mode (which it does in zoom out mode).

## Why?
The issue with the visualizer is that it renders in a slot outside the canvas in a slot, so it isn't scaled when zoomed out mode is activated the way the canvas does. It'd probably be a good idea to look at making it scale simultaneously with the canvas. It might be prudent for the zoomed out mode implementation to settle a bit first before doing that. There are still some ongoing changes to the scaling mechanism.

An alternative could also be to finalize #64321, which moves the grid visualisation inside the editor canvas, which should mean it scales along with the canvas. That PR had a few blockers though.

## How?
Adds some additional checks for template lock and the block editing modes and `return null` from the visualizer components when these checks return `isVisible === false`.

There are two places this has to be added:
- `packages/block-editor/src/hooks/grid-visualizer.js` - renders when the grid block itself is selected
- `packages/block-editor/src/hooks/layout-child.js` - renders when an inner block of the grid is selected

## Remaining issues
The grid visualizer still briefly appears incorrectly sized while the canvas zoomed back in:

https://github.com/user-attachments/assets/14aaf60a-0d82-49e1-be1e-adadcc82b149

I'm thinking through ways to solve that 🤔 

## Testing Instructions
1. Add a grid and add some content to a template (inserting the grid at the root level)
2. Enable Zoomed Out Mode
3. Observe that the visualizer no longer shows incorrectly.

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="949" alt="Screenshot 2024-10-11 at 3 14 21 pm" src="https://github.com/user-attachments/assets/04526442-d078-471d-b88f-41a697b493c2">

#### After
<img width="946" alt="Screenshot 2024-10-11 at 3 13 55 pm" src="https://github.com/user-attachments/assets/db43ef4b-2d34-42f3-a82b-3a53d7873341">
