### PR TITLE
Pull request automation: use full npm install

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -17,24 +17,8 @@ jobs:
                   ref: trunk
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-            - name: Use desired version of Node.js
-              uses: actions/setup-node@0a44ba7841725637a19e28fa30b79a866c81b0a6 # v4.0.4
-              with:
-                  node-version-file: '.nvmrc'
-                  check-latest: true
-
-            - name: Cache NPM packages
-              uses: actions/cache@3624ceb22c1c5a301c8db4169662070a689d9ea8 # v4.1.1
-              with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pr-automation-cache-${{ hashFiles('**/package-lock.json') }}
-
-            # Changing into the action's directory and running `npm install` is much
-            # faster than a full project-wide `npm ci`.
-            - name: Install NPM dependencies
-              run: npm install
-              working-directory: packages/project-management-automation
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
 
             - uses: ./packages/project-management-automation
               with:

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -14,7 +14,7 @@ jobs:
             # isn't necessarily `trunk` (e.g. in the case of a merge).
             - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
               with:
-                  ref: trunk
+                  ref: pull-request-automation/use-regular-npm-install
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
             - name: Setup Node.js and install dependencies

--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -14,7 +14,7 @@ jobs:
             # isn't necessarily `trunk` (e.g. in the case of a merge).
             - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
               with:
-                  ref: pull-request-automation/use-regular-npm-install
+                  ref: trunk
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
             - name: Setup Node.js and install dependencies


### PR DESCRIPTION

## What?

Use full npm install for the pull-request-automation workflow.

This installation is larger and slower, however I suspect that is likely to be offset by caching.
This is also blocking work on the migration to npm workspaces that has its own merits in #66272.

## Why?

The pull-request-automation workflow creates problems when migrating to npm workspaces:

https://github.com/WordPress/gutenberg/actions/runs/11435991643/job/31813748278

Extracted from https://github.com/WordPress/gutenberg/pull/66272.

## How?

Use the regular npm installation flows shared by other github actions in the project.

## Testing Instructions

CI passes. [pull-request-automation workflow runs as expected.](https://github.com/WordPress/gutenberg/actions/runs/11458362531/job/31880563287?pr=66314)
