### PR TITLE
Block bindings: allow the field types matching attribute types in bindings.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -5,6 +5,7 @@ import { __ } from '@wordpress/i18n';
 import {
 	getBlockBindingsSource,
 	getBlockBindingsSources,
+	getBlockType,
 } from '@wordpress/blocks';
 import {
 	__experimentalItemGroup as ItemGroup,
@@ -29,6 +30,7 @@ import {
 import { unlock } from '../lock-unlock';
 import InspectorControls from '../components/inspector-controls';
 import BlockContext from '../components/block-context';
+import { useBlockEditContext } from '../components/block-edit';
 import { useBlockBindingsUtils } from '../utils/block-bindings';
 import { store as blockEditorStore } from '../store';
 
@@ -50,9 +52,20 @@ const useToolsPanelDropdownMenuProps = () => {
 };
 
 function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
+	const { clientId } = useBlockEditContext();
 	const registeredSources = getBlockBindingsSources();
 	const { updateBlockBindings } = useBlockBindingsUtils();
 	const currentKey = binding?.args?.key;
+	const attributeType = useSelect(
+		( select ) => {
+			const { name: blockName } =
+				select( blockEditorStore ).getBlock( clientId );
+			const _attributeType =
+				getBlockType( blockName ).attributes?.[ attribute ]?.type;
+			return _attributeType === 'rich-text' ? 'string' : _attributeType;
+		},
+		[ clientId ]
+	);
 	return (
 		<>
 			{ Object.entries( fieldsList ).map( ( [ name, fields ], i ) => (
@@ -63,29 +76,33 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 								{ registeredSources[ name ].label }
 							</DropdownMenuV2.GroupLabel>
 						) }
-						{ Object.entries( fields ).map( ( [ key, args ] ) => (
-							<DropdownMenuV2.RadioItem
-								key={ key }
-								onChange={ () =>
-									updateBlockBindings( {
-										[ attribute ]: {
-											source: name,
-											args: { key },
-										},
-									} )
-								}
-								name={ attribute + '-binding' }
-								value={ key }
-								checked={ key === currentKey }
-							>
-								<DropdownMenuV2.ItemLabel>
-									{ args?.label }
-								</DropdownMenuV2.ItemLabel>
-								<DropdownMenuV2.ItemHelpText>
-									{ args?.value }
-								</DropdownMenuV2.ItemHelpText>
-							</DropdownMenuV2.RadioItem>
-						) ) }
+						{ Object.entries( fields )
+							.filter(
+								( [ , args ] ) => args?.type === attributeType
+							)
+							.map( ( [ key, args ] ) => (
+								<DropdownMenuV2.RadioItem
+									key={ key }
+									onChange={ () =>
+										updateBlockBindings( {
+											[ attribute ]: {
+												source: name,
+												args: { key },
+											},
+										} )
+									}
+									name={ attribute + '-binding' }
+									value={ key }
+									checked={ key === currentKey }
+								>
+									<DropdownMenuV2.ItemLabel>
+										{ args?.label }
+									</DropdownMenuV2.ItemLabel>
+									<DropdownMenuV2.ItemHelpText>
+										{ args?.value }
+									</DropdownMenuV2.ItemHelpText>
+								</DropdownMenuV2.RadioItem>
+							) ) }
 					</DropdownMenuV2.Group>
 					{ i !== Object.keys( fieldsList ).length - 1 && (
 						<DropdownMenuV2.Separator />

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -64,7 +64,7 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute, binding } ) {
 				getBlockType( blockName ).attributes?.[ attribute ]?.type;
 			return _attributeType === 'rich-text' ? 'string' : _attributeType;
 		},
-		[ clientId ]
+		[ clientId, attribute ]
 	);
 	return (
 		<>

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -90,7 +90,6 @@ function gutenberg_test_block_bindings_registration() {
 		'post',
 		'text_custom_field',
 		array(
-			'label'        => 'Text custom field',
 			'default'      => 'Value of the text custom field',
 			'show_in_rest' => true,
 			'single'       => true,
@@ -102,6 +101,18 @@ function gutenberg_test_block_bindings_registration() {
 		'url_custom_field',
 		array(
 			'default'      => '#url-custom-field',
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'string',
+		)
+	);
+	// Register different types of custom fields for testing.
+	register_meta(
+		'post',
+		'string_custom_field',
+		array(
+			'label'        => 'String custom field',
+			'default'      => '',
 			'show_in_rest' => true,
 			'single'       => true,
 			'type'         => 'string',

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -21,14 +21,17 @@ function gutenberg_test_block_bindings_registration() {
 		'text_field'  => array(
 			'label' => 'Text Field Label',
 			'value' => 'Text Field Value',
+			'type'  => 'string',
 		),
 		'url_field'   => array(
 			'label' => 'URL Field Label',
 			'value' => $testing_url,
+			'type'  => 'string',
 		),
 		'empty_field' => array(
 			'label' => 'Empty Field Label',
 			'value' => '',
+			'type'  => 'string',
 		),
 	);
 

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -112,10 +112,18 @@ function gutenberg_test_block_bindings_registration() {
 		'object_custom_field',
 		array(
 			'label'        => 'Object custom field',
-			'show_in_rest' => true,
+			'show_in_rest' => array(
+				'schema' => array(
+					'type'       => 'object',
+					'properties' => array(
+						'foo' => array(
+							'type' => 'string',
+						),
+					),
+				),
+			),
 			'single'       => true,
 			'type'         => 'object',
-			'default'      => json_decode( json_encode( array( 'foo' => 'bar' ) ), false ),
 		)
 	);
 	register_meta(

--- a/packages/e2e-tests/plugins/block-bindings.php
+++ b/packages/e2e-tests/plugins/block-bindings.php
@@ -90,6 +90,7 @@ function gutenberg_test_block_bindings_registration() {
 		'post',
 		'text_custom_field',
 		array(
+			'label'        => 'Text custom field',
 			'default'      => 'Value of the text custom field',
 			'show_in_rest' => true,
 			'single'       => true,
@@ -106,6 +107,69 @@ function gutenberg_test_block_bindings_registration() {
 			'type'         => 'string',
 		)
 	);
+	register_meta(
+		'post',
+		'object_custom_field',
+		array(
+			'label'        => 'Object custom field',
+			'show_in_rest' => true,
+			'single'       => true,
+			'type'         => 'object',
+			'default'      => json_decode( json_encode( array( 'foo' => 'bar' ) ), false ),
+		)
+	);
+	register_meta(
+		'post',
+		'array_custom_field',
+		array(
+			'label'        => 'Array custom field',
+			'show_in_rest' => array(
+				'schema' => array(
+					'type'  => 'array',
+					'items' => array(
+						'type' => 'string',
+					),
+				),
+			),
+			'single'       => true,
+			'type'         => 'array',
+			'default'      => array(),
+		)
+	);
+	register_meta(
+		'post',
+		'number',
+		array(
+			'label'        => 'Number custom field',
+			'type'         => 'number',
+			'show_in_rest' => true,
+			'single'       => true,
+			'default'      => 5.5,
+		)
+	);
+	register_meta(
+		'post',
+		'integer',
+		array(
+			'label'        => 'Integer custom field',
+			'type'         => 'integer',
+			'show_in_rest' => true,
+			'single'       => true,
+			'default'      => 5,
+		)
+	);
+	register_meta(
+		'post',
+		'boolean',
+		array(
+			'label'        => 'Boolean custom field',
+			'type'         => 'boolean',
+			'show_in_rest' => true,
+			'single'       => true,
+			'default'      => true,
+		)
+	);
+
 	// Register CPT custom fields.
 	register_meta(
 		'post',

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -56,10 +56,8 @@ function getPostMetaFields( select, context ) {
 			key !== 'footnotes' &&
 			// Don't include private fields.
 			key.charAt( 0 ) !== '_' &&
-			// Don't support boolean, object, and array fields yet.
-			typeof entityMetaValues?.[ key ] !== 'boolean' &&
-			typeof entityMetaValues?.[ key ] !== 'object' &&
-			! Array.isArray( entityMetaValues?.[ key ] )
+			// Only support string types.
+			typeof entityMetaValues?.[ key ] === 'string'
 		) {
 			metaFields[ key ] = {
 				label: props.title || key,

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -55,9 +55,7 @@ function getPostMetaFields( select, context ) {
 			// Don't include footnotes.
 			key !== 'footnotes' &&
 			// Don't include private fields.
-			key.charAt( 0 ) !== '_' &&
-			// Only support string types.
-			typeof entityMetaValues?.[ key ] === 'string'
+			key.charAt( 0 ) !== '_'
 		) {
 			metaFields[ key ] = {
 				label: props.title || key,
@@ -66,6 +64,7 @@ function getPostMetaFields( select, context ) {
 					entityMetaValues?.[ key ] ??
 					// When using the default, an empty string IS NOT a valid value.
 					( props.default || undefined ),
+				type: props.type,
 			};
 		}
 	} );

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -51,8 +51,16 @@ function getPostMetaFields( select, context ) {
 	const registeredFields = getRegisteredPostMeta( context?.postType );
 	const metaFields = {};
 	Object.entries( registeredFields || {} ).forEach( ( [ key, props ] ) => {
-		// Don't include footnotes or private fields.
-		if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
+		if (
+			// Don't include footnotes.
+			key !== 'footnotes' &&
+			// Don't include private fields.
+			key.charAt( 0 ) !== '_' &&
+			// Don't support boolean, object, and array fields yet.
+			typeof entityMetaValues?.[ key ] !== 'boolean' &&
+			typeof entityMetaValues?.[ key ] !== 'object' &&
+			! Array.isArray( entityMetaValues?.[ key ] )
+		) {
 			metaFields[ key ] = {
 				label: props.title || key,
 				value:

--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -51,12 +51,8 @@ function getPostMetaFields( select, context ) {
 	const registeredFields = getRegisteredPostMeta( context?.postType );
 	const metaFields = {};
 	Object.entries( registeredFields || {} ).forEach( ( [ key, props ] ) => {
-		if (
-			// Don't include footnotes.
-			key !== 'footnotes' &&
-			// Don't include private fields.
-			key.charAt( 0 ) !== '_'
-		) {
+		// Don't include footnotes or private fields.
+		if ( key !== 'footnotes' && key.charAt( 0 ) !== '_' ) {
 			metaFields[ key ] = {
 				label: props.title || key,
 				value:

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -236,14 +236,14 @@ test.describe( 'Post Meta source', () => {
 			} ) => {
 				const globalField = page
 					.getByRole( 'menuitemradio' )
-					.filter( { hasText: 'text_custom_field' } );
+					.filter( { hasText: 'Text custom field' } );
 				await expect( globalField ).toBeVisible();
 			} );
 			test( 'should not include protected fields', async ( { page } ) => {
 				// Ensure the fields have loaded by checking the field is visible.
 				const globalField = page
 					.getByRole( 'menuitemradio' )
-					.filter( { hasText: 'text_custom_field' } );
+					.filter( { hasText: 'Text custom field' } );
 				await expect( globalField ).toBeVisible();
 				// Check the protected fields are not visible.
 				const protectedField = page
@@ -322,7 +322,7 @@ test.describe( 'Post Meta source', () => {
 			// Check the post meta fields are not visible.
 			const globalField = page
 				.getByRole( 'menuitemradio' )
-				.filter( { hasText: 'text_custom_field' } );
+				.filter( { hasText: 'Text custom field' } );
 			await expect( globalField ).toBeHidden();
 			const movieField = page
 				.getByRole( 'menuitemradio' )

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -236,14 +236,14 @@ test.describe( 'Post Meta source', () => {
 			} ) => {
 				const globalField = page
 					.getByRole( 'menuitemradio' )
-					.filter( { hasText: 'Text custom field' } );
+					.filter( { hasText: 'text_custom_field' } );
 				await expect( globalField ).toBeVisible();
 			} );
 			test( 'should not include protected fields', async ( { page } ) => {
 				// Ensure the fields have loaded by checking the field is visible.
 				const globalField = page
 					.getByRole( 'menuitemradio' )
-					.filter( { hasText: 'Text custom field' } );
+					.filter( { hasText: 'text_custom_field' } );
 				await expect( globalField ).toBeVisible();
 				// Check the protected fields are not visible.
 				const protectedField = page
@@ -258,6 +258,7 @@ test.describe( 'Post Meta source', () => {
 			test( 'should show the default value if it is defined', async ( {
 				page,
 			} ) => {
+				await page.pause();
 				const fieldButton = page
 					.getByRole( 'menuitemradio' )
 					.filter( { hasText: 'Movie field label' } );
@@ -322,7 +323,7 @@ test.describe( 'Post Meta source', () => {
 			// Check the post meta fields are not visible.
 			const globalField = page
 				.getByRole( 'menuitemradio' )
-				.filter( { hasText: 'Text custom field' } );
+				.filter( { hasText: 'text_custom_field' } );
 			await expect( globalField ).toBeHidden();
 			const movieField = page
 				.getByRole( 'menuitemradio' )
@@ -567,7 +568,7 @@ test.describe( 'Post Meta source', () => {
 				.click();
 			await expect(
 				page.getByRole( 'menuitemradio', {
-					name: 'Text custom field',
+					name: 'String custom field',
 				} )
 			).toBeVisible();
 			await expect(

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -574,12 +574,12 @@ test.describe( 'Post Meta source', () => {
 				page.getByRole( 'menuitemradio', {
 					name: 'Number custom field',
 				} )
-			).toBeVisible();
+			).toBeHidden();
 			await expect(
 				page.getByRole( 'menuitemradio', {
 					name: 'Integer custom field',
 				} )
-			).toBeVisible();
+			).toBeHidden();
 			await expect(
 				page.getByRole( 'menuitemradio', {
 					name: 'Boolean custom field',

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -547,5 +547,54 @@ test.describe( 'Post Meta source', () => {
 				.filter( { hasText: 'Movie field label' } );
 			await expect( movieField ).toBeVisible();
 		} );
+		test( 'should not be possible to connect non-supported fields through the attributes panel', async ( {
+			editor,
+			page,
+		} ) => {
+			await editor.insertBlock( {
+				name: 'core/paragraph',
+			} );
+			await page.getByLabel( 'Attributes options' ).click();
+			await page
+				.getByRole( 'menuitemcheckbox', {
+					name: 'Show content',
+				} )
+				.click();
+			await page
+				.getByRole( 'button', {
+					name: 'content',
+				} )
+				.click();
+			await expect(
+				page.getByRole( 'menuitemradio', {
+					name: 'Text custom field',
+				} )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'menuitemradio', {
+					name: 'Number custom field',
+				} )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'menuitemradio', {
+					name: 'Integer custom field',
+				} )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'menuitemradio', {
+					name: 'Boolean custom field',
+				} )
+			).toBeHidden();
+			await expect(
+				page.getByRole( 'menuitemradio', {
+					name: 'Object custom field',
+				} )
+			).toBeHidden();
+			await expect(
+				page.getByRole( 'menuitemradio', {
+					name: 'Array custom field',
+				} )
+			).toBeHidden();
+		} );
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -258,7 +258,6 @@ test.describe( 'Post Meta source', () => {
 			test( 'should show the default value if it is defined', async ( {
 				page,
 			} ) => {
-				await page.pause();
 				const fieldButton = page
 					.getByRole( 'menuitemradio' )
 					.filter( { hasText: 'Movie field label' } );


### PR DESCRIPTION
I still want to:
- Explore if this should be handled at a framework level or is the source the one in charge of ensuring to pass valid values. I want to check how other APIs like `updateBlockAttributes` handle this.
- Explore if we should disable number and integers. All the supported attributes are type "string" if I am not mistaken. And converting numbers to strings can get tricky because it will trigger errors when we do setValues.
- Explore if it would be better to check the attribute type with the field type.
- Add more e2e tests to cover those use cases.

## What?
Fix a bug where the Attributes panel breaks the block when there are fields with type "object" or "array" defined.

## Why?
This is not the expected behavior.

## How?
Restricting the type of fields that can be used.

## Testing Instructions
I added a e2e test.
1. Register object, number, and integer custom fields:
```
register_meta(
	'post',
	'object_custom_field',
	array(
		'label'        => 'Object custom field',
		'show_in_rest' => array(
			'schema' => array(
				'type'       => 'object',
				'properties' => array(
					'foo' => array(
						'type' => 'string',
					),
				),
			),
		),
		'single'       => true,
		'type'         => 'object',
	)
);

register_meta(
	'post',
	'number',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'number',
		'default'      => 1,
	)
);

register_meta(
	'post',
	'integer',
	array(
		'show_in_rest' => true,
		'single'       => true,
		'type'         => 'integer',
		'default'      => 2,
	)
);
```
2. Go to a page, click on a paragraph, go to the attributes panel.
3. Try to connect the content and see it is not possible to connect to the object field. Previously, it was and it broke the block.