### PR TITLE
Fields: Fix React Compiler mutation errors

### DIFF
--- a/packages/fields/src/fields/slug/slug-edit.tsx
+++ b/packages/fields/src/fields/slug/slug-edit.tsx
@@ -38,15 +38,15 @@ const SlugEdit = ( {
 	const permalinkPrefix = prefix;
 	const permalinkSuffix = suffix;
 	const isEditable = PERMALINK_POSTNAME_REGEX.test( permalinkTemplate );
-	const originalSlug = useRef( slug );
-	const slugToDisplay = slug || originalSlug.current;
+	const originalSlugRef = useRef( slug );
+	const slugToDisplay = slug || originalSlugRef.current;
 	const permalink = isEditable
 		? `${ permalinkPrefix }${ slugToDisplay }${ permalinkSuffix }`
 		: safeDecodeURIComponent( data.link || '' );
 
 	useEffect( () => {
-		if ( slug && originalSlug.current === undefined ) {
-			originalSlug.current = slug;
+		if ( slug && originalSlugRef.current === undefined ) {
+			originalSlugRef.current = slug;
 		}
 	}, [ slug ] );
 
@@ -111,7 +111,7 @@ const SlugEdit = ( {
 						} }
 						onBlur={ () => {
 							if ( slug === '' ) {
-								onChangeControl( originalSlug.current );
+								onChangeControl( originalSlugRef.current );
 							}
 						} }
 						aria-describedby={ postUrlSlugDescriptionId }

--- a/packages/fields/src/fields/slug/slug-view.tsx
+++ b/packages/fields/src/fields/slug/slug-view.tsx
@@ -10,15 +10,15 @@ import type { BasePost } from '../../types';
 
 const SlugView = ( { item }: { item: BasePost } ) => {
 	const slug = item.slug;
-	const originalSlug = useRef( slug );
+	const originalSlugRef = useRef( slug );
 
 	useEffect( () => {
-		if ( slug && originalSlug.current === undefined ) {
-			originalSlug.current = slug;
+		if ( slug && originalSlugRef.current === undefined ) {
+			originalSlugRef.current = slug;
 		}
 	}, [ slug ] );
 
-	const slugToDisplay = slug || originalSlug.current;
+	const slugToDisplay = slug || originalSlugRef.current;
 
 	return `/${ slugToDisplay ?? '' }`;
 };


### PR DESCRIPTION
## What?
Resolves a few straightforward violations of the React Compiler anti-mutation rules.

## Why?
To resolve a few errors related to mutations in #61788.

## How?
We're renaming some refs, so their name ends in`Ref`. This is necessary for the `enableTreatRefLikeIdentifiersAsRefs` config flag of React Compiler to work well.

## Testing Instructions
Shouldn't be necessary. This is a code style change. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
