### PR TITLE
Try dark toolbar for the write mode

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -75,6 +75,7 @@ export function PrivateBlockToolbar( {
 		showLockButtons,
 		showSwitchSectionStyleButton,
 		hasFixedToolbar,
+		isNavigationMode,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -89,6 +90,7 @@ export function PrivateBlockToolbar( {
 			getSettings,
 			getParentSectionBlock,
 			isZoomOut,
+			isNavigationMode: _isNavigationMode,
 		} = unlock( select( blockEditorStore ) );
 		const selectedBlockClientIds = getSelectedBlockClientIds();
 		const selectedBlockClientId = selectedBlockClientIds[ 0 ];
@@ -148,6 +150,7 @@ export function PrivateBlockToolbar( {
 			showLockButtons: ! isZoomOut(),
 			showSwitchSectionStyleButton: isZoomOut(),
 			hasFixedToolbar: getSettings().hasFixedToolbar,
+			isNavigationMode: _isNavigationMode(),
 		};
 	}, [] );
 
@@ -174,13 +177,12 @@ export function PrivateBlockToolbar( {
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = clsx( 'block-editor-block-contextual-toolbar', {
 		'has-parent': showParentSelector,
-		'is-inverted-toolbar': ! isDefaultEditingMode && ! hasFixedToolbar,
+		'is-inverted-toolbar': isNavigationMode && ! hasFixedToolbar,
 	} );
 
 	const innerClasses = clsx( 'block-editor-block-toolbar', {
 		'is-synced': isSynced,
 		'is-connected': isUsingBindings,
-		'is-dark-toolbar': ! isDefaultEditingMode && ! hasFixedToolbar,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -174,13 +174,13 @@ export function PrivateBlockToolbar( {
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = clsx( 'block-editor-block-contextual-toolbar', {
 		'has-parent': showParentSelector,
-		'is-contentonly-mode': ! isDefaultEditingMode && ! hasFixedToolbar,
+		'is-dark-toolbar': ! isDefaultEditingMode && ! hasFixedToolbar,
 	} );
 
 	const innerClasses = clsx( 'block-editor-block-toolbar', {
 		'is-synced': isSynced,
 		'is-connected': isUsingBindings,
-		'is-contentonly-mode': ! isDefaultEditingMode && ! hasFixedToolbar,
+		'is-dark-toolbar': ! isDefaultEditingMode && ! hasFixedToolbar,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -74,6 +74,7 @@ export function PrivateBlockToolbar( {
 		showGroupButtons,
 		showLockButtons,
 		showSwitchSectionStyleButton,
+		hasFixedToolbar,
 	} = useSelect( ( select ) => {
 		const {
 			getBlockName,
@@ -85,6 +86,7 @@ export function PrivateBlockToolbar( {
 			getBlockAttributes,
 			getBlockParentsByBlockName,
 			getTemplateLock,
+			getSettings,
 			getParentSectionBlock,
 			isZoomOut,
 		} = unlock( select( blockEditorStore ) );
@@ -119,6 +121,7 @@ export function PrivateBlockToolbar( {
 		const _hasTemplateLock = selectedBlockClientIds.some(
 			( id ) => getTemplateLock( id ) === 'contentOnly'
 		);
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -144,6 +147,7 @@ export function PrivateBlockToolbar( {
 			showGroupButtons: ! isZoomOut(),
 			showLockButtons: ! isZoomOut(),
 			showSwitchSectionStyleButton: isZoomOut(),
+			hasFixedToolbar: getSettings().hasFixedToolbar,
 		};
 	}, [] );
 
@@ -170,11 +174,13 @@ export function PrivateBlockToolbar( {
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = clsx( 'block-editor-block-contextual-toolbar', {
 		'has-parent': showParentSelector,
+		'is-contentonly-mode': ! isDefaultEditingMode && ! hasFixedToolbar,
 	} );
 
 	const innerClasses = clsx( 'block-editor-block-toolbar', {
 		'is-synced': isSynced,
 		'is-connected': isUsingBindings,
+		'is-contentonly-mode': ! isDefaultEditingMode && ! hasFixedToolbar,
 	} );
 
 	return (

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -174,7 +174,7 @@ export function PrivateBlockToolbar( {
 	// Shifts the toolbar to make room for the parent block selector.
 	const classes = clsx( 'block-editor-block-contextual-toolbar', {
 		'has-parent': showParentSelector,
-		'is-dark-toolbar': ! isDefaultEditingMode && ! hasFixedToolbar,
+		'is-inverted-toolbar': ! isDefaultEditingMode && ! hasFixedToolbar,
 	} );
 
 	const innerClasses = clsx( 'block-editor-block-toolbar', {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -57,25 +57,6 @@
 		}
 	}
 
-	&.is-contentonly-mode {
-		background-color: $gray-900;
-		color: $white;
-		button {
-			color: $white;
-			background-color: $gray-900 !important;
-		}
-		.block-editor-block-switcher__toggle {
-			color: $white;
-		}
-		.components-toolbar-group,
-		.components-toolbar {
-			border-right-color: $gray-600 !important;
-		}
-		.is-pressed {
-			color: var(--wp-admin-theme-color);
-		}
-	}
-
 	> :last-child,
 	> :last-child .components-toolbar-group,
 	> :last-child .components-toolbar,

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -57,6 +57,22 @@
 		}
 	}
 
+	&.is-contentonly-mode {
+		background-color: $gray-900;
+		color: $white;
+		button {
+			color: $white;
+			background-color: $gray-900 !important;
+		}
+		.block-editor-block-switcher__toggle {
+			color: $white;
+		}
+		.components-toolbar-group,
+		.components-toolbar {
+			border-right-color: $gray-600 !important;
+		}
+	}
+
 	> :last-child,
 	> :last-child .components-toolbar-group,
 	> :last-child .components-toolbar,
@@ -91,6 +107,10 @@
 
 	&.is-unstyled {
 		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
+	}
+
+	&.is-contentonly-mode {
+		background-color: $gray-900;
 	}
 
 	.block-editor-block-toolbar {

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -71,6 +71,9 @@
 		.components-toolbar {
 			border-right-color: $gray-600 !important;
 		}
+		.is-pressed {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 
 	> :last-child,

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -93,10 +93,6 @@
 		box-shadow: 0 $border-width 0 0 rgba($color: #000, $alpha: 0.133); // 0.133 = $gray-200 but with alpha.
 	}
 
-	&.is-contentonly-mode {
-		background-color: $gray-900;
-	}
-
 	.block-editor-block-toolbar {
 		overflow: auto;
 		overflow-y: hidden;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -143,13 +143,25 @@
 		background-color: $gray-900;
 		color: $gray-100;
 
+		&.block-editor-block-contextual-toolbar {
+			border-color: $gray-800;
+		}
+
 		button {
-			color: $gray-200;
-			background-color: $gray-900 !important;
+			color: $gray-300;
 
 			&:hover {
 				color: $white;
 			}
+
+			&:focus::before {
+				box-shadow: inset 0 0 0 1px $gray-900, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+			}
+		}
+
+		.block-editor-block-parent-selector .block-editor-block-parent-selector__button {
+			border-color: $gray-800;
+			background-color: $gray-900;
 		}
 
 		.block-editor-block-switcher__toggle {
@@ -158,7 +170,7 @@
 
 		.components-toolbar-group,
 		.components-toolbar {
-			border-right-color: $gray-700 !important;
+			border-right-color: $gray-800 !important;
 		}
 
 		.is-pressed {

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -141,18 +141,26 @@
 
 	.is-dark-toolbar {
 		background-color: $gray-900;
-		color: $white;
+		color: $gray-100;
+
 		button {
-			color: $white;
+			color: $gray-200;
 			background-color: $gray-900 !important;
+
+			&:hover {
+				color: $white;
+			}
 		}
+
 		.block-editor-block-switcher__toggle {
-			color: $white;
+			color: $gray-100;
 		}
+
 		.components-toolbar-group,
 		.components-toolbar {
-			border-right-color: $gray-600 !important;
+			border-right-color: $gray-700 !important;
 		}
+
 		.is-pressed {
 			color: var(--wp-admin-theme-color);
 		}

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -139,7 +139,7 @@
 		border-right-color: $gray-900;
 	}
 
-	.is-dark-toolbar {
+	.is-inverted-toolbar {
 		background-color: $gray-900;
 		color: $gray-100;
 

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -130,13 +130,28 @@
 		}
 	}
 
-	.block-editor-block-toolbar {
-		overflow: visible;
-	}
-
 	.block-editor-block-toolbar .components-toolbar-group,
 	.block-editor-block-toolbar .components-toolbar {
 		border-right-color: $gray-900;
+	}
+
+	.is-dark-toolbar {
+		background-color: $gray-900;
+		color: $white;
+		button {
+			color: $white;
+			background-color: $gray-900 !important;
+		}
+		.block-editor-block-switcher__toggle {
+			color: $white;
+		}
+		.components-toolbar-group,
+		.components-toolbar {
+			border-right-color: $gray-600 !important;
+		}
+		.is-pressed {
+			color: var(--wp-admin-theme-color);
+		}
 	}
 
 	// Hide the block toolbar if the insertion point is shown.

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -130,6 +130,10 @@
 		}
 	}
 
+	.block-editor-block-toolbar {
+		overflow: visible;
+	}
+
 	.block-editor-block-toolbar .components-toolbar-group,
 	.block-editor-block-toolbar .components-toolbar {
 		border-right-color: $gray-900;


### PR DESCRIPTION
## What?

Solves #66054

Let's try adding an additional affordance to write mode to help you understand what "mode" you're in, writing or design, by leveraging the pre-existing styles for select mode. This way there's a clear visual affordance to indicate the difference in experiences.

## Why?
Part of [66054](https://github.com/WordPress/gutenberg/issues/66054)

## How?
I’ve applied the conditions for the `is-contentonly-mode `class, which gets added when the write mode is activated. I also tried to add the SCSS to match the design. While I did my best to ensure the SCSS is correct, I believe it can be further optimized through the review process if necessary.

## Testing Instructions
 1. Open a post or page.
 2. Insert a any block or pattern.
 3. Then change the mode to write mode see the toolbar in darkmode.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b7e6e5d5-15ab-4e85-8712-52ed656ecee9
