### PR TITLE
Editor: Use plugin context hook in 'PluginPreviewMenuItem'

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -878,9 +878,9 @@ function onPreviewClick() {
 }
 
 const ExternalPreviewMenuItem = () => (
-	<PreviewDropdownMenuItem icon={ external } onClick={ onPreviewClick }>
+	<PluginPreviewMenuItem icon={ external } onClick={ onPreviewClick }>
 		{ __( 'Preview in new tab' ) }
-	</PreviewDropdownMenuItem>
+	</PluginPreviewMenuItem>
 );
 registerPlugin( 'external-preview-menu-item', {
 	render: ExternalPreviewMenuItem,

--- a/packages/editor/src/components/plugin-preview-menu-item/index.js
+++ b/packages/editor/src/components/plugin-preview-menu-item/index.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
-import { withPluginContext } from '@wordpress/plugins';
+import { usePluginContext } from '@wordpress/plugins';
 import { ActionItem } from '@wordpress/interface';
 
 /**
@@ -27,12 +26,12 @@ import { ActionItem } from '@wordpress/interface';
  * }
  *
  * const ExternalPreviewMenuItem = () => (
- *   <PreviewDropdownMenuItem
+ *   <PluginPreviewMenuItem
  *     icon={ external }
  *     onClick={ onPreviewClick }
  *   >
  *     { __( 'Preview in new tab' ) }
- *   </PreviewDropdownMenuItem>
+ *   </PluginPreviewMenuItem>
  * );
  * registerPlugin( 'external-preview-menu-item', {
  *     render: ExternalPreviewMenuItem,
@@ -41,12 +40,14 @@ import { ActionItem } from '@wordpress/interface';
  *
  * @return {Component} The rendered menu item component.
  */
-export default compose(
-	withPluginContext( ( context, ownProps ) => {
-		return {
-			as: ownProps.as ?? MenuItem,
-			icon: ownProps.icon || context.icon,
-			name: 'core/plugin-preview-menu',
-		};
-	} )
-)( ActionItem );
+export default function PluginPreviewMenuItem( props ) {
+	const context = usePluginContext();
+	return (
+		<ActionItem
+			name="core/plugin-preview-menu"
+			as={ props.as ?? MenuItem }
+			icon={ props.icon || context.icon }
+			{ ...props }
+		/>
+	);
+}


### PR DESCRIPTION
## What?
This is a follow-up to #64644.
Similar to #53302.

PR updates the new `PluginPreviewMenuItem` component to use the `usePluginContext` hook instead of HOC.

## Why?
Using the context hook should be preferred over HOC.

## Testing Instructions
1. Open a post.
2. Run the test snippet.
3. Confirm that the new preview item was added and works as before.

The feature also has e2e test coverage.

<details><summary>Test snippet</summary>
<p>

```js
const { createElement: el } = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginPreviewMenuItem = wp.editor.PluginPreviewMenuItem;

function TestPluginPreviewMenuItem() {
	return el(
		PluginPreviewMenuItem,
		{
			// icon: 'smiley',
			onClick: () => console.log( 'Click!' ),
		},
		'Test Preview'
	);
}

registerPlugin( 'external-preview-menu-item', {
    icon: 'pets',
	render: TestPluginPreviewMenuItem,
} );
```

</p>
</details>

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-23 at 08 25 10](https://github.com/user-attachments/assets/6c6ad481-fd8c-4fc5-b824-8dad3f231c45)
