### PR TITLE
Block editor: remove patterns UI stylesheet from iframe

### DIFF
--- a/backport-changelog/6.8/7604.md
+++ b/backport-changelog/6.8/7604.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/7604
 
 * https://github.com/WordPress/gutenberg/pull/66285
 * https://github.com/WordPress/gutenberg/pull/66302
+* https://github.com/WordPress/gutenberg/pull/66306

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -320,13 +320,13 @@ function gutenberg_register_packages_styles( $styles ) {
 	);
 	$styles->add_data( 'wp-format-library', 'rtl', 'replace' );
 
+	// Only add CONTENT styles here that should be enqueued in the iframe!
 	$wp_edit_blocks_dependencies = array(
 		'wp-components',
 		// This need to be added before the block library styles,
 		// The block library styles override the "reset" styles.
 		'wp-reset-editor-styles',
 		'wp-block-library',
-		'wp-patterns',
 		// Until #37466, we can't specifically add them as editor styles yet,
 		// so we must hard-code it here as a dependency.
 		'wp-block-editor-content',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This stylesheet contains only rules that target pattern UI components such as popover, toolbars, and inspector controls.

Overall I find this stylesheet a bit strange. It's a weird package abstraction imo (at least when looking at the styles).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Clean up

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Test the pattern overrides UI. For example I created a pattern, edited original, selected a block in the pattern and made sure the pattern overrides button under Advances is still 100% width.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
