### PR TITLE
Hide inserter pattern/media panel when there are no categories

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -24,7 +24,7 @@ function BlockPatternsTab( {
 	selectedCategory,
 	onInsert,
 	rootClientId,
-	onHasCategories,
+	setHasCategories,
 	children,
 } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
@@ -39,8 +39,8 @@ function BlockPatternsTab( {
 	);
 
 	useEffect( () => {
-		onHasCategories( !! categories.length );
-	}, [ categories, onHasCategories ] );
+		setHasCategories( !! categories.length );
+	}, [ categories, setHasCategories ] );
 
 	if ( isResolvingPatterns ) {
 		return (

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -24,6 +24,7 @@ function BlockPatternsTab( {
 	selectedCategory,
 	onInsert,
 	rootClientId,
+	onHasCategories,
 	children,
 } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
@@ -36,6 +37,10 @@ function BlockPatternsTab( {
 			unlock( select( blockEditorStore ) ).isResolvingPatterns(),
 		[]
 	);
+
+	useEffect( () => {
+		onHasCategories( !! categories.length );
+	}, [ categories, onHasCategories ] );
 
 	if ( isResolvingPatterns ) {
 		return (

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -24,7 +24,7 @@ function MediaTab( {
 	rootClientId,
 	selectedCategory,
 	onSelectCategory,
-	onHasCategories,
+	setHasCategories,
 	onInsert,
 	children,
 } ) {
@@ -51,8 +51,8 @@ function MediaTab( {
 	);
 
 	useEffect( () => {
-		onHasCategories( !! categories.length );
-	}, [ categories, onHasCategories ] );
+		setHasCategories( !! categories.length );
+	}, [ categories, setHasCategories ] );
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;

--- a/packages/block-editor/src/components/inserter/media-tab/media-tab.js
+++ b/packages/block-editor/src/components/inserter/media-tab/media-tab.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
 import { Button } from '@wordpress/components';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,6 +24,7 @@ function MediaTab( {
 	rootClientId,
 	selectedCategory,
 	onSelectCategory,
+	onHasCategories,
 	onInsert,
 	children,
 } ) {
@@ -48,6 +49,10 @@ function MediaTab( {
 			} ) ),
 		[ mediaCategories ]
 	);
+
+	useEffect( () => {
+		onHasCategories( !! categories.length );
+	}, [ categories, onHasCategories ] );
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,6 +67,8 @@ function InserterMenu(
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
+
+	const [ hasCategories, setHasCategories ] = useState( true );
 	function getInitialTab() {
 		if ( __experimentalInitialTab ) {
 			return __experimentalInitialTab;
@@ -146,10 +148,12 @@ function InserterMenu(
 
 	const showPatternPanel =
 		selectedTab === 'patterns' &&
+		hasCategories &&
 		! delayedFilterValue &&
 		!! selectedPatternCategory;
 
-	const showMediaPanel = selectedTab === 'media' && !! selectedMediaCategory;
+	const showMediaPanel =
+		selectedTab === 'media' && !! selectedMediaCategory && hasCategories;
 
 	const inserterSearch = useMemo( () => {
 		if ( selectedTab === 'media' ) {
@@ -242,6 +246,9 @@ function InserterMenu(
 				onInsert={ onInsertPattern }
 				onSelectCategory={ onClickPatternCategory }
 				selectedCategory={ selectedPatternCategory }
+				onHasCategories={ ( _hasCategories ) =>
+					setHasCategories( _hasCategories )
+				}
 			>
 				{ showPatternPanel && (
 					<PatternCategoryPreviews
@@ -270,6 +277,9 @@ function InserterMenu(
 				selectedCategory={ selectedMediaCategory }
 				onSelectCategory={ setSelectedMediaCategory }
 				onInsert={ onInsert }
+				onHasCategories={ ( _hasCategories ) =>
+					setHasCategories( _hasCategories )
+				}
 			>
 				{ showMediaPanel && (
 					<MediaCategoryPanel

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -246,9 +246,7 @@ function InserterMenu(
 				onInsert={ onInsertPattern }
 				onSelectCategory={ onClickPatternCategory }
 				selectedCategory={ selectedPatternCategory }
-				onHasCategories={ ( _hasCategories ) =>
-					setHasCategories( _hasCategories )
-				}
+				setHasCategories={ setHasCategories }
 			>
 				{ showPatternPanel && (
 					<PatternCategoryPreviews
@@ -277,9 +275,7 @@ function InserterMenu(
 				selectedCategory={ selectedMediaCategory }
 				onSelectCategory={ setSelectedMediaCategory }
 				onInsert={ onInsert }
-				onHasCategories={ ( _hasCategories ) =>
-					setHasCategories( _hasCategories )
-				}
+				setHasCategories={ setHasCategories }
 			>
 				{ showMediaPanel && (
 					<MediaCategoryPanel


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes part of https://github.com/WordPress/gutenberg/issues/65833
Pairs with the fix in #66214

Hides the slide-out pattern/media inserter panel when there are no categories.

## How?
The code here is a little ropey, since we need a child component to control part of its parent. The `InserterMenu` component becomes wider whenever the additional panel slides out, but only the child `BlockPatternsTab` and `BlockMediaTab` components know whether there are actually any categories to be displayed (and patterns or media to be displayed in the slide out panel).

I understand it's not great, but it's a fix only targeted at wp/6.7. In trunk, patterns are shown all the time because of https://github.com/WordPress/gutenberg/pull/65611, which wasn't backported (an alternative could be to backport it). So this code won't live on in the codebase.

## Testing Instructions
1. Open a Page in the site editor
2. Select a block that can have a pattern inserter after it
3. Open the inserter, switch to the patterns tab and select a category
4. Now select the Post Content block

In trunk: A weird empty state is shown
In this PR: The slide out panel slides back in and the inserter shows 'No results'

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="998" alt="Screenshot 2024-10-18 at 4 46 50 pm" src="https://github.com/user-attachments/assets/ee0f4d15-6d86-4857-81c1-adc8e0e22c10">

#### After
<img width="876" alt="Screenshot 2024-10-18 at 4 44 23 pm" src="https://github.com/user-attachments/assets/a982c757-673a-4195-85dc-43666225f8c9">
