### PR TITLE
Fix : Badge Color contrast

### DIFF
--- a/packages/edit-site/src/components/post-list/style.scss
+++ b/packages/edit-site/src/components/post-list/style.scss
@@ -66,7 +66,7 @@
 
 .edit-site-post-list__title-badge {
 	background: $gray-100;
-	color: $gray-700;
+	color: $gray-800;
 	padding: 0 $grid-unit-05;
 	border-radius: $radius-small;
 	font-size: 12px;

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -44,7 +44,7 @@
 
 .editor-post-card-panel__title-badge {
 	background: $gray-100;
-	color: $gray-700;
+	color: $gray-800;
 	padding: 0 $grid-unit-05;
 	border-radius: $radius-small;
 	font-size: 12px;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66322

## What?
<!-- In a few words, what is the PR actually doing? -->
- Improve `color-contrast` from [`4.04:1`](https://www.joedolson.com/tools/color-contrast.php?type=hex&color=757575&color2=f0f0f0) to [`11.75:1`](https://www.joedolson.com/tools/color-contrast.php?type=hex&color=2f2f2f&color2=f0f0f0)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/66322

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Change `text-color` for `post list title` and `post card title` badge to `$gray-800`

## Screenshots or screencast <!-- if applicable -->

| Posts Page | Homepage | Posts List |
| --- | --- | --- |
| <img width="204" alt="Screenshot 2024-10-23 at 12 59 42 PM" src="https://github.com/user-attachments/assets/5e10f77d-e548-486c-9c48-fcdfcba2cee3"> | <img width="199" alt="Screenshot 2024-10-23 at 12 59 49 PM" src="https://github.com/user-attachments/assets/38ce7c7c-3a1e-4e38-b3f2-497da903e735"> | <img width="356" alt="Screenshot 2024-10-23 at 12 59 59 PM" src="https://github.com/user-attachments/assets/f23fda9d-742f-4241-b169-bebb45fb1978"> |



