### PR TITLE
Backport Disable zoom out toggle button when Style Book is open to WP 6.7

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -139,6 +139,7 @@ function Header( {
 					// when the publish sidebar has been closed.
 					<PostSavedState forceIsDirty={ forceIsDirty } />
 				) }
+
 				<PreviewDropdown
 					forceIsAutosaveable={ forceIsDirty }
 					disabled={ isNestedEntity }
@@ -149,7 +150,9 @@ function Header( {
 				/>
 				<PostViewLink />
 
-				{ isEditorIframed && isWideViewport && <ZoomOutToggle /> }
+				{ isEditorIframed && isWideViewport && (
+					<ZoomOutToggle disabled={ forceDisableBlockTools } />
+				) }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />

--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -14,7 +14,7 @@ import { store as preferencesStore } from '@wordpress/preferences';
  */
 import { unlock } from '../../lock-unlock';
 
-const ZoomOutToggle = () => {
+const ZoomOutToggle = ( { disabled } ) => {
 	const { isZoomOut, showIconLabels } = useSelect( ( select ) => ( {
 		isZoomOut: unlock( select( blockEditorStore ) ).isZoomOut(),
 		showIconLabels: select( preferencesStore ).get(
@@ -38,6 +38,8 @@ const ZoomOutToggle = () => {
 
 	return (
 		<Button
+			accessibleWhenDisabled
+			disabled={ disabled }
 			onClick={ handleZoomOut }
 			icon={ zoomOutIcon }
 			label={ __( 'Toggle Zoom Out' ) }


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

Manual backport of https://github.com/WordPress/gutenberg/pull/66228 resolving some minor conflicts in positioning in header.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Backporting

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Resolve conflicts.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow instructions from https://github.com/WordPress/gutenberg/pull/66228 and verify same result.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
