### PR TITLE
Fix: Show paragraph block variations in rich text inserter

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -6,6 +6,7 @@ import {
 	createBlock,
 	createBlocksFromInnerBlocksTemplate,
 	parse,
+	store as blocksStore,
 } from '@wordpress/blocks';
 import { useMemo } from '@wordpress/element';
 
@@ -36,22 +37,30 @@ function createBlockCompleter() {
 		triggerPrefix: '/',
 
 		useItems( filterValue ) {
-			const { rootClientId, selectedBlockName, prioritizedBlocks } =
+			const { rootClientId, selectedBlockId, prioritizedBlocks } =
 				useSelect( ( select ) => {
 					const {
 						getSelectedBlockClientId,
-						getBlockName,
+						getBlock,
 						getBlockListSettings,
 						getBlockRootClientId,
 					} = select( blockEditorStore );
+					const { getActiveBlockVariation } = select( blocksStore );
 					const selectedBlockClientId = getSelectedBlockClientId();
+					const { name: blockName, attributes } = getBlock(
+						selectedBlockClientId
+					);
+					const activeBlockVariation = getActiveBlockVariation(
+						blockName,
+						attributes
+					);
 					const _rootClientId = getBlockRootClientId(
 						selectedBlockClientId
 					);
 					return {
-						selectedBlockName: selectedBlockClientId
-							? getBlockName( selectedBlockClientId )
-							: null,
+						selectedBlockId: activeBlockVariation
+							? `${ blockName }/${ activeBlockVariation.name }`
+							: blockName,
 						rootClientId: _rootClientId,
 						prioritizedBlocks:
 							getBlockListSettings( _rootClientId )
@@ -78,11 +87,11 @@ function createBlockCompleter() {
 					  );
 
 				return initialFilteredItems
-					.filter( ( item ) => item.name !== selectedBlockName )
+					.filter( ( item ) => item.id !== selectedBlockId )
 					.slice( 0, SHOWN_BLOCK_TYPES );
 			}, [
 				filterValue,
-				selectedBlockName,
+				selectedBlockId,
 				items,
 				categories,
 				collections,


### PR DESCRIPTION
Co-authored by @DAreRodz 

## What?
Right now, when a user creates a block variation of the paragraph block, it doesn't appear in the inserter of the rich text. In this pull request, I propose including them, but I'd like to ask if this is intended or not.

If we want to change the current behavior, I can add some e2e tests.

**How it works right now**

When you type `/` in a paragraph block, it shows neither the paragraph or the block variations in the inserter.

**How it works in this pull request**
- In a normal paragraph: It doesn't show the paragraph block but it shows the block variations.
- When a block variation is selected: it shows the default paragraph block but it doesn't show the selected block variation.

## Why?
It could make sense to include variations there to replicate the behavior of the inserter, as discussed here: https://github.com/WordPress/gutenberg/pull/23364

## How?
I'm checking the `item.id` instead of the `item.name`. It is the only way I found to differ between variations and the default block.

## Testing Instructions
1. Go to a page and post.
2. Register a block variation of the paragraph block:
```js
wp.blocks.registerBlockVariation( 'core/paragraph', {
    name: 'paragraph-red',
    title: 'Red Paragraph',
    attributes: {
        textColor: 'vivid-red',
    },
    isActive: [ 'textColor' ],
} );
```
3. Go to a paragraph and type `/` and check the paragraph doesn't show.
4. Type `/red` and check the variation shows.
5. Select the variation.
6. Type `/` and check the paragraph shows.
7. Type `/red` and check the variation doesn't show.
