### PR TITLE
Navigation block: fix block appender size

### DIFF
--- a/packages/block-library/src/navigation/editor.scss
+++ b/packages/block-library/src/navigation/editor.scss
@@ -203,6 +203,7 @@ $color-control-label-height: 20px;
 .wp-block-navigation .wp-block + .block-list-appender .block-editor-button-block-appender {
 	background-color: $gray-900;
 	color: $white;
+	height: $button-size-small;
 
 	// This needs specificity to override an inherited padding.
 	// That source padding in turn has high specificity to protect


### PR DESCRIPTION
## What?

This PR changes the height of the navigation block inserter so that it is an exact square.

## Why?

As part of an effort to standardize buttons to a default 40px size, [#65225](https://github.com/WordPress/gutenberg/pull/65225/files#diff-4cdcf916fb8cf5f88b98cd9e95ab532d90369cd768334f7896720a2b85c018bbR63) added `__next40pxDefaultSize` to the block appender. Normal block appenders are correct to be 40px in size, but the Navigation block is expected to be 24px as before.

## How?

Override the default 40px height with a 24px height. This is a temporary fix for WP 6.7, we may need to update to the dropdown appender in the feature as [this comment indicates](https://github.com/WordPress/gutenberg/blob/0ee8ce4536a2fc57ddeef10b9ada4bf9ceb07cdd/packages/block-library/src/navigation/editor.scss#L199-L202).


## Testing Instructions

Select the Navigation block and Submenu block and check the size of the block appenders.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/c3110e8e-e327-436c-aa0e-c3090efc76de)
![image](https://github.com/user-attachments/assets/9712acff-afcc-4f77-9bdf-a7a01d223dea)

### After

![image](https://github.com/user-attachments/assets/3dce1d2b-ef5c-4a2c-a3f1-bac888e2f9c5)

![image](https://github.com/user-attachments/assets/0eba337e-850e-4406-91ff-2c46a7063de7)
