### PR TITLE
Compose: Fix React Complier error for 'useCopyToClipboard'

### DIFF
--- a/packages/compose/src/hooks/use-copy-to-clipboard/index.js
+++ b/packages/compose/src/hooks/use-copy-to-clipboard/index.js
@@ -6,7 +6,7 @@ import Clipboard from 'clipboard';
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, useLayoutEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,7 +20,9 @@ import useRefEffect from '../use-ref-effect';
  */
 function useUpdatedRef( value ) {
 	const ref = useRef( value );
-	ref.current = value;
+	useLayoutEffect( () => {
+		ref.current = value;
+	}, [ value ] );
 	return ref;
 }
 


### PR DESCRIPTION
## What?
Part of #61788.

PR fixes the React Compiler error for the `useCopyToClipboard` hook.

```
Mutating a value returned from a function whose return value should not be mutated  react-compiler/react-compiler
```

## Why?
It's recommended to avoid reading/writing refs during the render.

## How?
Correctly implement the [latest ref pattern](https://www.epicreact.dev/the-latest-ref-pattern-in-react).

## Testing Instructions
1. Open a post or page.
2. Copy a block from the block Options dropdown.
3. Paste it.
4. Confirm everything works as before.

### Testing Instructions for Keyboard
Same.
