### PR TITLE
Theme JSON: cached resolved URIs

### DIFF
--- a/backport-changelog/6.8/7596.md
+++ b/backport-changelog/6.8/7596.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7596
+
+* https://github.com/WordPress/gutenberg/pull/66155

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -861,9 +861,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return $resolved_theme_uris;
 		}
 
-		$current_stylesheet_directory = get_stylesheet_directory();
-		if ( $current_stylesheet_directory && ! empty( static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] ) ) {
-			return static::$resolved_theme_uris_cache[ $current_stylesheet_directory ];
+		$theme_json_data               = $theme_json->get_raw_data();
+		$resolved_theme_uris_cache_key = md5( wp_json_encode( $theme_json_data ) );
+
+		if ( ! empty( static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ] ) ) {
+			return static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ];
 		}
 
 		$theme_json_data = $theme_json->get_raw_data();
@@ -917,9 +919,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				}
 			}
 		}
-		if ( $current_stylesheet_directory ) {
-			static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] = $resolved_theme_uris;
-		}
+		static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ] = $resolved_theme_uris;
 		return $resolved_theme_uris;
 	}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -849,6 +849,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 * @since 6.7.0 Added support for resolving block styles.
+	 * @since 6.8.0 Added caching for resolved theme URIs.
 	 *
 	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
 	 * @return array An array of resolved paths.

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -92,6 +92,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	protected static $theme_json_file_cache = array();
 
 	/**
+	 * Cache for resolved files per theme.
+	 *
+	 * @since 6.8.0
+	 * @var array
+	 */
+	protected static $resolved_theme_uris_cache = array();
+
+	/**
 	 * Processes a file that adheres to the theme.json schema
 	 * and returns an array with its contents, or a void array if none found.
 	 *
@@ -696,20 +704,22 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *              and `$i18n_schema` variables to reset.
 	 * @since 6.1.0 Added the `$blocks` and `$blocks_cache` variables
 	 *              to reset.
+	 * @since 6.8.0 Added the `$resolved_theme_uris_cache` variable to reset.
 	 */
 	public static function clean_cached_data() {
-		static::$core                     = null;
-		static::$blocks                   = null;
-		static::$blocks_cache             = array(
+		static::$core                      = null;
+		static::$blocks                    = null;
+		static::$blocks_cache              = array(
 			'core'   => array(),
 			'blocks' => array(),
 			'theme'  => array(),
 			'user'   => array(),
 		);
-		static::$theme                    = null;
-		static::$user                     = null;
-		static::$user_custom_post_type_id = null;
-		static::$i18n_schema              = null;
+		static::$theme                     = null;
+		static::$user                      = null;
+		static::$user_custom_post_type_id  = null;
+		static::$i18n_schema               = null;
+		static::$resolved_theme_uris_cache = array();
 	}
 
 	/**
@@ -850,6 +860,11 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return $resolved_theme_uris;
 		}
 
+		$current_stylesheet_directory = get_stylesheet_directory();
+		if ( $current_stylesheet_directory && ! empty( static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] ) ) {
+			return static::$resolved_theme_uris_cache[ $current_stylesheet_directory ];
+		}
+
 		$theme_json_data = $theme_json->get_raw_data();
 
 		// Using the same file convention when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
@@ -901,7 +916,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				}
 			}
 		}
-
+		if ( $current_stylesheet_directory ) {
+			static::$resolved_theme_uris_cache[ $current_stylesheet_directory ] = $resolved_theme_uris;
+		}
 		return $resolved_theme_uris;
 	}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -868,8 +868,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return static::$resolved_theme_uris_cache[ $resolved_theme_uris_cache_key ];
 		}
 
-		$theme_json_data = $theme_json->get_raw_data();
-
 		// Using the same file convention when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
 		$placeholder = 'file:./';
 

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1369,8 +1369,8 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected_data, $actual, 'Resolved theme uris do not match.' );
 
 		// Test that resolved theme uris are cached.
-		$current_stylesheet_directory = get_stylesheet_directory();
-		$expected_cache_data          = array( "$current_stylesheet_directory" => $actual );
+		$cache_key           = md5( wp_json_encode( $theme_json->get_raw_data() ) );
+		$expected_cache_data = array( "$cache_key" => $actual );
 		$this->assertSame( $expected_cache_data, static::$property_resolved_theme_uris_cache->getValue(), 'Resolved theme uris cache data does not match.' );
 	}
 

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1366,55 +1366,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_resolved_theme_uris( $theme_json );
 		remove_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
 
-		$this->assertSame( $expected_data, $actual );
-	}
+		$this->assertSame( $expected_data, $actual, 'Resolved theme uris do not match.' );
 
-	public function test_get_resolved_theme_uris_cache() {
-		$theme_json = new WP_Theme_JSON_Gutenberg(
-			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'styles'  => array(
-					'background' => array(
-						'backgroundImage' => array(
-							'url' => 'file:./example/img/image.png',
-						),
-					),
-					'blocks'     => array(
-						'core/quote' => array(
-							'background' => array(
-								'backgroundImage' => array(
-									'url' => 'file:./example/img/quote.jpg',
-								),
-							),
-						),
-						'core/verse' => array(
-							'background' => array(
-								'backgroundImage' => array(
-									'url' => 'file:./example/img/verse.gif',
-								),
-							),
-						),
-					),
-				),
-			)
-		);
-
-		/*
-		 * This filter callback normalizes the return value from `get_theme_file_uri`
-		 * to guard against changes in test environments.
-		 * The test suite otherwise returns full system dir path, e.g.,
-		 * /wordpress-phpunit/includes/../data/themedir1/default/example/img/image.png
-		 */
-		$filter_theme_file_uri_callback = function ( $file ) {
-			return 'https://example.org/wp-content/themes/example-theme/example/' . explode( 'example/', $file )[1];
-		};
-		add_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
-		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_resolved_theme_uris( $theme_json );
-		remove_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
-
+		// Test that resolved theme uris are cached.
 		$current_stylesheet_directory = get_stylesheet_directory();
-		$expected_data                = array( "$current_stylesheet_directory" => $actual );
-		$this->assertSame( $expected_data, static::$property_resolved_theme_uris_cache->getValue() );
+		$expected_cache_data          = array( "$current_stylesheet_directory" => $actual );
+		$this->assertSame( $expected_cache_data, static::$property_resolved_theme_uris_cache->getValue(), 'Resolved theme uris cache data does not match.' );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -32,6 +32,20 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	private static $property_blocks_cache_orig_value;
 
 	/**
+	 * WP_Theme_JSON_Resolver_Gutenberg::$resolved_theme_uris_cache property.
+	 *
+	 * @var ReflectionProperty
+	 */
+	private static $property_resolved_theme_uris_cache;
+
+	/**
+	 * Original value of the WP_Theme_JSON_Resolver_Gutenberg::$resolved_theme_uris_cache property.
+	 *
+	 * @var array
+	 */
+	private static $property_resolved_theme_uris_cache_orig_value;
+
+	/**
 	 * WP_Theme_JSON_Resolver_Gutenberg::$core property.
 	 *
 	 * @var ReflectionProperty
@@ -81,11 +95,16 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		static::$property_core = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'core' );
 		static::$property_core->setAccessible( true );
 		static::$property_core_orig_value = static::$property_core->getValue();
+
+		static::$property_resolved_theme_uris_cache = new ReflectionProperty( WP_Theme_JSON_Resolver_Gutenberg::class, 'resolved_theme_uris_cache' );
+		static::$property_resolved_theme_uris_cache->setAccessible( true );
+		static::$property_resolved_theme_uris_cache_orig_value = static::$property_resolved_theme_uris_cache->getValue();
 	}
 
 	public static function tear_down_after_class() {
 		static::$property_blocks_cache->setValue( null, static::$property_blocks_cache_orig_value );
 		static::$property_core->setValue( null, static::$property_core_orig_value );
+		static::$property_resolved_theme_uris_cache->setValue( null, static::$property_resolved_theme_uris_cache_orig_value );
 		parent::tear_down_after_class();
 	}
 
@@ -1348,6 +1367,54 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		remove_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
 
 		$this->assertSame( $expected_data, $actual );
+	}
+
+	public function test_get_resolved_theme_uris_cache() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'background' => array(
+						'backgroundImage' => array(
+							'url' => 'file:./example/img/image.png',
+						),
+					),
+					'blocks'     => array(
+						'core/quote' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/quote.jpg',
+								),
+							),
+						),
+						'core/verse' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/verse.gif',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		/*
+		 * This filter callback normalizes the return value from `get_theme_file_uri`
+		 * to guard against changes in test environments.
+		 * The test suite otherwise returns full system dir path, e.g.,
+		 * /wordpress-phpunit/includes/../data/themedir1/default/example/img/image.png
+		 */
+		$filter_theme_file_uri_callback = function ( $file ) {
+			return 'https://example.org/wp-content/themes/example-theme/example/' . explode( 'example/', $file )[1];
+		};
+		add_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
+		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_resolved_theme_uris( $theme_json );
+		remove_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
+
+		$current_stylesheet_directory = get_stylesheet_directory();
+		$expected_data                = array( "$current_stylesheet_directory" => $actual );
+		$this->assertSame( $expected_data, static::$property_resolved_theme_uris_cache->getValue() );
 	}
 
 	/**


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Implement "pretty basic caching" for resolved theme URIs in `WP_Theme_JSON_Resolver::get_resolved_theme_uris`.



## Why?

The intention to improve performance, even if slightly. 

`WP_Theme_JSON_Resolver::get_resolved_theme_uris`, and `WP_Theme_JSON_Resolver::resolve_theme_file_uris` which calls it, is fired multiple times in a single session to:

1. Generate styles
2. Deliver resolved URIs in a global styles controller response.

Results will become more pronounced as other relative paths are introduced, e.g., [fonts](https://github.com/WordPress/gutenberg/pull/65019), and more blocks support background images.

Cached data is not be stored persistently across page loads.

## How?

Simple object caching.

## Testing Instructions

Run `npm run test:unit:php:base -- --filter WP_Theme_JSON_Resolver_Gutenberg_Test`

Create a theme.json with background image paths defined for several blocks.

Ensure these appear as expected in the editor and frontend.

In the theme.json file, replace one or several paths with new asset paths. Check that the styles have been updated and the editor/frontend looks good.

Here is some test JSON based on current assets in TT5:

```json
{
	"$schema": "../../schemas/json/theme.json",
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "file:./assets/images/category-anthuriums.webp"
			}
		},
		"blocks": {
			"core/group": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/category-cactus.webp"
					}
				}
			},
			"core/post-content": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/hero-podcast.webp"
					}
				}
			},
			"core/quote": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/category-sunflowers.webp"
					}
				}
			},
			"core/pullquote": {
				"background": {
					"backgroundImage": {
						"url": "file:./assets/images/dallas-creek-square.webp"
					}
				}
			}
		}
	}
}

```

