### PR TITLE
Fix scaling animation for device previews

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -42,14 +42,7 @@
 	@include animation__fade-in($speed, $delay);
 }
 
-@mixin editor-canvas-resize-animation( $additional-transition-rules: null ) {
-	$resizeAnimation: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
-
-	@if $additional-transition-rules {
-		transition: $resizeAnimation, unquote($additional-transition-rules);
-	} @else {
-		transition: $resizeAnimation;
-	}
-
+@mixin editor-canvas-resize-animation( $additional-transition-rules... ) {
+	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96), $additional-transition-rules;
 	@include reduce-motion("transition");
 }

--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -42,7 +42,7 @@
 	@include animation__fade-in($speed, $delay);
 }
 
-@mixin editor-canvas-resize-animation( $additional-transition-rules... ) {
+@mixin editor-canvas-resize-animation($additional-transition-rules...) {
 	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96), $additional-transition-rules;
 	@include reduce-motion("transition");
 }

--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -41,3 +41,15 @@
 	@warn "The `edit-post__fade-in-animation` mixin is deprecated. Use `animation__fade-in` instead.";
 	@include animation__fade-in($speed, $delay);
 }
+
+@mixin editor-canvas-resize-animation( $additional-transition-rules: null ) {
+	$resizeAnimation: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
+
+	@if $additional-transition-rules {
+		transition: $resizeAnimation, unquote($additional-transition-rules);
+	} @else {
+		transition: $resizeAnimation;
+	}
+
+	@include reduce-motion("transition");
+}

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -5,6 +5,5 @@ iframe[name="editor-canvas"] {
 	display: block;
 	background-color: transparent;
 	// Handles transitions between device previews
-	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
-	@include reduce-motion("transition");
+	@include editor-canvas-resize-animation;
 }

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -4,4 +4,7 @@ iframe[name="editor-canvas"] {
 	height: 100%;
 	display: block;
 	background-color: transparent;
+	// Handles transitions between device previews
+	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
+	@include reduce-motion("transition");
 }

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -8,13 +8,13 @@
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation( "transform 0s, scale 0s, padding 0s" );
+	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s );
 
 	&.zoom-out-animation {
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
-		@include editor-canvas-resize-animation( "transform 0s" );
+		@include editor-canvas-resize-animation( transform 0s );
 	}
 }
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -5,20 +5,16 @@
 
 .block-editor-iframe__html {
 	transform-origin: top center;
-	// 400ms should match the animation speed used in iframe/index.js
-	$zoomOutAnimation: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
-
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	transition: $zoomOutAnimation, transform 0s scale 0s;
-	@include reduce-motion("transition");
+	@include editor-canvas-resize-animation( "transform 0s, scale 0s, padding 0s" );
 
 	&.zoom-out-animation {
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
-		transition: $zoomOutAnimation, transform 0s;
+		@include editor-canvas-resize-animation( "transform 0s" );
 	}
 }
 
@@ -30,7 +26,7 @@
 	$outer-container-width: var(--wp-block-editor-iframe-zoom-out-outer-container-width);
 	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
 	// Apply an X translation to center the scaled content within the available space.
-	transform: translateX(calc(( #{$outer-container-width} - #{ $container-width }) / 2 / #{$scale}));
+	transform: translateX(calc((#{$outer-container-width} - #{$container-width}) / 2 / #{$scale}));
 	scale: #{$scale};
 	background-color: $gray-300;
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -8,13 +8,13 @@
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s );
+	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s);
 
 	&.zoom-out-animation {
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
-		@include editor-canvas-resize-animation( transform 0s );
+		@include editor-canvas-resize-animation(transform 0s);
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes the scaling animation between device previews because [I was wrong.](https://github.com/WordPress/gutenberg/pull/66034/files#r1797432704) 😅 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Device previews should have a scaling animation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the animation back in. I'm not adding the mixin again, as they need to be handled slightly differently anyways.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to View button in header
- Change to a different device
- Animation should happen to transition between device previews
- Test zoom out scaling between sidebars opening/closing. Should match animations on trunk.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
