### PR TITLE
Upgrade Playwright to v1.48

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.47.0",
+				"@playwright/test": "1.48.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -7096,12 +7096,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.47.0.tgz",
-			"integrity": "sha512-SgAdlSwYVpToI4e/IH19IHHWvoijAYH5hu2MWSXptRypLSnzj51PcGD+rsOXFayde4P9ZLi+loXVwArg6IUkCA==",
+			"version": "1.48.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
+			"integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.47.0"
+				"playwright": "1.48.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41274,12 +41274,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.47.0.tgz",
-			"integrity": "sha512-jOWiRq2pdNAX/mwLiwFYnPHpEZ4rM+fRSQpRHwEwZlP2PUANvL3+aJOF/bvISMhFD30rqMxUB4RJx9aQbfh4Ww==",
+			"version": "1.48.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
+			"integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.47.0"
+				"playwright-core": "1.48.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -41292,9 +41292,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.47.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.47.0.tgz",
-			"integrity": "sha512-1DyHT8OqkcfCkYUD9zzUTfg7EfTd+6a8MkD/NWOvjo0u/SCNd5YmY/lJwFvUZOxJbWNds+ei7ic2+R/cRz/PDg==",
+			"version": "1.48.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
+			"integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -56607,7 +56607,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.47.0",
+				"@playwright/test": "^1.48.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.47.0",
+		"@playwright/test": "1.48.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.47.0",
+		"@playwright/test": "^1.48.1",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.48

## What's new?
https://playwright.dev/docs/release-notes#version-148

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.