### PR TITLE
Fix padding appender hook

### DIFF
--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -31,7 +31,7 @@ export function usePaddingAppender( enabled ) {
 					return;
 				}
 
-				event.stopPropagation();
+				event.preventDefault();
 
 				const blockOrder = registry
 					.select( blockEditorStore )

--- a/packages/edit-post/src/components/layout/use-padding-appender.js
+++ b/packages/edit-post/src/components/layout/use-padding-appender.js
@@ -16,7 +16,13 @@ export function usePaddingAppender( enabled ) {
 	const effect = useRefEffect(
 		( node ) => {
 			function onMouseDown( event ) {
-				if ( event.target !== node ) {
+				if (
+					event.target !== node &&
+					// Tests for the parent element because in the iframed editor if the click is
+					// below the padding the target will be the parent element (html) and should
+					// still be treated as intent to append.
+					event.target !== node.parentElement
+				) {
 					return;
 				}
 
@@ -50,9 +56,12 @@ export function usePaddingAppender( enabled ) {
 					insertDefaultBlock();
 				}
 			}
-			node.addEventListener( 'mousedown', onMouseDown );
+			const { ownerDocument } = node;
+			// Adds the listener on the document so that in the iframed editor clicks below the
+			// padding can be handled as they too should be treated as intent to append.
+			ownerDocument.addEventListener( 'mousedown', onMouseDown );
 			return () => {
-				node.removeEventListener( 'mousedown', onMouseDown );
+				ownerDocument.removeEventListener( 'mousedown', onMouseDown );
 			};
 		},
 		[ registry ]


### PR DESCRIPTION
## What?

Fixes for a couple bugs of the padding appender

## Why?

- the newly inserted block was not focused (fixes #65849)
- clicks below the "padding" (in the iframed editor) were not working (unreported, I think)

## How and how come?
Regarding the broken focus, it was due to a combination of #65414 and #64992. In #64992, `preventDefault` was replaced with a `stopPropagation` and fixed a couple odd issues but since #65414 it needs to go back to `preventDefault` and that’s how it’s fixed here.

The click below the padding didn’t work (in the iframed editor) for two reasons:
- the click listener being on the `body` meant clicks below the padding were not caught because they are on the `html`
- an early return when the event target was other than the `body` would still prevent appending even if the prior point is addressed.

To fix it, the click listener is added to the document and, in its handler, the early return is avoided if the parent element (of the ref’d node) was the event target.

## Testing Instructions
In the Post editor, both with and without the iframe:
1. Click below the last block
2. Verify a default block is inserted and is focused
3. Focus a preceding block
4. Click below the last block
5. Verify the empty default block is focused again

Also, because the click listener is now at the document level it’s good to verify that in the non-iframed editor clicks in the editor UI that are below the last block don’t errantly insert a block. 

## Screenshots or screencast <!-- if applicable -->
A background color is applied to the "padding" to make it visible when clicking below that.

### No iframe

https://github.com/user-attachments/assets/8d40ec89-ec89-49b9-8203-ca19750ba454

### iframe

https://github.com/user-attachments/assets/0216a6fc-c7ef-4f92-b1a4-38e95e6f7886


