### PR TITLE
Post Content: Add border and spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -616,7 +616,7 @@ Displays the contents of a post or page. ([Source](https://github.com/WordPress/
 
 -	**Name:** core/post-content
 -	**Category:** theme
--	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), background (backgroundImage, backgroundSize), color (background, gradients, link, text), dimensions (minHeight), layout, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 
 ## Date
 

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -6,12 +6,19 @@
 	"category": "theme",
 	"description": "Displays the contents of a post or page.",
 	"textdomain": "default",
-	"usesContext": [ "postId", "postType", "queryId" ],
+	"usesContext": [
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"example": {
 		"viewportWidth": 350
 	},
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"html": false,
 		"layout": true,
 		"background": {
@@ -51,6 +58,18 @@
 			"__experimentalLetterSpacing": true,
 			"__experimentalDefaultControls": {
 				"fontSize": true
+			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
 			}
 		}
 	},

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -34,6 +34,7 @@
 		"spacing": {
 			"blockGap": true,
 			"padding": true,
+			"margin": true,
 			"__experimentalDefaultControls": {
 				"margin": false,
 				"padding": false

--- a/packages/block-library/src/post-content/block.json
+++ b/packages/block-library/src/post-content/block.json
@@ -6,19 +6,12 @@
 	"category": "theme",
 	"description": "Displays the contents of a post or page.",
 	"textdomain": "default",
-	"usesContext": [
-		"postId",
-		"postType",
-		"queryId"
-	],
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"example": {
 		"viewportWidth": 350
 	},
 	"supports": {
-		"align": [
-			"wide",
-			"full"
-		],
+		"align": [ "wide", "full" ],
 		"html": false,
 		"layout": true,
 		"background": {


### PR DESCRIPTION
## What?
Add border block support to the post content block.
Part of https://github.com/WordPress/gutenberg/issues/43247
Part of https://github.com/WordPress/gutenberg/issues/43243

## Why?
The post content block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions

1. Go to the Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
2. Make sure that the content block's border is configurable via Global Styles
3. Verify that Global Styles are applied correctly in the editor and frontend
4. Edit the post, Add content block and Apply the border styles
5. Verify that block styles take precedence over global styles
6. Verify that block borders display correctly in both the editor and frontend


## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="post-content-border" src="https://github.com/user-attachments/assets/1de12e8b-67bb-4964-b90d-c83557f072a3">
