### PR TITLE
Tabs and TabPanel: Fix arrow key navigation in RTL

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `ColorPalette`: prevent overflow of custom color button background ([#66152](https://github.com/WordPress/gutenberg/pull/66152)).
+-   `Tabs` and `TabPanel`: Fix arrow key navigation in RTL ([#66201](https://github.com/WordPress/gutenberg/pull/66201)).
 
 ### Enhancements
 

--- a/packages/components/src/tab-panel/index.tsx
+++ b/packages/components/src/tab-panel/index.tsx
@@ -16,6 +16,7 @@ import {
 	useCallback,
 } from '@wordpress/element';
 import { useInstanceId, usePrevious } from '@wordpress/compose';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -120,6 +121,7 @@ const UnforwardedTabPanel = (
 		orientation,
 		selectOnMove,
 		defaultSelectedId: prependInstanceId( initialTabName ),
+		rtl: isRTL(),
 	} );
 
 	const selectedTabName = extractTabName(

--- a/packages/components/src/tabs/index.tsx
+++ b/packages/components/src/tabs/index.tsx
@@ -14,6 +14,7 @@ import {
 	useMemo,
 	useRef,
 } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -45,6 +46,7 @@ function Tabs( {
 			onSelect?.( strippedDownId );
 		},
 		selectedId: selectedTabId && `${ instanceId }-${ selectedTabId }`,
+		rtl: isRTL(),
 	} );
 
 	const isControlled = selectedTabId !== undefined;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #64963

Respect writing direction when using arrow keys to navigate the tabs in the `Tabs` and `TabPanel` components

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should respect the writing direction

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

using the `rtl` utility to detect writing direction, and passing that information to the underlying ariakit store

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- See default Storybook story for `Tabs` and `TabPanel`
- Toggle the examples to RTL mode in the toolbar.
- Test that arrow key navigation works as expected.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/f1a98769-82d3-4d56-b582-200257500918" /> | <video src="https://github.com/user-attachments/assets/b8088d69-a743-4b37-9b3c-ec5e116bca21" /> |

