### PR TITLE
Query Pagination Next: Add border and spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -745,7 +745,7 @@ Displays the next posts page link. ([Source](https://github.com/WordPress/gutenb
 -	**Name:** core/query-pagination-next
 -	**Category:** theme
 -	**Parent:** core/query-pagination
--	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Page Numbers

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -29,6 +29,14 @@
 				"background": true
 			}
 		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/query-pagination-next/block.json
+++ b/packages/block-library/src/query-pagination-next/block.json
@@ -44,6 +44,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
## What?
Add border and spacing block support to the Query Pagination Next ( Next Page ) block.

Part of https://github.com/WordPress/gutenberg/issues/43247
Part of https://github.com/WordPress/gutenberg/issues/43243

## Why?

`Query Pagination Next ( Next Page ) `block is missing border and spacing support.

## How?
Adds the border and spacing block support in block.json

## Testing Instructions

- Go to Appearance > Editor > Styles > Edit Styles > Blocks.
- Ensure the Query Pagination Next (Next Page) block's border and spacing is configurable via Global Styles.
- Confirm Global Styles are applied correctly in both the editor and frontend.
- Edit a template or page and add a Query Loop block.
- Select a variation (e.g., Title & Date) and adjust pagination to display the "Next Link."
- Select the Next Page block and verify border, radius and spacing settings are available.
- Check that block styles take precedence over Global Styles.
- Ensure borders and spacing display correctly in both the editor and frontend.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

In Backend:
![query_next_backend](https://github.com/user-attachments/assets/5f3a3022-4993-4565-a0b8-47c807e8af3f)


In Frontend:

![query_next_frontend](https://github.com/user-attachments/assets/cd5dd84f-c8b0-4870-8cd9-6e5094b35f8e)
