### PR TITLE
Fix flash when clicking template name in the editor when a plugin registered template matches a default WP theme template

### DIFF
--- a/backport-changelog/6.7/7676.md
+++ b/backport-changelog/6.7/7676.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7676
+
+* https://github.com/WordPress/gutenberg/pull/66359

--- a/lib/compat/wordpress-6.6/block-template-utils.php
+++ b/lib/compat/wordpress-6.6/block-template-utils.php
@@ -215,10 +215,6 @@ function _gutenberg_get_block_templates_files( $template_type, $query = array() 
 					$template_files[ $template_slug ] = $candidate;
 				}
 
-				if ( 'page' === $post_type && 'page' === $template_slug ) {
-					$template_files[ $template_slug ] = $candidate;
-				}
-
 				// @core-merge: This code will go into Core's '_get_block_templates_files' function.
 				// The custom templates with no associated post-types are available for all post-types.
 				if ( $post_type && ! isset( $candidate['postTypes'] ) && $is_custom ) {

--- a/lib/compat/wordpress-6.6/block-template-utils.php
+++ b/lib/compat/wordpress-6.6/block-template-utils.php
@@ -215,6 +215,10 @@ function _gutenberg_get_block_templates_files( $template_type, $query = array() 
 					$template_files[ $template_slug ] = $candidate;
 				}
 
+				if ( 'page' === $post_type && 'page' === $template_slug ) {
+					$template_files[ $template_slug ] = $candidate;
+				}
+
 				// @core-merge: This code will go into Core's '_get_block_templates_files' function.
 				// The custom templates with no associated post-types are available for all post-types.
 				if ( $post_type && ! isset( $candidate['postTypes'] ) && $is_custom ) {

--- a/lib/compat/wordpress-6.7/compat.php
+++ b/lib/compat/wordpress-6.7/compat.php
@@ -40,7 +40,13 @@ function _gutenberg_add_block_templates_from_registry( $query_result, $query, $t
 	}
 
 	if ( ! isset( $query['wp_id'] ) ) {
-		$template_files = _gutenberg_get_block_templates_files( $template_type );
+		// We need to unset the post_type query param because some templates
+		// would be excluded otherwise, like `page.html` when looking for
+		// `page` templates.
+		// See: https://github.com/WordPress/gutenberg/issues/65584
+		$template_files_query = $query;
+		unset( $template_files_query['post_type'] );
+		$template_files = _gutenberg_get_block_templates_files( $template_type, $template_files_query );
 
 		/*
 		 * Add templates registered in the template registry. Filtering out the ones which have a theme file.

--- a/lib/compat/wordpress-6.7/compat.php
+++ b/lib/compat/wordpress-6.7/compat.php
@@ -40,7 +40,7 @@ function _gutenberg_add_block_templates_from_registry( $query_result, $query, $t
 	}
 
 	if ( ! isset( $query['wp_id'] ) ) {
-		$template_files = _gutenberg_get_block_templates_files( $template_type, $query );
+		$template_files = _gutenberg_get_block_templates_files( $template_type );
 
 		/*
 		 * Add templates registered in the template registry. Filtering out the ones which have a theme file.


### PR DESCRIPTION
## What?

Fixes https://github.com/WordPress/gutenberg/issues/65584.

Backport PR https://github.com/WordPress/wordpress-develop/pull/7676.

Many themes (including TT4) have templates for specific post types (ie: `page.html`) but don't specify their `postTypes` in `theme.json`. That's because in some cases it's not needed (ie: `page.html` is automatically used for pages, `single.html` is automatically used for posts, etc.).

That caused the templates endpoint to filter out plugin-registered templates incorrectly. If the `$query` passed to the endpoint contained a `post_type`, theme templates that didn't explicitly match that post type would be ignored. So if a theme had a `page.html` and a plugin registered a `page` template, the one from the plugin would be used, which is incorrect.

In the UI, that caused a visual glitch when clicking on the Template setting in the post/page editor.

## How?

Removing `$query` from `_gutenberg_get_block_templates_files()` so we get all templates, not only the ones matching the specific `$post_type`. When getting all templates from the theme, we can correctly filter out any duplicate coming from a plugin.

## Testing Instructions

1. Add the following code to your site:

```
add_action( 'init', function() {
	register_block_template(
		'templates//page',
		[
			'title' => 'My Single Page',
			'description' => 'This is my single page template',
			'content' => '<!-- wp:paragraph --><p>This is a plugin-registered template.</p><!-- /wp:paragraph -->',
			'post_types' => [ 'page' ],
		]
	);
	register_block_template(
		'templates//single',
		[
			'title' => 'My Single Post',
			'description' => 'This is my single post template',
			'content' => '<!-- wp:paragraph --><p>This is a plugin-registered template.</p><!-- /wp:paragraph -->',
			'post_types' => [ 'post' ],
		]
	);
} );
```
2. Create a new page.
3. The Template setting should be set to "Pages".
4. Click on "Pages" and verify there is no flash.
5. Repeat with a post.

## Screenshots or screencast

[Enregistrament de pantalla del 2024-10-23 10-13-53.webm](https://github.com/user-attachments/assets/b8b76360-5f70-4839-8220-36bfb1b087a3)
