### PR TITLE
Revise zoom layout shift fix

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -1,6 +1,9 @@
 .block-editor-iframe__body {
 	position: relative;
-	border: 0.01px solid transparent;
+	// Ensures margins of children are contained so that the body background paints behind them.
+	// Otherwise, the background of html (when zoomed out) would show there and appear broken. It’s
+	// important mostly for post-only views yet conceivably an issue in templated views too.
+	display: flow-root;
 }
 
 .block-editor-iframe__html {

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -1,9 +1,5 @@
 .block-editor-iframe__body {
 	position: relative;
-	// Ensures margins of children are contained so that the body background paints behind them.
-	// Otherwise, the background of html (when zoomed out) would show there and appear broken. It’s
-	// important mostly for post-only views yet conceivably an issue in templated views too.
-	display: flow-root;
 }
 
 .block-editor-iframe__html {

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -356,7 +356,10 @@ function VisualEditor( {
 		return [
 			...( styles ?? [] ),
 			{
-				css: `.is-root-container{display:flow-root;${
+				// Ensures margins of children are contained so that the body background paints behind them.
+				// Otherwise, the background of html (when zoomed out) would show there and appear broken. It’s
+				// important mostly for post-only views yet conceivably an issue in templated views too.
+				css: `:where(.block-editor-iframe__body){display:flow-root;}.is-root-container{display:flow-root;${
 					// Some themes will have `min-height: 100vh` for the root container,
 					// which isn't a requirement in auto resize mode.
 					enableResizing ? 'min-height:0!important;' : ''


### PR DESCRIPTION
## What?
A revised way to fix the layout shift that #66041 fixed and an alternative way to fix #66297.

## Why?
The a `border` rule used in the prior PR caused #66297 and also introduces minute layout differences in unintended places. Here’s one @ramonjd spotted https://github.com/WordPress/gutenberg/pull/66041#discussion_r1811577469

https://github.com/user-attachments/assets/f5b2dd18-4ca8-40fc-b6c2-1929e5ebbe79

## How?
Steals Ramon’s idea https://github.com/WordPress/gutenberg/pull/66041#discussion_r1811587699 to use `display: flow-root`

## Testing Instructions
### No layout shift (from #66041)
1. Go to the post editor, zoom out. There should be no layout shift.

### No vertical scrollbar in focused editor
1. Open the site editor.
2. Open the pattern or template part editor.

There should be no vertical scrollbar.

## Screenshots or screencast <!-- if applicable -->
