### PR TITLE
Block Editor: Fix 'useInstanceId' hook reference

### DIFF
--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -376,10 +376,14 @@ const elementTypes = [
 	},
 ];
 
+// Used for generating the instance ID
+const STYLE_BLOCK_PROPS_REFERENCE = {};
+
 function useBlockProps( { name, style } ) {
-	const blockElementsContainerIdentifier = `wp-elements-${ useInstanceId(
-		useBlockProps
-	) }`;
+	const blockElementsContainerIdentifier = useInstanceId(
+		STYLE_BLOCK_PROPS_REFERENCE,
+		'wp-elements'
+	);
 
 	const baseElementSelector = `.${ blockElementsContainerIdentifier }`;
 	const blockElementStyles = style?.elements;


### PR DESCRIPTION
## What?
This is similar to #65733.

> This PR updates the instances where we reference hooks within `useInstanceId` to use stable objects instead. 
> 
> ## Why?
> In React 19, the React Compiler doesn't like it when we're referencing hooks and not calling them:
> 
> ```
> Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values 
> ```
> 
> See https://github.com/WordPress/gutenberg/pull/61788 for more details.
> 
> ## How?
> We're using dedicated inline stable object references instead of the hooks themselves. Whether we're referencing the function or a neighbor object, `useInstanceId` will be the same.

## Testing Instructions
1. Open Site Editor.
2. Change block styles.
3. Confirm they work as before.
