### PR TITLE
Add a landing section to stylebook tabs

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -202,6 +202,11 @@ function GlobalStylesStyleBook() {
 					navigator.goTo( '/colors/palette' );
 					return;
 				}
+				if ( blockName === 'typography' ) {
+					// Go to typography Global Styles.
+					navigator.goTo( '/typography' );
+					return;
+				}
 
 				// Now go to the selected block.
 				navigator.goTo( '/blocks/' + encodeURIComponent( blockName ) );

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
@@ -131,7 +131,8 @@ export default function GlobalStylesUIWrapper() {
 							// Go to color palettes Global Styles.
 							onPathChange( '/colors/palette' );
 							return;
-						} else if ( blockName === 'typography' ) {
+						}
+						if ( blockName === 'typography' ) {
 							// Go to typography Global Styles.
 							onPathChange( '/typography' );
 							return;

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
@@ -131,6 +131,10 @@ export default function GlobalStylesUIWrapper() {
 							// Go to color palettes Global Styles.
 							onPathChange( '/colors/palette' );
 							return;
+						} else if ( blockName === 'typography' ) {
+							// Go to typography Global Styles.
+							onPathChange( '/typography' );
+							return;
 						}
 
 						// Now go to the selected block.

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -108,6 +108,11 @@ export const STYLE_BOOK_THEME_SUBCATEGORIES: Omit<
 
 export const STYLE_BOOK_CATEGORIES: StyleBookCategory[] = [
 	{
+		slug: 'landing',
+		title: __( 'Landing' ),
+		blocks: [],
+	},
+	{
 		slug: 'text',
 		title: __( 'Text' ),
 		blocks: [

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -252,6 +252,10 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	}
 
 	.edit-site-style-book__example-preview {
+		width: 100%;
+	}
+	
+	.is-wide .edit-site-style-book__example-preview {
 		width: calc(100% - 120px);
 	}
 

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -252,7 +252,7 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	}
 
 	.edit-site-style-book__example-preview {
-		width: 100%;
+		width: calc(100% - 120px);
 	}
 
 	.edit-site-style-book__example-preview .block-editor-block-list__insertion-point,

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -108,8 +108,8 @@ export const STYLE_BOOK_THEME_SUBCATEGORIES: Omit<
 
 export const STYLE_BOOK_CATEGORIES: StyleBookCategory[] = [
 	{
-		slug: 'landing',
-		title: __( 'Landing' ),
+		slug: 'overview',
+		title: __( 'Overview' ),
 		blocks: [],
 	},
 	{

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -96,7 +96,7 @@ function getLandingBlockExamples(
 	// (duplicate for now)
 	const headingsExample = {
 		name: 'core/heading',
-		title: __( 'Heading' ),
+		title: __( 'Headings' ),
 		category: 'landing',
 		blocks: createBlock( 'core/heading', {
 			content: `AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789{(...)},?!*&:;_@#$`,

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -99,10 +99,7 @@ function getLandingBlockExamples(
 		title: __( 'Headings' ),
 		category: 'landing',
 		blocks: createBlock( 'core/heading', {
-			content: `AaBbCcDdEeFfGgHhIi
-				JjKkLlMmNnOoPpQqRrSs
-				TtUuVvWwXxYyZz
-				0123456789{(...)},?!*&:;_@#$`,
+			content: `AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789{(...)},?!*&:;_@#$`,
 			level: 1,
 		} ),
 	};

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -63,6 +63,88 @@ function getColorExamples( colors: MultiOriginPalettes ): BlockExample[] {
 }
 
 /**
+ * Returns examples for the landing page.
+ *
+ * @param {MultiOriginPalettes} colors Global Styles color palettes per origin.
+ * @return {BlockExample[]} An array of block examples.
+ */
+function getLandingBlockExamples(
+	colors: MultiOriginPalettes
+): BlockExample[] {
+	const examples: BlockExample[] = [];
+
+	// Get theme palette from colors.
+	const themePalette = colors.colors.find(
+		( origin: ColorOrigin ) => origin.slug === 'theme'
+	);
+
+	const themeColorexample: BlockExample = {
+		name: 'theme-colors',
+		title: __( 'Theme Colors' ),
+		category: 'landing',
+		content: (
+			<ColorExamples colors={ themePalette.colors } type={ colors } />
+		),
+	};
+
+	examples.push( themeColorexample );
+
+	// Use our own example for the Heading block so that we can show multiple
+	// heading levels.
+	// (duplicate for now)
+	const headingsExample = {
+		name: 'core/heading',
+		title: __( 'Headings' ),
+		category: 'landing',
+		blocks: createBlock( 'core/heading', {
+			content: `AaBbCcDdEeFfGgHhIi
+				JjKkLlMmNnOoPpQqRrSs
+				TtUuVvWwXxYyZz
+				0123456789{(...)},?!*&:;_@#$`,
+			level: 1,
+		} ),
+	};
+	examples.push( headingsExample );
+
+	const paragraphExample = {
+		name: 'core/paragraph',
+		title: __( 'Paragraphs' ),
+		category: 'landing',
+		blocks: createBlock( 'core/paragraph', {
+			content: `There was an Old Man of Vienna, 
+					Who lived upon Tincture of Senna; 
+					When that did not agree, he took Camomile Tea, 
+					That nasty Old Man of Vienna.`,
+		} ),
+	};
+	examples.push( paragraphExample );
+
+	const otherBlockExamples = [
+		'core/image',
+		'core/separator',
+		'core/buttons',
+		'core/pullquote',
+		'core/search',
+	];
+
+	// Get examples for other blocks and put them in order of above array.
+	otherBlockExamples.forEach( ( blockName ) => {
+		const blockType = getBlockType( blockName );
+		if ( blockType && blockType.example ) {
+			const blockExample: BlockExample = {
+				name: blockName,
+				title: blockType.title,
+				category: 'landing',
+				blocks: getBlockFromExample( blockName, blockType.example ),
+			};
+			examples.push( blockExample );
+		}
+	} );
+
+	return examples;
+}
+
+/**
  * Returns a list of examples for registered block types.
  *
  * @param {MultiOriginPalettes} colors Global styles colors grouped by origin e.g. Core, Theme, and User.
@@ -109,5 +191,12 @@ export function getExamples( colors: MultiOriginPalettes ): BlockExample[] {
 	};
 	const colorExamples = getColorExamples( colors );
 
-	return [ headingsExample, ...colorExamples, ...nonHeadingBlockExamples ];
+	const landingBlockExamples = getLandingBlockExamples( colors );
+
+	return [
+		headingsExample,
+		...colorExamples,
+		...nonHeadingBlockExamples,
+		...landingBlockExamples,
+	];
 }

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -81,7 +81,7 @@ function getLandingBlockExamples(
 	if ( themePalette ) {
 		const themeColorexample: BlockExample = {
 			name: 'theme-colors',
-			title: __( 'Theme Colors' ),
+			title: __( 'Colors' ),
 			category: 'landing',
 			content: (
 				<ColorExamples colors={ themePalette.colors } type={ colors } />
@@ -91,32 +91,37 @@ function getLandingBlockExamples(
 		examples.push( themeColorexample );
 	}
 
-	// Use our own example for the Heading block so that we can show multiple
-	// heading levels.
-	// (duplicate for now)
-	const headingsExample = {
-		name: 'core/heading',
-		title: __( 'Headings' ),
-		category: 'landing',
-		blocks: createBlock( 'core/heading', {
-			content: `AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789{(...)},?!*&:;_@#$`,
-			level: 1,
-		} ),
-	};
-	examples.push( headingsExample );
+	const headingBlock = createBlock( 'core/heading', {
+		content: __(
+			`AaBbCcDdEeFfGgHhiiJjKkLIMmNnOoPpQakRrssTtUuVVWwXxxYyZzOl23356789X{(…)},2!*&:/A@HELFO™`
+		),
+		level: 1,
+	} );
+	const firstParagraphBlock = createBlock( 'core/paragraph', {
+		content: `A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically
+composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the`,
+	} );
+	const secondParagraphBlock = createBlock( 'core/paragraph', {
+		content: `text into smaller, manageable chunks, allowing readers to scan and comprehend the content more easily. Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or
+pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block`,
+	} );
 
-	const paragraphExample = {
-		name: 'core/paragraph',
-		title: __( 'Paragraph' ),
+	const textExample = {
+		name: 'theme-text',
+		title: __( 'Text' ),
 		category: 'landing',
-		blocks: createBlock( 'core/paragraph', {
-			content: `There was an Old Man of Vienna, 
-					Who lived upon Tincture of Senna; 
-					When that did not agree, he took Camomile Tea, 
-					That nasty Old Man of Vienna.`,
-		} ),
+		blocks: [
+			headingBlock,
+			createBlock(
+				'core/group',
+				{
+					layout: { type: 'grid', columnCount: 2 },
+				},
+				[ firstParagraphBlock, secondParagraphBlock ]
+			),
+		],
 	};
-	examples.push( paragraphExample );
+	examples.push( textExample );
 
 	const otherBlockExamples = [
 		'core/image',

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -115,7 +115,16 @@ pieces of information. In terms of formatting, paragraphs in websites are common
 			createBlock(
 				'core/group',
 				{
-					layout: { type: 'grid', columnCount: 2 },
+					layout: {
+						type: 'grid',
+						columnCount: 2,
+						minimumColumnWidth: '12rem',
+					},
+					style: {
+						spacing: {
+							blockGap: '1.5rem',
+						},
+					},
 				},
 				[ firstParagraphBlock, secondParagraphBlock ]
 			),

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -98,12 +98,14 @@ function getLandingBlockExamples(
 		level: 1,
 	} );
 	const firstParagraphBlock = createBlock( 'core/paragraph', {
-		content: `A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically
-composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the`,
+		content: __(
+			`A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the`
+		),
 	} );
 	const secondParagraphBlock = createBlock( 'core/paragraph', {
-		content: `text into smaller, manageable chunks, allowing readers to scan and comprehend the content more easily. Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or
-pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block`,
+		content: __(
+			`text into smaller, manageable chunks, allowing readers to scan and comprehend the content more easily. Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block`
+		),
 	} );
 
 	const textExample = {

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -96,7 +96,7 @@ function getLandingBlockExamples(
 	// (duplicate for now)
 	const headingsExample = {
 		name: 'core/heading',
-		title: __( 'Headings' ),
+		title: __( 'Heading' ),
 		category: 'landing',
 		blocks: createBlock( 'core/heading', {
 			content: `AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz0123456789{(...)},?!*&:;_@#$`,
@@ -107,7 +107,7 @@ function getLandingBlockExamples(
 
 	const paragraphExample = {
 		name: 'core/paragraph',
-		title: __( 'Paragraphs' ),
+		title: __( 'Paragraph' ),
 		category: 'landing',
 		blocks: createBlock( 'core/paragraph', {
 			content: `There was an Old Man of Vienna, 

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -78,16 +78,18 @@ function getLandingBlockExamples(
 		( origin: ColorOrigin ) => origin.slug === 'theme'
 	);
 
-	const themeColorexample: BlockExample = {
-		name: 'theme-colors',
-		title: __( 'Theme Colors' ),
-		category: 'landing',
-		content: (
-			<ColorExamples colors={ themePalette.colors } type={ colors } />
-		),
-	};
+	if ( themePalette ) {
+		const themeColorexample: BlockExample = {
+			name: 'theme-colors',
+			title: __( 'Theme Colors' ),
+			category: 'landing',
+			content: (
+				<ColorExamples colors={ themePalette.colors } type={ colors } />
+			),
+		};
 
-	examples.push( themeColorexample );
+		examples.push( themeColorexample );
+	}
 
 	// Use our own example for the Heading block so that we can show multiple
 	// heading levels.

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -109,8 +109,8 @@ function getOverviewBlockExamples(
 	} );
 
 	const textExample = {
-		name: 'theme-text',
-		title: __( 'Text' ),
+		name: 'typography',
+		title: __( 'Typography' ),
 		category: 'overview',
 		blocks: [
 			headingBlock,

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -63,12 +63,12 @@ function getColorExamples( colors: MultiOriginPalettes ): BlockExample[] {
 }
 
 /**
- * Returns examples for the landing page.
+ * Returns examples for the overview page.
  *
  * @param {MultiOriginPalettes} colors Global Styles color palettes per origin.
  * @return {BlockExample[]} An array of block examples.
  */
-function getLandingBlockExamples(
+function getOverviewBlockExamples(
 	colors: MultiOriginPalettes
 ): BlockExample[] {
 	const examples: BlockExample[] = [];
@@ -82,7 +82,7 @@ function getLandingBlockExamples(
 		const themeColorexample: BlockExample = {
 			name: 'theme-colors',
 			title: __( 'Colors' ),
-			category: 'landing',
+			category: 'overview',
 			content: (
 				<ColorExamples colors={ themePalette.colors } type={ colors } />
 			),
@@ -99,19 +99,19 @@ function getLandingBlockExamples(
 	} );
 	const firstParagraphBlock = createBlock( 'core/paragraph', {
 		content: __(
-			`A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the`
+			`A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the text into smaller, manageable chunks, allowing readers to scan the content more easily.`
 		),
 	} );
 	const secondParagraphBlock = createBlock( 'core/paragraph', {
 		content: __(
-			`text into smaller, manageable chunks, allowing readers to scan and comprehend the content more easily. Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block`
+			`Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block of text. This visual separation helps visually distinguish one paragraph from another, creating a clear and organized layout that guides the reader through the content smoothly.`
 		),
 	} );
 
 	const textExample = {
 		name: 'theme-text',
 		title: __( 'Text' ),
-		category: 'landing',
+		category: 'overview',
 		blocks: [
 			headingBlock,
 			createBlock(
@@ -149,7 +149,7 @@ function getLandingBlockExamples(
 			const blockExample: BlockExample = {
 				name: blockName,
 				title: blockType.title,
-				category: 'landing',
+				category: 'overview',
 				blocks: getBlockFromExample( blockName, blockType.example ),
 			};
 			examples.push( blockExample );
@@ -206,12 +206,12 @@ export function getExamples( colors: MultiOriginPalettes ): BlockExample[] {
 	};
 	const colorExamples = getColorExamples( colors );
 
-	const landingBlockExamples = getLandingBlockExamples( colors );
+	const overviewBlockExamples = getOverviewBlockExamples( colors );
 
 	return [
 		headingsExample,
 		...colorExamples,
 		...nonHeadingBlockExamples,
-		...landingBlockExamples,
+		...overviewBlockExamples,
 	];
 }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -203,6 +203,22 @@ function StyleBook( {
 		[ examples ]
 	);
 
+	const examplesForSinglePageUse = [];
+	const landingCategoryExamples = getExamplesByCategory(
+		{ slug: 'landing' },
+		examples
+	);
+	examplesForSinglePageUse.push( ...landingCategoryExamples.examples );
+	const otherExamples = examples.filter( ( example ) => {
+		return (
+			example.category !== 'landing' &&
+			! landingCategoryExamples.examples.find(
+				( landingExample ) => landingExample.name === example.name
+			)
+		);
+	} );
+	examplesForSinglePageUse.push( ...otherExamples );
+
 	const { base: baseConfig } = useContext( GlobalStylesContext );
 	const goTo = getStyleBookNavigationFromPath( path );
 
@@ -286,7 +302,7 @@ function StyleBook( {
 					</Tabs>
 				) : (
 					<StyleBookBody
-						examples={ examples }
+						examples={ examplesForSinglePageUse }
 						isSelected={ isSelected }
 						onClick={ onClick }
 						onSelect={ onSelect }

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -204,16 +204,16 @@ function StyleBook( {
 	);
 
 	const examplesForSinglePageUse = [];
-	const landingCategoryExamples = getExamplesByCategory(
-		{ slug: 'landing' },
+	const overviewCategoryExamples = getExamplesByCategory(
+		{ slug: 'overview' },
 		examples
 	);
-	examplesForSinglePageUse.push( ...landingCategoryExamples.examples );
+	examplesForSinglePageUse.push( ...overviewCategoryExamples.examples );
 	const otherExamples = examples.filter( ( example ) => {
 		return (
-			example.category !== 'landing' &&
-			! landingCategoryExamples.examples.find(
-				( landingExample ) => landingExample.name === example.name
+			example.category !== 'overview' &&
+			! overviewCategoryExamples.examples.find(
+				( overviewExample ) => overviewExample.name === example.name
 			)
 		);
 	} );

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -103,7 +103,7 @@ test.describe( 'Style Book', () => {
 		await page
 			.frameLocator( '[name="style-book-canvas"]' )
 			.getByRole( 'button', {
-				name: 'Open Quote styles in Styles panel',
+				name: 'Open Pullquote styles in Styles panel',
 			} )
 			.click();
 

--- a/test/e2e/specs/site-editor/style-book.spec.js
+++ b/test/e2e/specs/site-editor/style-book.spec.js
@@ -52,14 +52,10 @@ test.describe( 'Style Book', () => {
 			'[name="style-book-canvas"]'
 		);
 
+		// In the Overview tab, expect a button for the main typography section.
 		await expect(
 			styleBookIframe.getByRole( 'button', {
-				name: 'Open Headings styles in Styles panel',
-			} )
-		).toBeVisible();
-		await expect(
-			styleBookIframe.getByRole( 'button', {
-				name: 'Open Paragraph styles in Styles panel',
+				name: 'Open Typography styles in Styles panel',
 			} )
 		).toBeVisible();
 
@@ -83,13 +79,13 @@ test.describe( 'Style Book', () => {
 		await page
 			.frameLocator( '[name="style-book-canvas"]' )
 			.getByRole( 'button', {
-				name: 'Open Headings styles in Styles panel',
+				name: 'Open Image styles in Styles panel',
 			} )
 			.click();
 
 		await expect(
 			page.locator(
-				'role=region[name="Editor settings"i] >> role=heading[name="Heading"i]'
+				'role=region[name="Editor settings"i] >> role=heading[name="Image"i]'
 			)
 		).toBeVisible();
 	} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #66517.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Open stylebook by clicking on Styles from the left hand side black sidebar, then clicking on Preview and selecting Style book from the dropdown.
2. See that the first blocks to appear are the same as in the landing page designs from #66517.
3. Open stylebook by clicking on Styles in the top right hand side of the editable canvas, and selecting Style Book from the top of the right hand side bar.
4. See there's now a Landing tab.
5. In either view, clicking on any of the blocks should take you to the relevant section of the global styles interface.

Given that the stylebook view in the left hand sidebar has everything in one long scroll, I deduped the items from the Landing section and added them in at the top.

## Screenshots or screencast <!-- if applicable -->

<img width="1455" alt="Screenshot 2024-10-29 at 1 57 12 pm" src="https://github.com/user-attachments/assets/79aae4ff-1df5-4ea6-88dc-391d370dda5a">


<img width="1425" alt="Screenshot 2024-11-06 at 10 00 36 am" src="https://github.com/user-attachments/assets/56cc0825-ba14-4e81-aa1d-8928ebc0b4f9">
