### PR TITLE
Disable Width Settings in Button Block

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -37,6 +37,7 @@ import {
 	__experimentalGetElementClassName,
 	store as blockEditorStore,
 	useBlockEditingMode,
+	useSettings,
 } from '@wordpress/block-editor';
 import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
@@ -256,6 +257,9 @@ function ButtonEdit( props ) {
 		[ context, isSelected, metadata?.bindings?.url ]
 	);
 
+	const [ buttonWidth ] = useSettings( 'blocks.core/button' );
+	const isWidthPanelEnabled = false !== buttonWidth?.[ 0 ]?.width;
+
 	return (
 		<>
 			<div
@@ -370,12 +374,14 @@ function ButtonEdit( props ) {
 						/>
 					</Popover>
 				) }
-			<InspectorControls>
-				<WidthPanel
-					selectedWidth={ width }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
+			{ isWidthPanelEnabled && (
+				<InspectorControls>
+					<WidthPanel
+						selectedWidth={ width }
+						setAttributes={ setAttributes }
+					/>
+				</InspectorControls>
+			) }
 			<InspectorControls group="advanced">
 				{ isLinkTag && (
 					<TextControl


### PR DESCRIPTION
## What?
Fixes Part of this [issue](https://github.com/WordPress/gutenberg/issues/38767) 

This PR introduces the ability to disable the button block's width settings through the theme.json file.

## Why?
This functionality is important for themes that are tailored to specific designs, where controlling the button width setting may be unnecessary or undesired. This provides better flexibility for theme developers, allowing them to disable the width controls as needed.

## How?
The edit.js file of the button block has been updated to retrieve the width value from the theme’s theme.json file. If the width setting is disabled (i.e., set to false), the width panel is no longer displayed in the editor for the button block.

## Testing Instructions

1. Checkout this branch to your local

2. Include the following JSON object within the settings section of the theme.json file for the active theme:

```
"blocks": {
	"core/button": [
		{
			"width": false
		}
	]
},
```
3. Now insert button block in the editor and check the width Settings of the button and it will be removed. Just update false to true in theme.json and check the width Settings and it can be seen.


### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->
For no changes in theme.json or adding width value to true

![button_with_settings](https://github.com/user-attachments/assets/bc6ed84e-ccaf-4494-b9d1-6df1b1706e88)

For theme.json width value false

![button_without_settings](https://github.com/user-attachments/assets/b6fb2780-502e-43db-861b-a457998c92d2)

