### PR TITLE
Tabs: restore vertical alignment for tabs content

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -46,9 +46,3 @@
 .block-editor-block-inspector__no-block-tools {
 	border-top: $border-width solid $gray-300;
 }
-
-.block-editor-block-inspector__tab-item {
-	flex: 1 1 0px;
-	display: flex;
-	justify-content: center;
-}

--- a/packages/block-editor/src/components/inspector-controls-tabs/index.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/index.js
@@ -46,18 +46,13 @@ export default function InspectorControlsTabs( {
 				<Tabs.TabList>
 					{ tabs.map( ( tab ) =>
 						showIconLabels ? (
-							<Tabs.Tab
-								key={ tab.name }
-								tabId={ tab.name }
-								className={ tab.className }
-							>
+							<Tabs.Tab key={ tab.name } tabId={ tab.name }>
 								{ tab.title }
 							</Tabs.Tab>
 						) : (
 							<Tooltip text={ tab.title } key={ tab.name }>
 								<Tabs.Tab
 									tabId={ tab.name }
-									className={ tab.className }
 									aria-label={ tab.title }
 								>
 									<Icon icon={ tab.icon } />

--- a/packages/block-editor/src/components/inspector-controls-tabs/utils.js
+++ b/packages/block-editor/src/components/inspector-controls-tabs/utils.js
@@ -9,7 +9,6 @@ export const TAB_SETTINGS = {
 	title: __( 'Settings' ),
 	value: 'settings',
 	icon: cog,
-	className: 'block-editor-block-inspector__tab-item',
 };
 
 export const TAB_STYLES = {
@@ -17,7 +16,6 @@ export const TAB_STYLES = {
 	title: __( 'Styles' ),
 	value: 'styles',
 	icon: styles,
-	className: 'block-editor-block-inspector__tab-item',
 };
 
 export const TAB_LIST_VIEW = {
@@ -25,5 +23,4 @@ export const TAB_LIST_VIEW = {
 	title: __( 'List View' ),
 	value: 'list-view',
 	icon: listView,
-	className: 'block-editor-block-inspector__tab-item',
 };

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+-   `Tabs`: restore vertical alignent for tabs content ([#66215](https://github.com/WordPress/gutenberg/pull/66215)).
 -   `Tabs`: fix indicator animation ([#66198](https://github.com/WordPress/gutenberg/pull/66198)).
 -   `ColorPalette`: prevent overflow of custom color button background ([#66152](https://github.com/WordPress/gutenberg/pull/66152)).
 -   `RadioGroup`: Fix arrow key navigation in RTL ([#66202](https://github.com/WordPress/gutenberg/pull/66202)).

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -207,7 +207,6 @@ export const Tab = styled( Ariakit.Tab )`
 	[aria-orientation='horizontal'] & {
 		padding-inline: ${ space( 4 ) };
 		height: ${ space( 12 ) };
-		text-align: center;
 		scroll-margin: 24px;
 
 		&::after {
@@ -219,7 +218,6 @@ export const Tab = styled( Ariakit.Tab )`
 	[aria-orientation='vertical'] & {
 		padding: ${ space( 2 ) } ${ space( 3 ) };
 		min-height: ${ space( 10 ) };
-		text-align: start;
 
 		&[aria-selected='true'] {
 			color: ${ COLORS.theme.accent };
@@ -237,6 +235,13 @@ export const TabChildren = styled.span`
 
 	display: flex;
 	align-items: center;
+
+	[aria-orientation='horizontal'] & {
+		justify-content: center;
+	}
+	[aria-orientation='vertical'] & {
+		justify-content: start;
+	}
 `;
 
 export const TabChevron = styled( Icon )`

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -234,6 +234,9 @@ export const Tab = styled( Ariakit.Tab )`
 
 export const TabChildren = styled.span`
 	flex-grow: 1;
+
+	display: flex;
+	align-items: center;
 `;
 
 export const TabChevron = styled( Icon )`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR re-introduces some layout styles to `Tabs.Tab` so that the tab contents are vertically centered

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixing an involuntary regression

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By re-adding flexbox styles to the Tab container

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the "With Tab Icons and Tooltips" Storybook example
- Verify the vertical alignment of the icons, make sure the icons are vertically centered

Note: the centering fix can't be seen when the tabs only contain text, as that's already working as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before (trunk) | After (this PR) |
|---|---|
| ![Screenshot 2024-10-17 at 18 08 53](https://github.com/user-attachments/assets/2c59a297-9a02-45cb-b91d-efe6577465e0) | ![Screenshot 2024-10-17 at 18 09 14](https://github.com/user-attachments/assets/b279db9b-855b-4b8b-b6ee-40069afeb4a1) |