### PR TITLE
Redo zoom out expand empty entry content

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -20,7 +20,6 @@
 .block-editor-iframe__html.is-zoomed-out {
 	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
 	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
 	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
 	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
 	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
@@ -42,6 +41,6 @@
 	padding-bottom: calc(#{$frame-size} / #{$scale});
 
 	body {
-		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+		min-height: 100vh;
 	}
 }

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -43,16 +43,5 @@
 
 	body {
 		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
-
-		> .is-root-container:not(.wp-block-post-content) {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			height: 100%;
-
-			> main {
-				flex: 1;
-			}
-		}
 	}
 }

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -209,21 +209,6 @@ function Iframe( {
 		};
 	}, [] );
 
-	const [ iframeWindowInnerHeight, setIframeWindowInnerHeight ] = useState();
-
-	const iframeResizeRef = useRefEffect( ( node ) => {
-		const nodeWindow = node.ownerDocument.defaultView;
-
-		setIframeWindowInnerHeight( nodeWindow.innerHeight );
-		const onResize = () => {
-			setIframeWindowInnerHeight( nodeWindow.innerHeight );
-		};
-		nodeWindow.addEventListener( 'resize', onResize );
-		return () => {
-			nodeWindow.removeEventListener( 'resize', onResize );
-		};
-	}, [] );
-
 	const [ windowInnerWidth, setWindowInnerWidth ] = useState();
 
 	const windowResizeRef = useRefEffect( ( node ) => {
@@ -259,10 +244,6 @@ function Iframe( {
 		clearerRef,
 		writingFlowRef,
 		disabledRef,
-		// Avoid resize listeners when not needed, these will trigger
-		// unnecessary re-renders when animating the iframe width, or when
-		// expanding preview iframes.
-		isZoomedOut ? iframeResizeRef : null,
 	] );
 
 	// Correct doctype is required to enable rendering in standards
@@ -371,10 +352,6 @@ function Iframe( {
 			`${ contentHeight }px`
 		);
 		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ iframeWindowInnerHeight }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-container-width',
 			`${ containerWidth }px`
 		);
@@ -394,9 +371,6 @@ function Iframe( {
 				'--wp-block-editor-iframe-zoom-out-content-height'
 			);
 			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-inner-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
 				'--wp-block-editor-iframe-zoom-out-container-width'
 			);
 			iframeDocument.documentElement.style.removeProperty(
@@ -407,7 +381,6 @@ function Iframe( {
 		scale,
 		frameSize,
 		iframeDocument,
-		iframeWindowInnerHeight,
 		contentHeight,
 		containerWidth,
 		windowInnerWidth,

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -119,6 +119,7 @@ function VisualEditor( {
 		isDesignPostType,
 		postType,
 		isPreview,
+		isEditedPostEmpty,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostId,
@@ -127,6 +128,7 @@ function VisualEditor( {
 			getEditorSettings,
 			getRenderingMode,
 			getDeviceType,
+			isEditedPostEmpty: getIsEditedPostEmpty,
 		} = select( editorStore );
 		const { getPostType, getEditedEntityRecord } = select( coreStore );
 		const postTypeSlug = getCurrentPostType();
@@ -167,6 +169,7 @@ function VisualEditor( {
 			isFocusedEntity: !! editorSettings.onNavigateToPreviousEntityRecord,
 			postType: postTypeSlug,
 			isPreview: editorSettings.isPreviewMode,
+			isEditedPostEmpty: getIsEditedPostEmpty(),
 		};
 	}, [] );
 	const { isCleanNewPost } = useSelect( editorStore );
@@ -363,10 +366,15 @@ function VisualEditor( {
 					// Some themes will have `min-height: 100vh` for the root container,
 					// which isn't a requirement in auto resize mode.
 					enableResizing ? 'min-height:0!important;' : ''
-				}}`,
+				}}${
+					// Vertically expands the top-level post content block when zoomed out on an empty post.
+					isEditedPostEmpty && isZoomedOut
+						? '.entry-content {min-height: 33vh;}'
+						: ''
+				}`,
 			},
 		];
-	}, [ styles, enableResizing ] );
+	}, [ styles, enableResizing, isEditedPostEmpty, isZoomedOut ] );
 
 	return (
 		<div


### PR DESCRIPTION
## What?
Expands the main content area when zoomed out. A redo of #59512.

## Why?
Since #66041, the content area no longer expands when zooming out and makes it harder to hit the drop zone over an empty post.

## How?
- Removes some outdated styles that were left around from the previous implementation
- Adds a new more isolated style to expand the top-level post content block when zoomed out
- Revises the `min-height` applied to the `body` when zoomed out and removes code that had been required for that

## Testing Instructions
1. Open an empty or new post/page.
2. If you’re in the Post editor, enable the "Show template" option from "Template options" in the "Settings" sidebar.
3. Open the inserter and the "Patterns" tab
4. Note that the layout shifts because the post content block has expanded in height
5. Insert a pattern by dragging it over the page
6. Undo the edit to return to an empty post
7. Switch off the "Show template" option
8. Note there’s no difference from trunk, i.e. the post content block is not expanded in height

## Screenshots or screencast <!-- if applicable -->

### Trunk

https://github.com/user-attachments/assets/0f5c5422-b393-4da9-9238-82fd016f00f1

### This branch

https://github.com/user-attachments/assets/2115e183-fd65-4638-ae78-a26f86e410d2


