### PR TITLE
Buttons: Fix the initial white space in nofollow rel

### DIFF
--- a/packages/block-library/src/button/get-updated-link-attributes.js
+++ b/packages/block-library/src/button/get-updated-link-attributes.js
@@ -40,7 +40,7 @@ export function getUpdatedLinkAttributes( {
 	if ( nofollow ) {
 		updatedRel = updatedRel?.includes( NOFOLLOW_REL )
 			? updatedRel
-			: updatedRel + ` ${ NOFOLLOW_REL }`;
+			: ( updatedRel + ` ${ NOFOLLOW_REL }` ).trim();
 	} else {
 		const relRegex = new RegExp( `\\b${ NOFOLLOW_REL }\\s*`, 'g' );
 		updatedRel = updatedRel?.replace( relRegex, '' ).trim();

--- a/packages/block-library/src/button/test/get-updated-link-attributes.js
+++ b/packages/block-library/src/button/test/get-updated-link-attributes.js
@@ -79,6 +79,21 @@ describe( 'getUpdatedLinkAttributes method', () => {
 		expect( result.rel ).toEqual( 'rel_value nofollow' );
 	} );
 
+	it( 'should correctly update link attributes with nofollow without spacing', () => {
+		const options = {
+			url: 'example.com',
+			opensInNewTab: false,
+			nofollow: true,
+			rel: '',
+		};
+
+		const result = getUpdatedLinkAttributes( options );
+
+		expect( result.url ).toEqual( 'http://example.com' );
+		expect( result.linkTarget ).toEqual( undefined );
+		expect( result.rel ).toEqual( 'nofollow' );
+	} );
+
 	it( 'should correctly handle rel with existing nofollow values and remove duplicates', () => {
 		const options = {
 			url: 'example.com',


### PR DESCRIPTION
## What?
Fixes: #66300 

## Why?
When the button settings don't specify a rel attribute value and the user clicks on 'Mark as nofollow' in the link's advanced settings, an extra space is added to the rel attribute in the button link.

## How?
This PR trims the final value of `rel` attribute to remove redundant initial space.

## Testing Instructions

1. Add a button block and insert a link
2. Edit the link and check the mark as nofollow option
3. View the resulting HTML code via the Code editor
4. OR inspect the button element via the browser
5. Notice the link's rel="nofollow" attribute should not have space before the value

## Screenshots or screencast

https://github.com/user-attachments/assets/3cb982a2-57dd-42ac-b303-95f491770f8a


