### PR TITLE
Zoom-out: Move default background to the iframe component

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -3,7 +3,6 @@ iframe[name="editor-canvas"] {
 	width: 100%;
 	height: 100%;
 	display: block;
-	background-color: transparent;
 	// Handles transitions between device previews
 	@include editor-canvas-resize-animation;
 	background-color: $gray-300;

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -6,4 +6,5 @@ iframe[name="editor-canvas"] {
 	background-color: transparent;
 	// Handles transitions between device previews
 	@include editor-canvas-resize-animation;
+	background-color: $gray-300;
 }

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -1,6 +1,5 @@
 .edit-site-editor-canvas-container {
 	height: 100%;
-	background-color: $gray-300;
 
 	// Controls height of editor and editor canvas container (style book, global styles revisions previews etc.)
 	iframe {

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -1,7 +1,6 @@
 .editor-visual-editor {
 	position: relative;
 	display: flex;
-	background-color: $gray-300;
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -2,6 +2,11 @@
 	position: relative;
 	display: flex;
 
+	// This duplicates the iframe background but it's necessary in some situations
+	// when the iframe doesn't cover the whole canvas
+	// like the "focused entities".
+	background-color: $gray-300;
+
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
 

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -7,6 +7,13 @@
 	// like the "focused entities".
 	background-color: $gray-300;
 
+	// This overrides the iframe background since it's applied again here
+	// It also prevents some style glitches if `editor-visual-editor`
+	// like when hovering the preview in the site editor.
+	iframe[name="editor-canvas"] {
+		background-color: transparent;
+	}
+
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
 

--- a/storybook/stories/playground/zoom-out/index.js
+++ b/storybook/stories/playground/zoom-out/index.js
@@ -50,7 +50,7 @@ export default function EditorZoomOut( { zoomLevel } ) {
 		<div
 			className="editor-zoom-out"
 			onKeyDown={ ( event ) => event.stopPropagation() }
-			style={ { background: '#ddd', border: '1px solid gray' } }
+			style={ { border: '1px solid gray' } }
 		>
 			<BlockEditorProvider
 				value={ blocks }


### PR DESCRIPTION
## What?

When you trigger zoom-out, the iframe content is scaled down revealing some empty space on the right/left of the document. In both site editor and post editors, there's a background color applied to this area that "blends" with the frame size of the zoom-out. That said, if you're triggering zoom-out in a third-party block editor (like the storybook story), that space remains "white".

This PR moves that background style to the iframe component that way it's applied by default to all iframes and all block editors.

It solves this comment https://github.com/WordPress/gutenberg/pull/66240#discussion_r1806540596

## Testing Instructions

1- There should be no background changes in the editor in zoom-out mode or not.
2- zoom-out background is still correct in the storybook story even without the extra style.