### PR TITLE
Wrap overflow: auto in media query for smaller screens only

### DIFF
--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -60,6 +60,10 @@ html.interface-interface-skeleton__html-container {
 		overflow: auto;
 	}
 
+	@include break-medium() {
+		overflow-y: auto;
+	}
+
 	// In future versions of Mobile Safari, hopefully overscroll-behavior will be supported.
 	// This allows us to disallow the scroll-chaining and rubber-banding that is currently
 	// is the cause of the issue outlined above.

--- a/packages/interface/src/components/interface-skeleton/style.scss
+++ b/packages/interface/src/components/interface-skeleton/style.scss
@@ -56,7 +56,9 @@ html.interface-interface-skeleton__html-container {
 	// or beyond the bottom of the page when the soft keyboard is showing, you scroll
 	// the body element and can scroll the toolbar out of view.
 	// This is still preferable, though, as it allows the editor to function at all.
-	overflow: auto;
+	@media (max-width: #{ ($break-medium - 1) }) {
+		overflow: auto;
+	}
 
 	// In future versions of Mobile Safari, hopefully overscroll-behavior will be supported.
 	// This allows us to disallow the scroll-chaining and rubber-banding that is currently


### PR DESCRIPTION
## What?
Addresses #66161 and #66156

## Why?
The appearance of double vertical scrollbars was occurring in certain instances of the interface where the viewport height was small. It seemed to be triggered by the `overflow: auto`, which had a previous code comment indicating that the `overflow: auto` was implemented to circumvent issues with mobile Safari. Based on the commentary it seems we would want the `overflow: auto` to only impact smaller horizontal screens and not smaller vertical screens.

## How?
By wrapping the `overflow: auto` in a media query: `@media (max-width: #{ ($break-medium - 1) }) ` we make sure the overflow is only applied to smaller horizontal screens.

## Testing Instructions

The original bug reported in #66161 impacts small vertical screens.

1. Open the block editor on a desktop device with a small vertical height.
2. Open the block inserter sidebar and note the right-most vertical scrollbar(s)
3. Begin typing to find a block and note the right-most vertical scrollbar(s)

## Screenshots or screencast 

| Before | After |
|---------|------------|
| <video src="https://github.com/user-attachments/assets/eb734078-14b8-4819-b90e-07554c799de8"> | <video src="https://github.com/user-attachments/assets/35533ffd-5129-4503-a4f4-dce68dc5978d"> |
