### PR TITLE
Tabs: update indicator more reactively

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   `RadioGroup`: Fix arrow key navigation in RTL ([#66202](https://github.com/WordPress/gutenberg/pull/66202)).
 -   `Tabs` and `TabPanel`: Fix arrow key navigation in RTL ([#66201](https://github.com/WordPress/gutenberg/pull/66201)).
 -   `Tabs`: override tablist's tabindex only when necessary ([#66209](https://github.com/WordPress/gutenberg/pull/66209)).
+-   `Tabs`: update indicator more reactively ([#66207](https://github.com/WordPress/gutenberg/pull/66207)).
 
 ### Enhancements
 

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -68,9 +68,13 @@ export const TabList = forwardRef<
 	const items = useStoreState( store, 'items' );
 	const [ parent, setParent ] = useState< HTMLElement >();
 	const refs = useMergeRefs( [ ref, setParent ] );
-	const selectedRect = useTrackElementOffsetRect(
-		store?.item( selectedId )?.element
-	);
+
+	const selectedItem = store?.item( selectedId );
+	const renderedItems = Ariakit.useStoreState( store, 'renderedItems' );
+	const selectedItemIndex = renderedItems?.indexOf( selectedItem! ) ?? -1;
+	const selectedRect = useTrackElementOffsetRect( selectedItem?.element, [
+		selectedItemIndex,
+	] );
 
 	// Track overflow to show scroll hints.
 	const overflow = useTrackOverflow( parent, {

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import * as Ariakit from '@ariakit/react';
+import clsx from 'clsx';
 
 /**
  * WordPress dependencies
@@ -14,11 +15,10 @@ import { useMergeRefs } from '@wordpress/compose';
  * Internal dependencies
  */
 import type { TabListProps } from './types';
+import type { WordPressComponentProps } from '../context';
+import type { ElementOffsetRect } from '../utils/element-rect';
 import { useTabsContext } from './context';
 import { StyledTabList } from './styles';
-import type { WordPressComponentProps } from '../context';
-import clsx from 'clsx';
-import type { ElementOffsetRect } from '../utils/element-rect';
 import { useTrackElementOffsetRect } from '../utils/element-rect';
 import { useTrackOverflow } from './use-track-overflow';
 import { useAnimatedOffsetRect } from '../utils/hooks/use-animated-offset-rect';

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -71,7 +71,13 @@ export const TabList = forwardRef<
 
 	const selectedItem = store?.item( selectedId );
 	const renderedItems = Ariakit.useStoreState( store, 'renderedItems' );
-	const selectedItemIndex = renderedItems?.indexOf( selectedItem! ) ?? -1;
+
+	const selectedItemIndex =
+		renderedItems && selectedItem
+			? renderedItems.indexOf( selectedItem )
+			: -1;
+	// Use selectedItemIndex as a dependency to force recalculation when the
+	// selected item index changes (elements are swapped / added / removed).
 	const selectedRect = useTrackElementOffsetRect( selectedItem?.element, [
 		selectedItemIndex,
 	] );

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useStoreState } from '@ariakit/react';
+import * as Ariakit from '@ariakit/react';
 
 /**
  * WordPress dependencies
@@ -62,10 +62,10 @@ export const TabList = forwardRef<
 >( function TabList( { children, ...otherProps }, ref ) {
 	const { store } = useTabsContext() ?? {};
 
-	const selectedId = useStoreState( store, 'selectedId' );
-	const activeId = useStoreState( store, 'activeId' );
-	const selectOnMove = useStoreState( store, 'selectOnMove' );
-	const items = useStoreState( store, 'items' );
+	const selectedId = Ariakit.useStoreState( store, 'selectedId' );
+	const activeId = Ariakit.useStoreState( store, 'activeId' );
+	const selectOnMove = Ariakit.useStoreState( store, 'selectOnMove' );
+	const items = Ariakit.useStoreState( store, 'items' );
 	const [ parent, setParent ] = useState< HTMLElement >();
 	const refs = useMergeRefs( [ ref, setParent ] );
 

--- a/packages/components/src/utils/element-rect.ts
+++ b/packages/components/src/utils/element-rect.ts
@@ -141,7 +141,9 @@ export function useTrackElementOffsetRect(
 	const intervalRef = useRef< ReturnType< typeof setInterval > >();
 
 	const measure = useEvent( () => {
-		if ( targetElement ) {
+		// Check that the targetElement is still attached to the DOM, in case
+		// it was removed since the last `measure` call.
+		if ( targetElement && targetElement.isConnected ) {
 			const elementOffsetRect = getElementOffsetRect( targetElement );
 			if ( elementOffsetRect ) {
 				setIndicatorPosition( elementOffsetRect );

--- a/packages/components/src/utils/element-rect.ts
+++ b/packages/components/src/utils/element-rect.ts
@@ -134,7 +134,8 @@ const POLL_RATE = 100;
  * milliseconds until it succeeds.
  */
 export function useTrackElementOffsetRect(
-	targetElement: HTMLElement | undefined | null
+	targetElement: HTMLElement | undefined | null,
+	deps: unknown[] = []
 ) {
 	const [ indicatorPosition, setIndicatorPosition ] =
 		useState< ElementOffsetRect >( NULL_ELEMENT_OFFSET_RECT );
@@ -172,6 +173,16 @@ export function useTrackElementOffsetRect(
 			setIndicatorPosition( NULL_ELEMENT_OFFSET_RECT );
 		}
 	}, [ setElement, targetElement ] );
+
+	// Escape hatch to force a remeasurement when something else changes rather
+	// than the target elements' ref or size (for example, the target element
+	// can change its position within the tablist).
+	useLayoutEffect( () => {
+		measure();
+		// `measure` is a stable function, so it's safe to omit it from the deps array.
+		// deps can't be statically analyzed by ESLint
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, deps );
 
 	return indicatorPosition;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #65576

Improve how `Tabs` reacts to changes to tabs in the tablist other than resizing 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes a bug 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

So far, we were re-measuring the indicator position only when the tab's dimensions change (via a `ResizeObserver), but this was not enough. For example, a tab item could be swapped with another one, or one or more tab items could be added/removed to the tablist.

The changes in this PR introduce a way to add a dependency array to the hook in charge of measuring the indicator size, so that we can arbitrarily recalculate. For now, `Tabs` is using the index of the selected tab item as the dependency, but in the future we may want to add more as needed (even use a `MutationObserver`).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

The bug flagged in #65576 should be gone.

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| <video src="https://github.com/user-attachments/assets/5feaa858-f866-44c5-89bf-0127bb33931f" /> | <video src="https://github.com/user-attachments/assets/102f6ec4-ba04-42b0-b8ce-c4c6e750e00d" /> |
