### PR TITLE
Add filter for returned style variations

### DIFF
--- a/backport-changelog/6.7/7559.md
+++ b/backport-changelog/6.7/7559.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7559
+
+* https://github.com/WordPress/gutenberg/pull/66079

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -828,7 +828,17 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				$variations[] = $variation;
 			}
 		}
-		return $variations;
+
+		/**
+		 * Filters the default style variations for the given directory
+		 *
+		 * @since 6.7.0
+		 *
+		 * @param array $variations An array of style variations.
+		 * @param string $directory The directory to get the style variations from.
+		 * @param string $scope The scope or type of style variation to retrieve e.g. theme, block etc.
+		 */
+		return apply_filters( 'wp_theme_json_style_variations', $variations, $directory, $scope );
 	}
 
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -834,9 +834,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @since 6.7.0
 		 *
-		 * @param array $variations An array of style variations.
-		 * @param string $directory The directory to get the style variations from.
-		 * @param string $scope The scope or type of style variation to retrieve e.g. theme, block etc.
+		 * @param array  $variations An array of style variations.
+		 * @param string $directory  The directory to get the style variations from.
+		 * @param string $scope 	 The scope or type of style variation to retrieve e.g. theme, block etc.
 		 */
 		return apply_filters( 'wp_theme_json_style_variations', $variations, $directory, $scope );
 	}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -836,7 +836,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @param array  $variations An array of style variations.
 		 * @param string $directory  The directory to get the style variations from.
-		 * @param string $scope 	 The scope or type of style variation to retrieve e.g. theme, block etc.
+		 * @param string $scope 		 The scope or type of style variation to retrieve e.g. theme, block etc.
 		 */
 		return apply_filters( 'wp_theme_json_style_variations', $variations, $directory, $scope );
 	}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -836,7 +836,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @param array  $variations An array of style variations.
 		 * @param string $directory  The directory to get the style variations from.
-		 * @param string $scope 		 The scope or type of style variation to retrieve e.g. theme, block etc.
+		 * @param string $scope      The scope or type of style variation to retrieve e.g. theme, block etc.
 		 */
 		return apply_filters( 'wp_theme_json_style_variations', $variations, $directory, $scope );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Adds a filter to allow developers to edit/hide/show/etc theme variations

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Allows plugins to add new variations, or allows developers (plugin/theme) to conditionally hide/show variations. 

It's also just in the spirit of WordPress filters to have a filter here.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
```php
function extendable_custom_theme_json($variations, $scope)
{
    if (!count($variations)) return $variations;
    unset($variations[0]) // just an example - not a useful use case
    return $variations;
}
add_filter('wp_theme_json_style_variations', 'extendable_custom_theme_json', 10, 2);
```

closes https://github.com/WordPress/gutenberg/issues/66078
