### PR TITLE
.screen-reader-text CSS update for a11y add-container.js

### DIFF
--- a/packages/a11y/src/script/add-container.js
+++ b/packages/a11y/src/script/add-container.js
@@ -18,8 +18,6 @@ export default function addContainer( ariaLive = 'polite' ) {
 			'height: 1px;' +
 			'width: 1px;' +
 			'overflow: hidden;' +
-			'clip: rect(1px, 1px, 1px, 1px);' +
-			'-webkit-clip-path: inset(50%);' +
 			'clip-path: inset(50%);' +
 			'border: 0;' +
 			'word-wrap: normal !important;'


### PR DESCRIPTION
## What?
Addresses part of #65954

## Why?
The utility `.screen-reader-text` CSS is used in several places throughout the Gutenberg code base. In #65409 it came up that we should update all the areas to match the changing CSS rules proposed in #65409.

## How?

Remove the unnecessary `clip: rect(1px, 1px, 1px, 1px);` and `-webkit-clip-path: inset(50%);` rules from the `packages/a11y/src/script/add-container.js`

### Style attribute

| Before | After |
| --- | --- |
| ![Screenshot 2024-09-17 at 17 48 21](https://github.com/user-attachments/assets/78ac6566-28d9-4f8c-8fff-bd31d27aec67) | ![Screenshot 2024-09-17 at 17 48 57](https://github.com/user-attachments/assets/e7453807-cfad-4d0d-b293-c50daabb53f7) |
