### PR TITLE
Spacer : Added color support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -884,7 +884,7 @@ Add white space between blocks and customize its height. ([Source](https://githu
 
 -	**Name:** core/spacer
 -	**Category:** design
--	**Supports:** anchor, interactivity (clientNavigation), spacing (margin)
+-	**Supports:** anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin)
 -	**Attributes:** height, width
 
 ## Table

--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -24,6 +24,11 @@
 				"margin": true
 			}
 		},
+		"color": {
+			"text": false,
+			"background": true,
+			"gradients": true
+		},
 		"interactivity": {
 			"clientNavigation": true
 		}


### PR DESCRIPTION

## What?

Adding color support for Spacer block.
Part of https://github.com/WordPress/gutenberg/issues/43245

## Why?

Spacer block is missing color support. 


## How?

Adds the color block support with bg color settings via block.json


## Testing Instructions

- Navigate to template/page edit.
- Then add spacer block and apply the background color .
- Verify that background color display correctly in both the editor and frontend.

## Screenshots or screencast 

Backend:
![spacercolorbackend](https://github.com/user-attachments/assets/8a2a7c6f-4b5d-457f-ad8a-d050cdcd2c12)

Frontend:
![spacercolorfrontend](https://github.com/user-attachments/assets/d53a14ad-52ee-4852-b780-875ad24dd4f2)
