### PR TITLE
BlockHTML: Use fallback for initial value instead of state sync

### DIFF
--- a/packages/block-editor/src/components/block-list/block-html.js
+++ b/packages/block-editor/src/components/block-list/block-html.js
@@ -6,7 +6,7 @@ import TextareaAutosize from 'react-autosize-textarea';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	getBlockAttributes,
@@ -21,7 +21,7 @@ import {
  */
 import { store as blockEditorStore } from '../../store';
 
-function BlockHTML( { clientId } ) {
+export default function BlockHTML( { clientId } ) {
 	const [ html, setHtml ] = useState( '' );
 	const block = useSelect(
 		( select ) => select( blockEditorStore ).getBlock( clientId ),
@@ -41,7 +41,7 @@ function BlockHTML( { clientId } ) {
 			block.attributes
 		);
 
-		// If html is empty  we reset the block to the default HTML and mark it as valid to avoid triggering an error
+		// If html is empty we reset the block to the default HTML and mark it as valid to avoid triggering an error
 		const content = html ? html : getSaveContent( blockType, attributes );
 		const [ isValid ] = html
 			? validateBlock( {
@@ -63,18 +63,12 @@ function BlockHTML( { clientId } ) {
 		}
 	};
 
-	useEffect( () => {
-		setHtml( getBlockContent( block ) );
-	}, [ block ] );
-
 	return (
 		<TextareaAutosize
 			className="block-editor-block-list__block-html-textarea"
-			value={ html }
+			value={ html || getBlockContent( block ) }
 			onBlur={ onChange }
 			onChange={ ( event ) => setHtml( event.target.value ) }
 		/>
 	);
 }
-
-export default BlockHTML;


### PR DESCRIPTION
## What?
PR updates `BlockHTML` and removes initial value sync using an effect favoring fallback value.

## Why?
A micro-optimization for the component.

## Testing Instructions
1. Open a post or page.
2. Instead, a block and edit it as HTML.
3. Confirm that the initial value is rendered as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-10-26 at 03 23 54](https://github.com/user-attachments/assets/f4447e5a-e822-412e-a48e-d949ec476fab)
