### PR TITLE
Memoize pattern objects returned from getAllowedPatterns (6.7 backport)

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2363,6 +2363,21 @@ const getAllowedPatternsDependants = ( select ) => ( state, rootClientId ) => [
 	...getInsertBlockTypeDependants( state, rootClientId ),
 ];
 
+const patternsWithParsedBlocks = new WeakMap();
+function enhancePatternWithParsedBlocks( pattern ) {
+	let enhancedPattern = patternsWithParsedBlocks.get( pattern );
+	if ( ! enhancedPattern ) {
+		enhancedPattern = {
+			...pattern,
+			get blocks() {
+				return getParsedPattern( pattern ).blocks;
+			},
+		};
+		patternsWithParsedBlocks.set( pattern, enhancedPattern );
+	}
+	return enhancedPattern;
+}
+
 /**
  * Returns the list of allowed patterns for inner blocks children.
  *
@@ -2379,14 +2394,7 @@ export const __experimentalGetAllowedPatterns = createRegistrySelector(
 			const { allowedBlockTypes } = getSettings( state );
 			const parsedPatterns = patterns
 				.filter( ( { inserter = true } ) => !! inserter )
-				.map( ( pattern ) => {
-					return {
-						...pattern,
-						get blocks() {
-							return getParsedPattern( pattern ).blocks;
-						},
-					};
-				} );
+				.map( enhancePatternWithParsedBlocks );
 
 			const availableParsedPatterns = parsedPatterns.filter(
 				( pattern ) =>


### PR DESCRIPTION
Backport of #66159 to the `wp/6.7` branch. There were merge conflicts so the backport needs to be done manually.