### PR TITLE
Style Book: fix comment output in styles

### DIFF
--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -143,6 +143,13 @@ export const STYLE_BOOK_CATEGORIES: StyleBookCategory[] = [
 	},
 ];
 
+// Forming a "block formatting context" to prevent margin collapsing.
+// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
+const ROOT_CONTAINER = `
+	.is-root-container {
+		display: flow-root;
+	}
+`;
 // The content area of the Style Book is rendered within an iframe so that global styles
 // are applied to elements within the entire content area. To support elements that are
 // not part of the block previews, such as headings and layout for the block previews,
@@ -151,16 +158,12 @@ export const STYLE_BOOK_CATEGORIES: StyleBookCategory[] = [
 // applied to the `button` element, targeted via `.edit-site-style-book__example`.
 // This is to ensure that browser default styles for buttons are not applied to the previews.
 export const STYLE_BOOK_IFRAME_STYLES = `
-	// Forming a "block formatting context" to prevent margin collapsing.
-	// @see https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Block_formatting_context
-	.is-root-container {
-		display: flow-root;
-	}
-
 	body {
 		position: relative;
 		padding: 32px !important;
 	}
+
+	${ ROOT_CONTAINER }
 
 	.edit-site-style-book__examples {
 		max-width: 1200px;


### PR DESCRIPTION
## What?
Removes a JS comment that is output in the Style Book styles. It looks like this came about in #65430.

## Why?
The comment prevents the adjacent ruleset from applying.

## How?
Keeps the comment yet moves it out of the styles string.

## Testing Instructions
1. Open the Style Book
2. Inspect a `.root-container` element
3. Verify its computed `display` is `flow-root`

## Screenshots or screencast <!-- if applicable -->

In case it helps illustrate the issue and how it can be verified in trunk here’s a demo showing it. The `root-containers` are given a background color and the paragraph some margins so it’s visible when they become contained.

https://github.com/user-attachments/assets/9f4c7a6d-db54-461b-a802-dc1530911347

