### PR TITLE
Query Pagination Numbers: Add border and spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -755,7 +755,7 @@ Displays a list of page numbers for pagination. ([Source](https://github.com/Wor
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
 -	**Parent:** core/query-pagination
--	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), spacing (margin, padding), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** midSize
 
 ## Previous Page

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -755,7 +755,7 @@ Displays a list of page numbers for pagination. ([Source](https://github.com/Wor
 -	**Name:** core/query-pagination-numbers
 -	**Category:** theme
 -	**Parent:** core/query-pagination
--	**Supports:** color (background, gradients, ~~text~~), spacing (margin, padding), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** midSize
 
 ## Previous Page

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -4,7 +4,9 @@
 	"name": "core/query-pagination-numbers",
 	"title": "Page Numbers",
 	"category": "theme",
-	"parent": [ "core/query-pagination" ],
+	"parent": [
+		"core/query-pagination"
+	],
 	"description": "Displays a list of page numbers for pagination.",
 	"textdomain": "default",
 	"attributes": {
@@ -13,7 +15,11 @@
 			"default": 2
 		}
 	},
-	"usesContext": [ "queryId", "query", "enhancedPagination" ],
+	"usesContext": [
+		"queryId",
+		"query",
+		"enhancedPagination"
+	],
 	"supports": {
 		"reusable": false,
 		"html": false,
@@ -36,6 +42,10 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true
 		},
 		"__experimentalBorder": {
 			"radius": true,

--- a/packages/block-library/src/query-pagination-numbers/block.json
+++ b/packages/block-library/src/query-pagination-numbers/block.json
@@ -37,6 +37,18 @@
 				"fontSize": true
 			}
 		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
+		},
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION
## What?
Add border block support to the Pagination numbers block.
Part of https://github.com/WordPress/gutenberg/issues/43247
Part of https://github.com/WordPress/gutenberg/issues/43243

## Why?
The pagination numbers block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions

1. Go to the Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
2. Make sure that the Pagination block's border is configurable via Global Styles
3. Verify that Global Styles are applied correctly in the editor and frontend
4. Edit the template/page, Add a pagination block and Apply the border styles
5. Verify that block styles take precedence over global styles
6. Verify that block borders display correctly in both the editor and frontend

## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="pagination-number" src="https://github.com/user-attachments/assets/6ad2b07f-6b1a-44c0-8c9a-53d93c5b2aad">
