### PR TITLE
Don't switch editor mode when changing entities

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -153,9 +153,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		],
 		[ settings.styles, canvas, currentPostIsTrashed ]
 	);
-	const { __unstableSetEditorMode, resetZoomLevel } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 	const { createSuccessNotice } = useDispatch( noticesStore );
 	const history = useHistory();
 	const onActionPerformed = useCallback(
@@ -263,9 +261,6 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 											showTooltip
 											tooltipPosition="middle right"
 											onClick={ () => {
-												__unstableSetEditorMode(
-													'edit'
-												);
 												resetZoomLevel();
 
 												// TODO: this is a temporary solution to navigate to the posts list if we are

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -249,15 +249,19 @@ export default function useInitEditedEntityFromURL() {
 		useResolveEditedEntityAndContext( params );
 
 	const { setEditedEntity } = useDispatch( editSiteStore );
-	const { __unstableSetEditorMode, resetZoomLevel } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	useEffect( () => {
 		if ( isReady ) {
-			__unstableSetEditorMode( 'edit' );
 			resetZoomLevel();
 			setEditedEntity( postType, postId, context );
 		}
-	}, [ isReady, postType, postId, context, setEditedEntity ] );
+	}, [
+		isReady,
+		postType,
+		postId,
+		context,
+		setEditedEntity,
+		resetZoomLevel,
+	] );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

⚠️ Do not backport to `wp/6.7`. This PR is incompatible with that branch.

Avoid REST API call caused by resetting editor mode on:

- toggle of `W` sidebar
- change of entity

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In `trunk` the editorMode is now a preference. That means changing it will trigger a REST request. 

Props to @ellatrix for spotting this one.

Moreover, the Zoom Out is no longer coupled to editorMode. Rather it relies solely on `zoomLevel` state. Therefore this call is redundant in `trunk` (only!).

This is all predicated on the assumption that we do not wish to reset a user activate preference when moving between entities in the Editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Removes the call to set the editor mode in the relevant portions of code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

First verify the bug. 

- Check out `trunk`
- Open dev tools and go to `Network` and filter by search string `rest_route=%2Fwp%2Fv2%2Fusers%2Fm`. This is the REST request to the user preferences endpoint.
- Site Editor -> Pages -> Choose any page
- Activate Zoom Out mode.
- Click `W` to activate left hand sidebar
- See an network request to the endpoint in dev tools.
- Under `Pages` click between a few pages and then click on the canvas to edit any page.
- Activate Zoom Out again.
- Now use your _browser_ `Back` button. See the network request triggered as you move between Pages.

Now check this branch resolves.

- Perform same steps as above 
- Verify no network requests
- Verify that Zoom Out is still disengaged when you open `W` sidebar or move between entities.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
