### PR TITLE
Gutenberg_REST_Posts_Controller_6_7: Support exact search in the REST API posts endpoint.

### DIFF
--- a/lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php
+++ b/lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php
@@ -154,6 +154,13 @@ class Gutenberg_REST_Posts_Controller_6_7 extends WP_REST_Posts_Controller {
 			}
 		}
 
+		if (
+			isset( $registered['search_semantics'], $request['search_semantics'] )
+			&& 'exact' === $request['search_semantics']
+		) {
+			$args['exact'] = true;
+		}
+
 		$args = $this->prepare_tax_query( $args, $request );
 
 		if ( ! empty( $request['format'] ) ) {
@@ -394,6 +401,12 @@ class Gutenberg_REST_Posts_Controller_6_7 extends WP_REST_Posts_Controller {
 				'type'        => 'integer',
 			);
 		}
+
+		$query_params['search_semantics'] = array(
+			'description' => __( 'How to interpret the search input.' ),
+			'type'        => 'string',
+			'enum'        => array( 'exact' ),
+		);
 
 		$query_params['offset'] = array(
 			'description' => __( 'Offset the result set by a specific number of items.' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Introduces the changes from https://core.trac.wordpress.org/changeset/59034/ to Gutenberg_REST_Posts_Controller_6_7

fixes #66069

## Why?
WordPress 6.7 is going to add support for the `exact` `search_semantics` to the REST API posts controller ( see https://core.trac.wordpress.org/changeset/59034/ ) and since the Gutenberg 19.4.0 is overriding related controller ( `Gutenberg_REST_Posts_Controller_6_7` ) it's necessary to port the logic in order to preserve the new feature when Gutenberg is run on WordPress 6.7

## How?
Ports the logic introduced to WordPress in the https://core.trac.wordpress.org/changeset/59034/

## Testing Instructions
Create posts similar to the ones in related PHPUnit tests ( see https://core.trac.wordpress.org/changeset/59034/ ) and perform search via the REST API endpoints (again, similarly to what the WordPress PHPUnit tests do)
