### PR TITLE
[6.7] Zoom-out (contentOnly): show more menu in block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu-controls/index.js
+++ b/packages/block-editor/src/components/block-settings-menu-controls/index.js
@@ -58,7 +58,8 @@ const BlockSettingsMenuControlsSlot = ( { fillProps, clientIds = null } ) => {
 	const convertToGroupButtonProps =
 		useConvertToGroupButtonProps( selectedClientIds );
 	const { isGroupable, isUngroupable } = convertToGroupButtonProps;
-	const showConvertToGroupButton = isGroupable || isUngroupable;
+	const showConvertToGroupButton =
+		( isGroupable || isUngroupable ) && ! isContentOnly;
 
 	return (
 		<Slot

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -56,6 +56,15 @@ export function BlockSettingsDropdown( {
 	const currentClientId = block?.clientId;
 	const count = clientIds.length;
 	const firstBlockClientId = clientIds[ 0 ];
+
+	const isZoomOut = useSelect( ( select ) => {
+		const { __unstableGetEditorMode } = unlock(
+			select( blockEditorStore )
+		);
+
+		return __unstableGetEditorMode() === 'zoom-out';
+	} );
+
 	const {
 		firstParentClientId,
 		onlyBlock,
@@ -235,7 +244,7 @@ export function BlockSettingsDropdown( {
 										clientId={ firstBlockClientId }
 									/>
 								) }
-								{ ! isContentOnly && (
+								{ ( ! isContentOnly || isZoomOut ) && (
 									<CopyMenuItem
 										clientIds={ clientIds }
 										onCopy={ onCopy }

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -255,9 +255,7 @@ export function PrivateBlockToolbar( {
 					</>
 				) }
 				<BlockEditVisuallyButton clientIds={ blockClientIds } />
-				{ isDefaultEditingMode && (
-					<BlockSettingsMenu clientIds={ blockClientIds } />
-				) }
+				<BlockSettingsMenu clientIds={ blockClientIds } />
 			</div>
 		</NavigableToolbar>
 	);

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -13,6 +13,7 @@ import {
 	BlockEditorProvider,
 	BlockContextProvider,
 	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { store as noticesStore } from '@wordpress/notices';
 import { privateApis as editPatternsPrivateApis } from '@wordpress/patterns';
@@ -188,6 +189,15 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 				},
 				[ post.type ]
 			);
+
+		const isZoomOut = useSelect( ( select ) => {
+			const { __unstableGetEditorMode } = unlock(
+				select( blockEditorStore )
+			);
+
+			return __unstableGetEditorMode() === 'zoom-out';
+		} );
+
 		const shouldRenderTemplate = !! template && mode !== 'post-only';
 		const rootLevelPost = shouldRenderTemplate ? template : post;
 		const defaultBlockContext = useMemo( () => {
@@ -334,7 +344,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 								<>
 									<PatternsMenuItems />
 									<TemplatePartMenuItems />
-									<ContentOnlySettingsMenu />
+									{ ! isZoomOut && (
+										<ContentOnlySettingsMenu />
+									) }
 									{ mode === 'template-locked' && (
 										<DisableNonPageContentBlocks />
 									) }

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -342,10 +342,12 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							{ children }
 							{ ! settings.__unstableIsPreviewMode && (
 								<>
-									<PatternsMenuItems />
-									<TemplatePartMenuItems />
 									{ ! isZoomOut && (
-										<ContentOnlySettingsMenu />
+										<>
+											<PatternsMenuItems />
+											<TemplatePartMenuItems />
+											<ContentOnlySettingsMenu />
+										</>
 									) }
 									{ mode === 'template-locked' && (
 										<DisableNonPageContentBlocks />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Since zoom-out mode is automatically `contentOnly` mode, this condition will cause the "more" menu in the block toolbar to disappear. It's actually shown in trunk and was fixed here:

https://github.com/WordPress/gutenberg/pull/65485/files#diff-9ac2a4466e7c0a85aaff0b40c5d7bc64c894132528ca3c879db4bebb438617dcL245-L247

I do wonder if we should try to backport all of #65485 or not. Cc @youknowriad.

Also, since this is `contentOnly` mode, should the group/ungroup buttons be removed? I went ahead and removed them, but not sure if they were left in place intentionally.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There's no way to trash patterns in zoom-out mode in 6.7 without the use of the keyboard. Fixes https://github.com/WordPress/gutenberg/issues/66287

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove the requirement to be in the default editing mode.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->



- Engage Zoom Out
- Click on a section
- Toggle the "3 dots" block settings menu
- Check the options are stable for Zoom Out (should be primarily delete and copy)
- Repeat above for:
    - Pages in the _Site_ Editor
    - Pages in the _Post_ Editor

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
