### PR TITLE
Block inserter: prevent editor from crashing if `blockType.parent` is a string

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1628,7 +1628,7 @@ const isBlockVisibleInTheInserter = (
 	checkedBlocks.add( blockName );
 
 	// If parent blocks are not visible, child blocks should be hidden too.
-	if ( !! blockType.parent?.length ) {
+	if ( Array.isArray( blockType?.parent ) ) {
 		return blockType.parent.some(
 			( name ) =>
 				( blockName !== name &&

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1628,8 +1628,18 @@ const isBlockVisibleInTheInserter = (
 	checkedBlocks.add( blockName );
 
 	// If parent blocks are not visible, child blocks should be hidden too.
-	if ( Array.isArray( blockType?.parent ) ) {
-		return blockType.parent.some(
+	//
+	// In some scenarios, blockType.parent may be a string.
+	// A better approach would be sanitize parent in all the places that can be modified:
+	// block registration, processBlockType, filters, etc.
+	// In the meantime, this is a hotfix to prevent the editor from crashing.
+	const parent =
+		typeof blockType.parent === 'string' ||
+		blockType.parent instanceof String
+			? [ blockType.parent ]
+			: blockType.parent;
+	if ( Array.isArray( parent ) ) {
+		return parent.some(
 			( name ) =>
 				( blockName !== name &&
 					isBlockVisibleInTheInserter(
@@ -1643,6 +1653,7 @@ const isBlockVisibleInTheInserter = (
 				name === 'core/post-content'
 		);
 	}
+
 	return true;
 };
 


### PR DESCRIPTION
Potential fix for https://wordpress.org/support/topic/error-after-update-228/

## What?

Fixes an error when blocks' `parent` property is a string.

## Why?

In the forum, I ran into [a report](https://wordpress.org/support/topic/error-after-update-228/) where users have the editor crash when trying to open the inserter. Environment conditions are WordPress 6.6.2 and Gutenberg 15.6. The first error hints at `TypeError: n.parent.some is not a function at ...`.

Investigating a bit, it seems related to https://github.com/WordPress/gutenberg/pull/65700 The report is recent (matches the Gutenberg version where that PR was introduced), the users report issues when inserting blocks, and there's no other place in the codebase that uses `parent.some`. See [conversation](https://github.com/WordPress/gutenberg/pull/65700/files#r1806315983).

While reproducing the exact user conditions is difficult (e.g.: asking them what 3rd party block libraries do they have, etc.), we can be more explicit about the check.

## How?

Update the check for the parent so it verifies it's the type we want it to be: a non-empty array. 

## Testing Instructions

The best I could come up with is the following:

- Register a block that passes a string as the parent property:

```js
registerBlockType( 'test/parent-some-bug', {
	title: 'Parent is string',
	parent: 'test/parent-is-string',
	save: () => {
		return '';
	}
} );
```
- Go to the editor.

Using `trunk`, the editor would crash. With this PR, it doesn't.

## Further work

As suggested in https://github.com/WordPress/gutenberg/pull/65700/files#r1806317308 we should look at enforcing the `blockType.parent` property being an array if that is its only valid value. Given how long we haven't enforced it, doing that now may be side-effects and requires a longer investigation and testing period than this approach — hence why I prioritized preparing this hotfix.