### PR TITLE
Gallery: Fix React Compiler reassignment error

### DIFF
--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -65,7 +65,7 @@ import useGetMedia from './use-get-media';
 import GapStyles from './gap-styles';
 
 const MAX_COLUMNS = 8;
-let linkOptions = [
+const LINK_OPTIONS = [
 	{
 		icon: customLink,
 		label: __( 'Link images to attachment pages' ),
@@ -117,13 +117,13 @@ export default function GalleryEdit( props ) {
 		onFocus,
 	} = props;
 
-	const lightboxSetting = useSettings( 'blocks.core/image.lightbox' )[ 0 ];
+	const [ lightboxSetting ] = useSettings( 'blocks.core/image.lightbox' );
 
-	if ( ! lightboxSetting?.allowEditing ) {
-		linkOptions = linkOptions.filter(
-			( option ) => option.value !== LINK_DESTINATION_LIGHTBOX
-		);
-	}
+	const linkOptions = ! lightboxSetting?.allowEditing
+		? LINK_OPTIONS.filter(
+				( option ) => option.value !== LINK_DESTINATION_LIGHTBOX
+		  )
+		: LINK_OPTIONS;
 
 	const { columns, imageCrop, randomOrder, linkTarget, linkTo, sizeSlug } =
 		attributes;


### PR DESCRIPTION
## What?
Part of #61788.

PR fixes the variable reassignment side-effect in the Gallery block.

## Why?

> Unexpected reassignment of a variable which was defined outside of the component. Components and hooks should be pure and side-effect free, but variable reassignment is a form of side-effect. If this variable is used in rendering, use useState instead. (https://react.dev/reference/rules/components-and-hooks-must-be-pure#side-effects-must-run-outside-of-render).

## Testing Instructions
- Make sure that you have enabled lightbox from theme.json
- Add gallery block
- Check if `Expand on click` option is available under link control
- Test `Expand on click` option function and compare it with `Image` block's lightbox functionality
- Try with different lightbox setting, and note lightbox attributes in image block under gallery block

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-24 at 15 06 37](https://github.com/user-attachments/assets/cba5751a-b580-44b1-bbf9-08ba69304e19)
