### PR TITLE
Zoom Out: Fix bouncy drop zones

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -202,10 +202,10 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				getBlockSettings,
 				getSectionRootClientId,
 			} = unlock( select( blockEditorStore ) );
-			let _isDropZoneDisabled;
 
 			if ( ! clientId ) {
-				return { isDropZoneDisabled: _isDropZoneDisabled };
+				// Disable the root drop zone when zoomed out.
+				return { isDropZoneDisabled: isZoomOut() };
 			}
 
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
@@ -214,7 +214,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			const parentClientId = getBlockRootClientId( clientId );
 			const [ defaultLayout ] = getBlockSettings( clientId, 'layout' );
 
-			_isDropZoneDisabled = blockEditingMode === 'disabled';
+			let _isDropZoneDisabled = blockEditingMode === 'disabled';
 
 			if ( isZoomOut() ) {
 				// In zoom out mode, we want to disable the drop zone for the sections.

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -207,6 +207,8 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				const sectionRootClientId = getSectionRootClientId();
 				// Disable the root drop zone when zoomed out and the section root client id
 				// is not the root block list (represented by an empty string).
+				// This avoids drag handling bugs caused by having two block lists acting as 
+				// drop zones - the actual 'root' block list and the section root.
 				return {
 					isDropZoneDisabled:
 						isZoomOut() && sectionRootClientId !== '',

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -207,7 +207,7 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				const sectionRootClientId = getSectionRootClientId();
 				// Disable the root drop zone when zoomed out and the section root client id
 				// is not the root block list (represented by an empty string).
-				// This avoids drag handling bugs caused by having two block lists acting as 
+				// This avoids drag handling bugs caused by having two block lists acting as
 				// drop zones - the actual 'root' block list and the section root.
 				return {
 					isDropZoneDisabled:

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -204,8 +204,13 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 			} = unlock( select( blockEditorStore ) );
 
 			if ( ! clientId ) {
-				// Disable the root drop zone when zoomed out.
-				return { isDropZoneDisabled: isZoomOut() };
+				const sectionRootClientId = getSectionRootClientId();
+				// Disable the root drop zone when zoomed out and the section root client id
+				// is not the root block list (represented by an empty string).
+				return {
+					isDropZoneDisabled:
+						isZoomOut() && sectionRootClientId !== '',
+				};
 			}
 
 			const { hasBlockSupport, getBlockType } = select( blocksStore );
@@ -221,7 +226,6 @@ export function useInnerBlocksProps( props = {}, options = {} ) {
 				// The inner blocks belonging to the section drop zone is
 				// already disabled by the blocks themselves being disabled.
 				const sectionRootClientId = getSectionRootClientId();
-
 				_isDropZoneDisabled = clientId !== sectionRootClientId;
 			}
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -287,7 +287,7 @@ function isInsertionPoint( targetToCheck, ownerDocument ) {
 	return !! (
 		defaultView &&
 		targetToCheck instanceof defaultView.HTMLElement &&
-		targetToCheck.dataset.isInsertionPoint
+		targetToCheck.closest( '[data-is-insertion-point]' )
 	);
 }
 


### PR DESCRIPTION
## What?
Fixes #65927 (or at least one of the main issues)

## Why?
Block drag and drop uses the `useBlockDropZone` hook. Rather than each block being a drop zone, each block list is a drop zone.

For Zoom Out, only the 'section' blocks are interactive—the only block list that's supposed to be active as a drop zone is the one represented by the `sectionRootClientId`. This is handled by the `useSelect` in the `useInnerBlocksProps` hook, it returns `isDropZoneDisabled: true` for any block lists that are not the section root, and that's used to prevent binding the `useBlockDropZone` hook.

The bug - that hook has an early `if ( ! clientId )` return in the `useSelect`, which always returns a falsey for the `isDropZoneDisabled` value, so in a lot of cases zoom out would accidentally have two blocks lists acting as drop zones - the actual 'root' block list and the section root.

This extra drop zone causes some rogue `onDragLeave` events triggering `hideInsertionPoint`.

## How?
Adds some extra logic in the selector for the root block list when zoom out is active. It is valid for the sectionRoot to be the actual root, so this is checked.

Separately I've also added some extra safety to the `isInsertionPoint` check, as this only tests against the outer element and not nested elements of the insertion point.

## Testing Instructions
1. Edit a template like Blog Homepage in the site editor
2. Insert some patterns as sections. Add lots of top margin above one section
3. Open the inserter on patterns tab, select a category
4. Try dragging one of the patterns over the pattern with the margin, then drag into the margin area and back again repeatedly

In trunk: The Insertion Points shows and hides itself as you drag between the block and the margin
In this PR: The Insertion Point stays present as you drag back and forth.

## Screenshots or screencast <!-- if applicable -->
#### Before
https://github.com/user-attachments/assets/26bd5232-e2a8-4cdd-b067-29c93b73679f

#### After
https://github.com/user-attachments/assets/e3d6b165-6f00-47f5-9b75-5e128cb85648

