### PR TITLE
ToggleGroupControl: Don't set value on focus after a reset

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `Tabs`: fix skipping indication animation glitch ([#65878](https://github.com/WordPress/gutenberg/pull/65878)).
 -   `ToggleGroupControl`: Don't autoselect option on first group focus ([#65892](https://github.com/WordPress/gutenberg/pull/65892)).
 -   `Button`: fix `box-shadow` transition for secondary variation ([#66045](https://github.com/WordPress/gutenberg/pull/66045)).
+-   `ToggleGroupControl`: Don't set value on focus after a reset ([#66151](https://github.com/WordPress/gutenberg/pull/66151)).
 
 ### Deprecations
 

--- a/packages/components/src/toggle-group-control/test/index.tsx
+++ b/packages/components/src/toggle-group-control/test/index.tsx
@@ -175,6 +175,32 @@ describe.each( [
 		expect( radio ).not.toBeChecked();
 	} );
 
+	if ( mode === 'controlled' ) {
+		it( 'should not set a value on focus, after the value is reset', async () => {
+			render(
+				<Component label="Test Toggle Group Control" value="jack">
+					{ options }
+				</Component>
+			);
+
+			expect( screen.getByRole( 'radio', { name: 'J' } ) ).toBeChecked();
+
+			await click( screen.getByRole( 'button', { name: 'Reset' } ) );
+
+			expect(
+				screen.getByRole( 'radio', { name: 'J' } )
+			).not.toBeChecked();
+
+			await press.ShiftTab();
+			expect(
+				screen.getByRole( 'radio', { name: 'R' } )
+			).not.toBeChecked();
+			expect(
+				screen.getByRole( 'radio', { name: 'J' } )
+			).not.toBeChecked();
+		} );
+	}
+
 	it( 'should render tooltip where `showTooltip` === `true`', async () => {
 		render(
 			<Component label="Test Toggle Group Control">

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -141,14 +141,14 @@ function ToggleGroupControlOptionBase(
 					<Ariakit.Radio
 						disabled={ disabled }
 						onFocusVisible={ () => {
-							const selectedValueIsNullish =
+							const selectedValueIsEmpty =
 								toggleGroupControlContext.value === null ||
 								toggleGroupControlContext.value === '';
 
 							// Conditions ensure that the first visible focus to a radio group
 							// without a selected option will not automatically select the option.
 							if (
-								! selectedValueIsNullish ||
+								! selectedValueIsEmpty ||
 								toggleGroupControlContext.activeItemIsNotFirstItem?.()
 							) {
 								toggleGroupControlContext.setValue( value );

--- a/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control-option-base/component.tsx
@@ -141,10 +141,14 @@ function ToggleGroupControlOptionBase(
 					<Ariakit.Radio
 						disabled={ disabled }
 						onFocusVisible={ () => {
+							const selectedValueIsNullish =
+								toggleGroupControlContext.value === null ||
+								toggleGroupControlContext.value === '';
+
 							// Conditions ensure that the first visible focus to a radio group
 							// without a selected option will not automatically select the option.
 							if (
-								toggleGroupControlContext.value !== null ||
+								! selectedValueIsNullish ||
 								toggleGroupControlContext.activeItemIsNotFirstItem?.()
 							) {
 								toggleGroupControlContext.setValue( value );

--- a/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/as-radio-group.tsx
@@ -9,7 +9,7 @@ import { useStoreState } from '@ariakit/react';
  * WordPress dependencies
  */
 import { useInstanceId } from '@wordpress/compose';
-import { forwardRef, useMemo } from '@wordpress/element';
+import { forwardRef, useEffect, useMemo } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
 /**
@@ -72,6 +72,13 @@ function UnforwardedToggleGroupControlAsRadioGroup(
 
 	const selectedValue = useStoreState( radio, 'value' );
 	const setValue = radio.setValue;
+
+	// Ensures that the active id is also reset after the value is "reset" by the consumer.
+	useEffect( () => {
+		if ( selectedValue === '' ) {
+			radio.setActiveId( undefined );
+		}
+	}, [ radio, selectedValue ] );
 
 	const groupContextValue = useMemo(
 		(): ToggleGroupControlContextProps => ( {


### PR DESCRIPTION
Bug discovered in https://github.com/WordPress/gutenberg/pull/65386#discussion_r1798762479

## What?

Fixes an incomplete bug fix in #65892 where ToggleGroupControl could still autoselect an option on focus after the selected value was reset by the consumer.

### Testing Instructions for Keyboard

Modify the Storybook story so it has a reset button, like this:

```diff
diff --git a/packages/components/src/toggle-group-control/stories/index.story.tsx b/packages/components/src/toggle-group-control/stories/index.story.tsx
index 92f1e60762..01e5fc4eae 100644
--- a/packages/components/src/toggle-group-control/stories/index.story.tsx
+++ b/packages/components/src/toggle-group-control/stories/index.story.tsx
@@ -48,15 +48,18 @@ const Template: StoryFn< typeof ToggleGroupControl > = ( {
 		useState< ToggleGroupControlProps[ 'value' ] >();
 
 	return (
-		<ToggleGroupControl
-			__nextHasNoMarginBottom
-			{ ...props }
-			onChange={ ( ...changeArgs ) => {
-				setValue( ...changeArgs );
-				onChange?.( ...changeArgs );
-			} }
-			value={ value }
-		/>
+		<>
+			<ToggleGroupControl
+				__nextHasNoMarginBottom
+				{ ...props }
+				onChange={ ( ...changeArgs ) => {
+					setValue( ...changeArgs );
+					onChange?.( ...changeArgs );
+				} }
+				value={ value }
+			/>
+			<button onClick={ () => setValue( undefined ) }>Reset</button>
+		</>
 	);
 };

1. Select a value.
2. Reset the value using the reset button.
3. Using the keyboard, focus back onto the component. A value should not be selected automatically.

```
