### PR TITLE
Spacer: Add border support

### DIFF
--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -26,6 +26,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-spacer-editor",


### PR DESCRIPTION
## What?
Add border block support to the Spacer block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Spacer` block is missing border support.

## How?
Adds the border block support in block.json

## Testing Instructions

- Go to Global Styles setting ( under appearance > editor > styles > edit styles > blocks )
- Make sure that Spacer block's border is configurable via Global Styles
- Verify that Global Styles are applied correctly in the editor and frontend
- Edit template/page, Add Spacer block and Apply the border styles
- Verify that block styles take precedence over global styles
- Verify that block borders display correctly in both the editor and frontend

### Testing Instructions for Keyboard
None

## Screenshots or screencast <!-- if applicable -->

In Backend:
![spacer_backend](https://github.com/user-attachments/assets/907cc100-f381-41b0-b8e3-b249e3bf47bb)


In Frontend:
![spacer_frontend](https://github.com/user-attachments/assets/c81f07a8-a905-4e7c-930f-d3d6196ff4d7)

