### PR TITLE
Scripts: Add BlueOak-1.0.0 license to GPL2 compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
 		"lint:pkg-json": "wp-scripts lint-pkg-json . 'packages/*/package.json'",
 		"native": "npm run --prefix packages/react-native-editor",
 		"other:changelog": "node ./bin/plugin/cli.js changelog",
-		"other:check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2 --ignore=@react-native-community/cli,@react-native-community/cli-platform-ios,@ampproject/remapping,human-signals,fb-watchman,bser,walker,chrome-launcher,lighthouse-logger,chromium-edge-launcher\" \"wp-scripts check-licenses --dev --ignore=jackspeak,path-scurry,package-json-from-dist\"",
+		"other:check-licenses": "concurrently \"wp-scripts check-licenses --prod --gpl2 --ignore=@react-native-community/cli,@react-native-community/cli-platform-ios,@ampproject/remapping,human-signals,fb-watchman,walker,chrome-launcher,lighthouse-logger,chromium-edge-launcher\" \"wp-scripts check-licenses --dev\"",
 		"preother:check-local-changes": "npm run docs:build",
 		"other:check-local-changes": "node ./bin/check-local-changes.js",
 		"other:cherry-pick": "node ./bin/cherry-pick.mjs",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add BlueOak-1.0.0 the GPLv2-comatible licenses recognized by check-licenses ([#66139](https://github.com/WordPress/gutenberg/pull/66139)).
+
 ### Internal
 
 -   Refactor to extract license related logic to a reusable module ([#66179](https://github.com/WordPress/gutenberg/pull/66179)).

--- a/packages/scripts/utils/license.js
+++ b/packages/scripts/utils/license.js
@@ -58,6 +58,7 @@ const gpl2CompatibleLicenses = [
 	'0BSD',
 	'Apache-2.0 WITH LLVM-exception',
 	'Artistic-2.0',
+	'BlueOak-1.0.0',
 	'BSD-2-Clause',
 	'BSD-3-Clause-W3C',
 	'BSD-3-Clause',


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Add  BlueOak-1.0.0 to GPLv2 compatible licenses recognized by wp-scripts check-licenses.

This license appears on some npm packages. It intended to be highly
permissive. The website states that it should be GPLv2 compatible:

> Is the model license compatible with GPL?
> The Council doesn’t see any reason why software licensed under the
> Blue Oak Model License 1.0.0 can’t be used, combined, and distributed
> with software under GPLv2, LGPLv2.1, GPLv3, LGPLv3, or AGPLv3.

https://blueoakcouncil.org/license-faq

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


## Why?

The license appears in Gutenberg's dependencies and seems to be compatible. Add it.



## Testing Instructions

Run this on trunk and this branch:

```sh
./node_modules/.bin/wp-scripts check-licenses --gpl2
```

Trunk shows errors errors with the license:

```
…
 ERROR  Module bser has an incompatible license 'Apache-2.0'.
 ERROR  Module jackspeak has an incompatible license 'BlueOak-1.0.0'.
 ERROR  Module package-json-from-dist has an incompatible license 'BlueOak-1.0.0'.
 ERROR  Module path-scurry has an incompatible license 'BlueOak-1.0.0'.
 ERROR  Module lazy-universal-dotenv has an incompatible license 'Apache-2.0'.
 ERROR  Module @swc/core has an incompatible license 'Apache-2.0'.
…
```

This branch does not.

