### PR TITLE
Fix empty Patterns inserter when selecting section root when editing Pages in Site Editor

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -79,7 +79,8 @@ function useInsertionPoint( {
 				getBlockRootClientId,
 				getBlockIndex,
 				getBlockOrder,
-			} = select( blockEditorStore );
+				getSectionRootClientId,
+			} = unlock( select( blockEditorStore ) );
 			const selectedBlockClientId = getSelectedBlockClientId();
 
 			let _destinationRootClientId = rootClientId;
@@ -92,9 +93,16 @@ function useInsertionPoint( {
 				// Insert after a specific client ID.
 				_destinationIndex = getBlockIndex( clientId );
 			} else if ( ! isAppender && selectedBlockClientId ) {
-				_destinationRootClientId = getBlockRootClientId(
-					selectedBlockClientId
-				);
+				const sectionRootClientId = getSectionRootClientId();
+
+				if ( sectionRootClientId === selectedBlockClientId ) {
+					_destinationRootClientId = sectionRootClientId;
+				} else {
+					_destinationRootClientId = getBlockRootClientId(
+						selectedBlockClientId
+					);
+				}
+
 				_destinationIndex = getBlockIndex( selectedBlockClientId ) + 1;
 			} else {
 				// Insert at the end of the list.

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -97,13 +97,16 @@ function useInsertionPoint( {
 
 				if ( sectionRootClientId === selectedBlockClientId ) {
 					_destinationRootClientId = sectionRootClientId;
+					_destinationIndex = getBlockOrder(
+						_destinationRootClientId
+					).length;
 				} else {
 					_destinationRootClientId = getBlockRootClientId(
 						selectedBlockClientId
 					);
+					_destinationIndex =
+						getBlockIndex( selectedBlockClientId ) + 1;
 				}
-
-				_destinationIndex = getBlockIndex( selectedBlockClientId ) + 1;
 			} else {
 				// Insert at the end of the list.
 				_destinationIndex = getBlockOrder(

--- a/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-insertion-point.js
@@ -80,6 +80,7 @@ function useInsertionPoint( {
 				getBlockIndex,
 				getBlockOrder,
 				getSectionRootClientId,
+				__unstableGetEditorMode,
 			} = unlock( select( blockEditorStore ) );
 			const selectedBlockClientId = getSelectedBlockClientId();
 
@@ -95,7 +96,13 @@ function useInsertionPoint( {
 			} else if ( ! isAppender && selectedBlockClientId ) {
 				const sectionRootClientId = getSectionRootClientId();
 
-				if ( sectionRootClientId === selectedBlockClientId ) {
+				// Avoids empty inserter when the selected block is acting
+				// as the "root".
+				// See https://github.com/WordPress/gutenberg/pull/66214.
+				if (
+					__unstableGetEditorMode() === 'zoom-out' &&
+					sectionRootClientId === selectedBlockClientId
+				) {
 					_destinationRootClientId = sectionRootClientId;
 					_destinationIndex = getBlockOrder(
 						_destinationRootClientId


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix empty Patterns inserter when `core/post-content` is selected when editing a `Page` in the Site Editor

Fixes https://github.com/WordPress/gutenberg/issues/65833

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As [detailed in the Issue](https://github.com/WordPress/gutenberg/issues/65833#issuecomment-2419786754), it's possible to select the `core/post-content` block when editing Pages in the Site Editor. This is expected functionality for Zoom Out.

However, when selecting this block the Patterns inserter shows "empty" because the block root for the block is part of the Template and is thus disabled.

This provides a confusing UX because this section is acting as the defacto "root" of the canvas and thus when selected it should:

- show Patterns
- allow patterns to be inserted inside it.

The problem is:

- [the Patterns "look up" code can accept an "Optional target root client ID"](https://github.com/WordPress/gutenberg/blob/388dd815225f6b880b180c75686ce4ec08bb4139/packages/block-editor/src/store/selectors.js#L2422-L2430) which is then used to filter the found patterns.
- this `rootClientId` is provided by the variable `destinationRootClientId` returned from the `useInsertionPoint` hook which [gets passed to `<PatternCategoryPreviews>`](https://github.com/WordPress/gutenberg/blob/4f3da917d2991b6e2cb08bf9ee72b1c2b07a6bc0/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js#L52-L56)
- if a block is selected then the logic within `useInsertionPoint` means that the `_destinationRootClientId` is set by calling `getBlockRootClientId(selectedBlockClientId)`. This returns the root block from which the block is nested which is then used to determine which Patterns are elligable. Remember it is this value which ultimately [gets passed to `__experimentalGetAllowedPatterns()` as `rootClientId`](https://github.com/WordPress/gutenberg/blob/388dd815225f6b880b180c75686ce4ec08bb4139/packages/block-editor/src/store/selectors.js#L2426)
- when editing a _Page_ in the Site Editor the block returned by `getBlockRootClientId(selectedBlockClientId)` is sometimes part of the _Template_ and is thus `disabled` via `getBlockEditingMode`. Typically it's the `<main>` block that wraps `Header`, `Post Content` and `Footer`.
- this means no Patterns can be inserted into that block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

What we need to do is ensure that if the selected block is the `sectionRootClientId` then we consider it to be the "root block" for which to look up eligible Patterns.

When a Pattern is inserted, we set the insertion index to be at the end of the section root block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Site Editor
- Open a Page
- Insert a few paragraph blocks (non-full width blocks) so that it's easy to click into the whitespace and select the post content block.
- Opens Patterns tab - should Zoom Out
- Select a Pattern category
- Click on the whitespace to the left/right of your paragraphs - this should select the `core/post-content` block.
- See that Pattern inserter is not empty.
- Select a Pattern
- See Pattern inserted as the last block _within_ the Post Content.
- Disable Zoom Out using the Zoom Out toggle button.
- Confirm the same fix still applies even when not Zoomed Out.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before


https://github.com/user-attachments/assets/6a7ba493-68a4-4ad9-bb82-d4a6308111ac




#### After


https://github.com/user-attachments/assets/65d742a0-881e-42dd-b68d-ca5329174913


