### PR TITLE
Fix the navigation issue inside cover blocks

### DIFF
--- a/packages/block-library/src/cover/style.scss
+++ b/packages/block-library/src/cover/style.scss
@@ -100,6 +100,12 @@
 		color: inherit;
 		// Reset the fixed LTR direction at the root of the block in RTL languages.
 		/*rtl:raw: direction: rtl; */
+
+		// Reset the z-index to auto when the body has a modal open. So when the
+		// modal is inside the cover, it doesn't create a stacking context.
+		@at-root .has-modal-open & {
+			z-index: auto;
+		}
 	}
 
 	// Position: Top

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -73,7 +73,6 @@ import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 
-// Custom hook for managing responsive menu state.
 function useResponsiveMenu( navRef ) {
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] =
 		useState( false );

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -93,7 +93,7 @@ function useResponsiveMenu( navRef ) {
 		}
 
 		return () => {
-			htmlElement.classList.remove( 'has-modal-open' );
+			htmlElement?.classList.remove( 'has-modal-open' );
 		};
 	}, [ navRef, isResponsiveMenuOpen ] );
 

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -91,6 +91,10 @@ function useResponsiveMenu( navRef ) {
 		} else {
 			htmlElement.classList.remove( 'has-modal-open' );
 		}
+
+		return () => {
+			htmlElement.classList.remove( 'has-modal-open' );
+		};
 	}, [ navRef, isResponsiveMenuOpen ] );
 
 	return [ isResponsiveMenuOpen, setResponsiveMenuVisibility ];

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -73,6 +73,30 @@ import AccessibleDescription from './accessible-description';
 import AccessibleMenuDescription from './accessible-menu-description';
 import { unlock } from '../../lock-unlock';
 
+// Custom hook for managing responsive menu state.
+function useResponsiveMenu( navRef ) {
+	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] =
+		useState( false );
+
+	useEffect( () => {
+		if ( ! navRef.current ) {
+			return;
+		}
+
+		const htmlElement = navRef.current.closest( 'html' );
+
+		// Add a `has-modal-open` class to the <html> when the responsive
+		// menu is open. This reproduces the same behavior of the frontend.
+		if ( isResponsiveMenuOpen ) {
+			htmlElement.classList.add( 'has-modal-open' );
+		} else {
+			htmlElement.classList.remove( 'has-modal-open' );
+		}
+	}, [ navRef, isResponsiveMenuOpen ] );
+
+	return [ isResponsiveMenuOpen, setResponsiveMenuVisibility ];
+}
+
 function ColorTools( {
 	textColor,
 	setTextColor,
@@ -284,8 +308,10 @@ function Navigation( {
 		__unstableMarkNextChangeAsNotPersistent,
 	} = useDispatch( blockEditorStore );
 
+	const navRef = useRef();
+
 	const [ isResponsiveMenuOpen, setResponsiveMenuVisibility ] =
-		useState( false );
+		useResponsiveMenu( navRef );
 
 	const [ overlayMenuPreview, setOverlayMenuPreview ] = useState( false );
 
@@ -366,8 +392,6 @@ function Navigation( {
 		navigationFallbackId,
 		__unstableMarkNextChangeAsNotPersistent,
 	] );
-
-	const navRef = useRef();
 
 	// The standard HTML5 tag for the block wrapper.
 	const TagName = 'nav';

--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -82,7 +82,7 @@ function useResponsiveMenu( navRef ) {
 			return;
 		}
 
-		const htmlElement = navRef.current.closest( 'html' );
+		const htmlElement = navRef.current.ownerDocument.documentElement;
 
 		// Add a `has-modal-open` class to the <html> when the responsive
 		// menu is open. This reproduces the same behavior of the frontend.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Previously, we implemented [this fix](https://github.com/WordPress/gutenberg/pull/65626), but [a regression was found](https://github.com/WordPress/gutenberg/issues/66067), so it was [reverted](https://github.com/WordPress/gutenberg/pull/66074), and we are sending this new fix using a different approach.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Many users are having and reporting this issue.
See
- https://github.com/WordPress/gutenberg/issues/45353
- https://github.com/Automattic/wp-calypso/issues/75439
- https://github.com/Automattic/wp-calypso/issues/79317

The reason is that the cover inner blocks container contains a z-index, crating a stacking context for what is inside.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The new solution changes the `z-index` of the cover inner blocks container to `auto` when the navigation is open (`has-modal-open` applied to the `html`). I don't consider it as the ideal solution, but it's the simplest and probably the safest one.

What I would see as "ideal" (best in terms of good practices of code if we were creating it from scratch) solutions (and the reason that I didn't implement them):

1. Having the menu opened in a totally different context would be the ideal solution to avoid any stacking context issues. But besides it being a big change, it could impact other things, like not inheriting styles from the current context and creating other unexpected style issues.
2. Change the order of the cover elements (just invert the image and the color effect span). With this, we could remove the `z-index` of the elements, and it would solve the issue. The problem would be the block deprecation and a complex code to maintain both versions to not break the styles on the frontend until the user re-saves the cover block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. In a template or a post add a Cover block.
2. Inside the cover block, add a Navigation block.
3. After the previously created Cover block, add another Cover block.
4. Visit the site in the frontend, on a small screen.
5. Open the menu, and make sure it's displayed over the whole content.

cc @aaronrobertshaw in case you could re-test it.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/98bdfda3-4608-4869-90b1-887b09eaab89