### PR TITLE
Backport "pull request automation use regular npm install"

### DIFF
--- a/.github/workflows/pull-request-automation.yml
+++ b/.github/workflows/pull-request-automation.yml
@@ -17,24 +17,8 @@ jobs:
                   ref: trunk
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
-            - name: Use desired version of Node.js
-              uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
-              with:
-                  node-version-file: '.nvmrc'
-                  check-latest: true
-
-            - name: Cache NPM packages
-              uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-              with:
-                  # npm cache files are stored in `~/.npm` on Linux/macOS
-                  path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.node }}-npm-pr-automation-cache-${{ hashFiles('**/package-lock.json') }}
-
-            # Changing into the action's directory and running `npm install` is much
-            # faster than a full project-wide `npm ci`.
-            - name: Install NPM dependencies
-              run: npm install
-              working-directory: packages/project-management-automation
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
 
             - uses: ./packages/project-management-automation
               with:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Backport of https://github.com/WordPress/gutenberg/pull/66314/.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because CI is failing `npm install` on the `wp/6.7` branch. 

See discussion in WP Slack https://wordpress.slack.com/archives/C02QB2JS7/p1729680379803689.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Manual backport. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Deferring to @sirreal to double check this makes sense.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
