### PR TITLE
Site editor: remove "default" admin CSS

### DIFF
--- a/backport-changelog/6.8/7642.md
+++ b/backport-changelog/6.8/7642.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7642
+
+* https://github.com/WordPress/gutenberg/pull/66431

--- a/lib/compat/wordpress-6.8/remove-default-css.php
+++ b/lib/compat/wordpress-6.8/remove-default-css.php
@@ -1,9 +1,11 @@
 <?php
 
-add_action( 'admin_enqueue_scripts', function( $hook ) {
+function gutenberg_remove_default_css( $hook ) {
 	// Maybe also remove on post.php when Gutenberg is enabled for posts.
 	if ( 'site-editor.php' !== $hook ) {
 		return;
 	}
 	wp_dequeue_style( 'colors' );
-} );
+}
+
+add_action( 'admin_enqueue_scripts', 'gutenberg_remove_default_css' );

--- a/lib/compat/wordpress-6.8/remove-default-css.php
+++ b/lib/compat/wordpress-6.8/remove-default-css.php
@@ -1,0 +1,9 @@
+<?php
+
+add_action( 'admin_enqueue_scripts', function( $hook ) {
+	// Maybe also remove on post.php when Gutenberg is enabled for posts.
+	if ( 'site-editor.php' !== $hook ) {
+		return;
+	}
+	wp_dequeue_style( 'colors' );
+} );

--- a/lib/load.php
+++ b/lib/load.php
@@ -47,6 +47,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.7/rest-api.php';
 
 	// WordPress 6.8 compat.
+	require __DIR__ . '/compat/wordpress-6.8/remove-default-css.php';
 	require __DIR__ . '/compat/wordpress-6.8/block-comments.php';
 	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php';
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We are loading a TON of css in the site editor that never use. The culprit seems to be the `colors` handle, which in turn enqueues `wp-admin`. `wp-admin` in turn enqueues basically all css of every admin screen there is:

```
array(
    'dashicons',
    'common',
    'forms',
    'admin-menu',
    'dashboard',
    'list-tables',
    'edit',
    'revisions',
    'media',
    'themes',
    'about',
    'nav-menus',
    'widgets',
    'site-icon',
    'l10n'
)
```

I don't know why this was ever done, but that ship has sailed for the normal admin. For the site editor however, we should be a lot more picky and explicitly add the dependencies we need to our own stylesheet. That's already the case: as you will see, even after dequeuing `colors`, the handles that we need such as `dashicons`, `common`, `forms` etc. are still loading.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

One of the thousand needles that degrades site editing loading performance. Note that each extra stylesheet is a blocking request.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Dequeue `colors`. This is added to all admin pages here:

https://github.com/WordPress/wordpress-develop/blob/de38e8eeecf80a7ca5ee870ec68a59897216b33b/src/wp-admin/admin-header.php#L93

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load the site editor and check that the `list-tables` CSS file is gone for example.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
