### PR TITLE
Fix extra scrollbar appearing when searching in the inserter

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -123,6 +123,12 @@ $block-inserter-tabs-height: 44px;
 }
 
 .block-editor-inserter__panel-header {
+	// Use `position: relative` to ensure any absolute positioned child elements are
+	// positioned relative to the panel header.
+	// This makes the overflow rule of the panel work correctly, particularly when the
+	// `VisuallyHidden` component is used within the inserter UI.
+	position: relative;
+
 	display: inline-flex;
 	align-items: center;
 	padding: $grid-unit-20 $grid-unit-20 0;

--- a/packages/block-editor/src/components/tabbed-sidebar/style.scss
+++ b/packages/block-editor/src/components/tabbed-sidebar/style.scss
@@ -32,4 +32,10 @@
 	flex-direction: column;
 	overflow-y: auto;
 	scrollbar-gutter: auto;
+
+	// Use `position: relative` to ensure any absolute positioned child elements are
+	// positioned relative to the tab panel.
+	// This makes the overflow rule of the panel work correctly, particularly when the
+	// `VisuallyHidden` component is used within the inserter UI.
+	position: relative;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #66161

## Why?
This is the same kind of issue that has occurred before. The `VisuallyHidden` component is implemented following best practices, but it uses `position: absolute` internally, which means it needs a `position: relative` parent. Without that, due to a CSS quirk, it can overflow a parent of the scroll container, which results in a scrollbar appearing in an unexpected place.

Not sure if there's anything further we can do to prevent this considering it keeps happening. Maybe we need to add a `position: relative` wrapper to `VisuallyHidden`. I'll think on it!

## How?
Adds `position: relative` in a couple of places - in the 'tabbed-sidebar' which means we prevent the unexpected overflows if `VisuallyHidden` is used anywhere else unexpectedly. Also in `inserter-panel__header` so that if this component is used anywhere else it won't cause unexpected overflows. Comments are added to ensure future devs have context when refactoring these styles.

## Testing Instructions
1. Open the block inserter
2. Type a few letters in the search input (something that will return results)
3. Observe that the scrollbars are as expected (one in the inserter and one in the canvas

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="787" alt="Screenshot 2024-10-18 at 10 13 12 am" src="https://github.com/user-attachments/assets/9d4c5050-8ebe-478d-8183-17e3f3203293">

#### After
<img width="785" alt="Screenshot 2024-10-18 at 10 13 44 am" src="https://github.com/user-attachments/assets/f4c08c1f-ae92-4d81-b16b-25da43e4caab">
