### PR TITLE
Revert "Update z-index hierarchy"

### DIFF
--- a/packages/base-styles/_z-index.scss
+++ b/packages/base-styles/_z-index.scss
@@ -31,10 +31,12 @@ $z-layers: (
 	".interface-interface-skeleton__header": 30,
 	".interface-interface-skeleton__content": 20,
 	".edit-widgets-header": 30,
+	".wp-block-cover__inner-container": 1, // InnerBlocks area inside cover image block.
 	".wp-block-cover.is-placeholder .components-placeholder.is-large": 1, // Cover block resizer component inside a large placeholder.
-	".wp-block-cover.has-background-dim::before": 0, // Overlay area inside block cover need to be higher than the video background.
-	".wp-block-cover__image-background": -1, // Image background inside cover block.
-	".wp-block-cover__video-background": -1, // Video background inside cover block.
+	".wp-block-cover.has-background-dim::before": 1, // Overlay area inside block cover need to be higher than the video background.
+	".block-library-cover__padding-visualizer": 2, // BoxControl visualizer needs to be +1 higher than .wp-block-cover.has-background-dim::before
+	".wp-block-cover__image-background": 0, // Image background inside cover block.
+	".wp-block-cover__video-background": 0, // Video background inside cover block.
 	".wp-block-template-part__placeholder-preview-filter-input": 1,
 
 	// Fixed position appender:

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -42,6 +42,7 @@
 	// Shown while media is being uploaded
 	.components-spinner {
 		position: absolute;
+		z-index: z-index(".wp-block-cover__inner-container");
 		top: 50%;
 		left: 50%;
 		transform: translate(-50%, -50%); // Account for spinner dimensions

--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -95,8 +95,8 @@
 	}
 
 	.wp-block-cover__inner-container {
-		position: relative;
 		width: 100%;
+		z-index: z-index(".wp-block-cover__inner-container");
 		color: inherit;
 		// Reset the fixed LTR direction at the root of the block in RTL languages.
 		/*rtl:raw: direction: rtl; */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Revert WordPress/gutenberg#65626

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The [original solution](https://github.com/WordPress/gutenberg/pull/65626) introduced a [new issue](https://github.com/WordPress/gutenberg/issues/66067). The reason is that a negative `z-index` will be behind any parent, which means that any parent with a background would be displayed on top of the image.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Create a group block.
2. Add a cover block inside the group with an image.
3. Add a background to the group (it could be through styles with a background or a normal background).
4. Make sure the image continues visible.

## Screenshots or screencast <!-- if applicable -->

<img width="907" alt="Screenshot 2024-10-11 at 16 34 15" src="https://github.com/user-attachments/assets/1e42bdf0-215e-4874-8398-507841e2a82a">
