### PR TITLE
Fix zoom out shortcut on Windows

### DIFF
--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -12,6 +12,7 @@ import {
 	useShortcut,
 	store as keyboardShortcutsStore,
 } from '@wordpress/keyboard-shortcuts';
+import { isAppleOS } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
@@ -40,7 +41,9 @@ const ZoomOutToggle = ( { disabled } ) => {
 			category: 'global',
 			description: __( 'Enter or exit zoom out.' ),
 			keyCombination: {
-				modifier: 'primaryShift',
+				// `primaryShift+0` (`ctrl+shift+0`) is the shortcut for switching
+				// to input mode in Windows, so apply a different key combination.
+				modifier: isAppleOS() ? 'primaryShift' : 'secondary',
 				character: '0',
 			},
 		} );


### PR DESCRIPTION
Follow-up #66400
Fixes #66449

## What?
This PR fixes the zoom-out toggle shortcut to work on Windows OS.

## Why?

As explained in [this comment](https://github.com/WordPress/gutenberg/issues/66449#issuecomment-2439474051), `primaryShift + 0 (ctrl + shift + 0)` may not work on Windows OS with IME enabled.

## How?

From my research, there are four possible new key combinations:

- `Shift + 0 (shift + 0)`
- `Alt + 0 (alt + 0)`
- `Ctrl + Alt + 0 (primaryAlt + 0)`
- `Ctrl + Shift + Alt + 0 (secondary + 0)`

Of these, I chose `Ctrl + Shift + Alt + 0`, which is similar to the full-screen mode toggle shortcut (`Ctrl + Shift + Alt + F`):

![image](https://github.com/user-attachments/assets/ef829aeb-66d3-49ce-9e2f-421449aab448)

## Testing Instructions

I would be happy if someone could test this PR on Windows OS, but I would also be happy if someone could at least test it on MacOS to make sure the shortcuts work as before.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/49a02c73-b961-43a5-94ce-cdf54512c840


