### PR TITLE
Create block: Update template to use new performance tools for blocks coming in 6.7

### DIFF
--- a/packages/create-block/lib/init-package-json.js
+++ b/packages/create-block/lib/init-package-json.js
@@ -47,6 +47,9 @@ module.exports = async ( {
 						build: isDynamicVariant
 							? 'wp-scripts build --webpack-copy-php'
 							: 'wp-scripts build',
+						postbuild: 'npm run build-blocks-manifest',
+						'build-blocks-manifest':
+							'wp-scripts build-blocks-manifest',
 						format: 'wp-scripts format',
 						'lint:css': 'wp-scripts lint-style',
 						'lint:js': 'wp-scripts lint-js',

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -48,7 +48,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 	if ( function_exists( 'wp_register_block_metadata_collection' ) ) {
 		// Register the block metadata.
 		wp_register_block_metadata_collection(
-			__DIR__ . '/build'
+			__DIR__ . '/build',
 			__DIR__ . '/build/blocks-manifest.php'
 		);
 	}

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -42,6 +42,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+
+	// Register the block metadata.
+	wp_register_block_metadata_collection(
+		__DIR__ . '/build'
+		__DIR__ . '/build/blocks-manifest.php'
+	);
+
+	// Register the block
 	register_block_type( __DIR__ . '/build' );
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -43,11 +43,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 
-	// Register the block metadata.
-	wp_register_block_metadata_collection(
-		__DIR__ . '/build'
-		__DIR__ . '/build/blocks-manifest.php'
-	);
+
+	// wp_register_block_metadata_collection was introduced in WP 6.7.
+	if ( function_exists( 'wp_register_block_metadata_collection' ) ) {
+		// Register the block metadata.
+		wp_register_block_metadata_collection(
+			__DIR__ . '/build'
+			__DIR__ . '/build/blocks-manifest.php'
+		);
+	}
 
 	// Register the block
 	register_block_type( __DIR__ . '/build' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds the new `wp_register_block_metadata_collection()` function and associated `npm` commands to the standard template for `create-block`.

I've wrapped the `wp_register_block_metadata_collection` in a `function_exists` check so this could be merged before 6.7. but it's probably better to merge after it's released

Closes #66484

## Why?
Performance improvements are a good thing and by adding this to the template to new scaffolded blocks, extenders will get the benefits for all new blocks.


## Testing Instructions
1. Checkout this branch
2. cd into `packages/create-block`
3. Run `node index.js new-block`
4. Confirm that a plugin is created with the new function in the `new-block.php` file
5. Confirm that there is a new `build-blocks-manifest` command  and a `postbuild` command that references it.
