### PR TITLE
Preload: fix multiple regressions around global styles

### DIFF
--- a/backport-changelog/6.8/7661.md
+++ b/backport-changelog/6.8/7661.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7661
+
+* https://github.com/WordPress/gutenberg/pull/66468

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -10,13 +10,15 @@
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name || 'core/edit-post' === $context->name ) {
-		$paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet() . '?context=view';
+		$stylesheet = get_stylesheet();
+		$global_styles_path = '/wp/v2/global-styles/themes/' . $stylesheet;
+		$paths[] = $global_styles_path . '?context=view';
+		foreach ($paths as $key => $path) {
+			if ($path === $global_styles_path) {
+				unset($paths[$key]);
+			}
+		}
 	}
-	return array_diff(
-		$paths,
-		array(
-			'/wp/v2/global-styles/themes/' . get_stylesheet(),
-		)
-	);
+	return $paths;
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_8', 10, 2 );

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -10,12 +10,12 @@
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name || 'core/edit-post' === $context->name ) {
-		$stylesheet = get_stylesheet();
+		$stylesheet        	= get_stylesheet();
 		$global_styles_path = '/wp/v2/global-styles/themes/' . $stylesheet;
-		$paths[] = $global_styles_path . '?context=view';
-		foreach ($paths as $key => $path) {
-			if ($path === $global_styles_path) {
-				unset($paths[$key]);
+		$paths[]            = $global_styles_path . '?context=view';
+		foreach ( $paths as $key => $path ) {
+			if ( $path === $global_styles_path ) {
+				unset( $paths[ $key ] );
 			}
 		}
 	}

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * Preload theme and global styles paths to avoid flash of variation styles in
+ * post editor.
+ *
+ * @param array                   $paths REST API paths to preload.
+ * @param WP_Block_Editor_Context $context Current block editor context.
+ * @return array Filtered preload paths.
+ */
+function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
+	if ( 'core/edit-site' === $context->name || 'core/edit-post' === $context->name ) {
+        $paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet() . '?context=view';
+	}
+	return array_diff(
+        $paths,
+        array(
+            '/wp/v2/global-styles/themes/' . get_stylesheet(),
+        )
+    );
+}
+add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_8', 10, 2 );

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -10,13 +10,13 @@
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name || 'core/edit-post' === $context->name ) {
-        $paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet() . '?context=view';
+		$paths[] = '/wp/v2/global-styles/themes/' . get_stylesheet() . '?context=view';
 	}
 	return array_diff(
-        $paths,
-        array(
-            '/wp/v2/global-styles/themes/' . get_stylesheet(),
-        )
-    );
+		$paths,
+		array(
+			'/wp/v2/global-styles/themes/' . get_stylesheet(),
+		)
+	);
 }
 add_filter( 'block_editor_rest_api_preload_paths', 'gutenberg_block_editor_preload_paths_6_8', 10, 2 );

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -14,7 +14,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		$stylesheet       = get_stylesheet();
 		$global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 		$paths[]          = '/wp/v2/global-styles/themes/' . $stylesheet . '?context=view';
-		$paths[]          = '/wp/v2/global-styles/' . $global_styles_id . '?context=view';
+		$paths[]          = array( '/wp/v2/global-styles/' . $global_styles_id, 'OPTIONS' );
 		$excluded_paths[] = '/wp/v2/global-styles/themes/' . $stylesheet;
 		$excluded_paths[] = '/wp/v2/global-styles/' . $global_styles_id;
 	}

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -14,6 +14,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		$stylesheet       = get_stylesheet();
 		$global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
 		$paths[]          = '/wp/v2/global-styles/themes/' . $stylesheet . '?context=view';
