### PR TITLE
Remove most of the occurrences of the verb toggle.

### DIFF
--- a/packages/block-editor/src/components/block-full-height-alignment-control/index.js
+++ b/packages/block-editor/src/components/block-full-height-alignment-control/index.js
@@ -7,7 +7,7 @@ import { fullscreen } from '@wordpress/icons';
 
 function BlockFullHeightAlignmentControl( {
 	isActive,
-	label = __( 'Toggle full height' ),
+	label = __( 'Full height' ),
 	onToggle,
 	isDisabled,
 } ) {

--- a/packages/block-library/src/cover/test/edit.js
+++ b/packages/block-library/src/cover/test/edit.js
@@ -119,9 +119,7 @@ describe( 'Cover block', () => {
 				'min-height: 100vh;'
 			);
 
-			await userEvent.click(
-				screen.getByLabelText( 'Toggle full height' )
-			);
+			await userEvent.click( screen.getByLabelText( 'Full height' ) );
 
 			expect( screen.getByLabelText( 'Block: Cover' ) ).toHaveStyle(
 				'min-height: 100vh;'

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -66,7 +66,7 @@ function DropCapControl( { clientId, attributes, setAttributes } ) {
 	} else if ( dropCap ) {
 		helpText = __( 'Showing large initial letter.' );
 	} else {
-		helpText = __( 'Toggle to show a large initial letter.' );
+		helpText = __( 'Show a large initial letter.' );
 	}
 
 	return (

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -376,7 +376,7 @@ export default function SearchEdit( {
 			<BlockControls>
 				<ToolbarGroup>
 					<ToolbarButton
-						title={ __( 'Toggle search label' ) }
+						title={ __( 'Show search label' ) }
 						icon={ toggleLabel }
 						onClick={ () => {
 							setAttributes( {

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -676,7 +676,7 @@ describe( 'useSelect', () => {
 				return (
 					<>
 						<div role="status">{ state }</div>
-						<button onClick={ toggle }>Toggle</button>
+						<button onClick={ toggle }>Open</button>
 					</>
 				);
 			} );
@@ -693,7 +693,7 @@ describe( 'useSelect', () => {
 				'count2:0'
 			);
 
-			act( () => screen.getByText( 'Toggle' ).click() );
+			act( () => screen.getByText( 'Open' ).click() );
 
 			expect( selectCount1 ).toHaveBeenCalledTimes( 1 );
 			expect( selectCount2 ).toHaveBeenCalledTimes( 1 );

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/element';
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import { funnel } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -124,7 +124,7 @@ export function FilterVisibilityToggle( {
 				className="dataviews-filters__visibility-toggle"
 				size="compact"
 				icon={ funnel }
-				label={ __( 'Toggle filter display' ) }
+				label={ _x( 'Filter', 'verb' ) }
 				onClick={ () => {
 					if ( ! isShowingFilter ) {
 						setOpenedFilter( null );

--- a/packages/edit-post/src/components/keyboard-shortcuts/index.js
+++ b/packages/edit-post/src/components/keyboard-shortcuts/index.js
@@ -22,7 +22,7 @@ function KeyboardShortcuts() {
 		registerShortcut( {
 			name: 'core/edit-post/toggle-fullscreen',
 			category: 'global',
-			description: __( 'Toggle fullscreen mode.' ),
+			description: __( 'Enable or disable fullscreen mode.' ),
 			keyCombination: {
 				modifier: 'secondary',
 				character: 'f',

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -412,7 +412,7 @@ export default function PostList( { postType } ) {
 							size="compact"
 							isPressed={ quickEdit }
 							icon={ drawerRight }
-							label={ __( 'Details panel' ) }
+							label={ __( 'Details' ) }
 							onClick={ () => {
 								history.push( {
 									...location.params,

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -98,8 +98,8 @@ function useEditorCommandLoader() {
 	commands.push( {
 		name: 'core/toggle-distraction-free',
 		label: isDistractionFree
-			? __( 'Exit Distraction Free' )
-			: __( 'Enter Distraction Free' ),
+			? __( 'Exit Distraction free' )
+			: __( 'Enter Distraction free' ),
 		callback: ( { close } ) => {
 			toggleDistractionFree();
 			close();
@@ -117,7 +117,9 @@ function useEditorCommandLoader() {
 
 	commands.push( {
 		name: 'core/toggle-spotlight-mode',
-		label: __( 'Toggle spotlight' ),
+		label: isFocusMode
+			? __( 'Exit Spotlight mode' )
+			: __( 'Enter Spotlight mode' ),
 		callback: ( { close } ) => {
 			toggle( 'core', 'focusMode' );
 			close();
@@ -160,7 +162,7 @@ function useEditorCommandLoader() {
 
 	commands.push( {
 		name: 'core/toggle-top-toolbar',
-		label: __( 'Toggle top toolbar' ),
+		label: __( 'Top toolbar' ),
 		callback: ( { close } ) => {
 			toggle( 'core', 'fixedToolbar' );
 			if ( isDistractionFree ) {
@@ -224,7 +226,7 @@ function useEditorCommandLoader() {
 
 	commands.push( {
 		name: 'core/open-settings-sidebar',
-		label: __( 'Toggle settings sidebar' ),
+		label: __( 'Show or hide the Settings panel.' ),
 		icon: isRTL() ? drawerLeft : drawerRight,
 		callback: ( { close } ) => {
 			const activeSidebar = getActiveComplementaryArea( 'core' );
@@ -239,7 +241,7 @@ function useEditorCommandLoader() {
 
 	commands.push( {
 		name: 'core/open-block-inspector',
-		label: __( 'Toggle block inspector' ),
+		label: __( 'Show or hide the Block settings panel' ),
 		icon: blockDefault,
 		callback: ( { close } ) => {
 			const activeSidebar = getActiveComplementaryArea( 'core' );

--- a/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
+++ b/packages/editor/src/components/global-keyboard-shortcuts/register-shortcuts.js
@@ -72,7 +72,7 @@ function EditorKeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/editor/toggle-list-view',
 			category: 'global',
-			description: __( 'Open the List View.' ),
+			description: __( 'Show or hide the List View.' ),
 			keyCombination: {
 				modifier: 'access',
 				character: 'o',
@@ -82,7 +82,7 @@ function EditorKeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/editor/toggle-distraction-free',
 			category: 'global',
-			description: __( 'Toggle distraction free mode.' ),
+			description: __( 'Enter or exit distraction free mode.' ),
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: '\\',
@@ -92,7 +92,7 @@ function EditorKeyboardShortcutsRegister() {
 		registerShortcut( {
 			name: 'core/editor/toggle-sidebar',
 			category: 'global',
-			description: __( 'Show or hide the Settings sidebar.' ),
+			description: __( 'Show or hide the Settings panel.' ),
 			keyCombination: {
 				modifier: 'primaryShift',
 				character: ',',

--- a/packages/editor/src/components/post-sticky/test/index.js
+++ b/packages/editor/src/components/post-sticky/test/index.js
@@ -35,23 +35,23 @@ function setupUseSelectMock( { hasStickyAction, postType } ) {
 describe( 'PostSticky', () => {
 	it( 'should not render anything if the post type is not "post"', () => {
 		setupUseSelectMock( { hasStickyAction: true, postType: 'page' } );
-		render( <PostStickyCheck>Can Toggle Sticky</PostStickyCheck> );
+		render( <PostStickyCheck>Can Show Sticky</PostStickyCheck> );
 		expect(
-			screen.queryByText( 'Can Toggle Sticky' )
+			screen.queryByText( 'Can Show Sticky' )
 		).not.toBeInTheDocument();
 	} );
 
 	it( "should not render anything if post doesn't support stickying", () => {
 		setupUseSelectMock( { hasStickyAction: false, postType: 'post' } );
-		render( <PostStickyCheck>Can Toggle Sticky</PostStickyCheck> );
+		render( <PostStickyCheck>Can Show Sticky</PostStickyCheck> );
 		expect(
-			screen.queryByText( 'Can Toggle Sticky' )
+			screen.queryByText( 'Can Show Sticky' )
 		).not.toBeInTheDocument();
 	} );
 
 	it( 'should render if the post supports stickying', () => {
 		setupUseSelectMock( { hasStickyAction: true, postType: 'post' } );
-		render( <PostStickyCheck>Can Toggle Sticky</PostStickyCheck> );
-		expect( screen.getByText( 'Can Toggle Sticky' ) ).toBeVisible();
+		render( <PostStickyCheck>Can Show Sticky</PostStickyCheck> );
+		expect( screen.getByText( 'Can Show Sticky' ) ).toBeVisible();
 	} );
 } );

--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -841,8 +841,8 @@ export const toggleDistractionFree =
 				.dispatch( noticesStore )
 				.createInfoNotice(
 					isDistractionFree
-						? __( 'Distraction free off.' )
-						: __( 'Distraction free on.' ),
+						? __( 'Distraction free mode deactivated.' )
+						: __( 'Distraction free mode activated.' ),
 					{
 						id: 'core/editor/distraction-free-mode/notice',
 						type: 'snackbar',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66369

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes the verb 'toggle' from most of the UI.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The verb `toggle` is not well translatable in many languages and should not be used in the UI.
It's a well known issue, see https://github.com/WordPress/gutenberg/discussions/42492 and Trac https://core.trac.wordpress.org/ticket/34753 (November 2015).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Either removes or replaces the verb 'toggle' from translatabel strings.

Note:
I kept two occurrences:
- One in [a native file](https://github.com/WordPress/gutenberg/blob/71bb8b82227757728514f3f64941f52ec53d453c/packages/components/src/mobile/bottom-sheet/switch-cell.native.js#L60) for the mobile apps, not sure where this is used and I'm not keen to work on the native files anyways. Anyone willing to fix this occurrence is welcome.
- One in [an Interactivity API template](https://github.com/WordPress/gutenberg/blob/71bb8b82227757728514f3f64941f52ec53d453c/packages/create-block-interactive-template/block-templates/render.php.mustache#L45). I _think_ this is a demo template so the usage fo the verb 'toggle' is not important here. Please correct me if I'm missing something.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Please check all the occurrences one by one and check if the changes make sense.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
