### PR TITLE
Add missing CHANGELOG entries for #64067 

### DIFF
--- a/packages/interactivity-router/CHANGELOG.md
+++ b/packages/interactivity-router/CHANGELOG.md
@@ -7,8 +7,10 @@
 -   Improvements to the experimental full-page navigation ([#64067](https://github.com/WordPress/gutenberg/pull/64067)):
     -   Remove the `src` attributes from prefetched script tags.
     -   Use `.textContent` instead of `.innerText` to set `<script>` contents.
-    -   Use `populateInitialData()` with state from the server.
+    -   Use [`populateServerData()`](https://github.com/WordPress/gutenberg/blob/9671329c386d2b743f14ef314823fbf915366ebd/packages/interactivity/src/store.ts#L269) with state from the server.
     -   Wait for the `load` event of the script element before evaluating it.
+    -   Make `renderRegions()` an async function.
+    -   Only prefetch **module** scripts, never prefetch regular scripts. That's because regular scripts (without `async` or `defer` attributes) found in the head are blocking and must be executed in order. When prefetching there is no guarantee that the scripts will execute in the order they are prefetched. Module scripts can be executed in any order.
 
 ## 2.9.0 (2024-10-03)
 


### PR DESCRIPTION
The `CHANGELOG.md` updates in https://github.com/WordPress/gutenberg/pull/64067 were incomplete. This PR adds more relevant information.