### PR TITLE
BaseControl: Auto-generate readme

### DIFF
--- a/bin/api-docs/gen-components-docs/get-subcomponent-descriptions.mjs
+++ b/bin/api-docs/gen-components-docs/get-subcomponent-descriptions.mjs
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import fs from 'node:fs/promises';
+import babel from '@babel/core';
+import { parse as commentParser } from 'comment-parser';
+
+/**
+ * Try to get subcomponent descriptions from the main component Object.assign() call.
+ */
+export async function getDescriptionsForSubcomponents(
+	filePath,
+	mainComponentName
+) {
+	const fileContent = await fs.readFile( filePath, 'utf8' );
+	const parsedFile = babel.parse( fileContent, {
+		filename: filePath,
+	} );
+	const mainComponent = parsedFile.program.body
+		.filter( ( node ) => node.type === 'ExportNamedDeclaration' )
+		.flatMap( ( node ) => node.declaration?.declarations )
+		.find( ( node ) => node?.id.name === mainComponentName );
+
+	if (
+		! (
+			// If the main component export has `Object.assign( ... )`
+			(
+				mainComponent?.init?.type === 'CallExpression' &&
+				mainComponent?.init?.callee?.object?.name === 'Object' &&
+				mainComponent?.init?.callee?.property?.name === 'assign'
+			)
+		)
+	) {
+		return;
+	}
+
+	const properties = mainComponent?.init?.arguments[ 1 ]?.properties.map(
+		( node ) => [
+			node.key.name,
+			commentParser( `/*${ node.leadingComments[ 0 ].value }*/`, {
+				spacing: 'preserve',
+			} )?.[ 0 ]?.description,
+		]
+	);
+	return Object.fromEntries( properties );
+}

