### PR TITLE
Post Template: Add border support

### DIFF
--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -51,6 +51,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-post-template",


### PR DESCRIPTION
## What?
Add border and spacing block support to the Post Template block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Template` block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions

- Go to Appearance > Editor > Styles > Edit Styles > Blocks.
- Ensure the Post Template block's border is configurable via Global Styles.
- Confirm Global Styles are applied correctly in both the editor and frontend.
- Edit a template or page and add a Query Loop block.
- Select a variation (e.g., Title & Date) to list all the posts.
- Select the Post Template block and verify border and radius settings are available.
- Check that block styles take precedence over Global Styles.
- Ensure borders display correctly in both the editor and frontend.

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

In Frontend:

![post_template_front1](https://github.com/user-attachments/assets/d8ec8405-6c57-46a7-8fc6-962f487228ba)


In Backend:

![post_template_front](https://github.com/user-attachments/assets/6285f9c9-93ac-406c-8405-6c10849d6d51)
