### PR TITLE
Blocks: Adds check for parent before showing convert to pattern button

### DIFF
--- a/packages/patterns/src/components/pattern-convert-button.js
+++ b/packages/patterns/src/components/pattern-convert-button.js
@@ -6,6 +6,7 @@ import {
 	isReusableBlock,
 	createBlock,
 	serialize,
+	getBlockType,
 } from '@wordpress/blocks';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { useState, useCallback } from '@wordpress/element';
@@ -60,6 +61,15 @@ export default function PatternConvertButton( {
 
 			const blocks = getBlocksByClientId( clientIds ) ?? [];
 
+			// Check if the block has reusable support defined.
+			const hasReusableBlockSupport = ( blockName ) => {
+				const blockType = getBlockType( blockName );
+				const hasParent = blockType && 'parent' in blockType;
+
+				// If the block has a parent, check with false as default, otherwise with true.
+				return hasBlockSupport( blockName, 'reusable', ! hasParent );
+			};
+
 			const isReusable =
 				blocks.length === 1 &&
 				blocks[ 0 ] &&
@@ -82,7 +92,7 @@ export default function PatternConvertButton( {
 						// Hide on invalid blocks.
 						block.isValid &&
 						// Hide when block doesn't support being made into a pattern.
-						hasBlockSupport( block.name, 'reusable', true )
+						hasReusableBlockSupport( block.name )
 				) &&
 				// Hide when current doesn't have permission to do that.
 				// Blocks refers to the wp_block post type, this checks the ability to create a post of that type.


### PR DESCRIPTION
## What?
Fixes: #35223 

## Why?
When a block defines a `parent` it was still possible to select the "child" block and make it reusable.

## How?
This PR adds a check for "parent" type before showing the "convert to patterns" (reusable). It adds the default value of reusable support to false if not defined in the block supports. 

## Testing Instructions
1. Create a custom block with parent key.
2. Insert the block in the parent container block. 
3. Select the "child block" and click on the 3 dots in Blocks List view in editor. 
4. It should not show the "Convert to pattern" button until we intentionally specifies the "reusable" support to `true` in Child Block's block.json

## Screenshots

**Default State (Without adding reusable key in support)**
<img width="815" alt="image" src="https://github.com/user-attachments/assets/bee926fb-b09b-4dba-b8ab-e8f2dc494606">

**After defining reusable as true**
<img width="678" alt="image" src="https://github.com/user-attachments/assets/fb7feb3e-b3b0-4a98-a4c8-f22a7dc9002b">

