### PR TITLE
Remove relative position from sidebar tabpanel

### DIFF
--- a/packages/block-editor/src/components/tabbed-sidebar/style.scss
+++ b/packages/block-editor/src/components/tabbed-sidebar/style.scss
@@ -32,10 +32,4 @@
 	flex-direction: column;
 	overflow-y: auto;
 	scrollbar-gutter: auto;
-
-	// Use `position: relative` to ensure any absolute positioned child elements are
-	// positioned relative to the tab panel.
-	// This makes the overflow rule of the panel work correctly, particularly when the
-	// `VisuallyHidden` component is used within the inserter UI.
-	position: relative;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes pattern preview display in the sidebar:


https://github.com/user-attachments/assets/1675d593-e038-41b9-a5ce-92442f4e4488


Removes a `position: relative` introduced in #66229 that isn't strictly needed to fix the bug that PR addresses.

The original issue was caused by a `VisuallyHidden` component attached to the search bar in the panel header. That is fixed by the `position: relative` added to the header component. Adding `position: relative` to the tabpanel itself interferes with the pattern preview slideout sections, which are positioned relatively to the canvas.

As @talldan mentioned in the previous PR, it might be worth looking into fixing this in `VisuallyHidden` itself, but this close to RC1 it's best to aim for the smallest possible fix 😅 

Thanks to @ramonjd for locating the line responsible for the breakage!

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post and add enough content to it that the body is scrollable.
2. Open the "Add" sidebar, use search to search for a block;
3. No extra scrollbars should appear in the editor - #66161 should remain fixed.
4. Open the Patterns tab, click on a section and check that previews display correctly:

<img width="1156" alt="Screenshot 2024-10-21 at 11 06 20 am" src="https://github.com/user-attachments/assets/bb8dda45-26fa-4adf-b8cd-9a8e6f70a357">
