### PR TITLE
Image Block: Show snackbar error notice when HEIC image is added

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -256,6 +256,21 @@ export default function Image( {
 		if ( undefined !== embedBlock ) {
 			onReplace( embedBlock );
 		}
+
+		// Check if the image is of HEIC type.
+		if ( url.endsWith( '.heic' ) ) {
+			const filename = getFilename( url );
+			createErrorNotice(
+				sprintf(
+					/* translators: %s: file name */
+					__(
+						'The image file "%s" is in HEIC format, which is not supported by your browser. Consider converting it to JPEG and re-uploading.'
+					),
+					filename
+				),
+				{ type: 'snackbar' }
+			);
+		}
 	}
 
 	function onImageLoad( event ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes part of: #66293 

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a 'snackbar' error notice for HEIC image uploads.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When an HEIC file is uploaded to a server that does not support HEIC to JPEG conversion, and the browser (such as Chrome or Firefox) does not support displaying HEIC, users see the alt text 'This image has an empty alt attribute; its file name is ...', however if we upload an HEIC image from the Media Library. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added an error notice of type 'snackbar' on image error after checking if the uploaded image is HEIC type.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open a post or page in the WordPress editor.
2. Add a `core/image` block. 
3. Upload an HEIC image file.
4. Observe the error notice that appears, which should include the filename and a suggestion to convert the image to JPEG.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a9518621-31cb-4864-95c2-2464cdff22b4


