### PR TITLE
ItemGroup: Improve stories to default to bordered and separated

### DIFF
--- a/packages/components/src/item-group/stories/index.story.tsx
+++ b/packages/components/src/item-group/stories/index.story.tsx
@@ -69,8 +69,7 @@ export const NonClickableItems: StoryFn< typeof ItemGroup > = Template.bind(
 	{}
 );
 NonClickableItems.args = {
-	isBordered: true,
-	isSeparated: true,
+	...Default.args,
 	children: (
 		[
 			{
@@ -87,8 +86,7 @@ NonClickableItems.args = {
 
 export const CustomItemSize: StoryFn< typeof ItemGroup > = Template.bind( {} );
 CustomItemSize.args = {
-	isBordered: true,
-	isSeparated: true,
+	...Default.args,
 	children: (
 		[
 			{

--- a/packages/components/src/item-group/stories/index.story.tsx
+++ b/packages/components/src/item-group/stories/index.story.tsx
@@ -37,6 +37,8 @@ const Template: StoryFn< typeof ItemGroup > = ( props ) => (
 
 export const Default: StoryFn< typeof ItemGroup > = Template.bind( {} );
 Default.args = {
+	isBordered: true,
+	isSeparated: true,
 	children: (
 		[
 			{
@@ -67,6 +69,8 @@ export const NonClickableItems: StoryFn< typeof ItemGroup > = Template.bind(
 	{}
 );
 NonClickableItems.args = {
+	isBordered: true,
+	isSeparated: true,
 	children: (
 		[
 			{
@@ -83,6 +87,8 @@ NonClickableItems.args = {
 
 export const CustomItemSize: StoryFn< typeof ItemGroup > = Template.bind( {} );
 CustomItemSize.args = {
+	isBordered: true,
+	isSeparated: true,
 	children: (
 		[
 			{
@@ -98,9 +104,9 @@ CustomItemSize.args = {
 	 ).map( mapPropsToItem ),
 };
 
-export const WithBorder: StoryFn< typeof ItemGroup > = Template.bind( {} );
-WithBorder.args = {
+export const WithoutBorder: StoryFn< typeof ItemGroup > = Template.bind( {} );
+WithoutBorder.args = {
 	...Default.args,
-	isBordered: true,
-	isSeparated: true,
+	isBordered: false,
+	isSeparated: false,
 };


### PR DESCRIPTION
## What?
Improves the `ItemGroup` stories to have bordered and separated styles.

## Why?
Because this is the most common usage and it demonstrates better how the component is composed.

## How?
Enabling `isBordered` and `isSeparated` for all stories, and inverting the "WithBorder" story to be a "WithoutBorder" one. 

## Testing Instructions
Spin up a Storybook instance and test `ItemGroup` - go through all stories and ensure bordered and separated is now the default, and the non-bordered story works correctly.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|---|---|
|![Screenshot 2024-10-16 at 12 48 49](https://github.com/user-attachments/assets/b34d374f-d1d9-4866-837e-94845298082f)|![Screenshot 2024-10-16 at 12 48 35](https://github.com/user-attachments/assets/33e14458-4d3e-4533-8680-9fb31bdeac8f)|



