### PR TITLE
Footnotes: Remove extra callback when parsing content

### DIFF
--- a/packages/core-data/src/hooks/use-entity-block-editor.js
+++ b/packages/core-data/src/hooks/use-entity-block-editor.js
@@ -91,11 +91,6 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 		getEntityRecordEdits,
 	] );
 
-	const updateFootnotes = useCallback(
-		( _blocks ) => updateFootnotesFromMeta( _blocks, meta ),
-		[ meta ]
-	);
-
 	const onChange = useCallback(
 		( newBlocks, options ) => {
 			const noChange = blocks === newBlocks;
@@ -111,7 +106,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 				selection,
 				content: ( { blocks: blocksForSerialization = [] } ) =>
 					__unstableSerializeAndClean( blocksForSerialization ),
-				...updateFootnotes( newBlocks ),
+				...updateFootnotesFromMeta( newBlocks, meta ),
 			};
 
 			editEntityRecord( kind, name, id, edits, {
@@ -124,7 +119,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 			name,
 			id,
 			blocks,
-			updateFootnotes,
+			meta,
 			__unstableCreateUndoLevel,
 			editEntityRecord,
 		]
@@ -133,7 +128,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 	const onInput = useCallback(
 		( newBlocks, options ) => {
 			const { selection, ...rest } = options;
-			const footnotesChanges = updateFootnotes( newBlocks );
+			const footnotesChanges = updateFootnotesFromMeta( newBlocks, meta );
 			const edits = { selection, ...footnotesChanges };
 
 			editEntityRecord( kind, name, id, edits, {
@@ -141,7 +136,7 @@ export default function useEntityBlockEditor( kind, name, { id: _id } = {} ) {
 				...rest,
 			} );
 		},
-		[ kind, name, id, updateFootnotes, editEntityRecord ]
+		[ kind, name, id, meta, editEntityRecord ]
 	);
 
 	return [ blocks, onInput, onChange ];


### PR DESCRIPTION
## What?
This PR removes the extra callback for updating footnotes when parsing content, which seems to be unnecessary since #52577.

## Why?
React Compiler seems to dislike instances where a cached function depends on another cached function. See #66361 that experiments with React Compiler and generates errors in the post editor (see screenshot below).

## How?
I found this behavior unexpected and would like to dig further into it. But in the meantime, it does look like the inner callback is unnecessary, (since #52577) so I'm removing it, in favor of the outer ones. Removing the inner callbacks and moving the dependency to them fixes the issue. 

## Testing Instructions
This shouldn't have any impact on behavior, but you can test it with a post with many footnotes and ensure they continue to work well. 

Performance test results should also not be impacted negatively.

You can also test this with React Compiler:
- Checkout #66361
- Run `npm install`
- Cherry-pick the commit from this PR
- Run `npm run dev`
- Verify you don't get the errors from the screenshot

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-10-23 at 16 07 39](https://github.com/user-attachments/assets/67a48bfa-590e-4a95-b14f-2deac7ee72fb)