### PR TITLE
Query Pagination Previous: Add border and spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -765,7 +765,7 @@ Displays the previous posts page link. ([Source](https://github.com/WordPress/gu
 -	**Name:** core/query-pagination-previous
 -	**Category:** theme
 -	**Parent:** core/query-pagination
--	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Query Title

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -29,6 +29,14 @@
 				"background": true
 			}
 		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/query-pagination-previous/block.json
+++ b/packages/block-library/src/query-pagination-previous/block.json
@@ -44,6 +44,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What?
Add border and spacing block support to the Query Pagination Previous  ( Previous Page ) block.

Part of https://github.com/WordPress/gutenberg/issues/43247
Part of https://github.com/WordPress/gutenberg/issues/43243

## Why?
`Query Pagination Previous  ( Previous Page ) ` block is missing border and spacing support.

## How?
Adds the border and spacing block support in block.json

## Testing Instructions

- Go to Appearance > Editor > Styles > Edit Styles > Blocks.
- Ensure the Query Pagination Previous (Previous Page) block's border and spacing is configurable via Global Styles.
- Confirm Global Styles are applied correctly in both the editor and frontend.
- Edit a template or page and add a Query Loop block.
- Select a variation (e.g., Title & Date) and adjust pagination to display the "Previous Link."
- Select the Previous Page block and verify border, radius and spacing settings are available.
- Check that block styles take precedence over Global Styles.
- Ensure borders and spacing display correctly in both the editor and frontend.

### Testing Instructions for Keyboard
None.

## Screenshots or screencast <!-- if applicable -->

In Backend:

![query_prev_backend](https://github.com/user-attachments/assets/bdcd84a3-9017-4a11-b787-22f72937eb05)



In Front End:

![query_prev_frontend](https://github.com/user-attachments/assets/c8c86f67-34f4-491e-ad26-09692674e7cd)

