### PR TITLE
Tabs: override tablist's tabindex only when necessary

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `ColorPalette`: prevent overflow of custom color button background ([#66152](https://github.com/WordPress/gutenberg/pull/66152)).
 -   `RadioGroup`: Fix arrow key navigation in RTL ([#66202](https://github.com/WordPress/gutenberg/pull/66202)).
 -   `Tabs` and `TabPanel`: Fix arrow key navigation in RTL ([#66201](https://github.com/WordPress/gutenberg/pull/66201)).
+-   `Tabs`: override tablist's tabindex only when necessary ([#66209](https://github.com/WordPress/gutenberg/pull/66209)).
 
 ### Enhancements
 

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -112,7 +112,12 @@ export const TabList = forwardRef<
 			ref={ refs }
 			store={ store }
 			render={ ( props ) => (
-				<div { ...props } tabIndex={ props.tabIndex ?? -1 } />
+				<div
+					{ ...props }
+					// Fallback to -1 to prevent browsers from making the tablist
+					// tabbable when it is a scrolling container.
+					tabIndex={ props.tabIndex ?? -1 }
+				/>
 			) }
 			onBlur={ onBlur }
 			data-select-on-move={ selectOnMove ? 'true' : 'false' }

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -111,8 +111,10 @@ export const TabList = forwardRef<
 		<StyledTabList
 			ref={ refs }
 			store={ store }
+			render={ ( props ) => (
+				<div { ...props } tabIndex={ props.tabIndex ?? -1 } />
+			) }
 			onBlur={ onBlur }
-			tabIndex={ -1 }
 			data-select-on-move={ selectOnMove ? 'true' : 'false' }
 			{ ...otherProps }
 			className={ clsx(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from https://github.com/WordPress/gutenberg/pull/66097#discussion_r1801287450

This PR tweaks the `Tabs.Tablist` component so that the element's tabbability is primarily controlled by ariakit 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the tablist element has a fixed `tabIndex={-1}`, which is in place to prevent browsers from focussing the tablist when it's a scroll container — we want to opt out from it since the component knows how to handle keyboard scrolling without interference from the browser.

But this override is a bit too invasive and prevents `ariakit` from setting `tabindex={0}` when the selected tab id is `null` — in that case, in fact, the tablist is meant to be tabbable.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Tweak the tablist code, giving priority to ariakit's `tabIndex` value and only setting `tabIndex={-1}` if a value from `ariakit` is not provided.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- set up a controlled `Tab` component
- set `selectedTabId` to `null`
- make sure that no tabs are selected, no tab panels are shown
- press tab — make sure that the tablist receives focus, and that pressing arrow keys correctly selects tabs in the tablist
