### PR TITLE
Navigation: Add border and spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -472,7 +472,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 -	**Name:** core/navigation
 -	**Category:** theme
 -	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
--	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
+-	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, margin, padding, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
 -	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 
 ## Custom Link

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -18,7 +18,11 @@
 		"core/buttons"
 	],
 	"description": "A collection of blocks that allow visitors to get around your site.",
-	"keywords": [ "menu", "navigation", "links" ],
+	"keywords": [
+		"menu",
+		"navigation",
+		"links"
+	],
 	"textdomain": "default",
 	"attributes": {
 		"ref": {
@@ -82,8 +86,16 @@
 			"default": 5
 		},
 		"templateLock": {
-			"type": [ "string", "boolean" ],
-			"enum": [ "all", "insert", "contentOnly", false ]
+			"type": [
+				"string",
+				"boolean"
+			],
+			"enum": [
+				"all",
+				"insert",
+				"contentOnly",
+				false
+			]
 		}
 	},
 	"providesContext": {
@@ -103,7 +115,10 @@
 		"maxNestingLevel": "maxNestingLevel"
 	},
 	"supports": {
-		"align": [ "wide", "full" ],
+		"align": [
+			"wide",
+			"full"
+		],
 		"ariaLabel": true,
 		"html": false,
 		"inserter": true,
@@ -116,14 +131,22 @@
 			"__experimentalFontFamily": true,
 			"__experimentalLetterSpacing": true,
 			"__experimentalTextDecoration": true,
-			"__experimentalSkipSerialization": [ "textDecoration" ],
+			"__experimentalSkipSerialization": [
+				"textDecoration"
+			],
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
 		},
 		"spacing": {
 			"blockGap": true,
-			"units": [ "px", "em", "rem", "vh", "vw" ],
+			"units": [
+				"px",
+				"em",
+				"rem",
+				"vh",
+				"vw"
+			],
 			"__experimentalDefaultControls": {
 				"blockGap": true
 			}
@@ -135,6 +158,18 @@
 			"allowSizingOnChildren": true,
 			"default": {
 				"type": "flex"
+			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
 			}
 		},
 		"interactivity": true,

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -139,6 +139,8 @@
 			}
 		},
 		"spacing": {
+			"margin": true,
+			"padding": true,
 			"blockGap": true,
 			"units": [
 				"px",


### PR DESCRIPTION
## What?
Add border block support to the navigation block.
Part of https://github.com/WordPress/gutenberg/issues/43247
Part of https://github.com/WordPress/gutenberg/issues/43243

## Why?
The Navigation block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions
1. Go to the Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
2. Make sure that the navigation block's border is configurable via Global Styles
3. Verify that Global Styles are applied correctly in the editor and frontend
4. Edit the template/page, Add a Navigation block and Apply the border styles
5. Verify that block styles take precedence over global styles
6. Verify that block borders display correctly in both the editor and frontend

### Note
Please confirm that we need a border for items and a wrapper for navigation as shown in the frontend image below.

## Screenshots or screencast <!-- if applicable -->
FrontEnd:
<img width="1433" alt="navigation-front" src="https://github.com/user-attachments/assets/573f1947-57a4-4460-be83-64911519d21d">

Backend:
<img width="1433" alt="navigation-backend" src="https://github.com/user-attachments/assets/b7d44440-5a5c-42c0-bc75-711d13652641">
