### PR TITLE
Fix : Global styles revisions close button overlaps scrollbar

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -134,15 +134,18 @@ function EditorCanvasContainer( {
 						onKeyDown={ closeOnEscape }
 						aria-label={ title }
 					>
-						{ shouldShowCloseButton && (
-							<Button
-								size="compact"
-								className="edit-site-editor-canvas-container__close-button"
-								icon={ closeSmall }
-								label={ closeButtonLabel || __( 'Close' ) }
-								onClick={ onCloseContainer }
-							/>
-						) }
+						<div className="edit-site-editor-canvas-container__header">
+							<span>{ title }</span>
+							{ shouldShowCloseButton && (
+								<Button
+									size="compact"
+									className="edit-site-editor-canvas-container__close-button"
+									icon={ closeSmall }
+									label={ closeButtonLabel || __( 'Close' ) }
+									onClick={ onCloseContainer }
+								/>
+							) }
+						</div>
 						{ childrenWithProps }
 					</section>
 				</ResizableEditor>

--- a/packages/edit-site/src/components/editor-canvas-container/index.js
+++ b/packages/edit-site/src/components/editor-canvas-container/index.js
@@ -18,6 +18,11 @@ import {
 } from '@wordpress/editor';
 
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * Internal dependencies
  */
 import { unlock } from '../../lock-unlock';
@@ -46,6 +51,7 @@ function getEditorCanvasContainerTitle( view ) {
 
 function EditorCanvasContainer( {
 	children,
+	className,
 	closeButtonLabel,
 	onClose,
 	enableResizing = false,
@@ -114,7 +120,12 @@ function EditorCanvasContainer( {
 
 	return (
 		<EditorContentSlotFill.Fill>
-			<div className="edit-site-editor-canvas-container">
+			<div
+				className={ clsx(
+					'edit-site-editor-canvas-container',
+					className
+				) }
+			>
 				<ResizableEditor enableResizing={ enableResizing }>
 					{ /* eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions */ }
 					<section

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -32,4 +32,12 @@
 	top: $grid-unit-10;
 	z-index: 2;
 	background: $white;
+
+	// Prevents Scrollbar overlapping the close button when viewing revisions.
+	&[aria-label="Close revisions"] {
+		position: relative;
+		top: 0;
+		margin: 8px 0;
+		left: calc(100% - #{$grid-unit-50});
+	}
 }

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -12,35 +12,27 @@
 	.edit-site-layout.is-full-canvas & {
 		padding: $grid-unit-30 $grid-unit-30 0;
 	}
-}
 
-.edit-site-editor-canvas-container__section {
-	background: $white; // Fallback color, overridden by JavaScript.
-	border-radius: $radius-large;
-	bottom: 0;
-	left: 0;
-	overflow: hidden;
-	position: absolute;
-	right: 0;
-	top: 0;
-	transition: all 0.3s; // Match .block-editor-iframe__body transition.
-}
-
-.edit-site-editor-canvas-container__close-button {
-	position: absolute;
-	right: $grid-unit-10;
-	top: $grid-unit-10;
-	z-index: 2;
-	background: $white;
-}
-
-.edit-site-revisions {
-
-	// Prevents Scrollbar overlapping the close button when viewing revisions.
-	.edit-site-editor-canvas-container__close-button {
-		position: relative;
+	&__section {
+		background: $white; // Fallback color, overridden by JavaScript.
+		border-radius: $radius-large;
+		bottom: 0;
+		left: 0;
+		overflow: hidden;
+		position: absolute;
+		right: 0;
 		top: 0;
-		margin: 8px 0;
-		left: calc(100% - #{$grid-unit-50});
+		transition: all 0.3s; // Match .block-editor-iframe__body transition.
+	}
+
+	&__header {
+		display: flex;
+		align-items: center;
+		padding: $grid-unit-10 $grid-unit-10 $grid-unit-10 $grid-unit-20;
+		font-weight: 500;
+	}
+
+	&__close-button {
+		margin-left: auto;
 	}
 }

--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -32,9 +32,12 @@
 	top: $grid-unit-10;
 	z-index: 2;
 	background: $white;
+}
+
+.edit-site-revisions {
 
 	// Prevents Scrollbar overlapping the close button when viewing revisions.
-	&[aria-label="Close revisions"] {
+	.edit-site-editor-canvas-container__close-button {
 		position: relative;
 		top: 0;
 		margin: 8px 0;

--- a/packages/edit-site/src/components/revisions/index.js
+++ b/packages/edit-site/src/components/revisions/index.js
@@ -72,6 +72,7 @@ function Revisions( { userConfig, blocks } ) {
 			title={ __( 'Revisions' ) }
 			closeButtonLabel={ __( 'Close revisions' ) }
 			enableResizing
+			className="edit-site-revisions"
 		>
 			<Iframe
 				className="edit-site-revisions__iframe"

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -200,6 +200,7 @@ function StyleBook( {
 			onClose={ onClose }
 			enableResizing={ enableResizing }
 			closeButtonLabel={ showCloseButton ? __( 'Close' ) : null }
+			className="edit-site-style-book"
 		>
 			<div
 				className={ clsx( 'edit-site-style-book', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Add breathing-space for the `Close Button` for `Global Styles Revisions` view to prevent the `scrollbar` from overlapping on the `button`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/66435

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Sets the `position` as `relative` for the `Close Button` when viewing revisions
- Add `spacing` and `alignment` styles to match that of the `Style Book Close Button` view

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open "Revisions" from the "Styles" sidebar
2. Switch between "Revisions" and "Style Book" to see them lining up the exact same.
3. See if the close button is overlapping the scrollbar

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1163" alt="Screenshot 2024-10-25 at 2 11 59 PM" src="https://github.com/user-attachments/assets/056499ab-2765-4023-8fde-ad60caa48a7e"> | <img width="1158" alt="Screenshot 2024-10-25 at 2 11 34 PM" src="https://github.com/user-attachments/assets/9cff6aba-fd7a-4ecd-901b-0ac2931d1f78"> |

