### PR TITLE
Transform categories title into blocks in the categories block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -933,6 +933,15 @@ Display the description of categories, tags and custom taxonomies when viewing a
 -	**Supports:** align (full, wide), color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** textAlign
 
+## Term Title
+
+Display the title of categories, tags and custom taxonomies ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/term-title))
+
+-	**Name:** core/term-title
+-	**Category:** theme
+-	**Supports:** align (full, wide), color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** textAlign
+
 ## Text Columns (deprecated)
 
 This block is deprecated. Please use the Columns block instead. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/text-columns))

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -119,6 +119,7 @@ function gutenberg_reregister_core_block_types() {
 				'tag-cloud.php'                    => 'core/tag-cloud',
 				'template-part.php'                => 'core/template-part',
 				'term-description.php'             => 'core/term-description',
+				'term-title.php'                   => 'core/term-title',
 			),
 		),
 		__DIR__ . '/../build/edit-widgets/blocks/'  => array(

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -16,16 +16,69 @@ import {
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
+	BlockContextProvider,
+	__experimentalUseBlockPreview as useBlockPreview,
 	InspectorControls,
 	useBlockProps,
+	useInnerBlocksProps,
+	store as blockEditorStore,
 	RichText,
 } from '@wordpress/block-editor';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
+import { memo, useMemo, useState } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+const TEMPLATE = [ [ 'core/term-title' ] ];
+
+function CategoriesItemBlock() {
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: clsx( 'wp-block-taxonomy' ) },
+		{ template: TEMPLATE }
+	);
+	return <li { ...innerBlocksProps } />;
+}
+
+function CategoriesItemBlockPreview( {
+	blocks,
+	blockContextId,
+	setActiveBlockContextId,
+	isHidden,
+} ) {
+	const blockPreviewProps = useBlockPreview( {
+		blocks,
+		props: {
+			className: clsx( 'wp-block-taxonomy' ),
+		},
+	} );
+
+	const handleOnClick = () => {
+		setActiveBlockContextId( blockContextId );
+	};
+
+	const style = {
+		display: isHidden ? 'none' : undefined,
+	};
+
+	return (
+		<li
+			{ ...blockPreviewProps }
+			tabIndex={ 0 }
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+			role="button"
+			onClick={ handleOnClick }
+			onKeyPress={ handleOnClick }
+			style={ style }
+		/>
+	);
+}
+
+const MemoizedCategoriesItemBlockPreview = memo( CategoriesItemBlockPreview );
 
 export default function CategoriesEdit( {
+	clientId,
 	attributes: {
 		displayAsDropdown,
 		showHierarchy,
@@ -66,10 +119,28 @@ export default function CategoriesEdit( {
 		query.parent = 0;
 	}
 
+	const [ activeBlockContextId, setActiveBlockContextId ] = useState();
 	const { records: categories, isResolving } = useEntityRecords(
 		'taxonomy',
 		taxonomySlug,
 		query
+	);
+
+	const blocks = useSelect(
+		( select ) => {
+			const { getBlocks } = select( blockEditorStore );
+			return getBlocks( clientId );
+		},
+		[ clientId ]
+	);
+
+	const blockContexts = useMemo(
+		() =>
+			categories?.map( ( term ) => ( {
+				taxonomyType: term.taxonomy,
+				taxonomyId: term.id,
+			} ) ),
+		[ categories ]
 	);
 
 	const getCategoriesList = ( parentId ) => {
@@ -89,34 +160,58 @@ export default function CategoriesEdit( {
 		! name ? __( '(Untitled)' ) : decodeEntities( name ).trim();
 
 	const renderCategoryList = () => {
-		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;
-		const categoriesList = getCategoriesList( parentId );
-		return categoriesList.map( ( category ) =>
-			renderCategoryListItem( category )
+		return (
+			<>
+				{ blockContexts &&
+					blockContexts.map( ( blockContext ) => (
+						<BlockContextProvider
+							key={ blockContext.taxonomyId }
+							value={ blockContext }
+						>
+							{ blockContext.taxonomyId ===
+							( activeBlockContextId ||
+								blockContexts[ 0 ]?.taxonomyId ) ? (
+								<CategoriesItemBlock />
+							) : null }
+							<MemoizedCategoriesItemBlockPreview
+								blocks={ blocks }
+								blockContextId={ blockContext.taxonomyId }
+								setActiveBlockContextId={
+									setActiveBlockContextId
+								}
+								isHidden={
+									blockContext.taxonomyId ===
+									( activeBlockContextId ||
+										blockContexts[ 0 ]?.taxonomyId )
+								}
+							/>
+						</BlockContextProvider>
+					) ) }
+			</>
 		);
 	};
 
-	const renderCategoryListItem = ( category ) => {
-		const childCategories = getCategoriesList( category.id );
-		const { id, link, count, name } = category;
-		return (
-			<li key={ id } className={ `cat-item cat-item-${ id }` }>
-				<a href={ link } target="_blank" rel="noreferrer noopener">
-					{ renderCategoryName( name ) }
-				</a>
-				{ showPostCounts && ` (${ count })` }
-				{ isHierarchicalTaxonomy &&
-					showHierarchy &&
-					!! childCategories.length && (
-						<ul className="children">
-							{ childCategories.map( ( childCategory ) =>
-								renderCategoryListItem( childCategory )
-							) }
-						</ul>
-					) }
-			</li>
-		);
-	};
+	// const renderCategoryListItem = ( category ) => {
+	// 	const childCategories = getCategoriesList( category.id );
+	// 	const { id, link, count, name } = category;
+	// 	return (
+	// 		<li key={ id } className={ `cat-item cat-item-${ id }` }>
+	// 			<a href={ link } target="_blank" rel="noreferrer noopener">
+	// 				{ renderCategoryName( name ) }
+	// 			</a>
+	// 			{ showPostCounts && ` (${ count })` }
+	// 			{ isHierarchicalTaxonomy &&
+	// 				showHierarchy &&
+	// 				!! childCategories.length && (
+	// 					<ul className="children">
+	// 						{ childCategories.map( ( childCategory ) =>
+	// 							renderCategoryListItem( childCategory )
+	// 						) }
+	// 					</ul>
+	// 				) }
+	// 		</li>
+	// 	);
+	// };
 
 	const renderCategoryDropdown = () => {
 		const parentId = isHierarchicalTaxonomy && showHierarchy ? 0 : null;

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -117,6 +117,7 @@ import * as tableOfContents from './table-of-contents';
 import * as tagCloud from './tag-cloud';
 import * as templatePart from './template-part';
 import * as termDescription from './term-description';
+import * as termTitle from './term-title';
 import * as textColumns from './text-columns';
 import * as verse from './verse';
 import * as video from './video';
@@ -229,6 +230,7 @@ const getAllBlocks = () => {
 		homeLink,
 		logInOut,
 		termDescription,
+		termTitle,
 		queryTitle,
 		postAuthorBiography,
 	];

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -64,6 +64,7 @@
 @import "./table/style.scss";
 @import "./table-of-contents/style.scss";
 @import "./term-description/style.scss";
+@import "./term-title/style.scss";
 @import "./text-columns/style.scss";
 @import "./verse/style.scss";
 @import "./video/style.scss";

--- a/packages/block-library/src/term-title/block.json
+++ b/packages/block-library/src/term-title/block.json
@@ -1,0 +1,58 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 3,
+	"name": "core/term-title",
+	"title": "Term Title",
+	"category": "theme",
+	"description": "Display the title of categories, tags and custom taxonomies",
+	"textdomain": "default",
+	"attributes": {
+		"textAlign": {
+			"type": "string"
+		}
+	},
+	"usesContext": [ "taxonomyId", "taxonomyType" ],
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"color": {
+			"link": true,
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		},
+		"interactivity": {
+			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
+		}
+	}
+}

--- a/packages/block-library/src/term-title/edit.js
+++ b/packages/block-library/src/term-title/edit.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps } from '@wordpress/block-editor';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+export default function TermTitleEdit( { context } ) {
+	const blockProps = useBlockProps();
+	const { taxonomyId, taxonomyType } = context;
+	const termTitle = useSelect(
+		( select ) => {
+			return select( coreStore ).getEntityRecord(
+				'taxonomy',
+				taxonomyType,
+				taxonomyId
+			)?.name;
+		},
+		[ taxonomyId, taxonomyType ]
+	);
+
+	return <span { ...blockProps }>{ termTitle || __( 'Term Title' ) }</span>;
+}

--- a/packages/block-library/src/term-title/index.js
+++ b/packages/block-library/src/term-title/index.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { title as icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import initBlock from '../utils/init-block';
+import metadata from './block.json';
+import edit from './edit';
+
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon,
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/term-title/index.php
+++ b/packages/block-library/src/term-title/index.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Server-side rendering of the `core/term-title` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `core/term-title` block on the server.
+ *
+ * @since 6.8.0
+ *
+ * @param array $attributes Block attributes.
+ *
+ * @return string Returns the title of the current taxonomy term, if available
+ */
+function render_block_core_term_title( $attributes ) {
+	$term_title = '';
+
+	if ( is_category() || is_tag() || is_tax() ) {
+		$term_title = single_term_title();
+	}
+
+	if ( empty( $term_title ) ) {
+		return '';
+	}
+
+	$classes = array();
+	if ( isset( $attributes['textAlign'] ) ) {
+		$classes[] = 'has-text-align-' . $attributes['textAlign'];
+	}
+	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
+		$classes[] = 'has-link-color';
+	}
+	$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => implode( ' ', $classes ) ) );
+
+	return sprintf(
+		'<a %1$s>%2$s</a>',
+		$wrapper_attributes,
+		$title
+	);
+}
+
+/**
+ * Registers the `core/term-title` block on the server.
+ *
+ * @since 6.8.0
+ */
+function register_block_core_term_title() {
+	register_block_type_from_metadata(
+		__DIR__ . '/term-title',
+		array(
+			'render_callback' => 'render_block_core_term_title',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_term_title' );

--- a/packages/block-library/src/term-title/init.js
+++ b/packages/block-library/src/term-title/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/packages/block-library/src/term-title/style.scss
+++ b/packages/block-library/src/term-title/style.scss
@@ -1,0 +1,3 @@
+.wp-block-term-title {
+	// Add styles
+}


### PR DESCRIPTION
## What?
In this pull request, I'm exploring the possibility of creating a new "Term title" block and using it inside the Categories block. Right now, the categories list markup is "hardcoded", and it limits the users for customization. With this approach, it would work similar to Post Template & Post Title, where users can apply styles to the Post Title and be applied in all the existing ones in the Query Loop:

https://github.com/user-attachments/assets/ad29531d-91db-45a2-9a04-e4f41a480247

## Should we deprecate the Categories block in favor of a Taxonomies block?

While working on this, I wondered if the whole categories block should be deprecated in favor of a new "Taxonomies" block. These are some reasons for this:
- It started as a "categories" block to list the categories but it has evolved to serve any taxonomy. The naming and code feel confusing sometimes.
- As mentioned, the styling isn't too flexible and I can see many users wanting to change the default one.
- Same issues happen when the "dropdown" setting is enabled:
![Screenshot 2024-10-28 at 10 40 59](https://github.com/user-attachments/assets/36a72c20-5ac7-4d79-b1d1-d6f6d9dbe000)
- Right now, it is rendering links in the editor that redirect to the respective category, which I believe shouldn't happen.
- It is adding an inline script for the dropdown, which should probably use the Interactivity API: [link](https://github.com/WordPress/gutenberg/blob/53bb5ff55bad2e9e874b7588faa089a6d0fe8cb9/packages/block-library/src/categories/index.php#L101-L118).

## Why?

## How?

## Testing Instructions
WIP
