### PR TITLE
[6.7] Activate zoom out only on large viewport

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -16,7 +16,7 @@ import {
 } from '@wordpress/element';
 import { VisuallyHidden, SearchControl, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDebouncedInput } from '@wordpress/compose';
+import { useDebouncedInput, useViewportMatch } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
 
 /**
@@ -67,6 +67,7 @@ function InserterMenu(
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
+	const isLargeViewport = useViewportMatch( 'large', '>=' );
 
 	const [ hasCategories, setHasCategories ] = useState( true );
 	function getInitialTab() {
@@ -82,7 +83,7 @@ function InserterMenu(
 
 	const shouldUseZoomOut =
 		selectedTab === 'patterns' || selectedTab === 'media';
-	useZoomOut( shouldUseZoomOut );
+	useZoomOut( shouldUseZoomOut && isLargeViewport );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =
 		useInsertionPoint( {

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -67,7 +67,7 @@ function InserterMenu(
 	const [ patternFilter, setPatternFilter ] = useState( 'all' );
 	const [ selectedMediaCategory, setSelectedMediaCategory ] =
 		useState( null );
-	const isLargeViewport = useViewportMatch( 'large', '>=' );
+	const isLargeViewport = useViewportMatch( 'large' );
 
 	const [ hasCategories, setHasCategories ] = useState( true );
 	function getInitialTab() {

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -3,6 +3,7 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
+import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -22,6 +23,7 @@ export function useZoomOut( zoomOut = true ) {
 
 	const originalEditingModeRef = useRef( null );
 	const mode = __unstableGetEditorMode();
+	const isWideViewport = useViewportMatch( 'large' );
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
@@ -43,7 +45,9 @@ export function useZoomOut( zoomOut = true ) {
 
 	// The effect opens the zoom-out view if we want it open and it's not currently in zoom-out mode.
 	useEffect( () => {
-		if ( zoomOut && mode !== 'zoom-out' ) {
+		if ( ! isWideViewport ) {
+			setZoomLevel( 100 );
+		} else if ( zoomOut && mode !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
 			setZoomLevel( 50 );
 		} else if (
@@ -59,5 +63,6 @@ export function useZoomOut( zoomOut = true ) {
 		__unstableSetEditorMode,
 		zoomOut,
 		setZoomLevel,
+		isWideViewport,
 	] ); // Mode is deliberately excluded from the dependencies so that the effect does not run when mode changes.
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -3,7 +3,6 @@
  */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
-import { useViewportMatch } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -23,7 +22,6 @@ export function useZoomOut( zoomOut = true ) {
 
 	const originalEditingModeRef = useRef( null );
 	const mode = __unstableGetEditorMode();
-	const isWideViewport = useViewportMatch( 'large' );
 
 	useEffect( () => {
 		// Only set this on mount so we know what to return to when we unmount.
@@ -45,9 +43,7 @@ export function useZoomOut( zoomOut = true ) {
 
 	// The effect opens the zoom-out view if we want it open and it's not currently in zoom-out mode.
 	useEffect( () => {
-		if ( ! isWideViewport ) {
-			setZoomLevel( 100 );
-		} else if ( zoomOut && mode !== 'zoom-out' ) {
+		if ( zoomOut && mode !== 'zoom-out' ) {
 			__unstableSetEditorMode( 'zoom-out' );
 			setZoomLevel( 50 );
 		} else if (
@@ -63,6 +59,5 @@ export function useZoomOut( zoomOut = true ) {
 		__unstableSetEditorMode,
 		zoomOut,
 		setZoomLevel,
-		isWideViewport,
 	] ); // Mode is deliberately excluded from the dependencies so that the effect does not run when mode changes.
 }


### PR DESCRIPTION
Apply the same fix as #66308 to the `wp/6.7` branch

## What?

This PR resets the zoom out mode so that the inserter doesn't get narrower on smaller viewports.

## Why?

I don't think the zoomed out mode is intended for use on small viewports.

## How?

There is a difference in the implementation of the `useZoomOut` hook between `trunk` and the `wp/6.7` branch. Since we cannot backport #66308 directly, we need to manually apply the same change to the `wp/6.7` branch.

## Testing Instructions

- Open the post editor.
- Open the main inserter.
- Click the Patterns tab.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/bca72d1f-44e5-4b16-81cc-59765912c677)| ![image](https://github.com/user-attachments/assets/c359d74f-a69c-41c5-a1bf-7a38e83f79e5) | 