### PR TITLE
Style Book: Fix React Compiler error

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -179,21 +179,19 @@ function StyleBook( {
 		( select ) => select( blockEditorStore ).getSettings(),
 		[]
 	);
+	const [ globalStyles ] = useGlobalStylesOutputWithConfig( mergedConfig );
 
 	const settings = useMemo(
 		() => ( {
 			...originalSettings,
+			styles:
+				! isObjectEmpty( globalStyles ) && ! isObjectEmpty( userConfig )
+					? globalStyles
+					: originalSettings.styles,
 			isPreviewMode: true,
 		} ),
-		[ originalSettings ]
+		[ globalStyles, originalSettings, userConfig ]
 	);
-
-	const [ globalStyles ] = useGlobalStylesOutputWithConfig( mergedConfig );
-
-	settings.styles =
-		! isObjectEmpty( globalStyles ) && ! isObjectEmpty( userConfig )
-			? globalStyles
-			: settings.styles;
 
 	return (
 		<EditorCanvasContainer


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/pull/61788.

PR avoids mutating the `settings` object and moves the `settings.style` related logic into the `useMemo` hook, which fixes the React Compiler error.

```
Mutating a value returned from a function whose return value should not be mutated  react-compiler/react-compiler
```

## Why?
Mutating objects returned by hooks can have unexpected side effects.

## Testing Instructions
1. Smoke test the Style Book view.
2. Confirm everything works as before.
