### PR TITLE
Query Loop Block: Remove redundant sticky state

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -62,7 +62,7 @@ export default function QueryInspectorControls( props ) {
 		format,
 	} = query;
 	const allowedControls = useAllowedControls( attributes );
-	const [ showSticky, setShowSticky ] = useState( postType === 'post' );
+	const showSticky = postType === 'post';
 	const {
 		postTypesTaxonomiesMap,
 		postTypesSelectOptions,
@@ -70,9 +70,6 @@ export default function QueryInspectorControls( props ) {
 	} = usePostTypes();
 	const taxonomies = useTaxonomies( postType );
 	const isPostTypeHierarchical = useIsPostTypeHierarchical( postType );
-	useEffect( () => {
-		setShowSticky( postType === 'post' );
-	}, [ postType ] );
 	const onPostTypeChange = ( newValue ) => {
 		const updateQuery = { postType: newValue };
 		// We need to dynamically update the `taxQuery` property,


### PR DESCRIPTION
## What?
Remove unnecessary state from the Query Loop block.

## Why?
Because code can be simplified and the data can be derived from existing state / props.

## How?
We're deriving the variable from the existing props / state.

## Testing Instructions
* Insert a Query Loop and select a pattern with some posts.
* Open the inspector controls of the block
* Verify toggling the Post Type field still works:
  * "Sticky Posts" field is visible when "Post Type" is "Post"
  * "Sticky Posts" field is hidden when "Post Type" is "Page".

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
