### PR TITLE
Adds categories to Storybooks navigation

### DIFF
--- a/packages/components/src/button/stories/index.story.tsx
+++ b/packages/components/src/button/stories/index.story.tsx
@@ -22,7 +22,8 @@ import './style.css';
 import Button from '..';
 
 const meta: Meta< typeof Button > = {
-	title: 'Components/Button',
+	title: 'Components/Actions/Button',
+	id: 'components-button',
 	component: Button,
 	argTypes: {
 		// Overrides a limitation of the docgen interpreting our TS types for this as required.

--- a/packages/components/src/card/stories/index.story.tsx
+++ b/packages/components/src/card/stories/index.story.tsx
@@ -22,7 +22,8 @@ const meta: Meta< typeof Card > = {
 	component: Card,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { CardHeader, CardBody, CardDivider, CardMedia, CardFooter },
-	title: 'Components/Card',
+	title: 'Components/Containers/Card',
+	id: 'components-card',
 	argTypes: {
 		as: {
 			control: { type: null },

--- a/packages/components/src/navigable-container/stories/navigable-menu.story.tsx
+++ b/packages/components/src/navigable-container/stories/navigable-menu.story.tsx
@@ -9,7 +9,8 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { NavigableMenu } from '..';
 
 const meta: Meta< typeof NavigableMenu > = {
-	title: 'Components/NavigableMenu',
+	title: 'Components/Containers/NavigableMenu',
+	id: 'components-navigablemenu',
 	component: NavigableMenu,
 	argTypes: {
 		children: { control: { type: null } },

--- a/packages/components/src/navigable-container/stories/tabbable-container.story.tsx
+++ b/packages/components/src/navigable-container/stories/tabbable-container.story.tsx
@@ -9,7 +9,8 @@ import type { Meta, StoryFn } from '@storybook/react';
 import { TabbableContainer } from '..';
 
 const meta: Meta< typeof TabbableContainer > = {
-	title: 'Components/TabbableContainer',
+	title: 'Components/Containers/TabbableContainer',
+	id: 'components-tabbablecontainer',
 	component: TabbableContainer,
 	argTypes: {
 		children: { control: { type: null } },

--- a/packages/components/src/panel/stories/index.story.tsx
+++ b/packages/components/src/panel/stories/index.story.tsx
@@ -17,7 +17,8 @@ import InputControl from '../../input-control';
 import { wordpress } from '@wordpress/icons';
 
 const meta: Meta< typeof Panel > = {
-	title: 'Components/Panel',
+	title: 'Components/Containers/Panel',
+	id: 'components-panel',
 	component: Panel,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { PanelRow, PanelBody },

--- a/packages/components/src/tab-panel/stories/index.story.tsx
+++ b/packages/components/src/tab-panel/stories/index.story.tsx
@@ -14,7 +14,8 @@ import { link, more, wordpress } from '@wordpress/icons';
 import TabPanel from '..';
 
 const meta: Meta< typeof TabPanel > = {
-	title: 'Components/TabPanel',
+	title: 'Components/Containers/TabPanel',
+	id: 'components-tabpanel',
 	component: TabPanel,
 	parameters: {
 		actions: { argTypesRegex: '^on.*' },

--- a/packages/components/src/tabs/stories/index.story.tsx
+++ b/packages/components/src/tabs/stories/index.story.tsx
@@ -20,7 +20,8 @@ import Tooltip from '../../tooltip';
 import Icon from '../../icon';
 
 const meta: Meta< typeof Tabs > = {
-	title: 'Components (Experimental)/Tabs',
+	title: 'Components/Containers/Tabs',
+	id: 'components-tabs',
 	component: Tabs,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170

--- a/storybook/manager-head.html
+++ b/storybook/manager-head.html
@@ -10,6 +10,7 @@
 			'navigation',
 			'navigator',
 			'progressbar',
+			'tabs',
 			'theme',
 		];
 		const REDIRECTS = [

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -127,6 +127,12 @@ export const parameters = {
 				'Playground',
 				'BlockEditor',
 				'Components',
+				[
+					'Introduction',
+					'Contributing Guidelines',
+					'Actions',
+					'Containers',
+				],
 				'Components (Experimental)',
 				'Icons',
 			],


### PR DESCRIPTION
## What?
This pull request includes several changes to the Storybook configuration and component metadata to improve organization and consistency. The most important changes include updating the titles and IDs of various components and adding new categories to the Storybook sidebar.

Changes to component metadata:

* [`packages/components/src/button/stories/index.story.tsx`](diffhunk://#diff-4c267068cfff85094aa0481bb8bd5f76b2f18a918f71fbcc1b495d5e1fa7ff55L25-R26): Updated the title to 'Components/Actions/Button' and added an ID 'components-button'.
* [`packages/components/src/card/stories/index.story.tsx`](diffhunk://#diff-01ea488375f15f4087947f782f6ae6aa62dff3040fb3edd6d067bc8b5e8132f9L25-R26): Updated the title to 'Components/Containers/Card' and added an ID 'components-card'.
* [`packages/components/src/navigable-container/stories/navigable-menu.story.tsx`](diffhunk://#diff-c87cf122266dfc6a88b6c09093aae3b959b841100f5e1d67f86aa93c0321d401L12-R13): Updated the title to 'Components/Containers/NavigableMenu' and added an ID 'components-navigablemenu'.
* [`packages/components/src/navigable-container/stories/tabbable-container.story.tsx`](diffhunk://#diff-2df61b5f6288249c98eead4202825411465f2bd1efa88b6aafe8139aec9eca16L12-R13): Updated the title to 'Components/Containers/TabbableContainer' and added an ID 'components-tabbablecontainer'.
* [`packages/components/src/panel/stories/index.story.tsx`](diffhunk://#diff-b16c2c88592a6c61d6d77dab11943b41fe6e1e06b37424c209a5cc39a9216a58L20-R21): Updated the title to 'Components/Containers/Panel' and added an ID 'components-panel'.
* [`packages/components/src/tab-panel/stories/index.story.tsx`](diffhunk://#diff-959818a6997b509d9a1861679562ed7f247d4bec1c4e9cb7c2715055d17702e0L17-R18): Updated the title to 'Components/Containers/TabPanel' and added an ID 'components-tabpanel'.
* [`packages/components/src/tabs/stories/index.story.tsx`](diffhunk://#diff-68475fecef86d243ae252ba87e8a7ec78a578a3a5ce3c3583355d067f54637f2L23-R24): Updated the title to 'Components/Containers/Tabs' and added an ID 'components-tabs'.

This creates an 'Actions' category and a 'Containers' category within the left-hand navigation. 
This change represents 2 out of the 12 categories to be introduced, it's smaller scope allows me to test run committing before making larger changes at a later date and time.  

## Why?
This change is part of the larger [Storybook Improvements](https://make.wordpress.org/design/2024/09/17/design-systems-storybook-improvements/) and the [shared Sitemap](https://www.figma.com/board/0ZfHa37xxWoMqy7McezUNX/WordPress.org-Storybook-Sitemap?node-id=126-5118&t=ruCtnVTDVjHTfksc-1). 

## How?
Adding Categories that helps organize and group components into sections based on their role and function within the library makes our library easier to navigate and understand. 

## Screenshots
![CleanShot 2024-10-11 at 11 58 39@2x](https://github.com/user-attachments/assets/dfe7904a-737f-4b4a-9694-37d1654da041)

