### PR TITLE
SpacingSizesControl: Use generic label for linked button

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/linked-button.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/linked-button.js
@@ -3,20 +3,10 @@
  */
 import { Button, Tooltip } from '@wordpress/components';
 import { link, linkOff } from '@wordpress/icons';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 export default function LinkedButton( { isLinked, ...props } ) {
-	const label = isLinked
-		? sprintf(
-				// translators: 1. Type of spacing being modified (padding, margin, etc).
-				__( 'Unlink %1$s' ),
-				props.label.toLowerCase()
-		  ).trim()
-		: sprintf(
-				// translators: 1. Type of spacing being modified (padding, margin, etc).
-				__( 'Link %1$s' ),
-				props.label.toLowerCase()
-		  ).trim();
+	const label = isLinked ? __( 'Unlink sides' ) : __( 'Link sides' );
 
 	return (
 		<Tooltip text={ label }>


### PR DESCRIPTION
Addresses the issue mentioned in [this comment](https://github.com/WordPress/gutenberg/pull/65193#issuecomment-2419585680)

## What?
Uses a generic label for the linked button of the `SpacingSizesControl` component.

## Why?

The current implementation uses the label of the component itself as part of the text, which may not be appropriate for localization. Additionally, the placeholder text is forcibly changed to lower case via the `toLowerCase()` method, which may not generate the proper text for some languages.

## How?

I use the label `Unlink sides`, `Link sides`, which [were also used before](https://github.com/WordPress/gutenberg/blob/4c60efe0d991c202b6bdc2f93d56e4a8273ab074/packages/block-editor/src/components/spacing-sizes-control/linked-button.js#L9).

## Testing Instructions

- Insert a block that supports padding or margin.
- Open the Dimensions panel.
- Focus the linked button and check the tooltip text.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/9610764a-cdc5-491f-8e97-f0be385040bf)| ![image](https://github.com/user-attachments/assets/be52f2d7-d630-49f9-9508-16507e6cfc49)|
| ![image](https://github.com/user-attachments/assets/6b8e9071-779d-4bcb-a23e-be956f942bff)| ![image](https://github.com/user-attachments/assets/de38c3a4-4a68-4ab1-80b4-6061d4607eed)| 