### PR TITLE
Add argument with post ID to the editor.savePost hook

### DIFF
--- a/packages/edit-post/src/store/actions.js
+++ b/packages/edit-post/src/store/actions.js
@@ -481,7 +481,7 @@ export const initializeMetaBoxes =
 		addAction(
 			'editor.savePost',
 			'core/edit-post/save-metaboxes',
-			async ( options ) => {
+			async ( post, options ) => {
 				if ( ! options.isAutosave && select.hasMetaBoxes() ) {
 					await dispatch.requestMetaBoxUpdates();
 				}

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -278,7 +278,11 @@ export const savePost =
 
 		if ( ! error ) {
 			try {
-				await doActionAsync( 'editor.savePost', options );
+				await doActionAsync(
+					'editor.savePost',
+					{ id: previousRecord.id },
+					options
+				);
 			} catch ( err ) {
 				error = err;
 			}


### PR DESCRIPTION
When writing the [dev note](https://github.com/WordPress/gutenberg/issues/65784#issuecomment-2413481249) for the `editor.savePost` action, I noticed it has a serious problem: the identity of the saved post (the ID and optionally other fields) is not passed to the action at all. The handler doesn't know anything about the post it's dealing with. It gets only the `options`, which contain flags like `isAutosave` and `isPreview` and nothing more.

This PR fixes that by adding a first argument, and object with the `id` field. The goal is mainly to be forward compatible:
- reserve the first argument for info about the post before WP 6.7 ships and it's too late.
- make the `post` argument extensible in the future. It's an object that currently contains the `id` field, and it the future it can have more fields.

The `editor.preSavePost` has a similar API already: first argument is `edits`, an object which includes the `id` field, and the second argument is the `options`.

We got to this situation because originally the hook was motivated by the "save metaboxes" action. And accidentally, the "save metaboxes" doesn't need to know the post ID, because it can read it from the metabox forms inside the page HTML. But other users of the hook are likely to run into big trouble very soon.