### PR TITLE
Theme JSON: remove redundant check and relocate $selectors assignment

### DIFF
--- a/backport-changelog/6.8/7575.md
+++ b/backport-changelog/6.8/7575.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7575
+
+* https://github.com/WordPress/gutenberg/pull/66154

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2732,17 +2732,13 @@ class WP_Theme_JSON_Gutenberg {
 	 * @return array The block nodes in theme.json.
 	 */
 	private static function get_block_nodes( $theme_json, $selectors = array(), $options = array() ) {
-		$selectors = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
-		$nodes     = array();
-		if ( ! isset( $theme_json['styles'] ) ) {
-			return $nodes;
-		}
+		$nodes = array();
 
-		// Blocks.
 		if ( ! isset( $theme_json['styles']['blocks'] ) ) {
 			return $nodes;
 		}
 
+		$selectors               = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
 		$include_variations      = $options['include_block_style_variations'] ?? false;
 		$include_node_paths_only = $options['include_node_paths_only'] ?? false;
 


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? How?

Remove redundant check for `$theme_json['styles']`, which means `WP_Theme_JSON::get_blocks_metadata()` is only called if necessary.

This also has the potential to slightly improve the performance of functions such as [wp_add_global_styles_for_blocks](https://github.com/wordpress/wordpress-develop/blob/trunk/src/wp-includes/global-styles-and-settings.php#L254) that call `WP_Theme_JSON::get_styles_block_nodes()`, where no block styles exist.


## Testing Instructions
CI tests should pass.
Smoke test in a block theme with lots of block styles, like TT4 and a theme with none, like Emptytheme


