### PR TITLE
Remove unnecessary Tooltip component from radius control linked button

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/linked-button.js
+++ b/packages/block-editor/src/components/border-radius-control/linked-button.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Button, Tooltip } from '@wordpress/components';
+import { Button } from '@wordpress/components';
 import { link, linkOff } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -9,15 +9,13 @@ export default function LinkedButton( { isLinked, ...props } ) {
 	const label = isLinked ? __( 'Unlink radii' ) : __( 'Link radii' );
 
 	return (
-		<Tooltip text={ label }>
-			<Button
-				{ ...props }
-				className="component-border-radius-control__linked-button"
-				size="small"
-				icon={ isLinked ? link : linkOff }
-				iconSize={ 24 }
-				aria-label={ label }
-			/>
-		</Tooltip>
+		<Button
+			{ ...props }
+			className="component-border-radius-control__linked-button"
+			size="small"
+			icon={ isLinked ? link : linkOff }
+			iconSize={ 24 }
+			label={ label }
+		/>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/issues/66271

## What?
<!-- In a few words, what is the PR actually doing? -->
Quick code quality PR to remove unnecessary usage of the Tooltip component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code quality

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove Tooltip component and leverage the built-in Button `label` prop.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Select a Group block.
- In the block Settings panel, go to Styles > Radius
- Hover or focus the 'Unlink / link radii' button.
- Observe the button tooltip is unchanged: 'Unlink radii' or 'Link radii' depending on the UI state.
- Observe the accessible name (aria-label) of the Button is unchanged and matches the tooltip.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-10-21 at 11 26 00](https://github.com/user-attachments/assets/05cc4a74-872a-41e5-9335-cb10839f454d)
