### PR TITLE
Global styles: Alphabetize items.

### DIFF
--- a/packages/edit-site/src/components/global-styles/root-menu.js
+++ b/packages/edit-site/src/components/global-styles/root-menu.js
@@ -44,13 +44,13 @@ function RootMenu() {
 	return (
 		<>
 			<ItemGroup>
-				{ hasTypographyPanel && (
+				{ hasBackgroundPanel && (
 					<NavigationButtonAsItem
-						icon={ typography }
-						path="/typography"
-						aria-label={ __( 'Typography styles' ) }
+						icon={ background }
+						path="/background"
+						aria-label={ __( 'Background styles' ) }
 					>
-						{ __( 'Typography' ) }
+						{ __( 'Background' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasColorPanel && (
@@ -62,13 +62,13 @@ function RootMenu() {
 						{ __( 'Colors' ) }
 					</NavigationButtonAsItem>
 				) }
-				{ hasBackgroundPanel && (
+				{ hasLayoutPanel && (
 					<NavigationButtonAsItem
-						icon={ background }
-						path="/background"
-						aria-label={ __( 'Background styles' ) }
+						icon={ layout }
+						path="/layout"
+						aria-label={ __( 'Layout styles' ) }
 					>
-						{ __( 'Background' ) }
+						{ __( 'Layout' ) }
 					</NavigationButtonAsItem>
 				) }
 				{ hasShadowPanel && (
@@ -80,13 +80,13 @@ function RootMenu() {
 						{ __( 'Shadows' ) }
 					</NavigationButtonAsItem>
 				) }
-				{ hasLayoutPanel && (
+				{ hasTypographyPanel && (
 					<NavigationButtonAsItem
-						icon={ layout }
-						path="/layout"
-						aria-label={ __( 'Layout styles' ) }
+						icon={ typography }
+						path="/typography"
+						aria-label={ __( 'Typography styles' ) }
 					>
-						{ __( 'Layout' ) }
+						{ __( 'Typography' ) }
 					</NavigationButtonAsItem>
 				) }
 			</ItemGroup>


### PR DESCRIPTION
## What?

Global styles has grown in items to the following:

![before](https://github.com/user-attachments/assets/538e296d-7173-4678-9d77-703835d1c89d)

That's, in order:

* Typography
* Colors
* Background
* Shadows
* Layout

While there has arguably been some curation in the order of these, given recent additions, it's not clearly curated anymore. Especially if additional items were to be added, it would feel increasingly random. This PR alphabetizes:

![after](https://github.com/user-attachments/assets/8b12bf02-e50f-4023-98cc-db165e8af53b)

This is slightly more predictable as far as scanning the page for a particular item. 

## Testing Instructions

Open the site editor, open the global styles inspector, and notice the new order of items there.