### PR TITLE
Fix latest post block spacing issue.

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -50,15 +50,9 @@
 	font-size: 0.8125em;
 }
 
-.wp-block-latest-posts__post-excerpt {
-	margin-top: 1em;
+.wp-block-latest-posts__post-excerpt, .wp-block-latest-posts__post-full-content {
+	margin-top: 0.5em;
 	margin-bottom: 1em;
-}
-
-/* Added space between block title & block full content */
-.wp-block-latest-posts__post-full-content {
-    margin-bottom: 1em;
-    margin-top: 1em;
 }
 
 .wp-block-latest-posts__featured-image {

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -51,8 +51,14 @@
 }
 
 .wp-block-latest-posts__post-excerpt {
-	margin-top: 0.5em;
+	margin-top: 1em;
 	margin-bottom: 1em;
+}
+
+/* Added space between block title & block full content */
+.wp-block-latest-posts__post-full-content {
+    margin-bottom: 1em;
+    margin-top: 1em;
 }
 
 .wp-block-latest-posts__featured-image {

--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -50,7 +50,8 @@
 	font-size: 0.8125em;
 }
 
-.wp-block-latest-posts__post-excerpt, .wp-block-latest-posts__post-full-content {
+.wp-block-latest-posts__post-excerpt,
+.wp-block-latest-posts__post-full-content {
 	margin-top: 0.5em;
 	margin-bottom: 1em;
 }


### PR DESCRIPTION
fixes https://github.com/WordPress/gutenberg/issues/66412
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I have created PR to add little bit space between post title & post full content.

## Why?
I have checked latest post block and found that there is no spacing between "Block Post Title" & "Block Post Content". I think that there should be some space.

## How?
By adding some space between post title & post content.

## Testing Instructions

- Type / to choose a block
- Select Latest post block
- Change its post content from "Excerpt" to "Full Post"
- Save the changes and publish the page.
- View the editor side & front-end side.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Here, I have attached screenshots for only one theme**(Twenty Fifteen)**

**Twenty Fifteen theme:**

![after-resolved-twenty-fifteen-latest-post-block-editor-side](https://github.com/user-attachments/assets/65a498a7-8482-437e-b955-34be4bfd1456)
![aftr-resolved-twenty-fifteen-latest-post-block-front-side](https://github.com/user-attachments/assets/551514bb-41f5-44fe-9dde-36664733619a)


Thanks,