### PR TITLE
 Add post title link in template editor

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -116,6 +116,22 @@ export default function PostTitleEdit( {
 				/>
 			</TagName>
 		);
+	} else if ( isLink ) {
+		/* If the postType or postId is not set, It might be in template editor. Just show the title as a link.
+		 * This is a fallback for the case where the postType and postId are not set.
+		 */
+		titleElement = (
+			<TagName { ...blockProps }>
+				<a
+					href={ link }
+					target={ linkTarget }
+					onClick={ ( event ) => event.preventDefault() }
+					dangerouslySetInnerHTML={ {
+						__html: __( 'Title' ),
+					} }
+				/>
+			</TagName>
+		);
 	}
 
 	return (


### PR DESCRIPTION
## What?
This PR adds the link tag to post title when selected in the template editor.
For better understanding go through the [issue](https://github.com/WordPress/gutenberg/issues/65691)

## Why?
Fixes: #65691 

## How?
This PR adds the necessary anchor tag when we have link option enabled.

## Testing Instructions
- Head over to the template editor and add the Title block to it.
- Enable the "Make title a link" block setting in the editor sidebar.
- Review the block markup in the page source. There will be a anchor tag.

## Screenshots or screencast
### Before
<img width="1710" alt="Screenshot 2024-10-22 at 1 35 35 PM" src="https://github.com/user-attachments/assets/db0ede0b-3858-4ae7-b1c9-bdf44b5e9e13">

### After
<img width="1710" alt="Screenshot 2024-10-22 at 1 35 51 PM" src="https://github.com/user-attachments/assets/dafeff7d-df4d-4c8d-9667-0b28446c5fcc">
