### PR TITLE
Block Library: Cleanup unnecessary notice removal

### DIFF
--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -155,15 +155,11 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 	);
 
 	// If a user clicks to a link prevent redirection and show a warning.
-	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
-	let noticeId;
+	const { createWarningNotice } = useDispatch( noticeStore );
 	const showRedirectionPreventedNotice = ( event ) => {
 		event.preventDefault();
-		// Remove previous warning if any, to show one at a time per block.
-		removeNotice( noticeId );
-		noticeId = `block-library/core/latest-posts/redirection-prevented/${ instanceId }`;
 		createWarningNotice( __( 'Links are disabled in the editor.' ), {
-			id: noticeId,
+			id: `block-library/core/latest-posts/redirection-prevented/${ instanceId }`,
 			type: 'snackbar',
 		} );
 	};

--- a/packages/block-library/src/table-of-contents/edit.js
+++ b/packages/block-library/src/table-of-contents/edit.js
@@ -17,7 +17,7 @@ import {
 	ToolbarGroup,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { renderToString, useRef } from '@wordpress/element';
+import { renderToString } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
 import { store as noticeStore } from '@wordpress/notices';
@@ -58,15 +58,11 @@ export default function TableOfContentsEdit( {
 	);
 
 	// If a user clicks to a link prevent redirection and show a warning.
-	const { createWarningNotice, removeNotice } = useDispatch( noticeStore );
-	const noticeIdRef = useRef();
+	const { createWarningNotice } = useDispatch( noticeStore );
 	const showRedirectionPreventedNotice = ( event ) => {
 		event.preventDefault();
-		// Remove previous warning if any, to show one at a time per block.
-		removeNotice( noticeIdRef.current );
-		noticeIdRef.current = `block-library/core/table-of-contents/redirection-prevented/${ instanceId }`;
 		createWarningNotice( __( 'Links are disabled in the editor.' ), {
-			id: noticeIdRef.current,
+			id: `block-library/core/table-of-contents/redirection-prevented/${ instanceId }`,
 			type: 'snackbar',
 		} );
 	};


### PR DESCRIPTION
## What?
Cleans up a couple of notice removals that are unnecessary. 

A better alternative to #66404.

## Why?
Because removing notices manually is unnecessary; the reducer will do it anyway - see https://github.com/WordPress/gutenberg/pull/66404#discussion_r1814755088

Also, helps with fixing some errors reported by React Compiler, see #66331 and https://github.com/WordPress/gutenberg/pull/61788.

## How?
Removing the notice removal and the related variables. 

## Testing Instructions
* Start a new post
* Insert a couple of "Latest Posts" blocks
* Click on any of the links in each of the block instances.
* Verify that for each block we have an independent notice, one per block instance.
* Verify that if you click links inside a single block instance multiple times, you keep having that same notice, and no duplicate notices are created for that particular block.
* Make sure you have some headings in the post.
* Repeat the same steps as above for the "Table of Contents" block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
