### PR TITLE
Remove purple coloring from DocumentBar and PostCard

### DIFF
--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -67,10 +67,6 @@
 	flex: 1;
 	overflow: hidden;
 	text-overflow: ellipsis;
-
-	.editor-document-bar.is-global & {
-		color: var(--wp-block-synced-color);
-	}
 }
 
 .editor-document-bar__post-type-label {

--- a/packages/editor/src/components/post-card-panel/style.scss
+++ b/packages/editor/src/components/post-card-panel/style.scss
@@ -34,14 +34,6 @@
 	}
 }
 
-.editor-post-card-panel__icon.is-sync {
-	fill: var(--wp-block-synced-color);
-
-	& + .editor-post-card-panel__title {
-		color: var(--wp-block-synced-color);
-	}
-}
-
 .editor-post-card-panel__title-badge {
 	background: $gray-100;
 	color: $gray-800;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/65168

From the issue:

>As an affordance, the purple color applied in the DocumentBar is not helping to communicate the "global" nature of templates, synced patterns, and template parts. It's just not connective in this presentation, and with the addition of post type labels in https://github.com/WordPress/gutenberg/issues/65167 — arguably, not necessary.

> I propose we simplify a bit, removing the purple color within the DocumentBar and PostCard



## Testing Instructions
There should be no purple coloring in the above components for templates, synced patterns, and template parts.


## Screenshots

Check the `Save your changes.` command(s).

Before            |  After
:-------------------------:|:-------------------------:
<img width="774" alt="Screenshot 2024-10-25 at 12 21 07 PM" src="https://github.com/user-attachments/assets/8aaff811-85ae-4451-a111-09ebe445313c"> |<img width="774" alt="after" src="https://github.com/user-attachments/assets/4940dc74-9c7e-434f-8e02-4c851f0fa252">
