### PR TITLE
Storybook: Organizes components under 'Utilities'

### DIFF
--- a/packages/components/src/animate/stories/index.story.tsx
+++ b/packages/components/src/animate/stories/index.story.tsx
@@ -10,7 +10,8 @@ import { Animate } from '..';
 import Notice from '../../notice';
 
 const meta: Meta< typeof Animate > = {
-	title: 'Components/Animate',
+	title: 'Components/Utilities/Animate',
+	id: 'components-animate',
 	component: Animate,
 	parameters: {
 		controls: { expanded: true },

--- a/packages/components/src/composite/stories/index.story.tsx
+++ b/packages/components/src/composite/stories/index.story.tsx
@@ -16,7 +16,8 @@ import { Composite } from '..';
 import { Tooltip } from '../../tooltip';
 
 const meta: Meta< typeof Composite > = {
-	title: 'Components/Composite',
+	title: 'Components/Utilities/Composite',
+	id: 'components-composite',
 	component: Composite,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170

--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -18,7 +18,8 @@ import TextareaControl from '../../textarea-control/';
 import { VStack } from '../../v-stack/';
 
 const meta: Meta< typeof Disabled > = {
-	title: 'Components/Disabled',
+	title: 'Components/Utilities/Disabled',
+	id: 'components-disabled',
 	component: Disabled,
 	argTypes: {
 		as: { control: { type: null } },

--- a/packages/components/src/draggable/stories/index.story.tsx
+++ b/packages/components/src/draggable/stories/index.story.tsx
@@ -18,7 +18,8 @@ import Draggable from '..';
 
 const meta: Meta< typeof Draggable > = {
 	component: Draggable,
-	title: 'Components/Draggable',
+	title: 'Components/Utilities/Draggable',
+	id: 'components-draggable',
 	argTypes: {
 		elementId: { control: { type: null } },
 		__experimentalDragComponent: { control: { type: null } },

--- a/packages/components/src/keyboard-shortcuts/stories/index.story.tsx
+++ b/packages/components/src/keyboard-shortcuts/stories/index.story.tsx
@@ -10,7 +10,8 @@ import KeyboardShortcuts from '..';
 
 const meta: Meta< typeof KeyboardShortcuts > = {
 	component: KeyboardShortcuts,
-	title: 'Components/KeyboardShortcuts',
+	title: 'Components/Utilities/KeyboardShortcuts',
+	id: 'components-keyboardshortcuts',
 	parameters: {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/resizable-box/stories/index.story.tsx
+++ b/packages/components/src/resizable-box/stories/index.story.tsx
@@ -14,7 +14,8 @@ import ResizableBox from '..';
 import { useState } from '@wordpress/element';
 
 const meta: Meta< typeof ResizableBox > = {
-	title: 'Components/ResizableBox',
+	title: 'Components/Utilities/ResizableBox',
+	id: 'components-resizablebox',
 	component: ResizableBox,
 	argTypes: {
 		children: { control: { type: null } },

--- a/packages/components/src/sandbox/stories/index.story.tsx
+++ b/packages/components/src/sandbox/stories/index.story.tsx
@@ -10,7 +10,8 @@ import SandBox from '..';
 
 const meta: Meta< typeof SandBox > = {
 	component: SandBox,
-	title: 'Components/SandBox',
+	title: 'Components/Utilities/SandBox',
+	id: 'components-sandbox',
 	argTypes: {
 		onFocus: { control: { type: null } },
 	},

--- a/packages/components/src/scroll-lock/stories/index.story.tsx
+++ b/packages/components/src/scroll-lock/stories/index.story.tsx
@@ -17,7 +17,8 @@ import ScrollLock from '..';
 
 const meta: Meta< typeof ScrollLock > = {
 	component: ScrollLock,
-	title: 'Components/ScrollLock',
+	title: 'Components/Utilities/ScrollLock',
+	id: 'components-scrolllock',
 	parameters: {
 		controls: { hideNoControlsWarning: true },
 		docs: { canvas: { sourceState: 'shown' } },

--- a/packages/components/src/shortcut/stories/index.story.tsx
+++ b/packages/components/src/shortcut/stories/index.story.tsx
@@ -10,7 +10,8 @@ import Shortcut from '../';
 
 const meta: Meta< typeof Shortcut > = {
 	component: Shortcut,
-	title: 'Components/Shortcut',
+	title: 'Components/Utilities/Shortcut',
+	id: 'components-shortcut',
 	parameters: {
 		controls: {
 			expanded: true,

--- a/packages/components/src/slot-fill/stories/index.story.tsx
+++ b/packages/components/src/slot-fill/stories/index.story.tsx
@@ -15,7 +15,8 @@ import { Slot, Fill, Provider as SlotFillProvider } from '../';
 
 const meta: Meta< typeof Slot > = {
 	component: Slot,
-	title: 'Components/SlotFill',
+	title: 'Components/Utilities/SlotFill',
+	id: 'components-slotfill',
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { Fill, SlotFillProvider },
 	argTypes: {

--- a/packages/components/src/theme/stories/index.story.tsx
+++ b/packages/components/src/theme/stories/index.story.tsx
@@ -13,7 +13,8 @@ import { HStack } from '../../h-stack';
 
 const meta: Meta< typeof Theme > = {
 	component: Theme,
-	title: 'Components/Theme',
+	title: 'Components/Utilities/Theme',
+	id: 'components-theme',
 	argTypes: {
 		accent: { control: { type: 'color' } },
 		background: { control: { type: 'color' } },

--- a/packages/components/src/visually-hidden/stories/index.story.tsx
+++ b/packages/components/src/visually-hidden/stories/index.story.tsx
@@ -10,7 +10,8 @@ import { VisuallyHidden } from '..';
 
 const meta: Meta< typeof VisuallyHidden > = {
 	component: VisuallyHidden,
-	title: 'Components/VisuallyHidden',
+	title: 'Components/Utilities/VisuallyHidden',
+	id: 'components-visuallyhidden',
 	argTypes: {
 		children: { control: { type: null } },
 		as: { control: { type: 'text' } },

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -132,6 +132,7 @@ export const parameters = {
 					'Contributing Guidelines',
 					'Actions',
 					'Containers',
+					'Utilities',
 				],
 				'Components (Experimental)',
 				'Icons',


### PR DESCRIPTION
## What?
This pull request includes changes to update the categorization of several components in the Storybook configuration. The updates involve changing the `title` and adding an `id` to better reflect the components' roles as utilities.

Changes to component categorization:

* [`packages/components/src/animate/stories/index.story.tsx`](diffhunk://#diff-90a8f8fb2fa5408400b45ceafa79b80d9300f861a0cd9c57276d4696430c4a25L13-R14): Updated `title` to 'Components/Utilities/Animate' and added `id` as 'components-animate'.
* [`packages/components/src/composite/stories/index.story.tsx`](diffhunk://#diff-9f4e3586ab6373dd7040a2836a214af8131c2687b2f620ef56bde389f09c9e3fL19-R20): Updated `title` to 'Components/Utilities/Composite' and added `id` as 'components-composite'.
* [`packages/components/src/disabled/stories/index.story.tsx`](diffhunk://#diff-8ab4721a7fddf366bd6ffb5da0fafb0ebf1c7bae69e201f51c2ee7dab84d99f2L21-R22): Updated `title` to 'Components/Utilities/Disabled' and added `id` as 'components-disabled'.
* [`packages/components/src/keyboard-shortcuts/stories/index.story.tsx`](diffhunk://#diff-7de8bc965e42ce76d80ccb8a08a012f8283fd56f7a911db54414e820cc132a72L13-R14): Updated `title` to 'Components/Utilities/KeyboardShortcuts' and added `id` as 'components-keyboardshortcuts'.
* [`packages/components/src/sandbox/stories/index.story.tsx`](diffhunk://#diff-b68a4e0f8db883479ed68383c1d55b564447c0729d3947cc1fa870a533f8d6b5L13-R14): Updated `title` to 'Components/Utilities/SandBox' and added `id` as 'components-sandbox'.

## Why?
This change is part of the larger [Storybook Improvements](https://make.wordpress.org/design/2024/09/17/design-systems-storybook-improvements/) and the [shared Sitemap](https://www.figma.com/board/0ZfHa37xxWoMqy7McezUNX/WordPress.org-Storybook-Sitemap?node-id=126-5118&t=ruCtnVTDVjHTfksc-1).

## How?
Organizing components in to functional groups helps categorize the content and easier to navigate and understand.


## Testing Instructions
1. `npm run storybook:dev`
2. Observe the updated navigation

## Screenshot
![CleanShot 2024-10-17 at 10 17 04@2x](https://github.com/user-attachments/assets/24a804be-64fd-49ee-9958-5a9f176ac6cd)

