### PR TITLE
Fix extraneous scrollbar in device previews

### DIFF
--- a/packages/block-editor/src/components/iframe/style.scss
+++ b/packages/block-editor/src/components/iframe/style.scss
@@ -1,7 +1,6 @@
 .block-editor-iframe__container {
 	width: 100%;
 	height: 100%;
-	overflow-x: hidden;
 }
 
 .block-editor-iframe__scale-container {


### PR DESCRIPTION
## What?
A style revision to fix #66156

## Why?
We don’t need a third scrolling area.

## How?
Removes `overflow-x: hidden;` from `Iframe`’s `__container` element. This prevents a BFC being formed because `overflow-y` implicitly becomes `auto`. That was causing the element to contain the vertical margins that are added to the iframe in device previews. Those margins plus the `100%` height of the child seems to be the what creates the overflow.

## More notes
Changing the `overflow-x: hidden` to `overflow: hidden` also seems to work but also seems unnecessary. The `overflow-x: hidden` rule originated in #61424 and perhaps was necessary then yet now it seems to have no purpose.

## Testing Instructions

General tip: make sure your OS is set to always show scrollbars as it makes these types of issues easier to spot.

### Device Previews and zoom out
1. Go to the Post or Site editor
2. Change to either the Tablet or Mobile device preview
3. Vertically shorten your browser’s window so that the device preview overflows if doesn’t
4. Verify there is not three scrolling areas
5. Verify that when scrolled to the bottom the margin below the device preview is present
6. Zoom out 
7. Try various things and verify you can’t produce any extraneous scrollbars around the canvas

### No regression of #65977 
1- Run storybook locally npm run storybook:dev
2- Open the playground box story
3- Notice that the height of the canvas is set to 500px, there's no extra border for the iframe and that the width of the canvas is 100%

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/52a1ad06-fa0f-4ab5-98f3-f98c23f636e3

