### PR TITLE
Tabs: remove custom logic

### DIFF
--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -6,6 +6,7 @@ import {
 	privateApis as componentsPrivateApis,
 	__unstableMotion as motion,
 } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -31,10 +32,22 @@ function CategoryTabs( {
 
 	const previousSelectedCategory = usePrevious( selectedCategory );
 
+	const selectedTabId = selectedCategory ? selectedCategory.name : null;
+	const [ activeTabId, setActiveId ] = useState();
+	const firstTabId = categories?.[ 0 ]?.name;
+	useEffect( () => {
+		// If there is no active tab, make the first tab the active tab, so that
+		// when focus is moved to the tablist, the first tab will be focused
+		// despite not being selected
+		if ( selectedTabId === null && ! activeTabId && firstTabId ) {
+			setActiveId( firstTabId );
+		}
+	}, [ selectedTabId, activeTabId, firstTabId, setActiveId ] );
+
 	return (
 		<Tabs
 			selectOnMove={ false }
-			selectedTabId={ selectedCategory ? selectedCategory.name : null }
+			selectedTabId={ selectedTabId }
 			orientation="vertical"
 			onSelect={ ( categoryId ) => {
 				// Pass the full category object
@@ -44,6 +57,8 @@ function CategoryTabs( {
 					)
 				);
 			} }
+			activeTabId={ activeTabId }
+			onActiveTabIdChange={ setActiveId }
 		>
 			<Tabs.TabList className="block-editor-inserter__category-tablist">
 				{ categories.map( ( category ) => (

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 ### Experimental
 
+-   `Tabs`: remove internal custom logic ([#66097](https://github.com/WordPress/gutenberg/pull/66097)).
 -   `Tabs`: add props to control active tab item ([#66223](https://github.com/WordPress/gutenberg/pull/66223)).
 -   `Tabs`: restore vertical alignent for tabs content ([#66215](https://github.com/WordPress/gutenberg/pull/66215)).
 -   `Tabs`: fix indicator animation ([#66198](https://github.com/WordPress/gutenberg/pull/66198)).

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -2,13 +2,12 @@
  * External dependencies
  */
 import * as Ariakit from '@ariakit/react';
-import { useStoreState } from '@ariakit/react';
 
 /**
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
 /**
@@ -53,37 +52,10 @@ export const Tabs = Object.assign(
 			rtl: isRTL(),
 		} );
 
-		const isControlled = selectedTabId !== undefined;
-
-		const { items, activeId } = useStoreState( store );
+		const { items, activeId } = Ariakit.useStoreState( store );
 		const { setActiveId } = store;
 
-		// Keep track of whether tabs have been populated. This is used to prevent
-		// certain effects from firing too early while tab data and relevant
-		// variables are undefined during the initial render.
-		const tabsHavePopulatedRef = useRef( false );
-		if ( items.length > 0 ) {
-			tabsHavePopulatedRef.current = true;
-		}
-
-		const firstEnabledTab = items.find( ( item ) => {
-			// Ariakit internally refers to disabled tabs as `dimmed`.
-			return ! item.dimmed;
-		} );
-
 		useEffect( () => {
-			// If there is no active tab, fallback to place focus on the first enabled tab
-			// so there is always an active element
-			if ( selectedTabId === null && ! activeId && firstEnabledTab?.id ) {
-				setActiveId( firstEnabledTab.id );
-			}
-		}, [ selectedTabId, activeId, firstEnabledTab?.id, setActiveId ] );
-
-		useEffect( () => {
-			if ( ! isControlled ) {
-				return;
-			}
-
 			requestAnimationFrame( () => {
 				const focusedElement =
 					items?.[ 0 ]?.element?.ownerDocument.activeElement;
@@ -103,7 +75,7 @@ export const Tabs = Object.assign(
 					setActiveId( focusedElement.id );
 				}
 			} );
-		}, [ activeId, isControlled, items, setActiveId ] );
+		}, [ activeId, items, setActiveId ] );
 
 		const contextValue = useMemo(
 			() => ( {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -80,45 +80,6 @@ export const Tabs = Object.assign(
 			( item ) => item.id === `${ instanceId }-${ defaultTabId }`
 		);
 
-		// Handle selecting the initial tab.
-		useLayoutEffect( () => {
-			if ( isControlled ) {
-				return;
-			}
-
-			// Wait for the denoted initial tab to be declared before making a
-			// selection. This ensures that if a tab is declared lazily it can
-			// still receive initial selection, as well as ensuring no tab is
-			// selected if an invalid `defaultTabId` is provided.
-			if ( defaultTabId && ! initialTab ) {
-				return;
-			}
-
-			// If the currently selected tab is missing (i.e. removed from the DOM),
-			// fall back to the initial tab or the first enabled tab if there is
-			// one. Otherwise, no tab should be selected.
-			if ( ! items.find( ( item ) => item.id === selectedId ) ) {
-				if ( initialTab && ! initialTab.dimmed ) {
-					setSelectedId( initialTab?.id );
-					return;
-				}
-
-				if ( firstEnabledTab ) {
-					setSelectedId( firstEnabledTab.id );
-				} else if ( tabsHavePopulatedRef.current ) {
-					setSelectedId( null );
-				}
-			}
-		}, [
-			firstEnabledTab,
-			initialTab,
-			defaultTabId,
-			isControlled,
-			items,
-			selectedId,
-			setSelectedId,
-		] );
-
 		// Handle the currently selected tab becoming disabled.
 		useLayoutEffect( () => {
 			if ( ! selectedTab?.dimmed ) {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -76,41 +76,6 @@ export const Tabs = Object.assign(
 			// Ariakit internally refers to disabled tabs as `dimmed`.
 			return ! item.dimmed;
 		} );
-		const initialTab = items.find(
-			( item ) => item.id === `${ instanceId }-${ defaultTabId }`
-		);
-
-		// Handle the currently selected tab becoming disabled.
-		useLayoutEffect( () => {
-			if ( ! selectedTab?.dimmed ) {
-				return;
-			}
-
-			// In controlled mode, we trust that disabling tabs is done
-			// intentionally, and don't select a new tab automatically.
-			if ( isControlled ) {
-				setSelectedId( null );
-				return;
-			}
-
-			// If the currently selected tab becomes disabled, fall back to the
-			// `defaultTabId` if possible. Otherwise select the first
-			// enabled tab (if there is one).
-			if ( initialTab && ! initialTab.dimmed ) {
-				setSelectedId( initialTab.id );
-				return;
-			}
-
-			if ( firstEnabledTab ) {
-				setSelectedId( firstEnabledTab.id );
-			}
-		}, [
-			firstEnabledTab,
-			initialTab,
-			isControlled,
-			selectedTab?.dimmed,
-			setSelectedId,
-		] );
 
 		// Clear `selectedId` if the active tab is removed from the DOM in controlled mode.
 		useLayoutEffect( () => {

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -8,12 +8,7 @@ import { useStoreState } from '@ariakit/react';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import {
-	useEffect,
-	useLayoutEffect,
-	useMemo,
-	useRef,
-} from '@wordpress/element';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
 /**
@@ -60,8 +55,8 @@ export const Tabs = Object.assign(
 
 		const isControlled = selectedTabId !== undefined;
 
-		const { items, selectedId, activeId } = useStoreState( store );
-		const { setSelectedId, setActiveId } = store;
+		const { items, activeId } = useStoreState( store );
+		const { setActiveId } = store;
 
 		// Keep track of whether tabs have been populated. This is used to prevent
 		// certain effects from firing too early while tab data and relevant
@@ -71,28 +66,10 @@ export const Tabs = Object.assign(
 			tabsHavePopulatedRef.current = true;
 		}
 
-		const selectedTab = items.find( ( item ) => item.id === selectedId );
 		const firstEnabledTab = items.find( ( item ) => {
 			// Ariakit internally refers to disabled tabs as `dimmed`.
 			return ! item.dimmed;
 		} );
-
-		// Clear `selectedId` if the active tab is removed from the DOM in controlled mode.
-		useLayoutEffect( () => {
-			if ( ! isControlled ) {
-				return;
-			}
-
-			// Once the tabs have populated, if the `selectedTabId` still can't be
-			// found, clear the selection.
-			if (
-				tabsHavePopulatedRef.current &&
-				!! selectedTabId &&
-				! selectedTab
-			) {
-				setSelectedId( null );
-			}
-		}, [ isControlled, selectedTab, selectedTabId, setSelectedId ] );
 
 		useEffect( () => {
 			// If there is no active tab, fallback to place focus on the first enabled tab

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -19,6 +19,22 @@ import { Tab } from './tab';
 import { TabList } from './tablist';
 import { TabPanel } from './tabpanel';
 
+function externalToInternalTabId(
+	externalId: string | undefined | null,
+	instanceId: string
+) {
+	return externalId && `${ instanceId }-${ externalId }`;
+}
+
+function internalToExternalTabId(
+	internalId: string | undefined | null,
+	instanceId: string
+) {
+	return typeof internalId === 'string'
+		? internalId.replace( `${ instanceId }-`, '' )
+		: internalId;
+}
+
 /**
  * Display one panel of content at a time with a tabbed interface, based on the
  * WAI-ARIA Tabs Pattern⁠.
@@ -34,21 +50,34 @@ export const Tabs = Object.assign(
 		onSelect,
 		children,
 		selectedTabId,
+		activeTabId,
+		defaultActiveTabId,
+		onActiveTabIdChange,
 	}: TabsProps ) {
 		const instanceId = useInstanceId( Tabs, 'tabs' );
 		const store = Ariakit.useTabStore( {
 			selectOnMove,
 			orientation,
-			defaultSelectedId:
-				defaultTabId && `${ instanceId }-${ defaultTabId }`,
-			setSelectedId: ( selectedId ) => {
-				const strippedDownId =
-					typeof selectedId === 'string'
-						? selectedId.replace( `${ instanceId }-`, '' )
-						: selectedId;
-				onSelect?.( strippedDownId );
+			defaultSelectedId: externalToInternalTabId(
+				defaultTabId,
+				instanceId
+			),
+			setSelectedId: ( newSelectedId ) => {
+				onSelect?.(
+					internalToExternalTabId( newSelectedId, instanceId )
+				);
 			},
-			selectedId: selectedTabId && `${ instanceId }-${ selectedTabId }`,
+			selectedId: externalToInternalTabId( selectedTabId, instanceId ),
+			defaultActiveId: externalToInternalTabId(
+				defaultActiveTabId,
+				instanceId
+			),
+			setActiveId: ( newActiveId ) => {
+				onActiveTabIdChange?.(
+					internalToExternalTabId( newActiveId, instanceId )
+				);
+			},
+			activeId: externalToInternalTabId( activeTabId, instanceId ),
 			rtl: isRTL(),
 		} );
 

--- a/packages/components/src/tabs/tab.tsx
+++ b/packages/components/src/tabs/tab.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import * as Ariakit from '@ariakit/react';
+
+/**
  * WordPress dependencies
  */
 
@@ -22,13 +27,27 @@ export const Tab = forwardRef<
 	HTMLButtonElement,
 	Omit< WordPressComponentProps< TabProps, 'button', false >, 'id' >
 >( function Tab( { children, tabId, disabled, render, ...otherProps }, ref ) {
-	const context = useTabsContext();
-	if ( ! context ) {
+	const { store, instanceId } = useTabsContext() ?? {};
+
+	// If the active item is not connected, the tablist may end up in a state
+	// where none of the tabs are tabbable. In this case, we force all tabs to
+	// be tabbable, so that as soon as an item received focus, it becomes active
+	// and Tablist goes back to working as expected.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return
+	const tabbable = Ariakit.useStoreState( store, ( state ) => {
+		return (
+			state?.activeId !== null &&
+			! store?.item( state?.activeId )?.element?.isConnected
+		);
+	} );
+
+	if ( ! store ) {
 		warning( '`Tabs.Tab` must be wrapped in a `Tabs` component.' );
 		return null;
 	}
-	const { store, instanceId } = context;
+
 	const instancedTabId = `${ instanceId }-${ tabId }`;
+
 	return (
 		<StyledTab
 			ref={ ref }
@@ -36,6 +55,7 @@ export const Tab = forwardRef<
 			id={ instancedTabId }
 			disabled={ disabled }
 			render={ render }
+			tabbable={ tabbable }
 			{ ...otherProps }
 		>
 			<StyledTabChildren>{ children }</StyledTabChildren>

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -248,7 +248,7 @@ describe( 'Tabs', () => {
 			expect( alphaButton ).toHaveFocus();
 		} );
 
-		it( 'should focus the first tab, even if disabled, when the current selected tab id doesnt match an existing one', async () => {
+		it( "should focus the first tab, even if disabled, when the current selected tab id doesn't match an existing one", async () => {
 			const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
 				tabObj.tabId === 'alpha'
 					? {

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -729,8 +729,7 @@ describe( 'Tabs', () => {
 				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 			} );
 
-			// Shouldn't this just stay on the same tab?
-			it( 'should fall back to the tab associated to `defaultTabId` if the currently active tab is removed', async () => {
+			it( 'should not have any selected tabs if the currently selected tab is removed, even if a tab is matching the defaultTabId', async () => {
 				const mockOnSelect = jest.fn();
 
 				const { rerender } = await render(
@@ -1113,7 +1112,7 @@ describe( 'Tabs', () => {
 			// No tabpanel should be rendered either
 			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
 		} );
-		it( 'should not have a selected tab if the active tab is removed', async () => {
+		it( 'should not have a selected tab if the active tab is removed, but should select a tab that gets added if it matches the selectedTabId', async () => {
 			const { rerender } = await render(
 				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 			);
@@ -1147,15 +1146,7 @@ describe( 'Tabs', () => {
 				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 			);
 
-			// No tab should be selected i.e. it doesn't reselect the previously
-			// removed tab.
-			await waitFor( () => {
-				expect(
-					screen.queryByRole( 'tab', { selected: true } )
-				).not.toBeInTheDocument();
-			} );
-			// No tabpanel should be rendered either
-			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 		} );
 
 		describe( 'Disabled tab', () => {

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -191,6 +191,8 @@ describe( 'Tabs', () => {
 		it( 'should focus on the related TabPanel when pressing the Tab key', async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
 
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+
 			const selectedTabPanel = await screen.findByRole( 'tabpanel' );
 
 			// Tab should initially focus the first tab in the tablist, which
@@ -223,6 +225,8 @@ describe( 'Tabs', () => {
 			await render(
 				<UncontrolledTabs tabs={ TABS_WITH_ALPHA_FOCUSABLE_FALSE } />
 			);
+
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 
 			const alphaButton = await screen.findByRole( 'button', {
 				name: /alpha button/i,
@@ -335,6 +339,8 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+
 			// onSelect gets called on the initial render. It should be called
 			// with the first enabled tab, which is alpha.
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
@@ -370,12 +376,14 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// onSelect gets called on the initial render.
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-			// Tab to focus the tablist. Make sure Alpha is focused.
 			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect( await getSelectedTab() ).not.toHaveFocus();
+
+			// onSelect gets called on the initial render.
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Tab to focus the tablist. Make sure Alpha is focused.
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -403,14 +411,14 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// onSelect gets called on the initial render. It should be called
-			// with the first enabled tab, which is alpha.
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+			expect( await getSelectedTab() ).not.toHaveFocus();
+
+			// onSelect gets called on the initial render.
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
-			// Tab to focus the tablist. Make sure alpha is focused.
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
+			// Tab to focus the tablist. Make sure Alpha is focused.
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
 
@@ -502,16 +510,17 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			// onSelect gets called on the initial render. It should be called
-			// with the first enabled tab, which is alpha.
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+			expect( await getSelectedTab() ).not.toHaveFocus();
+
+			// onSelect gets called on the initial render.
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
 			// Tab to focus the tablist. Make sure Alpha is focused.
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
 			await press.Tab();
 			expect( await getSelectedTab() ).toHaveFocus();
+
 			// Confirm onSelect has not been re-called
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 
@@ -550,6 +559,9 @@ describe( 'Tabs', () => {
 		it( 'should not focus the next tab when the Tab key is pressed', async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
 
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+			expect( await getSelectedTab() ).not.toHaveFocus();
+
 			// Tab should initially focus the first tab in the tablist, which
 			// is Alpha.
 			await press.Tab();
@@ -579,8 +591,10 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			// onSelect gets called on the initial render. It should be called
-			// with the first enabled tab, which is alpha.
+			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+			expect( await getSelectedTab() ).not.toHaveFocus();
+
+			// onSelect gets called on the initial render.
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
@@ -715,6 +729,8 @@ describe( 'Tabs', () => {
 					<UncontrolledTabs tabs={ TABS } defaultTabId="beta" />
 				);
 
+				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+
 				await rerender(
 					<UncontrolledTabs tabs={ TABS } defaultTabId="alpha" />
 				);
@@ -821,9 +837,16 @@ describe( 'Tabs', () => {
 					<UncontrolledTabs tabs={ TABS } defaultTabId="delta" />
 				);
 
-				// There should be no selected tab yet.
+				// No tab should be selected i.e. it doesn't fall back to first tab.
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument()
+				);
+
+				// No tabpanel should be rendered either
 				expect(
-					screen.queryByRole( 'tab', { selected: true } )
+					screen.queryByRole( 'tabpanel' )
 				).not.toBeInTheDocument();
 
 				await rerender(
@@ -860,6 +883,8 @@ describe( 'Tabs', () => {
 						onSelect={ mockOnSelect }
 					/>
 				);
+
+				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 
 				expect(
 					screen.getByRole( 'tab', { name: 'Delta' } )
@@ -1072,7 +1097,7 @@ describe( 'Tabs', () => {
 
 			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 		} );
-		it( 'should not render any tab if `selectedTabId` does not match any known tab', async () => {
+		it( 'should not have a selected tab if `selectedTabId` does not match any known tab', async () => {
 			await render(
 				<ControlledTabs
 					tabs={ TABS_WITH_DELTA }
@@ -1087,7 +1112,7 @@ describe( 'Tabs', () => {
 			// No tabpanel should be rendered either
 			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
 		} );
-		it( 'should not render any tab if the active tab is removed', async () => {
+		it( 'should not have a selected tab if the active tab is removed', async () => {
 			const { rerender } = await render(
 				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 			);
@@ -1128,7 +1153,7 @@ describe( 'Tabs', () => {
 		} );
 
 		describe( 'Disabled tab', () => {
-			it( 'should not render any tab if `selectedTabId` refers to a disabled tab', async () => {
+			it( 'should not have a selected tab if `selectedTabId` refers to a disabled tab', async () => {
 				const TABS_WITH_DELTA_WITH_BETA_DISABLED = TABS_WITH_DELTA.map(
 					( tabObj ) =>
 						tabObj.tabId === 'beta'
@@ -1160,7 +1185,7 @@ describe( 'Tabs', () => {
 					screen.queryByRole( 'tabpanel' )
 				).not.toBeInTheDocument();
 			} );
-			it( 'should not render any tab when the selected tab becomes disabled', async () => {
+			it( 'should not have a selected tab when the selected tab becomes disabled', async () => {
 				const { rerender } = await render(
 					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 				);
@@ -1227,6 +1252,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Beta'
+						);
+
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
 						await waitFor( async () =>
@@ -1271,6 +1300,10 @@ describe( 'Tabs', () => {
 									selectOnMove={ selectOnMove }
 								/>
 							</>
+						);
+
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Beta'
 						);
 
 						// Tab key should focus the currently selected tab, which is Beta.
@@ -1331,6 +1364,8 @@ describe( 'Tabs', () => {
 				await render(
 					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 				);
+
+				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 
 				await press.Tab();
 

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -129,7 +129,11 @@ const ControlledTabs = ( {
 				) ) }
 			</Tabs.TabList>
 			{ tabs.map( ( tabObj ) => (
-				<Tabs.TabPanel key={ tabObj.tabId } tabId={ tabObj.tabId }>
+				<Tabs.TabPanel
+					key={ tabObj.tabId }
+					tabId={ tabObj.tabId }
+					focusable={ tabObj.tabpanel?.focusable }
+				>
 					{ tabObj.content }
 				</Tabs.TabPanel>
 			) ) }
@@ -244,7 +248,7 @@ describe( 'Tabs', () => {
 			expect( alphaButton ).toHaveFocus();
 		} );
 
-		it( 'should focus on the first enabled tab when pressing the Tab key if no tab is selected', async () => {
+		it( 'should focus the first tab, even if disabled, when the current selected tab id doesnt match an existing one', async () => {
 			const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
 				tabObj.tabId === 'alpha'
 					? {
@@ -260,7 +264,7 @@ describe( 'Tabs', () => {
 			await render(
 				<ControlledTabs
 					tabs={ TABS_WITH_ALPHA_DISABLED }
-					selectedTabId={ null }
+					selectedTabId="non-existing-tab"
 				/>
 			);
 
@@ -275,6 +279,11 @@ describe( 'Tabs', () => {
 			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
 
 			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', { name: 'Alpha' } )
+			).toHaveFocus();
+
+			await press.ArrowRight();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Beta' } )
 			).toHaveFocus();
@@ -1228,12 +1237,12 @@ describe( 'Tabs', () => {
 
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
-						await waitFor( async () =>
-							expect( await getSelectedTab() ).toHaveTextContent(
-								'Beta'
-							)
+						expect( await getSelectedTab() ).toHaveTextContent(
+							'Beta'
 						);
-						expect( await getSelectedTab() ).toHaveFocus();
+						expect(
+							screen.getByRole( 'tab', { name: 'Beta' } )
+						).toHaveFocus();
 
 						await rerender(
 							<ControlledTabs
@@ -1243,12 +1252,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// When the selected tab is changed, it should not automatically receive focus.
-
+						// When the selected tab is changed, focus should not be changed.
 						expect( await getSelectedTab() ).toHaveTextContent(
 							'Gamma'
 						);
-
 						expect(
 							screen.getByRole( 'tab', { name: 'Beta' } )
 						).toHaveFocus();
@@ -1282,7 +1289,9 @@ describe( 'Tabs', () => {
 						expect( await getSelectedTab() ).toHaveTextContent(
 							'Beta'
 						);
-						expect( await getSelectedTab() ).toHaveFocus();
+						expect(
+							screen.getByRole( 'tab', { name: 'Beta' } )
+						).toHaveFocus();
 
 						await rerender(
 							<>
@@ -1296,7 +1305,6 @@ describe( 'Tabs', () => {
 						);
 
 						// When the selected tab is changed, it should not automatically receive focus.
-
 						expect( await getSelectedTab() ).toHaveTextContent(
 							'Gamma'
 						);

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1118,6 +1118,8 @@ describe( 'Tabs', () => {
 				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
 			);
 
+			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+
 			// Remove beta
 			await rerender(
 				<ControlledTabs
@@ -1136,6 +1138,7 @@ describe( 'Tabs', () => {
 					screen.queryByRole( 'tab', { selected: true } )
 				).not.toBeInTheDocument()
 			);
+
 			// No tabpanel should be rendered either
 			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
 
@@ -1146,9 +1149,11 @@ describe( 'Tabs', () => {
 
 			// No tab should be selected i.e. it doesn't reselect the previously
 			// removed tab.
-			expect(
-				screen.queryByRole( 'tab', { selected: true } )
-			).not.toBeInTheDocument();
+			await waitFor( () => {
+				expect(
+					screen.queryByRole( 'tab', { selected: true } )
+				).not.toBeInTheDocument();
+			} );
 			// No tabpanel should be rendered either
 			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
 		} );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -264,6 +264,16 @@ describe( 'Tabs', () => {
 				/>
 			);
 
+			// No tab should be selected i.e. it doesn't fall back to first tab.
+			await waitFor( () =>
+				expect(
+					screen.queryByRole( 'tab', { selected: true } )
+				).not.toBeInTheDocument()
+			);
+
+			// No tabpanel should be rendered either
+			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tab', { name: 'Beta' } )
@@ -649,39 +659,20 @@ describe( 'Tabs', () => {
 					await screen.findByRole( 'tabpanel', { name: 'Alpha' } )
 				).toBeInTheDocument();
 			} );
-			it( 'should fall back to first enabled tab if the active tab is removed', async () => {
+			it( 'should not have a selected tab if the currently selected tab is removed', async () => {
 				const { rerender } = await render(
 					<UncontrolledTabs tabs={ TABS } />
 				);
 
+				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+				expect( await getSelectedTab() ).not.toHaveFocus();
+
+				// Tab to focus the tablist. Make sure Alpha is focused.
+				await press.Tab();
+				expect( await getSelectedTab() ).toHaveFocus();
+
 				// Remove first item from `TABS` array
 				await rerender( <UncontrolledTabs tabs={ TABS.slice( 1 ) } /> );
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-			it( 'should not load any tab if the active tab is removed and there are no enabled tabs', async () => {
-				const TABS_WITH_BETA_GAMMA_DISABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId !== 'alpha'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS_WITH_BETA_GAMMA_DISABLED } />
-				);
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-				// Remove alpha
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_BETA_GAMMA_DISABLED.slice( 1 ) }
-					/>
-				);
 
 				// No tab should be selected i.e. it doesn't fall back to first tab.
 				await waitFor( () =>
@@ -763,7 +754,17 @@ describe( 'Tabs', () => {
 					/>
 				);
 
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
+				// No tab should be selected i.e. it doesn't fall back to first tab.
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument()
+				);
+
+				// No tabpanel should be rendered either
+				expect(
+					screen.queryByRole( 'tabpanel' )
+				).not.toBeInTheDocument();
 			} );
 
 			it( 'should fall back to the tab associated to `defaultTabId` if the currently active tab becomes disabled', async () => {

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1186,10 +1186,12 @@ describe( 'Tabs', () => {
 						screen.queryByRole( 'tab', { selected: true } )
 					).not.toBeInTheDocument();
 				} );
-				// No tabpanel should be rendered either
+
+				// Despite the beta tab not being selected, the matching tabpanel
+				// is selected?
 				expect(
-					screen.queryByRole( 'tabpanel' )
-				).not.toBeInTheDocument();
+					screen.getByRole( 'tabpanel', { name: 'Beta' } )
+				).toBeVisible();
 			} );
 			it( 'should not have a selected tab when the selected tab becomes disabled', async () => {
 				const { rerender } = await render(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to #66011

Remove most custom logic in the `Tabs` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For a detailed explanation of the logic being removed, refer to the behaviors 1 to 4 listed in #66011. Behavior 6 is being kept for the time being, while the logic is incorporated directly in `ariakit` (see https://github.com/ariakit/ariakit/issues/4213).

- Some logic felt arbitrary, and it was agreed that if such a niche behavior would pop up, it should be addressed by the tab consumer;
- Some logic felt unnecessary (either fixed by ariakit in the meantime, or just extra)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Custom logic being removed (from #66011):

> * [Initial tab selection](https://github.com/WordPress/gutenberg/blob/609a3c8d38a0608b41b1827ec4a8c1f812487ef2/packages/components/src/tabs/index.tsx#L72-L109):
>   
>   * if a `defaultTabId` is specified, `Tabs` will select an initial tab only if there is a tab matching `defaultTabId`. If there isn't a matching tab, `Tabs` won't have an initially selected tab. If a tab with a matching id is added lazily, `Tabs` will select it.
>   * the initial tab is also used as a fallback when the currently selected tab can't be found anymore. If the initial tab also can't be found, the `Tabs` component won't have any selected tab;
>   * This bunch of logic only applied in uncontrolled mode — the idea being that a consumer controlling the component is in charge of handling these edge cases;
> * [The currently selected tab becomes disabled](https://github.com/WordPress/gutenberg/blob/609a3c8d38a0608b41b1827ec4a8c1f812487ef2/packages/components/src/tabs/index.tsx#L111-L141):
>   
>   * the main assumption is that a disabled tab cannot stay as the selected tab;
>   * In controlled mode, `Tabs` assumes that the consumer of the component is in charge of the situation, and therefore it un-selects the previously active, now disabled tab;
>   * In uncontrolled more, if the currently selected tab becomes disabled, `Tabs` falls back to the `defaultTabId` if possible. Otherwise, it selects the first enabled tab (if there is one).
> * In controlled mode, [`Tabs` will reset the active tab id (ie. no tabs are active) if a tab associated to the currently selected ID can't be found](https://github.com/WordPress/gutenberg/blob/609a3c8d38a0608b41b1827ec4a8c1f812487ef2/packages/components/src/tabs/index.tsx#L143-L158)
> * [If there is no active tab, fallback to place focus on the first enabled tab, so there is always an active element](https://github.com/WordPress/gutenberg/blob/609a3c8d38a0608b41b1827ec4a8c1f812487ef2/packages/components/src/tabs/index.tsx#L160-L166)

Process:

- Remove one hook at a time
- Fix tests
- Repeat
- Move custom logic in consumer-land to handle special cases


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Look at the unit test changes, understand if the changes feel reasonable;
- Smoke test tabs usage in Storybook and in the editor.
  - In particular, [this usage](https://github.com/WordPress/gutenberg/pull/66097#discussion_r1801253430) should continue to work as expected

Specific behaviours to check:

- if no `selectedId` or `defaultSelectedId` props are passed and refer to an existing tab id, `Tabs` will automatically select the first non-disabled tab and shows related tab-panel;
- if `selectedId` or `defaultSelectedId` props are passed but refer to a tab id that doesn't exist, `Tabs` won't show any tabs as selected and won't show any tabpanels;
- if the `selectedId` prop is passed but refers to a tab id that doesn't exist, and the tab is later added to the react tree, `Tabs` will correctly select that tab; this won't work with `defaultSelectedId`, since that prop only works for the initial render;
- if `selectedId` or `defaultSelectedId` props have a value of `null`, no tabs will be selected and no tabpanels will be shown, and the tablist itself will become tabbable; when focus in on the tablist, pressing arrow keys will select tabs;
- if `selectedId` or `defaultSelectedId` props are passed and refer to a disabled tab, that tab will be selected anyway (and its associated tabpanel will be shown);
- if the currently selected tab becomes disabled, it continues to say selected (and its associated tabpanel continues to show);
- - if the currently selected tab gets removed, no tabs are selected (and no tab panels are shown);
- if for any reason there is no active tab id (for example, as a result of clearing the selected tab id, or for removing the previously active tab from the DOM), all tabs in the tablist should become tabbable so that they can capture keyboard focus. As soon as a tab receives focus, all tabs will go back to default behaviour.

Note: there is [a toolbar e2e test that is expected to fail](https://github.com/WordPress/gutenberg/pull/65907#issuecomment-2406408450), since this PR is currently based off #65907.

For added context, here is also a (potentially incomplete) history of recent changes to the `Tabs` component, specifically to how it handles initial selection, disabled tabs, removed tabs, and general focus handling:

- https://github.com/WordPress/gutenberg/pull/55287
- https://github.com/WordPress/gutenberg/pull/56658
- https://github.com/WordPress/gutenberg/pull/57696
- https://github.com/WordPress/gutenberg/pull/58625
- https://github.com/WordPress/gutenberg/pull/60681