### PR TITLE
Re-order spacing side controls when unlinked

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/utils.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/utils.js
@@ -14,7 +14,7 @@ import {
 
 export const RANGE_CONTROL_MAX_SIZE = 8;
 
-export const ALL_SIDES = [ 'top', 'right', 'bottom', 'left' ];
+export const ALL_SIDES = [ 'top', 'bottom', 'left', 'right' ];
 
 export const DEFAULT_VALUES = {
 	top: undefined,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This change is from the suggestions from [this comment](https://github.com/WordPress/gutenberg/issues/63963#issuecomment-2419559890)

![ordered-spacing-controls](https://github.com/user-attachments/assets/2807283d-28d9-4d9d-8b4e-3b9046077d0b)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Verify spacing controls (padding, margin) in styles panel. Now they should be in the following order.

* `Top`, `bottom`, `left`, `right` when unlinked.
* `Top + bottom`, `Left + Right` when linked.
