### PR TITLE
Editor: Use plugin context hook in 'PluginMoreMenuItem'

### DIFF
--- a/packages/editor/src/components/plugin-more-menu-item/index.js
+++ b/packages/editor/src/components/plugin-more-menu-item/index.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
 import { MenuItem } from '@wordpress/components';
-import { withPluginContext } from '@wordpress/plugins';
+import { usePluginContext } from '@wordpress/plugins';
 import { ActionItem } from '@wordpress/interface';
 
 /**
@@ -62,12 +61,14 @@ import { ActionItem } from '@wordpress/interface';
  *
  * @return {Component} The component to be rendered.
  */
-export default compose(
-	withPluginContext( ( context, ownProps ) => {
-		return {
-			as: ownProps.as ?? MenuItem,
-			icon: ownProps.icon || context.icon,
-			name: 'core/plugin-more-menu',
-		};
-	} )
-)( ActionItem );
+export default function PluginMoreMenuItem( props ) {
+	const context = usePluginContext();
+	return (
+		<ActionItem
+			name="core/plugin-more-menu"
+			as={ props.as ?? MenuItem }
+			icon={ props.icon || context.icon }
+			{ ...props }
+		/>
+	);
+}


### PR DESCRIPTION
## What?
Similar to #66350.

PR updates the new `PluginMoreMenuItem` component to use the `usePluginContext` hook instead of HOC.

## Why?
Using the context hook should be preferred over HOC.

## Testing Instructions
1. Open a post.
2. Run the test snippet.
3. Confirm that the new "more menu" item was added to the "Options" dropdown.

<details><summary>Test snippet</summary>
<p>

```js
const { createElement: el } = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginMoreMenuItem = wp.editor.PluginMoreMenuItem;

function TestPluginMoreMenuItem() {
	return el(
		PluginMoreMenuItem,
		{
			// icon: 'smiley',
            onClick: () => console.log( 'Click!' ),
		},
		'Test Plugin More Menu Item'
	);
}

registerPlugin( 'external-more-menu-item', {
    icon: 'pets',
	render: TestPluginMoreMenuItem,
} );
```

</p>
</details>

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-23 at 08 59 23](https://github.com/user-attachments/assets/7d705cc1-d07f-42e7-b1e5-2bb4ce9677c9)
