### PR TITLE
Fix: Paragraphs in Classic block lose ID during conversion - Issue - #63022

### DIFF
--- a/packages/blocks/src/api/raw-handling/html-to-blocks.js
+++ b/packages/blocks/src/api/raw-handling/html-to-blocks.js
@@ -55,6 +55,12 @@ export function htmlToBlocks( html, handler ) {
 			if ( node.hasAttribute( 'class' ) ) {
 				block.attributes.className = node.getAttribute( 'class' );
 			}
+
+			// Add the ids if present.
+			if ( node.hasAttribute( 'id' ) ) {
+				block.attributes.id = node.getAttribute( 'id' );
+			}
+
 			return block;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Fixes - #63022

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- While converting paragrpahs from classic editor to blocks, the IDs were not preserved and had some inconsistencies.
- See - https://github.com/WordPress/gutenberg/issues/42172 and https://github.com/WordPress/gutenberg/issues/63022

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- PR checks for the `id` attribute and sets the id attribute to block if found.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open any post/page.
- View it in `code editor`.
- Paste the below code,

```
<p id="teaser" class="teaser">Get value for money now. Click the button and contact us for a high-quality, used copier that works like new, but costs a lot less.</p>
```
- Exit code editor, click on the paragraph, there would be option to convert it to blocks and click it to transform to block.
- Now, switch back to code editor and see the id is preserved.
- Double check by checking the `Advanced` tab in inspector controls and would see the `HTML` anchor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/eb03fc90-71e3-44c7-88d4-95c9b9439c85