### PR TITLE
Fix: Return result from wp_register_block_template function

### DIFF
--- a/lib/compat/wordpress-6.7/block-templates.php
+++ b/lib/compat/wordpress-6.7/block-templates.php
@@ -63,7 +63,7 @@ if ( ! function_exists( 'wp_register_block_template' ) ) {
 	 */
 	function wp_register_block_template( $template_name, $args = array() ) {
 		_deprecated_function( __FUNCTION__, 'Gutenberg 19.4.0', 'register_block_template' );
-		register_block_template( $template_name, $args );
+		return register_block_template( $template_name, $args );
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
- While reviewing PR #65958 , I noticed that the deprecated function wp_register_block_template does not return a result. This seems to have been overlooked.
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The function `wp_register_block_template` is deprecated, and the legacy code that makes use of the return result might break, as no result is being returned. That's why it is necessary to return the result here.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- It simply returns the results from the newly renamed function `register_block_template`.
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
[Reffering example from #65958 PR]
1. Add this code to an existing plugin or in a code snippet using the [Code Snippets plugin](https://wordpress.org/plugins/code-snippets/):. If you use `wp_register_block_template` and utilize the return result, it will work as expected.
```php
add_action(
	'init',
	function () {
		$template = wp_register_block_template(
			'gutenberg//plugin-template',
			array(
				'title'       => 'Plugin Template',
				'description' => 'A template registered by a plugin.',
				'content'     => '<!-- wp:template-part {"slug":"header","tagName":"header"} /--><!-- wp:group {"tagName":"main","layout":{"inherit":true}} --><main class="wp-block-group"><!-- wp:paragraph --><p>This is a plugin-registered template.</p><!-- /wp:paragraph --></main><!-- /wp:group -->',
			)
		);
		print_r( $template );
		add_action(
			'category_template_hierarchy',
			function () {
				return array( 'plugin-template' );
			}
		);
	}
);
```
2. The `print_r( $template )` statement should be visible on any page of the site. It should return a `WP_Block_Template or WP_Error` object.
```php
if ( $template instanceof WP_Error ) {
    // Handle WP_Error object
}

if ( $template instanceof WP_Block_Template ) {
    // Handle WP_Block_Template object
} 
```
3. Go to a post category in the frontend (ie: /category/test-category/) and verify the Plugin Template contents are rendered.
4. Go to Appearance > Editor > Templates and verify the Plugin Template appears with the correct title and description.
5. Make some edits to the template. Verify they are applied in the frontend.
6. Revert the edits and verify edits are reverted in the frontend as well.
7. Edit the previous code snippet adding these lines:
```php
		unregister_block_template( 'gutenberg//plugin-template' );
```
8. Verify the template no longer appears under Appearance > Editor > Templates and going to a post category in the frontend doesn't render it either.
