### PR TITLE
Block Editor: No need to unlock public actions

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -18,7 +18,6 @@ import { Icon, edit as editIcon } from '@wordpress/icons';
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../store';
-import { unlock } from '../../lock-unlock';
 
 const selectIcon = (
 	<SVG
@@ -36,9 +35,7 @@ function ToolSelector( props, ref ) {
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
 		[]
 	);
-	const { __unstableSetEditorMode } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 
 	return (
 		<Dropdown


### PR DESCRIPTION
## What?
PR removes unnecessary unlocking for public `__unstableSetEditorMode` action.

## Why?
This is probably a leftover from #66141.

## Testing Instructions
1. Open a post or page.
2. Confirm you can switch block editor modes as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-20 at 07 57 39](https://github.com/user-attachments/assets/57c9e044-ebf2-4d29-b4d8-162492493ee6)
