### PR TITLE
Add "show template" to preview dropdown.

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -15,7 +15,7 @@ import {
 	__unstableAnimatePresence as AnimatePresence,
 } from '@wordpress/components';
 import { BlockIcon } from '@wordpress/block-editor';
-import { chevronLeftSmall, chevronRightSmall } from '@wordpress/icons';
+import { chevronLeftSmall, chevronRightSmall, layout } from '@wordpress/icons';
 import { displayShortcut } from '@wordpress/keycodes';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as commandsStore } from '@wordpress/commands';
@@ -58,12 +58,14 @@ export default function DocumentBar( props ) {
 		isNotFound,
 		templateTitle,
 		onNavigateToPreviousEntityRecord,
+		isTemplatePreview,
 	} = useSelect( ( select ) => {
 		const {
 			getCurrentPostType,
 			getCurrentPostId,
 			getEditorSettings,
 			__experimentalGetTemplateInfo: getTemplateInfo,
+			getRenderingMode,
 		} = select( editorStore );
 		const {
 			getEditedEntityRecord,
@@ -95,6 +97,7 @@ export default function DocumentBar( props ) {
 			templateTitle: _templateInfo.title,
 			onNavigateToPreviousEntityRecord:
 				getEditorSettings().onNavigateToPreviousEntityRecord,
+			isTemplatePreview: getRenderingMode() === 'template-locked',
 		};
 	}, [] );
 
@@ -141,6 +144,12 @@ export default function DocumentBar( props ) {
 					>
 						{ __( 'Back' ) }
 					</MotionButton>
+				) }
+				{ ! isTemplate && isTemplatePreview && (
+					<BlockIcon
+						icon={ layout }
+						className="editor-document-bar__icon-layout"
+					/>
 				) }
 			</AnimatePresence>
 			{ isNotFound ? (

--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -145,13 +145,13 @@ export default function DocumentBar( props ) {
 						{ __( 'Back' ) }
 					</MotionButton>
 				) }
-				{ ! isTemplate && isTemplatePreview && (
-					<BlockIcon
-						icon={ layout }
-						className="editor-document-bar__icon-layout"
-					/>
-				) }
 			</AnimatePresence>
+			{ ! isTemplate && isTemplatePreview && (
+				<BlockIcon
+					icon={ layout }
+					className="editor-document-bar__icon-layout"
+				/>
+			) }
 			{ isNotFound ? (
 				<Text>{ __( 'Document not found' ) }</Text>
 			) : (

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -105,8 +105,11 @@
 
 .editor-document-bar__icon-layout.editor-document-bar__icon-layout {
 	position: absolute;
-
+	display: none;
 	svg {
 		fill: $gray-600;
+	}
+	@include break-small {
+		display: flex;
 	}
 }

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -105,6 +105,7 @@
 
 .editor-document-bar__icon-layout.editor-document-bar__icon-layout {
 	position: absolute;
+	padding-left: $grid-unit-15;
 	display: none;
 	svg {
 		fill: $gray-600;

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -102,3 +102,7 @@
 		background-color: transparent;
 	}
 }
+
+.editor-document-bar__icon-layout {
+	position: absolute;
+}

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -103,6 +103,10 @@
 	}
 }
 
-.editor-document-bar__icon-layout {
+.editor-document-bar__icon-layout.editor-document-bar__icon-layout {
 	position: absolute;
+
+	svg {
+		fill: $gray-600;
+	}
 }

--- a/packages/editor/src/components/document-bar/style.scss
+++ b/packages/editor/src/components/document-bar/style.scss
@@ -105,8 +105,9 @@
 
 .editor-document-bar__icon-layout.editor-document-bar__icon-layout {
 	position: absolute;
-	padding-left: $grid-unit-15;
+	margin-left: $grid-unit-15;
 	display: none;
+	pointer-events: none;
 	svg {
 		fill: $gray-600;
 	}

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -16,7 +16,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { desktop, mobile, tablet, external } from '@wordpress/icons';
+import { desktop, mobile, tablet, external, check } from '@wordpress/icons';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -31,21 +31,29 @@ import PostPreviewButton from '../post-preview-button';
 import { unlock } from '../../lock-unlock';
 
 export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
-	const { deviceType, homeUrl, isTemplate, isViewable, showIconLabels } =
-		useSelect( ( select ) => {
-			const { getDeviceType, getCurrentPostType } = select( editorStore );
-			const { getEntityRecord, getPostType } = select( coreStore );
-			const { get } = select( preferencesStore );
-			const _currentPostType = getCurrentPostType();
-			return {
-				deviceType: getDeviceType(),
-				homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
-				isTemplate: _currentPostType === 'wp_template',
-				isViewable: getPostType( _currentPostType )?.viewable ?? false,
-				showIconLabels: get( 'core', 'showIconLabels' ),
-			};
-		}, [] );
-	const { setDeviceType } = useDispatch( editorStore );
+	const {
+		deviceType,
+		homeUrl,
+		isTemplate,
+		isViewable,
+		showIconLabels,
+		isTemplateHidden,
+	} = useSelect( ( select ) => {
+		const { getDeviceType, getCurrentPostType } = select( editorStore );
+		const { getRenderingMode } = unlock( select( editorStore ) );
+		const { getEntityRecord, getPostType } = select( coreStore );
+		const { get } = select( preferencesStore );
+		const _currentPostType = getCurrentPostType();
+		return {
+			deviceType: getDeviceType(),
+			homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
+			isTemplate: _currentPostType === 'wp_template',
+			isViewable: getPostType( _currentPostType )?.viewable ?? false,
+			showIconLabels: get( 'core', 'showIconLabels' ),
+			isTemplateHidden: getRenderingMode() === 'post-only',
+		};
+	}, [] );
+	const { setDeviceType, setRenderingMode } = useDispatch( editorStore );
 	const { resetZoomLevel } = unlock( useDispatch( blockEditorStore ) );
 
 	const handleDevicePreviewChange = ( newDeviceType ) => {
@@ -139,6 +147,24 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 										__( '(opens in a new tab)' )
 									}
 								</VisuallyHidden>
+							</MenuItem>
+						</MenuGroup>
+					) }
+					{ ! isTemplate && (
+						<MenuGroup>
+							<MenuItem
+								icon={ ! isTemplateHidden ? check : undefined }
+								isSelected={ ! isTemplateHidden }
+								role="menuitemcheckbox"
+								onClick={ () => {
+									setRenderingMode(
+										isTemplateHidden
+											? 'template-locked'
+											: 'post-only'
+									);
+								} }
+							>
+								{ __( 'Show template' ) }
 							</MenuItem>
 						</MenuGroup>
 					) }

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -38,8 +38,10 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 		isViewable,
 		showIconLabels,
 		isTemplateHidden,
+		templateId,
 	} = useSelect( ( select ) => {
-		const { getDeviceType, getCurrentPostType } = select( editorStore );
+		const { getDeviceType, getCurrentPostType, getCurrentTemplateId } =
+			select( editorStore );
 		const { getRenderingMode } = unlock( select( editorStore ) );
 		const { getEntityRecord, getPostType } = select( coreStore );
 		const { get } = select( preferencesStore );
@@ -51,6 +53,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 			isViewable: getPostType( _currentPostType )?.viewable ?? false,
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isTemplateHidden: getRenderingMode() === 'post-only',
+			templateId: getCurrentTemplateId(),
 		};
 	}, [] );
 	const { setDeviceType, setRenderingMode } = useDispatch( editorStore );
@@ -150,7 +153,7 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 							</MenuItem>
 						</MenuGroup>
 					) }
-					{ ! isTemplate && (
+					{ ! isTemplate && !! templateId && (
 						<MenuGroup>
 							<MenuItem
 								icon={ ! isTemplateHidden ? check : undefined }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #66429.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open the post editor.
2. Click the "View" button on the upper right hand side and check that a "Show template" option now displays inside the dropdown.
3. Clicking "Show template" should enable the template preview in the editor.
4. In the Pages section of the site editor, this option should also be available but there the template preview is enabled by default.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
