### PR TITLE
Remove toggle verb from post list data views 'Toggle details panel'

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -412,7 +412,7 @@ export default function PostList( { postType } ) {
 							size="compact"
 							isPressed={ quickEdit }
 							icon={ drawerRight }
-							label={ __( 'Toggle details panel' ) }
+							label={ __( 'Details panel' ) }
 							onClick={ () => {
 								history.push( {
 									...location.params,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: #66319

## What?
<!-- In a few words, what is the PR actually doing? -->

The verb 'toggle' isn't well translatable in many languages and should not be used.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Address part of https://github.com/WordPress/gutenberg/issues/61483, improving localization.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes 'Toggle' from 'Toggle details panel' and makes it 'Details panel'.
Not making it Title case as suggest [here](https://github.com/WordPress/gutenberg/issues/61483) to keep in line with surrounding buttons. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Go to Admin Dasbboard > Gutenberg > Experiments and enable Quick Edit in DataViews > Save changes
2. Go to the Site editor > Pages
3. Switch the data views to Table or Grid layout
4. Notice that the button is now 'Details panel' button in the top bar

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
1. Go to Admin Dasbboard > Gutenberg > Experiments and enable Quick Edit in DataViews > Save changes
2. Go to the Site editor > Pages
3. Switch the data views to Table or Grid layout
4. Tab to the 'Details panel' button and notice that the label is updated to 'Details pane'

## Screenshots or screencast <!-- if applicable -->
<img width="158" alt="image" src="https://github.com/user-attachments/assets/a2c4b42b-4e7f-4790-846b-863a227f634d">

