### PR TITLE
Edit Site: Remove redundant state in `StyleVariationsContainer`

### DIFF
--- a/packages/edit-site/src/components/global-styles/style-variations-container.js
+++ b/packages/edit-site/src/components/global-styles/style-variations-container.js
@@ -3,7 +3,7 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
-import { useContext, useEffect, useMemo, useState } from '@wordpress/element';
+import { useContext, useMemo } from '@wordpress/element';
 import { __experimentalGrid as Grid } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
@@ -20,12 +20,7 @@ const { GlobalStylesContext } = unlock( blockEditorPrivateApis );
 
 export default function StyleVariationsContainer( { gap = 2 } ) {
 	const { user } = useContext( GlobalStylesContext );
-	const [ currentUserStyles, setCurrentUserStyles ] = useState( user );
-	const userStyles = currentUserStyles?.styles;
-
-	useEffect( () => {
-		setCurrentUserStyles( user );
-	}, [ user ] );
+	const userStyles = user?.styles;
 
 	const variations = useSelect( ( select ) => {
 		return select(


### PR DESCRIPTION
## What?
Remove unnecessary state from the `StyleVariationsContainer` component.

## Why?
Because code can be simplified and the data can be derived from existing state / props.

## How?
We're deriving the variable from the existing props / state.

## Testing Instructions
* Open the site editor on a theme with style variations
* Verify switching style variations still works.
* Verify user global styles are still considered and work correctly. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
