### PR TITLE
Latest Posts Border Block Support

### DIFF
--- a/packages/block-library/src/latest-posts/block.json
+++ b/packages/block-library/src/latest-posts/block.json
@@ -111,6 +111,18 @@
 				"fontSize": true
 			}
 		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
+		},
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
## What?
Add border block support to the Latest Posts block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Latest Posts` block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that Latest Posts block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add Latest Posts block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend


### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

In Backend:
![latest_posts_backend](https://github.com/user-attachments/assets/ec6a38b0-2df7-4e3e-b4fe-2e6646841244)

In Frontend:
![latest_posts_frontend](https://github.com/user-attachments/assets/ccb5b5c9-7ff1-4959-a78c-7dd6d05e571d)

