### PR TITLE
Fix: Text overflow in Patterns filter

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -158,7 +158,7 @@ export function PatternsFilter( {
 								value={ patternSyncFilter }
 							/>
 						</MenuGroup>
-						<div className="block-editor-tool-selector__help">
+						<div className="block-editor-inserter__patterns-filter-help">
 							{ createInterpolateElement(
 								__(
 									'Patterns are available from the <Link>WordPress.org Pattern Directory</Link>, bundled in the active theme, or created by users on this site. Only patterns created on this site can be synced.'

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -266,6 +266,13 @@ $block-inserter-tabs-height: 44px;
 	margin-top: $grid-unit-30;
 }
 
+.block-editor-inserter__patterns-filter-help {
+	padding: $grid-unit-20;
+	border-top: $border-width solid $gray-300;
+	color: $gray-700;
+	min-width: 280px;
+}
+
 .block-editor-inserter__media-list,
 .block-editor-block-patterns-list {
 	overflow-y: auto;


### PR DESCRIPTION
Related to #65561

## What?

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/88a5adb2-6be2-4979-93d5-03759136aada) | ![image](https://github.com/user-attachments/assets/dc265e2c-a6a9-494c-b168-95c8826beb14)| 

## Why?

#65561 applies [zero padding when there is a MenuGroup in the dropdown](https://github.com/WordPress/gutenberg/pull/65561/files#diff-e904f9d4e362f2cf75edd55962d00ee6171b8ea936297e3f3c199a03d8106051R9-R10), but the text in the patterns filter has a negative margin to counteract the padding, causing overflow.

## How?

First of all, the `.block-editor-tool-selector__help` selector doesn't seem right because it's for the text in the Tools dropdown:

![image](https://github.com/user-attachments/assets/83e919a4-8381-4a8f-b3dc-b5f004aeea6a)

So I created a new selector for the Patterns filter and removed the margin.

## Testing Instructions

- Insert > Pattern tab > All > Press the Filter Patterns button
- There should be no overflow.
