### PR TITLE
Rich Text: Fix React Complier error for 'useEventListeners'

### DIFF
--- a/packages/rich-text/src/component/event-listeners/index.js
+++ b/packages/rich-text/src/component/event-listeners/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useRef, useLayoutEffect } from '@wordpress/element';
+import { useMemo, useRef, useInsertionEffect } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -25,9 +25,9 @@ const allEventListeners = [
 
 export function useEventListeners( props ) {
 	const propsRef = useRef( props );
-	useLayoutEffect( () => {
+	useInsertionEffect( () => {
 		propsRef.current = props;
-	}, [ props ] );
+	} );
 	const refEffects = useMemo(
 		() => allEventListeners.map( ( refEffect ) => refEffect( propsRef ) ),
 		[ propsRef ]

--- a/packages/rich-text/src/component/event-listeners/index.js
+++ b/packages/rich-text/src/component/event-listeners/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useRef } from '@wordpress/element';
+import { useMemo, useRef, useLayoutEffect } from '@wordpress/element';
 import { useRefEffect } from '@wordpress/compose';
 
 /**
@@ -25,7 +25,9 @@ const allEventListeners = [
 
 export function useEventListeners( props ) {
 	const propsRef = useRef( props );
-	propsRef.current = props;
+	useLayoutEffect( () => {
+		propsRef.current = props;
+	}, [ props ] );
 	const refEffects = useMemo(
 		() => allEventListeners.map( ( refEffect ) => refEffect( propsRef ) ),
 		[ propsRef ]


### PR DESCRIPTION
## What?
Part of #61788.
Similar to #66444.

PR fixes the React Compiler error for the `useEventListeners` hook.

```
Mutating a value returned from a function whose return value should not be mutated  react-compiler/react-compiler
```

## Why?
It's recommended to avoid reading/writing refs during the render.

## How?
Correctly implement the [latest ref pattern](https://www.epicreact.dev/the-latest-ref-pattern-in-react).

## Testing Instructions
None. Rich Text has extensive e2e test coverage; they should catch any regression.
