### PR TITLE
Inline commenting - Change new comment input option to use Textareacontrol

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -8,7 +8,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Button,
-	TextControl,
+	TextareaControl,
 } from '@wordpress/components';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
@@ -91,7 +91,7 @@ export function AddComment( {
 					{ currentUser?.name ?? '' }
 				</span>
 			</HStack>
-			<TextControl
+			<TextareaControl
 				__next40pxDefaultSize
 				__nextHasNoMarginBottom
 				value={ inputComment }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Partof - https://github.com/WordPress/gutenberg/issues/66377

## What?
<!-- In a few words, what is the PR actually doing? -->
- PR changes from `Textcontrol` to `Textareacontrol` to add the new comments.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- Inline comments can be long so needs better UX to add the comments.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR updates to use `Textareacontrol`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Enable experimental inline commenting option.
2. Go to any post/page.
3. Add any block, check to add the inline comment.
4. You would see the text area input to add the comment.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Nil

## Screenshots or screencast <!-- if applicable -->
<img width="640" alt="Screenshot 2024-10-24 at 9 44 06 AM" src="https://github.com/user-attachments/assets/1dd08233-ffa4-4b1e-ac13-28a43c0768e3">
