### PR TITLE
BlockGroupToolbar: Better i18n context for toolbar labels

### DIFF
--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -85,27 +85,27 @@ function BlockGroupToolbar() {
 		<ToolbarGroup>
 			<ToolbarButton
 				icon={ group }
-				label={ _x( 'Group', 'verb' ) }
+				label={ _x( 'Group', 'action: convert blocks to group' ) }
 				onClick={ onConvertToGroup }
 			/>
 			{ canInsertRow && (
 				<ToolbarButton
 					icon={ row }
-					label={ _x( 'Row', 'single horizontal line' ) }
+					label={ _x( 'Row', 'action: convert blocks to row' ) }
 					onClick={ onConvertToRow }
 				/>
 			) }
 			{ canInsertStack && (
 				<ToolbarButton
 					icon={ stack }
-					label={ _x( 'Stack', 'verb' ) }
+					label={ _x( 'Stack', 'action: convert blocks to stack' ) }
 					onClick={ onConvertToStack }
 				/>
 			) }
 			{ canInsertGrid && (
 				<ToolbarButton
 					icon={ grid }
-					label={ _x( 'Grid', 'verb' ) }
+					label={ _x( 'Grid', 'action: convert blocks to grid' ) }
 					onClick={ onConvertToGrid }
 				/>
 			) }


### PR DESCRIPTION
Make it less confusing for translators to translate the actions in `BlockGroupToolbar`, specifically the buttons to convert a selection of blocks to a Group, a Row, a Stack or a Grid.

https://github.com/user-attachments/assets/4abe53ff-25e6-4d77-beb6-948dcda01ab0

/cc @pedro-mendonca 