### PR TITLE
Fix unset array key warning in block-bindings.php

### DIFF
--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -57,7 +57,7 @@ function gutenberg_update_meta_args_with_label( $args ) {
 	}
 
 	$schema = array( 'title' => $args['label'] );
-	if ( ! is_array( $args['show_in_rest'] ) ) {
+	if ( ! empty( $args['show_in_rest'] ) && ! is_array( $args['show_in_rest'] ) ) {
 		$args['show_in_rest'] = array(
 			'schema' => $schema,
 		);

--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -56,8 +56,13 @@ function gutenberg_update_meta_args_with_label( $args ) {
 		return $args;
 	}
 
+	// Don't update schema if not exposed to REST
+	if ( ! isset( $args['show_in_rest'] ) ) {
+		return $args;
+	}
+
 	$schema = array( 'title' => $args['label'] );
-	if ( ! empty( $args['show_in_rest'] ) && ! is_array( $args['show_in_rest'] ) ) {
+	if ( ! is_array( $args['show_in_rest'] ) ) {
 		$args['show_in_rest'] = array(
 			'schema' => $schema,
 		);


### PR DESCRIPTION
This has been throwing an error for several weeks on one of my sites

Simplest fix is to just bail early if it's unset

PHP Warning:  Undefined array key "show_in_rest" in /var/www/wp-content/plugins/gutenberg/lib/compat/wordpress-6.7/block-bindings.php on line 70

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix undefined array key warning

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
My error logs have been filling up

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Bail early if it's unset.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
I'm not 100% sure which custom post type this is throwing from, but I'm leaning towards buddypress.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
No more warning thrown from block-bindings.php

## Screenshots or screencast <!-- if applicable -->
n/a
