### PR TITLE
Fix: JSON Schema Docgen doesn't work on Windows OS

### DIFF
--- a/bin/api-docs/gen-theme-reference.mjs
+++ b/bin/api-docs/gen-theme-reference.mjs
@@ -9,7 +9,7 @@
  */
 import fs from 'node:fs/promises';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
-import { fileURLToPath } from 'url'
+import { fileURLToPath } from 'node:url'
 
 /**
  * @typedef {import('@apidevtools/json-schema-ref-parser').JSONSchema} JSONSchema

--- a/bin/api-docs/gen-theme-reference.mjs
+++ b/bin/api-docs/gen-theme-reference.mjs
@@ -9,6 +9,7 @@
  */
 import fs from 'node:fs/promises';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
+import { fileURLToPath } from 'url'
 
 /**
  * @typedef {import('@apidevtools/json-schema-ref-parser').JSONSchema} JSONSchema
@@ -19,20 +20,20 @@ import $RefParser from '@apidevtools/json-schema-ref-parser';
  *
  * @type {URL}
  */
-const THEME_JSON_SCHEMA_URL = new URL(
+const THEME_JSON_SCHEMA_PATH = fileURLToPath( new URL(
 	'../../schemas/json/theme.json',
 	import.meta.url
-);
+) );
 
 /**
  * Path to docs file.
  *
  * @type {URL}
  */
-const REFERENCE_DOC_URL = new URL(
+const REFERENCE_DOC_PATH = fileURLToPath( new URL(
 	'../../docs/reference-guides/theme-json-reference/theme-json-living.md',
 	import.meta.url
-);
+) );
 
 /**
  * Start token for matching string in doc file.
@@ -266,14 +267,14 @@ function generateDocs( themeJson ) {
  */
 async function main() {
 	const themeJson = await $RefParser.dereference(
-		THEME_JSON_SCHEMA_URL.pathname,
+		THEME_JSON_SCHEMA_PATH,
 		{
 			parse: { binary: false, text: false, yaml: false },
 			resolve: { external: false },
 		}
 	);
 
-	const themeJsonReference = await fs.readFile( REFERENCE_DOC_URL, {
+	const themeJsonReference = await fs.readFile( REFERENCE_DOC_PATH, {
 		encoding: 'utf8',
 		flag: 'r',
 	} );
@@ -285,7 +286,7 @@ async function main() {
 		`${ START_TOKEN }\n${ generatedDocs }\n${ END_TOKEN }`
 	);
 
-	await fs.writeFile( REFERENCE_DOC_URL, updatedThemeJsonReference, {
+	await fs.writeFile( REFERENCE_DOC_PATH, updatedThemeJsonReference, {
 		encoding: 'utf8',
 	} );
 }

--- a/bin/api-docs/gen-theme-reference.mjs
+++ b/bin/api-docs/gen-theme-reference.mjs
@@ -9,7 +9,7 @@
  */
 import fs from 'node:fs/promises';
 import $RefParser from '@apidevtools/json-schema-ref-parser';
-import { fileURLToPath } from 'node:url'
+import { fileURLToPath } from 'node:url';
 
 /**
  * @typedef {import('@apidevtools/json-schema-ref-parser').JSONSchema} JSONSchema
@@ -20,20 +20,21 @@ import { fileURLToPath } from 'node:url'
  *
  * @type {URL}
  */
-const THEME_JSON_SCHEMA_PATH = fileURLToPath( new URL(
-	'../../schemas/json/theme.json',
-	import.meta.url
-) );
+const THEME_JSON_SCHEMA_PATH = fileURLToPath(
+	new URL( '../../schemas/json/theme.json', import.meta.url )
+);
 
 /**
  * Path to docs file.
  *
  * @type {URL}
  */
-const REFERENCE_DOC_PATH = fileURLToPath( new URL(
-	'../../docs/reference-guides/theme-json-reference/theme-json-living.md',
-	import.meta.url
-) );
+const REFERENCE_DOC_PATH = fileURLToPath(
+	new URL(
+		'../../docs/reference-guides/theme-json-reference/theme-json-living.md',
+		import.meta.url
+	)
+);
 
 /**
  * Start token for matching string in doc file.
@@ -266,13 +267,10 @@ function generateDocs( themeJson ) {
  * Main function.
  */
 async function main() {
-	const themeJson = await $RefParser.dereference(
-		THEME_JSON_SCHEMA_PATH,
-		{
-			parse: { binary: false, text: false, yaml: false },
-			resolve: { external: false },
-		}
-	);
+	const themeJson = await $RefParser.dereference( THEME_JSON_SCHEMA_PATH, {
+		parse: { binary: false, text: false, yaml: false },
+		resolve: { external: false },
+	} );
 
 	const themeJsonReference = await fs.readFile( REFERENCE_DOC_PATH, {
 		encoding: 'utf8',


### PR DESCRIPTION
Related to #63868

Reported in [this comment](https://wordpress.slack.com/archives/C02QB2JS7/p1729757325508839) on Slack

<details><summary>Original report</summary>

> Since yesterday I am having problems passing the pre-commit check when I use Windows 11. (Yes I have ran npm run distclean and npm ci)
> There seems to be something wrong with the paths used in the json-schema-ref-parser or gen-theme-reference.mjs:
> I don't think it should be D:\\D:\\ one should be correct.
> stack: 'JSONParserError: Error opening file "D:\\D:\\LocalSites\\67\\app\\public\\wp-content\\plugins\\gutenberg\\schemas\\json\\theme.json"
> ENOENT: no such file or directory (edited) 

</details> 

## What?

This PR fixes the `docs:theme-ref` command so that it works on Windows OS.

## Why?

When running the `docs:theme-ref` command on Windows OS, the following error occurs:

```
{
  stack: 'JSONParserError: Error opening file "D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json" \n' +
    "ENOENT: no such file or directory, open 'D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json'\n" +
    '    at Object.read (D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\node_modules\\@apidevtools\\json-schema-ref-parser\\dist\\lib\\resolvers\\file.js:61:19)',
  code: 'ERESOLVER',
  name: 'ResolverError',
  message: 'Error opening file "D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json" \n' +
    "ENOENT: no such file or directory, open 'D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json'",
  source: 'D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json',
  path: null,
  toJSON: [Function: toJSON],
  ioErrorCode: 'ENOENT',
  footprint: 'null+D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json+ERESOLVER+Error opening file "D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json" \n' +
    "ENOENT: no such file or directory, open 'D:\\D:\\Desktop\\wp_dev\\WordPress\\gutenberg\\schemas\\json\\theme.json'",
  toString: [Function: toString]
}
```

When we investigated this issue, we found that `THEME_JSON_SCHEMA_URL.pathname` has an invalid path like the following:

```
/D:/Desktop/wp_dev/WordPress/gutenberg/schemas/json/theme.json
```

I found a similar report about this path in the node project: https://github.com/nodejs/node/issues/37845

## How?

According to [the comment](https://github.com/nodejs/node/issues/37845#issuecomment-803451705), this path is a valid URL, but it seems that the URL needs to be converted to a path:

> This is the correct output. URLs are not paths. You should convert the url to a path and then perform resolution using that: https://nodejs.org/api/url.html#url_url_fileurltopath_url

## Testing Instructions

- Make some changes to the `schemas/json/theme.json` file.
- Run `npm run docs:theme-ref`.
- The `theme-json-living.md` file should be updated.
