### PR TITLE
Components: Fix React Compiler error for 'useAutocomplete'

### DIFF
--- a/packages/components/src/autocomplete/index.tsx
+++ b/packages/components/src/autocomplete/index.tsx
@@ -97,7 +97,7 @@ export function useAutocomplete( {
 		( ( props: AutocompleterUIProps ) => JSX.Element | null ) | null
 	>( null );
 
-	const backspacing = useRef( false );
+	const backspacingRef = useRef( false );
 
 	function insertCompletion( replacement: React.ReactNode ) {
 		if ( autocompleter === null ) {
@@ -177,7 +177,7 @@ export function useAutocomplete( {
 	}
 
 	function handleKeyDown( event: KeyboardEvent ) {
-		backspacing.current = event.key === 'Backspace';
+		backspacingRef.current = event.key === 'Backspace';
 
 		if ( ! autocompleter ) {
 			return;
@@ -323,7 +323,7 @@ export function useAutocomplete( {
 		// Ex: "Some text @marcelo sekkkk" <--- "kkkk" caused a mismatch, but
 		// if the user presses backspace here, it will show the completion popup again.
 		const matchingWhileBackspacing =
-			backspacing.current && wordsFromTrigger.length <= 3;
+			backspacingRef.current && wordsFromTrigger.length <= 3;
 
 		if ( mismatch && ! ( matchingWhileBackspacing || hasOneTriggerWord ) ) {
 			if ( autocompleter ) {


### PR DESCRIPTION
## What?
Part of #61788.
Similar to #66464.

Resolves anti-mutation React Compiler error for the `useAutocomplete` hook.

## Why?
We're renaming some refs, so their name ends in`Ref`. This is necessary for the `enableTreatRefLikeIdentifiersAsRefs` config flag of the React Compiler to work well.

## Testing Instructions
It shouldn't be necessary. This is a code style change.
