### PR TITLE
Import only the actually used PostCSS exports

### DIFF
--- a/packages/block-editor/src/utils/transform-styles/index.js
+++ b/packages/block-editor/src/utils/transform-styles/index.js
@@ -2,7 +2,8 @@
  * External dependencies
  */
 import * as parsel from 'parsel-js';
-import postcss, { CssSyntaxError } from 'postcss';
+import Processor from 'postcss/lib/processor';
+import CssSyntaxError from 'postcss/lib/css-syntax-error';
 import prefixSelector from 'postcss-prefix-selector';
 import rebaseUrl from 'postcss-urlrebase';
 
@@ -100,7 +101,7 @@ function transformStyle(
 			wrapperSelector,
 		];
 
-		return postcss(
+		return new Processor(
 			[
 				wrapperSelector &&
 					prefixSelector( {


### PR DESCRIPTION
Avoid importing things from `postcss` package because the imported object has the entire PostCSS API in various fields. Let's import only the two specific things that we actually use. That should:
1. improve bundle size
2. avoid importing APIs like `postcss.fromJSON` that use Node.js filesystem API and that are not going to work in a browser.