### PR TITLE
Tabs: overhaul unit tests

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Internal
 
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
+-   Improve `Tabs` unit tests ([#66140](https://github.com/WordPress/gutenberg/pull/66140)).
 
 ## 28.13.0 (2024-11-27)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,7 +10,6 @@
 ### Internal
 
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
--   Improve `Tabs` unit tests ([#66140](https://github.com/WordPress/gutenberg/pull/66140)).
 
 ## 28.13.0 (2024-11-27)
 
@@ -21,7 +20,7 @@
 -   `FontSizePicker`: Deprecate 36px default size ([#66920](https://github.com/WordPress/gutenberg/pull/66920)).
 -   `ComboboxControl`: Deprecate 36px default size ([#66900](https://github.com/WordPress/gutenberg/pull/66900)).
 -   `ToggleGroupControl`: Deprecate 36px default size ([#66747](https://github.com/WordPress/gutenberg/pull/66747)).
--   `RangeControl`: Deprecate 36px default size ([#66721](https://github.com/WordPress/gutenberg/pull/66721)). 
+-   `RangeControl`: Deprecate 36px default size ([#66721](https://github.com/WordPress/gutenberg/pull/66721)).
 
 ### Bug Fixes
 

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -50,6 +50,30 @@ const TABS: Tab[] = [
 	},
 ];
 
+const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
+	tabObj.tabId === 'alpha'
+		? {
+				...tabObj,
+				tab: {
+					...tabObj.tab,
+					disabled: true,
+				},
+		  }
+		: tabObj
+);
+
+const TABS_WITH_BETA_DISABLED = TABS.map( ( tabObj ) =>
+	tabObj.tabId === 'beta'
+		? {
+				...tabObj,
+				tab: {
+					...tabObj.tab,
+					disabled: true,
+				},
+		  }
+		: tabObj
+);
+
 const TABS_WITH_DELTA: Tab[] = [
 	...TABS,
 	{
@@ -141,9 +165,6 @@ const ControlledTabs = ( {
 	);
 };
 
-const getSelectedTab = async () =>
-	await screen.findByRole( 'tab', { selected: true } );
-
 let originalGetClientRects: () => DOMRectList;
 
 describe( 'Tabs', () => {
@@ -162,13 +183,29 @@ describe( 'Tabs', () => {
 		window.HTMLElement.prototype.getClientRects = originalGetClientRects;
 	} );
 
-	describe( 'Accessibility and semantics', () => {
-		it( 'should use the correct aria attributes', async () => {
+	describe( 'Adherence to spec and basic behavior', () => {
+		it( 'should apply the correct roles, semantics and attributes', async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
 			const tabList = screen.getByRole( 'tablist' );
 			const allTabs = screen.getAllByRole( 'tab' );
-			const selectedTabPanel = await screen.findByRole( 'tabpanel' );
+			const allTabpanels = screen.getAllByRole( 'tabpanel' );
 
 			expect( tabList ).toBeVisible();
 			expect( tabList ).toHaveAttribute(
@@ -178,132 +215,123 @@ describe( 'Tabs', () => {
 
 			expect( allTabs ).toHaveLength( TABS.length );
 
-			// The selected `tab` aria-controls the active `tabpanel`,
-			// which is `aria-labelledby` the selected `tab`.
-			expect( selectedTabPanel ).toBeVisible();
+			// Only 1 tab panel is accessible — the one associated with the
+			// selected tab. The selected `tab` aria-controls the active
+			/// `tabpanel`, which is `aria-labelledby` the selected `tab`.
+			expect( allTabpanels ).toHaveLength( 1 );
+
+			expect( allTabpanels[ 0 ] ).toBeVisible();
 			expect( allTabs[ 0 ] ).toHaveAttribute(
 				'aria-controls',
-				selectedTabPanel.getAttribute( 'id' )
+				allTabpanels[ 0 ].getAttribute( 'id' )
 			);
-			expect( selectedTabPanel ).toHaveAttribute(
+			expect( allTabpanels[ 0 ] ).toHaveAttribute(
 				'aria-labelledby',
 				allTabs[ 0 ].getAttribute( 'id' )
 			);
 		} );
-	} );
-	describe( 'Focus Behavior', () => {
-		it( 'should focus on the related TabPanel when pressing the Tab key', async () => {
-			await render( <UncontrolledTabs tabs={ TABS } /> );
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-			const selectedTabPanel = await screen.findByRole( 'tabpanel' );
-
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', { name: 'Alpha' } )
-			).toHaveFocus();
-
-			// By default the tabpanel should receive focus
-			await press.Tab();
-			expect( selectedTabPanel ).toHaveFocus();
-		} );
-		it( 'should not focus on the related TabPanel when pressing the Tab key if `focusable: false` is set', async () => {
-			const TABS_WITH_ALPHA_FOCUSABLE_FALSE = TABS.map( ( tabObj ) =>
-				tabObj.tabId === 'alpha'
-					? {
-							...tabObj,
-							content: (
-								<>
-									Selected Tab: Alpha
-									<button>Alpha Button</button>
-								</>
-							),
-							tabpanel: { focusable: false },
-					  }
-					: tabObj
-			);
+		it( 'should associate each `tab` with the correct `tabpanel`, even if they are not rendered in the same order', async () => {
+			const TABS_WITH_DELTA_REVERSED = [ ...TABS_WITH_DELTA ].reverse();
 
 			await render(
-				<UncontrolledTabs tabs={ TABS_WITH_ALPHA_FOCUSABLE_FALSE } />
+				<Tabs>
+					<Tabs.TabList>
+						{ TABS_WITH_DELTA.map( ( tabObj ) => (
+							<Tabs.Tab
+								key={ tabObj.tabId }
+								tabId={ tabObj.tabId }
+								className={ tabObj.tab.className }
+								disabled={ tabObj.tab.disabled }
+							>
+								{ tabObj.title }
+							</Tabs.Tab>
+						) ) }
+					</Tabs.TabList>
+					{ TABS_WITH_DELTA_REVERSED.map( ( tabObj ) => (
+						<Tabs.TabPanel
+							key={ tabObj.tabId }
+							tabId={ tabObj.tabId }
+							focusable={ tabObj.tabpanel?.focusable }
+						>
+							{ tabObj.content }
+						</Tabs.TabPanel>
+					) ) }
+				</Tabs>
 			);
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-			const alphaButton = await screen.findByRole( 'button', {
-				name: /alpha button/i,
-			} );
-
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
+			// Alpha is the initially selected tab,and should render the correct tabpanel
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
 			expect(
-				await screen.findByRole( 'tab', { name: 'Alpha' } )
-			).toHaveFocus();
-			// Because the alpha tabpanel is set to `focusable: false`, pressing
-			// the Tab key should focus the button, not the tabpanel
-			await press.Tab();
-			expect( alphaButton ).toHaveFocus();
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			// Select Beta, make sure the correct tabpanel is rendered
+			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			// Select Gamma, make sure the correct tabpanel is rendered
+			await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+
+			// Select Delta, make sure the correct tabpanel is rendered
+			await click( screen.getByRole( 'tab', { name: 'Delta' } ) );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Delta',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Delta',
+				} )
+			).toBeVisible();
 		} );
 
-		it( "should focus the first tab, even if disabled, when the current selected tab id doesn't match an existing one", async () => {
-			const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
-				tabObj.tabId === 'alpha'
-					? {
-							...tabObj,
-							tab: {
-								...tabObj.tab,
-								disabled: true,
-							},
-					  }
-					: tabObj
-			);
-
-			await render(
-				<ControlledTabs
-					tabs={ TABS_WITH_ALPHA_DISABLED }
-					selectedTabId="non-existing-tab"
-				/>
-			);
-
-			// No tab should be selected i.e. it doesn't fall back to first tab.
-			await waitFor( () =>
-				expect(
-					screen.queryByRole( 'tab', { selected: true } )
-				).not.toBeInTheDocument()
-			);
-
-			// No tabpanel should be rendered either
-			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
-
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', { name: 'Alpha' } )
-			).toHaveFocus();
-
-			await press.ArrowRight();
-			expect(
-				await screen.findByRole( 'tab', { name: 'Beta' } )
-			).toHaveFocus();
-
-			await press.ArrowRight();
-			expect(
-				await screen.findByRole( 'tab', { name: 'Gamma' } )
-			).toHaveFocus();
-
-			await press.Tab();
-			await press.ShiftTab();
-			expect(
-				await screen.findByRole( 'tab', { name: 'Gamma' } )
-			).toHaveFocus();
-		} );
-	} );
-
-	describe( 'Tab Attributes', () => {
 		it( "should apply the tab's `className` to the tab button", async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
 			expect(
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
@@ -317,280 +345,738 @@ describe( 'Tabs', () => {
 		} );
 	} );
 
-	describe( 'Tab Activation', () => {
-		it( 'defaults to automatic tab activation (pointer clicks)', async () => {
+	describe( 'pointer interactions', () => {
+		it( 'should select a tab when clicked', async () => {
 			const mockOnSelect = jest.fn();
 
 			await render(
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// Alpha is the initially selected tab
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
 			expect(
-				await screen.findByRole( 'tabpanel', { name: 'Alpha' } )
-			).toBeInTheDocument();
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
 			// Click on Beta, make sure beta is the selected tab
 			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
 			expect(
-				screen.getByRole( 'tabpanel', { name: 'Beta' } )
-			).toBeInTheDocument();
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
 
-			// Click on Alpha, make sure beta is the selected tab
+			// Click on Alpha, make sure alpha is the selected tab
 			await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
 			expect(
-				screen.getByRole( 'tabpanel', { name: 'Alpha' } )
-			).toBeInTheDocument();
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-		} );
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
-		it( 'defaults to automatic tab activation (arrow keys)', async () => {
-			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-			// onSelect gets called on the initial render. It should be called
-			// with the first enabled tab, which is alpha.
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Tab to focus the tablist. Make sure alpha is focused.
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
-			await press.Tab();
-			expect( await getSelectedTab() ).toHaveFocus();
-
-			// Navigate forward with arrow keys and make sure the Beta tab is
-			// selected automatically.
-			await press.ArrowRight();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-			// Navigate backwards with arrow keys. Make sure alpha is
-			// selected automatically.
-			await press.ArrowLeft();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 		} );
 
-		it( 'wraps around the last/first tab when using arrow keys', async () => {
+		it( 'should not select a disabled tab when clicked', async () => {
 			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
-
-			// onSelect gets called on the initial render.
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Tab to focus the tablist. Make sure Alpha is focused.
-			await press.Tab();
-			expect( await getSelectedTab() ).toHaveFocus();
-
-			// Navigate backwards with arrow keys and make sure that the Gamma tab
-			// (the last tab) is selected automatically.
-			await press.ArrowLeft();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
-
-			// Navigate forward with arrow keys. Make sure alpha (the first tab) is
-			// selected automatically.
-			await press.ArrowRight();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-		} );
-
-		it( 'should not move tab selection when pressing the up/down arrow keys, unless the orientation is changed to `vertical`', async () => {
-			const mockOnSelect = jest.fn();
-
-			const { rerender } = await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
-
-			// onSelect gets called on the initial render.
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Tab to focus the tablist. Make sure Alpha is focused.
-			await press.Tab();
-			expect( await getSelectedTab() ).toHaveFocus();
-
-			// Press the arrow up key, nothing happens.
-			await press.ArrowUp();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Press the arrow down key, nothing happens
-			await press.ArrowDown();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Change orientation to `vertical`. When the orientation is vertical,
-			// left/right arrow keys are replaced by up/down arrow keys.
-			await rerender(
-				<UncontrolledTabs
-					tabs={ TABS }
-					onSelect={ mockOnSelect }
-					orientation="vertical"
-				/>
-			);
-
-			expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
-				'aria-orientation',
-				'vertical'
-			);
-
-			// Make sure alpha is still focused.
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
-
-			// Navigate forward with arrow keys and make sure the Beta tab is
-			// selected automatically.
-			await press.ArrowDown();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-			// Navigate backwards with arrow keys. Make sure alpha is
-			// selected automatically.
-			await press.ArrowUp();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Navigate backwards with arrow keys. Make sure alpha is
-			// selected automatically.
-			await press.ArrowUp();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
-
-			// Navigate backwards with arrow keys. Make sure alpha is
-			// selected automatically.
-			await press.ArrowDown();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 5 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-		} );
-
-		it( 'should move focus on a tab even if disabled with arrow key, but not with pointer clicks', async () => {
-			const mockOnSelect = jest.fn();
-
-			const TABS_WITH_DELTA_DISABLED = TABS_WITH_DELTA.map( ( tabObj ) =>
-				tabObj.tabId === 'delta'
-					? {
-							...tabObj,
-							tab: {
-								...tabObj.tab,
-								disabled: true,
-							},
-					  }
-					: tabObj
-			);
 
 			await render(
 				<UncontrolledTabs
-					tabs={ TABS_WITH_DELTA_DISABLED }
+					tabs={ TABS_WITH_BETA_DISABLED }
 					onSelect={ mockOnSelect }
 				/>
 			);
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
-			// onSelect gets called on the initial render.
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
-			// Tab to focus the tablist. Make sure Alpha is focused.
-			await press.Tab();
-			expect( await getSelectedTab() ).toHaveFocus();
+			// Clicking on Beta does not result in beta being selected
+			// because the tab is disabled.
+			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
 
-			// Confirm onSelect has not been re-called
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-			// Press the right arrow key three times. Since the delta tab is disabled:
-			// - it won't be selected. The gamma tab will be selected instead, since
-			//   it was the tab that was last selected before delta. Therefore, the
-			//   `mockOnSelect` function gets called only twice (and not three times)
-			// - it will receive focus, when using arrow keys
-			await press.ArrowRight();
-			await press.ArrowRight();
-			await press.ArrowRight();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
 			expect(
-				screen.getByRole( 'tab', { name: 'Delta' } )
-			).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
-			// Navigate backwards with arrow keys. The gamma tab receives focus.
-			// The `mockOnSelect` callback doesn't fire, since the gamma tab was
-			// already selected.
-			await press.ArrowLeft();
-			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
 
-			// Click on the disabled tab. Compared to using arrow keys to move the
-			// focus, disabled tabs ignore pointer clicks — and therefore, they don't
-			// receive focus, nor they cause the `mockOnSelect` function to fire.
-			await click( screen.getByRole( 'tab', { name: 'Delta' } ) );
-			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-			expect( await getSelectedTab() ).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+	describe( 'initial tab selection', () => {
+		describe( 'when a selected tab id is not specified', () => {
+			describe( 'when left `undefined` [Uncontrolled]', () => {
+				it( 'should choose the first tab as selected', async () => {
+					await render( <UncontrolledTabs tabs={ TABS } /> );
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Alpha is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					// Press tab. The selected tab (alpha) received focus.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should choose the first non-disabled tab if the first tab is disabled', async () => {
+					await render(
+						<UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } />
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Beta is automatically selected as the selected tab, since alpha is
+					// disabled.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					// Press tab. The selected tab (beta) received focus. The corresponding
+					// tabpanel is shown.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+				} );
+			} );
+			describe( 'when `null` [Controlled]', () => {
+				it( 'should not have a selected tab nor show any tabpanels, make the tablist tabbable and still allow selecting tabs', async () => {
+					await render(
+						<ControlledTabs tabs={ TABS } selectedTabId={ null } />
+					);
+
+					// Wait for the tablist to be tabbable as a mean to know
+					// that ariakit has finished initializing.
+					await waitFor( () =>
+						expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+							'tabindex',
+							'0'
+						)
+					);
+					// No initially selected tabs or tabpanels.
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument()
+					);
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument()
+					);
+
+					// Press tab. The tablist receives focus
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tablist' )
+					).toHaveFocus();
+
+					// Press right arrow to select the first tab (alpha) and
+					// show the related tabpanel.
+					await press.ArrowRight();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+					expect(
+						await screen.findByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+				} );
+			} );
 		} );
 
-		it( 'should not focus the next tab when the Tab key is pressed', async () => {
+		describe( 'when a selected tab id is specified', () => {
+			describe( 'through the `defaultTabId` prop [Uncontrolled]', () => {
+				it( 'should select the initial tab matching the `defaultTabId` prop', async () => {
+					await render(
+						<UncontrolledTabs tabs={ TABS } defaultTabId="beta" />
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Beta is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					// Press tab. The selected tab (beta) received focus. The corresponding
+					// tabpanel is shown.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should select the initial tab matching the `defaultTabId` prop even if the tab is disabled', async () => {
+					await render(
+						<UncontrolledTabs
+							tabs={ TABS_WITH_BETA_DISABLED }
+							defaultTabId="beta"
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Beta is automatically selected as the selected tab despite being
+					// disabled, respecting the `defaultTabId` prop.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					// Press tab. The selected tab (beta) received focus, since it is
+					// accessible despite being disabled.
+					await press.Tab();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+				} );
+
+				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab when `defaultTabId` prop does not match any known tab', async () => {
+					await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="non-existing-tab"
+						/>
+					);
+
+					// Wait for the tablist to be tabbable as a mean to know
+					// that ariakit has finished initializing.
+					await waitFor( () =>
+						expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+							'tabindex',
+							'-1'
+						)
+					);
+					// No initially selected tabs or tabpanels.
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument()
+					);
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument()
+					);
+
+					// Press tab. The first tab receives focus, but it's
+					// not selected.
+					await press.Tab();
+					expect(
+						screen.getByRole( 'tab', { name: 'Alpha' } )
+					).toHaveFocus();
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument()
+					);
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument()
+					);
+
+					// Press right arrow to select the next tab (beta) and
+					// show the related tabpanel.
+					await press.ArrowRight();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						await screen.findByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+				} );
+
+				it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab, even when disabled, when `defaultTabId` prop does not match any known tab', async () => {
+					await render(
+						<UncontrolledTabs
+							tabs={ TABS_WITH_ALPHA_DISABLED }
+							defaultTabId="non-existing-tab"
+						/>
+					);
+
+					// Wait for the tablist to be tabbable as a mean to know
+					// that ariakit has finished initializing.
+					await waitFor( () =>
+						expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+							'tabindex',
+							'-1'
+						)
+					);
+					// No initially selected tabs or tabpanels.
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument()
+					);
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument()
+					);
+
+					// Press tab. The first tab receives focus, but it's
+					// not selected.
+					await press.Tab();
+					expect(
+						screen.getByRole( 'tab', { name: 'Alpha' } )
+					).toHaveFocus();
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument()
+					);
+					await waitFor( () =>
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument()
+					);
+
+					// Press right arrow to select the next tab (beta) and
+					// show the related tabpanel.
+					await press.ArrowRight();
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						await screen.findByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+				} );
+
+				it( 'should ignore any changes to the `defaultTabId` prop after the first render', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Beta is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					// Changing the defaultTabId prop to gamma should not have any effect.
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+			} );
+
+			describe( 'through the `selectedTabId` prop [Controlled]', () => {
+				describe( 'when the `selectedTabId` matches an existing tab', () => {
+					it( 'should choose the initial tab matching the `selectedTabId`', async () => {
+						await render(
+							<ControlledTabs
+								tabs={ TABS }
+								selectedTabId="beta"
+							/>
+						);
+
+						// Waiting for a tab to be selected is a sign that the component
+						// has fully initialized.
+						// Beta is automatically selected as the selected tab.
+						// The corresponding tabpanel is shown.
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+
+						// Press tab. The selected tab (beta) received focus, since it is
+						// accessible despite being disabled.
+						await press.Tab();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+					} );
+
+					it( 'should choose the initial tab matching the `selectedTabId` even if a `defaultTabId` is passed', async () => {
+						await render(
+							<ControlledTabs
+								tabs={ TABS }
+								defaultTabId="beta"
+								selectedTabId="gamma"
+							/>
+						);
+
+						// Waiting for a tab to be selected is a sign that the component
+						// has fully initialized.
+						// Gamma is automatically selected as the selected tab.
+						// The corresponding tabpanel is shown.
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Gamma',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Gamma',
+							} )
+						).toBeVisible();
+
+						// Press tab. The selected tab (gamma) received focus, since it is
+						// accessible despite being disabled.
+						await press.Tab();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Gamma',
+							} )
+						).toHaveFocus();
+					} );
+
+					it( 'should choose the initial tab matching the `selectedTabId` even if the tab is disabled', async () => {
+						await render(
+							<ControlledTabs
+								tabs={ TABS_WITH_BETA_DISABLED }
+								selectedTabId="beta"
+							/>
+						);
+
+						// Waiting for a tab to be selected is a sign that the component
+						// has fully initialized.
+						// Beta is automatically selected as the selected tab despite being
+						// disabled, respecting the `defaultTabId` prop.
+						// The corresponding tabpanel is shown.
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+
+						// Press tab. The selected tab (beta) received focus, since it is
+						// accessible despite being disabled.
+						await press.Tab();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+					} );
+				} );
+
+				describe( "when the `selectedTabId` doesn't match an existing tab", () => {
+					it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab', async () => {
+						await render(
+							<ControlledTabs
+								tabs={ TABS }
+								selectedTabId="non-existing-tab"
+							/>
+						);
+
+						// Wait for the tablist to be tabbable as a mean to know
+						// that ariakit has finished initializing.
+						await waitFor( () =>
+							expect(
+								screen.getByRole( 'tablist' )
+							).toHaveAttribute( 'tabindex', '-1' )
+						);
+						// No initially selected tabs or tabpanels.
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tab', { selected: true } )
+							).not.toBeInTheDocument()
+						);
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tabpanel' )
+							).not.toBeInTheDocument()
+						);
+
+						// Press tab. The first tab receives focus, but it's
+						// not selected.
+						await press.Tab();
+						expect(
+							screen.getByRole( 'tab', { name: 'Alpha' } )
+						).toHaveFocus();
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tab', { selected: true } )
+							).not.toBeInTheDocument()
+						);
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tabpanel' )
+							).not.toBeInTheDocument()
+						);
+
+						// Press right arrow to select the next tab (beta) and
+						// show the related tabpanel.
+						await press.ArrowRight();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+						expect(
+							await screen.findByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+					} );
+
+					it( 'should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab even when disabled', async () => {
+						await render(
+							<ControlledTabs
+								tabs={ TABS_WITH_ALPHA_DISABLED }
+								selectedTabId="non-existing-tab"
+							/>
+						);
+
+						// Wait for the tablist to be tabbable as a mean to know
+						// that ariakit has finished initializing.
+						await waitFor( () =>
+							expect(
+								screen.getByRole( 'tablist' )
+							).toHaveAttribute( 'tabindex', '-1' )
+						);
+						// No initially selected tabs or tabpanels.
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tab', { selected: true } )
+							).not.toBeInTheDocument()
+						);
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tabpanel' )
+							).not.toBeInTheDocument()
+						);
+
+						// Press tab. The first tab receives focus, but it's
+						// not selected.
+						await press.Tab();
+						expect(
+							screen.getByRole( 'tab', { name: 'Alpha' } )
+						).toHaveFocus();
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tab', { selected: true } )
+							).not.toBeInTheDocument()
+						);
+						await waitFor( () =>
+							expect(
+								screen.queryByRole( 'tabpanel' )
+							).not.toBeInTheDocument()
+						);
+
+						// Press right arrow to select the next tab (beta) and
+						// show the related tabpanel.
+						await press.ArrowRight();
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+						expect(
+							await screen.findByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+					} );
+				} );
+			} );
+		} );
+	} );
+
+	// TODO: loop on both uncontrolled and controlled
+	describe( 'keyboard interactions', () => {
+		it( 'should handle the tablist as one tab stop', async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
+			// Press tab. The selected tab (alpha) received focus.
 			await press.Tab();
 			expect(
-				await screen.findByRole( 'tab', { name: 'Alpha' } )
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
 			).toHaveFocus();
 
-			// Because all other tabs should have `tabindex=-1`, pressing Tab
-			// should NOT move the focus to the next tab, which is Beta.
-			// Instead, focus should go to the currently selected tabpanel (alpha).
+			// By default the tabpanel should receive focus
 			await press.Tab();
 			expect(
 				await screen.findByRole( 'tabpanel', {
@@ -599,7 +1085,149 @@ describe( 'Tabs', () => {
 			).toHaveFocus();
 		} );
 
-		it( 'switches to manual tab activation when the `selectOnMove` prop is set to `false`', async () => {
+		it( 'should not focus the tabpanel container when its `focusable` property is set to `false`', async () => {
+			await render(
+				<UncontrolledTabs
+					tabs={ TABS.map( ( tabObj ) =>
+						tabObj.tabId === 'alpha'
+							? {
+									...tabObj,
+									content: (
+										<>
+											Selected Tab: Alpha
+											<button>Alpha Button</button>
+										</>
+									),
+									tabpanel: { focusable: false },
+							  }
+							: tabObj
+					) }
+				/>
+			);
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+
+			// In this case, the tabpanel container is skipped and focus is
+			// moved directly to its contents
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'button', {
+					name: 'Alpha Button',
+				} )
+			).toHaveFocus();
+		} );
+
+		it( 'should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation)', async () => {
+			const mockOnSelect = jest.fn();
+
+			await render(
+				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
+			);
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Focus the tablist (and the selected tab, alpha)
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+
+			// Press the right arrow key to select the beta tab
+			await press.ArrowRight();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+			// Press the right arrow key to select the gamma tab
+			await press.ArrowRight();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Gamma',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+			// Press the left arrow key to select the beta tab
+			await press.ArrowLeft();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+		} );
+
+		it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation)', async () => {
 			const mockOnSelect = jest.fn();
 
 			await render(
@@ -610,615 +1238,449 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			expect( await getSelectedTab() ).not.toHaveFocus();
-
-			// onSelect gets called on the initial render.
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Click on Alpha and make sure it is selected.
-			// onSelect shouldn't fire since the selected tab didn't change.
-			await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
 			expect(
-				await screen.findByRole( 'tab', { name: 'Alpha' } )
-			).toHaveFocus();
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
-			// Navigate forward with arrow keys. Make sure Beta is focused, but
-			// that the tab selection happens only when pressing the spacebar
-			// or enter key. onSelect shouldn't fire since the selected tab
-			// didn't change.
+			// Focus the tablist (and the selected tab, alpha)
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+
+			// Press the right arrow key to move focus to the beta tab,
+			// but without selecting it
 			await press.ArrowRight();
+
 			expect(
-				await screen.findByRole( 'tab', { name: 'Beta' } )
+				screen.getByRole( 'tab', {
+					selected: false,
+					name: 'Beta',
+				} )
 			).toHaveFocus();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 
-			await press.Enter();
+			// Press the space key to click the beta tab, and select it.
+			// The same should be true with any other mean of clicking the tab button
+			// (ie. mouse click, enter key).
+			await press.Space();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+		} );
+
+		it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
+			const mockOnSelect = jest.fn();
+
+			const { rerender } = await render(
+				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
+			);
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Focus the tablist (and the selected tab, alpha)
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+
+			// Press the up arrow key, but the focused/selected tab does not change.
+			await press.ArrowUp();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+			// Press the down arrow key, but the focused/selected tab does not change.
+			await press.ArrowDown();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+			// Change the orientation to "vertical" and rerender the component.
+			await rerender(
+				<UncontrolledTabs
+					tabs={ TABS }
+					onSelect={ mockOnSelect }
+					orientation="vertical"
+				/>
+			);
+
+			// Pressing the down arrow key now selects the next tab (beta).
+			await press.ArrowDown();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
 
-			// Navigate forward with arrow keys. Make sure Gamma (last tab) is
-			// focused, but that tab selection happens only when pressing the
-			// spacebar or enter key. onSelect shouldn't fire since the selected
-			// tab didn't change.
-			await press.ArrowRight();
+			// Pressing the up arrow key now selects the previous tab (alpha).
+			await press.ArrowUp();
+
 			expect(
-				await screen.findByRole( 'tab', { name: 'Gamma' } )
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
 			).toHaveFocus();
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
 			expect(
-				screen.getByRole( 'tab', { name: 'Gamma' } )
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+		} );
+
+		it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
+			const mockOnSelect = jest.fn();
+
+			await render(
+				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
+			);
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Focus the tablist (and the selected tab, alpha)
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
 			).toHaveFocus();
 
-			await press.Space();
+			// Press the left arrow key to loop around and select the gamma tab
+			await press.ArrowLeft();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Gamma',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+			// Press the right arrow key to loop around and select the alpha tab
+			await press.ArrowRight();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+		} );
+
+		// TODO: mock writing direction to RTL
+		it.skip( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
+			const mockOnSelect = jest.fn();
+
+			await render(
+				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
+			);
+
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+			// Focus the tablist (and the selected tab, alpha)
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
+
+			// Press the left arrow key to select the beta tab
+			await press.ArrowLeft();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+			// Press the left arrow key to select the gamma tab
+			await press.ArrowLeft();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Gamma',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
-		} );
-	} );
-	describe( 'Uncontrolled mode', () => {
-		describe( 'Without `defaultTabId` prop', () => {
-			it( 'should render first tab', async () => {
-				await render( <UncontrolledTabs tabs={ TABS } /> );
 
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect(
-					await screen.findByRole( 'tabpanel', { name: 'Alpha' } )
-				).toBeInTheDocument();
-			} );
-			it( 'should not have a selected tab if the currently selected tab is removed', async () => {
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS } />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( await getSelectedTab() ).not.toHaveFocus();
-
-				// Tab to focus the tablist. Make sure Alpha is focused.
-				await press.Tab();
-				expect( await getSelectedTab() ).toHaveFocus();
-
-				// Remove first item from `TABS` array
-				await rerender( <UncontrolledTabs tabs={ TABS.slice( 1 ) } /> );
-
-				// No tab should be selected i.e. it doesn't fall back to first tab.
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument()
-				);
-
-				// No tabpanel should be rendered either
-				expect(
-					screen.queryByRole( 'tabpanel' )
-				).not.toBeInTheDocument();
-			} );
-		} );
-
-		describe( 'With `defaultTabId`', () => {
-			it( 'should render the tab set by `defaultTabId` prop', async () => {
-				await render(
-					<UncontrolledTabs tabs={ TABS } defaultTabId="beta" />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-
-			it( 'should not select a tab when `defaultTabId` does not match any known tab', async () => {
-				await render(
-					<UncontrolledTabs
-						tabs={ TABS }
-						defaultTabId="does-not-exist"
-					/>
-				);
-
-				// No tab should be selected i.e. it doesn't fall back to first tab.
-				expect(
-					screen.queryByRole( 'tab', { selected: true } )
-				).not.toBeInTheDocument();
-
-				// No tabpanel should be rendered either
-				expect(
-					screen.queryByRole( 'tabpanel' )
-				).not.toBeInTheDocument();
-			} );
-			it( 'should not change tabs when defaultTabId is changed', async () => {
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS } defaultTabId="beta" />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				await rerender(
-					<UncontrolledTabs tabs={ TABS } defaultTabId="alpha" />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-
-			it( 'should not have any selected tabs if the currently selected tab is removed, even if a tab is matching the defaultTabId', async () => {
-				const mockOnSelect = jest.fn();
-
-				const { rerender } = await render(
-					<UncontrolledTabs
-						tabs={ TABS }
-						defaultTabId="gamma"
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-
-				await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS.slice( 1 ) }
-						defaultTabId="gamma"
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				// No tab should be selected i.e. it doesn't fall back to first tab.
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument()
-				);
-
-				// No tabpanel should be rendered either
-				expect(
-					screen.queryByRole( 'tabpanel' )
-				).not.toBeInTheDocument();
-			} );
-
-			it( 'should keep the currently selected tab even if it becomes disabled', async () => {
-				const mockOnSelect = jest.fn();
-
-				const { rerender } = await render(
-					<UncontrolledTabs
-						tabs={ TABS }
-						defaultTabId="gamma"
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-
-				await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-				const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId === 'alpha'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_ALPHA_DISABLED }
-						defaultTabId="gamma"
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			} );
-
-			it( 'should have no active tabs when the tab associated to `defaultTabId` is removed while being the active tab', async () => {
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS } defaultTabId="gamma" />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-
-				// Remove gamma
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS.slice( 0, 2 ) }
-						defaultTabId="gamma"
-					/>
-				);
-
-				expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
-				// No tab should be selected i.e. it doesn't fall back to first tab.
-				expect(
-					screen.queryByRole( 'tab', { selected: true } )
-				).not.toBeInTheDocument();
-				// No tabpanel should be rendered either
-				expect(
-					screen.queryByRole( 'tabpanel' )
-				).not.toBeInTheDocument();
-			} );
-
-			it( 'waits for the tab with the `defaultTabId` to be present in the `tabs` array before selecting it', async () => {
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS } defaultTabId="delta" />
-				);
-
-				// No tab should be selected i.e. it doesn't fall back to first tab.
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument()
-				);
-
-				// No tabpanel should be rendered either
-				expect(
-					screen.queryByRole( 'tabpanel' )
-				).not.toBeInTheDocument();
-
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_DELTA }
-						defaultTabId="delta"
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Delta' );
-			} );
-		} );
-
-		describe( 'Disabled tab', () => {
-			it( 'should disable the tab when `disabled` is `true`', async () => {
-				const mockOnSelect = jest.fn();
-
-				const TABS_WITH_DELTA_DISABLED = TABS_WITH_DELTA.map(
-					( tabObj ) =>
-						tabObj.tabId === 'delta'
-							? {
-									...tabObj,
-									tab: {
-										...tabObj.tab,
-										disabled: true,
-									},
-							  }
-							: tabObj
-				);
-
-				await render(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_DELTA_DISABLED }
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-
-				expect(
-					screen.getByRole( 'tab', { name: 'Delta' } )
-				).toHaveAttribute( 'aria-disabled', 'true' );
-
-				// onSelect gets called on the initial render.
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-				// Move focus to the tablist, make sure alpha is focused.
-				await press.Tab();
-				expect(
-					screen.getByRole( 'tab', { name: 'Alpha' } )
-				).toHaveFocus();
-
-				// onSelect should not be called since the disabled tab is
-				// highlighted, but not selected.
-				await press.ArrowLeft();
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-				// Delta (which is disabled) has focus
-				expect(
-					screen.getByRole( 'tab', { name: 'Delta' } )
-				).toHaveFocus();
-
-				// Alpha retains the selection, even if it's not focused.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-			} );
-
-			it( 'should select first enabled tab when the initial tab is disabled', async () => {
-				const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId === 'alpha'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } />
-				);
-
-				// As alpha (first tab) is disabled,
-				// the first enabled tab should be beta.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Re-enable all tabs
-				await rerender( <UncontrolledTabs tabs={ TABS } /> );
-
-				// Even if the initial tab becomes enabled again, the selected
-				// tab doesn't change.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-
-			it( 'should select the tab associated to `defaultTabId` even if the tab is disabled', async () => {
-				const TABS_ONLY_GAMMA_ENABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId !== 'gamma'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-				const { rerender } = await render(
-					<UncontrolledTabs
-						tabs={ TABS_ONLY_GAMMA_ENABLED }
-						defaultTabId="beta"
-					/>
-				);
-
-				// As alpha (first tab), and beta (the initial tab), are both
-				// disabled the first enabled tab should be gamma.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Re-enable all tabs
-				await rerender(
-					<UncontrolledTabs tabs={ TABS } defaultTabId="beta" />
-				);
-
-				// Even if the initial tab becomes enabled again, the selected tab doesn't
-				// change.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-
-			it( 'should keep the currently tab as selected even when it becomes disabled', async () => {
-				const mockOnSelect = jest.fn();
-				const { rerender } = await render(
-					<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-				const TABS_WITH_ALPHA_DISABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId === 'alpha'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-
-				// Disable alpha
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_ALPHA_DISABLED }
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-				// Re-enable all tabs
-				await rerender(
-					<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			} );
-
-			it( 'should select the tab associated to `defaultTabId` even when disabled', async () => {
-				const mockOnSelect = jest.fn();
-
-				const { rerender } = await render(
-					<UncontrolledTabs
-						tabs={ TABS }
-						onSelect={ mockOnSelect }
-						defaultTabId="gamma"
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-
-				const TABS_WITH_GAMMA_DISABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId === 'gamma'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-
-				// Disable gamma
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_GAMMA_DISABLED }
-						onSelect={ mockOnSelect }
-						defaultTabId="gamma"
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-
-				// Re-enable all tabs
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS }
-						onSelect={ mockOnSelect }
-						defaultTabId="gamma"
-					/>
-				);
-
-				// Confirm that alpha is still selected, and that onSelect has
-				// not been called again.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-				expect( mockOnSelect ).not.toHaveBeenCalled();
-			} );
-		} );
-	} );
-
-	describe( 'Controlled mode', () => {
-		it( 'should render the tab specified by the `selectedTabId` prop', async () => {
-			await render(
-				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-			);
-
-			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			expect(
-				await screen.findByRole( 'tabpanel', { name: 'Beta' } )
-			).toBeInTheDocument();
-		} );
-		it( 'should render the specified `selectedTabId`, and ignore the `defaultTabId` prop', async () => {
-			await render(
-				<ControlledTabs
-					tabs={ TABS }
-					selectedTabId="gamma"
-					defaultTabId="beta"
-				/>
-			);
-
-			expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-		} );
-		it( 'should not have a selected tab if `selectedTabId` does not match any known tab', async () => {
-			await render(
-				<ControlledTabs
-					tabs={ TABS_WITH_DELTA }
-					selectedTabId="does-not-exist"
-				/>
-			);
+			// Press the right arrow key to select the beta tab
+			await press.ArrowRight();
 
 			expect(
-				screen.queryByRole( 'tab', { selected: true } )
-			).not.toBeInTheDocument();
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Beta',
+				} )
+			).toBeVisible();
 
-			// No tabpanel should be rendered either
-			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
 		} );
