### PR TITLE
Site Editor: Fix button hover style in sidebar navigation screen

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -19,7 +19,7 @@
 		padding-right: 0;
 	}
 
-	.components-button {
+	.block-editor-list-view-block-select-button {
 		color: $gray-600;
 		&:hover,
 		&:focus,


### PR DESCRIPTION
Follow-up #65361

## What?

This PR fixes the styling of items in the site editor's navigation screen.

## Why?

In #65361, buttons in the list view were replaced with `a` elements instead of `Button` components, so the expected styles by the `.components-button` selector are no longer applied.

## Testing Instructions

- Visit the Navigation screen in the site editor.
- Check out how items are styled when selected, focused, and hovered.

## Screenshots or screencast <!-- if applicable -->

In the screenshot below, each item has the following states. Make sure the correct text color is applied to items in either state.

- First item: selected
- Second item: focused
- Third item: hovered

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/dcdfc2bd-2b8d-40b5-b1a3-b0f97e03e69e)| ![image](https://github.com/user-attachments/assets/9406c408-2a17-4abd-99e6-4207aed5c032) | 