### PR TITLE
Block Bindings: Enable synced pattern overrides for attributes with `role: content` property

### DIFF
--- a/lib/compat/wordpress-6.6/blocks.php
+++ b/lib/compat/wordpress-6.6/blocks.php
@@ -31,7 +31,7 @@ function gutenberg_replace_pattern_override_default_binding( $parsed_block ) {
 		// Build an binding array of all supported attributes.
 		// Note that this also omits the `__default` attribute from the
 		// resulting array.
-		if ( ! isset( $supported_block_attributes[ $parsed_block['blockName'] ] ) ) {
+		if ( ! isset( $supported_block_attrs[ $parsed_block['blockName'] ] ) ) {
 			// get block type
 			$block_registry        = WP_Block_Type_Registry::get_instance();
 			$block_type            = $block_registry->get_registered( $parsed_block['blockName'] );
@@ -46,7 +46,7 @@ function gutenberg_replace_pattern_override_default_binding( $parsed_block ) {
 				}
 			}
 		} else {
-			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
+			foreach ( $supported_block_attrs[ $parsed_block['blockName'] ] as $attribute_name ) {
 				// Retain any non-pattern override bindings that might be present.
 				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
 					? $bindings[ $attribute_name ]

--- a/lib/compat/wordpress-6.6/blocks.php
+++ b/lib/compat/wordpress-6.6/blocks.php
@@ -31,11 +31,27 @@ function gutenberg_replace_pattern_override_default_binding( $parsed_block ) {
 		// Build an binding array of all supported attributes.
 		// Note that this also omits the `__default` attribute from the
 		// resulting array.
-		foreach ( $supported_block_attrs[ $parsed_block['blockName'] ] as $attribute_name ) {
-			// Retain any non-pattern override bindings that might be present.
-			$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
-				? $bindings[ $attribute_name ]
-				: array( 'source' => 'core/pattern-overrides' );
+		if ( ! isset( $supported_block_attributes[ $parsed_block['blockName'] ] ) ) {
+			// get block type
+			$block_registry        = WP_Block_Type_Registry::get_instance();
+			$block_type            = $block_registry->get_registered( $parsed_block['blockName'] );
+			$attribute_definitions = $block_type->attributes;
+
+			foreach ( $attribute_definitions as $attribute_name => $attribute_definition ) {
+				// Include the attribute in the updated bindings if the role is set to 'content'.
+				if ( isset( $attribute_definition['role'] ) && 'content' === $attribute_definition['role'] ) {
+					$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+						? $bindings[ $attribute_name ]
+						: array( 'source' => 'core/pattern-overrides' );
+				}
+			}
+		} else {
+			foreach ( $supported_block_attributes[ $parsed_block['blockName'] ] as $attribute_name ) {
+				// Retain any non-pattern override bindings that might be present.
+				$updated_bindings[ $attribute_name ] = isset( $bindings[ $attribute_name ] )
+					? $bindings[ $attribute_name ]
+					: array( 'source' => 'core/pattern-overrides' );
+			}
 		}
 		$parsed_block['attrs']['metadata']['bindings'] = $updated_bindings;
 	}

--- a/packages/editor/src/hooks/pattern-overrides.js
+++ b/packages/editor/src/hooks/pattern-overrides.js
@@ -6,7 +6,7 @@ import { privateApis as patternsPrivateApis } from '@wordpress/patterns';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useBlockEditingMode } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { getBlockBindingsSource } from '@wordpress/blocks';
+import { getBlockBindingsSource, getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -36,8 +36,12 @@ const {
  */
 const withPatternOverrideControls = createHigherOrderComponent(
 	( BlockEdit ) => ( props ) => {
+		const blockType = getBlockType( props.name );
 		const isSupportedBlock =
-			!! PARTIAL_SYNCING_SUPPORTED_BLOCKS[ props.name ];
+			!! PARTIAL_SYNCING_SUPPORTED_BLOCKS[ props.name ] ||
+			Object.values( blockType.attributes ).some(
+				( attribute ) => attribute.role === 'content'
+			);
 
 		return (
 			<>

--- a/packages/patterns/src/api/index.js
+++ b/packages/patterns/src/api/index.js
@@ -4,6 +4,11 @@
 import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
 
 /**
+ * WordPress dependencies
+ */
+import { getBlockType } from '@wordpress/blocks';
+
+/**
  * Determines whether a block is overridable.
  *
  * @param {WPBlock} block The block to test.
@@ -11,10 +16,16 @@ import { PARTIAL_SYNCING_SUPPORTED_BLOCKS } from '../constants';
  * @return {boolean} `true` if a block is overridable, `false` otherwise.
  */
 export function isOverridableBlock( block ) {
-	return (
+	const blockType = getBlockType( block.name );
+	const isSupportedBlock =
 		Object.keys( PARTIAL_SYNCING_SUPPORTED_BLOCKS ).includes(
 			block.name
-		) &&
+		) ||
+		Object.values( blockType.attributes ).some(
+			( attribute ) => attribute.role === 'content'
+		);
+	return (
+		isSupportedBlock &&
 		!! block.attributes.metadata?.name &&
 		!! block.attributes.metadata?.bindings &&
 		Object.values( block.attributes.metadata.bindings ).some(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
An early experiment exploring enabling synced pattern overrides for blocks that have attributes with the `role: content` property.
See issue https://github.com/WordPress/gutenberg/issues/64870
Must be used in conjunction with core PR https://github.com/WordPress/wordpress-develop/pull/7658

Alternative to https://github.com/WordPress/gutenberg/pull/66266

## What?
<!-- In a few words, what is the PR actually doing? -->

It enables synced pattern overrides for custom blocks with the `role: content` property:
- It allows you to enable those overrides via the patterns UI in the site editor
- After inserting a pattern into a post, you must manually paste in the block bindings markup
- You should be able to see the overridden content in the published post

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

We'd like to begin exploring expanding block bindings compatibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For the UI, for now it just enables the overrides for any block that has `role: content`. _To do_: Restrict this to just custom blocks.

It also adds some handling on the PHP side to ensure the overrides are rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Use this [WordPress Playround link](https://playground.wordpress.net/?core-pr=7597&gutenberg-pr=66518&php=7.4&wp=beta&networking=yes&language=&multisite=no&random=18myt9hhfwp#%7B%22$schema%22:%22https://playground.wordpress.net/blueprint-schema.json%22,%22landingPage%22:%22/wp-admin%22,%22login%22:true,%22preferredVersions%22:%7B%22php%22:%227.4%22%7D,%22features%22:%7B%22networking%22:true%7D%7D) to test this Gutenberg PR in conjunction with core PR https://github.com/WordPress/wordpress-develop/pull/7658
2. Download, install, and active this [dynamic icon block](https://github.com/artemiomorales/dynamic-icon-block/releases/tag/v0.1) in the Playground instance.
3. Create a new synced pattern and add the dynamic icon block.
4. Enable overrides on the block by giving it a the name "Dynamic Icon".
5. Save the pattern and add it to a post.
6. Publish and view the post; see that the icon is a circle.
7. Back in the post editor, open the code editor and add `"content":{"Dynamic Icon":{"icon":"square"}}` to the pattern block's JSON, making sure to not overwrite your `ref` id. Here's an example:
```
<!-- wp:block {"ref":1014,"content":{"Dynamic Icon":{"icon":"square"}}} /-->
```
7. Publish and view the post; see that the icon is now a square.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/deadd32c-b9b6-4485-880e-6142d23a4fe9