### PR TITLE
Revert the "Manage fonts" button in Global Styles

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-families.js
+++ b/packages/edit-site/src/components/global-styles/font-families.js
@@ -6,9 +6,11 @@ import {
 	__experimentalText as Text,
 	__experimentalItemGroup as ItemGroup,
 	__experimentalVStack as VStack,
+	__experimentalHStack as HStack,
 	Button,
 } from '@wordpress/components';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
+import { settings } from '@wordpress/icons';
 import { useContext } from '@wordpress/element';
 
 /**
@@ -67,10 +69,18 @@ function FontFamilies() {
 				/>
 			) }
 
-			<VStack spacing={ 4 }>
+			<VStack spacing={ 2 }>
+				<HStack justify="space-between">
+					<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
+					<Button
+						onClick={ () => setModalTabOpen( 'installed-fonts' ) }
+						label={ __( 'Manage fonts' ) }
+						icon={ settings }
+						size="small"
+					/>
+				</HStack>
 				{ activeFonts.length > 0 && (
 					<>
-						<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
 						<ItemGroup size="large" isBordered isSeparated>
 							{ activeFonts.map( ( font ) => (
 								<FontFamilyItem
@@ -82,31 +92,30 @@ function FontFamilies() {
 					</>
 				) }
 				{ ! hasFonts && (
-					<VStack>
-						<Subtitle level={ 3 }>{ __( 'Fonts' ) }</Subtitle>
+					<>
 						<Text as="p">
 							{ hasInstalledFonts
 								? __( 'No fonts activated.' )
 								: __( 'No fonts installed.' ) }
 						</Text>
-					</VStack>
+						<Button
+							className="edit-site-global-styles-font-families__manage-fonts"
+							variant="secondary"
+							__next40pxDefaultSize
+							onClick={ () => {
+								setModalTabOpen(
+									hasInstalledFonts
+										? 'installed-fonts'
+										: 'upload-fonts'
+								);
+							} }
+						>
+							{ hasInstalledFonts
+								? __( 'Manage fonts' )
+								: __( 'Add fonts' ) }
+						</Button>
+					</>
 				) }
-				<Button
-					className="edit-site-global-styles-font-families__manage-fonts"
-					variant="secondary"
-					__next40pxDefaultSize
-					onClick={ () => {
-						setModalTabOpen(
-							hasInstalledFonts
-								? 'installed-fonts'
-								: 'upload-fonts'
-						);
-					} }
-				>
-					{ hasInstalledFonts
-						? __( 'Manage fonts' )
-						: __( 'Add fonts' ) }
-				</Button>
 			</VStack>
 		</>
 	);

--- a/test/e2e/specs/site-editor/font-library.spec.js
+++ b/test/e2e/specs/site-editor/font-library.spec.js
@@ -38,7 +38,7 @@ test.describe( 'Font Library', () => {
 			).toBeVisible();
 		} );
 
-		test( 'should display the "Add fonts" button', async ( { page } ) => {
+		test( 'should display the "Manage fonts" icon', async ( { page } ) => {
 			await page
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
@@ -46,10 +46,10 @@ test.describe( 'Font Library', () => {
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
-			const addFontsButton = page.getByRole( 'button', {
-				name: 'Add fonts',
+			const manageFontsIcon = page.getByRole( 'button', {
+				name: 'Manage fonts',
 			} );
-			await expect( addFontsButton ).toBeVisible();
+			await expect( manageFontsIcon ).toBeVisible();
 		} );
 	} );
 
@@ -66,9 +66,7 @@ test.describe( 'Font Library', () => {
 			} );
 		} );
 
-		test( 'should display the "Manage fonts" button', async ( {
-			page,
-		} ) => {
+		test( 'should display the "Manage fonts" icon', async ( { page } ) => {
 			await page
 				.getByRole( 'region', { name: 'Editor top bar' } )
 				.getByRole( 'button', { name: 'Styles' } )
@@ -76,13 +74,13 @@ test.describe( 'Font Library', () => {
 			await page
 				.getByRole( 'button', { name: 'Typography Styles' } )
 				.click();
-			const manageFontsButton = page.getByRole( 'button', {
+			const manageFontsIcon = page.getByRole( 'button', {
 				name: 'Manage fonts',
 			} );
-			await expect( manageFontsButton ).toBeVisible();
+			await expect( manageFontsIcon ).toBeVisible();
 		} );
 
-		test( 'should open the "Manage fonts" modal when clicking the "Manage fonts" button', async ( {
+		test( 'should open the "Manage fonts" modal when clicking the "Manage fonts" icon', async ( {
 			page,
 		} ) => {
 			await page


### PR DESCRIPTION
Fixes #65574

## What?
This PR reverts the "Manage fonts" button that was persistently displayed when managing fonts in the Global Styles → Typography. Now, this "Manage fonts" button only displays when there are no active fonts. If there are no fonts installed, the button will read "Add fonts". This behavior is similar to 6.6. 

## Why?
There is an [open discussion](https://github.com/WordPress/gutenberg/issues/65574#issuecomment-2404465146) about whether this button should be displayed. As we are approaching the 6.7 release, the release leads agreed to revert to 6.6 functionality and continue this discussion for future Gutenberg releases. 

| 6.6 | 6.7 before this PR | 6.7 with this PR |
|-|-|-|
|<img width="361" alt="image" src="https://github.com/user-attachments/assets/5e94e6ea-7f2e-45e4-8ce6-2c53da806d40">|<img width="448" alt="image" src="https://github.com/user-attachments/assets/5f572ea9-c1f0-49dd-a0ed-aa12a820def7">|<img width="353" alt="image" src="https://github.com/user-attachments/assets/77cb0366-3b7b-402f-9f19-68973590b38a">|