### PR TITLE
Link UI: build static page check into search API

### DIFF
--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-post-search-handler.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-post-search-handler.php
@@ -5,11 +5,11 @@ add_filter( 'wp_rest_search_handlers', 'gutenberg_rest_post_search_handler' );
 class Gutenberg_REST_Post_Search_Handler extends WP_REST_Post_Search_Handler {
 	public function prepare_item( $id, $fields ) {
 		$data = parent::prepare_item( $id, $fields );
-		if ($id === (int) get_option( 'page_on_front' )) {
-			$data[ 'is_front_page' ] = true;
+		if ( (int) get_option( 'page_on_front' ) === $id ) {
+			$data['is_front_page'] = true;
 		}
-		if ($id === (int) get_option( 'page_for_posts' )) {
-			$data[ 'is_blog_home' ] = true;
+		if ( (int) get_option( 'page_for_posts' ) === $id ) {
+			$data['is_blog_home'] = true;
 		}
 		return $data;
 	}

--- a/lib/compat/wordpress-6.8/wp-rest-post-search-handler.php
+++ b/lib/compat/wordpress-6.8/wp-rest-post-search-handler.php
@@ -1,0 +1,21 @@
+<?php
+
+add_filter( 'wp_rest_search_handlers', 'gutenberg_rest_post_search_handler' );
+
+class Gutenberg_REST_Post_Search_Handler extends WP_REST_Post_Search_Handler {
+    public function prepare_item( $id, $fields ) {
+        $data = parent::prepare_item( $id, $fields );
+        if ($id === (int) get_option( 'page_on_front' )) {
+            $data['is_front_page'] = true;
+        }
+        if ($id === (int) get_option( 'page_for_posts' )) {
+            $data['is_blog_home'] = true;
+        }
+        return $data;
+    }
+}
+
+function gutenberg_rest_post_search_handler( $handlers ) {
+	$handlers[] = new Gutenberg_REST_Post_Search_Handler();
+	return $handlers;
+}

--- a/lib/compat/wordpress-6.8/wp-rest-post-search-handler.php
+++ b/lib/compat/wordpress-6.8/wp-rest-post-search-handler.php
@@ -3,16 +3,16 @@
 add_filter( 'wp_rest_search_handlers', 'gutenberg_rest_post_search_handler' );
 
 class Gutenberg_REST_Post_Search_Handler extends WP_REST_Post_Search_Handler {
-    public function prepare_item( $id, $fields ) {
-        $data = parent::prepare_item( $id, $fields );
-        if ($id === (int) get_option( 'page_on_front' )) {
-            $data['is_front_page'] = true;
-        }
-        if ($id === (int) get_option( 'page_for_posts' )) {
-            $data['is_blog_home'] = true;
-        }
-        return $data;
-    }
+	public function prepare_item( $id, $fields ) {
+		$data = parent::prepare_item( $id, $fields );
+		if ($id === (int) get_option( 'page_on_front' )) {
+			$data[ 'is_front_page' ] = true;
+		}
+		if ($id === (int) get_option( 'page_for_posts' )) {
+			$data[ 'is_blog_home' ] = true;
+		}
+		return $data;
+	}
 }
 
 function gutenberg_rest_post_search_handler( $handlers ) {

--- a/lib/load.php
+++ b/lib/load.php
@@ -50,7 +50,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/remove-default-css.php';
 	require __DIR__ . '/compat/wordpress-6.8/block-comments.php';
 	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php';
-	require __DIR__ . '/compat/wordpress-6.8/wp-rest-post-search-handler.php';
+	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-post-search-handler.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/lib/load.php
+++ b/lib/load.php
@@ -50,6 +50,7 @@ if ( class_exists( 'WP_REST_Controller' ) ) {
 	require __DIR__ . '/compat/wordpress-6.8/remove-default-css.php';
 	require __DIR__ . '/compat/wordpress-6.8/block-comments.php';
 	require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php';
+	require __DIR__ . '/compat/wordpress-6.8/wp-rest-post-search-handler.php';
 
 	// Plugin specific code.
 	require_once __DIR__ . '/class-wp-rest-global-styles-controller-gutenberg.php';

--- a/packages/block-editor/src/components/link-control/use-search-handler.js
+++ b/packages/block-editor/src/components/link-control/use-search-handler.js
@@ -51,26 +51,11 @@ const handleEntitySearch = async (
 	val,
 	suggestionsQuery,
 	fetchSearchSuggestions,
-	withCreateSuggestion,
-	pageOnFront,
-	pageForPosts
+	withCreateSuggestion
 ) => {
 	const { isInitialSuggestions } = suggestionsQuery;
 
 	const results = await fetchSearchSuggestions( val, suggestionsQuery );
-
-	// Identify front page and update type to match.
-	results.map( ( result ) => {
-		if ( Number( result.id ) === pageOnFront ) {
-			result.isFrontPage = true;
-			return result;
-		} else if ( Number( result.id ) === pageForPosts ) {
-			result.isBlogHome = true;
-			return result;
-		}
-
-		return result;
-	} );
 
 	// If displaying initial suggestions just return plain results.
 	if ( isInitialSuggestions ) {
@@ -108,19 +93,10 @@ export default function useSearchHandler(
 	allowDirectEntry,
 	withCreateSuggestion
 ) {
-	const { fetchSearchSuggestions, pageOnFront, pageForPosts } = useSelect(
-		( select ) => {
-			const { getSettings } = select( blockEditorStore );
-
-			return {
-				pageOnFront: getSettings().pageOnFront,
-				pageForPosts: getSettings().pageForPosts,
-				fetchSearchSuggestions:
-					getSettings().__experimentalFetchLinkSuggestions,
-			};
-		},
-		[]
-	);
+	const fetchSearchSuggestions = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return getSettings().__experimentalFetchLinkSuggestions;
+	}, [] );
 
 	const directEntryHandler = allowDirectEntry
 		? handleDirectEntry
@@ -134,16 +110,12 @@ export default function useSearchHandler(
 						val,
 						{ ...suggestionsQuery, isInitialSuggestions },
 						fetchSearchSuggestions,
-						withCreateSuggestion,
-						pageOnFront,
-						pageForPosts
+						withCreateSuggestion
 				  );
 		},
 		[
 			directEntryHandler,
 			fetchSearchSuggestions,
-			pageOnFront,
-			pageForPosts,
 			suggestionsQuery,
 			withCreateSuggestion,
 		]

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -121,8 +121,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		hiddenBlockTypes,
 		canUseUnfilteredHTML,
 		userCanCreatePages,
-		pageOnFront,
-		pageForPosts,
 		userPatternCategories,
 		restBlockPatternCategories,
 		sectionRootClientId,
@@ -131,7 +129,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			const {
 				canUser,
 				getRawEntityRecord,
-				getEntityRecord,
 				getUserPatternCategories,
 				getBlockPatternCategories,
 			} = select( coreStore );
@@ -139,12 +136,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			const { getBlockTypes } = select( blocksStore );
 			const { getBlocksByName, getBlockAttributes } =
 				select( blockEditorStore );
-			const siteSettings = canUser( 'read', {
-				kind: 'root',
-				name: 'site',
-			} )
-				? getEntityRecord( 'root', 'site' )
-				: undefined;
 
 			function getSectionRootBlock() {
 				if ( renderingMode === 'template-locked' ) {
@@ -185,8 +176,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					kind: 'postType',
 					name: 'page',
 				} ),
-				pageOnFront: siteSettings?.page_on_front,
-				pageForPosts: siteSettings?.page_for_posts,
 				userPatternCategories: getUserPatternCategories(),
 				restBlockPatternCategories: getBlockPatternCategories(),
 				sectionRootClientId: getSectionRootBlock(),
@@ -321,8 +310,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 			// Check these two properties: they were not present in the site editor.
 			__experimentalCreatePageEntity: createPageEntity,
 			__experimentalUserCanCreatePages: userCanCreatePages,
-			pageOnFront,
-			pageForPosts,
 			__experimentalPreferPatternsOnRoot: postType === 'wp_template',
 			templateLock:
 				postType === 'wp_navigation' ? 'insert' : settings.templateLock,
@@ -352,8 +339,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		undo,
 		createPageEntity,
 		userCanCreatePages,
-		pageOnFront,
-		pageForPosts,
 		postType,
 		setIsInserterOpened,
 		sectionRootClientId,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Rather than the block editor settings needing to be aware of "page on front" etc., it should be build into the search API.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Separation of concerns, avoid loading site settings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The `search` endpoint of the REST API should be adjusted to include whether a page is the front or blog page, to serve our UI needs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Change the front page via the site "reading" settings. Create a link and search for the page.

<img width="486" alt="Screenshot 2024-10-25 at 20 14 59" src="https://github.com/user-attachments/assets/91683967-5f86-415b-9949-89fcc8f38175">


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
