### PR TITLE
[WIP] - centralize editor canvas container hooks and logic

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -132,6 +132,8 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 	}, [] );
 	useEditorTitle();
 	const _isPreviewingTheme = isPreviewingTheme();
+	// This checks the fills length. It might be faster to test editorCanvasView === undefined && editorCanvasView !== 'global-styles-css' instead
+	// from a custom hook.
 	const hasDefaultEditorCanvasView = ! useHasEditorCanvasContainer();
 	const iframeProps = useEditorIframeProps();
 	const isEditMode = canvasMode === 'edit';
@@ -158,9 +160,8 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		],
 		[ settings.styles, canvasMode, currentPostIsTrashed ]
 	);
-	const { setCanvasMode, openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
+	const { setCanvasMode, openGeneralSidebar, setEditorCanvasContainerView } =
+		unlock( useDispatch( editSiteStore ) );
 
 	useEffect( () => {
 		if (

--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -11,6 +11,7 @@ import {
 	store as editorStore,
 	privateApis as editorPrivateApis,
 } from '@wordpress/editor';
+import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -23,6 +24,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import DefaultSidebar from './default-sidebar';
 
 const { interfaceStore } = unlock( editorPrivateApis );
+const { useLocation } = unlock( routerPrivateApis );
 
 export default function GlobalStylesSidebar() {
 	const {
@@ -32,6 +34,7 @@ export default function GlobalStylesSidebar() {
 		hasRevisions,
 		isRevisionsOpened,
 		isRevisionsStyleBookOpened,
+		isGlobalStylesOpen,
 	} = useSelect( ( select ) => {
 		const { getActiveComplementaryArea } = select( interfaceStore );
 		const { getEditorCanvasContainerView, getCanvasMode } = unlock(
@@ -52,12 +55,14 @@ export default function GlobalStylesSidebar() {
 		const globalStyles = globalStylesId
 			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
 			: undefined;
+		const _isGlobalStylesOpen =
+			_isEditCanvasMode &&
+			'edit-site/global-styles' === getActiveComplementaryArea( 'core' );
 
 		return {
 			isStyleBookOpened: 'style-book' === canvasContainerView,
 			shouldClearCanvasContainerView:
-				'edit-site/global-styles' !==
-					getActiveComplementaryArea( 'core' ) ||
+				! _isGlobalStylesOpen ||
 				! _isVisualEditorMode ||
 				! _isEditCanvasMode,
 			showListViewByDefault: _showListViewByDefault,
@@ -67,13 +72,22 @@ export default function GlobalStylesSidebar() {
 				'global-styles-revisions:style-book' === canvasContainerView,
 			isRevisionsOpened:
 				'global-styles-revisions' === canvasContainerView,
+			isGlobalStylesOpen: _isGlobalStylesOpen,
 		};
 	}, [] );
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
+	const { params } = useLocation();
 
 	useEffect( () => {
+/*		if (
+			isGlobalStylesOpen &&
+			params.path === '/wp_global_styles/style-book'
+		) {
+			setEditorCanvasContainerView( 'style-book' );
+			return;
+		}*/
 		if ( shouldClearCanvasContainerView ) {
 			setEditorCanvasContainerView( undefined );
 		}
@@ -125,6 +139,7 @@ export default function GlobalStylesSidebar() {
 			icon={ styles }
 			closeLabel={ __( 'Close Styles' ) }
 			panelClassName="edit-site-global-styles-sidebar__panel"
+			isActiveByDefault={ params?.path.startsWith( '/wp_global_styles' ) }
 			header={
 				<Flex
 					className="edit-site-global-styles-sidebar__header"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Open global styles sidebar and style book based on param

- need to think about state - the url param should update as style book is closed
- and should this be in the history?

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
