### PR TITLE
Block Bindings: Enable bindings for all attributes with 'role: content' property

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -127,7 +127,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	const blockEditContext = useBlockEditContext();
 	const hasBlockBindings = !! blockEditContext[ blockBindingsKey ];
 	const bindingsStyle =
-		hasBlockBindings && canBindBlock( name )
+		hasBlockBindings && canBindBlock()
 			? {
 					'--wp-admin-theme-color': 'var(--wp-block-synced-color)',
 					'--wp-admin-theme-color--rgb':

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -166,10 +166,7 @@ export function RichTextWrapper(
 
 	const { disableBoundBlock, bindingsPlaceholder, bindingsLabel } = useSelect(
 		( select ) => {
-			if (
-				! blockBindings?.[ identifier ] ||
-				! canBindBlock( blockName )
-			) {
+			if ( ! blockBindings?.[ identifier ] || ! canBindBlock() ) {
 				return {};
 			}
 

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -261,7 +261,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 	const filteredBindings = { ...bindings };
 	Object.keys( filteredBindings ).forEach( ( key ) => {
 		if (
-			! canBindAttribute( blockName, key ) ||
+			! canBindAttribute() ||
 			filteredBindings[ key ].source === 'core/pattern-overrides'
 		) {
 			delete filteredBindings[ key ];


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This is an early experiment exploring enabling block bindings for all attributes with the `role: content` property.
See issue https://github.com/WordPress/gutenberg/issues/64870

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
We'd like to begin exploring how to enable bindings for more blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Right now, it just disables the mechanisms for restricting bindings to certain blocks and attributes in the editor — and instead, it checks if the attributes have the `role: content` property.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
This is an exploratory prototype. but you can try connecting blocks in the editor that were previously incompatible with bindings, like List, Quote, and Pull Quote.