### PR TITLE
Fix: Activate zoom out on large viewport

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -9,6 +9,7 @@ import { useEffect } from '@wordpress/element';
  */
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
@@ -20,12 +21,13 @@ export function useZoomOut( zoomOut = true ) {
 		useDispatch( blockEditorStore )
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
+	const isWideViewport = useViewportMatch( 'large' );
 
 	useEffect( () => {
 		const isZoomOutOnMount = isZoomOut();
 
 		return () => {
-			if ( isZoomOutOnMount ) {
+			if ( isZoomOutOnMount && isWideViewport ) {
 				setZoomLevel( 50 );
 			} else {
 				resetZoomLevel();
@@ -34,7 +36,7 @@ export function useZoomOut( zoomOut = true ) {
 	}, [] );
 
 	useEffect( () => {
-		if ( zoomOut ) {
+		if ( zoomOut && isWideViewport ) {
 			setZoomLevel( 50 );
 		} else {
 			resetZoomLevel();

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -41,5 +41,5 @@ export function useZoomOut( zoomOut = true ) {
 		} else {
 			resetZoomLevel();
 		}
-	}, [ zoomOut, setZoomLevel, resetZoomLevel ] );
+	}, [ zoomOut, setZoomLevel, resetZoomLevel, isWideViewport ] );
 }


### PR DESCRIPTION
## What?
Solve https://github.com/WordPress/gutenberg/issues/66205

## Why?
Part of https://github.com/WordPress/gutenberg/issues/66205

## Testing Instructions
- Open the post editor.
- Open the main inserter.
- Click the Patterns tab.