### PR TITLE
Interactivity API: Fix reactivity of undefined objects and arrays added with `deepMerge`

### DIFF
--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 -   Fix an issue where "default" could not be used as a directive suffix ([#65815](https://github.com/WordPress/gutenberg/pull/65815)).
 -   Correctly handle lazily added, deeply nested properties with `deepMerge()` ([#65465](https://github.com/WordPress/gutenberg/pull/65465)).
+-   Fix reactivity of undefined objects and arrays added with `deepMerge()` ([#66183](https://github.com/WordPress/gutenberg/pull/66183)).
 
 ## 6.9.0 (2024-10-03)
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix reactivity of undefined objects and arrays added with `deepMerge()` ([#66183](https://github.com/WordPress/gutenberg/pull/66183)).
+
 ## 6.10.0 (2024-10-16)
 
 ### Internal
@@ -12,7 +16,6 @@
 
 -   Fix an issue where "default" could not be used as a directive suffix ([#65815](https://github.com/WordPress/gutenberg/pull/65815)).
 -   Correctly handle lazily added, deeply nested properties with `deepMerge()` ([#65465](https://github.com/WordPress/gutenberg/pull/65465)).
--   Fix reactivity of undefined objects and arrays added with `deepMerge()` ([#66183](https://github.com/WordPress/gutenberg/pull/66183)).
 
 ## 6.9.0 (2024-10-03)
 

--- a/packages/interactivity/src/proxies/state.ts
+++ b/packages/interactivity/src/proxies/state.ts
@@ -335,7 +335,10 @@ const deepMergeRecursive = (
 			if ( isNew || ( override && ! isPlainObject( target[ key ] ) ) ) {
 				target[ key ] = {};
 				if ( propSignal ) {
-					propSignal.setValue( target[ key ] );
+					const ns = getNamespaceFromProxy( proxy );
+					propSignal.setValue(
+						proxifyState( ns, target[ key ] as Object )
+					);
 				}
 			}
 			if ( isPlainObject( target[ key ] ) ) {
@@ -344,7 +347,11 @@ const deepMergeRecursive = (
 		} else if ( override || isNew ) {
 			Object.defineProperty( target, key, desc );
 			if ( propSignal ) {
-				propSignal.setValue( desc.value );
+				const { value } = desc;
+				const ns = getNamespaceFromProxy( proxy );
+				propSignal.setValue(
+					shouldProxy( value ) ? proxifyState( ns, value ) : value
+				);
 			}
 		}
 	}

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -465,5 +465,61 @@ describe( 'Interactivity API', () => {
 			expect( target.message.content ).toBeUndefined();
 			expect( target.message.fontStyle ).toBeUndefined();
 		} );
+
+		it( 'should keep reactivity of objects that are initially undefined', () => {
+			const target: any = proxifyState( 'test', {} );
+
+			let deepValue: any;
+			const spy = jest.fn( () => {
+				deepValue = target.obj?.nested;
+			} );
+			effect( spy );
+
+			// Initial call, the deep value is undefined
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( deepValue ).toBeUndefined();
+
+			// Use deepMerge to add a deeply nested object to the target
+			deepMerge( target, { obj: { nested: 'value 1' } } );
+
+			// The effect should be called again
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( deepValue ).toBe( 'value 1' );
+
+			// Modify the nested value
+			target.obj.nested = 'value 2';
+
+			// The effect should be called again
+			expect( spy ).toHaveBeenCalledTimes( 3 );
+			expect( deepValue ).toBe( 'value 2' );
+		} );
+
+		it( 'should keep reactivity of arrays that are initially undefined', () => {
+			const target: any = proxifyState( 'test', {} );
+
+			let deepValue: any;
+			const spy = jest.fn( () => {
+				deepValue = target.array?.[ 0 ];
+			} );
+			effect( spy );
+
+			// Initial call, the deep value is undefined
+			expect( spy ).toHaveBeenCalledTimes( 1 );
+			expect( deepValue ).toBeUndefined();
+
+			// Use deepMerge to add an array to the target
+			deepMerge( target, { array: [ 'value 1' ] } );
+
+			// The effect should be called again
+			expect( spy ).toHaveBeenCalledTimes( 2 );
+			expect( deepValue ).toBe( 'value 1' );
+
+			// Modify the array value
+			target.array[ 0 ] = 'value 2';
+
+			// The effect should be called again
+			expect( spy ).toHaveBeenCalledTimes( 3 );
+			expect( deepValue ).toBe( 'value 2' );
+		} );
 	} );
 } );

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -379,7 +379,10 @@ describe( 'Interactivity API', () => {
 			const target = proxifyState< any >( 'test', { a: 1, b: 2 } );
 			const source = { a: 1, b: 2, c: 3 };
 
-			const spy = jest.fn( () => Object.keys( target ) );
+			let keys: any;
+			const spy = jest.fn( () => {
+				keys = Object.keys( target );
+			} );
 			effect( spy );
 
 			expect( spy ).toHaveBeenCalledTimes( 1 );
@@ -387,7 +390,7 @@ describe( 'Interactivity API', () => {
 			deepMerge( target, source, false );
 
 			expect( spy ).toHaveBeenCalledTimes( 2 );
-			expect( spy ).toHaveLastReturnedWith( [ 'a', 'b', 'c' ] );
+			expect( keys ).toEqual( [ 'a', 'b', 'c' ] );
 		} );
 
 		it( 'should handle deeply nested properties that are initially undefined', () => {

--- a/packages/interactivity/src/proxies/test/deep-merge.ts
+++ b/packages/interactivity/src/proxies/test/deep-merge.ts
@@ -415,6 +415,13 @@ describe( 'Interactivity API', () => {
 
 			// Reading the value directly should also work
 			expect( target.a.b.c.d ).toBe( 'test value' );
+
+			// Modify the nested value
+			target.a.b.c.d = 'new test value';
+
+			// The effect should be called again
+			expect( spy ).toHaveBeenCalledTimes( 3 );
+			expect( deepValue ).toBe( 'new test value' );
 		} );
 
 		it( 'should overwrite values that become objects', () => {
@@ -464,34 +471,6 @@ describe( 'Interactivity API', () => {
 			expect( target.message ).toBe( 'hello' );
 			expect( target.message.content ).toBeUndefined();
 			expect( target.message.fontStyle ).toBeUndefined();
-		} );
-
-		it( 'should keep reactivity of objects that are initially undefined', () => {
-			const target: any = proxifyState( 'test', {} );
-
-			let deepValue: any;
-			const spy = jest.fn( () => {
-				deepValue = target.obj?.nested;
-			} );
-			effect( spy );
-
-			// Initial call, the deep value is undefined
-			expect( spy ).toHaveBeenCalledTimes( 1 );
-			expect( deepValue ).toBeUndefined();
-
-			// Use deepMerge to add a deeply nested object to the target
-			deepMerge( target, { obj: { nested: 'value 1' } } );
-
-			// The effect should be called again
-			expect( spy ).toHaveBeenCalledTimes( 2 );
-			expect( deepValue ).toBe( 'value 1' );
-
-			// Modify the nested value
-			target.obj.nested = 'value 2';
-
-			// The effect should be called again
-			expect( spy ).toHaveBeenCalledTimes( 3 );
-			expect( deepValue ).toBe( 'value 2' );
 		} );
 
 		it( 'should keep reactivity of arrays that are initially undefined', () => {


### PR DESCRIPTION
## What?

Fixes a regression that breaks the reactivity of props from lazily instantiated objects/arrays inside the iAPI state or context.

The bug affects all directives reading properties from **any** lazily instantiated objects, e.g., those created by a module loaded asynchronously or during client-side navigation, impacting developers with such cases.

At this moment, it affects the loading bar that the  `@wordpress/interactivity-router` module shows during navigations, which currently requires the following PHP code to work correctly ([link](https://github.com/sirreal/wordpress-develop/blob/e09839e079b75bd32e9bab0aad0502c0ee333886/src/wp-includes/interactivity-api/class-wp-interactivity-api.php#L1045-L1056)), although it shouldn't be necessary:

```php
/*
 * Initialize the `core/router` store.
 * If the store is not initialized like this with minimal
 * navigation object, the interactivity-router script module
 * errors.
 */
$this->state(
	'core/router',
	array(
		'navigation' => new stdClass(),
	)
);
```

Props to @sirreal for pointing this out in https://github.com/sirreal/wordpress-develop/pull/8.

## Why?

The bug could affect developers whose blocks depend on lazily instantiated objects/arrays inside the iAPI state or context.

## How?

This PR fixes the `deepMerge()` function, ensuring it "proxifies" newly created objects and arrays so they become "reactive".

## Testing Instructions

The following instructions should be followed in a WP instance where [this lines](https://github.com/sirreal/wordpress-develop/blob/e09839e079b75bd32e9bab0aad0502c0ee333886/src/wp-includes/interactivity-api/class-wp-interactivity-api.php#L1045-L1056) are removed.

To reproduce the issue:
1. **Check out `trunk`**
2. In the site editor, ensure the homepage contains a Query block with the "Force page reload" setting disabled.
3. Ensure you have enough posts to have more than one page in the Query block.
4. Visit the homepage of your dev site.
5. Log out to hide the admin top bar.
6. Open the browser dev tools. In the Network tab, set a slow throttling preset so the next page takes some time to load.
7. In the pagination block, click on "next page".
8. Check that the top bar doesn't appear.

To ensure the issue is fixed:
1. **Check out this PR**
2. Repeat previous steps 2 to 7.
3. Check that the top bar now appears as expected.