### PR TITLE
[6.7] Editor: Remove edit template menu item from block settings menu in blocks outside template. (#65560)

### DIFF
--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -46,9 +46,10 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 					getBlockAttributes( patternParent ).ref
 				);
 			} else {
-				const { getCurrentTemplateId } = select( editorStore );
+				const { getCurrentTemplateId, getRenderingMode } =
+					select( editorStore );
 				const templateId = getCurrentTemplateId();
-				const { getContentLockingParent, getRenderingMode } = unlock(
+				const { getContentLockingParent } = unlock(
 					select( blockEditorStore )
 				);
 				if (

--- a/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
+++ b/packages/editor/src/components/block-settings-menu/content-only-settings-menu.js
@@ -48,10 +48,14 @@ function ContentOnlySettingsMenuItems( { clientId, onClose } ) {
 			} else {
 				const { getCurrentTemplateId } = select( editorStore );
 				const templateId = getCurrentTemplateId();
-				const { getContentLockingParent } = unlock(
+				const { getContentLockingParent, getRenderingMode } = unlock(
 					select( blockEditorStore )
 				);
-				if ( ! getContentLockingParent( clientId ) && templateId ) {
+				if (
+					getRenderingMode() === 'template-locked' &&
+					! getContentLockingParent( clientId ) &&
+					templateId
+				) {
 					record = select( coreStore ).getEntityRecord(
 						'postType',
 						'wp_template',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Originally #65560.

I had to manually rebase. The problem is that there's a `getContentLockingParent` condition that is in the `6.7`, but not in `trunk`. And there's a `getBlockParents` condition that is in `trunk`, but not in `6.7`. 

I decided to only pick out the extra mode condition.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's needed for #66311.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
