### PR TITLE
Latest Posts: Use ref for redirection prevention notice ID

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -40,7 +40,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { store as noticeStore } from '@wordpress/notices';
 import { useInstanceId } from '@wordpress/compose';
-import { createInterpolateElement } from '@wordpress/element';
+import { createInterpolateElement, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -156,14 +156,14 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 
 	// If a user clicks to a link prevent redirection and show a warning.
 	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
-	let noticeId;
+	const noticeIdRef = useRef();
 	const showRedirectionPreventedNotice = ( event ) => {
 		event.preventDefault();
 		// Remove previous warning if any, to show one at a time per block.
-		removeNotice( noticeId );
-		noticeId = `block-library/core/latest-posts/redirection-prevented/${ instanceId }`;
+		removeNotice( noticeIdRef.current );
+		noticeIdRef.current = `block-library/core/latest-posts/redirection-prevented/${ instanceId }`;
 		createWarningNotice( __( 'Links are disabled in the editor.' ), {
-			id: noticeId,
+			id: noticeIdRef.current,
 			type: 'snackbar',
 		} );
 	};


### PR DESCRIPTION
## What?
This PR updates the redirection prevention notice ID to use a ref instead of a local variable. 

## Why?

A ref is a better solution than a local variable, see https://github.com/WordPress/gutenberg/pull/66331/files#r1811542384.

This is also a follow-up to https://github.com/WordPress/gutenberg/pull/66331

## How?
We're using a ref instead of a local variable.

## Testing Instructions
* Start a new post
* Insert a couple of "Latest Posts" blocks
* Click on any of the links in each of the block instances.
* Verify that for each block we have an independent notice, one per block instance.
* Verify that if you click links inside a single block instance multiple times, you keep having that same notice, and no duplicate notices are created for that particular block.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None