### PR TITLE
Block Bindings: Use `getEntityConfig` instead of `getPostTypes` to get available slugs

### DIFF
--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -304,7 +304,6 @@ async function loadPostTypeEntities() {
 			baseURLParams: { context: 'edit' },
 			name,
 			label: postType.name,
-			slug: postType.slug,
 			transientEdits: {
 				blocks: true,
 				selection: true,

--- a/packages/core-data/src/entities.js
+++ b/packages/core-data/src/entities.js
@@ -304,6 +304,7 @@ async function loadPostTypeEntities() {
 			baseURLParams: { context: 'edit' },
 			name,
 			label: postType.name,
+			slug: postType.slug,
 			transientEdits: {
 				blocks: true,
 				selection: true,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -179,7 +179,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					isReady: __unstableIsEditorReady(),
 					mode: getRenderingMode(),
 					selection: getEditorSelection(),
-					postTypes: getEntitiesConfig( 'postType' ),
+					postTypes:
+						post.type === 'wp_template'
+							? getEntitiesConfig( 'postType' )
+							: null,
 				};
 			}, [] );
 		const shouldRenderTemplate = !! template && mode !== 'post-only';

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -165,26 +165,29 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		__unstableTemplate: template,
 	} ) => {
 		const { editorSettings, selection, isReady, mode, postTypes } =
-			useSelect( ( select ) => {
-				const {
-					getEditorSettings,
-					getEditorSelection,
-					getRenderingMode,
-					__unstableIsEditorReady,
-				} = select( editorStore );
-				const { getEntitiesConfig } = select( coreStore );
+			useSelect(
+				( select ) => {
+					const {
+						getEditorSettings,
+						getEditorSelection,
+						getRenderingMode,
+						__unstableIsEditorReady,
+					} = select( editorStore );
+					const { getEntitiesConfig } = select( coreStore );
 
-				return {
-					editorSettings: getEditorSettings(),
-					isReady: __unstableIsEditorReady(),
-					mode: getRenderingMode(),
-					selection: getEditorSelection(),
-					postTypes:
-						post.type === 'wp_template'
-							? getEntitiesConfig( 'postType' )
-							: null,
-				};
-			}, [] );
+					return {
+						editorSettings: getEditorSettings(),
+						isReady: __unstableIsEditorReady(),
+						mode: getRenderingMode(),
+						selection: getEditorSelection(),
+						postTypes:
+							post.type === 'wp_template'
+								? getEntitiesConfig( 'postType' )
+								: null,
+					};
+				},
+				[ post.type ]
+			);
 		const shouldRenderTemplate = !! template && mode !== 'post-only';
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -164,7 +164,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
 	} ) => {
-		const { editorSettings, selection, isReady, mode, postTypes } =
+		const { editorSettings, selection, isReady, mode, postTypeEntities } =
 			useSelect(
 				( select ) => {
 					const {
@@ -180,7 +180,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 						isReady: __unstableIsEditorReady(),
 						mode: getRenderingMode(),
 						selection: getEditorSelection(),
-						postTypes:
+						postTypeEntities:
 							post.type === 'wp_template'
 								? getEntitiesConfig( 'postType' )
 								: null,
@@ -200,10 +200,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					postContext.postType = 'post';
 				} else if ( post.slug.split( '-' )[ 0 ] === 'single' ) {
 					// If the slug is single-{postType}, infer the post type from the name.
-					const postTypesNames =
-						postTypes?.map( ( entity ) => entity.name ) || [];
+					const postTypeNames =
+						postTypeEntities?.map( ( entity ) => entity.name ) ||
+						[];
 					const match = post.slug.match(
-						`^single-(${ postTypesNames.join( '|' ) })(?:-.+)?$`
+						`^single-(${ postTypeNames.join( '|' ) })(?:-.+)?$`
 					);
 					if ( match ) {
 						postContext.postType = match[ 1 ];
@@ -230,7 +231,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			post.type,
 			rootLevelPost.type,
 			rootLevelPost.slug,
-			postTypes,
+			postTypeEntities,
 		] );
 		const { id, type } = rootLevelPost;
 		const blockEditorSettings = useBlockEditorSettings(

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -172,14 +172,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					getRenderingMode,
 					__unstableIsEditorReady,
 				} = select( editorStore );
-				const { getPostTypes } = select( coreStore );
+				const { getEntitiesConfig } = select( coreStore );
 
 				return {
 					editorSettings: getEditorSettings(),
 					isReady: __unstableIsEditorReady(),
 					mode: getRenderingMode(),
 					selection: getEditorSelection(),
-					postTypes: getPostTypes( { per_page: -1 } ),
+					postTypes: getEntitiesConfig( 'postType' ),
 				};
 			}, [] );
 		const shouldRenderTemplate = !! template && mode !== 'post-only';

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -192,18 +192,18 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
 			const postContext = {};
-			// If it is a template, try to inherit the post type from the slug.
+			// If it is a template, try to inherit the post type from the name.
 			if ( post.type === 'wp_template' ) {
 				if ( post.slug === 'page' ) {
 					postContext.postType = 'page';
 				} else if ( post.slug === 'single' ) {
 					postContext.postType = 'post';
 				} else if ( post.slug.split( '-' )[ 0 ] === 'single' ) {
-					// If the slug is single-{postType}, infer the post type from the slug.
-					const postTypesSlugs =
-						postTypes?.map( ( entity ) => entity.slug ) || [];
+					// If the slug is single-{postType}, infer the post type from the name.
+					const postTypesNames =
+						postTypes?.map( ( entity ) => entity.name ) || [];
 					const match = post.slug.match(
-						`^single-(${ postTypesSlugs.join( '|' ) })(?:-.+)?$`
+						`^single-(${ postTypesNames.join( '|' ) })(?:-.+)?$`
 					);
 					if ( match ) {
 						postContext.postType = match[ 1 ];


### PR DESCRIPTION
## What?
As discussed [here](https://github.com/WordPress/gutenberg/pull/65705#issuecomment-2392986235), this [other pull request](https://github.com/WordPress/gutenberg/pull/65062) introduced a performance regression that I aim to palliate with this one.

## Why?
It should improve the performance metrics.

## How?
Change the logic to rely on `getEntityConfig` instead of `getPostTypes`. The information needed is already preloaded as seen [here](https://github.com/SantosGuillamot/wordpress-develop/blob/7e6d63302ba344595bed3cd5f5168733efabddbe/src/wp-admin/edit-form-blocks.php#L56), and it can be accessed with `getEntityConfig`.

This way, we skip an extra API call, which can be more important the more post types registered. This is an example of a movie template:

| Before | After |
|----------|----------|
| ![Screenshot 2024-10-14 at 18 01 23](https://github.com/user-attachments/assets/6ab55fdb-54e2-407f-8ec6-d0e217c966c4) | ![Screenshot 2024-10-14 at 18 08 45](https://github.com/user-attachments/assets/dd35b462-688a-4f0d-8f69-1ae30ae61e1b) |

## Testing Instructions
The firstBlock performance test should show an improvement.