### PR TITLE
Editor: No need to reset mode when changing device preview types

### DIFF
--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -46,12 +46,10 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			};
 		}, [] );
 	const { setDeviceType } = useDispatch( editorStore );
-	const { __unstableSetEditorMode } = useDispatch( blockEditorStore );
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
 		setDeviceType( newDeviceType );
-		__unstableSetEditorMode( 'edit' );
 		resetZoomLevel();
 	};
 


### PR DESCRIPTION
## What?
PR removes unnecessary editor mode reset when changing device preview types.

## Why?
It is no longer required after #66141. The action zoom-out state is exited via the `resetZoomLevel` action dispatch (#65652).

## Testing Instructions
1. Open a post or page.
2. Enable the zoom out.
3. Switch the device preview type.
4. Confirm that the zoom-out state is disabled.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/497a738d-40ee-4a7d-8c8d-f4abc39ee30c

