### PR TITLE
Query block: avoid setAttributes on mount for 'per page'

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -167,24 +167,21 @@ export default function PostTemplateEdit( {
 					Object.assign( query, builtTaxQuery );
 				}
 			}
-			if ( perPage ) {
-				// When we inherit from global query always need to set the
-				// `perPage` based on the reading settings.
-				if ( inherit ) {
-					query.per_page =
-						// Gets changes made via the template area posts per
-						// page setting. These won't be saved until the page is
-						// saved, but we should reflect this setting within the
-						// query loops that inherit it.
-						+getEntityRecordEdits( 'root', 'site' )
-							?.posts_per_page ||
-						( canUser( 'read', { kind: 'root', name: 'site' } )
-							? +getEntityRecord( 'root', 'site' )?.posts_per_page
-							: +getSettings().postsPerPage ) ||
-						INHERITED_QUERY_DEFAULT_PER_PAGE;
-				} else {
-					query.per_page = perPage || CUSTOM_QUERY_DEFAULT_PER_PAGE;
-				}
+			// When we inherit from global query always need to set the
+			// `perPage` based on the reading settings.
+			if ( inherit ) {
+				query.per_page =
+					// Gets changes made via the template area posts per
+					// page setting. These won't be saved until the page is
+					// saved, but we should reflect this setting within the
+					// query loops that inherit it.
+					+getEntityRecordEdits( 'root', 'site' )?.posts_per_page ||
+					( canUser( 'read', { kind: 'root', name: 'site' } )
+						? +getEntityRecord( 'root', 'site' )?.posts_per_page
+						: +getSettings().postsPerPage ) ||
+					INHERITED_QUERY_DEFAULT_PER_PAGE;
+			} else {
+				query.per_page = perPage || CUSTOM_QUERY_DEFAULT_PER_PAGE;
 			}
 			if ( author ) {
 				query.author = author;

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -14,7 +14,7 @@
 		"query": {
 			"type": "object",
 			"default": {
-				"perPage": null,
+				"perPage": 3,
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",

--- a/test/e2e/specs/site-editor/template-revert.spec.js
+++ b/test/e2e/specs/site-editor/template-revert.spec.js
@@ -248,7 +248,9 @@ class TemplateRevertUtils {
 						record.blocks
 					);
 				} else if ( record.content ) {
-					return record.content;
+					return window.wp.blocks.__unstableSerializeAndClean(
+						window.wp.blocks.parse( record.content )
+					);
 				}
 			}
 			return '';

--- a/test/integration/fixtures/blocks/core__query.json
+++ b/test/integration/fixtures/blocks/core__query.json
@@ -4,7 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"query": {
-				"perPage": null,
+				"perPage": 3,
 				"pages": 0,
 				"offset": 0,
 				"postType": "post",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We must avoid mount effects in blocks that set block attributes. In this particular case, it seems that the query block is setting the `perPage` query property on mount for inherited queries, which is in turn set as context to be consumed by the post template block (which actually does the querying.

It seems to me that, for inherited queries, the query block should not at all concern itself with the `perPage` property. It should be something that the post template block ignores and overrides for inherited queries. In fact, everything related to the `perPage` setting is disabled elsewhere when the query is set to inherit.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Separation of concerns, avoid passing setting around. Avoid triggering `setAttributes` on mount. When block attributes change on mount, it will also cause excessive re-renders and degrade performance.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Retrieve the data at the exact point where it's needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Test the query block (inherited) together with the posts per page settings.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
