### PR TITLE
Comment Title Block: Validate comments count is always an integer

### DIFF
--- a/packages/block-library/src/comments-title/index.php
+++ b/packages/block-library/src/comments-title/index.php
@@ -24,7 +24,7 @@ function render_block_core_comments_title( $attributes ) {
 	$show_post_title     = ! empty( $attributes['showPostTitle'] ) && $attributes['showPostTitle'];
 	$show_comments_count = ! empty( $attributes['showCommentsCount'] ) && $attributes['showCommentsCount'];
 	$wrapper_attributes  = get_block_wrapper_attributes( array( 'class' => $align_class_name ) );
-	$comments_count      = get_comments_number();
+	$comments_count      = (int) get_comments_number();
 	/* translators: %s: Post title. */
 	$post_title = sprintf( __( '&#8220;%s&#8221;' ), get_the_title() );
 	$tag_name   = 'h2';
@@ -32,13 +32,13 @@ function render_block_core_comments_title( $attributes ) {
 		$tag_name = 'h' . $attributes['level'];
 	}
 
-	if ( '0' === $comments_count ) {
+	if ( 0 === $comments_count ) {
 		return;
 	}
 
 	if ( $show_comments_count ) {
 		if ( $show_post_title ) {
-			if ( '1' === $comments_count ) {
+			if ( 1 === $comments_count ) {
 				/* translators: %s: Post title. */
 				$comments_title = sprintf( __( 'One response to %s' ), $post_title );
 			} else {
@@ -53,7 +53,7 @@ function render_block_core_comments_title( $attributes ) {
 					$post_title
 				);
 			}
-		} elseif ( '1' === $comments_count ) {
+		} elseif ( 1 === $comments_count ) {
 			$comments_title = __( 'One response' );
 		} else {
 			$comments_title = sprintf(
@@ -63,14 +63,14 @@ function render_block_core_comments_title( $attributes ) {
 			);
 		}
 	} elseif ( $show_post_title ) {
-		if ( '1' === $comments_count ) {
+		if ( 1 === $comments_count ) {
 			/* translators: %s: Post title. */
 			$comments_title = sprintf( __( 'Response to %s' ), $post_title );
 		} else {
 			/* translators: %s: Post title. */
 			$comments_title = sprintf( __( 'Responses to %s' ), $post_title );
 		}
-	} elseif ( '1' === $comments_count ) {
+	} elseif ( 1 === $comments_count ) {
 		$comments_title = __( 'Response' );
 	} else {
 		$comments_title = __( 'Responses' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: #66299 

## What?
<!-- In a few words, what is the PR actually doing? -->

Ensure the comments count is always treated as an integer in the `core/comments-title` block rendering function.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `get_comments_number()` function can return either an integer or a numeric string. This inconsistency can cause issues when checking for zero comments, especially when plugins filter the comment count to an integer. By casting the result to an integer, we ensure consistent behavior and correct condition checks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Cast the result of `get_comments_number()` to an integer and update all related condition checks to use integer comparisons.
- Kept `%s` as is instead of converting to `%d` to maintain consistency with `edit.js`.

## Testing Instructions
1. Use the `core/comments` block on a post template.
2. Ensure the post has no comments or use a plugin to filter the comment count to zero.
3. Verify that the title does not display "0 Responses" when there are no comments on the frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A - This change does not affect the user interface directly.

## Screenshots or screencast <!-- if applicable -->
N/A