### PR TITLE
Edit Site: Avoid recomputing variations when no theme variations

### DIFF
--- a/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
+++ b/packages/edit-site/src/hooks/use-theme-style-variations/use-theme-style-variations-by-property.js
@@ -13,6 +13,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { unlock } from '../../lock-unlock';
 
+const EMPTY_ARRAY = [];
 const { GlobalStylesContext, areGlobalStyleConfigsEqual } = unlock(
 	blockEditorPrivateApis
 );
@@ -82,7 +83,7 @@ export function useCurrentMergeThemeStyleVariationsWithUserConfig(
 			).__experimentalGetCurrentThemeGlobalStylesVariations();
 
 		return {
-			variationsFromTheme: _variationsFromTheme || [],
+			variationsFromTheme: _variationsFromTheme || EMPTY_ARRAY,
 		};
 	}, [] );
 	const { user: userVariation } = useContext( GlobalStylesContext );


### PR DESCRIPTION
## What?
This PR helps avoid recomputing the style variations when there are no variations provided by the theme, or they haven't loaded yet.

## Why?
Currently, there are unnecessary re-renders while loading, because we return a different empty array every time we check for theme style variations. This also triggers a misused `useSelect` warning:

![Screenshot 2024-10-15 at 19 43 59](https://github.com/user-attachments/assets/f05fd0f0-2471-46ef-994e-69fee496240e)

## How?
We're just reusing the same array.

## Testing Instructions
* Activate the Twenty Twenty-Four theme. 
* Go to `/wp-admin/site-editor.php?path=%2Fwp_global_styles`
* Verify the warning is gone.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