-		it( 'should not have a selected tab if the active tab is removed, but should select a tab that gets added if it matches the selectedTabId', async () => {
-			const { rerender } = await render(
-				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-			);
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+		it( 'should focus tabs in the tablist even if disabled', async () => {
+			const mockOnSelect = jest.fn();
 
-			// Remove beta
-			await rerender(
-				<ControlledTabs
-					tabs={ TABS.filter( ( tab ) => tab.tabId !== 'beta' ) }
-					selectedTabId="beta"
+			await render(
+				<UncontrolledTabs
+					tabs={ TABS_WITH_BETA_DISABLED }
+					onSelect={ mockOnSelect }
 				/>
 			);
 
-			expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+			// Waiting for a tab to be selected is a sign that the component
+			// has fully initialized.
+			// Alpha is automatically selected as the selected tab.
+			// The corresponding tabpanel is shown.
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
 
-			// No tab should be selected i.e. it doesn't fall back to first tab.
-			// `waitFor` is needed here to prevent testing library from
-			// throwing a 'not wrapped in `act()`' error.
-			await waitFor( () =>
-				expect(
-					screen.queryByRole( 'tab', { selected: true } )
-				).not.toBeInTheDocument()
-			);
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
-			// No tabpanel should be rendered either
-			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument();
+			// Focus the tablist (and the selected tab, alpha)
+			// Tab should initially focus the first tab in the tablist, which
+			// is Alpha.
+			await press.Tab();
+			expect(
+				await screen.findByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toHaveFocus();
 
-			// Restore beta
-			await rerender(
-				<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-			);
+			// Pressing the right arrow key moves focus to the beta tab, but alpha
+			// remains the selected tab because beta is disabled.
+			await press.ArrowRight();
 
-			expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+			expect(
+				screen.getByRole( 'tab', {
+					selected: false,
+					name: 'Beta',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Alpha',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+			// Press the right arrow key to select the gamma tab
+			await press.ArrowRight();
+
+			expect(
+				screen.getByRole( 'tab', {
+					selected: true,
+					name: 'Gamma',
+				} )
+			).toHaveFocus();
+			expect(
+				screen.getByRole( 'tabpanel', {
+					name: 'Gamma',
+				} )
+			).toBeVisible();
+
+			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
 		} );
 
-		describe( 'Disabled tab', () => {
-			it( 'should `selectedTabId` refers to a disabled tab', async () => {
-				const TABS_WITH_DELTA_WITH_BETA_DISABLED = TABS_WITH_DELTA.map(
-					( tabObj ) =>
-						tabObj.tabId === 'beta'
-							? {
-									...tabObj,
-									tab: {
-										...tabObj.tab,
-										disabled: true,
-									},
-							  }
-							: tabObj
-				);
-
-				await render(
-					<ControlledTabs
-						tabs={ TABS_WITH_DELTA_WITH_BETA_DISABLED }
-						selectedTabId="beta"
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-			it( 'should keep the currently selected tab as selected even when it becomes disabled', async () => {
-				const { rerender } = await render(
-					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				const TABS_WITH_BETA_DISABLED = TABS.map( ( tabObj ) =>
-					tabObj.tabId === 'beta'
-						? {
-								...tabObj,
-								tab: {
-									...tabObj.tab,
-									disabled: true,
-								},
-						  }
-						: tabObj
-				);
-
-				await rerender(
-					<ControlledTabs
-						tabs={ TABS_WITH_BETA_DISABLED }
-						selectedTabId="beta"
-					/>
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// re-enable all tabs
-				await rerender(
-					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-				);
-
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-			} );
-		} );
-		describe( 'When `selectedId` is changed by the controlling component', () => {
+		describe( 'When `selectedId` is changed by the controlling component [Controlled]', () => {
 			describe.each( [ true, false ] )(
 				'and `selectOnMove` is %s',
 				( selectOnMove ) => {
@@ -1231,17 +1693,28 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
-						);
+						// Waiting for a tab to be selected is a sign that the component
+						// has fully initialized.
+						// The corresponding tabpanel is shown.
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
 
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
-						);
 						expect(
-							screen.getByRole( 'tab', { name: 'Beta' } )
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
 						).toHaveFocus();
 
 						await rerender(
@@ -1253,17 +1726,28 @@ describe( 'Tabs', () => {
 						);
 
 						// When the selected tab is changed, focus should not be changed.
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Gamma'
-						);
 						expect(
-							screen.getByRole( 'tab', { name: 'Beta' } )
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Gamma',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tab', {
+								selected: false,
+								name: 'Beta',
+							} )
 						).toHaveFocus();
 
-						// Arrow keys should move focus to the next tab, which is Gamma
-						await press.ArrowRight();
+						// Arrow left should move focus to the previous tab (alpha).
+						// The alpha tab should be always focused, and should be selected
+						// when the `selectOnMove` prop is set to `true`.
+						await press.ArrowLeft();
 						expect(
-							screen.getByRole( 'tab', { name: 'Gamma' } )
+							screen.getByRole( 'tab', {
+								selected: selectOnMove,
+								name: 'Alpha',
+							} )
 						).toHaveFocus();
 					} );
 
@@ -1279,20 +1763,32 @@ describe( 'Tabs', () => {
 							</>
 						);
 
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
-						);
+						// Waiting for a tab to be selected is a sign that the component
+						// has fully initialized.
+						// The corresponding tabpanel is shown.
+						expect(
+							await screen.findByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
 
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
 						await press.Tab();
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Beta'
-						);
 						expect(
-							screen.getByRole( 'tab', { name: 'Beta' } )
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
 						).toHaveFocus();
 
+						// Change the selected tab to gamma via a controlled update.
 						await rerender(
 							<>
 								<button>Focus me</button>
@@ -1305,12 +1801,17 @@ describe( 'Tabs', () => {
 						);
 
 						// When the selected tab is changed, it should not automatically receive focus.
-						expect( await getSelectedTab() ).toHaveTextContent(
-							'Gamma'
-						);
-
 						expect(
-							screen.getByRole( 'tab', { name: 'Beta' } )
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Gamma',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tab', {
+								selected: false,
+								name: 'Beta',
+							} )
 						).toHaveFocus();
 
 						// Press shift+tab, move focus to the button before Tabs
@@ -1336,125 +1837,629 @@ describe( 'Tabs', () => {
 				}
 			);
 		} );
+	} );
 
-		describe( 'When `selectOnMove` is `true`', () => {
-			it( 'should automatically select a newly focused tab', async () => {
-				await render(
-					<ControlledTabs tabs={ TABS } selectedTabId="beta" />
-				);
+	describe( 'miscellaneous runtime changes', () => {
+		describe( 'removing a tab', () => {
+			describe( 'with no explicitly set initial tab', () => {
+				it( 'should not select a new tab when the selected tab is removed', async () => {
+					const mockOnSelect = jest.fn();
 
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
+					const { rerender } = await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							onSelect={ mockOnSelect }
+						/>
+					);
 
-				await press.Tab();
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
 
-				// Tab key should focus the currently selected tab, which is Beta.
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-				expect( await getSelectedTab() ).toHaveFocus();
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
 
-				// Arrow keys should select and move focus to the next tab.
-				await press.ArrowRight();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-				expect( await getSelectedTab() ).toHaveFocus();
+					// Select gamma
+					await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+					// Remove gamma
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS.slice( 0, 2 ) }
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+
+					// No tab should be selected i.e. it doesn't fall back to gamma,
+					// even if it matches the `defaultTabId` prop.
+					expect(
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument();
+					// No tabpanel should be rendered either
+					expect(
+						screen.queryByRole( 'tabpanel' )
+					).not.toBeInTheDocument();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				} );
+			} );
+
+			describe( 'through the `defaultTabId` prop [Uncontrolled]', () => {
+				it( 'should not select a new tab when the selected tab is removed', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+
+					// Remove gamma
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS.slice( 0, 2 ) }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+					// No tab should be selected i.e. it doesn't fall back to first tab.
+					expect(
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument();
+					// No tabpanel should be rendered either
+					expect(
+						screen.queryByRole( 'tabpanel' )
+					).not.toBeInTheDocument();
+
+					// Re-add gamma. Gamma becomes selected again.
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
+						TABS.length
+					);
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+
+				it( 'should not select the tab matching the `defaultTabId` prop as a fallback when the selected tab is removed', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Gamma',
+						} )
+					).toBeVisible();
+
+					// Select alpha
+					await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+					// Remove alpha
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS.slice( 1 ) }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+
+					// No tab should be selected i.e. it doesn't fall back to gamma,
+					// even if it matches the `defaultTabId` prop.
+					expect(
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument();
+					// No tabpanel should be rendered either
+					expect(
+						screen.queryByRole( 'tabpanel' )
+					).not.toBeInTheDocument();
+
+					// Re-add alpha. Alpha becomes selected again.
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="gamma"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
+						TABS.length
+					);
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				} );
+			} );
+			describe( 'through the `selectedTabId` prop [Controlled]', () => {
+				// TODO: same tests as above
 			} );
 		} );
-		describe( 'When `selectOnMove` is `false`', () => {
-			it( 'should apply focus without automatically changing the selected tab', async () => {
-				await render(
-					<ControlledTabs
+
+		describe( 'adding a tab', () => {
+			// TODO: describe each for controlled / uncontrolled
+			it( 'should select a newly added tab if it matches the `defaultTabId` prop [Uncontrolled]', async () => {
+				const mockOnSelect = jest.fn();
+
+				const { rerender } = await render(
+					<UncontrolledTabs
 						tabs={ TABS }
-						selectedTabId="beta"
-						selectOnMove={ false }
+						defaultTabId="delta"
+						onSelect={ mockOnSelect }
 					/>
 				);
 
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Tab key should focus the currently selected tab, which is Beta.
-				await press.Tab();
-				await waitFor( async () =>
+				// Wait for the tablist to be tabbable as a mean to know
+				// that ariakit has finished initializing.
+				await waitFor( () =>
+					expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+						'tabindex',
+						'-1'
+					)
+				);
+				// No initially selected tabs or tabpanels.
+				await waitFor( () =>
 					expect(
-						await screen.findByRole( 'tab', { name: 'Beta' } )
-					).toHaveFocus()
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument()
+				);
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'tabpanel' )
+					).not.toBeInTheDocument()
 				);
 
-				// Arrow key should move focus but not automatically change the selected tab.
-				await press.ArrowRight();
+				expect( mockOnSelect ).not.toHaveBeenCalled();
+
+				// Re-render with beta disabled.
+				await rerender(
+					<UncontrolledTabs
+						tabs={ TABS_WITH_DELTA }
+						defaultTabId="delta"
+						onSelect={ mockOnSelect }
+					/>
+				);
+
+				// Delta becomes selected
 				expect(
-					screen.getByRole( 'tab', { name: 'Gamma' } )
-				).toHaveFocus();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-
-				// Pressing the spacebar should select the focused tab.
-				await press.Space();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-
-				// Arrow key should move focus but not automatically change the selected tab.
-				await press.ArrowRight();
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Delta',
+					} )
+				).toBeVisible();
 				expect(
-					screen.getByRole( 'tab', { name: 'Alpha' } )
-				).toHaveFocus();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
+					screen.getByRole( 'tabpanel', {
+						name: 'Delta',
+					} )
+				).toBeVisible();
 
-				// Pressing the enter/return should select the focused tab.
-				await press.Enter();
-				expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
+				expect( mockOnSelect ).not.toHaveBeenCalled();
+			} );
+
+			it( 'should select a newly added tab if it matches the `selectedTabId` prop [Controlled]', async () => {
+				const mockOnSelect = jest.fn();
+
+				const { rerender } = await render(
+					<ControlledTabs
+						tabs={ TABS }
+						selectedTabId="delta"
+						onSelect={ mockOnSelect }
+					/>
+				);
+
+				// Wait for the tablist to be tabbable as a mean to know
+				// that ariakit has finished initializing.
+				await waitFor( () =>
+					expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+						'tabindex',
+						'-1'
+					)
+				);
+				// No initially selected tabs or tabpanels.
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'tab', { selected: true } )
+					).not.toBeInTheDocument()
+				);
+				await waitFor( () =>
+					expect(
+						screen.queryByRole( 'tabpanel' )
+					).not.toBeInTheDocument()
+				);
+
+				expect( mockOnSelect ).not.toHaveBeenCalled();
+
+				// Re-render with beta disabled.
+				await rerender(
+					<ControlledTabs
+						tabs={ TABS_WITH_DELTA }
+						selectedTabId="delta"
+						onSelect={ mockOnSelect }
+					/>
+				);
+
+				// Delta becomes selected
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Delta',
+					} )
+				).toBeVisible();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Delta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).not.toHaveBeenCalled();
 			} );
 		} );
-	} );
-	it( 'should associate each `Tab` with the correct `TabPanel`, even if they are not rendered in the same order', async () => {
-		const TABS_WITH_DELTA_REVERSED = [ ...TABS_WITH_DELTA ].reverse();
+		describe( 'a tab becomes disabled', () => {
+			// TODO: re-enable tabs
+			describe( 'when using the `defaultTabId` prop [Uncontrolled]', () => {
+				// TODO: use describe.each?
+				it( 'should keep the initial tab matching the `defaultTabId` prop as selected even if it becomes disabled', async () => {
+					const mockOnSelect = jest.fn();
 
-		await render(
-			<Tabs>
-				<Tabs.TabList>
-					{ TABS_WITH_DELTA.map( ( tabObj ) => (
-						<Tabs.Tab
-							key={ tabObj.tabId }
-							tabId={ tabObj.tabId }
-							className={ tabObj.tab.className }
-							disabled={ tabObj.tab.disabled }
-						>
-							{ tabObj.title }
-						</Tabs.Tab>
-					) ) }
-				</Tabs.TabList>
-				{ TABS_WITH_DELTA_REVERSED.map( ( tabObj ) => (
-					<Tabs.TabPanel
-						key={ tabObj.tabId }
-						tabId={ tabObj.tabId }
-						focusable={ tabObj.tabpanel?.focusable }
-					>
-						{ tabObj.content }
-					</Tabs.TabPanel>
-				) ) }
-			</Tabs>
-		);
+					const { rerender } = await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							defaultTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
 
-		// Alpha is the initially selected tab,and should render the correct tabpanel
-		expect( await getSelectedTab() ).toHaveTextContent( 'Alpha' );
-		expect( screen.getByRole( 'tabpanel' ) ).toHaveTextContent(
-			'Selected tab: Alpha'
-		);
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Beta is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
 
-		// Select Beta, make sure the correct tabpanel is rendered
-		await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
-		expect( await getSelectedTab() ).toHaveTextContent( 'Beta' );
-		expect( screen.getByRole( 'tabpanel' ) ).toHaveTextContent(
-			'Selected tab: Beta'
-		);
+					expect( mockOnSelect ).not.toHaveBeenCalled();
 
-		// Select Gamma, make sure the correct tabpanel is rendered
-		await click( screen.getByRole( 'tab', { name: 'Gamma' } ) );
-		expect( await getSelectedTab() ).toHaveTextContent( 'Gamma' );
-		expect( screen.getByRole( 'tabpanel' ) ).toHaveTextContent(
-			'Selected tab: Gamma'
-		);
+					// Re-render with beta disabled.
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS_WITH_BETA_DISABLED }
+							defaultTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
 
-		// Select Delta, make sure the correct tabpanel is rendered
-		await click( screen.getByRole( 'tab', { name: 'Delta' } ) );
-		expect( await getSelectedTab() ).toHaveTextContent( 'Delta' );
-		expect( screen.getByRole( 'tabpanel' ) ).toHaveTextContent(
-			'Selected tab: Delta'
-		);
+					// Beta continues to be selected and focused, even if it is disabled.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+
+				it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<UncontrolledTabs
+							tabs={ TABS }
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Alpha is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+					// Click on beta tab, beta becomes selected.
+					await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+					// Re-render with beta disabled.
+					await rerender(
+						<UncontrolledTabs
+							tabs={ TABS_WITH_BETA_DISABLED }
+							defaultTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Beta continues to be selected, even if it is disabled.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				} );
+			} );
+
+			describe( 'when using the `selectedTabId` prop [Controlled]', () => {
+				it( 'should keep the initial tab matching the `selectedTabId` prop as selected even if it becomes disabled [Controlled]', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<ControlledTabs
+							tabs={ TABS }
+							selectedTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Beta is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+
+					// Re-render with beta disabled.
+					await rerender(
+						<ControlledTabs
+							tabs={ TABS_WITH_BETA_DISABLED }
+							selectedTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Beta continues to be selected, even if it is disabled.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).not.toHaveBeenCalled();
+				} );
+
+				it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
+					const mockOnSelect = jest.fn();
+
+					const { rerender } = await render(
+						<ControlledTabs
+							tabs={ TABS }
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Waiting for a tab to be selected is a sign that the component
+					// has fully initialized.
+					// Alpha is automatically selected as the selected tab.
+					// The corresponding tabpanel is shown.
+					expect(
+						await screen.findByRole( 'tab', {
+							selected: true,
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Alpha',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+					// Click on beta tab, beta becomes selected.
+					await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toBeVisible();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+					// Re-render with beta disabled.
+					await rerender(
+						<ControlledTabs
+							tabs={ TABS_WITH_BETA_DISABLED }
+							defaultTabId="beta"
+							onSelect={ mockOnSelect }
+						/>
+					);
+
+					// Beta continues to be selected and focused, even if it is disabled.
+					expect(
+						screen.getByRole( 'tab', {
+							selected: true,
+							name: 'Beta',
+						} )
+					).toHaveFocus();
+					expect(
+						screen.getByRole( 'tabpanel', {
+							name: 'Beta',
+						} )
+					).toBeVisible();
+
+					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				} );
+			} );
+		} );
 	} );
 } );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -873,540 +873,544 @@ describe( 'Tabs', () => {
 		} );
 	} );
 
