### PR TITLE
Block registration: normalize blockType.parent to `array`

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1628,18 +1628,8 @@ const isBlockVisibleInTheInserter = (
 	checkedBlocks.add( blockName );
 
 	// If parent blocks are not visible, child blocks should be hidden too.
-	//
-	// In some scenarios, blockType.parent may be a string.
-	// A better approach would be sanitize parent in all the places that can be modified:
-	// block registration, processBlockType, filters, etc.
-	// In the meantime, this is a hotfix to prevent the editor from crashing.
-	const parent =
-		typeof blockType.parent === 'string' ||
-		blockType.parent instanceof String
-			? [ blockType.parent ]
-			: blockType.parent;
-	if ( Array.isArray( parent ) ) {
-		return parent.some(
+	if ( Array.isArray( blockType.parent ) ) {
+		return blockType.parent.some(
 			( name ) =>
 				( blockName !== name &&
 					isBlockVisibleInTheInserter(

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-### Bug fixes
+### Breaking changes
 
 - Normalize `blockType.parent` to be an array. While string values were never supported, they appeared to work with some unintended side-effects that have been fixed by [#66250](https://github.com/WordPress/gutenberg/pull/66250). For that reason, we've added some code that automatically migrates strings to arrays — though it still raises a warning.
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Bug fixes
+
 - Enforce `blockType.parent` to be an array. While `parent` being a string wasn't never supported, it worked with some unintended side-effects that have been fixed by [#66250](https://github.com/WordPress/gutenberg/pull/66250). For that reason, we've added some code that automatically migrates strings to arrays — though it still raises a warning.
 
 ## 13.10.0 (2024-10-16)

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Enforce `blockType.parent` to be an array. While `parent` being a string wasn't never supported, it worked with some unintended side-effects that have been fixed by [#66250](https://github.com/WordPress/gutenberg/pull/66250). For that reason, we've added some code that automatically migrates strings to arrays — though it still raises a warning.
+- Normalize `blockType.parent` to be an array. While string values were never supported, they appeared to work with some unintended side-effects that have been fixed by [#66250](https://github.com/WordPress/gutenberg/pull/66250). For that reason, we've added some code that automatically migrates strings to arrays — though it still raises a warning.
 
 ## 13.10.0 (2024-10-16)
 

--- a/packages/blocks/CHANGELOG.md
+++ b/packages/blocks/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Enforce `blockType.parent` to be an array. While `parent` being a string wasn't never supported, it worked with some unintended side-effects that have been fixed by [#66250](https://github.com/WordPress/gutenberg/pull/66250). For that reason, we've added some code that automatically migrates strings to arrays — though it still raises a warning.
+
 ## 13.10.0 (2024-10-16)
 
 ## 13.9.0 (2024-10-03)

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -232,6 +232,13 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		return;
 	}
 
+	if (
+		typeof settings?.parent === 'string' ||
+		settings?.parent instanceof String
+	) {
+		settings.parent = [ settings.parent ];
+	}
+
 	if ( 1 === settings?.parent?.length && name === settings.parent[ 0 ] ) {
 		warning(
 			'Block "' +

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -242,7 +242,10 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		settings.parent = [ settings.parent ];
 	}
 
-	if ( ! Array.isArray( settings?.parent ) && 'parent' in settings ) {
+	if (
+		! Array.isArray( settings?.parent ) &&
+		settings?.parent !== undefined
+	) {
 		warning(
 			'Block parent must be an array of block types, but it is ',
 			settings.parent

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -240,6 +240,9 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		settings?.parent instanceof String
 	) {
 		settings.parent = [ settings.parent ];
+		warning(
+			'Block parent must be an array of block types, but it is a string'
+		);
 	}
 
 	if (

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -240,9 +240,6 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		settings?.parent instanceof String
 	) {
 		settings.parent = [ settings.parent ];
-		warning(
-			'Block parent must be an array of block types, but it is a string'
-		);
 	}
 
 	if (

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -232,36 +232,6 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		return;
 	}
 
-	// Parent being an array hasn't been enforced in the past,
-	// so this is a way to maintain backwards compatibility
-	// with 3rd party blocks that may have been using it as a string.
-	if (
-		typeof settings?.parent === 'string' ||
-		settings?.parent instanceof String
-	) {
-		settings.parent = [ settings.parent ];
-	}
-
-	if (
-		! Array.isArray( settings?.parent ) &&
-		settings?.parent !== undefined
-	) {
-		warning(
-			'Block parent must be an array of block types, but it is ',
-			settings.parent
-		);
-		return;
-	}
-
-	if ( 1 === settings?.parent?.length && name === settings.parent[ 0 ] ) {
-		warning(
-			'Block "' +
-				name +
-				'" cannot be a parent of itself. Please remove the block name from the parent list.'
-		);
-		return;
-	}
-
 	if ( ! /^[a-z][a-z0-9-]*\/[a-z][a-z0-9-]*$/.test( name ) ) {
 		warning(
 			'Block names must contain a namespace prefix, include only lowercase alphanumeric characters or dashes, and start with a letter. Example: my-plugin/my-custom-block'

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -232,11 +232,22 @@ export function registerBlockType( blockNameOrMetadata, settings ) {
 		return;
 	}
 
+	// Parent being an array hasn't been enforced in the past,
+	// so this is a way to maintain backwards compatibility
+	// with 3rd party blocks that may have been using it as a string.
 	if (
 		typeof settings?.parent === 'string' ||
 		settings?.parent instanceof String
 	) {
 		settings.parent = [ settings.parent ];
+	}
+
+	if ( ! Array.isArray( settings?.parent ) && 'parent' in settings ) {
+		warning(
+			'Block parent must be an array of block types, but it is ',
+			settings.parent
+		);
+		return;
 	}
 
 	if ( 1 === settings?.parent?.length && name === settings.parent[ 0 ] ) {

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -749,8 +749,14 @@ describe( 'blocks', () => {
 				title: 'block title',
 				parent: 'core/paragraph',
 			};
-			registerBlockType( 'core/test-block-parent-string', blockType );
-			expect( getBlockType( 'core/test-block-parent-string' ) ).toEqual( {
+			const block = registerBlockType(
+				'core/test-block-parent-string',
+				blockType
+			);
+			expect( console ).toHaveWarnedWith(
+				'Parent must be undefined or an array of strings (block types), but it is a string.'
+			);
+			expect( block ).toEqual( {
 				name: 'core/test-block-parent-string',
 				save: noop,
 				category: 'text',

--- a/packages/blocks/src/api/test/registration.js
+++ b/packages/blocks/src/api/test/registration.js
@@ -742,6 +742,33 @@ describe( 'blocks', () => {
 			} );
 		} );
 
+		it( 'should transform parent string to array', () => {
+			const blockType = {
+				save: noop,
+				category: 'text',
+				title: 'block title',
+				parent: 'core/paragraph',
+			};
+			registerBlockType( 'core/test-block-parent-string', blockType );
+			expect( getBlockType( 'core/test-block-parent-string' ) ).toEqual( {
+				name: 'core/test-block-parent-string',
+				save: noop,
+				category: 'text',
+				title: 'block title',
+				icon: { src: BLOCK_ICON_DEFAULT },
+				attributes: {},
+				providesContext: {},
+				usesContext: [],
+				keywords: [],
+				selectors: {},
+				supports: {},
+				styles: [],
+				variations: [],
+				blockHooks: {},
+				parent: [ 'core/paragraph' ],
+			} );
+		} );
+
 		describe( 'applyFilters', () => {
 			afterEach( () => {
 				removeAllFilters( 'blocks.registerBlockType' );

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -197,5 +197,12 @@ export const processBlockType =
 			return;
 		}
 
+		if (
+			typeof settings.parent === 'string' ||
+			settings.parent instanceof String
+		) {
+			settings.parent = [ settings.parent ];
+		}
+
 		return settings;
 	};

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -205,9 +205,6 @@ export const processBlockType =
 			settings.parent instanceof String
 		) {
 			settings.parent = [ settings.parent ];
-			warning(
-				'Block parent must be an array of block types, but it is a string'
-			);
 		}
 
 		if (

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -197,11 +197,22 @@ export const processBlockType =
 			return;
 		}
 
+		// Parent being an array hasn't been enforced in the past,
+		// so this is a way to maintain backwards compatibility
+		// with 3rd party blocks that may have been using it as a string.
 		if (
 			typeof settings.parent === 'string' ||
 			settings.parent instanceof String
 		) {
 			settings.parent = [ settings.parent ];
+		}
+
+		if ( ! Array.isArray( settings?.parent ) && 'parent' in settings ) {
+			warning(
+				'Block parent must be an array of block types, but it is ',
+				settings?.parent
+			);
+			return;
 		}
 
 		return settings;

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -207,7 +207,10 @@ export const processBlockType =
 			settings.parent = [ settings.parent ];
 		}
 
-		if ( ! Array.isArray( settings?.parent ) && 'parent' in settings ) {
+		if (
+			! Array.isArray( settings?.parent ) &&
+			settings?.parent !== undefined
+		) {
 			warning(
 				'Block parent must be an array of block types, but it is ',
 				settings?.parent

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -205,6 +205,9 @@ export const processBlockType =
 			settings.parent instanceof String
 		) {
 			settings.parent = [ settings.parent ];
+			warning(
+				'Block parent must be an array of block types, but it is a string'
+			);
 		}
 
 		if (

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -201,8 +201,8 @@ export const processBlockType =
 		// so this is a way to maintain backwards compatibility
 		// with 3rd party blocks that may have been using it as a string.
 		if (
-			typeof settings.parent === 'string' ||
-			settings.parent instanceof String
+			typeof settings?.parent === 'string' ||
+			settings?.parent instanceof String
 		) {
 			settings.parent = [ settings.parent ];
 		}
@@ -212,8 +212,17 @@ export const processBlockType =
 			settings?.parent !== undefined
 		) {
 			warning(
-				'Block parent must be an array of block types, but it is ',
-				settings?.parent
+				'Block parent must be undefined or an array of block types, but it is ',
+				settings.parent
+			);
+			return;
+		}
+
+		if ( 1 === settings?.parent?.length && name === settings.parent[ 0 ] ) {
+			warning(
+				'Block "' +
+					name +
+					'" cannot be a parent of itself. Please remove the block name from the parent list.'
 			);
 			return;
 		}

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -197,14 +197,20 @@ export const processBlockType =
 			return;
 		}
 
-		// Parent being an array hasn't been enforced in the past,
-		// so this is a way to maintain backwards compatibility
-		// with 3rd party blocks that may have been using it as a string.
 		if (
 			typeof settings?.parent === 'string' ||
 			settings?.parent instanceof String
 		) {
 			settings.parent = [ settings.parent ];
+			warning(
+				'Parent must be undefined or an array of strings (block types), but it is a string.'
+			);
+			// Intentionally continue:
+			//
+			// While string values were never supported, they appeared to work with some unintended side-effects
+			// that have been fixed by [#66250](https://github.com/WordPress/gutenberg/pull/66250).
+			//
+			// To be backwards-compatible, this code that automatically migrates strings to arrays.
 		}
 
 		if (
@@ -212,7 +218,7 @@ export const processBlockType =
 			settings?.parent !== undefined
 		) {
 			warning(
-				'Block parent must be undefined or an array of block types, but it is ',
+				'Parent must be undefined or an array of block types, but it is ',
 				settings.parent
 			);
 			return;


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/66234

## What?

Casts `blockType.parent` to array if it's a string.

## Why?

While we haven't enforced it in any way, we have been operating under the assumption that `blockType.parent` is an array. Apparently, not always is and blocks may register it using a string. When processing input from 3rd parties, we should enforce the type so it's safe to operate with it during the whole lifecycle of the block (e.g.: to avoid issues like [this one](https://github.com/WordPress/gutenberg/pull/66234)).

## How?

- Removes the hotfix introduced at https://github.com/WordPress/gutenberg/pull/66234
- Cast to array in block registration 97cb5b53dc314651ef36dfe73c42cbb8cd37633e
- Cast to array in `'blocks.registerBlockType'` filter fe4e3bece5e5375a2ca6d5432e25ad6a3379f4f9

## Testing Instructions

Update the `parent` of a core block to be a string instead of array (e.g.: update the column block).

Test the following scenarios:

- Inserter:
  - Child block is listed but cannot be added if there's no parent.
  - If the parent block type is selected, the child block shows up as "suggested" and clicking on it adds a new child.
- In place inserter (`+` button):
  - Child block is not listed.
  - The parent block has specific affordances to add new children.

Trunk

- It's possible to add a child block (column) as top-level block. It shouldn't.
- It's possible to add a child block (column) within the same block type (column). It shouldn't.

https://github.com/user-attachments/assets/5c2a24a2-cb4c-4144-a956-37db8a380673

This PR

https://github.com/user-attachments/assets/5ecef613-c1f4-4924-8d78-7a36aa92a55f

