### PR TITLE
[WiP] Command Palette: Add `dataset` attributes to `wp_template` and `wp_te…

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -43,32 +43,45 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 	if ( ! commands.length ) {
 		return null;
 	}
-
 	return (
 		<>
-			{ commands.map( ( command ) => (
-				<Command.Item
-					key={ command.name }
-					value={ command.searchLabel ?? command.label }
-					onSelect={ () => command.callback( { close } ) }
-					id={ command.name }
-				>
-					<HStack
-						alignment="left"
-						className={ clsx( 'commands-command-menu__item', {
-							'has-icon': command.icon,
-						} ) }
+			{ commands.map( ( command ) => {
+				let postType;
+				let postId;
+				if ( command.name.startsWith( 'wp_template-' ) ) {
+					postType = 'wp_template';
+					postId = command.name.replace( 'wp_template-', '' );
+				} else if ( command.name.startsWith( 'wp_template_part-' ) ) {
+					postType = 'wp_template_part';
+					postId = command.name.replace( 'wp_template_part-', '' );
+				}
+
+				return (
+					<Command.Item
+						key={ command.name }
+						value={ command.searchLabel ?? command.label }
+						onSelect={ () => command.callback( { close } ) }
+						id={ command.name }
+						data-post-type={ postType }
+						data-post-id={ postId }
 					>
-						{ command.icon && <Icon icon={ command.icon } /> }
-						<span>
-							<TextHighlight
-								text={ command.label }
-								highlight={ search }
-							/>
-						</span>
-					</HStack>
-				</Command.Item>
-			) ) }
+						<HStack
+							alignment="left"
+							className={ clsx( 'commands-command-menu__item', {
+								'has-icon': command.icon,
+							} ) }
+						>
+							{ command.icon && <Icon icon={ command.icon } /> }
+							<span>
+								<TextHighlight
+									text={ command.label }
+									highlight={ search }
+								/>
+							</span>
+						</HStack>
+					</Command.Item>
+				);
+			} ) }
 		</>
 	);
 }


### PR DESCRIPTION
…mplate_part` commands

The attributes contain the post type and post id needed to form the site editor URL. They are added so the calypso's iframe bridge can bypass the the cross origin gutenframe issues.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
