### PR TITLE
Plugins: Deprecate 'withPluginContext' HOC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54856,6 +54856,7 @@
 				"@babel/runtime": "7.25.7",
 				"@wordpress/components": "*",
 				"@wordpress/compose": "*",
+				"@wordpress/deprecated": "*",
 				"@wordpress/element": "*",
 				"@wordpress/hooks": "*",
 				"@wordpress/icons": "*",

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -192,7 +192,7 @@ _Returns_
 
 #### withPluginContext
 
-> **Deprecated** Use `usePluginContext` hook instead.
+> **Deprecated** 6.8.0 Use `usePluginContext` hook instead.
 
 A Higher Order Component used to inject Plugin context to the wrapped component.
 

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -192,6 +192,8 @@ _Returns_
 
 #### withPluginContext
 
+> **Deprecated** Use `usePluginContext` hook instead.
+
 A Higher Order Component used to inject Plugin context to the wrapped component.
 
 _Parameters_

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -30,6 +30,7 @@
 		"@babel/runtime": "7.25.7",
 		"@wordpress/components": "*",
 		"@wordpress/compose": "*",
+		"@wordpress/deprecated": "*",
 		"@wordpress/element": "*",
 		"@wordpress/hooks": "*",
 		"@wordpress/icons": "*",

--- a/packages/plugins/src/components/plugin-context/index.tsx
+++ b/packages/plugins/src/components/plugin-context/index.tsx
@@ -35,7 +35,7 @@ export function usePluginContext() {
  * A Higher Order Component used to inject Plugin context to the
  * wrapped component.
  *
- * @deprecated Use `usePluginContext` hook instead.
+ * @deprecated 6.8.0 Use `usePluginContext` hook instead.
  *
  * @param  mapContextToProps Function called on every context change,
  *                           expected to return object of props to

--- a/packages/plugins/src/components/plugin-context/index.tsx
+++ b/packages/plugins/src/components/plugin-context/index.tsx
@@ -3,6 +3,7 @@
  */
 import { createContext, useContext } from '@wordpress/element';
 import { createHigherOrderComponent } from '@wordpress/compose';
+import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
@@ -34,6 +35,8 @@ export function usePluginContext() {
  * A Higher Order Component used to inject Plugin context to the
  * wrapped component.
  *
+ * @deprecated Use `usePluginContext` hook instead.
+ *
  * @param  mapContextToProps Function called on every context change,
  *                           expected to return object of props to
  *                           merge with the component's own props.
@@ -47,6 +50,10 @@ export const withPluginContext = (
 	) => T & PluginContext
 ) =>
 	createHigherOrderComponent( ( OriginalComponent ) => {
+		deprecated( 'wp.plugins.withPluginContext', {
+			since: '6.8.0',
+			alternative: 'wp.plugins.usePluginContext',
+		} );
 		return ( props ) => (
 			<Context.Consumer>
 				{ ( context ) => (

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -9,6 +9,7 @@
 	"references": [
 		{ "path": "../components" },
 		{ "path": "../compose" },
+		{ "path": "../deprecated" },
 		{ "path": "../element" },
 		{ "path": "../hooks" },
 		{ "path": "../icons" },


### PR DESCRIPTION
## What?
PR deprecated the `withPluginContext` HOC in favor of the "new" `usePluginContext` hook.

## Why?
Using the context hook should be preferred over HOC and finished work I started in #53291.

## Testing Instructions
1. Open a post or page.
2. It should log a deprecation warning in the console. Until the #66362 is merged.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-23 at 14 51 14](https://github.com/user-attachments/assets/df0f21b4-7615-4641-b003-0eb77e2b9cfc)
