### PR TITLE
Style Book: clean up layout

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -120,39 +120,38 @@ function StyleBook( {
 			>
 				{ resizeObserver }
 				{ showTabs ? (
-					<div className="edit-site-style-book__tabs">
-						<Tabs>
-							<div className="edit-site-style-book__tablist-container">
-								<Tabs.TabList>
-									{ tabs.map( ( tab ) => (
-										<Tabs.Tab
-											tabId={ tab.slug }
-											key={ tab.slug }
-										>
-											{ tab.title }
-										</Tabs.Tab>
-									) ) }
-								</Tabs.TabList>
-							</div>
-							{ tabs.map( ( tab ) => (
-								<Tabs.TabPanel
-									key={ tab.slug }
-									tabId={ tab.slug }
-									focusable={ false }
-								>
-									<StyleBookBody
-										category={ tab.slug }
-										examples={ examples }
-										isSelected={ isSelected }
-										onSelect={ onSelect }
-										settings={ settings }
-										sizes={ sizes }
-										title={ tab.title }
-									/>
-								</Tabs.TabPanel>
-							) ) }
-						</Tabs>
-					</div>
+					<Tabs>
+						<div className="edit-site-style-book__tablist-container">
+							<Tabs.TabList>
+								{ tabs.map( ( tab ) => (
+									<Tabs.Tab
+										tabId={ tab.slug }
+										key={ tab.slug }
+									>
+										{ tab.title }
+									</Tabs.Tab>
+								) ) }
+							</Tabs.TabList>
+						</div>
+						{ tabs.map( ( tab ) => (
+							<Tabs.TabPanel
+								key={ tab.slug }
+								tabId={ tab.slug }
+								focusable={ false }
+								className="edit-site-style-book__tabpanel"
+							>
+								<StyleBookBody
+									category={ tab.slug }
+									examples={ examples }
+									isSelected={ isSelected }
+									onSelect={ onSelect }
+									settings={ settings }
+									sizes={ sizes }
+									title={ tab.title }
+								/>
+							</Tabs.TabPanel>
+						) ) }
+					</Tabs>
 				) : (
 					<StyleBookBody
 						examples={ examples }

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -5,6 +5,10 @@
 	&.is-button {
 		border-radius: $radius-large;
 	}
+
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
 }
 
 .edit-site-style-book__iframe {
@@ -18,22 +22,18 @@
 }
 
 .edit-site-style-book__tablist-container {
-	background: $white;
+	flex-shrink: 0;
+	flex-grow: 0;
+
+	display: flex;
 	width: 100%;
 	padding-right: 56px;
-	display: flex;
-	position: absolute;
-	z-index: 1;
+	background: $white;
 }
 
-.edit-site-style-book__tabs {
-	[role="tabpanel"] {
-		bottom: 0;
-		left: 0;
-		overflow: auto;
-		padding: 0;
-		position: absolute;
-		right: 0;
-		top: $grid-unit-60; // Height of tabs.
-	}
+.edit-site-style-book__tabpanel {
+	flex-grow: 1;
+	flex-shrink: 0;
+
+	overflow: auto;
 }

--- a/packages/edit-site/src/components/style-book/style.scss
+++ b/packages/edit-site/src/components/style-book/style.scss
@@ -22,8 +22,7 @@
 }
 
 .edit-site-style-book__tablist-container {
-	flex-shrink: 0;
-	flex-grow: 0;
+	flex: none;
 
 	display: flex;
 	width: 100%;
@@ -32,8 +31,7 @@
 }
 
 .edit-site-style-book__tabpanel {
-	flex-grow: 1;
-	flex-shrink: 0;
+	flex: 1 0 auto;
 
 	overflow: auto;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR simplifies the layout of the style book

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Current layout is based on absolute positioning, which feels hacky and can lead to unexpected layouts down the line

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Switched to a vertical flexbox layout, which allows for the removal of a bunch of styles

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Visit the style book in the site editor
- Make sure the layout works as intended: the tablist stays at the top, while the canvas scrolls its contents
- Try switching tabs, and resizing the canvas

To test the layout without tabs, you can apply this diff:

```diff
diff --git a/packages/edit-site/src/components/style-book/index.js b/packages/edit-site/src/components/style-book/index.js
index 42b6e3f4fc..50e8e8e85e 100644
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -119,7 +119,7 @@ function StyleBook( {
 				} }
 			>
 				{ resizeObserver }
-				{ showTabs ? (
+				{ false ? (
 					<Tabs>
 						<div className="edit-site-style-book__tablist-container">
 							<Tabs.TabList>

```

## Screenshots or screencast <!-- if applicable -->

With tabs:

https://github.com/user-attachments/assets/8f97f76e-6db5-4aa0-9971-46c4603eb4d1

Without tabs:

![Screenshot 2024-10-18 at 18 56 03](https://github.com/user-attachments/assets/21eb68a9-da3a-42ae-9b94-f4c194e35c64)
