### PR TITLE
Fix : Duplicative link control label and placeholder

### DIFF
--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -122,8 +122,8 @@ const PREFERENCE_KEY = 'linkControlSettingsDrawer';
  * @param {WPLinkControlProps} props Component props.
  */
 function LinkControl( {
-	searchInputLabel,
-	searchInputPlaceholder,
+	searchInputLabel = null,
+	searchInputPlaceholder = null,
 	value,
 	settings = DEFAULT_LINK_SETTINGS,
 	onChange = noop,

--- a/packages/block-editor/src/components/link-control/index.js
+++ b/packages/block-editor/src/components/link-control/index.js
@@ -122,6 +122,7 @@ const PREFERENCE_KEY = 'linkControlSettingsDrawer';
  * @param {WPLinkControlProps} props Component props.
  */
 function LinkControl( {
+	searchInputLabel,
 	searchInputPlaceholder,
 	value,
 	settings = DEFAULT_LINK_SETTINGS,
@@ -390,6 +391,7 @@ function LinkControl( {
 						<LinkControlSearchInput
 							currentLink={ value }
 							className="block-editor-link-control__field block-editor-link-control__search-input"
+							label={ searchInputLabel }
 							placeholder={ searchInputPlaceholder }
 							value={ currentUrlInputValue }
 							withCreateSuggestion={ withCreateSuggestion }

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -26,6 +26,7 @@ const LinkControlSearchInput = forwardRef(
 			children,
 			currentLink = {},
 			className = null,
+			label = null,
 			placeholder = null,
 			withCreateSuggestion = false,
 			onCreateSuggestion = noop,
@@ -113,18 +114,16 @@ const LinkControlSearchInput = forwardRef(
 			}
 		};
 
-		const inputLabel = placeholder ?? __( 'Search or type URL' );
-
 		return (
 			<div className="block-editor-link-control__search-input-container">
 				<URLInput
 					disableSuggestions={ currentLink?.url === value }
-					label={ inputLabel }
+					label={ label ?? __( 'Search or type URL' ) }
 					hideLabelFromVision={ hideLabelFromVision }
 					className={ className }
 					value={ value }
 					onChange={ onInputChange }
-					placeholder={ inputLabel }
+					placeholder={ placeholder ?? __( 'Search' ) }
 					__experimentalRenderSuggestions={
 						showSuggestions ? handleRenderSuggestions : null
 					}

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -123,7 +123,7 @@ const LinkControlSearchInput = forwardRef(
 					className={ className }
 					value={ value }
 					onChange={ onInputChange }
-					placeholder={ placeholder ?? __( 'Search' ) }
+					placeholder={ placeholder }
 					__experimentalRenderSuggestions={
 						showSuggestions ? handleRenderSuggestions : null
 					}

--- a/packages/block-editor/src/components/link-control/search-input.js
+++ b/packages/block-editor/src/components/link-control/search-input.js
@@ -114,16 +114,20 @@ const LinkControlSearchInput = forwardRef(
 			}
 		};
 
+		const inputLabel = label ?? __( 'Search or type URL' );
+
 		return (
 			<div className="block-editor-link-control__search-input-container">
 				<URLInput
 					disableSuggestions={ currentLink?.url === value }
-					label={ label ?? __( 'Search or type URL' ) }
+					label={ inputLabel }
 					hideLabelFromVision={ hideLabelFromVision }
 					className={ className }
 					value={ value }
 					onChange={ onInputChange }
-					placeholder={ placeholder }
+					placeholder={
+						hideLabelFromVision ? inputLabel : placeholder
+					}
 					__experimentalRenderSuggestions={
 						showSuggestions ? handleRenderSuggestions : null
 					}

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -235,7 +235,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await page.getByPlaceholder( 'Search or type URL' ).fill( '' );
+		await page.getByPlaceholder( 'Search' ).fill( '' );
 		await page.keyboard.type( '/handbook' );
 
 		// Submit the link.
@@ -349,7 +349,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await page.getByPlaceholder( 'Search or type URL' ).fill( '' );
+		await page.getByPlaceholder( 'Search' ).fill( '' );
 		await page.keyboard.type( '/handbook' );
 
 		// Submit the link.
@@ -679,7 +679,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// Note: getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await linkPopover.getByPlaceholder( 'Search or type URL' ).fill( '' );
+		await linkPopover.getByPlaceholder( 'Search' ).fill( '' );
 		await page.keyboard.type( 'wordpress.org' );
 
 		// Save the link.

--- a/test/e2e/specs/editor/blocks/links.spec.js
+++ b/test/e2e/specs/editor/blocks/links.spec.js
@@ -235,7 +235,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await page.getByPlaceholder( 'Search' ).fill( '' );
+		await page.getByLabel( 'Search or type URL' ).fill( '' );
 		await page.keyboard.type( '/handbook' );
 
 		// Submit the link.
@@ -349,7 +349,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await page.getByPlaceholder( 'Search' ).fill( '' );
+		await page.getByLabel( 'Search or type URL' ).fill( '' );
 		await page.keyboard.type( '/handbook' );
 
 		// Submit the link.
@@ -679,7 +679,7 @@ test.describe( 'Links', () => {
 		// Change the URL.
 		// Note: getByPlaceholder required in order to handle Link Control component
 		// managing focus onto other inputs within the control.
-		await linkPopover.getByPlaceholder( 'Search' ).fill( '' );
+		await linkPopover.getByLabel( 'Search or type URL' ).fill( '' );
 		await page.keyboard.type( 'wordpress.org' );
 
 		// Save the link.

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -636,7 +636,7 @@ test.describe( 'Registered sources', () => {
 				.getByRole( 'button', { name: 'Edit link', exact: true } )
 				.click();
 			await page
-				.getByPlaceholder( 'Search or type URL' )
+				.getByPlaceholder( 'Search' )
 				.fill( '#url-custom-field-modified' );
 			await pageUtils.pressKeys( 'Enter' );
 
@@ -693,9 +693,7 @@ test.describe( 'Registered sources', () => {
 			await page
 				.getByRole( 'button', { name: 'Edit link', exact: true } )
 				.click();
-			await page
-				.getByPlaceholder( 'Search or type URL' )
-				.fill( testingImgSrc );
+			await page.getByPlaceholder( 'Search' ).fill( testingImgSrc );
 			await pageUtils.pressKeys( 'Enter' );
 
 			// Check that the image url attribute didn't change and still uses the placeholder.

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -636,7 +636,7 @@ test.describe( 'Registered sources', () => {
 				.getByRole( 'button', { name: 'Edit link', exact: true } )
 				.click();
 			await page
-				.getByPlaceholder( 'Search' )
+				.getByLabel( 'Search or type URL' )
 				.fill( '#url-custom-field-modified' );
 			await pageUtils.pressKeys( 'Enter' );
 
@@ -693,7 +693,7 @@ test.describe( 'Registered sources', () => {
 			await page
 				.getByRole( 'button', { name: 'Edit link', exact: true } )
 				.click();
-			await page.getByPlaceholder( 'Search' ).fill( testingImgSrc );
+			await page.getByLabel( 'Search or type URL' ).fill( testingImgSrc );
 			await pageUtils.pressKeys( 'Enter' );
 
 			// Check that the image url attribute didn't change and still uses the placeholder.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Prevent duplicate text for label and placeholder props of `LinkControlSearchInput` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/66313

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Add `label` prop to `LinkControlSearchInput` component
- The `label` prop get its value from `searchInputLabel` prop set for `LinkControl` component
