### PR TITLE
Update a few function definitions

### DIFF
--- a/packages/components/src/spacer/hook.ts
+++ b/packages/components/src/spacer/hook.ts
@@ -12,8 +12,9 @@ import { space } from '../utils/space';
 import { rtl, useCx } from '../utils';
 import type { SpacerProps } from './types';
 
-const isDefined = < T >( o: T ): o is Exclude< T, null | undefined > =>
-	typeof o !== 'undefined' && o !== null;
+function isDefined< T >( o: T ): o is Exclude< T, null | undefined > {
+	return typeof o !== 'undefined' && o !== null;
+}
 
 export function useSpacer(
 	props: WordPressComponentProps< SpacerProps, 'div' >

--- a/packages/data-controls/src/index.ts
+++ b/packages/data-controls/src/index.ts
@@ -154,7 +154,9 @@ export const __unstableAwaitPromise = function < T >( promise: Promise< T > ) {
  * store.
  */
 export const controls = {
-	AWAIT_PROMISE: < T >( { promise }: { promise: Promise< T > } ) => promise,
+	AWAIT_PROMISE< T >( { promise }: { promise: Promise< T > } ) {
+		return promise;
+	},
 	API_FETCH( { request }: { request: APIFetchOptions } ) {
 		return triggerFetch( request );
 	},

--- a/packages/fields/src/mutation/index.ts
+++ b/packages/fields/src/mutation/index.ts
@@ -10,9 +10,9 @@ import { dispatch } from '@wordpress/data';
  */
 import type { CoreDataError, Post } from '../types';
 
-const getErrorMessagesFromPromises = < T >(
+function getErrorMessagesFromPromises< T >(
 	allSettledResults: PromiseSettledResult< T >[]
-) => {
+) {
 	const errorMessages = new Set< string >();
 	// If there was at lease one failure.
 	if ( allSettledResults.length === 1 ) {
@@ -36,7 +36,7 @@ const getErrorMessagesFromPromises = < T >(
 		}
 	}
 	return errorMessages;
-};
+}
 
 export type NoticeSettings< T extends Post > = {
 	success: {


### PR DESCRIPTION
## What?
Changing a few arrow functions to be regular functions.

## Why?
To unblock #65463.

For some reason `@typescript-eslint/typescript-estree` breaks parsing those constructs when an arrow function is used, while using a regular function works well. 

When fixing those, we're able to run `react-scanner` properly without it failing on those functions

## How?
We're just changing a few arrow functions to be proper functions, the rest is the same

## Testing Instructions
- All checks should be green. This is a minor syntax change. 
- If you want to test with React Scanner:
  - Checkout #65463
  - Run `npm install`
  - Run `npm run component-usage-stats > stats.json`
  - You'll see 3 errors (see "screenshots or screencast" below)
  - Run `git cherry-pick 1257ccef14c3e0165a71a1195237ec37724f0273` to get the commit from this branch.
  - Run `npm run component-usage-stats > stats.json`
  - You'll see no errors. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Errors we see with #65463:
```
Failed to parse: gutenberg/packages/components/src/spacer/hook.ts
Failed to parse: gutenberg/packages/data-controls/src/index.ts
Failed to parse: gutenberg/packages/fields/src/mutation/index.ts
```