### PR TITLE
Zoom out: restore trash button

### DIFF
--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -77,6 +77,7 @@ export default function BlockToolbarPopover( {
 					__experimentalOnIndexChange={ ( index ) => {
 						initialToolbarItemIndexRef.current = index;
 					} }
+					__unstableContentRef={ __unstableContentRef }
 					variant="toolbar"
 				/>
 			</BlockPopover>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #66287.
This button was removed in #66200, and it restored the triple dots "more" menu.
This PR tries to restore the trash button and again remove the "more" menu.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-10-22 at 09 36 16](https://github.com/user-attachments/assets/4e327ae2-1b97-456b-9992-9ef5b04409b4)
