### PR TITLE
VisualEditor: Remove wide and full alignment CSS and alignment classes on the root container

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -263,7 +263,7 @@ function VisualEditor( {
 		);
 	}, [ editedPostTemplate?.content, editedPostTemplate?.blocks ] );
 
-	const { layout = {}, align = '' } = newestPostContentAttributes || {};
+	const { layout = {} } = newestPostContentAttributes || {};
 
 	const postContentLayoutClasses = useLayoutClasses(
 		newestPostContentAttributes,
@@ -274,8 +274,7 @@ function VisualEditor( {
 		{
 			'is-layout-flow': ! themeSupportsLayout,
 		},
-		themeSupportsLayout && postContentLayoutClasses,
-		align && ! [ 'wide', 'full' ].includes( align ) && `align${ align }`
+		themeSupportsLayout && postContentLayoutClasses
 	);
 
 	const postContentLayoutStyles = useLayoutStyles(

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -275,7 +275,7 @@ function VisualEditor( {
 			'is-layout-flow': ! themeSupportsLayout,
 		},
 		themeSupportsLayout && postContentLayoutClasses,
-		align && `align${ align }`
+		align && ! [ 'wide', 'full' ].includes( align ) && `align${ align }`
 	);
 
 	const postContentLayoutStyles = useLayoutStyles(
@@ -319,12 +319,6 @@ function VisualEditor( {
 		}
 		titleRef?.current?.focus();
 	}, [ autoFocus, isCleanNewPost ] );
-
-	// Add some styles for alignwide/alignfull Post Content and its children.
-	const alignCSS = `.is-root-container.alignwide { max-width: var(--wp--style--global--wide-size); margin-left: auto; margin-right: auto;}
-		.is-root-container.alignwide:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: var(--wp--style--global--wide-size);}
-		.is-root-container.alignfull { max-width: none; margin-left: auto; margin-right: auto;}
-		.is-root-container.alignfull:where(.is-layout-flow) > :not(.alignleft):not(.alignright) { max-width: none;}`;
 
 	const forceFullHeight = postType === NAVIGATION_POST_TYPE;
 	const enableResizing =
@@ -420,7 +414,6 @@ function VisualEditor( {
 									selector=".block-editor-block-list__layout.is-root-container"
 									layout={ postEditorLayout }
 								/>
-								{ align && <LayoutStyle css={ alignCSS } /> }
 								{ postContentLayoutStyles && (
 									<LayoutStyle
 										layout={ postContentLayout }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #52163. Note, this does _not_ fix https://github.com/WordPress/gutenberg/issues/60311 which had the opposite feedback. If this PR lands, we'll effectively be saying that #60311 is a "won't fix" 🙂

This PR proposes removing the wide and full alignment CSS on the root container of the visual editor. I'm happy to close out this PR if it isn't a desired path forward.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This CSS was in place so that the post and page editors could more closely resemble how a post might look in the context of a template. However, ever since the editors were unified, it's possible for users to switch on template preview mode (or in the case of page editing in the site editor, switch it off). In #52163 the feedback / discussion is that displaying post content full width in the post and page editors isn't a WYSIWYG experience and can make the editor feel broken.

The suggestion there was to remove the behaviour that detects wide / full width alignment and attempts to display content to the wide / full sizes in the post editor. Note: for posts and pages that use templates that do use content width, wide and full alignments should still be available _within_ the post content, so for example setting a Cover or Group block to wide or full in regular templates should work as before.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* In the visual editor, remove the `alignCSS` rules that attempted to make the editor (with template preview switched off) look more WYSIWYG
* Remove the output of align classes on the container

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Set up a test site running wordpress-develop trunk or WP 6.7 RC 1
2. Activate TT5 theme
3. In the site editor, go to templates and go to Add New Template
4. From the list, select `Single item: Post`
5. Select to create it for All Posts
6. You should then see a list to select from patterns to create your template. For this particular case, select this one that's optimised for photos:

<img width="430" alt="image" src="https://github.com/user-attachments/assets/5e3faafd-677f-4ac2-9100-502672c98ed3">

7. Select the Content block in this template, and toggle off "Inner blocks use content width" so that the content fills the container:

<img width="1795" alt="image" src="https://github.com/user-attachments/assets/344a6369-52c8-4e46-a84a-fc841f70ce7e">

8. Open up the post editor and add some content to the post. The content area should be constrained to a center column when template preview mode is off (the default state):

<img width="1796" alt="image" src="https://github.com/user-attachments/assets/1640431e-bf32-4010-a2e8-dde0e9127fcf">

9. If you toggle the template to show the preview, the content will display to the full size of the container as in the template:

<img width="1794" alt="image" src="https://github.com/user-attachments/assets/62e03dee-5010-477d-92de-35a35ab7ed97">

---

### Before

Note: on `trunk`, in this case, the content would have displayed edge-to-edge in the post editor:

<img width="1571" alt="image" src="https://github.com/user-attachments/assets/c35c863e-10bd-4855-8e4c-fe09328f1a4c">


