### PR TITLE
Make useZoomOut hook private

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -1075,14 +1075,6 @@ _Parameters_
 -   _override.id_ `?string`: Id of the style override, leave blank to create a new style.
 -   _override.css_ `string`: CSS to apply.
 
-### useZoomOut
-
-A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
-
-_Parameters_
-
--   _zoomOut_ `boolean`: If we should enter into zoomOut mode or not
-
 ### Warning
 
 _Related_

--- a/packages/block-editor/src/index.js
+++ b/packages/block-editor/src/index.js
@@ -13,7 +13,6 @@ export {
 	getGapCSSValue as __experimentalGetGapCSSValue,
 	getShadowClassesAndStyles as __experimentalGetShadowClassesAndStyles,
 	useCachedTruthy,
-	useZoomOut,
 	useStyleOverride,
 } from './hooks';
 export * from './components';

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -24,6 +24,7 @@ import {
 	useLayoutClasses,
 	useLayoutStyles,
 	__unstableBlockStyleVariationOverridesWithConfig,
+	useZoomOut,
 } from './hooks';
 import DimensionsTool from './components/dimensions-tool';
 import ResolutionTool from './components/resolution-tool';
@@ -78,6 +79,7 @@ lock( privateApis, {
 	TextAlignmentControl,
 	usesContextKey,
 	useFlashEditableBlocks,
+	useZoomOut,
 	globalStylesDataKey,
 	globalStylesLinksDataKey,
 	selectBlockPatternsKey,

--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -3,7 +3,7 @@
  */
 import { Card, CardBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useZoomOut } from '@wordpress/block-editor';
+import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
@@ -12,6 +12,9 @@ import { store as editorStore } from '@wordpress/editor';
  */
 import ScreenHeader from './header';
 import SidebarNavigationScreenGlobalStylesContent from '../sidebar-navigation-screen-global-styles/content';
+import { unlock } from '../../lock-unlock';
+
+const { useZoomOut } = unlock( blockEditorPrivateApis );
 
 function ScreenStyleVariations() {
 	// Style Variations should only be previewed in with


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Move useZoomOut hook to be private

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It was never intended to be public, and it's agreed that it is not ready or needed to be public at the moment as it's unstable and changes quickly. It's unlikely to be in use by a third party right now.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove it from public apis, move to private apis.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Inserter:
- Open insterter
- Click Patterns
- Canvas should zoom out
- Close inserter
- Canvas should zoom in

Styles:
- Open styles sidebar
- Click Browse Styles
- Canvas should zoom out
- Go back
- Canvas should zoom in

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
