### PR TITLE
Enhancement/deny block use

### DIFF
--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -576,7 +576,6 @@ function gutenberg_denied_block_types( $allowed_blocks, $editor_context ) {
             $allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
         }
     }
-    // Default: return the $allowed_blocks as is
     return array_values($allowed_blocks);
 }
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -525,58 +525,66 @@ add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtere
  * @param object $editor_context An object that contains information about the current context.
  * @return array The filtered list of allowed block types.
  */
-function gutenberg_denied_block_types( $allowed_blocks, $editor_context ) {
-    // If $allowed_blocks is empty or not provided, fetch all registered blocks
-    if ( ! $allowed_blocks || ! is_array( $allowed_blocks ) ) {
-        $allowed_blocks = array_keys( WP_Block_Type_Registry::get_instance()->get_all_registered() );
-    }
+function gutenberg_denied_block_types($allowed_blocks, $editor_context)
+{
+	// If $allowed_blocks is empty or not provided, fetch all registered blocks
+	if (!$allowed_blocks || !is_array($allowed_blocks)) {
+		$allowed_blocks = array_keys(WP_Block_Type_Registry::get_instance()->get_all_registered());
+	}
 
-    // Check if the current context is post or site editor
-    if ( isset( $editor_context->post ) ) {
-        // Get the current post type
-        $post_type = get_post_type( $editor_context->post );
+	// Check if the current context is post or site editor
+	if (isset($editor_context->post)) {
+		// Get the current post type
+		$post_type = get_post_type($editor_context->post);
 
-        // Example: Deny specific blocks for 'post' post type
-        if ( $post_type === 'post' ) {
-            // Deny specific blocks by removing them from $allowed_blocks
-            $denied_blocks = array(
-                'core/gallery',
-                'core/cover',
-            );
-            $allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
-        } elseif ( $post_type === 'page' ) {
-            // Deny specific blocks for pages
-            $denied_blocks = array(
-                'core/quote',
-                'core/video',
-            );
-            $allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
-        }
-    }
+		// Example: Deny specific blocks for 'post' post type
+		if ($post_type === 'post') {
+			// Deny specific blocks by removing them from $allowed_blocks
+			$denied_blocks = array(
+				'core/galledry',
+				'core/cover',
+			);
+			$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
+		} elseif ($post_type === 'page') {
+			// Deny specific blocks for pages
+			$denied_blocks = array(
+				'core/quote',
+				'core/video',
+			);
+			$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
+		}
+	}
 
-    // Deny blocks in the Site Editor context
-    if ( isset( $editor_context->name ) && 'core/edit-site' === $editor_context->name ) {
+	// Deny blocks in the Site Editor context
+	if (isset($editor_context->name) && 'core/edit-site' === $editor_context->name) {
 
-        // Get the template ID from the post being edited
-        $current_template = get_post();
+		if (isset($_GET['postId'])) { //phpcs:ignore
 
-        if ( $current_template && $current_template->post_name === 'home' ) {
-            // Deny specific blocks for the 'home' template
-            $denied_blocks = array(
-                'core/columns',
-                'core/quote',
-            );
-            $allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
-        } else {
-            // Deny specific blocks for other templates
-            $denied_blocks = array(
-                'core/gallery',
-                'core/cover',
-            );
-            $allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
-        }
-    }
-    return array_values($allowed_blocks);
+			$template_post_id = sanitize_text_field(wp_unslash($_GET['postId'])); //phpcs:ignore
+
+			$template_post = get_block_template($template_post_id,'wp_template');
+
+			if ($template_post) {
+				// Now you can use this template slug to apply conditions and deny blocks
+				if ('archive' === $template_post->slug) {
+					$denied_blocks = array(
+						'core/columns',
+						'core/quote',
+					);
+					$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
+				} elseif ($template_post->slug === 'single') {
+					// Deny specific blocks for other templates
+					$denied_blocks = array(
+						'core/gallery',
+						'core/cover',
+					);
+					$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
+				}
+			}
+
+		}
+	}
+	return array_values($allowed_blocks);
 }
 
-add_filter( 'allowed_block_types_all', 'gutenberg_denied_block_types', 10, 2 );
+add_filter('allowed_block_types_all', 'gutenberg_denied_block_types', 10, 2);

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -525,66 +525,65 @@ add_filter( 'force_filtered_html_on_import', '_gutenberg_footnotes_force_filtere
  * @param object $editor_context An object that contains information about the current context.
  * @return array The filtered list of allowed block types.
  */
-function gutenberg_denied_block_types($allowed_blocks, $editor_context)
-{
+function gutenberg_denied_block_types( $allowed_blocks, $editor_context ) {
 	// If $allowed_blocks is empty or not provided, fetch all registered blocks
-	if (!$allowed_blocks || !is_array($allowed_blocks)) {
-		$allowed_blocks = array_keys(WP_Block_Type_Registry::get_instance()->get_all_registered());
+	if ( ! $allowed_blocks || ! is_array( $allowed_blocks ) ) {
+		$allowed_blocks = array_keys( WP_Block_Type_Registry::get_instance()->get_all_registered() );
 	}
 
 	// Check if the current context is post or site editor
-	if (isset($editor_context->post)) {
+	if ( isset( $editor_context->post ) ) {
 		// Get the current post type
-		$post_type = get_post_type($editor_context->post);
+		$post_type = get_post_type( $editor_context->post );
 
 		// Example: Deny specific blocks for 'post' post type
-		if ($post_type === 'post') {
+		if ( $post_type === 'post' ) {
 			// Deny specific blocks by removing them from $allowed_blocks
 			$denied_blocks = array(
-				'core/galledry',
+				'core/gallery',
 				'core/cover',
 			);
-			$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
-		} elseif ($post_type === 'page') {
+			$allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
+		} elseif ( $post_type === 'page' ) {
 			// Deny specific blocks for pages
 			$denied_blocks = array(
 				'core/quote',
 				'core/video',
 			);
-			$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
+			$allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
 		}
 	}
 
 	// Deny blocks in the Site Editor context
-	if (isset($editor_context->name) && 'core/edit-site' === $editor_context->name) {
+	if ( isset( $editor_context->name ) && 'core/edit-site' === $editor_context->name ) {
+		if ( isset( $_GET['postId'] ) ) { //phpcs:ignore
 
-		if (isset($_GET['postId'])) { //phpcs:ignore
+			$template_post_id = sanitize_text_field( wp_unslash( $_GET['postId'] ) ); //phpcs:ignore
 
-			$template_post_id = sanitize_text_field(wp_unslash($_GET['postId'])); //phpcs:ignore
+			$template_post = get_block_template( $template_post_id, 'wp_template' );
 
-			$template_post = get_block_template($template_post_id,'wp_template');
-
-			if ($template_post) {
+			if ( $template_post ) {
 				// Now you can use this template slug to apply conditions and deny blocks
-				if ('archive' === $template_post->slug) {
+				if ( 'archive' === $template_post->slug ) {
 					$denied_blocks = array(
 						'core/columns',
 						'core/quote',
 					);
-					$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
-				} elseif ($template_post->slug === 'single') {
+					$allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
+				} elseif ( $template_post->slug === 'single' ) {
 					// Deny specific blocks for other templates
 					$denied_blocks = array(
 						'core/gallery',
 						'core/cover',
 					);
-					$allowed_blocks = array_diff($allowed_blocks, $denied_blocks);
+					$allowed_blocks = array_diff( $allowed_blocks, $denied_blocks );
 				}
 			}
-
 		}
 	}
-	return array_values($allowed_blocks);
+
+	return array_values( $allowed_blocks );
 }
+
 
 add_filter('allowed_block_types_all', 'gutenberg_denied_block_types', 10, 2);


### PR DESCRIPTION


## What?
This PR allows option to deny specific block only on specific post types and/or specific templates. Fix https://github.com/WordPress/gutenberg/issues/41062.

## Why?
It's sometimes desirable to limit blocks to certain post-type contexts (or, in a parallel fashion, to prevent a specific block from being used in a given context).

## How?

I created a straightforward filter to deny specific blocks from posts and pages based on the post_type. We can also specify which blocks should be removed from the site editor templates.

Currently, when clicking on templates from the template listing page, the page does not reload, so the filter does not apply until the template edit page is reloaded. 

If this way of handling the block restriction looks good, then **we can further develop the current code with option to handle on-click  scenario.**

For further improvement, we can also provide a backend option for users to specify which blocks to avoid for which post types if it needed.

## Testing Instructions

After that check out this branch:

Create a new post.
Search for Gallery/Cover block: it should not be visible.
Create a new page.
Search for Quote/Video block: it should not be visible.
Open the FSE.
Open the Archive template & reload
Search for Columns/Quote block: it should not be visible.
Open the single template & reload
Search for Gallery/Cover block: it should not be visible.

## Screenshots before and after adding filter

post-edit-after
![post-edit-after](https://github.com/user-attachments/assets/d2b87b3d-80e5-4544-be48-c44b6c972102)
post-edit-before
![post-edit-before](https://github.com/user-attachments/assets/83827ce3-5942-40bb-bee6-1da19b21e3e9)
template-edit-after
![template-edit-after](https://github.com/user-attachments/assets/13865aa8-c89a-4056-8183-ebcb9e54b833)
template-edit-before
![template-edit-before](https://github.com/user-attachments/assets/c57540db-de82-4008-b37c-3a512ce7f2cc)

Thanks.
