### PR TITLE
[6.7]  Zoom out: maintain scroll position (#61465)

### DIFF
--- a/packages/block-editor/src/components/iframe/bezier-easing.js
+++ b/packages/block-editor/src/components/iframe/bezier-easing.js
@@ -1,0 +1,120 @@
+/**
+ * https://github.com/gre/bezier-easing
+ * BezierEasing - use bezier curve for transition easing function
+ * by Gaëtan Renaudeau 2014 - 2015 – MIT License
+ */
+
+const NEWTON_ITERATIONS = 4;
+const NEWTON_MIN_SLOPE = 0.001;
+const SUBDIVISION_PRECISION = 0.0000001;
+const SUBDIVISION_MAX_ITERATIONS = 10;
+
+const kSplineTableSize = 11;
+const kSampleStepSize = 1.0 / ( kSplineTableSize - 1.0 );
+
+function A( aA1, aA2 ) {
+	return 1.0 - 3.0 * aA2 + 3.0 * aA1;
+}
+function B( aA1, aA2 ) {
+	return 3.0 * aA2 - 6.0 * aA1;
+}
+function C( aA1 ) {
+	return 3.0 * aA1;
+}
+
+// Returns x(t) given t, x1, and x2, or y(t) given t, y1, and y2.
+function calcBezier( aT, aA1, aA2 ) {
+	return ( ( A( aA1, aA2 ) * aT + B( aA1, aA2 ) ) * aT + C( aA1 ) ) * aT;
+}
+
+// Returns dx/dt given t, x1, and x2, or dy/dt given t, y1, and y2.
+function getSlope( aT, aA1, aA2 ) {
+	return 3.0 * A( aA1, aA2 ) * aT * aT + 2.0 * B( aA1, aA2 ) * aT + C( aA1 );
+}
+
+function binarySubdivide( aX, aA, aB, mX1, mX2 ) {
+	let currentX,
+		currentT,
+		i = 0;
+	do {
+		currentT = aA + ( aB - aA ) / 2.0;
+		currentX = calcBezier( currentT, mX1, mX2 ) - aX;
+		if ( currentX > 0.0 ) {
+			aB = currentT;
+		} else {
+			aA = currentT;
+		}
+	} while (
+		Math.abs( currentX ) > SUBDIVISION_PRECISION &&
+		++i < SUBDIVISION_MAX_ITERATIONS
+	);
+	return currentT;
+}
+
+function newtonRaphsonIterate( aX, aGuessT, mX1, mX2 ) {
+	for ( let i = 0; i < NEWTON_ITERATIONS; ++i ) {
+		const currentSlope = getSlope( aGuessT, mX1, mX2 );
+		if ( currentSlope === 0.0 ) {
+			return aGuessT;
+		}
+		const currentX = calcBezier( aGuessT, mX1, mX2 ) - aX;
+		aGuessT -= currentX / currentSlope;
+	}
+	return aGuessT;
+}
+
+export default function cubicBezier( mX1, mY1, mX2, mY2 ) {
+	if ( mX1 === mY1 && mX2 === mY2 ) {
+		return function linearEasing( x ) {
+			return x;
+		};
+	}
+
+	const sampleValues = new Float32Array( kSplineTableSize );
+	for ( let i = 0; i < kSplineTableSize; ++i ) {
+		sampleValues[ i ] = calcBezier( i * kSampleStepSize, mX1, mX2 );
+	}
+
+	function getTForX( aX ) {
+		let intervalStart = 0.0;
+		let currentSample = 1;
+		const lastSample = kSplineTableSize - 1;
+
+		for (
+			;
+			currentSample !== lastSample && sampleValues[ currentSample ] <= aX;
+			++currentSample
+		) {
+			intervalStart += kSampleStepSize;
+		}
+		--currentSample;
+
+		const dist =
+			( aX - sampleValues[ currentSample ] ) /
+			( sampleValues[ currentSample + 1 ] -
+				sampleValues[ currentSample ] );
+
+		const guessForT = intervalStart + dist * kSampleStepSize;
+
+		const initialSlope = getSlope( guessForT, mX1, mX2 );
+		if ( initialSlope >= NEWTON_MIN_SLOPE ) {
+			return newtonRaphsonIterate( aX, guessForT, mX1, mX2 );
+		} else if ( initialSlope === 0.0 ) {
+			return guessForT;
+		}
+		return binarySubdivide(
+			aX,
+			intervalStart,
+			intervalStart + kSampleStepSize,
+			mX1,
+			mX2
+		);
+	}
+
+	return function bezierEasing( x ) {
+		if ( x === 0 || x === 1 ) {
+			return x;
+		}
+		return calcBezier( getTForX( x ), mY1, mY2 );
+	};
+}

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,6 +20,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	usePrevious,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -421,6 +422,22 @@ function Iframe( {
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.
 	const shouldRenderFocusCaptureElements = tabIndex >= 0 && ! isPreviewMode;
+
+	const previousScale = usePrevious( scaleValue );
+
+	// Scroll based on the new scale
+	useEffect( () => {
+		if ( ! iframeDocument ) {
+			return;
+		}
+
+		const { documentElement } = iframeDocument;
+		const { scrollTop, scrollLeft } = documentElement;
+		const delta = 1 + scaleValue - previousScale;
+
+		documentElement.scrollTop = delta * scrollTop;
+		documentElement.scrollLeft = delta * scrollLeft;
+	}, [ scaleValue, previousScale, iframeDocument ] );
 
 	const iframe = (
 		<>

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -34,7 +34,11 @@ import { getCompatibilityStyles } from './get-compatibility-styles';
 import { store as blockEditorStore } from '../../store';
 import cubicBezier from './bezier-easing';
 
-const scrollEasing = cubicBezier( 0.46, 0.03, 0.52, 0.96 );
+// Easing function from the CSS editor-canvas-resize-animation.
+// const scrollEasing = cubicBezier( 0.46, 0.03, 0.52, 0.96 );
+
+// Complementary easing function to the CSS editor-canvas-resize-animation.
+const scrollEasing = cubicBezier( 1 - 0.52, 1 - 0.96, 1 - 0.46, 1 - 0.03 );
 
 function bubbleEvent( event, Constructor, frame ) {
 	const init = {};
@@ -434,7 +438,7 @@ function Iframe( {
 	const prevContainerHeightRef = useRef( containerHeight );
 
 	// Scroll based on the new scale
-	useEffect( () => {
+	useLayoutEffect( () => {
 		if ( ! iframeDocument ) {
 			return;
 		}
@@ -447,42 +451,42 @@ function Iframe( {
 			return;
 		}
 
+		const { documentElement } = iframeDocument;
+		const { scrollTop } = documentElement;
+
+		// Convert previous values to the zoomed in scale.
+		const scrollTopOriginal = Math.floor(
+			( scrollTop + containerHeightPrev / 2 - frameSizeValuePrev ) /
+				scaleValuePrev -
+				containerHeightPrev / 2
+		);
+
+		// Convert the zoomed in value to the new scale.
+		const scrollTopNext = Math.floor(
+			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
+				frameSizeValue -
+				containerHeight / 2
+		);
+
+		console.log( {
+			scaleValue,
+			scaleValuePrev,
+		} );
+		console.log( {
+			frameSizeValue,
+			frameSizeValuePrev,
+		} );
+		console.log( {
+			containerHeight,
+			containerHeightPrev,
+		} );
+		console.log( {
+			scrollTop,
+			scrollTopOriginal,
+			scrollTopNext,
+		} );
+
 		let raf = requestAnimationFrame( ( start ) => {
-			const { documentElement } = iframeDocument;
-			const { scrollTop } = documentElement;
-
-			// Convert previous values to the zoomed in scale.
-			const scrollTopOriginal = Math.floor(
-				( scrollTop + containerHeightPrev / 2 - frameSizeValuePrev ) /
-					scaleValuePrev -
-					containerHeightPrev / 2
-			);
-
-			// Convert the zoomed in value to the new scale.
-			const scrollTopNext = Math.floor(
-				( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
-					frameSizeValue -
-					containerHeight / 2
-			);
-
-			console.log( {
-				scaleValue,
-				scaleValuePrev,
-			} );
-			console.log( {
-				frameSizeValue,
-				frameSizeValuePrev,
-			} );
-			console.log( {
-				containerHeight,
-				containerHeightPrev,
-			} );
-			console.log( {
-				scrollTop,
-				scrollTopOriginal,
-				scrollTopNext,
-			} );
-
 			const duration = 400; // Should match the CSS transition duration.
 			console.log( documentElement.scrollTop, '0.000', '0.000' );
 			const step = ( timestamp ) => {

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -252,6 +252,14 @@ function Iframe( {
 		containerWidth
 	);
 
+	const maxWidth = 750;
+	const scaleValue =
+		scale === 'default'
+			? ( Math.min( containerWidth, maxWidth ) -
+					parseInt( frameSize ) * 2 ) /
+			  scaleContainerWidth
+			: scale;
+
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
 		useBubbleEvents( iframeDocument ),
@@ -343,7 +351,6 @@ function Iframe( {
 			return;
 		}
 
-		const maxWidth = 750;
 		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
 		// initialContainerWidth will be smaller than the full page, and reflow will happen
 		// when the canvas area becomes larger due to sidebars closing. This is a known but
@@ -354,11 +361,7 @@ function Iframe( {
 		// but calc( 100px / 2px ) is not.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scale === 'default'
-				? ( Math.min( containerWidth, maxWidth ) -
-						parseInt( frameSize ) * 2 ) /
-						scaleContainerWidth
-				: scale
+			scaleValue
 		);
 
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
@@ -404,7 +407,7 @@ function Iframe( {
 			);
 		};
 	}, [
-		scale,
+		scaleValue,
 		frameSize,
 		iframeDocument,
 		iframeWindowInnerHeight,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

> [!IMPORTANT]
> It's faster for me to uncover potential issues with the release by developing here instead of `trunk` right now.
>
> If there are no conflicts with `trunk` when development is done, I'll move these changes back over there to merge in `trunk` and follow the automated backport workflow.

## What?
<!-- In a few words, what is the PR actually doing? -->

Manual backport of #61465

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Animating the scroll position in JS to match the `editor-canvas-resize-animation` in CSS.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