+		$paths[]          = '/wp/v2/global-styles/themes/' . $stylesheet . '/variations?context=view';
 		$paths[]          = array( '/wp/v2/global-styles/' . $global_styles_id, 'OPTIONS' );
 		$excluded_paths[] = '/wp/v2/global-styles/themes/' . $stylesheet;
 		$excluded_paths[] = '/wp/v2/global-styles/' . $global_styles_id;

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -11,12 +11,12 @@
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	$excluded_paths = array();
 	if ( 'core/edit-site' === $context->name || 'core/edit-post' === $context->name ) {
-		$stylesheet         = get_stylesheet();
-		$global_styles_id   = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
-		$paths[]            = '/wp/v2/global-styles/themes/' . $stylesheet . '?context=view';
-		$paths[]            = '/wp/v2/global-styles/' . $global_styles_id . '?context=view';
-		$excluded_paths[]   = '/wp/v2/global-styles/themes/' . $stylesheet;
-		$excluded_paths[]   = '/wp/v2/global-styles/' . $global_styles_id;
+		$stylesheet       = get_stylesheet();
+		$global_styles_id = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+		$paths[]          = '/wp/v2/global-styles/themes/' . $stylesheet . '?context=view';
+		$paths[]          = '/wp/v2/global-styles/' . $global_styles_id . '?context=view';
+		$excluded_paths[] = '/wp/v2/global-styles/themes/' . $stylesheet;
+		$excluded_paths[] = '/wp/v2/global-styles/' . $global_styles_id;
 	}
 	foreach ( $paths as $key => $path ) {
 		if ( in_array( $path, $excluded_paths, true ) ) {

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -9,14 +9,18 @@
  * @return array Filtered preload paths.
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
+	$excluded_paths = array();
 	if ( 'core/edit-site' === $context->name || 'core/edit-post' === $context->name ) {
-		$stylesheet        	= get_stylesheet();
-		$global_styles_path = '/wp/v2/global-styles/themes/' . $stylesheet;
-		$paths[]            = $global_styles_path . '?context=view';
-		foreach ( $paths as $key => $path ) {
-			if ( $path === $global_styles_path ) {
-				unset( $paths[ $key ] );
-			}
+		$stylesheet         = get_stylesheet();
+		$global_styles_id   = WP_Theme_JSON_Resolver_Gutenberg::get_user_global_styles_post_id();
+		$paths[]            = '/wp/v2/global-styles/themes/' . $stylesheet . '?context=view';
+		$paths[]            = '/wp/v2/global-styles/' . $global_styles_id . '?context=view';
+		$excluded_paths[]   = '/wp/v2/global-styles/themes/' . $stylesheet;
+		$excluded_paths[]   = '/wp/v2/global-styles/' . $global_styles_id;
+	}
+	foreach ( $paths as $key => $path ) {
+		if ( in_array( $path, $excluded_paths, true ) ) {
+			unset( $paths[ $key ] );
 		}
 	}
 	return $paths;

--- a/lib/load.php
+++ b/lib/load.php
@@ -47,6 +47,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.7/rest-api.php';
 
 	// WordPress 6.8 compat.
+	require __DIR__ . '/compat/wordpress-6.8/preload.php';
 	require __DIR__ . '/compat/wordpress-6.8/remove-default-css.php';
 	require __DIR__ . '/compat/wordpress-6.8/block-comments.php';
 	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php';

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -644,6 +644,7 @@ export const __experimentalGetCurrentThemeBaseGlobalStyles =
 	() =>
 	async ( { resolveSelect, dispatch } ) => {
 		const currentTheme = await resolveSelect.getCurrentTheme();
+		// Please adjust the preloaded requests if this changes!
 		const themeGlobalStyles = await apiFetch( {
 			path: `/wp/v2/global-styles/themes/${ currentTheme.stylesheet }?context=view`,
 		} );
@@ -657,6 +658,7 @@ export const __experimentalGetCurrentThemeGlobalStylesVariations =
 	() =>
 	async ( { resolveSelect, dispatch } ) => {
 		const currentTheme = await resolveSelect.getCurrentTheme();
+		// Please adjust the preloaded requests if this changes!
 		const variations = await apiFetch( {
 			path: `/wp/v2/global-styles/themes/${ currentTheme.stylesheet }/variations?context=view`,
 		} );

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -66,11 +66,13 @@ function useGlobalStylesUserConfig() {
 			let record;
 
 			// Please adjust the preloaded requests if this changes!
-			const userCanEditGlobalStyles = canUser( 'update', {
-				kind: 'root',
-				name: 'globalStyles',
-				id: _globalStylesId,
-			} );
+			const userCanEditGlobalStyles = _globalStylesId
+				? canUser( 'update', {
+						kind: 'root',
+						name: 'globalStyles',
+						id: _globalStylesId,
+				  } )
+				: null;
 
 			if (
 				_globalStylesId &&

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -55,14 +55,30 @@ function useGlobalStylesUserConfig() {
 			const _globalStylesId =
 				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
 
+			// We want the global styles ID request to finish before triggering
+			// the OPTIONS request for user capabilities, otherwise it will
+			// fetch `/wp/v2/global-styles` instead of
+			// `/wp/v2/global-styles/{id}`!
+			if ( ! _globalStylesId ) {
+				return { isReady: false };
+			}
+
 			let record;
+
+			// Please adjust the preloaded requests if this changes!
 			const userCanEditGlobalStyles = canUser( 'update', {
 				kind: 'root',
 				name: 'globalStyles',
 				id: _globalStylesId,
 			} );
 
-			if ( _globalStylesId ) {
+			if (
+				_globalStylesId &&
+				// We want the OPTIONS request for user capabilities to finish
+				// before getting the records, otherwise we'll fetch both!
+				typeof userCanEditGlobalStyles === 'boolean'
+			) {
+				// Please adjust the preloaded requests if this changes!
 				if ( userCanEditGlobalStyles ) {
 					record = getEditedEntityRecord(
 						'root',

--- a/packages/editor/src/components/global-styles-provider/index.js
+++ b/packages/editor/src/components/global-styles-provider/index.js
@@ -55,16 +55,12 @@ function useGlobalStylesUserConfig() {
 			const _globalStylesId =
 				select( coreStore ).__experimentalGetCurrentGlobalStylesId();
 
+			let record;
+
 			// We want the global styles ID request to finish before triggering
 			// the OPTIONS request for user capabilities, otherwise it will
 			// fetch `/wp/v2/global-styles` instead of
 			// `/wp/v2/global-styles/{id}`!
-			if ( ! _globalStylesId ) {
-				return { isReady: false };
-			}
-
-			let record;
-
 			// Please adjust the preloaded requests if this changes!
 			const userCanEditGlobalStyles = _globalStylesId
 				? canUser( 'update', {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoids 5 blocking requests for Site Editor loading:

```
OPTIONS /wp/v2/global-styles (wrongly formatted request)
GET /wp/v2/global-styles/themes/twentytwentyfour?context=view (added view context in #65071, so cache miss)
OPTIONS /wp/v2/global-styles/12464 (not preloaded)
GET /wp/v2/global-styles/12464?context=view (should have never been fetched, user has edit caps)
GET /wp/v2/global-styles/themes/twentytwentyfour/variations?context=view (not preloaded)
```


There are multiple things going wrong after #65071 (cc @ramonjd):

* We're currently making TWO OPTIONS requests, one at `/wp/v2/global-styles` and one at `/wp/v2/global-styles/{id}`.
* No OPTIONS request is preloaded, even though the main request is.
* We are currently fetching global styles with BOTH `edit` and `view` context. This shouldn't be happening.
* USER Global Styles are currently preloaded, but only (1) with `edit` context and (2) WITHOUT any context, even though #65071 changed the request from no context at all to `view`.
* THEME Global Styles are no longer preloading at all because the request also changed from no context to `view`.
* This already happened before https://github.com/WordPress/gutenberg/pull/65071, but global styles variations are not preloaded.

To fix all the issues we should:

* Make sure the request that fetches the global styles ID finishes before continuing to check user capabilities with OPTIONS, otherwise we'll make two requests, one of which is useless.
* Preload the OPTIONS request.
* Make sure the OPTIONS request also finishes before continuing to fetch either the global styles in `view` or `edit` context. If we need `edit` for example, we shouldn't be fetching `view unnecessarily.
* We no longer need to preload the user global styles in view context for this reason.
* Add `view` context to the theme global styles path for preloading and remove the old path.
* Preload variations.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Optimise site editor loading.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check the network tab for these requests.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
