### PR TITLE
Revert "Site Editor: remove content styles outside canvas (#66432)"

### DIFF
--- a/backport-changelog/6.8/7643.md
+++ b/backport-changelog/6.8/7643.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/7643
-
-* https://github.com/WordPress/gutenberg/pull/66432

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -410,7 +410,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-site',
 		gutenberg_url( 'build/edit-site/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'common', 'forms', 'wp-commands', 'wp-preferences' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-edit-blocks', 'wp-commands', 'wp-preferences' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-site', 'rtl', 'replace' );


### PR DESCRIPTION
## What?

This reverts commit 8a2480a88e0bac2685b279ea377ae18d2523022f (#66432).

## Why?

#66432 prevents content CSS, i.e. CSS for block libraries, from being loaded outside of the iframe canvas. However, there are cases where the block itself applies CSS outside of its content, such as the block toolbar and the block sidebar.

To prevent content CSS from being loaded outside of the iframe canvas, I think we need to take the following two measures in advance:

- Identify blocks that apply CSS outside the iframe canvas
- Replace elements/components that have CSS applied to them with generic components or use inline CSS

For now, I think it's necessary to prevent unintended layout collapse.

## Testing Instructions

The following two are the blocks where layout problems are most noticeable.

### Site Logo Block

| Before | After |
|--------|--------|
| ![site-logo-before](https://github.com/user-attachments/assets/6652c850-6392-4cdc-a899-15543f013308) | ![image](https://github.com/user-attachments/assets/abd75677-710e-4bf2-aabc-e9dafb474cdf) |

### Image block with `contentOnly` Mode Enabled

| Before | After |
|--------|--------|
| ![image-before](https://github.com/user-attachments/assets/64eabc89-0f68-4623-8975-4ade35271814) | ![image](https://github.com/user-attachments/assets/6fd28e1e-4a81-4579-8ddb-51eb5631c2e1) |
