### PR TITLE
Fix: Hide non-svg icons when "Show button text labels" is active

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -177,7 +177,7 @@
 			width: auto;
 
 			// Hide the button icons when labels are set to display...
-			svg {
+			svg, img, .dashicon {
 				display: none;
 			}
 			// ... and display labels.

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -25,7 +25,7 @@ $block-editor-link-control-number-of-actions: 1;
 	.show-icon-labels & {
 		.components-button.has-icon {
 			// Hide the button icons when labels are set to display...
-			svg {
+			svg, img {
 				display: none;
 			}
 			// ... and display labels.

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -36,7 +36,7 @@
 			width: auto;
 
 			// Hide the button icons when labels are set to display...
-			svg {
+			svg, img, .dashicon {
 				display: none;
 			}
 			// ... and display labels.

--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -124,7 +124,7 @@
 		width: auto;
 
 		// Hide the button icons when labels are set to display...
-		svg {
+		svg, img, .dashicon {
 			display: none;
 		}
 		// ... and display labels.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adds `img` and `.dashicon` to the `.show-icon-labels` styles that currently only hide SVG icons.

Note: since GlobalStylesSidebar only has hard-coded icons, it's been excluded. Likewise, LinkControl only seems to potentially have <img> icons, so only img was added to the selector.

## Why?
Blocks, plugins, formats, etc can be registered with a dashicon or potentially an <img> element, rather than an SVG icon. Currently, if, say, a block has a dashicon for it's icon, that dashicon will still be visible when Show Button Text Labels is enabled, and it overlaps with the text.

## Testing Instructions
1. Register a custom block with a dashicon string for the icon.
2. Open editor, insert block.
3. Open Preferences > Accessibility, toggle on Show Button Text Labels
4. Toolbar icon for block should correctly show just the block name now.
5. Repeate with a custom format or plugin.

## Screenshots or screencast

Current handling with example block using dashicon icon.

![image](https://github.com/user-attachments/assets/854c4f28-c691-43d4-b97f-ed2e4de36da6)
