### PR TITLE
Fix site editor back button visual regressions

### DIFF
--- a/packages/edit-site/src/components/sidebar-button/index.js
+++ b/packages/edit-site/src/components/sidebar-button/index.js
@@ -11,7 +11,7 @@ import { Button } from '@wordpress/components';
 export default function SidebarButton( props ) {
 	return (
 		<Button
-			__next40pxDefaultSize
+			size="compact"
 			{ ...props }
 			className={ clsx( 'edit-site-sidebar-button', props.className ) }
 		/>

--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -14,7 +14,7 @@
 		outline: 3px solid transparent;
 	}
 
-	&:hover:not(:disabled,[aria-disabled=true]),
+	&:hover:not(:disabled,[aria-disabled="true"]),
 	&:focus-visible,
 	&:focus,
 	&:not([aria-disabled="true"]):active,

--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -17,7 +17,7 @@
 	&:hover:not(:disabled,[aria-disabled="true"]),
 	&:focus-visible,
 	&:focus,
-	&:not([aria-disabled="true"]):active,
+	&:not(:disabled,[aria-disabled="true"]):active,
 	&[aria-expanded="true"] {
 		color: $gray-100;
 	}

--- a/packages/edit-site/src/components/sidebar-button/style.scss
+++ b/packages/edit-site/src/components/sidebar-button/style.scss
@@ -14,7 +14,7 @@
 		outline: 3px solid transparent;
 	}
 
-	&:hover,
+	&:hover:not(:disabled,[aria-disabled=true]),
 	&:focus-visible,
 	&:focus,
 	&:not([aria-disabled="true"]):active,

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -68,7 +68,11 @@
 .edit-site-sidebar-navigation-screen__title {
 	flex-grow: 1;
 	overflow-wrap: break-word;
-	padding: $grid-unit-05 * 0.5 0 0 0;
+
+	&#{&},
+	&#{&} .edit-site-sidebar-navigation-screen__title {
+		line-height: $font-line-height-x-large;
+	}
 }
 
 .edit-site-sidebar-navigation-screen__actions {


### PR DESCRIPTION
## What?
Somewhere in the 6.7 dev cycle a couple of visual regressions were introduced to the back button in the site editor sidebar:

1. Blue color on hover / focus
2. `40px` sizing, which breaks alignment with the title

This PR addresses both issues.

## Why?
Visual polish.

## How?
1. The button now uses the `compact` (`32px`) size variant
2. I updated the `line-height` on the sidebar title to `font-line-height-x-large` (`32px`) to ensure alignment
3. Updated css to fix hover / focus color

## Testing Instructions
1. Open the site editor
2. Observe the back button in the sidebar is aligned with the title, and that it is not blue on hover / focus.

### Before

<img width="299" alt="Screenshot 2024-10-16 at 10 50 44" src="https://github.com/user-attachments/assets/12134feb-ed84-4cd9-9732-2d1d82ebc9e3">

### After

<img width="296" alt="Screenshot 2024-10-16 at 11 00 01" src="https://github.com/user-attachments/assets/5b4c817d-145c-4104-9b0b-c268a0f20045">

