### PR TITLE
Theme JSON: get_block_nodes - relocate $selectors assignment

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2738,9 +2738,13 @@ class WP_Theme_JSON_Gutenberg {
 			return $nodes;
 		}
 
-		$selectors               = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
 		$include_variations      = $options['include_block_style_variations'] ?? false;
 		$include_node_paths_only = $options['include_node_paths_only'] ?? false;
+
+		// If only node paths are to be returned, skip selector assignment.
+		if ( ! $include_node_paths_only ) {
+			$selectors = empty( $selectors ) ? static::get_blocks_metadata() : $selectors;
+		}
 
 		foreach ( $theme_json['styles']['blocks'] as $name => $node ) {
 			$node_path = array( 'styles', 'blocks', $name );


### PR DESCRIPTION
## What? How? Why?

Backport from https://github.com/WordPress/wordpress-develop/pull/7575

Skip `$selector` assignment if only nodes are to be returned. `$selector` isn't required in this case.

There is a slight performance boost:

See comment: https://github.com/WordPress/wordpress-develop/pull/7575#discussion_r1805874311



## Testing Instructions

CI should pass.
Smoke test a block theme. All blocks styles should display as expected.
