### PR TITLE
Memoize pattern objects returned from getAllowedPatterns

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2385,6 +2385,21 @@ const getAllowedPatternsDependants = ( select ) => ( state, rootClientId ) => [
 	...getInsertBlockTypeDependants( state, rootClientId ),
 ];
 
+const patternsWithParsedBlocks = new WeakMap();
+function enhancePatternWithParsedBlocks( pattern ) {
+	let enhancedPattern = patternsWithParsedBlocks.get( pattern );
+	if ( ! enhancedPattern ) {
+		enhancedPattern = {
+			...pattern,
+			get blocks() {
+				return getParsedPattern( pattern ).blocks;
+			},
+		};
+		patternsWithParsedBlocks.set( pattern, enhancedPattern );
+	}
+	return enhancedPattern;
+}
+
 /**
  * Returns the list of allowed patterns for inner blocks children.
  *
@@ -2406,14 +2421,7 @@ export const __experimentalGetAllowedPatterns = createRegistrySelector(
 				const { allowedBlockTypes } = getSettings( state );
 				const parsedPatterns = patterns
 					.filter( ( { inserter = true } ) => !! inserter )
-					.map( ( pattern ) => {
-						return {
-							...pattern,
-							get blocks() {
-								return getParsedPattern( pattern ).blocks;
-							},
-						};
-					} );
+					.map( enhancePatternWithParsedBlocks );
 
 				const availableParsedPatterns = parsedPatterns.filter(
 					( pattern ) =>


### PR DESCRIPTION
Fixes #65920. When switching between different blocks, the `getAllowedPatterns` selector calculates a list of patterns insertable into that block. And that list is further rendered by `useAsyncList`. When `useAsyncList` gets a new but identical list, it should keep the existing items rendered and incrementally add the new ones. But the pattern items are not identical, because each new `getAllowedPatterns` call creates a new pattern item, enhancing it with a `blocks` getter. And that makes `useAsyncList` rerender the list from scratch. The solution is to memoize the function that enhances the patterns.

**How to test:** Try to reproduce the rerendering behavior that @annezazu reports in #65920 (see the video in the initial comment). It disappears after this patch is applied.
