### PR TITLE
ESLint: Fix a couple of React Compiler reassignment errors

### DIFF
--- a/packages/block-editor/src/components/list-view/branch.js
+++ b/packages/block-editor/src/components/list-view/branch.js
@@ -5,7 +5,7 @@ import {
 	__experimentalTreeGridRow as TreeGridRow,
 	__experimentalTreeGridCell as TreeGridCell,
 } from '@wordpress/components';
-import { memo } from '@wordpress/element';
+import { memo, useRef } from '@wordpress/element';
 import { AsyncModeProvider, useSelect } from '@wordpress/data';
 
 /**
@@ -123,6 +123,8 @@ function ListViewBranch( props ) {
 		draggedClientIds,
 	} = useListViewContext();
 
+	const nextPositionRef = useRef();
+
 	if ( ! canParentExpand ) {
 		return null;
 	}
@@ -133,7 +135,7 @@ function ListViewBranch( props ) {
 	const blockCount = filteredBlocks.length;
 	// The appender means an extra row in List View, so add 1 to the row count.
 	const rowCount = showAppender ? blockCount + 1 : blockCount;
-	let nextPosition = listPosition;
+	nextPositionRef.current = listPosition;
 
 	return (
 		<>
@@ -141,7 +143,7 @@ function ListViewBranch( props ) {
 				const { clientId, innerBlocks } = block;
 
 				if ( index > 0 ) {
-					nextPosition += countBlocks(
+					nextPositionRef.current += countBlocks(
 						filteredBlocks[ index - 1 ],
 						expandedState,
 						draggedClientIds,
@@ -165,7 +167,7 @@ function ListViewBranch( props ) {
 					} );
 
 				const { itemInView } = fixedListWindow;
-				const blockInView = itemInView( nextPosition );
+				const blockInView = itemInView( nextPositionRef.current );
 
 				const position = index + 1;
 				const updatedPath =
@@ -218,7 +220,7 @@ function ListViewBranch( props ) {
 								showBlockMovers={ showBlockMovers }
 								path={ updatedPath }
 								isExpanded={ isDragged ? false : shouldExpand }
-								listPosition={ nextPosition }
+								listPosition={ nextPositionRef.current }
 								selectedClientIds={ selectedClientIds }
 								isSyncedBranch={ syncedBranch }
 								displacement={ displacement }
@@ -239,7 +241,7 @@ function ListViewBranch( props ) {
 								showBlockMovers={ showBlockMovers }
 								level={ level + 1 }
 								path={ updatedPath }
-								listPosition={ nextPosition + 1 }
+								listPosition={ nextPositionRef.current + 1 }
 								fixedListWindow={ fixedListWindow }
 								isBranchSelected={ isSelectedBranch }
 								selectedClientIds={ selectedClientIds }

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -17,7 +17,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { renderToString } from '@wordpress/element';
+import { renderToString, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { store as noticeStore } from '@wordpress/notices';
@@ -59,14 +59,14 @@ export default function TableOfContentsEdit( {
 
 	// If a user clicks to a link prevent redirection and show a warning.
 	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
-	let noticeId;
+	const noticeIdRef = useRef();
 	const showRedirectionPreventedNotice = ( event ) => {
 		event.preventDefault();
 		// Remove previous warning if any, to show one at a time per block.
-		removeNotice( noticeId );
-		noticeId = `block-library/core/table-of-contents/redirection-prevented/${ instanceId }`;
+		removeNotice( noticeIdRef.current );
+		noticeIdRef.current = `block-library/core/table-of-contents/redirection-prevented/${ instanceId }`;
 		createWarningNotice( __( 'Links are disabled in the editor.' ), {
-			id: noticeId,
+			id: noticeIdRef.current,
 			type: 'snackbar',
 		} );
 	};


### PR DESCRIPTION
## What?
Resolves a few straightforward violations of the React Compiler reassignment rule:

```
Reassigning a variable after render has completed can cause inconsistent behavior on subsequent renders. Consider using state instead
```

## Why?
To resolve a few errors related to reassignment in #61788.

## How?
We're using refs instead, to preserve the pre-existing non-reactive behavior. 

## Testing Instructions
* Load up a large post (make one with [this HTML](https://github.com/WordPress/gutenberg/blob/72b7d89dbcda2ba63bc1ad99e8fc5f33309401d3/test/performance/assets/large-post.html#L7) if you don't have one ready).
* Open the document overview, in list view. 
* Verify that as you scroll, the list works like before.
* Insert a Table of Contents block, making sure you have some headings in the post
* Click on one of the links, multiple times etc.
* Verify you get a single "Links are disabled in the editor." notice, as on trunk.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None