### PR TITLE
Block editor: remove reusable blocks stylesheet from iframe

### DIFF
--- a/backport-changelog/6.8/7604.md
+++ b/backport-changelog/6.8/7604.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7604
+
+* https://github.com/WordPress/gutenberg/pull/66285

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -327,7 +327,6 @@ function gutenberg_register_packages_styles( $styles ) {
 		'wp-reset-editor-styles',
 		'wp-block-library',
 		'wp-patterns',
-		'wp-reusable-blocks',
 		// Until #37466, we can't specifically add them as editor styles yet,
 		// so we must hard-code it here as a dependency.
 		'wp-block-editor-content',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Similar to #33496.

These styles are not needed within the canvas of the editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There's only a single rule that is related to a modal: https://github.com/WordPress/gutenberg/blob/da4ea0d4afcbee49a6963dfcbf00d237064751cf/packages/reusable-blocks/src/components/reusable-blocks-menu-items/style.scss

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Try the "create pattern" menu item for a block. The z-index seems to be there so that the popover of the block toolbar appears under the modal. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
