### PR TITLE
Border support added to comments

### DIFF
--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -45,6 +45,18 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-comments-editor",

--- a/packages/block-library/src/comments/block.json
+++ b/packages/block-library/src/comments/block.json
@@ -17,7 +17,10 @@
 		}
 	},
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"color": {
 			"gradients": true,
@@ -60,5 +63,8 @@
 		}
 	},
 	"editorStyle": "wp-block-comments-editor",
-	"usesContext": [ "postId", "postType" ]
+	"usesContext": [
+		"postId",
+		"postType"
+	]
 }

--- a/packages/block-library/src/comments/style.scss
+++ b/packages/block-library/src/comments/style.scss
@@ -13,7 +13,6 @@
 	}
 
 	/* end utility classes */
-
 	.navigation {
 		&::after {
 			content: "";
@@ -146,6 +145,7 @@
 :where(.wp-block-post-comments input[type="submit"]) {
 	border: none;
 }
+
 .wp-block-comments {
-    box-sizing: border-box;
+	box-sizing: border-box;
 }

--- a/packages/block-library/src/comments/style.scss
+++ b/packages/block-library/src/comments/style.scss
@@ -146,3 +146,6 @@
 :where(.wp-block-post-comments input[type="submit"]) {
 	border: none;
 }
+.wp-block-comments {
+    box-sizing: border-box;
+}


### PR DESCRIPTION
## What?
Add border block support to the Comments block.
Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
Comments block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

1. Go to the Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
2. Make sure that the Comments block's border is configurable via Global Styles
3. Verify that Global Styles are applied correctly in the editor and frontend
4. Edit the template/page, Add  Comments block and Apply the border styles
5. Verify that block styles take precedence over global styles
6. Verify that block borders display correctly in both the editor and frontend

## Screenshots or screencast <!-- if applicable -->
<img width="1440" alt="comments-border" src="https://github.com/user-attachments/assets/8bb9a9fd-cdd7-4420-a482-ee3f0a88234e">
