### PR TITLE
Components: Fix React Compiler error for 'useScrollRectIntoView'

### DIFF
--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -49,9 +49,14 @@ function useScrollRectIntoView(
 		const rightOverflow = childRightEdge + margin - parentRightEdge;
 		const leftOverflow = parentScroll - ( childLeft - margin );
 		if ( leftOverflow > 0 ) {
-			parent.scroll( { left: parentScroll - leftOverflow } );
+			/**
+			 * The optional chaining is used here to avoid unit test failures.
+			 * It can be removed when JSDOM supports `Element` scroll methods.
+			 * See: https://github.com/WordPress/gutenberg/pull/66498#issuecomment-2441146096
+			 */
+			parent.scroll?.( { left: parentScroll - leftOverflow } );
 		} else if ( rightOverflow > 0 ) {
-			parent.scroll( { left: parentScroll + rightOverflow } );
+			parent.scroll?.( { left: parentScroll + rightOverflow } );
 		}
 	}, [ margin, parent, rect ] );
 }

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -48,15 +48,21 @@ function useScrollRectIntoView(
 		const childRightEdge = childLeft + childWidth;
 		const rightOverflow = childRightEdge + margin - parentRightEdge;
 		const leftOverflow = parentScroll - ( childLeft - margin );
+
+		let scrollLeft = null;
 		if ( leftOverflow > 0 ) {
+			scrollLeft = parentScroll - leftOverflow;
+		} else if ( rightOverflow > 0 ) {
+			scrollLeft = parentScroll + rightOverflow;
+		}
+
+		if ( scrollLeft !== null ) {
 			/**
 			 * The optional chaining is used here to avoid unit test failures.
 			 * It can be removed when JSDOM supports `Element` scroll methods.
 			 * See: https://github.com/WordPress/gutenberg/pull/66498#issuecomment-2441146096
 			 */
-			parent.scroll?.( { left: parentScroll - leftOverflow } );
-		} else if ( rightOverflow > 0 ) {
-			parent.scroll?.( { left: parentScroll + rightOverflow } );
+			parent.scroll?.( { left: scrollLeft } );
 		}
 	}, [ margin, parent, rect ] );
 }

--- a/packages/components/src/tabs/tablist.tsx
+++ b/packages/components/src/tabs/tablist.tsx
@@ -49,9 +49,9 @@ function useScrollRectIntoView(
 		const rightOverflow = childRightEdge + margin - parentRightEdge;
 		const leftOverflow = parentScroll - ( childLeft - margin );
 		if ( leftOverflow > 0 ) {
-			parent.scrollLeft = parentScroll - leftOverflow;
+			parent.scroll( { left: parentScroll - leftOverflow } );
 		} else if ( rightOverflow > 0 ) {
-			parent.scrollLeft = parentScroll + rightOverflow;
+			parent.scroll( { left: parentScroll + rightOverflow } );
 		}
 	}, [ margin, parent, rect ] );
 }


### PR DESCRIPTION
## What?
Part of #61788.
Similar to #66492.

PR fixes React Compiler errors for the `useScrollRectIntoView` hook using [`Element.scroll`](https://developer.mozilla.org/en-US/docs/Web/API/Element/scroll) instead of the shorthand method.


## Testing Instructions
Smoke test Tabs components in Storybook and editors.
