### PR TITLE
PaletteEdit: Use `ItemGroup` and `Item`, and avoid custom styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `PaletteEdit`: use `Item` internally instead of custom styles ([#66164](https://github.com/WordPress/gutenberg/pull/66164)).
+
 ## 28.10.0 (2024-10-16)
 
 ### Bug Fixes

--- a/packages/components/src/palette-edit/index.tsx
+++ b/packages/components/src/palette-edit/index.tsx
@@ -24,7 +24,7 @@ import Button from '../button';
 import { ColorPicker } from '../color-picker';
 import { FlexItem } from '../flex';
 import { HStack } from '../h-stack';
-import { ItemGroup } from '../item-group';
+import { Item, ItemGroup } from '../item-group';
 import { VStack } from '../v-stack';
 import GradientPicker from '../gradient-picker';
 import ColorPalette from '../color-palette';
@@ -35,7 +35,6 @@ import {
 	PaletteEditStyles,
 	PaletteHeading,
 	IndicatorStyled,
-	PaletteItem,
 	NameContainer,
 	NameInputControl,
 	DoneButton,
@@ -213,7 +212,7 @@ function Option< T extends PaletteElement >( {
 	);
 
 	return (
-		<PaletteItem ref={ setPopoverAnchor } as="div">
+		<Item ref={ setPopoverAnchor } size="small">
 			<HStack justify="flex-start">
 				<Button
 					onClick={ () => {
@@ -282,7 +281,7 @@ function Option< T extends PaletteElement >( {
 					onClose={ () => setIsEditingColor( false ) }
 				/>
 			) }
-		</PaletteItem>
+		</Item>
 	);
 }
 
@@ -309,7 +308,7 @@ function PaletteEditListView< T extends PaletteElement >( {
 
 	return (
 		<VStack spacing={ 3 }>
-			<ItemGroup isRounded>
+			<ItemGroup isRounded isBordered isSeparated>
 				{ elements.map( ( element, index ) => (
 					<Option
 						isGradient={ isGradient }

--- a/packages/components/src/palette-edit/styles.ts
+++ b/packages/components/src/palette-edit/styles.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import styled from '@emotion/styled';
-import { css } from '@emotion/react';
 
 /**
  * Internal dependencies
@@ -10,7 +9,7 @@ import { css } from '@emotion/react';
 import Button from '../button';
 import { Heading } from '../heading';
 import { space } from '../utils/space';
-import { COLORS, CONFIG, font } from '../utils';
+import { COLORS, CONFIG } from '../utils';
 import { View } from '../view';
 import InputControl from '../input-control';
 import {
@@ -39,71 +38,6 @@ export const NameInputControl = styled( InputControl )`
 			border-color: transparent;
 			box-shadow: none;
 		}
-	}
-`;
-
-const buttonStyleReset = ( {
-	as,
-}: {
-	as: React.ComponentProps< typeof View >[ 'as' ];
-} ) => {
-	if ( as === 'button' ) {
-		return css`
-			display: flex;
-			align-items: center;
-			width: 100%;
-			appearance: none;
-			background: transparent;
-			border: none;
-			border-radius: 0;
-			padding: 0;
-			cursor: pointer;
-
-			&:hover {
-				color: ${ COLORS.theme.accent };
-			}
-		`;
-	}
-	return null;
-};
-
-export const PaletteItem = styled( View )`
-	${ buttonStyleReset }
-
-	padding-block: 3px;
-	padding-inline-start: ${ space( 3 ) };
-	border: 1px solid ${ CONFIG.surfaceBorderColor };
-	border-bottom-color: transparent;
-	font-size: ${ font( 'default.fontSize' ) };
-
-	&:focus-visible {
-		border-color: transparent;
-		box-shadow: 0 0 0 var( --wp-admin-border-width-focus )
-			${ COLORS.theme.accent };
-		// Windows high contrast mode.
-		outline: 2px solid transparent;
-		outline-offset: 0;
-	}
-
-	border-top-left-radius: ${ CONFIG.radiusSmall };
-	border-top-right-radius: ${ CONFIG.radiusSmall };
-
-	& + & {
-		border-top-left-radius: 0;
-		border-top-right-radius: 0;
-	}
-
-	&:last-child {
-		border-bottom-left-radius: ${ CONFIG.radiusSmall };
-		border-bottom-right-radius: ${ CONFIG.radiusSmall };
-		border-bottom-color: ${ CONFIG.surfaceBorderColor };
-	}
-
-	&.is-selected + & {
-		border-top-color: transparent;
-	}
-	&.is-selected {
-		border-color: ${ COLORS.theme.accent };
 	}
 `;
 


### PR DESCRIPTION
## What?
This PR updates `PaletteEdit` to make use of `Item` instead of implementing custom styles.

## Why?
`PaletteEdit` currently uses `ItemGroup` in an odd way, and defines its own `Item` with a bunch of custom styles. For better consistency, when using `ItemGroup` we should be using `Item` components.

## How?
- Updating `PaletteEdit` to use `ItemGroup` with `Item`, instead of building its own custom `PaletteItem`
- Cleaning up a bunch of redundant styles related to the removed custom `PaletteEdit` palette item.

Since this uses the `Item` built-in spacing, this introduces some visual changes, so I could use a look from @WordPress/gutenberg-design. I'm happy to address any suggestions while here, but they'll need to be done inside `Item`, and AFAIK, we're aiming to work on this separately (see https://github.com/WordPress/gutenberg/issues/64445). 

## Testing Instructions
* Spin up a Storybook instance and test `PaletteEdit`:
  * Click the vertical ellipsis
  * Click "Show details"
  * Add/remove colors
  * Verify borders and spacing makes sense across different viewports. 
* Test palette editing in the site editor:
  * Go to the site editor and open the Styles sidebar
  * Click "Colors" and then the active Palette.
  * Add/edit the custom palette and verify it looks good and works well.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

Storybook, `PaletteEdit`, default story, editing palette:

|Before|After|
|---|---|
|![Screenshot 2024-10-16 at 12 47 17](https://github.com/user-attachments/assets/c3beaa52-7a45-49bb-9ff2-1beb24c9f53a)|![Screenshot 2024-10-16 at 12 47 34](https://github.com/user-attachments/assets/b5951692-cb04-497c-9982-0d4fcbcd3a73)|

Site Editor, global styles, colors, editing palette:

|Before|After|
|---|---|
|![Screenshot 2024-10-16 at 12 42 58](https://github.com/user-attachments/assets/ffe34981-f0e9-4fad-b300-2e22ddbfaad8)|![Screenshot 2024-10-16 at 12 42 12](https://github.com/user-attachments/assets/45ddd9d8-19b9-4c2e-adbd-31305291e6c7)|



