### PR TITLE
Resets the Zoom on viewed/edited entity change

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -23,6 +23,7 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { decodeEntities } from '@wordpress/html-entities';
 import { Icon, arrowUpLeft } from '@wordpress/icons';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -153,6 +154,9 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		[ settings.styles, canvasMode, currentPostIsTrashed ]
 	);
 	const { setCanvasMode } = unlock( useDispatch( editSiteStore ) );
+	const { __unstableSetEditorMode, resetZoomLevel } = unlock(
+		useDispatch( blockEditorStore )
+	);
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const history = useHistory();
 	const onActionPerformed = useCallback(
@@ -261,6 +265,11 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 											tooltipPosition="middle right"
 											onClick={ () => {
 												setCanvasMode( 'view' );
+												__unstableSetEditorMode(
+													'edit'
+												);
+												resetZoomLevel();
+
 												// TODO: this is a temporary solution to navigate to the posts list if we are
 												// come here through `posts list` and are in focus mode editing a template, template part etc..
 												if (

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -5,6 +5,7 @@ import { useEffect, useMemo } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreDataStore } from '@wordpress/core-data';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -248,9 +249,14 @@ export default function useInitEditedEntityFromURL() {
 		useResolveEditedEntityAndContext( params );
 
 	const { setEditedEntity } = useDispatch( editSiteStore );
+	const { __unstableSetEditorMode, resetZoomLevel } = unlock(
+		useDispatch( blockEditorStore )
+	);
 
 	useEffect( () => {
 		if ( isReady ) {
+			__unstableSetEditorMode( 'edit' );
+			resetZoomLevel();
 			setEditedEntity( postType, postId, context );
 		}
 	}, [ isReady, postType, postId, context, setEditedEntity ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow up to https://github.com/WordPress/gutenberg/pull/65932.

Resets the Zoom Out when moving to view/edit a new entity. Avoids Zoom Out remaining engaged when navigating between Pages/Templates...etc in the Site Editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Retaining the Zoom Out state when moving between entities can be confusing and may lead to bugs when previewing in the frame.

For example, moving between Pages in the Site Editor leaves Zoom Out intact. That's confusing because Zoom Out is feels like it's an action taken when editing a given entity. It shouldn't persist.

I appreciate this is fairly opinionated so I'm happy to defer to @WordPress/gutenberg-design if they don't feel this is the right route.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Dispatches appropriate actions to reset Zoom when syncing entity with URL.

I elected not to put this in the `setEditedEntity` action because I didn't want to couple these two concepts too tightly.

An alternative would be to reset Zoom Out if the Site Editor "frame" is opened (the black left hand sidebar with the `W` logo).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Site Editor -> Pages
- Edit a Page
- Engage Zoom Out
- Open the frame and selected `Pages` again.
- Click between Pages
- See that Zoom Out is disengaged.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2c167a03-dea1-4870-bd24-de82af6e2cbd

