### PR TITLE
Blocks: Try parse caching

### DIFF
--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -310,8 +310,9 @@ const parseCache = new Map();
  * @return {Array} Block list.
  */
 export default function parse( content, options ) {
+	const cacheKey = JSON.stringify( { content, options } );
 	if ( parseCache.has( content ) ) {
-		return parseCache.get( content );
+		return parseCache.get( cacheKey );
 	}
 
 	const parsed = grammarParse( content ).reduce(
@@ -324,7 +325,7 @@ export default function parse( content, options ) {
 		},
 		[]
 	);
-	parseCache.set( content, parsed );
+	parseCache.set( cacheKey, parsed );
 
 	return parsed;
 }

--- a/packages/blocks/src/api/parser/index.js
+++ b/packages/blocks/src/api/parser/index.js
@@ -286,6 +286,8 @@ export function parseRawBlock( rawBlock, options ) {
 	return updatedBlock;
 }
 
+const parseCache = new Map();
+
 /**
  * Utilizes an optimized token-driven parser based on the Gutenberg grammar spec
  * defined through a parsing expression grammar to take advantage of the regular
@@ -308,11 +310,21 @@ export function parseRawBlock( rawBlock, options ) {
  * @return {Array} Block list.
  */
 export default function parse( content, options ) {
-	return grammarParse( content ).reduce( ( accumulator, rawBlock ) => {
-		const block = parseRawBlock( rawBlock, options );
-		if ( block ) {
-			accumulator.push( block );
-		}
-		return accumulator;
-	}, [] );
+	if ( parseCache.has( content ) ) {
+		return parseCache.get( content );
+	}
+
+	const parsed = grammarParse( content ).reduce(
+		( accumulator, rawBlock ) => {
+			const block = parseRawBlock( rawBlock, options );
+			if ( block ) {
+				accumulator.push( block );
+			}
+			return accumulator;
+		},
+		[]
+	);
+	parseCache.set( content, parsed );
+
+	return parsed;
 }


### PR DESCRIPTION
## What?
This PR attempts to cache the block parser function.

## Why?
Initially, the experimentation with React Compiler in https://github.com/WordPress/gutenberg/pull/66361 brought me here. I was getting a bunch of errors, which seemed to be occurring while parsing blocks. 

Then I realized, if we `parse()` 10 times a simple string like this:

```
<!-- wp:paragraph --><p>test paragraph</p><!-- /wp:paragraph -->
```

we'll always get 10 different arrays, with 10 different paragraph `WPBlock` objects. That's probably fine at first glance, but given that those blocks later influence the entire editor and cause re-rendering virtually everything (different client IDs in practice means different blocks, even if all block properties and attributes are the same). At a large scale, it might actually influence the editor performance. So, wouldn't it make sense if the same input always produces the same output (at least in a single user session)? 

Disclaimer: this may be a very naive conclusion: I'm not that familiar with the block parser, and I'm only trying out things. Ideally, assume that I'm missing something.

## How?
To get the `parse()` function to be more predictable, I'm introducing some naive caching to `parse()`. It's quite straightforward, because the input is a string, and an object of options. I'm building a predictable string key out of these 2 arguments and using that key for caching the `parse()` output. 

It was interesting that once I introduced the caching, I saw the errors reported from React Compiler drop from **65** to **7**!

This appears to be because we're calling `parse()` in some functions that are memoized, and with React Compiler, `useMemo()` doesn't seem to like functions that return different output on different calls. 

## Testing Instructions
* Editor should still work well
* All checks should be green
* There should be no performance regressions.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
