### PR TITLE
[WP 6.7] Tabs: Unify tab height to 48px/40px

### DIFF
--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -100,7 +100,7 @@ export const Tab = styled( Ariakit.Tab )`
 		box-shadow: none;
 		cursor: pointer;
 		line-height: 1.2; // Some languages characters e.g. Japanese may have a native higher line-height.
-		padding: ${ space( 4 ) };
+		padding: ${ space( 3 ) } ${ space( 4 ) };
 		margin-left: 0;
 		font-weight: 500;
 		text-align: inherit;


### PR DESCRIPTION
Fix the issue discovered in [this comment](https://github.com/WordPress/gutenberg/issues/65624#issuecomment-2423934860)

## What?

This PR standardizes the tab height to 48px/40px in the Tabs component.


## Why?

This issue is caused by a fluid height being applied to the tabs to prevent overlapping focus styles. In #62027, the vertical padding of the tabs was [changed from `3px` to `space( 4 ) = 16px`](https://github.com/WordPress/gutenberg/pull/62027/files?diff=unified&w=0#diff-3fd57d2d016c6bcd4daff46b55844f6018004956f2bc1fb1420e0d5ba549aebdR70). This may cause the tab height to exceed 40px or 48px depending on the tab content.

## How?

All of these issues have been resolved in the trunk branch. However, since the trunk branch contains various improvements and changes, it is not possible to backport directly from the `trunk` branch to the `wp/6.7` branch.

As I understand it, the Tabs component expected in WP 6.7 is as follows.

- Horizontal tab (icon):
  - The height is basically 48px.
  - When the tab content is long, the tab height changes fluidly.
  - Focus outlines do not overlap.
- Vertical tab:
  - the height should be 40px (See [#63446](https://github.com/WordPress/gutenberg/pull/63446))

To achieve these, I will submit the minimum changes to the `wp/6.7` branch.

## Testing Instructions

- Horizontal Tab:
  - Open the site editor.
  - Open the editor sidebar.
  - Tabs (Template, Block) height should still be **48px**.
  - Select a block that has Settings and Styles tabs.
  - The settings and style tabs height should now be **48px**.
- Horizontal Tab (fluid height):
  - Change the site language to Japanese.
  - Enable "Show button text labels" setting.
  - Open the site editor and select a navigation block.
  - Focus a tab in the block sidebar.
  - The focus outline should not overlap any text.
- Vertical Tab:
  - Select the Patterns tab from the main inserter.
  - The pattern category button height should still be **40px**.
  - Open the settings modal.
  - The tab panel height should now be **40px**.

## Screenshots

### Horizontal tab (icon)

|  Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/2764cfaf-17ac-4f1e-afee-85639edb5fc1) | ![image](https://github.com/user-attachments/assets/d5d18895-ac3d-4259-bebd-2c4fdc7f6340) |
| ![image](https://github.com/user-attachments/assets/d0035edc-c312-44ef-b68b-8fbce758fe9a) | ![image](https://github.com/user-attachments/assets/5e9429da-40b8-46f3-a0e7-cfe6e99495f7) |

### Horizontal tab (fluid height)

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/6187f1e9-9b15-48d5-aaec-2dbf97ddfbfd)| ![image](https://github.com/user-attachments/assets/17a9f61f-8d28-4908-aa07-a820c5631353)| 

###  Vertical tab

|  Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/a0435b22-6f63-4a4e-b961-7de12b0139a4) | ![image](https://github.com/user-attachments/assets/1b8dbd3f-dfd6-42e0-8910-5e9f199dfad7) |
| ![image](https://github.com/user-attachments/assets/54aab7e2-90f1-4e4b-8c3e-e3e22953d49a) | ![image](https://github.com/user-attachments/assets/7de5ac21-8fd2-4153-a2bb-e926633932ac) |