### PR TITLE
Feature : Refactor Autocomplete using DropdownMenu

### DIFF
--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -22,12 +22,12 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  */
 import getDefaultUseItems from './get-default-use-items';
 import Button from '../button';
-import Popover from '../popover';
 import { VisuallyHidden } from '../visually-hidden';
 import { createPortal } from 'react-dom';
 import type { AutocompleterUIProps, KeyedOption, WPCompleter } from './types';
+import DropdownMenu from '../dropdown-menu';
 
-type ListBoxProps = {
+type DropdownItemsProps = {
 	items: KeyedOption[];
 	onSelect: ( option: KeyedOption ) => void;
 	selectedIndex: number;
@@ -37,7 +37,7 @@ type ListBoxProps = {
 	Component?: React.ElementType;
 };
 
-function ListBox( {
+function DropdownItems( {
 	items,
 	onSelect,
 	selectedIndex,
@@ -45,11 +45,10 @@ function ListBox( {
 	listBoxId,
 	className,
 	Component = 'div',
-}: ListBoxProps ) {
+}: DropdownItemsProps ) {
 	return (
 		<Component
 			id={ listBoxId }
-			role="listbox"
 			className="components-autocomplete__results"
 		>
 			{ items.map( ( option, index ) => (
@@ -175,28 +174,37 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 		}
 
 		return (
-			<>
-				<Popover
-					focusOnMount={ false }
-					onClose={ onReset }
-					placement="top-start"
+			<div>
+				<DropdownMenu
+					label={ __( 'Select a block.' ) }
+					defaultOpen
+					icon={ <></> }
 					className="components-autocomplete__popover"
-					anchor={ popoverAnchor }
 					ref={ popoverRefs }
+					popoverProps={ {
+						anchor: popoverAnchor,
+						onClose: onReset,
+					} }
+					onClose={ onReset }
+					focusOnMount={ false }
 				>
-					<ListBox
-						items={ items }
-						onSelect={ onSelect }
-						selectedIndex={ selectedIndex }
-						instanceId={ instanceId }
-						listBoxId={ listBoxId }
-						className={ className }
-					/>
-				</Popover>
+					{ () => (
+						<>
+							<DropdownItems
+								items={ items }
+								onSelect={ onSelect }
+								selectedIndex={ selectedIndex }
+								instanceId={ instanceId }
+								listBoxId={ listBoxId }
+								className={ className }
+							/>
+						</>
+					) }
+				</DropdownMenu>
 				{ contentRef.current &&
 					needsA11yCompat &&
 					createPortal(
-						<ListBox
+						<DropdownItems
 							items={ items }
 							onSelect={ onSelect }
 							selectedIndex={ selectedIndex }
@@ -207,7 +215,7 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 						/>,
 						contentRef.current.ownerDocument.body
 					) }
-			</>
+			</div>
 		);
 	}
 

--- a/packages/components/src/autocomplete/style.scss
+++ b/packages/components/src/autocomplete/style.scss
@@ -1,6 +1,10 @@
-.components-autocomplete__popover .components-popover__content {
-	padding: $grid-unit-10;
-	min-width: 200px;
+.components-autocomplete__popover {
+	height: 0;
+
+	.components-popover__content {
+		padding: $grid-unit-10;
+		min-width: 200px;
+	}
 }
 
 .components-autocomplete__result.components-button {

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -53,7 +53,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 		disableOpenOnArrowDown = false,
 		text,
 		noIcons,
-
+		focusOnMount,
 		open,
 		defaultOpen,
 		onToggle: onToggleProp,
@@ -212,6 +212,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 			open={ open }
 			defaultOpen={ defaultOpen }
 			onToggle={ onToggleProp }
+			focusOnMount={ focusOnMount }
 		/>
 	);
 }

--- a/packages/components/src/dropdown-menu/types.ts
+++ b/packages/components/src/dropdown-menu/types.ts
@@ -142,6 +142,12 @@ export type DropdownMenuProps = {
 	 */
 	controls?: DropdownOption[] | DropdownOption[][];
 	/**
+	 * Prop to control whether the dropdown menu should focus on mount.
+	 *
+	 * @default true
+	 */
+	focusOnMount?: boolean;
+	/**
 	 * The controlled open state of the dropdown menu.
 	 * Must be used in conjunction with `onToggle`.
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Refactor `Autocomplete` component using `DropdownMenu` instead of custom `ListBox`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/64323

### Issues
- The `Type / to chose a block` text disappears when the `/` is erased
- After typing `/`, it works perfectly but when the `popover is open`, and we `switch tab` or the `window` and return to editor and remove the `/`, an error is thrown which `breaks the block`.
