### PR TITLE
Editor: Handle zoom out state via the 'switchEditorMode' action

### DIFF
--- a/packages/editor/src/components/text-editor/index.js
+++ b/packages/editor/src/components/text-editor/index.js
@@ -6,7 +6,6 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
 import { useEffect, useRef } from '@wordpress/element';
-import { store as blockEditorStore } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -14,7 +13,6 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '../../store';
 import PostTextEditor from '../post-text-editor';
 import PostTitleRaw from '../post-title/post-title-raw';
-import { unlock } from '../../lock-unlock';
 
 export default function TextEditor( { autoFocus = false } ) {
 	const { switchEditorMode } = useDispatch( editorStore );
@@ -28,20 +26,13 @@ export default function TextEditor( { autoFocus = false } ) {
 		};
 	}, [] );
 
-	const { resetZoomLevel, __unstableSetEditorMode } = unlock(
-		useDispatch( blockEditorStore )
-	);
-
 	const titleRef = useRef();
 	useEffect( () => {
-		resetZoomLevel();
-		__unstableSetEditorMode( 'edit' );
-
 		if ( autoFocus ) {
 			return;
 		}
 		titleRef?.current?.focus();
-	}, [ autoFocus, resetZoomLevel, __unstableSetEditorMode ] );
+	}, [ autoFocus ] );
 
 	return (
 		<div className="editor-text-editor">

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -883,9 +883,11 @@ export const switchEditorMode =
 	( { dispatch, registry } ) => {
 		registry.dispatch( preferencesStore ).set( 'core', 'editorMode', mode );
 
-		// Unselect blocks when we switch to a non visual mode.
 		if ( mode !== 'visual' ) {
+			// Unselect blocks when we switch to a non visual mode.
 			registry.dispatch( blockEditorStore ).clearSelectedBlock();
+			// Exit zoom out state when switching to a non visual mode.
+			unlock( registry.dispatch( blockEditorStore ) ).resetZoomLevel();
 		}
 
 		if ( mode === 'visual' ) {


### PR DESCRIPTION
## What?
This is a follow-up to #65932.

PR moves the logic to exit the zoom-out state to the `switchEditorMode` action instead of handling it during the `TextEditor` component render.

## Why?
* The `switchEditorMode` action already clears a couple of states when switching to non-visual modes. It makes sense to handle zoom-out here as well.
* Dispatching actions during events should be preferred over effects. TL;DR: Using effects should be the last resort when changing editor states.

## Testing Instructions
1. Enter to zoom out mode
2. Switch to the code editor and exit the code editor
3. Now, it should get back to zoom-out mode
4. It should work the same when templates are switched while in zoom-out mode.

### Testing Instructions for Keyboard
Same.
