### PR TITLE
Fix: Show Meta Boxes at the bottom of the screen regardless of the current rendering mode

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -414,6 +414,8 @@ function Layout( {
 			const { isZoomOut } = unlock( select( blockEditorStore ) );
 			const { getEditorMode, getRenderingMode } = select( editorStore );
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
+			const isRenderingTemplateLocked =
+				getRenderingMode() === 'template-locked';
 
 			return {
 				mode: getEditorMode(),
@@ -426,7 +428,7 @@ function Layout( {
 				isDistractionFree: get( 'core', 'distractionFree' ),
 				showMetaBoxes:
 					! DESIGN_POST_TYPES.includes( currentPostType ) &&
-					isRenderingPostOnly,
+					( isRenderingPostOnly || isRenderingTemplateLocked ),
 				isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 				templateId:
 					supportsTemplateMode &&

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -414,8 +414,6 @@ function Layout( {
 			const { isZoomOut } = unlock( select( blockEditorStore ) );
 			const { getEditorMode, getRenderingMode } = select( editorStore );
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
-			const isRenderingTemplateLocked =
-				getRenderingMode() === 'template-locked';
 
 			return {
 				mode: getEditorMode(),
@@ -426,9 +424,7 @@ function Layout( {
 					!! select( blockEditorStore ).getBlockSelectionStart(),
 				showIconLabels: get( 'core', 'showIconLabels' ),
 				isDistractionFree: get( 'core', 'distractionFree' ),
-				showMetaBoxes:
-					! DESIGN_POST_TYPES.includes( currentPostType ) &&
-					( isRenderingPostOnly || isRenderingTemplateLocked ),
+				showMetaBoxes: ! DESIGN_POST_TYPES.includes( currentPostType ),
 				isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 				templateId:
 					supportsTemplateMode &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

allow metaboxes to remain visible in `template-locked` rendering mode (closing #66507)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because in the `template-locked` rendering mode you are actively still editing a post. So any metaboxes should still be available. They should only disappear in the `template-only` mode.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

By adding an additional check if the mode is either `post-only` or `template-locked`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install a plugin such as Yoast which registers a Metabox
2. Activate that plugin
3. Open a post
4. Check the "Preview Template" option in the post sidebar under the template setting
5. Ensure the metabox is still visible in the `template-locked` mode
