### PR TITLE
Fix e2e Storybook config

### DIFF
--- a/test/storybook-playwright/storybook/main.js
+++ b/test/storybook-playwright/storybook/main.js
@@ -7,6 +7,7 @@ const config = {
 	...baseConfig,
 	addons: [ '@storybook/addon-toolbars' ],
 	docs: undefined,
+	staticDirs: undefined,
 	stories: [
 		'../../../packages/components/src/**/stories/e2e/*.story.@(js|tsx|mdx)',
 	],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes the e2e Storybook config that broke with #65764.

## How?

Just a quick fix for now, but we might want to remove the config composition if this starts to happen a lot.

## Testing Instructions

`npm run storybook:e2e:dev` should work again.
