### PR TITLE
Block Editor: Fix React Compiler error for Duotone

### DIFF
--- a/packages/block-editor/src/hooks/duotone.js
+++ b/packages/block-editor/src/hooks/duotone.js
@@ -302,12 +302,12 @@ function useDuotoneStyles( {
 			// `inline-block` is used instead of `none` to ensure that scroll
 			// position is not affected, as `none` results in the editor
 			// scrolling to the top of the block.
-			blockElement.style.display = 'inline-block';
+			blockElement.style.setProperty( 'display', 'inline-block' );
 			// Simply accessing el.offsetHeight flushes layout and style changes
 			// in WebKit without having to wait for setTimeout.
 			// eslint-disable-next-line no-unused-expressions
 			blockElement.offsetHeight;
-			blockElement.style.display = display;
+			blockElement.style.setProperty( 'display', display );
 		}
 		// `colors` must be a dependency so this effect runs when the colors
 		// change in Safari.


### PR DESCRIPTION
## What?
Part of #61788.

PR fixes React Compiler errors for the `useDuotoneStyles` hook using `setProperty` instead of the shorthand method.

## Testing Instructions
1. Open a post or page.
2. Confirm that Duotone works as before in Chrome and Safari

### Testing Instructions for Keyboard
Same.
