### PR TITLE
Safari: prevent focus capturing caused by flex display

### DIFF
--- a/packages/block-library/src/group/editor.scss
+++ b/packages/block-library/src/group/editor.scss
@@ -10,18 +10,6 @@
 	}
 }
 
-// Reset user select, but the next rule should take precedence for nested
-// groups.
-:where([data-has-multi-selection]:not([contenteditable="true"]) .wp-block-group > *) {
-	user-select: initial;
-}
-
-// When we are not multi-selecting, prevent children from capturing the
-// selection, which happens when the group is flex and children inlined.
-:where([data-has-multi-selection]:not([contenteditable="true"]) .wp-block-group) {
-	user-select: none;
-}
-
 // Place block list appender in the same place content will appear.
 [data-type="core/group"].is-selected {
 	.block-list-appender {

--- a/packages/rich-text/src/component/event-listeners/index.js
+++ b/packages/rich-text/src/component/event-listeners/index.js
@@ -13,6 +13,7 @@ import formatBoundaries from './format-boundaries';
 import deleteHandler from './delete';
 import inputAndSelection from './input-and-selection';
 import selectionChangeCompat from './selection-change-compat';
+import preventFocusCapture from './prevent-focus-capture';
 
 const allEventListeners = [
 	copyHandler,
@@ -21,6 +22,7 @@ const allEventListeners = [
 	deleteHandler,
 	inputAndSelection,
 	selectionChangeCompat,
+	preventFocusCapture,
 ];
 
 export function useEventListeners( props ) {

--- a/packages/rich-text/src/component/event-listeners/index.js
+++ b/packages/rich-text/src/component/event-listeners/index.js
@@ -13,7 +13,7 @@ import formatBoundaries from './format-boundaries';
 import deleteHandler from './delete';
 import inputAndSelection from './input-and-selection';
 import selectionChangeCompat from './selection-change-compat';
-import preventFocusCapture from './prevent-focus-capture';
+import { preventFocusCapture } from './prevent-focus-capture';
 
 const allEventListeners = [
 	copyHandler,

--- a/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
+++ b/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
@@ -1,0 +1,35 @@
+export default () => ( element ) => {
+	const { ownerDocument } = element;
+	const { defaultView } = ownerDocument;
+
+	let value = null;
+
+	function onPointerDown( event ) {
+		// Abort if the event is default prevented, we will not get a pointer up event.
+		if ( event.defaultPrevented ) {
+			return;
+		}
+		if ( event.target === element ) {
+			return;
+		}
+		if ( ! event.target.contains( element ) ) {
+			return;
+		}
+		value = element.getAttribute( 'contenteditable' );
+		element.setAttribute( 'contenteditable', 'false' );
+	}
+
+	function onPointerUp() {
+		if ( value !== null ) {
+			element.setAttribute( 'contenteditable', value );
+			value = null;
+		}
+	}
+
+	defaultView.addEventListener( 'pointerdown', onPointerDown );
+	defaultView.addEventListener( 'pointerup', onPointerUp );
+	return () => {
+		defaultView.removeEventListener( 'pointerdown', onPointerDown );
+		defaultView.removeEventListener( 'pointerup', onPointerUp );
+	};
+};

--- a/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
+++ b/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
@@ -17,6 +17,7 @@ export default () => ( element ) => {
 		}
 		value = element.getAttribute( 'contenteditable' );
 		element.setAttribute( 'contenteditable', 'false' );
+		defaultView.getSelection().removeAllRanges();
 	}
 
 	function onPointerUp() {

--- a/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
+++ b/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
@@ -1,36 +1,38 @@
-export default () => ( element ) => {
-	const { ownerDocument } = element;
-	const { defaultView } = ownerDocument;
+export function preventFocusCapture() {
+	return ( element ) => {
+		const { ownerDocument } = element;
+		const { defaultView } = ownerDocument;
 
-	let value = null;
+		let value = null;
 
-	function onPointerDown( event ) {
-		// Abort if the event is default prevented, we will not get a pointer up event.
-		if ( event.defaultPrevented ) {
-			return;
+		function onPointerDown( event ) {
+			// Abort if the event is default prevented, we will not get a pointer up event.
+			if ( event.defaultPrevented ) {
+				return;
+			}
+			if ( event.target === element ) {
+				return;
+			}
+			if ( ! event.target.contains( element ) ) {
+				return;
+			}
+			value = element.getAttribute( 'contenteditable' );
+			element.setAttribute( 'contenteditable', 'false' );
+			defaultView.getSelection().removeAllRanges();
 		}
-		if ( event.target === element ) {
-			return;
-		}
-		if ( ! event.target.contains( element ) ) {
-			return;
-		}
-		value = element.getAttribute( 'contenteditable' );
-		element.setAttribute( 'contenteditable', 'false' );
-		defaultView.getSelection().removeAllRanges();
-	}
 
-	function onPointerUp() {
-		if ( value !== null ) {
-			element.setAttribute( 'contenteditable', value );
-			value = null;
+		function onPointerUp() {
+			if ( value !== null ) {
+				element.setAttribute( 'contenteditable', value );
+				value = null;
+			}
 		}
-	}
 
-	defaultView.addEventListener( 'pointerdown', onPointerDown );
-	defaultView.addEventListener( 'pointerup', onPointerUp );
-	return () => {
-		defaultView.removeEventListener( 'pointerdown', onPointerDown );
-		defaultView.removeEventListener( 'pointerup', onPointerUp );
+		defaultView.addEventListener( 'pointerdown', onPointerDown );
+		defaultView.addEventListener( 'pointerup', onPointerUp );
+		return () => {
+			defaultView.removeEventListener( 'pointerdown', onPointerDown );
+			defaultView.removeEventListener( 'pointerup', onPointerUp );
+		};
 	};
-};
+}

--- a/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
+++ b/packages/rich-text/src/component/event-listeners/prevent-focus-capture.js
@@ -1,3 +1,9 @@
+/**
+ * Prevents focus from being captured by the element when clicking _outside_
+ * around the element. This may happen when the parent element is flex.
+ * @see https://github.com/WordPress/gutenberg/pull/65857
+ * @see https://github.com/WordPress/gutenberg/pull/66402
+ */
 export function preventFocusCapture() {
 	return ( element ) => {
 		const { ownerDocument } = element;

--- a/test/e2e/specs/editor/various/multi-block-selection.spec.js
+++ b/test/e2e/specs/editor/various/multi-block-selection.spec.js
@@ -728,7 +728,7 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 		] );
 	} );
 
-	test( 'should clear selection when clicking next to blocks (-firefox)', async ( {
+	test( 'should clear selection when clicking next to blocks', async ( {
 		page,
 		editor,
 		multiBlockSelectionUtils,
@@ -752,16 +752,13 @@ test.describe( 'Multi-block selection (@firefox, @webkit)', () => {
 				name: 'Block: Paragraph',
 			} )
 			.filter( { hasText: '1' } );
+		// For some reason in Chrome it requires two clicks, even though it
+		// doesn't when testing manually.
 		await paragraph1.click( {
 			position: { x: -1, y: 0 },
 			// Use force since it's outside the bounding box of the element.
 			force: true,
 		} );
-
-		await expect
-			.poll( multiBlockSelectionUtils.getSelectedFlatIndices )
-			.toEqual( [ 1 ] );
-
 		await paragraph1.click( {
 			position: { x: -1, y: 0 },
 			// Use force since it's outside the bounding box of the element.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following up from #65857.  The browser bug demonstrated: https://codepen.io/iseulde/pen/OJKNWOz

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can disable content editable when clicking a parent element to prevent it from capturing focus.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


Click on the group padding in Safari (try many times). It should not move focus to rich text.


```html
<!-- wp:group {"metadata":{"name":"Team members","categories":["about"],"patternName":"twentytwentyfour/team-4-col"},"align":"full","style":{"spacing":{"margin":{"top":"0","bottom":"0"},"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50","left":"var:preset|spacing|50","right":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
<div class="wp-block-group alignfull" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--50);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical","justifyContent":"center"}} -->
<div class="wp-block-group"><!-- wp:heading {"textAlign":"center","fontSize":"xx-large"} -->
<h2 class="wp-block-heading has-text-align-center has-xx-large-font-size">Meet our team</h2>
<!-- /wp:heading -->

<!-- wp:paragraph {"align":"center"} -->
<p class="has-text-align-center">Our comprehensive suite of professionals caters to a diverse team, ranging from seasoned architects to renowned engineers.</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
