### PR TITLE
Fix [Flaky Test] Entering zoomed out mode zooms the canvas

### DIFF
--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -12,9 +12,12 @@ test.describe( 'Zoom Out', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.beforeEach( async ( { admin, editor } ) => {
-		await admin.visitSiteEditor();
-		await editor.canvas.locator( 'body' ).click();
+	test.beforeEach( async ( { admin } ) => {
+		await admin.visitSiteEditor( {
+			postId: 'twentytwentyfour//index',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
 	} );
 
 	test( 'Entering zoomed out mode zooms the canvas', async ( {
@@ -41,6 +44,7 @@ test.describe( 'Zoom Out', () => {
 			const paddingValue = window.getComputedStyle( element ).paddingTop;
 			return parseFloat( paddingValue );
 		} );
+		await page.pause();
 		expect( htmlRect.y + paddingTop ).toBeGreaterThan( iframeRect.y );
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
 	} );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -44,7 +44,6 @@ test.describe( 'Zoom Out', () => {
 			const paddingValue = window.getComputedStyle( element ).paddingTop;
 			return parseFloat( paddingValue );
 		} );
-		await page.pause();
 		expect( htmlRect.y + paddingTop ).toBeGreaterThan( iframeRect.y );
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes https://github.com/WordPress/gutenberg/issues/66051

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

because the test was flaky and we can't have that :D

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The test setup was relying on clicking on the canvas once in the site editor and sometimes this would mean the scroll could be at the bottom of the page. This made the tests inconsistent. I'm changing it to directly open the template we are testing instead to ensure we are always at the top of the page

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Run `npm run test:e2e -- --repeat-each 20 -g "Entering zoomed out mode zooms the canvas"` to run the test 20 times and make sure it doesn't fail. It used to fail half of the time before in my local install