### PR TITLE
Site Editor: remove content styles outside canvas

### DIFF
--- a/backport-changelog/6.8/7643.md
+++ b/backport-changelog/6.8/7643.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7643
+
+* https://github.com/WordPress/gutenberg/pull/66432

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -410,7 +410,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-site',
 		gutenberg_url( 'build/edit-site/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-edit-blocks', 'wp-commands', 'wp-preferences' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'common', 'forms', 'wp-commands', 'wp-preferences' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-site', 'rtl', 'replace' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the Site Editor, we _always_ load the content in an iframe, so it's not necessary to load the content styles outside the canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Unnecessary styles loading.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We can remove `wp-edit-blocks`. There was an implicit dependency on `common` and `forms` that I've now made explicit.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Sanity check styles in the Site Editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