--- a/bin/api-docs/gen-components-docs/get-subcomponent-descriptions.mjs
+++ b/bin/api-docs/gen-components-docs/get-subcomponent-descriptions.mjs
@@ -37,7 +37,7 @@ export async function getDescriptionsForSubcomponents(
 	const properties = mainComponent?.init?.arguments[ 1 ]?.properties.map(
 		( node ) => [
 			node.key.name,
-			commentParser( `/*${ node.leadingComments[ 0 ].value }*/`, {
+			commentParser( `/*${ node.leadingComments?.[ 0 ].value }*/`, {
 				spacing: 'preserve',
 			} )?.[ 0 ]?.description,
 		]

--- a/bin/api-docs/gen-components-docs/index.mjs
+++ b/bin/api-docs/gen-components-docs/index.mjs
@@ -10,6 +10,7 @@ import path from 'path';
  * Internal dependencies
  */
 import { generateMarkdownDocs } from './markdown/index.mjs';
+import { getDescriptionsForSubcomponents } from './get-subcomponent-descriptions.mjs';
 
 const MANIFEST_GLOB = 'packages/components/src/**/docs-manifest.json';
 
@@ -79,8 +80,10 @@ await Promise.all(
 			displayName: manifest.displayName,
 		} );
 
-		const subcomponentTypeDocs = manifest.subcomponents?.map(
-			( subcomponent ) => {
+		let subcomponentDescriptions;
+
+		const subcomponentTypeDocs = await Promise.all(
+			manifest.subcomponents?.map( async ( subcomponent ) => {
 				const docs = getTypeDocsForComponent( {
 					manifestPath,
 					componentFilePath: subcomponent.filePath,
@@ -91,10 +94,29 @@ await Promise.all(
 					docs.displayName = subcomponent.preferredDisplayName;
 				}
 
+				if ( ! subcomponent.description ) {
+					subcomponentDescriptions ??=
+						getDescriptionsForSubcomponents(
+							path.resolve(
+								path.dirname( manifestPath ),
+								subcomponent.filePath
+							),
+							manifest.displayName
+						);
+
+					docs.description = ( await subcomponentDescriptions )?.[
+						subcomponent.displayName
+					];
+				}
+
 				return docs;
-			}
+			} ) ?? []
 		);
-		const docs = generateMarkdownDocs( { typeDocs, subcomponentTypeDocs } );
+
+		const docs = generateMarkdownDocs( {
+			typeDocs,
+			subcomponentTypeDocs,
+		} );
 		const outputFile = path.resolve(
 			path.dirname( manifestPath ),
 			'./README.md'

--- a/bin/api-docs/gen-components-docs/index.mjs
+++ b/bin/api-docs/gen-components-docs/index.mjs
@@ -99,7 +99,7 @@ await Promise.all(
 						getDescriptionsForSubcomponents(
 							path.resolve(
 								path.dirname( manifestPath ),
-								subcomponent.filePath
+								manifest.filePath
 							),
 							manifest.displayName
 						);

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -1,8 +1,10 @@
 # BaseControl
 
-`BaseControl` is a component used to generate labels and help text for components handling user inputs.
+<!-- This file is generated automatically and cannot be edited directly. Make edits via TypeScript types and TSDocs. -->
 
-## Usage
+<p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-basecontrol--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>
+
+`BaseControl` is a component used to generate labels and help text for components handling user inputs.
 
 ```jsx
 import { BaseControl, useBaseControlProps } from '@wordpress/components';
@@ -23,70 +25,80 @@ const MyCustomTextareaControl = ({ children, ...baseProps }) => (
 	);
 );
 ```
-
 ## Props
 
-The component accepts the following props:
-
-### id
-
-The HTML `id` of the control element (passed in as a child to `BaseControl`) to which labels and help text are being generated. This is necessary to accessibly associate the label with that element.
-
-The recommended way is to use the `useBaseControlProps` hook, which takes care of generating a unique `id` for you. Otherwise, if you choose to pass an explicit `id` to this prop, you are responsible for ensuring the uniqueness of the `id`.
-
--   Type: `String`
--   Required: No
-
-### label
-
-If this property is added, a label will be generated using label property as the content.
-
--   Type: `String`
--   Required: No
-
-### hideLabelFromVision
-
-If true, the label will only be visible to screen readers.
-
--   Type: `Boolean`
--   Required: No
-
-### help
-
-Additional description for the control. Only use for meaningful description or instructions for the control. An element containing the description will be programmatically associated to the BaseControl by the means of an `aria-describedby` attribute.
-
--   Type: `ReactNode`
--   Required: No
-
-### className
-
-Any other classes to add to the wrapper div.
-
--   Type: `String`
--   Required: No
-
-### children
-
-The content to be displayed within the BaseControl.
-
--   Type: `Element`
--   Required: Yes
-
-### __nextHasNoMarginBottom
+### `__nextHasNoMarginBottom`
 
 Start opting into the new margin-free styles that will become the default in a future version.
 
--   Type: `Boolean`
--   Required: No
--   Default: `false`
+ - Type: `boolean`
+ - Required: No
+ - Default: `false`
 
-## BaseControl.VisualLabel
+### `as`
+
+The HTML element or React component to render the component as.
+
+ - Type: `"symbol" | "object" | "label" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | "b" | "base" | "bdi" | "bdo" | "big" | "blockquote" | "body" | "br" | "button" | ... 516 more ... | ("view" & FunctionComponent<...>)`
+ - Required: No
+
+### `className`
+
+
+ - Type: `string`
+ - Required: No
+
+### `children`
+
+The content to be displayed within the `BaseControl`.
+
+ - Type: `ReactNode`
+ - Required: Yes
+
+### `help`
+
+Additional description for the control.
+
+Only use for meaningful description or instructions for the control. An element containing the description will be programmatically associated to the BaseControl by the means of an `aria-describedby` attribute.
+
+ - Type: `ReactNode`
+ - Required: No
+
+### `hideLabelFromVision`
+
+If true, the label will only be visible to screen readers.
+
+ - Type: `boolean`
+ - Required: No
+ - Default: `false`
+
+### `id`
+
+The HTML `id` of the control element (passed in as a child to `BaseControl`) to which labels and help text are being generated.
+This is necessary to accessibly associate the label with that element.
+
+The recommended way is to use the `useBaseControlProps` hook, which takes care of generating a unique `id` for you.
+Otherwise, if you choose to pass an explicit `id` to this prop, you are responsible for ensuring the uniqueness of the `id`.
+
+ - Type: `string`
+ - Required: No
+
+### `label`
+
+If this property is added, a label will be generated using label property as the content.
+
+ - Type: `ReactNode`
+ - Required: No
+
+## Subcomponents
+
+### BaseControl.VisualLabel
 
 `BaseControl.VisualLabel` is used to render a purely visual label inside a `BaseControl` component.
 
-It should only be used in cases where the children being rendered inside BaseControl are already accessibly labeled, e.g., a button, but we want an additional visual label for that section equivalent to the labels `BaseControl` would otherwise use if the `label` prop was passed.
-
-## Usage
+It should only be used in cases where the children being rendered inside `BaseControl` are already accessibly labeled,
+e.g., a button, but we want an additional visual label for that section equivalent to the labels `BaseControl` would
+otherwise use if the `label` prop was passed.
 
 ```jsx
 import { BaseControl } from '@wordpress/components';
@@ -101,19 +113,18 @@ const MyBaseControl = () => (
 	</BaseControl>
 );
 ```
+#### Props
 
-### Props
+##### `as`
 
-#### className
+The HTML element or React component to render the component as.
 
-Any other classes to add to the wrapper div.
+ - Type: `"symbol" | "object" | "label" | "a" | "abbr" | "address" | "area" | "article" | "aside" | "audio" | ...`
+ - Required: No
 
--   Type: `String`
--   Required: No
-
-#### children
+##### `children`
 
 The content to be displayed within the `BaseControl.VisualLabel`.
 
--   Type: `Element`
--   Required: Yes
+ - Type: `ReactNode`
+ - Required: Yes

--- a/packages/components/src/base-control/docs-manifest.json
+++ b/packages/components/src/base-control/docs-manifest.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "../../schemas/docs-manifest.json",
+	"displayName": "BaseControl",
+	"filePath": "./index.tsx",
+	"subcomponents": [
+		{
+			"displayName": "VisualLabel",
+			"preferredDisplayName": "BaseControl.VisualLabel",
+			"filePath": "./index.tsx"
+		}
+	]
+}

--- a/packages/components/src/base-control/stories/index.story.tsx
+++ b/packages/components/src/base-control/stories/index.story.tsx
@@ -12,6 +12,10 @@ import Button from '../../button';
 const meta: Meta< typeof BaseControl > = {
 	title: 'Components/BaseControl',
 	component: BaseControl,
+	subcomponents: {
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		'BaseControl.VisualLabel': BaseControl.VisualLabel,
+	},
 	argTypes: {
 		children: { control: { type: null } },
 		help: { control: { type: 'text' } },

--- a/packages/components/src/base-control/types.ts
+++ b/packages/components/src/base-control/types.ts
@@ -49,5 +49,8 @@ export type BaseControlProps = {
 };
 
 export type BaseControlVisualLabelProps = {
+	/**
+	 * The content to be displayed within the `BaseControl.VisualLabel`.
+	 */
 	children: ReactNode;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Switch the README for BaseControl to an auto-generated one (see also #66035).

## How?

To extract subcomponent descriptions from the [main component's `Object.assign`](https://github.com/WordPress/gutenberg/blob/76a5ba19f87a8391e8a1365dcd9e1318d73e1458/packages/components/src/base-control/index.tsx#L143-L165), we need some custom parsing with Babel because `react-docgen-typescript` does not pick this up.

This is somewhat unfortunate because:

1. The subcomponent description does need to be inside the `Object.assign` for the IDE (at least in VS Code) to pick it up.
2. Storybook currently doesn't display the subcomponent descriptions anywhere, but if they start to do so in a future version, it may not be able to pick up our descriptions.

But... it's fine for now.

## Testing Instructions

1. Verify the changes to the Storybook for BaseControl.
2. `npm run docs:components` to verify the changes to the README.  
