### PR TITLE
Remove clip and -webkit-clip for block-library common.scss

### DIFF
--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -75,8 +75,6 @@
 
 .screen-reader-text {
 	border: 0;
-	clip: rect(1px, 1px, 1px, 1px);
-	-webkit-clip-path: inset(50%);
 	clip-path: inset(50%);
 	height: 1px;
 	margin: -1px;
@@ -89,7 +87,6 @@
 
 .screen-reader-text:focus {
 	background-color: $gray-300;
-	clip: auto !important;
 	clip-path: none;
 	color: #444;
 	display: block;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Addresses part of https://github.com/WordPress/gutenberg/issues/65954

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The utility .screen-reader-text CSS is used in several places throughout the Gutenberg code base. In https://github.com/WordPress/gutenberg/pull/65409 it came up that we should update all the areas to match the changing CSS rules proposed in https://github.com/WordPress/gutenberg/pull/65409.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove the unnecessary `clip: rect(1px, 1px, 1px, 1px);` and `-webkit-clip-path: inset(50%);` rules from the packages/block-library/src/common.scss 

### Style attribute

| Before | After |
| --- | --- |
| ![Screenshot 2024-09-17 at 17 48 21](https://github.com/user-attachments/assets/78ac6566-28d9-4f8c-8fff-bd31d27aec67) | ![Screenshot 2024-09-17 at 17 48 57](https://github.com/user-attachments/assets/e7453807-cfad-4d0d-b293-c50daabb53f7) |