-	// TODO: loop on both uncontrolled and controlled
 	describe( 'keyboard interactions', () => {
-		it( 'should handle the tablist as one tab stop', async () => {
-			await render( <UncontrolledTabs tabs={ TABS } /> );
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			// Press tab. The selected tab (alpha) received focus.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// By default the tabpanel should receive focus
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-		} );
-
-		it( 'should not focus the tabpanel container when its `focusable` property is set to `false`', async () => {
-			await render(
-				<UncontrolledTabs
-					tabs={ TABS.map( ( tabObj ) =>
-						tabObj.tabId === 'alpha'
-							? {
-									...tabObj,
-									content: (
-										<>
-											Selected Tab: Alpha
-											<button>Alpha Button</button>
-										</>
-									),
-									tabpanel: { focusable: false },
-							  }
-							: tabObj
-					) }
-				/>
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// In this case, the tabpanel container is skipped and focus is
-			// moved directly to its contents
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'button', {
-					name: 'Alpha Button',
-				} )
-			).toHaveFocus();
-		} );
-
-		it( 'should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation)', async () => {
-			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Focus the tablist (and the selected tab, alpha)
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// Press the right arrow key to select the beta tab
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Beta',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-			// Press the right arrow key to select the gamma tab
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Gamma',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Gamma',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
-
-			// Press the left arrow key to select the beta tab
-			await press.ArrowLeft();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Beta',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-		} );
-
-		it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation)', async () => {
-			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs
-					tabs={ TABS }
-					onSelect={ mockOnSelect }
-					selectOnMove={ false }
-				/>
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Focus the tablist (and the selected tab, alpha)
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// Press the right arrow key to move focus to the beta tab,
-			// but without selecting it
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: false,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-			// Press the space key to click the beta tab, and select it.
-			// The same should be true with any other mean of clicking the tab button
-			// (ie. mouse click, enter key).
-			await press.Space();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Beta',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-		} );
-
-		it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
-			const mockOnSelect = jest.fn();
-
-			const { rerender } = await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Focus the tablist (and the selected tab, alpha)
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// Press the up arrow key, but the focused/selected tab does not change.
-			await press.ArrowUp();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-			// Press the down arrow key, but the focused/selected tab does not change.
-			await press.ArrowDown();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-			// Change the orientation to "vertical" and rerender the component.
-			await rerender(
-				<UncontrolledTabs
-					tabs={ TABS }
-					onSelect={ mockOnSelect }
-					orientation="vertical"
-				/>
-			);
-
-			// Pressing the down arrow key now selects the next tab (beta).
-			await press.ArrowDown();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Beta',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-			// Pressing the up arrow key now selects the previous tab (alpha).
-			await press.ArrowUp();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-		} );
-
-		it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
-			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Focus the tablist (and the selected tab, alpha)
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// Press the left arrow key to loop around and select the gamma tab
-			await press.ArrowLeft();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Gamma',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Gamma',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
-
-			// Press the right arrow key to loop around and select the alpha tab
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-		} );
-
-		// TODO: mock writing direction to RTL
-		it.skip( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
-			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Focus the tablist (and the selected tab, alpha)
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// Press the left arrow key to select the beta tab
-			await press.ArrowLeft();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Beta',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-			// Press the left arrow key to select the gamma tab
-			await press.ArrowLeft();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Gamma',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Gamma',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
-
-			// Press the right arrow key to select the beta tab
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Beta',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-		} );
-
-		it( 'should focus tabs in the tablist even if disabled', async () => {
-			const mockOnSelect = jest.fn();
-
-			await render(
-				<UncontrolledTabs
-					tabs={ TABS_WITH_BETA_DISABLED }
-					onSelect={ mockOnSelect }
-				/>
-			);
-
-			// Alpha is automatically selected as the selected tab.
-			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-			// Focus the tablist (and the selected tab, alpha)
-			// Tab should initially focus the first tab in the tablist, which
-			// is Alpha.
-			await press.Tab();
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toHaveFocus();
-
-			// Pressing the right arrow key moves focus to the beta tab, but alpha
-			// remains the selected tab because beta is disabled.
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: false,
-					name: 'Beta',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-
-			// Press the right arrow key to select the gamma tab
-			await press.ArrowRight();
-
-			expect(
-				screen.getByRole( 'tab', {
-					selected: true,
-					name: 'Gamma',
-				} )
-			).toHaveFocus();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Gamma',
-				} )
-			).toBeVisible();
-
-			expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+		describe.each( [
+			[ 'Uncontrolled', UncontrolledTabs ],
+			[ 'Controlled', ControlledTabs ],
+		] )( '[`%s`]', ( _mode, Component ) => {
+			it( 'should handle the tablist as one tab stop', async () => {
+				await render( <Component tabs={ TABS } /> );
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				// Press tab. The selected tab (alpha) received focus.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// By default the tabpanel should receive focus
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+			} );
+
+			it( 'should not focus the tabpanel container when its `focusable` property is set to `false`', async () => {
+				await render(
+					<Component
+						tabs={ TABS.map( ( tabObj ) =>
+							tabObj.tabId === 'alpha'
+								? {
+										...tabObj,
+										content: (
+											<>
+												Selected Tab: Alpha
+												<button>Alpha Button</button>
+											</>
+										),
+										tabpanel: { focusable: false },
+								  }
+								: tabObj
+						) }
+					/>
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// In this case, the tabpanel container is skipped and focus is
+				// moved directly to its contents
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'button', {
+						name: 'Alpha Button',
+					} )
+				).toHaveFocus();
+			} );
+
+			it( 'should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation)', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render(
+					<Component tabs={ TABS } onSelect={ mockOnSelect } />
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the right arrow key to select the beta tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Press the right arrow key to select the gamma tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+				// Press the left arrow key to select the beta tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+			} );
+
+			it( 'should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation)', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render(
+					<Component
+						tabs={ TABS }
+						onSelect={ mockOnSelect }
+						selectOnMove={ false }
+					/>
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the right arrow key to move focus to the beta tab,
+				// but without selecting it
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: false,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Press the space key to click the beta tab, and select it.
+				// The same should be true with any other mean of clicking the tab button
+				// (ie. mouse click, enter key).
+				await press.Space();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+			} );
+
+			it( 'should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical`', async () => {
+				const mockOnSelect = jest.fn();
+
+				const { rerender } = await render(
+					<Component tabs={ TABS } onSelect={ mockOnSelect } />
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the up arrow key, but the focused/selected tab does not change.
+				await press.ArrowUp();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Press the down arrow key, but the focused/selected tab does not change.
+				await press.ArrowDown();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Change the orientation to "vertical" and rerender the component.
+				await rerender(
+					<Component
+						tabs={ TABS }
+						onSelect={ mockOnSelect }
+						orientation="vertical"
+					/>
+				);
+
+				// Pressing the down arrow key now selects the next tab (beta).
+				await press.ArrowDown();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Pressing the up arrow key now selects the previous tab (alpha).
+				await press.ArrowUp();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+			} );
+
+			it( 'should loop tab focus at the end of the tablist when using arrow keys', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render(
+					<Component tabs={ TABS } onSelect={ mockOnSelect } />
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the left arrow key to loop around and select the gamma tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+				// Press the right arrow key to loop around and select the alpha tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+			} );
+
+			// TODO: mock writing direction to RTL
+			it.skip( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render(
+					<Component tabs={ TABS } onSelect={ mockOnSelect } />
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Press the left arrow key to select the beta tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Press the left arrow key to select the gamma tab
+				await press.ArrowLeft();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 3 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+
+				// Press the right arrow key to select the beta tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Beta',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+			} );
+
+			it( 'should focus tabs in the tablist even if disabled', async () => {
+				const mockOnSelect = jest.fn();
+
+				await render(
+					<Component
+						tabs={ TABS_WITH_BETA_DISABLED }
+						onSelect={ mockOnSelect }
+					/>
+				);
+
+				// Alpha is automatically selected as the selected tab.
+				await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+
+				// Focus the tablist (and the selected tab, alpha)
+				// Tab should initially focus the first tab in the tablist, which
+				// is Alpha.
+				await press.Tab();
+				expect(
+					await screen.findByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toHaveFocus();
+
+				// Pressing the right arrow key moves focus to the beta tab, but alpha
+				// remains the selected tab because beta is disabled.
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: false,
+						name: 'Beta',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Alpha',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+
+				// Press the right arrow key to select the gamma tab
+				await press.ArrowRight();
+
+				expect(
+					screen.getByRole( 'tab', {
+						selected: true,
+						name: 'Gamma',
+					} )
+				).toHaveFocus();
+				expect(
+					screen.getByRole( 'tabpanel', {
+						name: 'Gamma',
+					} )
+				).toBeVisible();
+
+				expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'gamma' );
+			} );
 		} );
 
 		describe( 'When `selectedId` is changed by the controlling component [Controlled]', () => {
@@ -1611,462 +1615,336 @@ describe( 'Tabs', () => {
 				} );
 			} );
 
-			describe( 'through the `defaultTabId` prop [Uncontrolled]', () => {
-				it( 'should not select a new tab when the selected tab is removed', async () => {
-					const mockOnSelect = jest.fn();
+			describe.each( [
+				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
+				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+			] )(
+				'when using the `%s` prop [%s]',
+				( propName, _mode, Component ) => {
+					it( 'should not select a new tab when the selected tab is removed', async () => {
+						const mockOnSelect = jest.fn();
 
-					const { rerender } = await render(
-						<UncontrolledTabs
-							tabs={ TABS }
-							defaultTabId="gamma"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						const initialComponentProps = {
+							tabs: TABS,
+							[ propName ]: 'gamma',
+							onSelect: mockOnSelect,
+						};
 
-					// Gamma is the selected tab.
-					await waitForComponentToBeInitializedWithSelectedTab(
-						'Gamma'
-					);
+						const { rerender } = await render(
+							<Component { ...initialComponentProps } />
+						);
 
-					// Remove gamma
-					await rerender(
-						<UncontrolledTabs
-							tabs={ TABS.slice( 0, 2 ) }
-							defaultTabId="gamma"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						// Gamma is the selected tab.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Gamma'
+						);
 
-					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
-					// No tab should be selected i.e. it doesn't fall back to first tab.
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument();
-					// No tabpanel should be rendered either
-					expect(
-						screen.queryByRole( 'tabpanel' )
-					).not.toBeInTheDocument();
+						// Remove gamma
+						await rerender(
+							<Component
+								{ ...initialComponentProps }
+								tabs={ TABS.slice( 0, 2 ) }
+							/>
+						);
 
-					// Re-add gamma. Gamma becomes selected again.
-					await rerender(
-						<UncontrolledTabs
-							tabs={ TABS }
-							defaultTabId="gamma"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
+							2
+						);
+						// No tab should be selected i.e. it doesn't fall back to first tab.
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument();
+						// No tabpanel should be rendered either
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument();
 
-					expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
-						TABS.length
-					);
+						// Re-add gamma. Gamma becomes selected again.
+						await rerender(
+							<Component { ...initialComponentProps } />
+						);
 
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Gamma',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Gamma',
-						} )
-					).toBeVisible();
+						expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
+							TABS.length
+						);
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
-				} );
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Gamma',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Gamma',
+							} )
+						).toBeVisible();
 
-				it( 'should not select the tab matching the `defaultTabId` prop as a fallback when the selected tab is removed', async () => {
-					const mockOnSelect = jest.fn();
+						expect( mockOnSelect ).not.toHaveBeenCalled();
+					} );
 
-					const { rerender } = await render(
-						<UncontrolledTabs
-							tabs={ TABS }
-							defaultTabId="gamma"
-							onSelect={ mockOnSelect }
-						/>
-					);
+					it( `should not select the tab matching the \`${ propName }\` prop as a fallback when the selected tab is removed`, async () => {
+						const mockOnSelect = jest.fn();
 
-					// Gamma is the selected tab.
-					await waitForComponentToBeInitializedWithSelectedTab(
-						'Gamma'
-					);
+						const initialComponentProps = {
+							tabs: TABS,
+							[ propName ]: 'gamma',
+							onSelect: mockOnSelect,
+						};
 
-					// Select alpha
-					await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
+						const { rerender } = await render(
+							<Component { ...initialComponentProps } />
+						);
 
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Alpha',
-						} )
-					).toHaveFocus();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Alpha',
-						} )
-					).toBeVisible();
+						// Gamma is the selected tab.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Gamma'
+						);
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+						// Select alpha
+						await click(
+							screen.getByRole( 'tab', { name: 'Alpha' } )
+						);
 
