### PR TITLE
Fix undo/redo Button size in Storybook playground

### DIFF
--- a/storybook/stories/playground/with-undo-redo/index.js
+++ b/storybook/stories/playground/with-undo-redo/index.js
@@ -52,6 +52,7 @@ export default function EditorWithUndoRedo() {
 						accessibleWhenDisabled
 						icon={ undoIcon }
 						label="Undo"
+						size="compact"
 					/>
 					<Button
 						onClick={ redo }
@@ -59,6 +60,7 @@ export default function EditorWithUndoRedo() {
 						accessibleWhenDisabled
 						icon={ redoIcon }
 						label="Redo"
+						size="compact"
 					/>
 					<BlockToolbar hideDragHandle />
 				</div>


### PR DESCRIPTION
In preparation for #65751

## What?

Fix the sizes of the undo/redo buttons in Storybook ▸ Playground ▸ Block Editor ▸ Undo Redo.

## Why?

The 32px compact size matches the size of the other toolbar buttons.

## Testing Instructions

See the Undo Redo story in the Storybook.

