### PR TITLE
Add featured image alt text

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -188,7 +188,26 @@ function PostFeaturedImage( {
 										<img
 											className="editor-post-featured-image__preview-image"
 											src={ mediaSourceUrl }
-											alt=""
+											alt={
+												media.alt_text
+													? sprintf(
+															// Translators: %s: The selected image alt text.
+															__(
+																'Current image: %s'
+															),
+															media.alt_text
+													  )
+													: sprintf(
+															// Translators: %s: The selected image filename.
+															__(
+																'The current image has no alternative text. The file name is: %s'
+															),
+															media.media_details
+																.sizes?.full
+																?.file ||
+																media.slug
+													  )
+											}
 										/>
 									) }
 									{ isLoading && <Spinner /> }

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -122,7 +122,7 @@ function PostFeaturedImage( {
 	}
 
 	/**
-	 * Generates a description for the given image media object.
+	 * Get image Alt text.
 	 *
 	 * @param {Object} imageMedia                               - The image media object.
 	 * @param {string} imageMedia.alt_text                      - The alternative text of the image.

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -121,6 +121,35 @@ function PostFeaturedImage( {
 		} );
 	}
 
+	/**
+	 * Generates a description for the given image media object.
+	 *
+	 * @param {Object} imageMedia                               - The image media object.
+	 * @param {string} imageMedia.alt_text                      - The alternative text of the image.
+	 * @param {Object} imageMedia.media_details                 - The media details of the image.
+	 * @param {Object} imageMedia.media_details.sizes           - The sizes of the image.
+	 * @param {Object} imageMedia.media_details.sizes.full      - The full size details of the image.
+	 * @param {string} imageMedia.media_details.sizes.full.file - The file name of the full size image.
+	 * @param {string} imageMedia.slug                          - The slug of the image.
+	 * @return {string} The description of the image.
+	 */
+	function getImageDescription( imageMedia ) {
+		if ( imageMedia.alt_text ) {
+			return sprintf(
+				// Translators: %s: The selected image alt text.
+				__( 'Current image: %s' ),
+				imageMedia.alt_text
+			);
+		}
+		return sprintf(
+			// Translators: %s: The selected image filename.
+			__(
+				'The current image has no alternative text. The file name is: %s'
+			),
+			imageMedia.media_details.sizes?.full?.file || imageMedia.slug
+		);
+	}
+
 	return (
 		<PostFeaturedImageCheck>
 			{ noticeUI }
@@ -130,21 +159,7 @@ function PostFeaturedImage( {
 						id={ `editor-post-featured-image-${ featuredImageId }-describedby` }
 						className="hidden"
 					>
-						{ media.alt_text &&
-							sprintf(
-								// Translators: %s: The selected image alt text.
-								__( 'Current image: %s' ),
-								media.alt_text
-							) }
-						{ ! media.alt_text &&
-							sprintf(
-								// Translators: %s: The selected image filename.
-								__(
-									'The current image has no alternative text. The file name is: %s'
-								),
-								media.media_details.sizes?.full?.file ||
-									media.slug
-							) }
+						{ getImageDescription( media ) }
 					</div>
 				) }
 				<MediaUploadCheck fallback={ instructions }>
@@ -188,26 +203,7 @@ function PostFeaturedImage( {
 										<img
 											className="editor-post-featured-image__preview-image"
 											src={ mediaSourceUrl }
-											alt={
-												media.alt_text
-													? sprintf(
-															// Translators: %s: The selected image alt text.
-															__(
-																'Current image: %s'
-															),
-															media.alt_text
-													  )
-													: sprintf(
-															// Translators: %s: The selected image filename.
-															__(
-																'The current image has no alternative text. The file name is: %s'
-															),
-															media.media_details
-																.sizes?.full
-																?.file ||
-																media.slug
-													  )
-											}
+											alt={ getImageDescription( media ) }
 										/>
 									) }
 									{ isLoading && <Spinner /> }

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -122,16 +122,16 @@ function PostFeaturedImage( {
 	}
 
 	/**
-	 * Get image Alt text.
+	 * Generates the featured image alt text for this editing context.
 	 *
-	 * @param {Object} imageMedia                               - The image media object.
-	 * @param {string} imageMedia.alt_text                      - The alternative text of the image.
-	 * @param {Object} imageMedia.media_details                 - The media details of the image.
-	 * @param {Object} imageMedia.media_details.sizes           - The sizes of the image.
-	 * @param {Object} imageMedia.media_details.sizes.full      - The full size details of the image.
-	 * @param {string} imageMedia.media_details.sizes.full.file - The file name of the full size image.
-	 * @param {string} imageMedia.slug                          - The slug of the image.
-	 * @return {string} The description of the image.
+	 * @param {Object} imageMedia                               The image media object.
+	 * @param {string} imageMedia.alt_text                      The alternative text of the image.
+	 * @param {Object} imageMedia.media_details                 The media details of the image.
+	 * @param {Object} imageMedia.media_details.sizes           The sizes of the image.
+	 * @param {Object} imageMedia.media_details.sizes.full      The full size details of the image.
+	 * @param {string} imageMedia.media_details.sizes.full.file The file name of the full size image.
+	 * @param {string} imageMedia.slug                          The slug of the image.
+	 * @return {string} The featured image alt text.
 	 */
 	function getImageDescription( imageMedia ) {
 		if ( imageMedia.alt_text ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Addresses part of #66005

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR ensures that when an image fails to load (i.e., is broken), the alt text is displayed in its place. If alt text is not provided, the image name will be displayed instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This update improves accessibility and enhances user experience by providing context when an image fails to load. Instead of leaving a blank space or displaying a broken image icon, the alt text or image name will be shown, offering users helpful information.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The implementation involves updating the image rendering logic to check if the image fails to load. If it does, the alt text (if available) will be displayed. If the alt text is not provided, the image name will be used as a fallback display.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Alt Text 1](https://github.com/user-attachments/assets/aed94853-b584-47f8-a5b1-fc0dec79b732)
![Alt Text 2](https://github.com/user-attachments/assets/ee379ba1-8769-4702-8dda-f7661f97e594)



