### PR TITLE
Block toolbar: account for scrollable blocks that affect the position of the block toolbar

### DIFF
--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -149,6 +149,14 @@ export function getVisibleElementBounds( element ) {
 		for ( const child of currentElement.children ) {
 			if ( isElementVisible( child ) ) {
 				const childBounds = child.getBoundingClientRect();
+				// If the child is larger than the parent, adjust the x and y values to account for any scrolling.
+				if ( childBounds.width > bounds.width ) {
+					childBounds.x = bounds.x;
+				}
+				if ( childBounds.height > bounds.height ) {
+					childBounds.y = bounds.y;
+					childBounds.height = bounds.height;
+				}
 				bounds = rectUnion( bounds, childBounds );
 				stack.push( child );
 			}


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/66112


## What?

The while that gets the rect bounds of the child, including the x and y values, which change when the element is scrolled. This change attempts to correct the overflow so the scrollable children do not influence the x,y values of the popover.


## Why?

Hard to control what you can't see. This makes the block toolbar positioning more robust for extenders.

## How?

Adjust calculated x/y values to account for any scrolling.

## Testing Instructions

### Navigation block with child extending beyond the nav block's bounds

This will confirm that the original fix from https://github.com/WordPress/gutenberg/pull/62711#issuecomment-2413101197 still works.

1. Switch to EmptyTheme and navigate to Appearance > Editor
2. Click on the canvas and add a navigation block to the header 
3. Move the navigation block to the very first position in the block list to force the toolbar below the block
4. Add a submenu to the navigation if it doesn't already have one
5. Ensure that the block toolbar moves down to accomodate the submenu when it is opened i.e. the toolbar shouldn't overlap the navigation or submenu blocks
6. Confirm the toolbar behaves appropriately when adding new submenu items or scrolling the overall page

### Scrollable block toolbars

Follow the nice and detailed instructions on https://github.com/WordPress/gutenberg/issues/66112

TL;DR

1. Edit a post, open dev tools and paste in the snippet from the issue to create some test blocks that scroll
2. Add the test blocks to a long post with several paragraphs
3. Select each of the horizontal and vertical scrolling blocks and confirm their toolbar stays in the correct location
4. Scroll down the page and ensure their toolbars disappear correctly as the block leaves the viewport

### Block Popovers and Visualizers

1. Edit a post and add blocks that have a block popover e.g. Cover block with its resizable popover
2. Add some blocks that support spacing visualizers e.g. Group block with padding and margin support
3. Confirm that the visualizers and popovers display appropriately (visualizers have some problems on trunk not matching the controls value immediately so ignore them)A



## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1e541993-cfa9-497a-aea1-00e45eb41daf



