### PR TITLE
Fix e2e test for padding appender

### DIFF
--- a/test/e2e/specs/editor/various/inserting-blocks.spec.js
+++ b/test/e2e/specs/editor/various/inserting-blocks.spec.js
@@ -45,6 +45,10 @@ test.describe( 'Inserting blocks (@firefox, @webkit)', () => {
 			{ name: 'core/image' },
 			{ name: 'core/paragraph' },
 		] );
+
+		await expect(
+			editor.canvas.locator( '[data-type="core/paragraph"]' )
+		).toBeFocused();
 	} );
 
 	test( 'inserts blocks by dragging and dropping from the global inserter', async ( {


### PR DESCRIPTION
## What?
Adds an assertion that the default block is focused once inserted.

## Why?
In trunk the feature has regressed and this test could have caught it. Closes #65138.

## Deep thoughts
It might be that another test would ideally have caught this and this test should be left as is. That’s because the padding appender feature’s implementation isn’t responsible for focusing the block it inserts. So the breakage is actually elsewhere, yet given this test is in a general `inserting-blocks` spec it seems fine to assert focus here. Still, maybe it’d work just as well to assert it in a different test.

## Testing Instructions
Note the test will fail until the bug is fixed.

