### PR TITLE
Fix focus from zoom inserter

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -70,6 +70,12 @@ function ZoomOutModeInserters() {
 		>
 			<ZoomOutModeInserterButton
 				onClick={ () => {
+					// Hotfix for wp/6.7 where focus is not transferred to the sidebar if the
+					// block library is already open.
+					const blockLibrary = document.querySelector(
+						'[aria-label="Block Library"]'
+					);
+
 					setInserterIsOpened( {
 						rootClientId: sectionRootClientId,
 						insertionIndex: index + 1,
@@ -79,6 +85,12 @@ function ZoomOutModeInserters() {
 					showInsertionPoint( sectionRootClientId, index + 1, {
 						operation: 'insert',
 					} );
+
+					// If the block library was available before we opened it with `setInserterIsOpened`, we need to
+					// send focus to the block library.
+					if ( blockLibrary ) {
+						blockLibrary.focus();
+					}
 				} }
 			/>
 		</BlockPopoverInbetween>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If the inserter (block library) is already open, clicking the Add pattern button from the canvas does not move focus.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block inserter receives focus on mount, but if it's already mounted, there isn't a way to move focus to it. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This adds a `document.querySelector( '[aria-label="Block Library"]' )?.focus()` in the Add pattern `onClick` to send focus to the inserter if it is already open.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Zoom out
- Focus a section
- Move focus to the Add pattern button
- Press Enter
- Press Tab
- Focus should be visible in the block library
- Repeat test with and without the block library open

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b1484ddc-51ad-48d5-980c-5ff7d9905014


