### PR TITLE
Editor: Multi-entity saving: Show correct count of entities to be saved

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -177,9 +177,9 @@ export function EntitiesSavedStatesExtensible( {
 									_n(
 										'There is <strong>%d site change</strong> waiting to be saved.',
 										'There are <strong>%d site changes</strong> waiting to be saved.',
-										sortedPartitionedSavables.length
+										dirtyEntityRecords.length
 									),
-									sortedPartitionedSavables.length
+									dirtyEntityRecords.length
 								),
 								{ strong: <strong /> }
 						  )


### PR DESCRIPTION
## What?

Fix the count of unsaved entities in the multi-entity saving UI:

<img width="941" alt="Screenshot 2024-10-25 at 16 25 06" src="https://github.com/user-attachments/assets/45ce8095-e1b3-4817-b710-f01cb6e1ef14">

The modal was incorrectly displaying the number of different *types* of entities to be saved. In the scenario above, it was incorrectly reporting **3** unsaved changed, because there were three types thereof (Site, Template, Template Part).

This result was inconsistent with the actual list of entities rendered underneath, as well as with the "Review _n_ changes" label on the left-hand sidebar.

For reference, the bug was introduced in #58706.

## How?

Read directly from the "source", i.e. the `dirtyEntityRecords` array available as component props. Disregard the value of `sortedPartitionedSavables`, which is a grouping of records obtained from `dirtyEntityRecords` and keyed by entity name.

## Testing Instructions
1. Open the site editor
2. Make changes to different key parts of the canvas (e.g. template content of the homepage, site title)
3. Without leaving the site editor, switch to another template (e.g. Templates > 404)
4. Make changes to that template
5. Press the "Review _n_ changes" button on the bottom-left corner to reveal the multi-entity saving flow
6. Confirm that the string "There are _n_ site changes waiting to be saved" displays the expected count