### PR TITLE
Fix latest comments block spacing issue.

### DIFF
--- a/packages/block-library/src/latest-comments/style.scss
+++ b/packages/block-library/src/latest-comments/style.scss
@@ -7,6 +7,8 @@ ol.wp-block-latest-comments {
 
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+
+	padding-left: 0;
 }
 
 // Following styles leverage :where so that typography block support styles and


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I have created this PR to remove spacing from "Latest Comments" block. 

## Why?
I have checked "Latest Comments" block and I have found that when we changed its background color we have facing its padding/space issue. After changed its background color the block padding/spacing is not same on editor side & front-end side. 

## How?
By removing extra spacing/padding from left side on front-end side. Now, it looks good.

## Testing Instructions

- Type / to choose a block
- Select Latest comments block
- Change its background color from block settings.
- Save the changes and publish the page.
- View the editor side & front-end side.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![latest-comments-block-editor](https://github.com/user-attachments/assets/df665bed-c858-4fd2-99af-8f5b8b018c47)
![latest-comments-block-front-end](https://github.com/user-attachments/assets/f70a2aa7-a894-4c6b-92e8-df6ac68cc5c1)