-					// Remove alpha
-					await rerender(
-						<UncontrolledTabs
-							tabs={ TABS.slice( 1 ) }
-							defaultTabId="gamma"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Alpha',
+							} )
+						).toHaveFocus();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Alpha',
+							} )
+						).toBeVisible();
 
-					expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+						expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+						expect( mockOnSelect ).toHaveBeenLastCalledWith(
+							'alpha'
+						);
 
-					// No tab should be selected i.e. it doesn't fall back to gamma,
-					// even if it matches the `defaultTabId` prop.
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument();
-					// No tabpanel should be rendered either
-					expect(
-						screen.queryByRole( 'tabpanel' )
-					).not.toBeInTheDocument();
+						// Remove alpha
+						await rerender(
+							<Component
+								{ ...initialComponentProps }
+								tabs={ TABS.slice( 1 ) }
+							/>
+						);
 
-					// Re-add alpha. Alpha becomes selected again.
-					await rerender(
-						<UncontrolledTabs
-							tabs={ TABS }
-							defaultTabId="gamma"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
+							2
+						);
 
-					expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
-						TABS.length
-					);
+						// No tab should be selected i.e. it doesn't fall back to gamma,
+						// even if it matches the `defaultTabId` prop.
+						expect(
+							screen.queryByRole( 'tab', { selected: true } )
+						).not.toBeInTheDocument();
+						// No tabpanel should be rendered either
+						expect(
+							screen.queryByRole( 'tabpanel' )
+						).not.toBeInTheDocument();
 
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Alpha',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Alpha',
-						} )
-					).toBeVisible();
+						// Re-add alpha. Alpha becomes selected again.
+						await rerender(
+							<Component { ...initialComponentProps } />
+						);
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-				} );
-			} );
-			describe( 'through the `selectedTabId` prop [Controlled]', () => {
-				// TODO: same tests as above
-			} );
+						expect( screen.getAllByRole( 'tab' ) ).toHaveLength(
+							TABS.length
+						);
+
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Alpha',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Alpha',
+							} )
+						).toBeVisible();
+
+						expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+					} );
+				}
+			);
 		} );
 
 		describe( 'adding a tab', () => {
-			// TODO: describe each for controlled / uncontrolled
-			it( 'should select a newly added tab if it matches the `defaultTabId` prop [Uncontrolled]', async () => {
-				const mockOnSelect = jest.fn();
+			describe.each( [
+				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
+				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+			] )(
+				'when using the `%s` prop [%s]',
+				( propName, _mode, Component ) => {
+					it( `should select a newly added tab if it matches the \`${ propName }\` prop`, async () => {
+						const mockOnSelect = jest.fn();
 
-				const { rerender } = await render(
-					<UncontrolledTabs
-						tabs={ TABS }
-						defaultTabId="delta"
-						onSelect={ mockOnSelect }
-					/>
-				);
+						const initialComponentProps = {
+							tabs: TABS,
+							[ propName ]: 'delta',
+							onSelect: mockOnSelect,
+						};
 
-				// No initially selected tabs or tabpanels, since the `defaultTabId`
-				// prop is mot matching any known tabs.
-				await waitForComponentToBeInitializedWithSelectedTab(
-					undefined
-				);
+						const { rerender } = await render(
+							<Component { ...initialComponentProps } />
+						);
 
-				expect( mockOnSelect ).not.toHaveBeenCalled();
+						// No initially selected tabs or tabpanels, since the `defaultTabId`
+						// prop is mot matching any known tabs.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							undefined
+						);
 
-				// Re-render with beta disabled.
-				await rerender(
-					<UncontrolledTabs
-						tabs={ TABS_WITH_DELTA }
-						defaultTabId="delta"
-						onSelect={ mockOnSelect }
-					/>
-				);
+						expect( mockOnSelect ).not.toHaveBeenCalled();
 
-				// Delta becomes selected
-				expect(
-					screen.getByRole( 'tab', {
-						selected: true,
-						name: 'Delta',
-					} )
-				).toBeVisible();
-				expect(
-					screen.getByRole( 'tabpanel', {
-						name: 'Delta',
-					} )
-				).toBeVisible();
+						// Re-render with beta disabled.
+						await rerender(
+							<Component
+								{ ...initialComponentProps }
+								tabs={ TABS_WITH_DELTA }
+							/>
+						);
 
-				expect( mockOnSelect ).not.toHaveBeenCalled();
-			} );
+						// Delta becomes selected
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Delta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Delta',
+							} )
+						).toBeVisible();
 
-			it( 'should select a newly added tab if it matches the `selectedTabId` prop [Controlled]', async () => {
-				const mockOnSelect = jest.fn();
-
-				const { rerender } = await render(
-					<ControlledTabs
-						tabs={ TABS }
-						selectedTabId="delta"
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				// No initially selected tabs or tabpanels, since the `selectedTabId`
-				// prop is mot matching any known tabs.
-				await waitForComponentToBeInitializedWithSelectedTab(
-					undefined
-				);
-
-				expect( mockOnSelect ).not.toHaveBeenCalled();
-
-				// Re-render with beta disabled.
-				await rerender(
-					<ControlledTabs
-						tabs={ TABS_WITH_DELTA }
-						selectedTabId="delta"
-						onSelect={ mockOnSelect }
-					/>
-				);
-
-				// Delta becomes selected
-				expect(
-					screen.getByRole( 'tab', {
-						selected: true,
-						name: 'Delta',
-					} )
-				).toBeVisible();
-				expect(
-					screen.getByRole( 'tabpanel', {
-						name: 'Delta',
-					} )
-				).toBeVisible();
-
-				expect( mockOnSelect ).not.toHaveBeenCalled();
-			} );
+						expect( mockOnSelect ).not.toHaveBeenCalled();
+					} );
+				}
+			);
 		} );
