### PR TITLE
Fix: Global styles navigation button accessible name

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
@@ -46,7 +46,11 @@ export default function SidebarNavigationScreenDetailsFooter( {
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-details-footer">
 			<SidebarNavigationItem
-				aria-label={ __( 'Revisions' ) }
+				aria-label={ sprintf(
+					/* translators: %s: human readable time difference */
+					__( 'Last modified %s' ),
+					humanTimeDiff( record.modified )
+				) }
 				{ ...hrefProps }
 				{ ...otherProps }
 			>


### PR DESCRIPTION
## What?
Fix Global styles footer button accessible name.

## Why?
fixes #66526 

## How?
- updated `aria-label` from `Revisions` to `Last modified %s` same as available text.

## Testing Instructions
- create style revision.
- open styles -> check `Last modified` accessible name.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f50426ca-c35c-44db-90e1-dee98135ce0e

