### PR TITLE
Navigation: Improve trigger for fallback navigation

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -43,9 +43,6 @@ function buildMenuLabel( title, id, status ) {
 	);
 }
 
-// Save a boolean to prevent us creating a fallback more than once per session.
-let hasCreatedFallback = false;
-
 export default function SidebarNavigationScreenNavigationMenus( { backPath } ) {
 	const {
 		records: navigationMenus,
@@ -61,13 +58,13 @@ export default function SidebarNavigationScreenNavigationMenus( { backPath } ) {
 		isResolvingNavigationMenus && ! hasResolvedNavigationMenus;
 
 	const { getNavigationFallbackId } = unlock( useSelect( coreStore ) );
+	const isCreatingNavigationFallback = useSelect(
+		( select ) =>
+			select( coreStore ).isResolving( 'getNavigationFallbackId' ),
+		[]
+	);
 
 	const firstNavigationMenu = navigationMenus?.[ 0 ];
-
-	// Save a boolean to prevent us creating a fallback more than once per session.
-	if ( firstNavigationMenu ) {
-		hasCreatedFallback = true;
-	}
 
 	// If there is no navigation menu found
 	// then trigger fallback algorithm to create one.
@@ -75,7 +72,8 @@ export default function SidebarNavigationScreenNavigationMenus( { backPath } ) {
 		! firstNavigationMenu &&
 		! isResolvingNavigationMenus &&
 		hasResolvedNavigationMenus &&
-		! hasCreatedFallback
+		// Ensure a fallback navigation is created only once
+		! isCreatingNavigationFallback
 	) {
 		getNavigationFallbackId();
 	}


### PR DESCRIPTION
## What?
Come up with an alternative solution for solving the problem #50321 intends to solve.

## Why?
#50321 uses an external flag for the component, which is against React's rules, and the React Compiler doesn't appreciate it (see #61788).

## How?
The goal of #50321 was to create fallback navigation only if there were no navigations at all, and create it only once for the session. 

This PR achieves it by checking if the request to create a fallback navigation is currently resolving. This simplifies the logic by avoiding an extra flag, and satisfies the React Compiler. 

## Testing Instructions
Same as in #50321.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None