### PR TITLE
Fix : Revisions for templates

### DIFF
--- a/packages/editor/src/components/post-last-revision/check.js
+++ b/packages/editor/src/components/post-last-revision/check.js
@@ -27,7 +27,7 @@ function PostLastRevisionCheck( { children } ) {
 		};
 	}, [] );
 
-	if ( ! lastRevisionId || revisionsCount < 2 ) {
+	if ( ! lastRevisionId || revisionsCount < 1 ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/post-last-revision/test/check.js
+++ b/packages/editor/src/components/post-last-revision/test/check.js
@@ -39,12 +39,20 @@ describe( 'PostLastRevisionCheck', () => {
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should not render anything if there is only one revision', () => {
-		setupDataMock( 1, 1 );
+	it( 'should not render anything if there is less than one revision', () => {
+		setupDataMock( 1, 0 );
 
 		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
 
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render anything if there is only one revision', () => {
+		setupDataMock( 1, 1 );
+
+		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );
+
+		expect( screen.queryByText( 'Children' ) ).toBeVisible();
 	} );
 
 	it( 'should render if there are two revisions', () => {

--- a/packages/editor/src/components/post-last-revision/test/check.js
+++ b/packages/editor/src/components/post-last-revision/test/check.js
@@ -47,7 +47,7 @@ describe( 'PostLastRevisionCheck', () => {
 		expect( screen.queryByText( 'Children' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'should render anything if there is only one revision', () => {
+	it( 'should render if there is only one revision', () => {
 		setupDataMock( 1, 1 );
 
 		render( <PostLastRevisionCheck>Children</PostLastRevisionCheck> );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Allow revisions for templates to be accessible when there's at least 1 available
- Update test to handle 0 and 1 revision scenarios

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/66106
> When I try to edit the Blog Home template or the Index template, the Revisions section starts showing only after I make three edits to the template. I expect the revisions to start displaying right after the first edit.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Reduce the count condition in `PostLastRevisionCheck` wrapper
