### PR TITLE
ResizableEditor: Add 2px to height to fix vertical scrollbar

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -384,7 +384,9 @@ function VisualEditor( {
 			<ResizableEditor
 				enableResizing={ enableResizing }
 				height={
-					sizes.height && ! forceFullHeight ? sizes.height : '100%'
+					sizes.height && ! forceFullHeight
+						? sizes.height + 1 // Add 1px to avoid scrollbars.
+						: '100%'
 				}
 			>
 				<BlockCanvas

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -385,7 +385,7 @@ function VisualEditor( {
 				enableResizing={ enableResizing }
 				height={
 					sizes.height && ! forceFullHeight
-						? sizes.height + 1 // Add 1px to avoid scrollbars.
+						? sizes.height + 2 // Add 2px to avoid scrollbars.
 						: '100%'
 				}
 			>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #66297, follows https://github.com/WordPress/gutenberg/pull/66041

Fix the issue of a vertical scrollbar unintentionally being displayed in the resizable editor due to the height being set to _just_ not tall enough when the iframe's size is not a rounded integer.

Note: this is a fairly naive fix, intended for 6.7. There might be a better way to go about this, so happy to close it out if folks have better ideas for a fix!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As of #66041 there is a sub-pixel border on the editor iframe to fix an issue with layout shifts during zooming. That fix caused the issue in #66297 as it turns out the resize observer that sets the height of the resizable editor rounds the height to an integer. This PR proposes adding `2px` of height clearance to the resizable editor to account for the sub pixel height difference.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Add `1px` to the height of the resizable editor, to avoid a vertical scrollbar

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. For the issue to be apparent, set your OS to always display scrollbars, if it doesn't already
2. Open up the site editor
3. Go to the Patterns editor and select or create a pattern to open the editor view that includes the resizable editor
4. On `trunk` note that there is a vertical scrollbar even if the pattern is short
5. With this PR applied, there should no longer be an unexpected scrollbar
6. Check that the added `1px` doesn't introduce any other visual issues

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/44819d5a-4c76-4691-a625-8233e5aacf5f) | ![image](https://github.com/user-attachments/assets/19180d5e-4b4f-40c3-b371-109006b020b0) |