### PR TITLE
Docs: Interactivity API - missing styles in the sample code

### DIFF
--- a/docs/reference-guides/interactivity-api/core-concepts/the-reactive-and-declarative-mindset.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/the-reactive-and-declarative-mindset.md
@@ -28,6 +28,15 @@ Take, for example, this interactive block with two buttons and a paragraph:
 	<p id="status-paragraph" class="inactive" hidden>this is inactive</p>
 </div>
 
+<style>
+	.active {
+		color: green;
+	}
+	.inactive {
+		color: red;
+	}
+</style>
+
 <script>
 	const showHideBtn = document.getElementById( 'show-hide-btn' );
 	const activateBtn = document.getElementById( 'activate-btn' );
@@ -101,6 +110,15 @@ The declarative approach simplifies the process by focusing on _what_ should hap
 		this is inactive
 	</p>
 </div>
+
+<style>
+	.active {
+		color: green;
+	}
+	.inactive {
+		color: red;
+	}
+</style>
 ```
 
 ```js


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
In the sample code in the ‘Declarative vs. imperative’ section:

> **The activate/deactivate button**: Toggles the paragraph's text and color between "active" (green) and "inactive" (red).

the paragraph text has no color due to the lack of styles.

Also, in the bug description:
> Therefore, the next time the user presses Show, the paragraph will not appear in red.

the lack of color in the text makes it difficult to see the difference on screen.

@juanmaguitar 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the style in the code.
This should be written in a separate file, but for simplicity, it is written directly in the html / php file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
