### PR TITLE
Data views: Fix alignment of action items in list layout

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -33,8 +33,7 @@ ul.dataviews-view-list {
 			.dataviews-view-list__item-actions {
 				flex-basis: min-content;
 				overflow: unset;
-				margin-inline: $grid-unit-10 0;
-				padding-right: $grid-unit-05;
+				padding-inline-end: $grid-unit-05;
 
 				.components-button {
 					opacity: 1;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -34,6 +34,7 @@ ul.dataviews-view-list {
 				flex-basis: min-content;
 				overflow: unset;
 				margin-inline: $grid-unit-10 0;
+				padding-right: $grid-unit-05;
 
 				.components-button {
 					opacity: 1;


### PR DESCRIPTION
## What?
Ensure action icon buttons in data views list layout are aligned with other actions buttons in the header and footer.

## Why?
Visual polish.

## Testing Instructions
1. Open a data view like page management in the site editor
2. Observe that the action items associated with each page are aligned with the actions in the header and footer.

In the screenshot below, the left is trunk, the right is this PR:

<img width="1282" alt="Screenshot 2024-10-21 at 10 08 39" src="https://github.com/user-attachments/assets/7e849cf6-b9fe-4f53-aa43-58c3d9efe5b8">


