### PR TITLE
RadioGroup: Fix arrow key navigation in RTL

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 -   `ColorPalette`: prevent overflow of custom color button background ([#66152](https://github.com/WordPress/gutenberg/pull/66152)).
+-   `RadioGroup`: Fix arrow key navigation in RTL  ([#66202](https://github.com/WordPress/gutenberg/pull/66202)).
 
 ### Enhancements
 

--- a/packages/components/src/radio-group/index.tsx
+++ b/packages/components/src/radio-group/index.tsx
@@ -7,6 +7,7 @@ import * as Ariakit from '@ariakit/react';
  * WordPress dependencies
  */
 import { useMemo, forwardRef } from '@wordpress/element';
+import { isRTL } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -34,6 +35,7 @@ function UnforwardedRadioGroup(
 		setValue: ( newValue ) => {
 			onChange?.( newValue ?? undefined );
 		},
+		rtl: isRTL(),
 	} );
 
 	const contextValue = useMemo(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #64963

Respect writing direction when using arrow keys to navigate the tabs in the `RadioGroup` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We should respect the writing direction

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

using the `rtl` utility to detect writing direction, and passing that information to the underlying ariakit store

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- See default Storybook story for `Tabs` and `TabPanel`
- Toggle the examples to RTL mode in the toolbar.
- Test that arrow key navigation works as expected.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/6ec38558-0756-4b2c-8224-f166befe2033" /> | <video src="https://github.com/user-attachments/assets/54cd9307-f37b-4695-80be-264305f3262f" /> 

