### PR TITLE
Button: prevent text wrapping on default variant

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -11,6 +11,7 @@
 	font-family: inherit;
 	font-weight: normal;
 	font-size: $default-font-size;
+	white-space: nowrap;
 	margin: 0;
 	border: 0;
 	cursor: pointer;
@@ -48,7 +49,6 @@
 	 */
 
 	&.is-primary {
-		white-space: nowrap;
 		background: $components-color-accent;
 		color: $components-color-accent-inverted;
 		text-decoration: none;
@@ -135,7 +135,6 @@
 	&.is-secondary {
 		box-shadow: inset 0 0 0 $border-width $components-color-accent;
 		outline: 1px solid transparent; // Shown in high contrast mode.
-		white-space: nowrap;
 		color: $components-color-accent;
 		background: transparent;
 
@@ -155,7 +154,6 @@
 	 */
 
 	&.is-tertiary {
-		white-space: nowrap;
 		color: $components-color-accent;
 		background: transparent;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #66049

Prevent text wrapping on the default variant of the `Button` component, in order to align it with all other variants

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The discrepancy in how text wraps across different variants of the `Button` component leads to inconsistent UI — and it looks like it was an oversight in the initial implementation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tweaked styles

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Make sure that text inside `Button` doesn't wrap to a new line in all variants (including the default variant)
- Smoke test the editor and make sure there are no regressions

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-10-11 at 16 15 40](https://github.com/user-attachments/assets/ef56cd3a-6e9d-451d-b9fd-9f616dbb437e) |  ![Screenshot 2024-10-11 at 16 16 12](https://github.com/user-attachments/assets/9ba68835-3351-43d4-9018-5765db9fbed0) |

