### PR TITLE
Table Block: Remove hasArrowIndicator prop

### DIFF
--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -465,7 +465,6 @@ function TableEdit( {
 					</BlockControls>
 					<BlockControls group="other">
 						<ToolbarDropdownMenu
-							hasArrowIndicator
 							icon={ table }
 							label={ __( 'Edit table' ) }
 							controls={ tableControls }


### PR DESCRIPTION
## What?
The hasArrowIndicator prop in the ToolbarDropdownMenu component was [removed over 4 years ago](https://github.com/WordPress/gutenberg/pull/19344/files#diff-da8d7b7eafd3a9a503ac2f8f120ef1c89ecf4d84112e1b8397f13ab526a310eeL41), and it no longer exists anywhere else, so it can be safely removed.

## Why?
Closes:- https://github.com/WordPress/gutenberg/issues/66203

## How?
By removing the hasArrowIndicator prop from the ToolbarDropdownMenu component