### PR TITLE
Global Styles: Fix React Compiler variable mutation error

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -301,18 +301,20 @@ function ShadowEditor( { shadow, onChange } ) {
 	const shadowParts = useMemo( () => getShadowParts( shadow ), [ shadow ] );
 
 	const onChangeShadowPart = ( index, part ) => {
-		shadowParts[ index ] = part;
-		onChange( shadowParts.join( ', ' ) );
+		const newShadowParts = shadowParts.map( ( p, i ) =>
+			i === index ? part : p
+		);
+		onChange( newShadowParts.join( ', ' ) );
 	};
 
 	const onAddShadowPart = () => {
-		shadowParts.push( defaultShadow );
-		onChange( shadowParts.join( ', ' ) );
+		const newShadowParts = [ ...shadowParts, defaultShadow ];
+		onChange( newShadowParts.join( ', ' ) );
 	};
 
 	const onRemoveShadowPart = ( index ) => {
-		shadowParts.splice( index, 1 );
-		onChange( shadowParts.join( ', ' ) );
+		const newShadowParts = shadowParts.filter( ( p, i ) => i !== index );
+		onChange( newShadowParts.join( ', ' ) );
 	};
 
 	return (

--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -301,20 +301,17 @@ function ShadowEditor( { shadow, onChange } ) {
 	const shadowParts = useMemo( () => getShadowParts( shadow ), [ shadow ] );
 
 	const onChangeShadowPart = ( index, part ) => {
-		const newShadowParts = shadowParts.map( ( p, i ) =>
-			i === index ? part : p
-		);
+		const newShadowParts = [ ...shadowParts ];
+		newShadowParts[ index ] = part;
 		onChange( newShadowParts.join( ', ' ) );
 	};
 
 	const onAddShadowPart = () => {
-		const newShadowParts = [ ...shadowParts, defaultShadow ];
-		onChange( newShadowParts.join( ', ' ) );
+		onChange( [ ...shadowParts, defaultShadow ].join( ', ' ) );
 	};
 
 	const onRemoveShadowPart = ( index ) => {
-		const newShadowParts = shadowParts.filter( ( p, i ) => i !== index );
-		onChange( newShadowParts.join( ', ' ) );
+		onChange( shadowParts.filter( ( p, i ) => i !== index ).join( ', ' ) );
 	};
 
 	return (


### PR DESCRIPTION
## What?
Part of #61788

PR avoids mutating the `shadowParts` variable returned by the `useMemo` hook and fixes the React Compiler ESLint error.

> Mutating a value returned from a function whose return value should not be mutated  react-compiler/react-compiler

## Why?
Most of the time, arrays and objects should be treated as immutable inside components.

## Testing Instructions
1. Navigate to Site Editor > Global Styles > Shadows.
2. Open any predefined Shadow.
3. Confirm you can add, change and remove shadow parts as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-24 at 15 56 22](https://github.com/user-attachments/assets/f06b12a5-150a-4124-8bbd-ff7d5432235f)
