### PR TITLE
HTML Block: Force HTML preview in view mode

### DIFF
--- a/packages/block-library/src/html/edit.js
+++ b/packages/block-library/src/html/edit.js
@@ -7,6 +7,7 @@ import {
 	BlockControls,
 	PlainText,
 	useBlockProps,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	ToolbarButton,
@@ -14,6 +15,7 @@ import {
 	ToolbarGroup,
 	VisuallyHidden,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useInstanceId } from '@wordpress/compose';
 
 /**
@@ -26,6 +28,10 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 	const isDisabled = useContext( Disabled.Context );
 
 	const instanceId = useInstanceId( HTMLEdit, 'html-edit-desc' );
+
+	const isPreviewMode = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings().isPreviewMode;
+	}, [] );
 
 	function switchToPreview() {
 		setIsPreview( true );
@@ -58,7 +64,7 @@ export default function HTMLEdit( { attributes, setAttributes, isSelected } ) {
 					</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
-			{ isPreview || isDisabled ? (
+			{ isPreview || isPreviewMode || isDisabled ? (
 				<>
 					<Preview
 						content={ attributes.content }

--- a/packages/block-library/src/html/preview.js
+++ b/packages/block-library/src/html/preview.js
@@ -23,14 +23,15 @@ const DEFAULT_STYLES = `
 
 export default function HTMLEditPreview( { content, isSelected } ) {
 	const settingStyles = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().styles || []
+		( select ) => select( blockEditorStore ).getSettings().styles,
+		[]
 	);
 
 	const styles = useMemo(
 		() => [
 			DEFAULT_STYLES,
 			...transformStyles(
-				settingStyles.filter( ( style ) => style.css )
+				( settingStyles ?? [] ).filter( ( style ) => style.css )
 			),
 		],
 		[ settingStyles ]

--- a/packages/block-library/src/html/preview.js
+++ b/packages/block-library/src/html/preview.js
@@ -23,7 +23,7 @@ const DEFAULT_STYLES = `
 
 export default function HTMLEditPreview( { content, isSelected } ) {
 	const settingStyles = useSelect(
-		( select ) => select( blockEditorStore ).getSettings().styles
+		( select ) => select( blockEditorStore ).getSettings().styles || []
 	);
 
 	const styles = useMemo(


### PR DESCRIPTION
Fixes #47819

## What?

This PR forces HTML preview in view mode regardless of what the mode of the HTML block is.

## Why?

In view mode we cannot edit blocks, and in addition, view mode should show as much of how the blocks will actually be rendered as possible.

## How?

check `getSettings().isPreviewMode`.

## Testing Instructions

- In the site editor, insert an HTML block.
- For example, enter code like the following:
  ```html
  <div style="color:red">Hello World</div>
  ```
- When you switch to view mode, you should see a preview of the HTML.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/8e10c43c-013b-44ba-94ce-92396fc02cd0

