### PR TITLE
Block Bindings: Allow label override when it is defined in client registration

### DIFF
--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -865,7 +865,7 @@ export const registerBlockBindingsSource = ( source ) => {
 		return;
 	}
 
-	if ( label && existingSource?.label ) {
+	if ( label && existingSource?.label && label !== existingSource?.label ) {
 		warning( 'Block bindings "' + name + '" source label was overriden.' );
 	}
 

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -854,14 +854,6 @@ export const registerBlockBindingsSource = ( source ) => {
 	}
 
 	// Check the `label` property is correct.
-	if ( label && existingSource?.label ) {
-		warning(
-			'Block bindings "' +
-				name +
-				'" source label is already defined in the server.'
-		);
-		return;
-	}
 
 	if ( ! label && ! existingSource?.label ) {
 		warning( 'Block bindings source must contain a label.' );
@@ -871,6 +863,10 @@ export const registerBlockBindingsSource = ( source ) => {
 	if ( label && typeof label !== 'string' ) {
 		warning( 'Block bindings source label must be a string.' );
 		return;
+	}
+
+	if ( label && existingSource?.label ) {
+		warning( 'Block bindings "' + name + '" source label was overriden.' );
 	}
 
 	// Check the `usesContext` property is correct.

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1512,20 +1512,23 @@ describe( 'blocks', () => {
 			expect( getBlockBindingsSource( 'core/testing' ) ).toBeUndefined();
 		} );
 
-		it( 'should not override label from the server', () => {
+		it( 'should override label from the server', () => {
 			// Simulate bootstrap source from the server.
 			registerBlockBindingsSource( {
-				name: 'core/server',
+				name: 'core/testing',
 				label: 'Server label',
 			} );
 			// Override the source with a different label in the client.
 			registerBlockBindingsSource( {
-				name: 'core/server',
+				name: 'core/testing',
 				label: 'Client label',
 			} );
 			expect( console ).toHaveWarnedWith(
-				'Block bindings "core/server" source label is already defined in the server.'
+				'Block bindings "core/testing" source label was overriden.'
 			);
+			const source = getBlockBindingsSource( 'core/testing' );
+			unregisterBlockBindingsSource( 'core/testing' );
+			expect( source.label ).toEqual( 'Client label' );
 		} );
 
 		// Check the `usesContext` array is correct.

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -1531,6 +1531,21 @@ describe( 'blocks', () => {
 			expect( source.label ).toEqual( 'Client label' );
 		} );
 
+		it( 'should keep label from the server when not defined in the client', () => {
+			// Simulate bootstrap source from the server.
+			registerBlockBindingsSource( {
+				name: 'core/testing',
+				label: 'Server label',
+			} );
+			// Override the source with a different label in the client.
+			registerBlockBindingsSource( {
+				name: 'core/testing',
+			} );
+			const source = getBlockBindingsSource( 'core/testing' );
+			unregisterBlockBindingsSource( 'core/testing' );
+			expect( source.label ).toEqual( 'Server label' );
+		} );
+
 		// Check the `usesContext` array is correct.
 		it( 'should reject invalid usesContext property', () => {
 			registerBlockBindingsSource( {

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -403,8 +403,7 @@ export function blockBindingsSources( state = {}, action ) {
 			return {
 				...state,
 				[ action.name ]: {
-					// Don't override the label if it's already set.
-					label: state[ action.name ]?.label || action.label,
+					label: action.label,
 					usesContext: getMergedUsesContext(
 						state[ action.name ]?.usesContext,
 						action.usesContext

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -403,7 +403,7 @@ export function blockBindingsSources( state = {}, action ) {
 			return {
 				...state,
 				[ action.name ]: {
-					label: action.label,
+					label: action.label || state[ action.name ]?.label,
 					usesContext: getMergedUsesContext(
 						state[ action.name ]?.usesContext,
 						action.usesContext


### PR DESCRIPTION
## What?
As discussed [here](https://github.com/WordPress/gutenberg/pull/66058#issuecomment-2411106127), and reported in other places, there are some concerns about not registering a source when the label is both defined in the server and in the client.

In this pull request, I'm fixing the behavior by overriding the label with the value coming from the client. From the feedback received, this should be the expected behavior.

There are mainly two questions:
* Which value should prevail, the value from the server, or the value from the client?
* Even if the registration is valid, should we still throw a console warning? In most cases, users should never define the label in both places.

## Why?
The current behavior is confusing for users.

## How?
For the moment, I kept the warning but register the source anyway, with the client value prevailing. Happy to make any changes based on discussions.

## Testing Instructions
I've updated the unit tests to reflect this. To test manually:
1. Register a source in the server:
```
register_block_bindings_source(
	'core/testing',
	array(
		'label'              => 'Server Label',
		'get_value_callback' => function () {},
	)
);
```
2. Register the same source in the client with a new label:
```
wp.blocks.registerBlockBindingsSource({
  name: "core/testing",
  label: "Client Label",
});
```
3. Connect a paragraph to this source and check it uses the client label:
```
<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"core/testing"}}}} -->
<p>Fallback</p>
<!-- /wp:paragraph -->
```