### PR TITLE
Add sorting by name or count in categories block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -79,7 +79,7 @@ Display a list of all terms of a given taxonomy. ([Source](https://github.com/Wo
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-	**Attributes:** displayAsDropdown, label, order, orderBy, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -39,6 +39,14 @@
 		"showLabel": {
 			"type": "boolean",
 			"default": true
+		},
+		"order": {
+			"type": "string",
+			"default": "desc"
+		},
+		"orderBy": {
+			"type": "string",
+			"default": "count"
 		}
 	},
 	"usesContext": [ "enhancedPagination" ],

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -42,11 +42,11 @@
 		},
 		"order": {
 			"type": "string",
-			"default": "desc"
+			"default": "asc"
 		},
 		"orderBy": {
 			"type": "string",
-			"default": "count"
+			"default": "name"
 		}
 	},
 	"usesContext": [ "enhancedPagination" ],

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -60,7 +60,7 @@ export default function CategoriesEdit( {
 		hide_empty: ! showEmpty,
 		context: 'view',
 		order,
-		orderBy,
+		orderby: orderBy,
 	};
 	if ( isHierarchicalTaxonomy && showOnlyTopLevel ) {
 		query.parent = 0;
@@ -91,13 +91,6 @@ export default function CategoriesEdit( {
 	const renderCategoryList = () => {
 		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
 		const categoriesList = getCategoriesList( parentId );
-		// TODO: Doing the sorting manually because it seems ordering by count
-		// is not working as expected in the REST API.
-		if ( orderBy === 'count' ) {
-			categoriesList.sort( ( a, b ) =>
-				order === 'desc' ? b.count - a.count : a.count - b.count
-			);
-		}
 		return categoriesList.map( ( category ) =>
 			renderCategoryListItem( category )
 		);

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -26,7 +26,8 @@ function render_block_core_categories( $attributes, $content, $block ) {
 	$args = array(
 		'echo'         => false,
 		'hierarchical' => ! empty( $attributes['showHierarchy'] ),
-		'orderby'      => 'name',
+		'orderby'      => $attributes['orderBy'],
+		'order'        => $attributes['order'],
 		'show_count'   => ! empty( $attributes['showPostCounts'] ),
 		'taxonomy'     => $attributes['taxonomy'],
 		'title_li'     => '',

--- a/test/integration/fixtures/blocks/core__categories.json
+++ b/test/integration/fixtures/blocks/core__categories.json
@@ -9,7 +9,9 @@
 			"showPostCounts": false,
 			"showOnlyTopLevel": false,
 			"showEmpty": false,
-			"showLabel": true
+			"showLabel": true,
+			"order": "asc",
+			"orderBy": "name"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
Add a new setting to the Categories block to be able to order the list of taxonomies based on the name or the posts count. It is similar to what the query loop is doing.

## Why?
They are supported queries and it provides more flexibility to the user.

## How?
Include `order` and `orderBy` in the block attributes and use their value in the query to retrieve the categories.

Additionally, I added a Select control with the different options.

## Testing Instructions
1. Create some categories in your site.
2. Create some posts assigned to the different categories.
3. Go to a page and add the "Categories list" block.
4. Check that there is a new Select control in the settings.
5. Try the different alternatives and check they work in the editor and in the frontend.