### PR TITLE
Theme export: convert uploaded URLs to relative path assets

### DIFF
--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -106,15 +106,29 @@ function gutenberg_generate_block_templates_export_file() {
 	if ( ! empty( $uris_to_migrate ) ) {
 		$uploads = wp_upload_dir();
 		foreach ( $uris_to_migrate as $uri ) {
-			$path         = explode( '.', $uri['target'] );
+			$href   = $uri['href'];
+			$target = $uri['target'];
+			if ( str_ends_with( $target, 'background.backgroundImage.url' ) ) {
+				/*
+				 * For background images, reset the backgroundImage object
+				 * to remove upload "id", "source", and "title".
+				 * Done by removing .url from the path to get the target, and setting
+				 * href to replace the `background.backgroundImage` object.
+				 */
+				$target = rtrim( $target, '.url' );
+				$href   = array(
+					'url' => $href,
+				);
+			}
+			$path         = explode( '.', $target );
 			$file         = str_replace( $uploads['baseurl'], $uploads['basedir'], $uri['name'] );
 			$file_content = file_get_contents( $file );
 			if ( ! $file_content ) {
 				continue;
 			}
-			// @TODO: Handle setting in WP_Theme_JSON_Resolver_Gutenberg, something akin to ::resolve_theme_file_uris().
-			// Reason is, we want to strip any superfluous information from backgroundImage object such as upload "id", "source", and "title".
-			_wp_array_set( $theme_json_raw, $path, $uri['href'] );
+
+			_wp_array_set( $theme_json_raw, $path, $href );
+
 			if ( $zip->locateName( 'assets' ) === false ) {
 				// Directory doesn't exist, so add it
 				$zip->addEmptyDir( 'assets' );

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -97,7 +97,12 @@ function gutenberg_generate_block_templates_export_file() {
 	}
 
 	// Find any uploaded files.
-	$uris_to_migrate = WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( $tree );
+	$uris_to_migrate = WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris(
+		$tree,
+		array(
+			'relative_path_prefix' => 'file:./assets/',
+		)
+	);
 	if ( ! empty( $uris_to_migrate ) ) {
 		$uploads = wp_upload_dir();
 		foreach ( $uris_to_migrate as $uri ) {
@@ -107,7 +112,7 @@ function gutenberg_generate_block_templates_export_file() {
 			if ( ! $file_content ) {
 				continue;
 			}
-			_wp_array_set( $theme_json_raw, $path, 'file:./assets/' . $uri['href'] );
+			_wp_array_set( $theme_json_raw, $path, $uri['href'] );
 			if ( $zip->locateName( 'assets' ) === false ) {
 				// Directory doesn't exist, so add it
 				$zip->addEmptyDir( 'assets' );

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -112,6 +112,8 @@ function gutenberg_generate_block_templates_export_file() {
 			if ( ! $file_content ) {
 				continue;
 			}
+			// @TODO: Handle setting in WP_Theme_JSON_Resolver_Gutenberg, something akin to ::resolve_theme_file_uris().
+			// Reason is, we want to strip any superfluous information from backgroundImage object such as upload "id", "source", and "title".
 			_wp_array_set( $theme_json_raw, $path, $uri['href'] );
 			if ( $zip->locateName( 'assets' ) === false ) {
 				// Directory doesn't exist, so add it

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -105,23 +105,27 @@ function gutenberg_generate_block_templates_export_file() {
 	preg_match_all( $pattern, $theme_json_encoded, $matches );
 
 	if ( ! empty( $matches ) ) {
-		$replacement     = '"file:./uploads/$1"';
-		$replace_pattern = '/"' . preg_quote( $uploads['baseurl'], '/' ) . '\/.*?\/([^\/"\s]+)"/';
-		// Find all uploaded file matches in theme_json_raw and replace them with the file name.
-		$theme_json_encoded = preg_replace( $replace_pattern, $replacement, $theme_json_encoded );
+		$replacement              = '"file:./assets/$1"';
+		$replace_pattern          = '/"' . preg_quote( $uploads['baseurl'], '/' ) . '\/.*?\/([^\/"\s]+)"/';
+		$theme_json_encoded       = preg_replace( $replace_pattern, $replacement, $theme_json_encoded );
+		$is_assets_folder_created = false;
 
-		// Add an uploads directory to the zip if $files isn't empty.
-		$zip->addEmptyDir( 'uploads' );
-
-		// Add each image to the uploads directory.
+		// Add each image to the assets directory.
 		foreach ( $matches[1] as $file ) {
 			$file         = str_replace( $uploads['baseurl'], $uploads['basedir'], $file );
 			$file_content = file_get_contents( $file );
 			if ( ! $file_content ) {
 				continue;
 			}
+			if ( ! $is_assets_folder_created ) {
+				if ( $zip->locateName( 'assets' ) === false ) {
+					// Directory doesn't exist, so add it
+					$zip->addEmptyDir( 'assets' );
+				}
+				$is_assets_folder_created = true;
+			}
 			$zip->addFromString(
-				'uploads/' . basename( parse_url( $file, PHP_URL_PATH ) ),
+				'assets/' . basename( parse_url( $file, PHP_URL_PATH ) ),
 				$file_content
 			);
 		}

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -108,7 +108,6 @@ function gutenberg_generate_block_templates_export_file() {
 		$replacement              = '"file:./assets/$1"';
 		$replace_pattern          = '/"' . preg_quote( $uploads['baseurl'], '/' ) . '\/.*?\/([^\/"\s]+)"/';
 		$theme_json_encoded       = preg_replace( $replace_pattern, $replacement, $theme_json_encoded );
-		$is_assets_folder_created = false;
 
 		// Add each image to the assets directory.
 		foreach ( $matches[1] as $file ) {
@@ -117,12 +116,9 @@ function gutenberg_generate_block_templates_export_file() {
 			if ( ! $file_content ) {
 				continue;
 			}
-			if ( ! $is_assets_folder_created ) {
-				if ( $zip->locateName( 'assets' ) === false ) {
-					// Directory doesn't exist, so add it
-					$zip->addEmptyDir( 'assets' );
-				}
-				$is_assets_folder_created = true;
+			if ( $zip->locateName( 'assets' ) === false ) {
+				// Directory doesn't exist, so add it
+				$zip->addEmptyDir( 'assets' );
 			}
 			$zip->addFromString(
 				'assets/' . basename( parse_url( $file, PHP_URL_PATH ) ),

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -12,6 +12,7 @@
  *
  * @since 5.9.0
  * @since 6.0.0 Adds the whole theme to the export archive.
+ * @since 6.8.0 Adds uploaded files to the export archive.
  *
  * @global string $wp_version The WordPress version string.
  *

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -105,9 +105,9 @@ function gutenberg_generate_block_templates_export_file() {
 	preg_match_all( $pattern, $theme_json_encoded, $matches );
 
 	if ( ! empty( $matches ) ) {
-		$replacement              = '"file:./assets/$1"';
-		$replace_pattern          = '/"' . preg_quote( $uploads['baseurl'], '/' ) . '\/.*?\/([^\/"\s]+)"/';
-		$theme_json_encoded       = preg_replace( $replace_pattern, $replacement, $theme_json_encoded );
+		$replacement        = '"file:./assets/$1"';
+		$replace_pattern    = '/"' . preg_quote( $uploads['baseurl'], '/' ) . '\/.*?\/([^\/"\s]+)"/';
+		$theme_json_encoded = preg_replace( $replace_pattern, $replacement, $theme_json_encoded );
 
 		// Add each image to the assets directory.
 		foreach ( $matches[1] as $file ) {

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -8,7 +8,7 @@
 /**
  * Finds an available path in a ZIP archive by appending a numeric suffix if needed.
  *
- * @since 6.8.0
+ * @since 7.1.0
  * @access private
  *
  * @param ZipArchive $zip  ZIP archive.
@@ -39,7 +39,7 @@ function gutenberg_get_available_zip_path( $zip, $path ) {
  *
  * @since 5.9.0
  * @since 6.0.0 Adds the whole theme to the export archive.
- * @since 6.8.0 Adds uploaded files to the export archive.
+ * @since 7.1.0 Adds uploaded files to the export archive.
  *
  * @global string $wp_version The WordPress version string.
  *

--- a/lib/block-template-utils.php
+++ b/lib/block-template-utils.php
@@ -6,6 +6,33 @@
  */
 
 /**
+ * Finds an available path in a ZIP archive by appending a numeric suffix if needed.
+ *
+ * @since 6.8.0
+ * @access private
+ *
+ * @param ZipArchive $zip  ZIP archive.
+ * @param string     $path Desired path in the ZIP archive.
+ * @return string Available path in the ZIP archive.
+ */
+function gutenberg_get_available_zip_path( $zip, $path ) {
+	$path       = ltrim( wp_normalize_path( $path ), '/' );
+	$path_info  = pathinfo( $path );
+	$directory  = ( ! empty( $path_info['dirname'] ) && '.' !== $path_info['dirname'] ) ? trailingslashit( $path_info['dirname'] ) : '';
+	$filename   = $path_info['filename'] ?? '';
+	$extension  = empty( $path_info['extension'] ) ? '' : '.' . $path_info['extension'];
+	$candidate  = $directory . $filename . $extension;
+	$file_index = 1;
+
+	while ( false !== $zip->locateName( $candidate ) || false !== $zip->locateName( trailingslashit( $candidate ) ) ) {
+		$candidate = $directory . $filename . '-' . $file_index . $extension;
+		++$file_index;
+	}
+
+	return $candidate;
+}
+
+/**
  * Creates an export of the current templates and
  * template parts from the site editor at the
  * specified path in a ZIP file.
@@ -104,9 +131,34 @@ function gutenberg_generate_block_templates_export_file() {
 		)
 	);
 	if ( ! empty( $uris_to_migrate ) ) {
-		$uploads = wp_upload_dir();
+		$uploads              = wp_upload_dir();
+		$uploaded_asset_paths = array();
 		foreach ( $uris_to_migrate as $uri ) {
-			$href   = $uri['href'];
+			$relative_file_path = $uri['relative_path'] ?? '';
+			if ( ! is_string( $relative_file_path ) || '' === $relative_file_path || validate_file( $relative_file_path ) > 0 ) {
+				continue;
+			}
+
+			$file = wp_normalize_path( trailingslashit( $uploads['basedir'] ) . $relative_file_path );
+			if ( ! is_file( $file ) || ! is_readable( $file ) ) {
+				continue;
+			}
+
+			if ( ! isset( $uploaded_asset_paths[ $file ] ) ) {
+				$file_content = file_get_contents( $file );
+				if ( false === $file_content ) {
+					continue;
+				}
+
+				$asset_path = gutenberg_get_available_zip_path( $zip, 'assets/' . $relative_file_path );
+				if ( false === $zip->addFromString( $asset_path, $file_content ) ) {
+					continue;
+				}
+
+				$uploaded_asset_paths[ $file ] = $asset_path;
+			}
+
+			$href   = 'file:./' . $uploaded_asset_paths[ $file ];
 			$target = $uri['target'];
 			if ( str_ends_with( $target, 'background.backgroundImage.url' ) ) {
 				/*
@@ -115,28 +167,13 @@ function gutenberg_generate_block_templates_export_file() {
 				 * Done by removing .url from the path to get the target, and setting
 				 * href to replace the `background.backgroundImage` object.
 				 */
-				$target = rtrim( $target, '.url' );
+				$target = substr( $target, 0, -strlen( '.url' ) );
 				$href   = array(
 					'url' => $href,
 				);
 			}
-			$path         = explode( '.', $target );
-			$file         = str_replace( $uploads['baseurl'], $uploads['basedir'], $uri['name'] );
-			$file_content = file_get_contents( $file );
-			if ( ! $file_content ) {
-				continue;
-			}
-
+			$path = explode( '.', $target );
 			_wp_array_set( $theme_json_raw, $path, $href );
-
-			if ( $zip->locateName( 'assets' ) === false ) {
-				// Directory doesn't exist, so add it
-				$zip->addEmptyDir( 'assets' );
-			}
-			$zip->addFromString(
-				'assets/' . basename( parse_url( $file, PHP_URL_PATH ) ),
-				$file_content
-			);
 		}
 	}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -929,9 +929,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 								$processed_theme_uris[] = call_user_func(
 									$options['value_func'],
 									array(
-										'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
-										'theme_value_prefix'   => $base_url,
-										'theme_value'          => $font_face['src'],
+										'theme_path'  => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
+										'theme_value_prefix' => $base_url,
+										'theme_value' => $font_face['src'],
 										'relative_path_prefix' => $relative_path_prefix,
 									)
 								);

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -877,13 +877,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		if ( ! empty( $should_process['images'] ) ) {
 			// Top level styles.
-			$background_image_url_path = array( 'styles', 'background', 'backgroundImage', 'url' );
-			$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
+			$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;
 			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
 				$processed_theme_uris[] = call_user_func(
 					$options['value_func'],
 					array(
-						'theme_path'           => $background_image_url_path,
+						'theme_path'           => 'styles.background.backgroundImage.url',
 						'theme_value_prefix'   => $base_url,
 						'theme_value'          => $background_image_url,
 						'relative_path_prefix' => $relative_path_prefix,
@@ -897,14 +896,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					if ( ! isset( $block_styles['background']['backgroundImage']['url'] ) ) {
 						continue;
 					}
-					$background_image_url_path = array( 'styles', 'blocks', $block_name, 'background', 'backgroundImage', 'url' );
-					$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
+					$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
 					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
 						if ( isset( $options['value_func'] ) && is_callable( $options['value_func'] ) ) {
 							$processed_theme_uris[] = call_user_func(
 								$options['value_func'],
 								array(
-									'theme_path'           => $background_image_url_path,
+									'theme_path'           => "styles.blocks.{$block_name}.background.backgroundImage.url",
 									'theme_value_prefix'   => $base_url,
 									'theme_value'          => $background_image_url,
 									'relative_path_prefix' => $relative_path_prefix,
@@ -928,26 +926,24 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					foreach ( $font_family['fontFace'] as  $font_face_key => $font_face ) {
 						if ( ! empty( $font_face['src'] ) ) {
 							if ( is_string( $font_face['src'] ) && str_starts_with( $font_face['src'], $base_url ) ) {
-								$font_url_path          = array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src' );
 								$processed_theme_uris[] = call_user_func(
 									$options['value_func'],
 									array(
-										'theme_path'  => $font_url_path,
-										'theme_value_prefix' => $base_url,
-										'theme_value' => $font_face['src'],
+										'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
+										'theme_value_prefix'   => $base_url,
+										'theme_value'          => $font_face['src'],
 										'relative_path_prefix' => $relative_path_prefix,
 									)
 								);
 							} elseif ( is_array( $font_face['src'] ) ) {
 								foreach ( $font_face['src'] as $source_key => $source ) {
 									if ( str_starts_with( $source, $base_url ) ) {
-										$font_url_path          = array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src', $source_key );
 										$processed_theme_uris[] = call_user_func(
 											$options['value_func'],
 											array(
-												'theme_path' => $font_url_path,
-												'theme_value_prefix' => $base_url,
-												'theme_value' => $source,
+												'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src.{$source_key}",
+												'theme_value_prefix'   => $base_url,
+												'theme_value'          => $source,
 												'relative_path_prefix' => $relative_path_prefix,
 											)
 										);
@@ -981,7 +977,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$processed_theme_uri = array(
 			'name'   => $args['theme_value'],
 			'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
-			'target' => implode( '.', $args['theme_path'] ),
+			'target' => $args['theme_path'],
 		);
 
 		$file_type = wp_check_filetype( $args['theme_value'] );
@@ -1009,7 +1005,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		return array(
 			'name'   => $args['theme_value'],
 			'href'   => $args['relative_path_prefix'] . basename( parse_url( $args['theme_value'], PHP_URL_PATH ) ),
-			'target' => implode( '.', $args['theme_path'] ),
+			'target' => $args['theme_path'],
 		);
 	}
 

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -953,56 +953,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * A helper function to resolve a relative path in theme.json to a theme absolute path.
-	 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
-	 *
-	 * @param {array} $args {
-	 *  An array of arguments to resolve URIs.
-	 * @type array  $theme_path         The path to the theme value.
-	 * @type string $theme_value_prefix The prefix of the theme value.
-	 * @type string $theme_value        The theme value.
-	 * @type string $relative_prefix    The relative prefix to append to the file.
-	 * }
-	 * @return array
-	 */
-	private static function resolve_relative_path_to_absolute_uri( $args ) {
-		$src_url             = str_replace( $args['theme_value_prefix'], '', $args['theme_value'] );
-		$processed_theme_uri = array(
-			'name'   => $args['theme_value'],
-			'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
-			'target' => $args['theme_path'],
-		);
-
-		$file_type = wp_check_filetype( $args['theme_value'] );
-		if ( isset( $file_type['type'] ) ) {
-			$processed_theme_uri['type'] = $file_type['type'];
-		}
-
-		return $processed_theme_uri;
-	}
-
-	/**
-	 * A helper function to migrate an absolute paths in theme.json to a theme relative path.
-	 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
-	 *
-	 * @param {array} $args {
-	 *  An array of arguments to resolve URIs.
-	 * @type array  $theme_path         The path to the theme value.
-	 * @type string $theme_value_prefix The prefix of the theme value.
-	 * @type string $theme_value        The theme value.
-	 * @type string $relative_prefix    The relative prefix to append to the file.
-	 * }
-	 * @return array
-	 */
-	private static function migrate_absolute_uri_to_relative_path( $args ) {
-		return array(
-			'name'   => $args['theme_value'],
-			'href'   => $args['relative_path_prefix'] . basename( parse_url( $args['theme_value'], PHP_URL_PATH ) ),
-			'target' => $args['theme_path'],
-		);
-	}
-
-	/**
 	 * Resolves relative paths in theme.json styles to theme absolute paths
 	 * and returns them in an array that can be embedded
 	 * as the value of `_link` object in REST API responses.
@@ -1015,7 +965,47 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array An array of resolved paths.
 	 */
 	public static function get_resolved_theme_uris( $theme_json ) {
-		return static::process_theme_uris( $theme_json );
+		/**
+		 * A helper function to resolve a relative path in theme.json to a theme absolute path.
+		 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
+		 *
+		 * @param {array} $args {
+		 *  An array of arguments to resolve URIs.
+		 * @type array  $theme_path         The path to the theme value.
+		 * @type string $theme_value_prefix The prefix of the theme value.
+		 * @type string $theme_value        The theme value.
+		 * @type string $relative_prefix    The relative prefix to append to the file.
+		 * }
+		 * @return array
+		 */
+		$resolve_relative_path_to_absolute_uri = function ( $args ) {
+			$src_url             = str_replace( $args['theme_value_prefix'], '', $args['theme_value'] );
+			$processed_theme_uri = array(
+				'name'   => $args['theme_value'],
+				'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
+				'target' => $args['theme_path'],
+			);
+
+			$file_type = wp_check_filetype( $args['theme_value'] );
+			if ( isset( $file_type['type'] ) ) {
+				$processed_theme_uri['type'] = $file_type['type'];
+			}
+
+			return $processed_theme_uri;
+		};
+
+		return static::process_theme_uris(
+			$theme_json,
+			array(
+				'should_process'     => array(
+					'images' => true,
+					'fonts'  => false,
+				),
+				'theme_value_prefix' => 'file:./',
+				// Resolves relative paths in theme.json styles to theme absolute paths.
+				'value_func'         => $resolve_relative_path_to_absolute_uri,
+			)
+		);
 	}
 
 	/**
@@ -1031,6 +1021,27 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array An array of migrated paths.
 	 */
 	public static function get_migrated_relative_theme_uris( $theme_json, $options = array() ) {
+		/**
+		 * A helper function to migrate an absolute paths in theme.json to a theme relative path.
+		 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
+		 *
+		 * @param {array} $args {
+		 *  An array of arguments to resolve URIs.
+		 * @type array  $theme_path         The path to the theme value.
+		 * @type string $theme_value_prefix The prefix of the theme value.
+		 * @type string $theme_value        The theme value.
+		 * @type string $relative_prefix    The relative prefix to append to the file.
+		 * }
+		 * @return array
+		 */
+		$migrate_absolute_uri_to_relative_path = function ( $args ) {
+			return array(
+				'name'   => $args['theme_value'],
+				'href'   => $args['relative_path_prefix'] . basename( parse_url( $args['theme_value'], PHP_URL_PATH ) ),
+				'target' => $args['theme_path'],
+			);
+		};
+
 		return static::process_theme_uris(
 			$theme_json,
 			array(
@@ -1039,7 +1050,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					'fonts'  => true,
 				),
 				'theme_value_prefix'   => $options['theme_value_prefix'] ?? wp_upload_dir()['baseurl'],
-				'value_func'           => array( static::class, 'migrate_absolute_uri_to_relative_path' ),
+				'value_func'           => $migrate_absolute_uri_to_relative_path,
 				'relative_path_prefix' => $options['relative_path_prefix'] ?? 'file:./',
 			)
 		);

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -864,24 +864,39 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		);
 
 		$should_process       = $options['should_process'] ?? array();
-		$theme_json_data      = $theme_json->get_raw_data();
+		$theme_json_data      = $options['theme_json_data'] ?? $theme_json->get_raw_data();
 		$theme_value_prefix   = $options['theme_value_prefix'];
 		$relative_path_prefix = $options['relative_path_prefix'];
+		$value_func           = $options['value_func'];
+
+		if ( ! is_array( $theme_json_data ) || ! is_callable( $value_func ) ) {
+			return $processed_theme_uris;
+		}
+
+		$process_theme_uri = static function ( $theme_path, $theme_value ) use ( &$processed_theme_uris, $theme_value_prefix, $relative_path_prefix, $value_func ) {
+			if ( ! is_string( $theme_value ) || ! str_starts_with( $theme_value, $theme_value_prefix ) ) {
+				return;
+			}
+
+			$processed_theme_uri = call_user_func(
+				$value_func,
+				array(
+					'theme_path'           => $theme_path,
+					'theme_value_prefix'   => $theme_value_prefix,
+					'theme_value'          => $theme_value,
+					'relative_path_prefix' => $relative_path_prefix,
+				)
+			);
+
+			if ( is_array( $processed_theme_uri ) && ! empty( $processed_theme_uri ) ) {
+				$processed_theme_uris[] = $processed_theme_uri;
+			}
+		};
 
 		if ( ! empty( $should_process['images'] ) ) {
 			// Top level styles.
 			$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;
-			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $theme_value_prefix ) ) {
-				$processed_theme_uris[] = call_user_func(
-					$options['value_func'],
-					array(
-						'theme_path'           => 'styles.background.backgroundImage.url',
-						'theme_value_prefix'   => $theme_value_prefix,
-						'theme_value'          => $background_image_url,
-						'relative_path_prefix' => $relative_path_prefix,
-					)
-				);
-			}
+			$process_theme_uri( 'styles.background.backgroundImage.url', $background_image_url );
 
 			// Block styles.
 			if ( ! empty( $theme_json_data['styles']['blocks'] ) ) {
@@ -890,57 +905,52 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 						continue;
 					}
 					$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
-					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $theme_value_prefix ) ) {
-						if ( isset( $options['value_func'] ) && is_callable( $options['value_func'] ) ) {
-							$processed_theme_uris[] = call_user_func(
-								$options['value_func'],
-								array(
-									'theme_path'           => "styles.blocks.{$block_name}.background.backgroundImage.url",
-									'theme_value_prefix'   => $theme_value_prefix,
-									'theme_value'          => $background_image_url,
-									'relative_path_prefix' => $relative_path_prefix,
-								)
-							);
-						}
-					}
+					$process_theme_uri( "styles.blocks.{$block_name}.background.backgroundImage.url", $background_image_url );
 				}
 			}
 		}
 
 		// Font URIs.
 		if ( ! empty( $should_process['fonts'] ) && ! empty( $theme_json_data['settings']['typography']['fontFamilies'] ) ) {
-			$font_families = array_merge(
-				$theme_json_data['settings']['typography']['fontFamilies']['theme'] ?? array(),
-				$theme_json_data['settings']['typography']['fontFamilies']['custom'] ?? array(),
-				$theme_json_data['settings']['typography']['fontFamilies']['default'] ?? array()
-			);
+			$font_families         = $theme_json_data['settings']['typography']['fontFamilies'];
+			$font_family_origins   = array( 'default', 'blocks', 'theme', 'custom' );
+			$font_families_by_path = array();
+			$root_font_families    = array();
+
 			foreach ( $font_families as $font_family_key => $font_family ) {
-				if ( ! empty( $font_family['fontFace'] ) ) {
-					foreach ( $font_family['fontFace'] as  $font_face_key => $font_face ) {
-						if ( ! empty( $font_face['src'] ) ) {
-							if ( is_string( $font_face['src'] ) && str_starts_with( $font_face['src'], $theme_value_prefix ) ) {
-								$processed_theme_uris[] = call_user_func(
-									$options['value_func'],
-									array(
-										'theme_path'  => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
-										'theme_value_prefix' => $theme_value_prefix,
-										'theme_value' => $font_face['src'],
-										'relative_path_prefix' => $relative_path_prefix,
-									)
-								);
-							} elseif ( is_array( $font_face['src'] ) ) {
-								foreach ( $font_face['src'] as $source_key => $source ) {
-									if ( str_starts_with( $source, $theme_value_prefix ) ) {
-										$processed_theme_uris[] = call_user_func(
-											$options['value_func'],
-											array(
-												'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src.{$source_key}",
-												'theme_value_prefix'   => $theme_value_prefix,
-												'theme_value'          => $source,
-												'relative_path_prefix' => $relative_path_prefix,
-											)
-										);
-									}
+				if ( in_array( $font_family_key, $font_family_origins, true ) ) {
+					$font_families_by_path[ "settings.typography.fontFamilies.{$font_family_key}" ] = $font_family;
+					continue;
+				}
+
+				$root_font_families[ $font_family_key ] = $font_family;
+			}
+
+			if ( ! empty( $root_font_families ) ) {
+				$font_families_by_path['settings.typography.fontFamilies'] = $root_font_families;
+			}
+
+			foreach ( $font_families_by_path as $font_family_path => $font_families ) {
+				if ( ! is_array( $font_families ) ) {
+					continue;
+				}
+
+				foreach ( $font_families as $font_family_key => $font_family ) {
+					if ( empty( $font_family['fontFace'] ) || ! is_array( $font_family['fontFace'] ) ) {
+						continue;
+					}
+
+					foreach ( $font_family['fontFace'] as $font_face_key => $font_face ) {
+						if ( empty( $font_face['src'] ) ) {
+							continue;
+						}
+
+						if ( is_string( $font_face['src'] ) ) {
+							$process_theme_uri( "{$font_family_path}.{$font_family_key}.fontFace.{$font_face_key}.src", $font_face['src'] );
+						} elseif ( is_array( $font_face['src'] ) ) {
+							foreach ( $font_face['src'] as $source_key => $source ) {
+								if ( is_string( $source ) ) {
+									$process_theme_uri( "{$font_family_path}.{$font_family_key}.fontFace.{$font_face_key}.src.{$source_key}", $source );
 								}
 							}
 						}
@@ -1035,10 +1045,30 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * @return array
 		 */
 		$migrate_absolute_uri_to_relative_path = function ( $args ) {
+			$theme_value_path  = wp_parse_url( $args['theme_value'], PHP_URL_PATH );
+			$theme_prefix_path = wp_parse_url( $args['theme_value_prefix'], PHP_URL_PATH );
+
+			if ( ! is_string( $theme_value_path ) || ! is_string( $theme_prefix_path ) ) {
+				return null;
+			}
+
+			$theme_value_path  = wp_normalize_path( rawurldecode( $theme_value_path ) );
+			$theme_prefix_path = trailingslashit( wp_normalize_path( rawurldecode( $theme_prefix_path ) ) );
+
+			if ( ! str_starts_with( $theme_value_path, $theme_prefix_path ) ) {
+				return null;
+			}
+
+			$relative_file_path = ltrim( substr( $theme_value_path, strlen( $theme_prefix_path ) ), '/' );
+			if ( '' === $relative_file_path || validate_file( $relative_file_path ) > 0 ) {
+				return null;
+			}
+
 			return array(
-				'name'   => $args['theme_value'],
-				'href'   => $args['relative_path_prefix'] . basename( parse_url( $args['theme_value'], PHP_URL_PATH ) ),
-				'target' => $args['theme_path'],
+				'name'          => $args['theme_value'],
+				'href'          => $args['relative_path_prefix'] . $relative_file_path,
+				'target'        => $args['theme_path'],
+				'relative_path' => $relative_file_path,
 			);
 		};
 
@@ -1049,9 +1079,10 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					'images' => true,
 					'fonts'  => true,
 				),
-				'theme_value_prefix'   => $options['theme_value_prefix'] ?? wp_upload_dir()['baseurl'],
+				'theme_json_data'      => $theme_json->get_data(),
+				'theme_value_prefix'   => trailingslashit( $options['theme_value_prefix'] ?? wp_upload_dir()['baseurl'] ),
 				'value_func'           => $migrate_absolute_uri_to_relative_path,
-				'relative_path_prefix' => $options['relative_path_prefix'] ?? 'file:./',
+				'relative_path_prefix' => trailingslashit( $options['relative_path_prefix'] ?? 'file:./' ),
 			)
 		);
 	}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -921,9 +921,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 								$processed_theme_uris[] = call_user_func(
 									$options['value_func'],
 									array(
-										'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
-										'theme_value_prefix'   => $base_url,
-										'theme_value'          => $font_face['src'],
+										'theme_path'  => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
+										'theme_value_prefix' => $base_url,
+										'theme_value' => $font_face['src'],
 										'relative_path_prefix' => $relative_path_prefix,
 									)
 								);

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -823,6 +823,25 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		return $variations;
 	}
 
+	/**
+	 * Processes theme URIs according to provided options.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
+	 * @param array                   $options    {
+	 *   Optional. An array of options to process theme URIs.
+	 *   @type array $should_process {
+	 *      Optional. An array of booleans to determine which URIs to process.
+	 *      @type bool $images Whether to process image URIs. Default true.
+	 *      @type bool $fonts  Whether to process font URIs. Default false.
+	 *  }
+	 *  @type string $base_url      The base URL to resolve URIs.
+	 *  @type string $relative_path_prefix The relative path to resolve URIs.
+	 *  @type callable $value_func  The function to resolve URIs.
+	 * }
+	 * @return array An array of resolved paths.
+	 */
 	private static function process_theme_uris( $theme_json, $options = array() ) {
 		$processed_theme_uris = array();
 
@@ -833,23 +852,35 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$options = wp_parse_args(
 			$options,
 			array(
-				'should_process' => array(
-					'background_images' => true,
+				'should_process'       => array(
+					'images' => true,
+					'fonts'  => false,
 				),
-				'placeholder'    => 'file:./',
+				'base_url'             => 'file:./',
+				'relative_path_prefix' => '',
+				'value_func'           => array( static::class, 'resolve_relative_path_to_absolute_uri' ),
 			)
 		);
 
-		$should_process  = $options['should_process'] ?? array();
-		$theme_json_data = $theme_json->get_raw_data();
-		$placeholder     = $options['placeholder'] ?? '';
+		$should_process       = $options['should_process'] ?? array();
+		$theme_json_data      = $theme_json->get_raw_data();
+		$base_url             = $options['base_url'];
+		$relative_path_prefix = $options['relative_path_prefix'];
 
-		if ( ! empty( $should_process['background_images'] ) ) {
+		if ( ! empty( $should_process['images'] ) ) {
 			// Top level styles.
 			$background_image_url_path = array( 'styles', 'background', 'backgroundImage', 'url' );
 			$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
-			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $placeholder ) ) {
-				$processed_theme_uris[] = call_user_func( $options['value_func'], $background_image_url_path, $placeholder, $background_image_url );
+			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
+				$processed_theme_uris[] = call_user_func(
+					$options['value_func'],
+					array(
+						'theme_path'           => $background_image_url_path,
+						'theme_value_prefix'   => $base_url,
+						'theme_value'          => $background_image_url,
+						'relative_path_prefix' => $relative_path_prefix,
+					)
+				);
 			}
 
 			// Block styles.
@@ -860,17 +891,25 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					}
 					$background_image_url_path = array( 'styles', 'blocks', $block_name, 'background', 'backgroundImage', 'url' );
 					$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
-					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $placeholder ) ) {
+					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
 						if ( isset( $options['value_func'] ) && is_callable( $options['value_func'] ) ) {
-							$processed_theme_uris[] = call_user_func( $options['value_func'], $background_image_url_path, $placeholder, $background_image_url );
+							$processed_theme_uris[] = call_user_func(
+								$options['value_func'],
+								array(
+									'theme_path'           => $background_image_url_path,
+									'theme_value_prefix'   => $base_url,
+									'theme_value'          => $background_image_url,
+									'relative_path_prefix' => $relative_path_prefix,
+								)
+							);
 						}
 					}
 				}
 			}
 		}
 
-		// Add font URIs.
-		if ( ! empty( $should_process['font_faces'] ) && ! empty( $theme_json_data['settings']['typography']['fontFamilies'] ) ) {
+		// Font URIs.
+		if ( ! empty( $should_process['fonts'] ) && ! empty( $theme_json_data['settings']['typography']['fontFamilies'] ) ) {
 			$font_families = array_merge(
 				$theme_json_data['settings']['typography']['fontFamilies']['theme'] ?? array(),
 				$theme_json_data['settings']['typography']['fontFamilies']['custom'] ?? array(),
@@ -880,13 +919,31 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				if ( ! empty( $font_family['fontFace'] ) ) {
 					foreach ( $font_family['fontFace'] as  $font_face_key => $font_face ) {
 						if ( ! empty( $font_face['src'] ) ) {
-							$sources = is_string( $font_face['src'] )
-								? array( $font_face['src'] )
-								: $font_face['src'];
-							foreach ( $sources as $source_key => $source ) {
-								if ( str_starts_with( $source, $placeholder ) ) {
-									$font_url_path          = is_string( $font_face['src'] ) ? array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src' ) : array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src', $source_key );
-									$processed_theme_uris[] = call_user_func( $options['value_func'], $font_url_path, $placeholder, $source );
+							if ( is_string( $font_face['src'] ) && str_starts_with( $font_face['src'], $base_url ) ) {
+								$font_url_path          = array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src' );
+								$processed_theme_uris[] = call_user_func(
+									$options['value_func'],
+									array(
+										'theme_path'  => $font_url_path,
+										'theme_value_prefix' => $base_url,
+										'theme_value' => $font_face['src'],
+										'relative_path_prefix' => $relative_path_prefix,
+									)
+								);
+							} elseif ( is_array( $font_face['src'] ) ) {
+								foreach ( $font_face['src'] as $source_key => $source ) {
+									if ( str_starts_with( $source, $base_url ) ) {
+										$font_url_path          = array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src', $source_key );
+										$processed_theme_uris[] = call_user_func(
+											$options['value_func'],
+											array(
+												'theme_path' => $font_url_path,
+												'theme_value_prefix' => $base_url,
+												'theme_value' => $source,
+												'relative_path_prefix' => $relative_path_prefix,
+											)
+										);
+									}
 								}
 							}
 						}
@@ -898,15 +955,28 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		return $processed_theme_uris;
 	}
 
-	private static function resolve_uri( $background_image_url_path, $placeholder, $background_image_url ) {
-		$file_type           = wp_check_filetype( $background_image_url );
-		$src_url             = str_replace( $placeholder, '', $background_image_url );
+	/**
+	 * A helper function to resolve a relative path in theme.json to a theme absolute path.
+	 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
+	 *
+	 * @param {array} $args {
+	 *  An array of arguments to resolve URIs.
+	 * @type array  $theme_path         The path to the theme value.
+	 * @type string $theme_value_prefix The prefix of the theme value.
+	 * @type string $theme_value        The theme value.
+	 * @type string $relative_prefix    The relative prefix to append to the file.
+	 * }
+	 * @return array
+	 */
+	private static function resolve_relative_path_to_absolute_uri( $args ) {
+		$src_url             = str_replace( $args['theme_value_prefix'], '', $args['theme_value'] );
 		$processed_theme_uri = array(
-			'name'   => $background_image_url,
+			'name'   => $args['theme_value'],
 			'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
-			'target' => implode( '.', $background_image_url_path ),
+			'target' => implode( '.', $args['theme_path'] ),
 		);
 
+		$file_type = wp_check_filetype( $args['theme_value'] );
 		if ( isset( $file_type['type'] ) ) {
 			$processed_theme_uri['type'] = $file_type['type'];
 		}
@@ -914,14 +984,25 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		return $processed_theme_uri;
 	}
 
-	private static function migrate_uri( $background_image_url_path, $placeholder, $background_image_url ) {
-		$processed_theme_uri = array(
-			'name'   => $background_image_url,
-			'href'   => basename( parse_url( $background_image_url, PHP_URL_PATH ) ),
-			'target' => implode( '.', $background_image_url_path ),
+	/**
+	 * A helper function to migrate an absolute paths in theme.json to a theme relative path.
+	 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
+	 *
+	 * @param {array} $args {
+	 *  An array of arguments to resolve URIs.
+	 * @type array  $theme_path         The path to the theme value.
+	 * @type string $theme_value_prefix The prefix of the theme value.
+	 * @type string $theme_value        The theme value.
+	 * @type string $relative_prefix    The relative prefix to append to the file.
+	 * }
+	 * @return array
+	 */
+	private static function migrate_absolute_uri_to_relative_path( $args ) {
+		return array(
+			'name'   => $args['theme_value'],
+			'href'   => $args['relative_path_prefix'] . basename( parse_url( $args['theme_value'], PHP_URL_PATH ) ),
+			'target' => implode( '.', $args['theme_path'] ),
 		);
-
-		return $processed_theme_uri;
 	}
 
 	/**
@@ -931,31 +1012,39 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 * @since 6.7.0 Added support for resolving block styles.
+	 * @since 6.8.0 Abstracting the process of resolving theme URIs.
 	 *
 	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
 	 * @return array An array of resolved paths.
 	 */
 	public static function get_resolved_theme_uris( $theme_json ) {
 		// Using the same file convention 'file:./' when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
-		return static::process_theme_uris(
-			$theme_json,
-			array(
-				'value_func' => array( static::class, 'resolve_uri' ),
-			)
-		);
+		return static::process_theme_uris( $theme_json );
 	}
 
+	/**
+	 * Migrates absolute paths that begin with a baseurl in theme.json styles to theme relative paths
+	 * and returns them in an array. In conjunction with copying the corresponding files to
+	 * a theme directory, migrating to relative paths is useful for migrating theme json to a new location.
+	 * The default is to migrate URIs from the site's uploads directory.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
+	 * @param {array}                 $options    Optional. A 'base_url' to find the target URI in theme.json, and a 'relative_path_prefix' to append to the file.
+	 * @return array An array of migrated paths.
+	 */
 	public static function get_migrated_relative_theme_uris( $theme_json, $options = array() ) {
-		$placeholder = wp_upload_dir()['baseurl'];
 		return static::process_theme_uris(
 			$theme_json,
 			array(
-				'should_process' => array(
-					'background_images' => true,
-					'font_faces'        => true,
+				'should_process'       => array(
+					'images' => true,
+					'fonts'  => true,
 				),
-				'placeholder'    => $placeholder,
-				'value_func'     => array( static::class, 'migrate_uri' ),
+				'base_url'             => $options['base_url'] ?? wp_upload_dir()['baseurl'],
+				'value_func'           => array( static::class, 'migrate_absolute_uri_to_relative_path' ),
+				'relative_path_prefix' => $options['relative_path_prefix'] ?? 'file:./',
 			)
 		);
 	}

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -823,6 +823,106 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		return $variations;
 	}
 
+	private static function process_theme_uris( $theme_json, $options = array() ) {
+		$processed_theme_uris = array();
+
+		if ( ! $theme_json instanceof WP_Theme_JSON_Gutenberg ) {
+			return $processed_theme_uris;
+		}
+
+		$options = wp_parse_args(
+			$options,
+			array(
+				'should_process' => array(
+					'background_images' => true,
+				),
+				'placeholder'    => 'file:./',
+			)
+		);
+
+		$should_process  = $options['should_process'] ?? array();
+		$theme_json_data = $theme_json->get_raw_data();
+		$placeholder     = $options['placeholder'] ?? '';
+
+		if ( ! empty( $should_process['background_images'] ) ) {
+			// Top level styles.
+			$background_image_url_path = array( 'styles', 'background', 'backgroundImage', 'url' );
+			$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
+			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $placeholder ) ) {
+				$processed_theme_uris[] = call_user_func( $options['value_func'], $background_image_url_path, $placeholder, $background_image_url );
+			}
+
+			// Block styles.
+			if ( ! empty( $theme_json_data['styles']['blocks'] ) ) {
+				foreach ( $theme_json_data['styles']['blocks'] as $block_name => $block_styles ) {
+					if ( ! isset( $block_styles['background']['backgroundImage']['url'] ) ) {
+						continue;
+					}
+					$background_image_url_path = array( 'styles', 'blocks', $block_name, 'background', 'backgroundImage', 'url' );
+					$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
+					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $placeholder ) ) {
+						if ( isset( $options['value_func'] ) && is_callable( $options['value_func'] ) ) {
+							$processed_theme_uris[] = call_user_func( $options['value_func'], $background_image_url_path, $placeholder, $background_image_url );
+						}
+					}
+				}
+			}
+		}
+
+		// Add font URIs.
+		if ( ! empty( $should_process['font_faces'] ) && ! empty( $theme_json_data['settings']['typography']['fontFamilies'] ) ) {
+			$font_families = array_merge(
+				$theme_json_data['settings']['typography']['fontFamilies']['theme'] ?? array(),
+				$theme_json_data['settings']['typography']['fontFamilies']['custom'] ?? array(),
+				$theme_json_data['settings']['typography']['fontFamilies']['default'] ?? array()
+			);
+			foreach ( $font_families as $font_family_key => $font_family ) {
+				if ( ! empty( $font_family['fontFace'] ) ) {
+					foreach ( $font_family['fontFace'] as  $font_face_key => $font_face ) {
+						if ( ! empty( $font_face['src'] ) ) {
+							$sources = is_string( $font_face['src'] )
+								? array( $font_face['src'] )
+								: $font_face['src'];
+							foreach ( $sources as $source_key => $source ) {
+								if ( str_starts_with( $source, $placeholder ) ) {
+									$font_url_path          = is_string( $font_face['src'] ) ? array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src' ) : array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src', $source_key );
+									$processed_theme_uris[] = call_user_func( $options['value_func'], $font_url_path, $placeholder, $source );
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+
+		return $processed_theme_uris;
+	}
+
+	private static function resolve_uri( $background_image_url_path, $placeholder, $background_image_url ) {
+		$file_type           = wp_check_filetype( $background_image_url );
+		$src_url             = str_replace( $placeholder, '', $background_image_url );
+		$processed_theme_uri = array(
+			'name'   => $background_image_url,
+			'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
+			'target' => implode( '.', $background_image_url_path ),
+		);
+
+		if ( isset( $file_type['type'] ) ) {
+			$processed_theme_uri['type'] = $file_type['type'];
+		}
+
+		return $processed_theme_uri;
+	}
+
+	private static function migrate_uri( $background_image_url_path, $placeholder, $background_image_url ) {
+		$processed_theme_uri = array(
+			'name'   => $background_image_url,
+			'href'   => basename( parse_url( $background_image_url, PHP_URL_PATH ) ),
+			'target' => implode( '.', $background_image_url_path ),
+		);
+
+		return $processed_theme_uri;
+	}
 
 	/**
 	 * Resolves relative paths in theme.json styles to theme absolute paths
@@ -836,65 +936,28 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array An array of resolved paths.
 	 */
 	public static function get_resolved_theme_uris( $theme_json ) {
-		$resolved_theme_uris = array();
+		// Using the same file convention 'file:./' when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
+		return static::process_theme_uris(
+			$theme_json,
+			array(
+				'value_func' => array( static::class, 'resolve_uri' ),
+			)
+		);
+	}
 
-		if ( ! $theme_json instanceof WP_Theme_JSON_Gutenberg ) {
-			return $resolved_theme_uris;
-		}
-
-		$theme_json_data = $theme_json->get_raw_data();
-
-		// Using the same file convention when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
-		$placeholder = 'file:./';
-
-		// Top level styles.
-		$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;
-		if (
-			isset( $background_image_url ) &&
-			is_string( $background_image_url ) &&
-			// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-			str_starts_with( $background_image_url, $placeholder ) ) {
-				$file_type          = wp_check_filetype( $background_image_url );
-				$src_url            = str_replace( $placeholder, '', $background_image_url );
-				$resolved_theme_uri = array(
-					'name'   => $background_image_url,
-					'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
-					'target' => 'styles.background.backgroundImage.url',
-				);
-				if ( isset( $file_type['type'] ) ) {
-					$resolved_theme_uri['type'] = $file_type['type'];
-				}
-				$resolved_theme_uris[] = $resolved_theme_uri;
-		}
-
-		// Block styles.
-		if ( ! empty( $theme_json_data['styles']['blocks'] ) ) {
-			foreach ( $theme_json_data['styles']['blocks'] as $block_name => $block_styles ) {
-				if ( ! isset( $block_styles['background']['backgroundImage']['url'] ) ) {
-					continue;
-				}
-				$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
-				if (
-					isset( $background_image_url ) &&
-					is_string( $background_image_url ) &&
-					// Skip if the src doesn't start with the placeholder, as there's nothing to replace.
-					str_starts_with( $background_image_url, $placeholder ) ) {
-					$file_type          = wp_check_filetype( $background_image_url );
-					$src_url            = str_replace( $placeholder, '', $background_image_url );
-					$resolved_theme_uri = array(
-						'name'   => $background_image_url,
-						'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
-						'target' => "styles.blocks.{$block_name}.background.backgroundImage.url",
-					);
-					if ( isset( $file_type['type'] ) ) {
-						$resolved_theme_uri['type'] = $file_type['type'];
-					}
-					$resolved_theme_uris[] = $resolved_theme_uri;
-				}
-			}
-		}
-
-		return $resolved_theme_uris;
+	public static function get_migrated_relative_theme_uris( $theme_json, $options = array() ) {
+		$placeholder = wp_upload_dir()['baseurl'];
+		return static::process_theme_uris(
+			$theme_json,
+			array(
+				'should_process' => array(
+					'background_images' => true,
+					'font_faces'        => true,
+				),
+				'placeholder'    => $placeholder,
+				'value_func'     => array( static::class, 'migrate_uri' ),
+			)
+		);
 	}
 
 	/**

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -826,21 +826,24 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	/**
 	 * Processes theme URIs according to provided options.
 	 *
-	 * @since 6.8.0
+	 * @since 7.1.0
 	 *
-	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
+	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme JSON instance.
 	 * @param array                   $options    {
-	 *   Optional. An array of options to process theme URIs.
-	 *   @type array $should_process {
-	 *      Optional. An array of booleans to determine which URIs to process.
-	 *      @type bool $images Whether to process image URIs. Default true.
-	 *      @type bool $fonts  Whether to process font URIs. Default false.
-	 *  }
-	 *  @type string $theme_value_prefix    The base URL to resolve URIs.
-	 *  @type string $relative_path_prefix The relative path to resolve URIs.
-	 *  @type callable $value_func  The function to resolve URIs.
+	 *     Optional. An array of options to process theme URIs.
+	 *
+	 *     @type array    $should_process {
+	 *         Optional. An array of booleans to determine which URIs to process.
+	 *
+	 *         @type bool $images Whether to process image URIs. Default true.
+	 *         @type bool $fonts  Whether to process font URIs. Default false.
+	 *     }
+	 *     @type array    $theme_json_data      Theme JSON data to process. Default raw data from `$theme_json`.
+	 *     @type string   $theme_value_prefix   The URI prefix to find in theme.json.
+	 *     @type string   $relative_path_prefix The relative path prefix to append to the file.
+	 *     @type callable $value_func           The function to process URIs.
 	 * }
-	 * @return array An array of resolved paths.
+	 * @return array An array of processed paths.
 	 */
 	private static function process_theme_uris( $theme_json, $options = array() ) {
 		$processed_theme_uris = array();
@@ -859,7 +862,15 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				// Using the same file convention 'file:./' when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
 				'theme_value_prefix'   => 'file:./',
 				'relative_path_prefix' => '',
-				'value_func'           => array( static::class, 'resolve_relative_path_to_absolute_uri' ),
+				'value_func'           => null,
+			)
+		);
+
+		$options['should_process'] = wp_parse_args(
+			is_array( $options['should_process'] ) ? $options['should_process'] : array(),
+			array(
+				'images' => true,
+				'fonts'  => false,
 			)
 		);
 
@@ -869,7 +880,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$relative_path_prefix = $options['relative_path_prefix'];
 		$value_func           = $options['value_func'];
 
-		if ( ! is_array( $theme_json_data ) || ! is_callable( $value_func ) ) {
+		if ( ! is_array( $theme_json_data ) || ! is_string( $theme_value_prefix ) || ! is_string( $relative_path_prefix ) || ! is_callable( $value_func ) ) {
 			return $processed_theme_uris;
 		}
 
@@ -969,9 +980,9 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *
 	 * @since 6.6.0
 	 * @since 6.7.0 Added support for resolving block styles.
-	 * @since 6.8.0 Abstracting the process of resolving theme URIs.
+	 * @since 7.1.0 Abstracted the process of resolving theme URIs.
 	 *
-	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
+	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme JSON instance.
 	 * @return array An array of resolved paths.
 	 */
 	public static function get_resolved_theme_uris( $theme_json ) {
@@ -979,12 +990,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 * A helper function to resolve a relative path in theme.json to a theme absolute path.
 		 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
 		 *
-		 * @param {array} $args {
+		 * @param array $args {
 		 *  An array of arguments to resolve URIs.
-		 * @type array  $theme_path         The path to the theme value.
-		 * @type string $theme_value_prefix The prefix of the theme value.
-		 * @type string $theme_value        The theme value.
-		 * @type string $relative_prefix    The relative prefix to append to the file.
+		 *  @type string $theme_path           The path to the theme value.
+		 *  @type string $theme_value_prefix   The prefix of the theme value.
+		 *  @type string $theme_value          The theme value.
+		 *  @type string $relative_path_prefix The relative prefix to append to the file.
 		 * }
 		 * @return array
 		 */
@@ -1019,30 +1030,41 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	}
 
 	/**
-	 * Migrates absolute paths that begin with a baseurl in theme.json styles to theme relative paths
+	 * Migrates absolute paths that begin with a base URL in theme.json styles to theme relative paths
 	 * and returns them in an array. In conjunction with copying the corresponding files to
-	 * a theme directory, migrating to relative paths is useful for migrating theme json to a new location.
+	 * a theme directory, migrating to relative paths is useful for migrating theme JSON to a new location.
 	 * The default is to migrate URIs from the site's uploads directory.
 	 *
-	 * @since 6.8.0
+	 * @since 7.1.0
 	 *
-	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
-	 * @param {array}                 $options    Optional. A 'theme_value_prefix' to find the target URI in theme.json, and a 'relative_path_prefix' to append to the file.
+	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme JSON instance.
+	 * @param array                   $options    {
+	 *     Optional. Options to migrate theme URIs.
+	 *
+	 *     @type string $theme_value_prefix   The URI prefix to find in theme.json.
+	 *                                        Default site's uploads base URL.
+	 *     @type string $relative_path_prefix The relative path prefix to append to the file.
+	 *                                        Default `file:./`.
+	 * }
 	 * @return array An array of migrated paths.
 	 */
 	public static function get_migrated_relative_theme_uris( $theme_json, $options = array() ) {
+		if ( ! $theme_json instanceof WP_Theme_JSON_Gutenberg ) {
+			return array();
+		}
+
 		/**
-		 * A helper function to migrate an absolute paths in theme.json to a theme relative path.
+		 * A helper function to migrate an absolute path in theme.json to a theme relative path.
 		 * Returns an array with keys based on link attributes for compatibility with REST API _link responses.
 		 *
-		 * @param {array} $args {
+		 * @param array $args {
 		 *  An array of arguments to resolve URIs.
-		 * @type array  $theme_path         The path to the theme value.
-		 * @type string $theme_value_prefix The prefix of the theme value.
-		 * @type string $theme_value        The theme value.
-		 * @type string $relative_prefix    The relative prefix to append to the file.
+		 *  @type string $theme_path           The path to the theme value.
+		 *  @type string $theme_value_prefix   The prefix of the theme value.
+		 *  @type string $theme_value          The theme value.
+		 *  @type string $relative_path_prefix The relative prefix to append to the file.
 		 * }
-		 * @return array
+		 * @return array|null Migrated URI data, or null when the URI is invalid for migration.
 		 */
 		$migrate_absolute_uri_to_relative_path = function ( $args ) {
 			$theme_value_path  = wp_parse_url( $args['theme_value'], PHP_URL_PATH );

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -836,7 +836,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 *      @type bool $images Whether to process image URIs. Default true.
 	 *      @type bool $fonts  Whether to process font URIs. Default false.
 	 *  }
-	 *  @type string $base_url      The base URL to resolve URIs.
+	 *  @type string $theme_value_prefix    The base URL to resolve URIs.
 	 *  @type string $relative_path_prefix The relative path to resolve URIs.
 	 *  @type callable $value_func  The function to resolve URIs.
 	 * }
@@ -856,7 +856,8 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					'images' => true,
 					'fonts'  => false,
 				),
-				'base_url'             => 'file:./',
+				// Using the same file convention 'file:./' when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
+				'theme_value_prefix'   => 'file:./',
 				'relative_path_prefix' => '',
 				'value_func'           => array( static::class, 'resolve_relative_path_to_absolute_uri' ),
 			)
@@ -864,18 +865,18 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		$should_process       = $options['should_process'] ?? array();
 		$theme_json_data      = $theme_json->get_raw_data();
-		$base_url             = $options['base_url'];
+		$theme_value_prefix   = $options['theme_value_prefix'];
 		$relative_path_prefix = $options['relative_path_prefix'];
 
 		if ( ! empty( $should_process['images'] ) ) {
 			// Top level styles.
 			$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;
-			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
+			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $theme_value_prefix ) ) {
 				$processed_theme_uris[] = call_user_func(
 					$options['value_func'],
 					array(
 						'theme_path'           => 'styles.background.backgroundImage.url',
-						'theme_value_prefix'   => $base_url,
+						'theme_value_prefix'   => $theme_value_prefix,
 						'theme_value'          => $background_image_url,
 						'relative_path_prefix' => $relative_path_prefix,
 					)
@@ -889,13 +890,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 						continue;
 					}
 					$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
-					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
+					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $theme_value_prefix ) ) {
 						if ( isset( $options['value_func'] ) && is_callable( $options['value_func'] ) ) {
 							$processed_theme_uris[] = call_user_func(
 								$options['value_func'],
 								array(
 									'theme_path'           => "styles.blocks.{$block_name}.background.backgroundImage.url",
-									'theme_value_prefix'   => $base_url,
+									'theme_value_prefix'   => $theme_value_prefix,
 									'theme_value'          => $background_image_url,
 									'relative_path_prefix' => $relative_path_prefix,
 								)
@@ -917,24 +918,24 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				if ( ! empty( $font_family['fontFace'] ) ) {
 					foreach ( $font_family['fontFace'] as  $font_face_key => $font_face ) {
 						if ( ! empty( $font_face['src'] ) ) {
-							if ( is_string( $font_face['src'] ) && str_starts_with( $font_face['src'], $base_url ) ) {
+							if ( is_string( $font_face['src'] ) && str_starts_with( $font_face['src'], $theme_value_prefix ) ) {
 								$processed_theme_uris[] = call_user_func(
 									$options['value_func'],
 									array(
 										'theme_path'  => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
-										'theme_value_prefix' => $base_url,
+										'theme_value_prefix' => $theme_value_prefix,
 										'theme_value' => $font_face['src'],
 										'relative_path_prefix' => $relative_path_prefix,
 									)
 								);
 							} elseif ( is_array( $font_face['src'] ) ) {
 								foreach ( $font_face['src'] as $source_key => $source ) {
-									if ( str_starts_with( $source, $base_url ) ) {
+									if ( str_starts_with( $source, $theme_value_prefix ) ) {
 										$processed_theme_uris[] = call_user_func(
 											$options['value_func'],
 											array(
 												'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src.{$source_key}",
-												'theme_value_prefix'   => $base_url,
+												'theme_value_prefix'   => $theme_value_prefix,
 												'theme_value'          => $source,
 												'relative_path_prefix' => $relative_path_prefix,
 											)
@@ -1014,7 +1015,6 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @return array An array of resolved paths.
 	 */
 	public static function get_resolved_theme_uris( $theme_json ) {
-		// Using the same file convention 'file:./' when registering web fonts. See: WP_Font_Face_Resolver:: to_theme_file_uri.
 		return static::process_theme_uris( $theme_json );
 	}
 
@@ -1027,7 +1027,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 	 * @since 6.8.0
 	 *
 	 * @param WP_Theme_JSON_Gutenberg $theme_json A theme json instance.
-	 * @param {array}                 $options    Optional. A 'base_url' to find the target URI in theme.json, and a 'relative_path_prefix' to append to the file.
+	 * @param {array}                 $options    Optional. A 'theme_value_prefix' to find the target URI in theme.json, and a 'relative_path_prefix' to append to the file.
 	 * @return array An array of migrated paths.
 	 */
 	public static function get_migrated_relative_theme_uris( $theme_json, $options = array() ) {
@@ -1038,7 +1038,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					'images' => true,
 					'fonts'  => true,
 				),
-				'base_url'             => $options['base_url'] ?? wp_upload_dir()['baseurl'],
+				'theme_value_prefix'   => $options['theme_value_prefix'] ?? wp_upload_dir()['baseurl'],
 				'value_func'           => array( static::class, 'migrate_absolute_uri_to_relative_path' ),
 				'relative_path_prefix' => $options['relative_path_prefix'] ?? 'file:./',
 			)

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -869,13 +869,12 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 
 		if ( ! empty( $should_process['images'] ) ) {
 			// Top level styles.
-			$background_image_url_path = array( 'styles', 'background', 'backgroundImage', 'url' );
-			$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
+			$background_image_url = $theme_json_data['styles']['background']['backgroundImage']['url'] ?? null;
 			if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
 				$processed_theme_uris[] = call_user_func(
 					$options['value_func'],
 					array(
-						'theme_path'           => $background_image_url_path,
+						'theme_path'           => 'styles.background.backgroundImage.url',
 						'theme_value_prefix'   => $base_url,
 						'theme_value'          => $background_image_url,
 						'relative_path_prefix' => $relative_path_prefix,
@@ -889,14 +888,13 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					if ( ! isset( $block_styles['background']['backgroundImage']['url'] ) ) {
 						continue;
 					}
-					$background_image_url_path = array( 'styles', 'blocks', $block_name, 'background', 'backgroundImage', 'url' );
-					$background_image_url      = _wp_array_get( $theme_json_data, $background_image_url_path, null );
+					$background_image_url = $block_styles['background']['backgroundImage']['url'] ?? null;
 					if ( is_string( $background_image_url ) && str_starts_with( $background_image_url, $base_url ) ) {
 						if ( isset( $options['value_func'] ) && is_callable( $options['value_func'] ) ) {
 							$processed_theme_uris[] = call_user_func(
 								$options['value_func'],
 								array(
-									'theme_path'           => $background_image_url_path,
+									'theme_path'           => "styles.blocks.{$block_name}.background.backgroundImage.url",
 									'theme_value_prefix'   => $base_url,
 									'theme_value'          => $background_image_url,
 									'relative_path_prefix' => $relative_path_prefix,
@@ -920,26 +918,24 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 					foreach ( $font_family['fontFace'] as  $font_face_key => $font_face ) {
 						if ( ! empty( $font_face['src'] ) ) {
 							if ( is_string( $font_face['src'] ) && str_starts_with( $font_face['src'], $base_url ) ) {
-								$font_url_path          = array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src' );
 								$processed_theme_uris[] = call_user_func(
 									$options['value_func'],
 									array(
-										'theme_path'  => $font_url_path,
-										'theme_value_prefix' => $base_url,
-										'theme_value' => $font_face['src'],
+										'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src",
+										'theme_value_prefix'   => $base_url,
+										'theme_value'          => $font_face['src'],
 										'relative_path_prefix' => $relative_path_prefix,
 									)
 								);
 							} elseif ( is_array( $font_face['src'] ) ) {
 								foreach ( $font_face['src'] as $source_key => $source ) {
 									if ( str_starts_with( $source, $base_url ) ) {
-										$font_url_path          = array( 'settings', 'typography', 'fontFamilies', $font_family_key, 'fontFace', $font_face_key, 'src', $source_key );
 										$processed_theme_uris[] = call_user_func(
 											$options['value_func'],
 											array(
-												'theme_path' => $font_url_path,
-												'theme_value_prefix' => $base_url,
-												'theme_value' => $source,
+												'theme_path'           => "settings.typography.fontFamilies.{$font_family_key}.fontFace.{$font_face_key}.src.{$source_key}",
+												'theme_value_prefix'   => $base_url,
+												'theme_value'          => $source,
 												'relative_path_prefix' => $relative_path_prefix,
 											)
 										);
@@ -973,7 +969,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		$processed_theme_uri = array(
 			'name'   => $args['theme_value'],
 			'href'   => sanitize_url( get_theme_file_uri( $src_url ) ),
-			'target' => implode( '.', $args['theme_path'] ),
+			'target' => $args['theme_path'],
 		);
 
 		$file_type = wp_check_filetype( $args['theme_value'] );
@@ -1001,7 +997,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		return array(
 			'name'   => $args['theme_value'],
 			'href'   => $args['relative_path_prefix'] . basename( parse_url( $args['theme_value'], PHP_URL_PATH ) ),
-			'target' => implode( '.', $args['theme_path'] ),
+			'target' => $args['theme_path'],
 		);
 	}
 

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -27,10 +27,11 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 			return $cached;
 		}
 	}
+
 	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$tree                = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
 	$supports_theme_json = wp_theme_has_theme_json();
-
+	var_dump( WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( $tree ) );
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );
 	} elseif ( empty( $types ) ) {

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -30,6 +30,8 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$tree = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
 
+	var_dump( WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( $tree ) );
+
 	$supports_theme_json = wp_theme_has_theme_json();
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -31,7 +31,7 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
 	$tree                = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
 	$supports_theme_json = wp_theme_has_theme_json();
-	var_dump( WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( $tree ) );
+
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );
 	} elseif ( empty( $types ) ) {

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -27,12 +27,10 @@ function gutenberg_get_global_stylesheet( $types = array() ) {
 			return $cached;
 		}
 	}
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
-	$tree = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
-
-	var_dump( WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( $tree ) );
-
+	$tree                = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$tree                = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
 	$supports_theme_json = wp_theme_has_theme_json();
+
 	if ( empty( $types ) && ! $supports_theme_json ) {
 		$types = array( 'variables', 'presets', 'base-layout-styles' );
 	} elseif ( empty( $types ) ) {

--- a/phpunit/block-template-test.php
+++ b/phpunit/block-template-test.php
@@ -34,4 +34,25 @@ class Tests_Block_Template extends WP_UnitTestCase {
 
 		unregister_block_template( $template_name );
 	}
+
+	public function test_gutenberg_get_available_zip_path_adds_suffix_for_existing_entries() {
+		if ( ! class_exists( 'ZipArchive' ) ) {
+			$this->markTestSkipped( 'The ZipArchive class is not available.' );
+		}
+
+		$zip_path = wp_tempnam( 'theme-export.zip' );
+		$zip      = new ZipArchive();
+
+		$this->assertTrue( $zip->open( $zip_path, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
+		$this->assertTrue( $zip->addFromString( 'assets/img/image.png', 'first image' ) );
+		$this->assertTrue( $zip->addFromString( 'assets/img/image-1.png', 'second image' ) );
+
+		$this->assertSame(
+			'assets/img/image-2.png',
+			gutenberg_get_available_zip_path( $zip, 'assets/img/image.png' )
+		);
+
+		$zip->close();
+		unlink( $zip_path );
+	}
 }

--- a/phpunit/block-template-test.php
+++ b/phpunit/block-template-test.php
@@ -43,6 +43,7 @@ class Tests_Block_Template extends WP_UnitTestCase {
 		$zip_path = wp_tempnam( 'theme-export.zip' );
 		$zip      = new ZipArchive();
 
+		$this->assertIsString( $zip_path );
 		$this->assertTrue( $zip->open( $zip_path, ZipArchive::CREATE | ZipArchive::OVERWRITE ) );
 		$this->assertTrue( $zip->addFromString( 'assets/img/image.png', 'first image' ) );
 		$this->assertTrue( $zip->addFromString( 'assets/img/image-1.png', 'second image' ) );

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1350,6 +1350,69 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSame( $expected_data, $actual );
 	}
 
+	public function test_get_migrated_relative_theme_uris() {
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'background' => array(
+						'backgroundImage' => array(
+							'url' => 'https://example.org/wp-content/uploads/img/image.png',
+						),
+					),
+					'blocks'     => array(
+						'core/quote' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'https://example.org/wp-content/uploads/img/quote.jpg',
+								),
+							),
+						),
+						'core/verse' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'https://example.org/wp-content/uploads/img/verse.gif',
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$expected_data = array(
+			array(
+				'name'   => 'https://example.org/wp-content/uploads/img/image.png',
+				'href'   => 'file:./image.png',
+				'target' => 'styles.background.backgroundImage.url',
+			),
+			array(
+				'name'   => 'https://example.org/wp-content/uploads/img/quote.jpg',
+				'href'   => 'file:./quote.jpg',
+				'target' => 'styles.blocks.core/quote.background.backgroundImage.url',
+			),
+			array(
+				'name'   => 'https://example.org/wp-content/uploads/img/verse.gif',
+				'href'   => 'file:./verse.gif',
+				'target' => 'styles.blocks.core/verse.background.backgroundImage.url',
+			),
+		);
+
+		/*
+		 * This filter callback normalizes the return value from `wp_upload_dir`
+		 * to guard against changes in test environments.
+		 */
+		$filter_upload_dir_callback = function ( $param ) {
+			$param['baseurl'] = 'https://example.org/wp-content/uploads';
+			return $param;
+		};
+		add_filter( 'upload_dir', $filter_upload_dir_callback );
+		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( $theme_json );
+		remove_filter( 'upload_dir', $filter_upload_dir_callback );
+
+		$this->assertSame( $expected_data, $actual );
+	}
+
 	/**
 	 * Tests that block style variations data gets merged in the following
 	 * priority order, from highest priority to lowest.

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1357,7 +1357,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'background' => array(
 						'backgroundImage' => array(
-							'url' => 'https://example.org/wp-content/uploads/img/image.png',
+							'id'    => 123,
+							'title' => 'A great image',
+							'url'   => 'https://example.org/wp-content/uploads/img/image.png',
 						),
 					),
 					'blocks'     => array(
@@ -1371,7 +1373,9 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 						'core/verse' => array(
 							'background' => array(
 								'backgroundImage' => array(
-									'url' => 'https://example.org/wp-content/uploads/img/verse.gif',
+									'id'     => 123,
+									'source' => 'file',
+									'url'    => 'https://example.org/wp-content/uploads/img/verse.gif',
 								),
 							),
 						),

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1353,13 +1353,13 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 	public function test_get_migrated_relative_theme_uris() {
 		$theme_json = new WP_Theme_JSON_Gutenberg(
 			array(
-				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-				'styles'  => array(
+				'version'  => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'   => array(
 					'background' => array(
 						'backgroundImage' => array(
 							'id'    => 123,
 							'title' => 'A great image',
-							'url'   => 'https://example.org/wp-content/uploads/img/image.png',
+							'url'   => 'https://example.org/wp-content/uploads/img/image.png?ver=123',
 						),
 					),
 					'blocks'     => array(
@@ -1379,6 +1379,64 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
+						'core/group' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'https://example.org/wp-content/uploads-private/img/group.jpg',
+								),
+							),
+						),
+					),
+				),
+				'settings' => array(
+					'typography' => array(
+						'fontFamilies' => array(
+							'theme'  => array(
+								array(
+									'name'       => 'Remote Sans',
+									'slug'       => 'remote-sans',
+									'fontFamily' => 'Remote Sans',
+									'fontFace'   => array(
+										array(
+											'fontFamily' => 'Remote Sans',
+											'src'        => 'https://example.com/fonts/remote-sans.woff2',
+										),
+									),
+								),
+								array(
+									'name'       => 'Remote Serif',
+									'slug'       => 'remote-serif',
+									'fontFamily' => 'Remote Serif',
+									'fontFace'   => array(
+										array(
+											'fontFamily' => 'Remote Serif',
+											'src'        => 'https://example.com/fonts/remote-serif.woff2',
+										),
+									),
+								),
+							),
+							'custom' => array(
+								array(
+									'name'       => 'Star Jedi',
+									'slug'       => 'star-jedi',
+									'fontFamily' => 'Star Jedi',
+									'fontFace'   => array(
+										array(
+											'fontFamily' => 'Star Jedi',
+											'src'        => 'https://example.org/wp-content/uploads/fonts/Starjedi.ttf',
+										),
+										array(
+											'fontFamily' => 'Star Jedi',
+											'src'        => array(
+												'https://example.org/wp-content/uploads/fonts/Starjedi.woff2',
+												'https://example.com/fonts/remote.woff2',
+												123,
+											),
+										),
+									),
+								),
+							),
+						),
 					),
 				),
 			)
@@ -1386,19 +1444,34 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 
 		$expected_data = array(
 			array(
-				'name'   => 'https://example.org/wp-content/uploads/img/image.png',
-				'href'   => 'file:./image.png',
-				'target' => 'styles.background.backgroundImage.url',
+				'name'          => 'https://example.org/wp-content/uploads/img/image.png?ver=123',
+				'href'          => 'file:./img/image.png',
+				'target'        => 'styles.background.backgroundImage.url',
+				'relative_path' => 'img/image.png',
 			),
 			array(
-				'name'   => 'https://example.org/wp-content/uploads/img/quote.jpg',
-				'href'   => 'file:./quote.jpg',
-				'target' => 'styles.blocks.core/quote.background.backgroundImage.url',
+				'name'          => 'https://example.org/wp-content/uploads/img/quote.jpg',
+				'href'          => 'file:./img/quote.jpg',
+				'target'        => 'styles.blocks.core/quote.background.backgroundImage.url',
+				'relative_path' => 'img/quote.jpg',
 			),
 			array(
-				'name'   => 'https://example.org/wp-content/uploads/img/verse.gif',
-				'href'   => 'file:./verse.gif',
-				'target' => 'styles.blocks.core/verse.background.backgroundImage.url',
+				'name'          => 'https://example.org/wp-content/uploads/img/verse.gif',
+				'href'          => 'file:./img/verse.gif',
+				'target'        => 'styles.blocks.core/verse.background.backgroundImage.url',
+				'relative_path' => 'img/verse.gif',
+			),
+			array(
+				'name'          => 'https://example.org/wp-content/uploads/fonts/Starjedi.ttf',
+				'href'          => 'file:./fonts/Starjedi.ttf',
+				'target'        => 'settings.typography.fontFamilies.2.fontFace.0.src',
+				'relative_path' => 'fonts/Starjedi.ttf',
+			),
+			array(
+				'name'          => 'https://example.org/wp-content/uploads/fonts/Starjedi.woff2',
+				'href'          => 'file:./fonts/Starjedi.woff2',
+				'target'        => 'settings.typography.fontFamilies.2.fontFace.1.src.0',
+				'relative_path' => 'fonts/Starjedi.woff2',
 			),
 		);
 
@@ -1415,6 +1488,21 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		remove_filter( 'upload_dir', $filter_upload_dir_callback );
 
 		$this->assertSame( $expected_data, $actual );
+
+		$exported_theme_json = $theme_json->get_data();
+		foreach ( $actual as $uri ) {
+			_wp_array_set( $exported_theme_json, explode( '.', $uri['target'] ), $uri['href'] );
+		}
+
+		$this->assertSame(
+			'file:./fonts/Starjedi.ttf',
+			$exported_theme_json['settings']['typography']['fontFamilies'][2]['fontFace'][0]['src']
+		);
+		$this->assertSame(
+			'file:./fonts/Starjedi.woff2',
+			$exported_theme_json['settings']['typography']['fontFamilies'][2]['fontFace'][1]['src'][0]
+		);
+		$this->assertArrayNotHasKey( 'custom', $exported_theme_json['settings']['typography']['fontFamilies'] );
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1488,6 +1488,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		remove_filter( 'upload_dir', $filter_upload_dir_callback );
 
 		$this->assertSame( $expected_data, $actual );
+		$this->assertSame( array(), WP_Theme_JSON_Resolver_Gutenberg::get_migrated_relative_theme_uris( array() ) );
 
 		$exported_theme_json = $theme_json->get_data();
 		foreach ( $actual as $uri ) {


### PR DESCRIPTION
🚧 

> [!WARNING]
> Experimental code - please don't treat it as ready yet. Thank you!

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How?

This is a first pass, so it's pretty rough and tumble. No tests or defensive coding yet.

This PR checks a theme tree for URIs containing the current site's upload path. If found:

- it replaces the paths with a relative equivalent: `'http://domain/wp-content/uploads/1/2/test.gif' >' file:./uploads/test.gif'`
- fetches the file and adds it to the zip in `/uploads`

The outcome is that the uploaded files become part of the new theme's asset library, and can therefore be installed anywhere.

## Why?

A theme can use uploaded files for:

- fonts
- background images

The paths to these assets are absolute URIs to the uploaded files.

Currently, when exporting themes these URIs are preserved in the theme.json, which means that the theme isn't "portable" in that relies on those hosted assets.


## Testing Instructions

1. In the site editor, go to global styles and upload a font or two.
2. Upload some images and use them as background images for the site or for quote/pullquote/group blocks.
3. Save the styles.
4. Now export the theme and open the zip.
5. In theme.json, the absolute paths to uploaded files should be converted to relative `file:./` paths
6. The uploaded files themselves should be available in `/uploads` in the zip.
7. Now upload the exported theme and activate it in your site. Check that it all works as expected.

### Exported theme.json [BEFORE]

```json
					"fontFace": [
						{
							"fontFamily": "\"Star Jedi\"",
							"fontStyle": "normal",
							"fontWeight": "400",
							"src": "http://localhost:8888/wp-content/uploads/fonts/Starjedi.ttf"
						}
					],
```

### Exported theme.json [AFTER]

```json
					"fontFace": [
						{
							"fontFamily": "\"Star Jedi\"",
							"fontStyle": "normal",
							"fontWeight": "400",
							"src": "file:./uploads/Starjedi.ttf"
						}
					],
```

## Screenshots or screencast <!-- if applicable -->
<img width="282" alt="Screenshot 2024-10-25 at 7 20 17 am" src="https://github.com/user-attachments/assets/c1a4a3b6-b0fc-44ea-be19-3981d4536ecb">
