### PR TITLE
Style Book: Avoid state/effect combo when generating values

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -24,13 +24,7 @@ import {
 import { privateApis as editorPrivateApis } from '@wordpress/editor';
 import { useSelect } from '@wordpress/data';
 import { useResizeObserver } from '@wordpress/compose';
-import {
-	useMemo,
-	useState,
-	memo,
-	useContext,
-	useEffect,
-} from '@wordpress/element';
+import { useMemo, useState, memo, useContext } from '@wordpress/element';
 import { ENTER, SPACE } from '@wordpress/keycodes';
 
 /**
@@ -148,7 +142,7 @@ function StyleBook( {
 	const [ textColor ] = useGlobalStyle( 'color.text' );
 	const [ backgroundColor ] = useGlobalStyle( 'color.background' );
 	const colors = useMultiOriginPalettes();
-	const [ examples, setExamples ] = useState( () => getExamples( colors ) );
+	const examples = useMemo( () => getExamples( colors ), [ colors ] );
 	const tabs = useMemo(
 		() =>
 			getTopLevelStyleBookCategories().filter( ( category ) =>
@@ -158,11 +152,6 @@ function StyleBook( {
 			),
 		[ examples ]
 	);
-
-	// Ensure color examples are kept in sync with Global Styles palette changes.
-	useEffect( () => {
-		setExamples( getExamples( colors ) );
-	}, [ colors ] );
 
 	const { base: baseConfig } = useContext( GlobalStylesContext );
 


### PR DESCRIPTION
## What?
This is a follow-up to #65692.

PR avoids using state/effect combo when generating/deriving example values in the Style Book and swaps it with the `useMemo` hook.

## Why?
The similar patterns are more suited for memoization hooks. Ref: https://x.com/sophiebits/status/1293710971274289152.

P.S. I'm sure there's also an example in React docs, but I can't find it now.

## Testing Instructions
See the instructions from the original PR - #65692.
