### PR TITLE
Resolve "Edit palette" visual regression in Global Styles > Colors

### DIFF
--- a/packages/edit-site/src/components/global-styles/palette.js
+++ b/packages/edit-site/src/components/global-styles/palette.js
@@ -55,34 +55,32 @@ function Palette( { name } ) {
 		? '/colors/palette'
 		: '/blocks/' + encodeURIComponent( name ) + '/colors/palette';
 
+	const paletteButtonText =
+		colors.length > 0 ? __( 'Edit palette' ) : __( 'Add colors' );
+
 	return (
 		<VStack spacing={ 3 }>
 			<Subtitle level={ 3 }>{ __( 'Palette' ) }</Subtitle>
 			<ItemGroup isBordered isSeparated>
-				<NavigationButtonAsItem path={ screenPath }>
+				<NavigationButtonAsItem
+					path={ screenPath }
+					aria-label={ paletteButtonText }
+				>
 					<HStack direction="row">
-						{ colors.length > 0 ? (
-							<>
-								<ZStack isLayered={ false } offset={ -8 }>
-									{ colors
-										.slice( 0, 5 )
-										.map( ( { color }, index ) => (
-											<ColorIndicatorWrapper
-												key={ `${ color }-${ index }` }
-											>
-												<ColorIndicator
-													colorValue={ color }
-												/>
-											</ColorIndicatorWrapper>
-										) ) }
-								</ZStack>
-								<FlexItem isBlock>
-									{ __( 'Edit palette' ) }
-								</FlexItem>
-							</>
-						) : (
+						{ colors.length <= 0 && (
 							<FlexItem>{ __( 'Add colors' ) }</FlexItem>
 						) }
+						<ZStack isLayered={ false } offset={ -8 }>
+							{ colors
+								.slice( 0, 5 )
+								.map( ( { color }, index ) => (
+									<ColorIndicatorWrapper
+										key={ `${ color }-${ index }` }
+									>
+										<ColorIndicator colorValue={ color } />
+									</ColorIndicatorWrapper>
+								) ) }
+						</ZStack>
 						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 					</HStack>
 				</NavigationButtonAsItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A visual regression from https://github.com/WordPress/gutenberg/pull/65124. This is a non-standard pattern that does not scale wise, especially considering i18n. The previous state is an improvement. 

## Testing Instructions
1. Open Site Editor. 
2. Open Global Styles. 
3. Open Colors panel. 
4. See fix.

## Screenshots or screencast <!-- if applicable -->

### Before 
![CleanShot 2024-10-25 at 17 04 05](https://github.com/user-attachments/assets/654de5a0-645a-4e99-b65f-5a5c7b747291)

### After
![CleanShot 2024-10-25 at 17 01 27](https://github.com/user-attachments/assets/c05075e2-39d5-45dd-83fa-896e5442a356)
![CleanShot 2024-10-25 at 17 01 07](https://github.com/user-attachments/assets/47f95093-092a-4ac4-86bf-ae0d595d02c5)

