### PR TITLE
Fix - Image block: Aspect ratio not responding when dimensions are not set.

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -9,6 +9,7 @@
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
+		width: fit-content;
 
 		@media (prefers-reduced-motion: no-preference) {
 			&.hide {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/issues/66175

Set image width to `fit-content` to solve aspect ratio problems in Firefox.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For the aspect ratio to work, at least in Firefox, the image's width must be set. If not, the aspect ratio doesn't work.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Setting the image width to `fit-content` so that it has a default.

## Testing Instructions
1. Install TT5.
2. Add a page.
3. Add the "Call to action with grid layout with products and link" pattern.
4. Save and view the page in Firefox.
5. Check that the first image of the grid has the square aspect ratio.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/34ffd99b-fd65-4e0c-8fe3-941cbe79ab04



