### PR TITLE
Core Data: fix __experimentalGetTemplateForLink resolver

### DIFF
--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -571,6 +571,10 @@ export const getAutosave =
 export const __experimentalGetTemplateForLink =
 	( link ) =>
 	async ( { dispatch, resolveSelect } ) => {
+		if ( ! link ) {
+			return;
+		}
+
 		let template;
 		try {
 			// This is NOT calling a REST endpoint but rather ends up with a response from


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I noticed that for some pages in the site editor, we are making incorrect API call. It seems that `__experimentalGetTemplateForLink` in the [query block](https://github.com/WordPress/gutenberg/blob/2036d7ed957b1b83436a673824a7511cfc9ee5ba/packages/block-library/src/query/edit/query-content.js#L56) is called without a link argument, yet still receives a string (and underneath successfully retrieves records. But the wrapper resolver (`__experimentalGetTemplateForLink`) tries to make an incorrect API call without this `link` argument present:

```
/wp-admin/site-editor.php?_wp-find-template=true&_locale=user
```

Which returns just HTML:

<img width="919" alt="Screenshot 2024-10-25 at 11 21 35" src="https://github.com/user-attachments/assets/7fa4fb38-9bbc-48f2-b3b0-d0810fcee51c">


You can test this by trying the following page with the TT4 theme:

```
/wp-admin/site-editor.php?postId=twentytwentyfour%2F%2Fhome&postType=wp_template&canvas=edit
```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The solution would be to return early in the resolver.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
