### PR TITLE
Quick Edit: Fix JS error when bulk editing pages

### DIFF
--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -65,13 +65,18 @@ function PostEditForm( { postType, postId } ) {
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {
 			if (
+				edits.status &&
 				edits.status !== 'future' &&
 				record.status === 'future' &&
 				new Date( record.date ) > new Date()
 			) {
 				edits.date = null;
 			}
-			if ( edits.status === 'private' && record.password ) {
+			if (
+				edits.status &&
+				edits.status === 'private' &&
+				record.password
+			) {
 				edits.password = '';
 			}
 			editEntityRecord( 'postType', postType, id, edits );


### PR DESCRIPTION
Related #55101 

## What?

I noticed that since the introduction of the status field to quick edit, bulk editing was broken. This fixes the JS error.

## Testing Instructions

1- Enable "quick edit" experiment
2- Go the pages table data view
3- Select multiple pages
4- Try changing the title of the pages at the same time using the quick edit panel
5- You should be able to edit and save the changes.