### PR TITLE
Fix: Add missing `post.slug` dependency to `useMemo`

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -222,6 +222,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 			shouldRenderTemplate,
 			post.id,
 			post.type,
+			post.slug,
 			rootLevelPost.type,
 			rootLevelPost.slug,
 			postTypes,


### PR DESCRIPTION
## What?
As reported [here](https://github.com/WordPress/gutenberg/pull/65639/files#r1800792391) by @youknowriad , there is a missing dependency in the `useMemo` hook.

## Why?
It can cause unexpected bugs.

## How?
Add the missing dependency to the hook.