### PR TITLE
useSelect: Make deps optional param.

### DIFF
--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -851,7 +851,7 @@ function Paste( { children } ) {
 _Parameters_
 
 -   _mapSelect_ `T`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
--   _deps_ `unknown[]=`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
+-   _deps_ `unknown[]`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_
 

--- a/packages/data/README.md
+++ b/packages/data/README.md
@@ -851,7 +851,7 @@ function Paste( { children } ) {
 _Parameters_
 
 -   _mapSelect_ `T`: Function called on every state change. The returned value is exposed to the component implementing this hook. The function receives the `registry.select` method on the first argument and the `registry` on the second argument. When a store key is passed, all selectors for the store will be returned. This is only meant for usage of these selectors in event callbacks, not for data needed to create the element tree.
--   _deps_ `unknown[]`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
+-   _deps_ `unknown[]=`: If provided, this memoizes the mapSelect so the same `mapSelect` is invoked on every state change unless the dependencies change.
 
 _Returns_
 

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -237,9 +237,9 @@ function useMappingSelect( suspense, mapSelect, deps ) {
  * In general, this custom React hook follows the
  * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
  *
- * @template {MapSelect} T
+ * @template {MapSelect} M
  * @overload
- * @param {T}         mapSelect Function called on every state change. The returned value is
+ * @param {M}         mapSelect Function called on every state change. The returned value is
  *                              exposed to the component implementing this hook. The function
  *                              receives the `registry.select` method on the first argument
  *                              and the `registry` on the second argument.
@@ -248,7 +248,7 @@ function useMappingSelect( suspense, mapSelect, deps ) {
  *                              callbacks, not for data needed to create the element tree.
  * @param {unknown[]} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
  *                              invoked on every state change unless the dependencies change.
- * @return {UseSelectReturn<T>} A custom react hook.
+ * @return {UseSelectReturn<M>} A custom react hook.
  */
 
 /**
@@ -257,16 +257,16 @@ function useMappingSelect( suspense, mapSelect, deps ) {
  * In general, this custom React hook follows the
  * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
  *
- * @template {StoreDescriptor<any>} T
+ * @template {StoreDescriptor<any>} S
  * @overload
- * @param {T} mapSelect Function called on every state change. The returned value is
+ * @param {S} mapSelect Function called on every state change. The returned value is
  *                      exposed to the component implementing this hook. The function
  *                      receives the `registry.select` method on the first argument
  *                      and the `registry` on the second argument.
  *                      When a store key is passed, all selectors for the store will be
  *                      returned. This is only meant for usage of these selectors in event
  *                      callbacks, not for data needed to create the element tree.
- * @return {UseSelectReturn<T>} A custom react hook.
+ * @return {UseSelectReturn<S>} A custom react hook.
  */
 
 /**

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -237,16 +237,54 @@ function useMappingSelect( suspense, mapSelect, deps ) {
  * In general, this custom React hook follows the
  * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
  *
+ * @template {MapSelect} T
+ * @overload
+ * @param {T}         mapSelect Function called on every state change. The returned value is
+ *                              exposed to the component implementing this hook. The function
+ *                              receives the `registry.select` method on the first argument
+ *                              and the `registry` on the second argument.
+ *                              When a store key is passed, all selectors for the store will be
+ *                              returned. This is only meant for usage of these selectors in event
+ *                              callbacks, not for data needed to create the element tree.
+ * @param {unknown[]} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
+ *                              invoked on every state change unless the dependencies change.
+ * @return {UseSelectReturn<T>} A custom react hook.
+ */
+
+/**
+ * Custom react hook for retrieving props from registered selectors.
+ *
+ * In general, this custom React hook follows the
+ * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
+ *
+ * @template {StoreDescriptor<any>} T
+ * @overload
+ * @param {T} mapSelect Function called on every state change. The returned value is
+ *                      exposed to the component implementing this hook. The function
+ *                      receives the `registry.select` method on the first argument
+ *                      and the `registry` on the second argument.
+ *                      When a store key is passed, all selectors for the store will be
+ *                      returned. This is only meant for usage of these selectors in event
+ *                      callbacks, not for data needed to create the element tree.
+ * @return {UseSelectReturn<T>} A custom react hook.
+ */
+
+/**
+ * Custom react hook for retrieving props from registered selectors.
+ *
+ * In general, this custom React hook follows the
+ * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
+ *
  * @template {MapSelect | StoreDescriptor<any>} T
- * @param {T}          mapSelect Function called on every state change. The returned value is
- *                               exposed to the component implementing this hook. The function
- *                               receives the `registry.select` method on the first argument
- *                               and the `registry` on the second argument.
- *                               When a store key is passed, all selectors for the store will be
- *                               returned. This is only meant for usage of these selectors in event
- *                               callbacks, not for data needed to create the element tree.
- * @param {unknown[]=} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
- *                               invoked on every state change unless the dependencies change.
+ * @param {T}         mapSelect Function called on every state change. The returned value is
+ *                              exposed to the component implementing this hook. The function
+ *                              receives the `registry.select` method on the first argument
+ *                              and the `registry` on the second argument.
+ *                              When a store key is passed, all selectors for the store will be
+ *                              returned. This is only meant for usage of these selectors in event
+ *                              callbacks, not for data needed to create the element tree.
+ * @param {unknown[]} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
+ *                              invoked on every state change unless the dependencies change.
  *
  * @example
  * ```js

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -238,15 +238,15 @@ function useMappingSelect( suspense, mapSelect, deps ) {
  * [rules of hooks](https://react.dev/reference/rules/rules-of-hooks).
  *
  * @template {MapSelect | StoreDescriptor<any>} T
- * @param {T}         mapSelect Function called on every state change. The returned value is
- *                              exposed to the component implementing this hook. The function
- *                              receives the `registry.select` method on the first argument
- *                              and the `registry` on the second argument.
- *                              When a store key is passed, all selectors for the store will be
- *                              returned. This is only meant for usage of these selectors in event
- *                              callbacks, not for data needed to create the element tree.
- * @param {unknown[]} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
- *                              invoked on every state change unless the dependencies change.
+ * @param {T}          mapSelect Function called on every state change. The returned value is
+ *                               exposed to the component implementing this hook. The function
+ *                               receives the `registry.select` method on the first argument
+ *                               and the `registry` on the second argument.
+ *                               When a store key is passed, all selectors for the store will be
+ *                               returned. This is only meant for usage of these selectors in event
+ *                               callbacks, not for data needed to create the element tree.
+ * @param {unknown[]=} deps      If provided, this memoizes the mapSelect so the same `mapSelect` is
+ *                               invoked on every state change unless the dependencies change.
  *
  * @example
  * ```js


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Update jsdoc to explicitly state that deps is optional.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The deps parameter in useSelect is optional, allowing usage such as const { getSettings } = useSelect( myCustomStore ). However, in the built type information, deps is set as a required parameter, causing this code to throw an error when using TypeScript. Therefore, we will revise the JSDoc to modify the generated type information.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. npm run build
2. check packages/data/build-types/components/use-select/index.d.ts
