### PR TITLE
Fix rich text toolbar corners

### DIFF
--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -9,7 +9,7 @@
 		margin-bottom: $grid-unit-10;
 		box-shadow: none;
 		outline: none;
-		border-radius: $radius-small; // Todo: revisit when applying the radius scale to the block toolbar
+		border-radius: $radius-small;
 	}
 
 	.components-toolbar {

--- a/packages/block-editor/src/components/rich-text/style.scss
+++ b/packages/block-editor/src/components/rich-text/style.scss
@@ -9,10 +9,15 @@
 		margin-bottom: $grid-unit-10;
 		box-shadow: none;
 		outline: none;
+		border-radius: $radius-small; // Todo: revisit when applying the radius scale to the block toolbar
 	}
 
 	.components-toolbar {
 		border-radius: $radius-small;
+	}
+
+	.components-toolbar-group {
+		background: none;
 	}
 
 	.components-toolbar__control,


### PR DESCRIPTION
## What?
Fix appearance of corners in rich text toolbars.

## Why?
See https://github.com/WordPress/gutenberg/issues/66134. Closes https://github.com/WordPress/gutenberg/issues/66134.

## How?
Mimics the technique used in the Block toolbar component. Ideally we revisit and fix this in the WP Components / Toolbar. But for 6.7 this seems acceptable to me.

## Testing Instructions
1. Insert an image block
2. Add a caption
3. Observe the corners on the caption toolbar match the corners on block toolbars

### Before
<img width="1760" alt="Screenshot 2024-10-16 at 10 46 42" src="https://github.com/user-attachments/assets/020f9d34-52e9-44dd-88e3-5bca92124182">


### After
<img width="1747" alt="Screenshot 2024-10-16 at 10 46 18" src="https://github.com/user-attachments/assets/07369e59-0602-4fd6-bdf6-70244ea805c5">
