### PR TITLE
Tabs: expose active tab item props, use ariakit prop types

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,10 @@
 
 -   `PaletteEdit`: use `Item` internally instead of custom styles ([#66164](https://github.com/WordPress/gutenberg/pull/66164)).
 
+### Experimental
+
+-   `Tabs`: add props to control active tab item ([#66223](https://github.com/WordPress/gutenberg/pull/66223)).
+
 ## 28.10.0 (2024-10-16)
 
 ### Bug Fixes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,12 +4,8 @@
 
 ### Bug Fixes
 
--   `Tabs`: restore vertical alignent for tabs content ([#66215](https://github.com/WordPress/gutenberg/pull/66215)).
--   `Tabs`: fix indicator animation ([#66198](https://github.com/WordPress/gutenberg/pull/66198)).
 -   `ColorPalette`: prevent overflow of custom color button background ([#66152](https://github.com/WordPress/gutenberg/pull/66152)).
 -   `RadioGroup`: Fix arrow key navigation in RTL ([#66202](https://github.com/WordPress/gutenberg/pull/66202)).
--   `Tabs` and `TabPanel`: Fix arrow key navigation in RTL ([#66201](https://github.com/WordPress/gutenberg/pull/66201)).
--   `Tabs`: override tablist's tabindex only when necessary ([#66209](https://github.com/WordPress/gutenberg/pull/66209)).
 
 ### Enhancements
 
@@ -18,6 +14,10 @@
 ### Experimental
 
 -   `Tabs`: add props to control active tab item ([#66223](https://github.com/WordPress/gutenberg/pull/66223)).
+-   `Tabs`: restore vertical alignent for tabs content ([#66215](https://github.com/WordPress/gutenberg/pull/66215)).
+-   `Tabs`: fix indicator animation ([#66198](https://github.com/WordPress/gutenberg/pull/66198)).
+-   `Tabs` and `TabPanel`: Fix arrow key navigation in RTL ([#66201](https://github.com/WordPress/gutenberg/pull/66201)).
+-   `Tabs`: override tablist's tabindex only when necessary ([#66209](https://github.com/WordPress/gutenberg/pull/66209)).
 
 ## 28.10.0 (2024-10-16)
 

--- a/packages/components/src/tabs/README.md
+++ b/packages/components/src/tabs/README.md
@@ -147,6 +147,33 @@ The function called when the `selectedTabId` changes.
 -   Required: No
 -   Default: `noop`
 
+###### `activeTabId`: `string | null`
+
+The current active tab `id`. The active tab is the tab element within the tablist widget that has DOM focus.
+
+- `null` represents the tablist (ie. the base composite element). Users
+  will be able to navigate out of it using arrow keys;
+- If `activeTabId` is initially set to `null`, the base composite element
+  itself will have focus and users will be able to navigate to it using
+  arrow keys.
+
+- Required: No
+
+###### `defaultActiveTabId`: `string | null`
+
+The tab id that should be active by default when the composite widget is rendered. If `null`, the tablist element itself will have focus and users will be able to navigate to it using arrow keys. If `undefined`, the first enabled item will be focused.
+
+_Note: this prop will be overridden by the `activeTabId` prop if it is provided._
+
+-   Required: No
+
+###### `onActiveTabIdChange`: `( ( activeId: string | null | undefined ) => void )`
+
+The function called when the `selectedTabId` changes.
+
+-   Required: No
+-   Default: `noop`
+
 ###### `orientation`: `'horizontal' | 'vertical' | 'both'`
 
 Defines the orientation of the tablist and determines which arrow keys can be used to move focus:

--- a/packages/components/src/tabs/README.md
+++ b/packages/components/src/tabs/README.md
@@ -115,7 +115,7 @@ The children elements, which should include one instance of the `Tabs.Tablist` c
 
 ###### `selectOnMove`: `boolean`
 
-Determines if the tab should be selected when it receives focus. If set to  `false`, the tab will only be selected upon clicking, not when using arrow keys to shift focus (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) for more info.
+Determines if the tab should be selected when it receives focus. If set to `false`, the tab will only be selected upon clicking, not when using arrow keys to shift focus (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) for more info.
 
 -   Required: No
 -   Default: `true`
@@ -136,7 +136,7 @@ The id of the tab whose panel is currently visible.
 
 If left `undefined`, it will be automatically set to the first enabled tab. If set to `null`, no tab will be selected, and the tablist will be tabbable.
 
-_Note: this prop will be overridden by the `selectedTabId` prop if it is provided (meaning the component will be use in "controlled" mode)._
+_Note: this prop will be overridden by the `selectedTabId` prop if it is provided (meaning the component will be used in "controlled" mode)._
 
 -   Required: No
 
@@ -201,7 +201,7 @@ The children elements, which should include one or more instances of the `Tabs.T
 
 ###### `tabId`: `string`
 
-The unique ID of the tab. It will be used to register the tab and match it to a corresponding `Tabs.Tabpanel` component. If not provided, a unique ID will be automatically generated.
+The unique ID of the tab. It will be used to register the tab and match it to a corresponding `Tabs.TabPanel` component. If not provided, a unique ID will be automatically generated.
 
 - Required: Yes
 

--- a/packages/components/src/tabs/README.md
+++ b/packages/components/src/tabs/README.md
@@ -109,45 +109,54 @@ Tabs is comprised of four individual components:
 
 ###### `children`: `React.ReactNode`
 
-The children elements, which should be at least a `Tabs.Tablist` component and a series of `Tabs.TabPanel` components.
+The children elements, which should include one instance of the `Tabs.Tablist` component and as many instances of the `Tabs.TabPanel` components as there are `Tabs.Tab` components.
 
 -   Required: Yes
 
 ###### `selectOnMove`: `boolean`
 
-When `true`, the tab will be selected when receiving focus (automatic tab activation). When `false`, the tab will be selected only when clicked (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) for more info.
+Determines if the tab should be selected when it receives focus. If set to  `false`, the tab will only be selected upon clicking, not when using arrow keys to shift focus (manual tab activation). See the [official W3C docs](https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/) for more info.
 
 -   Required: No
 -   Default: `true`
 
-###### `defaultTabId`: `string`
+###### `selectedTabId`: `string | null`
 
-The id of the tab to be selected upon mounting of component. If this prop is not set, the first tab will be selected by default. The id provided will be internally prefixed with a unique instance ID to avoid collisions.
+The id of the tab whose panel is currently visible.
 
-_Note: this prop will be overridden by the `selectedTabId` prop if it is provided. (Controlled Mode)_
+If left `undefined`, it will be automatically set to the first enabled tab, and the component assumes it is being used in "uncontrolled" mode.
+
+Consequently, any value different than `undefined` will set the component in "controlled" mode. When in "controlled" mode, the `null` value will result in no tabs being selected, and the tablist becoming tabbable.
+
+- Required: No
+
+###### `defaultTabId`: `string | null`
+
+The id of the tab whose panel is currently visible.
+
+If left `undefined`, it will be automatically set to the first enabled tab. If set to `null`, no tab will be selected, and the tablist will be tabbable.
+
+_Note: this prop will be overridden by the `selectedTabId` prop if it is provided (meaning the component will be use in "controlled" mode)._
 
 -   Required: No
 
 ###### `onSelect`: `( ( selectedId: string | null | undefined ) => void )`
 
-The function called when a tab has been selected. It is passed the selected tab's ID as an argument.
+The function called when the `selectedTabId` changes.
 
 -   Required: No
 -   Default: `noop`
 
-###### `orientation`: `horizontal | vertical`
+###### `orientation`: `'horizontal' | 'vertical' | 'both'`
 
-The orientation of the `tablist` (`vertical` or `horizontal`)
+Defines the orientation of the tablist and determines which arrow keys can be used to move focus:
+
+- `both`: all arrow keys work;
+- `horizontal`: only left and right arrow keys work;
+- `vertical`: only up and down arrow keys work.
 
 -   Required: No
 -   Default: `horizontal`
-
-###### `selectedTabId`: `string | null`
-
-The ID of the tab to display. This id is prepended with the `Tabs` instanceId internally.
-If left `undefined`, the component assumes it is being used in uncontrolled mode. Consequently, any value different than `undefined` will set the component in `controlled` mode. When in controlled mode, the `null` value will result in no tab being selected.
-
-- Required: No
 
 #### TabList
 
@@ -155,7 +164,7 @@ If left `undefined`, the component assumes it is being used in uncontrolled mode
 
 ###### `children`: `React.ReactNode`
 
-The children elements, which should be a series of `Tabs.TabPanel` components.
+The children elements, which should include one or more instances of the `Tabs.Tab` component.
 
 -   Required: No
 
@@ -165,26 +174,28 @@ The children elements, which should be a series of `Tabs.TabPanel` components.
 
 ###### `tabId`: `string`
 
-A unique identifier for the tab, which is used to generate a unique id for the underlying element. The value of this prop should match with the value of the `tabId` prop on the corresponding `Tabs.TabPanel` component.
+The unique ID of the tab. It will be used to register the tab and match it to a corresponding `Tabs.Tabpanel` component. If not provided, a unique ID will be automatically generated.
 
 - Required: Yes
 
 ###### `children`: `React.ReactNode`
 
-The children elements, generally the text to display on the tab.
+The contents of the tab.
 
 - Required: No
 
 ###### `disabled`: `boolean`
 
-Determines if the tab button should be disabled.
+Determines if the tab should be disabled. Note that disabled tabs can still be accessed via the keyboard when navigating through the tablist.
 
 - Required: No
 - Default: `false`
 
 ###### `render`: `React.ReactNode`
 
-The type of component to render the tab button as. If this prop is not provided, the tab button will be rendered as a `button` element.
+Allows the component to be rendered as a different HTML element or React component. The value can be a React element or a function that takes in the original component props and gives back a React element with the props merged.
+
+By default, the tab will be rendered as a `button` element.
 
 - Required: No
 
@@ -194,19 +205,23 @@ The type of component to render the tab button as. If this prop is not provided,
 
 ###### `children`: `React.ReactNode`
 
-The children elements, generally the content to display on the tabpanel.
+The contents of the tab panel.
 
 - Required: No
 
 ###### `tabId`: `string`
 
-A unique identifier for the tabpanel, which is used to generate an instanced id for the underlying element. The value of this prop should match with the value of the `tabId` prop on the corresponding `Tabs.Tab` component.
+The unique `id` of the `Tabs.Tab` component controlling this panel. This connection is used to assign the `aria-labelledby` attribute to the tab panel and to determine if the tab panel should be visible.
+
+If not provided, this link is automatically established by matching the order of `Tabs.Tab` and `Tabs.TabPanel` elements in the DOM.
 
 - Required: Yes
 
 ###### `focusable`: `boolean`
 
-Determines whether or not the tabpanel element should be focusable. If `false`, pressing the tab key will skip over the tabpanel, and instead focus on the first focusable element in the panel (if there is one).
+Determines whether or not the tabpanel element should be focusable.
+
+If `false`, pressing the tab key will skip over the tabpanel, and instead focus on the first focusable element in the panel (if there is one).
 
 - Required: No
 - Default: `true`

--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -79,7 +79,7 @@ export type TabsProps = {
 	 * Note: this prop will be overridden by the `activeTabId` prop if it is
 	 * provided.
 	 */
-	defaultActiveTabId?: Ariakit.CompositeStoreProps[ 'defaultActiveId' ];
+	defaultActiveTabId?: Ariakit.TabStoreProps[ 'defaultActiveId' ];
 	/**
 	 * A callback that gets called when the `activeTabId` state changes.
 	 */

--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -18,98 +18,114 @@ export type TabsContextProps =
 
 export type TabsProps = {
 	/**
-	 * The children elements, which should be at least a
-	 * `Tabs.Tablist` component and a series of `Tabs.TabPanel`
-	 * components.
+	 * The children elements, which should include one instance of the
+	 * `Tabs.Tablist` component and as many instances of the `Tabs.TabPanel`
+	 * components as there are `Tabs.Tab` components.
 	 */
-	children: React.ReactNode;
+	children: Ariakit.TabProps[ 'children' ];
 	/**
-	 * When `true`, the tab will be selected when receiving focus (automatic tab
-	 * activation). When `false`, the tab will be selected only when clicked
-	 * (manual tab activation). See the official W3C docs for more info.
+	 * Determines if the tab should be selected when it receives focus. If set to
+	 * `false`, the tab will only be selected upon clicking, not when using arrow
+	 * keys to shift focus (manual tab activation). See the official W3C docs
+	 * for more info.
 	 *
 	 * @default true
 	 *
 	 * @see https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 	 */
-	selectOnMove?: boolean;
+	selectOnMove?: Ariakit.TabStoreProps[ 'selectOnMove' ];
 	/**
-	 * The id of the tab to be selected upon mounting of component.
-	 * If this prop is not set, the first tab will be selected by default.
-	 * The id provided will be internally prefixed with the
-	 * `TabsContextProps.instanceId`.
+	 * The id of the tab whose panel is currently visible.
+	 *
+	 * If left `undefined`, it will be automatically set to the first enabled
+	 * tab, and the component assumes it is being used in "uncontrolled" mode.
+	 *
+	 * Consequently, any value different than `undefined` will set the component
+	 * in "controlled" mode. When in "controlled" mode, the `null` value will
+	 * result in no tabs being selected, and the tablist becoming tabbable.
+	 */
+	selectedTabId?: Ariakit.TabStoreProps[ 'selectedId' ];
+	/**
+	 * The id of the tab whose panel is currently visible.
+	 *
+	 * If left `undefined`, it will be automatically set to the first enabled
+	 * tab. If set to `null`, no tab will be selected, and the tablist will be
+	 * tabbable.
 	 *
 	 * Note: this prop will be overridden by the `selectedTabId` prop if it is
-	 * provided. (Controlled Mode)
+	 * provided (meaning the component will be use in "controlled" mode).
 	 */
-	defaultTabId?: string;
+	defaultTabId?: Ariakit.TabStoreProps[ 'defaultSelectedId' ];
 	/**
-	 * The function called when a tab has been selected.
-	 * It is passed the id of the newly selected tab as an argument.
+	 * The function called when the `selectedTabId` changes.
 	 */
-	onSelect?: ( selectedId: string | null | undefined ) => void;
-
+	onSelect?: Ariakit.TabStoreProps[ 'setSelectedId' ];
 	/**
-	 * The orientation of the tablist.
+	 * Defines the orientation of the tablist and determines which arrow keys
+	 * can be used to move focus:
+	 * - `both`: all arrow keys work.
+	 * - `horizontal`: only left and right arrow keys work.
+	 * - `vertical`: only up and down arrow keys work.
 	 *
-	 * @default `horizontal`
+	 * @default "horizontal"
 	 */
-	orientation?: 'horizontal' | 'vertical';
-	/**
-	 * The Id of the tab to display. This id is prepended with the `Tabs`
-	 * instanceId internally.
-	 *
-	 * If left `undefined`, the component assumes it is being used in
-	 * uncontrolled mode. Consequently, any value different than `undefined`
-	 * will set the component in `controlled` mode.
-	 * When in controlled mode, the `null` value will result in no tab being selected.
-	 */
-	selectedTabId?: string | null;
+	orientation?: Ariakit.TabStoreProps[ 'orientation' ];
 };
 
 export type TabListProps = {
 	/**
-	 * The children elements, which should be a series of `Tabs.TabPanel` components.
+	 * The children elements, which should include one or more instances of the
+	 * `Tabs.Tab` component.
 	 */
-	children?: React.ReactNode;
+	children: Ariakit.TabListProps[ 'children' ];
 };
+
+// TODO: consider prop name changes (tabId, selectedTabId)
+// switch to auto-generated README
+// compound technique
 
 export type TabProps = {
 	/**
-	 * The id of the tab, which is prepended with the `Tabs` instanceId.
-	 * The value of this prop should match with the value of the `tabId` prop on
-	 * the corresponding `Tabs.TabPanel` component.
+	 * The unique ID of the tab. It will be used to register the tab and match
+	 * it to a corresponding `Tabs.Tabpanel` component.
 	 */
-	tabId: string;
+	tabId: NonNullable< Ariakit.TabProps[ 'id' ] >;
 	/**
-	 * The children elements, generally the text to display on the tab.
+	 * The contents of the tab.
 	 */
-	children?: React.ReactNode;
+	children?: Ariakit.TabProps[ 'children' ];
 	/**
-	 * Determines if the tab button should be disabled.
+	 * Determines if the tab should be disabled. Note that disabled tabs can
+	 * still be accessed via the keyboard when navigating through the tablist.
 	 *
 	 * @default false
 	 */
-	disabled?: boolean;
+	disabled?: Ariakit.TabProps[ 'disabled' ];
 	/**
-	 * The type of component to render the tab button as. If this prop is not
-	 * provided, the tab button will be rendered as a `button` element.
+	 * Allows the component to be rendered as a different HTML element or React
+	 * component. The value can be a React element or a function that takes in the
+	 * original component props and gives back a React element with the props
+	 * merged.
+	 *
+	 * By default, the tab will be rendered as a `button` element.
 	 */
-	render?: React.ReactElement;
+	render?: Ariakit.TabProps[ 'render' ];
 };
 
 export type TabPanelProps = {
 	/**
-	 * The children elements, generally the content to display on the tabpanel.
+	 * The contents of the tab panel.
 	 */
-	children?: React.ReactNode;
+	children?: Ariakit.TabPanelProps[ 'children' ];
 	/**
-	 * A unique identifier for the tabpanel, which is used to generate an
-	 * instanced id for the underlying element.
-	 * The value of this prop should match with the value of the `tabId` prop on
-	 * the corresponding `Tabs.Tab` component.
+	 * The unique `id` of the `Tabs.Tab` component controlling this panel. This
+	 * connection is used to assign the `aria-labelledby` attribute to the tab
+	 * panel and to determine if the tab panel should be visible.
+	 *
+	 * If not provided, this link is automatically established by matching the
+	 * order of `Tabs.Tab` and `Tabs.TabPanel` elements in the DOM.
 	 */
-	tabId: string;
+	tabId: NonNullable< Ariakit.TabPanelProps[ 'tabId' ] >;
 	/**
 	 * Determines whether or not the tabpanel element should be focusable.
 	 * If `false`, pressing the tab key will skip over the tabpanel, and instead
@@ -117,5 +133,5 @@ export type TabPanelProps = {
 	 *
 	 * @default true
 	 */
-	focusable?: boolean;
+	focusable?: Ariakit.TabPanelProps[ 'focusable' ];
 };

--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -53,7 +53,7 @@ export type TabsProps = {
 	 * tabbable.
 	 *
 	 * Note: this prop will be overridden by the `selectedTabId` prop if it is
-	 * provided (meaning the component will be use in "controlled" mode).
+	 * provided (meaning the component will be used in "controlled" mode).
 	 */
 	defaultTabId?: Ariakit.TabStoreProps[ 'defaultSelectedId' ];
 	/**
@@ -111,7 +111,7 @@ export type TabListProps = {
 export type TabProps = {
 	/**
 	 * The unique ID of the tab. It will be used to register the tab and match
-	 * it to a corresponding `Tabs.Tabpanel` component.
+	 * it to a corresponding `Tabs.TabPanel` component.
 	 */
 	tabId: NonNullable< Ariakit.TabProps[ 'id' ] >;
 	/**

--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -61,6 +61,30 @@ export type TabsProps = {
 	 */
 	onSelect?: Ariakit.TabStoreProps[ 'setSelectedId' ];
 	/**
+	 * The current active tab `id`. The active tab is the tab element within the
+	 * tablist widget that has DOM focus.
+	 * - `null` represents the tablist (ie. the base composite element). Users
+	 *   will be able to navigate out of it using arrow keys.
+	 * - If `activeTabId` is initially set to `null`, the base composite element
+	 *   itself will have focus and users will be able to navigate to it using
+	 *   arrow keys.activeTabId
+	 */
+	activeTabId?: Ariakit.TabStoreProps[ 'activeId' ];
+	/**
+	 * The tab id that should be active by default when the composite widget is
+	 * rendered. If `null`, the tablist element itself will have focus
+	 * and users will be able to navigate to it using arrow keys. If `undefined`,
+	 * the first enabled item will be focused.
+	 *
+	 * Note: this prop will be overridden by the `activeTabId` prop if it is
+	 * provided.
+	 */
+	defaultActiveTabId?: Ariakit.CompositeStoreProps[ 'defaultActiveId' ];
+	/**
+	 * A callback that gets called when the `activeTabId` state changes.
+	 */
+	onActiveTabIdChange?: Ariakit.TabStoreProps[ 'setActiveId' ];
+	/**
 	 * Defines the orientation of the tablist and determines which arrow keys
 	 * can be used to move focus:
 	 * - `both`: all arrow keys work.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from https://github.com/WordPress/gutenberg/pull/66097#discussion_r1801290344

This PR adds 3 more props on the `Tabs` component: `activeTabId`, `defaultActiveTabId` and `onActiveTabIdChange`, and tweaks all prop types to use ariakit type defs under the hood

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The new props are necessary to control, in some cases, which tab is the active composite item (see https://github.com/WordPress/gutenberg/pull/66097#discussion_r1801290344).

Updating the prop types align `Tabs` with other recent ariakit-based components, such as `Composite` and `DropdownMenuV2`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added new props
- Updated types and some JSDocs
- Updated README to match new JSDocs

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Review the code and the README. No runtime changes.