+		// TODO: re-enable tabs
 		describe( 'a tab becomes disabled', () => {
-			// TODO: re-enable tabs
-			describe( 'when using the `defaultTabId` prop [Uncontrolled]', () => {
-				// TODO: use describe.each?
-				it( 'should keep the initial tab matching the `defaultTabId` prop as selected even if it becomes disabled', async () => {
-					const mockOnSelect = jest.fn();
+			describe.each( [
+				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
+				[ 'selectedTabId', 'Controlled', ControlledTabs ],
+			] )(
+				'when using the `%s` prop [%s]',
+				( propName, _mode, Component ) => {
+					it( `should keep the initial tab matching the \`${ propName }\` prop as selected even if it becomes disabled`, async () => {
+						const mockOnSelect = jest.fn();
 
-					const { rerender } = await render(
-						<UncontrolledTabs
-							tabs={ TABS }
-							defaultTabId="beta"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						const initialComponentProps = {
+							tabs: TABS,
+							[ propName ]: 'beta',
+							onSelect: mockOnSelect,
+						};
 
-					// Beta is the selected tab.
-					await waitForComponentToBeInitializedWithSelectedTab(
-						'Beta'
-					);
+						const { rerender } = await render(
+							<Component { ...initialComponentProps } />
+						);
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
+						// Beta is the selected tab.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Beta'
+						);
 
-					// Re-render with beta disabled.
-					await rerender(
-						<UncontrolledTabs
-							tabs={ TABS_WITH_BETA_DISABLED }
-							defaultTabId="beta"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						expect( mockOnSelect ).not.toHaveBeenCalled();
 
-					// Beta continues to be selected and focused, even if it is disabled.
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+						// Re-render with beta disabled.
+						await rerender(
+							<Component
+								{ ...initialComponentProps }
+								tabs={ TABS_WITH_BETA_DISABLED }
+							/>
+						);
 
-					expect( mockOnSelect ).not.toHaveBeenCalled();
-				} );
+						// Beta continues to be selected and focused, even if it is disabled.
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
 
-				it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
-					const mockOnSelect = jest.fn();
+						expect( mockOnSelect ).not.toHaveBeenCalled();
+					} );
 
-					const { rerender } = await render(
-						<UncontrolledTabs
-							tabs={ TABS }
-							onSelect={ mockOnSelect }
-						/>
-					);
+					it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
+						const mockOnSelect = jest.fn();
 
-					// Alpha is automatically selected as the selected tab.
-					await waitForComponentToBeInitializedWithSelectedTab(
-						'Alpha'
-					);
+						const { rerender } = await render(
+							<Component
+								tabs={ TABS }
+								onSelect={ mockOnSelect }
+							/>
+						);
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
+						// Alpha is automatically selected as the selected tab.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Alpha'
+						);
 
-					// Click on beta tab, beta becomes selected.
-					await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
+						expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
+						expect( mockOnSelect ).toHaveBeenLastCalledWith(
+							'alpha'
+						);
 
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+						// Click on beta tab, beta becomes selected.
+						await click(
+							screen.getByRole( 'tab', { name: 'Beta' } )
+						);
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
 
-					// Re-render with beta disabled.
-					await rerender(
-						<UncontrolledTabs
-							tabs={ TABS_WITH_BETA_DISABLED }
-							defaultTabId="beta"
-							onSelect={ mockOnSelect }
-						/>
-					);
+						expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+						expect( mockOnSelect ).toHaveBeenLastCalledWith(
+							'beta'
+						);
 
-					// Beta continues to be selected, even if it is disabled.
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toHaveFocus();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+						// Re-render with beta disabled.
+						await rerender(
+							<Component
+								tabs={ TABS_WITH_BETA_DISABLED }
+								onSelect={ mockOnSelect }
+							/>
+						);
 
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				} );
-			} );
+						// Beta continues to be selected, even if it is disabled.
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toHaveFocus();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
 
-			describe( 'when using the `selectedTabId` prop [Controlled]', () => {
-				it( 'should keep the initial tab matching the `selectedTabId` prop as selected even if it becomes disabled [Controlled]', async () => {
-					const mockOnSelect = jest.fn();
-
-					const { rerender } = await render(
-						<ControlledTabs
-							tabs={ TABS }
-							selectedTabId="beta"
-							onSelect={ mockOnSelect }
-						/>
-					);
-
-					// Beta is the selected tab.
-					await waitForComponentToBeInitializedWithSelectedTab(
-						'Beta'
-					);
-
-					expect( mockOnSelect ).not.toHaveBeenCalled();
-
-					// Re-render with beta disabled.
-					await rerender(
-						<ControlledTabs
-							tabs={ TABS_WITH_BETA_DISABLED }
-							selectedTabId="beta"
-							onSelect={ mockOnSelect }
-						/>
-					);
-
-					// Beta continues to be selected, even if it is disabled.
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
-
-					expect( mockOnSelect ).not.toHaveBeenCalled();
-				} );
-
-				it( 'should keep the current tab selected by the user as selected even if it becomes disabled', async () => {
-					const mockOnSelect = jest.fn();
-
-					const { rerender } = await render(
-						<ControlledTabs
-							tabs={ TABS }
-							onSelect={ mockOnSelect }
-						/>
-					);
-
-					// Alpha is automatically selected as the selected tab.
-					await waitForComponentToBeInitializedWithSelectedTab(
-						'Alpha'
-					);
-
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
-
-					// Click on beta tab, beta becomes selected.
-					await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
-
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
-
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
-
-					// Re-render with beta disabled.
-					await rerender(
-						<ControlledTabs
-							tabs={ TABS_WITH_BETA_DISABLED }
-							defaultTabId="beta"
-							onSelect={ mockOnSelect }
-						/>
-					);
-
-					// Beta continues to be selected and focused, even if it is disabled.
-					expect(
-						screen.getByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toHaveFocus();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
-
-					expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
-				} );
-			} );
+						expect( mockOnSelect ).toHaveBeenCalledTimes( 2 );
+					} );
+				}
+			);
 		} );
 	} );
 } );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -9,12 +9,23 @@ import { render } from '@ariakit/test/react';
  * WordPress dependencies
  */
 import { useEffect, useState } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { Tabs } from '..';
 import type { TabsProps } from '../types';
