### PR TITLE
Components: Prevent generated readmes duplicating h1 elements when published

### DIFF
--- a/bin/api-docs/gen-components-docs/markdown/index.mjs
+++ b/bin/api-docs/gen-components-docs/markdown/index.mjs
@@ -10,8 +10,8 @@ import { generateMarkdownPropsJson } from './props.mjs';
 
 export function generateMarkdownDocs( { typeDocs, subcomponentTypeDocs } ) {
 	const mainDocsJson = [
-		'<!-- This file is generated automatically and cannot be edited directly. -->\n',
 		{ h1: typeDocs.displayName },
+		'<!-- This file is generated automatically and cannot be edited directly. Make edits via TypeScript types and TSDocs. -->',
 		{
 			p: `<p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-${ typeDocs.displayName.toLowerCase() }--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>`,
 		},

--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -1,7 +1,6 @@
-<!-- This file is generated automatically and cannot be edited directly. -->
-
 # AlignmentMatrixControl
 
+<!-- This file is generated automatically and cannot be edited directly. Make edits via TypeScript types and TSDocs. -->
 
 <p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-alignmentmatrixcontrol--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>
 

--- a/packages/components/src/angle-picker-control/README.md
+++ b/packages/components/src/angle-picker-control/README.md
@@ -1,7 +1,6 @@
-<!-- This file is generated automatically and cannot be edited directly. -->
-
 # AnglePickerControl
 
+<!-- This file is generated automatically and cannot be edited directly. Make edits via TypeScript types and TSDocs. -->
 
 <p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-anglepickercontrol--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>
 


### PR DESCRIPTION
## What?

Fixes an issue with autogenerated component readmes (#66035) that causes a duplicate `h1` element when published to the Block Editor Handbook.

## Why?

[Autogenerated readmes](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/alignment-matrix-control/README.md?plain=1) have a duplicated `h1` element [when published](https://developer.wordpress.org/block-editor/reference-guides/components/alignment-matrix-control/), even though [manual readmes](https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/base-control/README.md?plain=1) also have a `h1` element at the top of the markdown and [don't get duplicated](https://developer.wordpress.org/block-editor/reference-guides/components/base-control/).

### Duplicated

<img width="600" alt="Top of doc page for AlignmentMatrixControl" src="https://github.com/user-attachments/assets/14a2116e-3537-4809-a5d9-f1bdc2b1c6d6">

### Non-duplicated
<img width="600" alt="Top of doc page for BaseControl" src="https://github.com/user-attachments/assets/2cd2d257-b39d-4a07-b2fd-2a530ea2f176">

Turns out, the [script](https://github.com/WordPress/wporg-developer/blob/034722c393dc768ad00b78887b04d781d87d6f67/source/wp-content/themes/wporg-developer-2023/inc/import-block-editor.php#L284-L288) that de-duplicates the `h1` only works when the very first thing in the markdown file is the `h1`.

## How?

Move the comment down so the `h1` can be the first thing in the markdown.

## Testing Instructions

We'll see when this is published 🤞 