+
+// Setup mocking the `isRTL` function to test arrow key navigation behavior.
+jest.mock( '@wordpress/i18n', () => {
+	const original = jest.requireActual( '@wordpress/i18n' );
+	return {
+		...original,
+		isRTL: jest.fn( () => false ),
+	};
+} );
+const mockedIsRTL = isRTL as jest.Mock;
 
 type Tab = {
 	tabId: string;
@@ -1263,7 +1274,10 @@ describe( 'Tabs', () => {
 			} );
 
 			// TODO: mock writing direction to RTL
-			it.skip( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
+			it( 'should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL', async () => {
+				// For this test only, mock the writing direction to RTL.
+				mockedIsRTL.mockImplementation( () => true );
+
 				const mockOnSelect = jest.fn();
 
 				await render(
@@ -1340,6 +1354,9 @@ describe( 'Tabs', () => {
 
 				expect( mockOnSelect ).toHaveBeenCalledTimes( 4 );
 				expect( mockOnSelect ).toHaveBeenLastCalledWith( 'beta' );
+
+				// Restore the original implementation of the isRTL function.
+				mockedIsRTL.mockRestore();
 			} );
 
 			it( 'should focus tabs in the tablist even if disabled', async () => {

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -583,7 +583,7 @@ describe( 'Tabs', () => {
 					);
 
 					// No initially selected tabs or tabpanels, since the `defaultTabId`
-					// prop is mot matching any known tabs.
+					// prop is not matching any known tabs.
 					await waitForComponentToBeInitializedWithSelectedTab(
 						undefined
 					);
@@ -630,7 +630,7 @@ describe( 'Tabs', () => {
 					);
 
 					// No initially selected tabs or tabpanels, since the `defaultTabId`
-					// prop is mot matching any known tabs.
+					// prop is not matching any known tabs.
 					await waitForComponentToBeInitializedWithSelectedTab(
 						undefined
 					);
@@ -795,7 +795,7 @@ describe( 'Tabs', () => {
 						);
 
 						// No initially selected tabs or tabpanels, since the `selectedTabId`
-						// prop is mot matching any known tabs.
+						// prop is not matching any known tabs.
 						await waitForComponentToBeInitializedWithSelectedTab(
 							undefined
 						);
@@ -842,7 +842,7 @@ describe( 'Tabs', () => {
 						);
 
 						// No initially selected tabs or tabpanels, since the `selectedTabId`
-						// prop is mot matching any known tabs.
+						// prop is not matching any known tabs.
 						await waitForComponentToBeInitializedWithSelectedTab(
 							undefined
 						);
@@ -1810,7 +1810,7 @@ describe( 'Tabs', () => {
 						);
 
 						// No initially selected tabs or tabpanels, since the `defaultTabId`
-						// prop is mot matching any known tabs.
+						// prop is not matching any known tabs.
 						await waitForComponentToBeInitializedWithSelectedTab(
 							undefined
 						);

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -167,6 +167,45 @@ const ControlledTabs = ( {
 
 let originalGetClientRects: () => DOMRectList;
 
+async function waitForComponentToBeInitializedWithSelectedTab(
+	selectedTabName: string | undefined
+) {
+	if ( ! selectedTabName ) {
+		// Wait for the tablist to be tabbable as a mean to know
+		// that ariakit has finished initializing.
+		await waitFor( () =>
+			expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
+				'tabindex',
+				expect.stringMatching( /^(0|-1)$/ )
+			)
+		);
+		// No initially selected tabs or tabpanels.
+		await waitFor( () =>
+			expect(
+				screen.queryByRole( 'tab', { selected: true } )
+			).not.toBeInTheDocument()
+		);
+		await waitFor( () =>
+			expect( screen.queryByRole( 'tabpanel' ) ).not.toBeInTheDocument()
+		);
+	} else {
+		// Waiting for a tab to be selected is a sign that the component
+		// has fully initialized.
+		expect(
+			await screen.findByRole( 'tab', {
+				selected: true,
+				name: selectedTabName,
+			} )
+		).toBeVisible();
+		// The corresponding tabpanel is also shown.
+		expect(
+			screen.getByRole( 'tabpanel', {
+				name: selectedTabName,
+			} )
+		).toBeVisible();
+	}
+}
+
 describe( 'Tabs', () => {
 	beforeAll( () => {
 		originalGetClientRects = window.HTMLElement.prototype.getClientRects;
@@ -187,21 +226,8 @@ describe( 'Tabs', () => {
 		it( 'should apply the correct roles, semantics and attributes', async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			const tabList = screen.getByRole( 'tablist' );
 			const allTabs = screen.getAllByRole( 'tab' );
@@ -260,22 +286,8 @@ describe( 'Tabs', () => {
 				</Tabs>
 			);
 
-			// Alpha is the initially selected tab,and should render the correct tabpanel
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			// Select Beta, make sure the correct tabpanel is rendered
 			await click( screen.getByRole( 'tab', { name: 'Beta' } ) );
@@ -323,15 +335,8 @@ describe( 'Tabs', () => {
 		it( "should apply the tab's `className` to the tab button", async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect(
 				await screen.findByRole( 'tab', { name: 'Alpha' } )
@@ -353,21 +358,8 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -419,21 +411,8 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -464,21 +443,10 @@ describe( 'Tabs', () => {
 				it( 'should choose the first tab as selected', async () => {
 					await render( <UncontrolledTabs tabs={ TABS } /> );
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
 					// Alpha is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Alpha',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Alpha',
-						} )
-					).toBeVisible();
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Alpha'
+					);
 
 					// Press tab. The selected tab (alpha) received focus.
 					await press.Tab();
@@ -495,22 +463,11 @@ describe( 'Tabs', () => {
 						<UncontrolledTabs tabs={ TABS_WITH_ALPHA_DISABLED } />
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
 					// Beta is automatically selected as the selected tab, since alpha is
 					// disabled.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Beta'
+					);
 
 					// Press tab. The selected tab (beta) received focus. The corresponding
 					// tabpanel is shown.
@@ -529,24 +486,9 @@ describe( 'Tabs', () => {
 						<ControlledTabs tabs={ TABS } selectedTabId={ null } />
 					);
 
-					// Wait for the tablist to be tabbable as a mean to know
-					// that ariakit has finished initializing.
-					await waitFor( () =>
-						expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
-							'tabindex',
-							'0'
-						)
-					);
 					// No initially selected tabs or tabpanels.
-					await waitFor( () =>
-						expect(
-							screen.queryByRole( 'tab', { selected: true } )
-						).not.toBeInTheDocument()
-					);
-					await waitFor( () =>
-						expect(
-							screen.queryByRole( 'tabpanel' )
-						).not.toBeInTheDocument()
+					await waitForComponentToBeInitializedWithSelectedTab(
+						undefined
 					);
 
 					// Press tab. The tablist receives focus
@@ -580,21 +522,10 @@ describe( 'Tabs', () => {
 						<UncontrolledTabs tabs={ TABS } defaultTabId="beta" />
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// Beta is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+					// Beta is the initially selected tab
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Beta'
+					);
 
 					// Press tab. The selected tab (beta) received focus. The corresponding
 					// tabpanel is shown.
@@ -615,22 +546,11 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
 					// Beta is automatically selected as the selected tab despite being
 					// disabled, respecting the `defaultTabId` prop.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Beta'
+					);
 
 					// Press tab. The selected tab (beta) received focus, since it is
 					// accessible despite being disabled.
@@ -651,24 +571,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Wait for the tablist to be tabbable as a mean to know
-					// that ariakit has finished initializing.
-					await waitFor( () =>
-						expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
-							'tabindex',
-							'-1'
-						)
-					);
-					// No initially selected tabs or tabpanels.
-					await waitFor( () =>
-						expect(
-							screen.queryByRole( 'tab', { selected: true } )
-						).not.toBeInTheDocument()
-					);
-					await waitFor( () =>
-						expect(
-							screen.queryByRole( 'tabpanel' )
-						).not.toBeInTheDocument()
+					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// prop is mot matching any known tabs.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						undefined
 					);
 
 					// Press tab. The first tab receives focus, but it's
@@ -712,24 +618,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Wait for the tablist to be tabbable as a mean to know
-					// that ariakit has finished initializing.
-					await waitFor( () =>
-						expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
-							'tabindex',
-							'-1'
-						)
-					);
-					// No initially selected tabs or tabpanels.
-					await waitFor( () =>
-						expect(
-							screen.queryByRole( 'tab', { selected: true } )
-						).not.toBeInTheDocument()
-					);
-					await waitFor( () =>
-						expect(
-							screen.queryByRole( 'tabpanel' )
-						).not.toBeInTheDocument()
+					// No initially selected tabs or tabpanels, since the `defaultTabId`
+					// prop is mot matching any known tabs.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						undefined
 					);
 
 					// Press tab. The first tab receives focus, but it's
@@ -776,21 +668,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// Beta is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+					// Beta is the initially selected tab
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Beta'
+					);
 
 					// Changing the defaultTabId prop to gamma should not have any effect.
 					await rerender(
@@ -827,21 +708,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// Waiting for a tab to be selected is a sign that the component
-						// has fully initialized.
-						// Beta is automatically selected as the selected tab.
-						// The corresponding tabpanel is shown.
-						expect(
-							await screen.findByRole( 'tab', {
-								selected: true,
-								name: 'Beta',
-							} )
-						).toBeVisible();
-						expect(
-							screen.getByRole( 'tabpanel', {
-								name: 'Beta',
-							} )
-						).toBeVisible();
+						// Beta is the initially selected tab
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Beta'
+						);
 
 						// Press tab. The selected tab (beta) received focus, since it is
 						// accessible despite being disabled.
@@ -863,21 +733,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// Waiting for a tab to be selected is a sign that the component
-						// has fully initialized.
-						// Gamma is automatically selected as the selected tab.
-						// The corresponding tabpanel is shown.
-						expect(
-							await screen.findByRole( 'tab', {
-								selected: true,
-								name: 'Gamma',
-							} )
-						).toBeVisible();
-						expect(
-							screen.getByRole( 'tabpanel', {
-								name: 'Gamma',
-							} )
-						).toBeVisible();
+						// Gamma is the initially selected tab
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Gamma'
+						);
 
 						// Press tab. The selected tab (gamma) received focus, since it is
 						// accessible despite being disabled.
@@ -898,22 +757,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// Waiting for a tab to be selected is a sign that the component
-						// has fully initialized.
-						// Beta is automatically selected as the selected tab despite being
-						// disabled, respecting the `defaultTabId` prop.
-						// The corresponding tabpanel is shown.
-						expect(
-							await screen.findByRole( 'tab', {
-								selected: true,
-								name: 'Beta',
-							} )
-						).toBeVisible();
-						expect(
-							screen.getByRole( 'tabpanel', {
-								name: 'Beta',
-							} )
-						).toBeVisible();
+						// Beta is the initially selected tab
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Beta'
+						);
 
 						// Press tab. The selected tab (beta) received focus, since it is
 						// accessible despite being disabled.
@@ -936,23 +783,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// Wait for the tablist to be tabbable as a mean to know
-						// that ariakit has finished initializing.
-						await waitFor( () =>
-							expect(
-								screen.getByRole( 'tablist' )
-							).toHaveAttribute( 'tabindex', '-1' )
-						);
-						// No initially selected tabs or tabpanels.
-						await waitFor( () =>
-							expect(
-								screen.queryByRole( 'tab', { selected: true } )
-							).not.toBeInTheDocument()
-						);
-						await waitFor( () =>
-							expect(
-								screen.queryByRole( 'tabpanel' )
-							).not.toBeInTheDocument()
+						// No initially selected tabs or tabpanels, since the `selectedTabId`
+						// prop is mot matching any known tabs.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							undefined
 						);
 
 						// Press tab. The first tab receives focus, but it's
@@ -996,23 +830,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// Wait for the tablist to be tabbable as a mean to know
-						// that ariakit has finished initializing.
-						await waitFor( () =>
-							expect(
-								screen.getByRole( 'tablist' )
-							).toHaveAttribute( 'tabindex', '-1' )
-						);
-						// No initially selected tabs or tabpanels.
-						await waitFor( () =>
-							expect(
-								screen.queryByRole( 'tab', { selected: true } )
-							).not.toBeInTheDocument()
-						);
-						await waitFor( () =>
-							expect(
-								screen.queryByRole( 'tabpanel' )
-							).not.toBeInTheDocument()
+						// No initially selected tabs or tabpanels, since the `selectedTabId`
+						// prop is mot matching any known tabs.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							undefined
 						);
 
 						// Press tab. The first tab receives focus, but it's
@@ -1057,15 +878,8 @@ describe( 'Tabs', () => {
 		it( 'should handle the tablist as one tab stop', async () => {
 			await render( <UncontrolledTabs tabs={ TABS } /> );
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			// Press tab. The selected tab (alpha) received focus.
 			await press.Tab();
@@ -1105,15 +919,8 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			// Tab should initially focus the first tab in the tablist, which
 			// is Alpha.
@@ -1142,21 +949,8 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1238,21 +1032,8 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1320,21 +1101,8 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1437,21 +1205,8 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1512,21 +1267,8 @@ describe( 'Tabs', () => {
 				<UncontrolledTabs tabs={ TABS } onSelect={ mockOnSelect } />
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1607,21 +1349,8 @@ describe( 'Tabs', () => {
 				/>
 			);
 
-			// Waiting for a tab to be selected is a sign that the component
-			// has fully initialized.
 			// Alpha is automatically selected as the selected tab.
-			// The corresponding tabpanel is shown.
-			expect(
-				await screen.findByRole( 'tab', {
-					selected: true,
-					name: 'Alpha',
-				} )
-			).toBeVisible();
-			expect(
-				screen.getByRole( 'tabpanel', {
-					name: 'Alpha',
-				} )
-			).toBeVisible();
+			await waitForComponentToBeInitializedWithSelectedTab( 'Alpha' );
 
 			expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 			expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1693,20 +1422,10 @@ describe( 'Tabs', () => {
 							/>
 						);
 
-						// Waiting for a tab to be selected is a sign that the component
-						// has fully initialized.
-						// The corresponding tabpanel is shown.
-						expect(
-							await screen.findByRole( 'tab', {
-								selected: true,
-								name: 'Beta',
-							} )
-						).toBeVisible();
-						expect(
-							screen.getByRole( 'tabpanel', {
-								name: 'Beta',
-							} )
-						).toBeVisible();
+						// Beta is the selected tab.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Beta'
+						);
 
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
@@ -1763,20 +1482,10 @@ describe( 'Tabs', () => {
 							</>
 						);
 
-						// Waiting for a tab to be selected is a sign that the component
-						// has fully initialized.
-						// The corresponding tabpanel is shown.
-						expect(
-							await screen.findByRole( 'tab', {
-								selected: true,
-								name: 'Beta',
-							} )
-						).toBeVisible();
-						expect(
-							screen.getByRole( 'tabpanel', {
-								name: 'Beta',
-							} )
-						).toBeVisible();
+						// Beta is the selected tab.
+						await waitForComponentToBeInitializedWithSelectedTab(
+							'Beta'
+						);
 
 						// Tab key should focus the currently selected tab, which is Beta.
 						await press.Tab();
@@ -1852,20 +1561,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Alpha',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Alpha',
-						} )
-					).toBeVisible();
+					// Alpha is automatically selected as the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Alpha'
+					);
 
 					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -1924,20 +1623,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Gamma',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Gamma',
-						} )
-					).toBeVisible();
+					// Gamma is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Gamma'
+					);
 
 					// Remove gamma
 					await rerender(
@@ -1997,20 +1686,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Gamma',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Gamma',
-						} )
-					).toBeVisible();
+					// Gamma is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Gamma'
+					);
 
 					// Select alpha
 					await click( screen.getByRole( 'tab', { name: 'Alpha' } ) );
@@ -2097,24 +1776,10 @@ describe( 'Tabs', () => {
 					/>
 				);
 
-				// Wait for the tablist to be tabbable as a mean to know
-				// that ariakit has finished initializing.
-				await waitFor( () =>
-					expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
-						'tabindex',
-						'-1'
-					)
-				);
-				// No initially selected tabs or tabpanels.
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument()
-				);
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tabpanel' )
-					).not.toBeInTheDocument()
+				// No initially selected tabs or tabpanels, since the `defaultTabId`
+				// prop is mot matching any known tabs.
+				await waitForComponentToBeInitializedWithSelectedTab(
+					undefined
 				);
 
 				expect( mockOnSelect ).not.toHaveBeenCalled();
@@ -2155,24 +1820,10 @@ describe( 'Tabs', () => {
 					/>
 				);
 
-				// Wait for the tablist to be tabbable as a mean to know
-				// that ariakit has finished initializing.
-				await waitFor( () =>
-					expect( screen.getByRole( 'tablist' ) ).toHaveAttribute(
-						'tabindex',
-						'-1'
-					)
-				);
-				// No initially selected tabs or tabpanels.
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tab', { selected: true } )
-					).not.toBeInTheDocument()
-				);
-				await waitFor( () =>
-					expect(
-						screen.queryByRole( 'tabpanel' )
-					).not.toBeInTheDocument()
+				// No initially selected tabs or tabpanels, since the `selectedTabId`
+				// prop is mot matching any known tabs.
+				await waitForComponentToBeInitializedWithSelectedTab(
+					undefined
 				);
 
 				expect( mockOnSelect ).not.toHaveBeenCalled();
@@ -2217,21 +1868,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// Beta is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+					// Beta is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Beta'
+					);
 
 					expect( mockOnSelect ).not.toHaveBeenCalled();
 
@@ -2270,21 +1910,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
 					// Alpha is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Alpha',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Alpha',
-						} )
-					).toBeVisible();
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Alpha'
+					);
 
 					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );
@@ -2345,21 +1974,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
-					// Beta is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Beta',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Beta',
-						} )
-					).toBeVisible();
+					// Beta is the selected tab.
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Beta'
+					);
 
 					expect( mockOnSelect ).not.toHaveBeenCalled();
 
@@ -2398,21 +2016,10 @@ describe( 'Tabs', () => {
 						/>
 					);
 
-					// Waiting for a tab to be selected is a sign that the component
-					// has fully initialized.
 					// Alpha is automatically selected as the selected tab.
-					// The corresponding tabpanel is shown.
-					expect(
-						await screen.findByRole( 'tab', {
-							selected: true,
-							name: 'Alpha',
-						} )
-					).toBeVisible();
-					expect(
-						screen.getByRole( 'tabpanel', {
-							name: 'Alpha',
-						} )
-					).toBeVisible();
+					await waitForComponentToBeInitializedWithSelectedTab(
+						'Alpha'
+					);
 
 					expect( mockOnSelect ).toHaveBeenCalledTimes( 1 );
 					expect( mockOnSelect ).toHaveBeenLastCalledWith( 'alpha' );

--- a/packages/components/src/tabs/test/index.tsx
+++ b/packages/components/src/tabs/test/index.tsx
@@ -1826,7 +1826,6 @@ describe( 'Tabs', () => {
 				}
 			);
 		} );
-		// TODO: re-enable tabs
 		describe( 'a tab becomes disabled', () => {
 			describe.each( [
 				[ 'defaultTabId', 'Uncontrolled', UncontrolledTabs ],
@@ -1863,6 +1862,24 @@ describe( 'Tabs', () => {
 						);
 
 						// Beta continues to be selected and focused, even if it is disabled.
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+
+						// Re-enable beta.
+						await rerender(
+							<Component { ...initialComponentProps } />
+						);
+
+						// Beta continues to be selected and focused.
 						expect(
 							screen.getByRole( 'tab', {
 								selected: true,
@@ -1935,6 +1952,27 @@ describe( 'Tabs', () => {
 								name: 'Beta',
 							} )
 						).toHaveFocus();
+						expect(
+							screen.getByRole( 'tabpanel', {
+								name: 'Beta',
+							} )
+						).toBeVisible();
+
+						// Re-enable beta.
+						await rerender(
+							<Component
+								tabs={ TABS }
+								onSelect={ mockOnSelect }
+							/>
+						);
+
+						// Beta continues to be selected and focused.
+						expect(
+							screen.getByRole( 'tab', {
+								selected: true,
+								name: 'Beta',
+							} )
+						).toBeVisible();
 						expect(
 							screen.getByRole( 'tabpanel', {
 								name: 'Beta',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up to #66097

Rewrite the suite of tests for the `Tabs` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The previous suite of tests was incomplete, flaky, and included many repetitions, and inaccurate descriptions.

The new suite:

- has more tests, especially on areas like initial tab selection, keyboard behavior, tabs becoming disabled, and tabs being removed from the document;
- is more robust, thanks to explicit assertions that make sure that the underlying ariakit component has fully initialized;
- is better organized, with a more clear subdivision of the tests and accurate descriptions
- has better assertions, following the RTL mantra "test from the point of view of the user"

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- I rewrote existing tests in a more robust and idiomatic way
- I deleted / grouped duplicate tests
- I added may tests, inspired from the changes applied in https://github.com/WordPress/gutenberg/pull/66097

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Read and review the test code
- Make sure the new suite of tests passes all checks reliably 

**This PR doesn't include any runtime changes.**

_(apologies for the size of the PR, but I couldn't really find a good way to split it into smaller pieces)_

## Screenshots or screencast <!-- if applicable -->

```
  Tabs
    Adherence to spec and basic behavior
      ✓ should apply the correct roles, semantics and attributes (81 ms)
      ✓ should associate each `tab` with the correct `tabpanel`, even if they are not rendered in the same order (420 ms)
      ✓ should apply the tab's `className` to the tab button (34 ms)
    pointer interactions
      ✓ should select a tab when clicked (325 ms)
      ✓ should not select a disabled tab when clicked (152 ms)
    initial tab selection
      when a selected tab id is not specified
        when left `undefined` [Uncontrolled]
          ✓ should choose the first tab as selected (141 ms)
          ✓ should choose the first non-disabled tab if the first tab is disabled (124 ms)
        when `null` [Controlled]
          ✓ should not have a selected tab nor show any tabpanels, make the tablist tabbable and still allow selecting tabs (247 ms)
      when a selected tab id is specified
        through the `defaultTabId` prop [Uncontrolled]
          ✓ should select the initial tab matching the `defaultTabId` prop (121 ms)
          ✓ should select the initial tab matching the `defaultTabId` prop even if the tab is disabled (110 ms)
          ✓ should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab when `defaultTabId` prop does not match any known tab (237 ms)
          ✓ should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab, even when disabled, when `defaultTabId` prop does not match any known tab (213 ms)
          ✓ should ignore any changes to the `defaultTabId` prop after the first render (39 ms)
        through the `selectedTabId` prop [Controlled]
          when the `selectedTabId` matches an existing tab
            ✓ should choose the initial tab matching the `selectedTabId` (128 ms)
            ✓ should choose the initial tab matching the `selectedTabId` even if a `defaultTabId` is passed (117 ms)
            ✓ should choose the initial tab matching the `selectedTabId` even if the tab is disabled (121 ms)
          when the `selectedTabId` doesn't match an existing tab
            ✓ should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab (241 ms)
            ✓ should not have a selected tab nor show any tabpanels, but allow tabbing to the first tab even when disabled (236 ms)
    keyboard interactions
      [`Uncontrolled`]
        ✓ should handle the tablist as one tab stop (246 ms)
        ✓ should not focus the tabpanel container when its `focusable` property is set to `false` (238 ms)
        ✓ should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation) (425 ms)
        ✓ should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation) (296 ms)
        ✓ should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical` (541 ms)
        ✓ should loop tab focus at the end of the tablist when using arrow keys (370 ms)
        ✓ should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL (492 ms)
        ✓ should focus tabs in the tablist even if disabled (276 ms)
      [`Controlled`]
        ✓ should handle the tablist as one tab stop (227 ms)
        ✓ should not focus the tabpanel container when its `focusable` property is set to `false` (245 ms)
        ✓ should select tabs in the tablist when using the left and right arrow keys by default (automatic tab activation) (408 ms)
        ✓ should not automatically select tabs in the tablist when pressing the left and right arrow keys if the `selectOnMove` prop is set to `false` (manual tab activation) (357 ms)
        ✓ should not select tabs in the tablist when using the up and down arrow keys, unless the `orientation` prop is set to `vertical` (530 ms)
        ✓ should loop tab focus at the end of the tablist when using arrow keys (287 ms)
        ✓ should swap the left and right arrow keys when selecting tabs if the writing direction is set to RTL (424 ms)
        ✓ should focus tabs in the tablist even if disabled (307 ms)
      When `selectedId` is changed by the controlling component [Controlled]
        and `selectOnMove` is true
          ✓ should continue to handle arrow key navigation properly (233 ms)
          ✓ should focus the correct tab when tabbing out and back into the tablist (446 ms)
        and `selectOnMove` is false
          ✓ should continue to handle arrow key navigation properly (237 ms)
          ✓ should focus the correct tab when tabbing out and back into the tablist (435 ms)
    miscellaneous runtime changes
      removing a tab
        with no explicitly set initial tab
          ✓ should not select a new tab when the selected tab is removed (170 ms)
        when using the `defaultTabId` prop [Uncontrolled]
          ✓ should not select a new tab when the selected tab is removed (53 ms)
          ✓ should not select the tab matching the `defaultTabId` prop as a fallback when the selected tab is removed (171 ms)
        when using the `selectedTabId` prop [Controlled]
          ✓ should not select a new tab when the selected tab is removed (48 ms)
          ✓ should not select the tab matching the `selectedTabId` prop as a fallback when the selected tab is removed (147 ms)
      adding a tab
        when using the `defaultTabId` prop [Uncontrolled]
          ✓ should select a newly added tab if it matches the `defaultTabId` prop (39 ms)
        when using the `selectedTabId` prop [Controlled]
          ✓ should select a newly added tab if it matches the `selectedTabId` prop (30 ms)
      a tab becomes disabled
        when using the `defaultTabId` prop [Uncontrolled]
          ✓ should keep the initial tab matching the `defaultTabId` prop as selected even if it becomes disabled (44 ms)
          ✓ should keep the current tab selected by the user as selected even if it becomes disabled (157 ms)
        when using the `selectedTabId` prop [Controlled]
          ✓ should keep the initial tab matching the `selectedTabId` prop as selected even if it becomes disabled (45 ms)
          ✓ should keep the current tab selected by the user as selected even if it becomes disabled (208 ms)

Test Suites: 1 passed, 1 total
Tests:       49 passed, 49 total
Snapshots:   0 total
```