### PR TITLE
Optimize `getVisibleElementBounds` in scrollable cases

### DIFF
--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -162,15 +162,14 @@ export function getVisibleElementBounds( element ) {
 	let currentElement;
 
 	while ( ( currentElement = stack.pop() ) ) {
-		for ( const child of currentElement.children ) {
-			if ( isElementVisible( child ) ) {
-				let childBounds = child.getBoundingClientRect();
-				// If the parent is scrollable, use parent's scrollable bounds.
-				if ( isScrollable( currentElement ) ) {
-					childBounds = currentElement.getBoundingClientRect();
+		// Children won’t affect bounds unless the element is not scrollable.
+		if ( ! isScrollable( currentElement ) ) {
+			for ( const child of currentElement.children ) {
+				if ( isElementVisible( child ) ) {
+					const childBounds = child.getBoundingClientRect();
+					bounds = rectUnion( bounds, childBounds );
+					stack.push( child );
 				}
-				bounds = rectUnion( bounds, childBounds );
-				stack.push( child );
 			}
 		}
 	}


### PR DESCRIPTION
## What?
A minor improvement of `getVisibleElementBounds`.

## Why?
To avoid extraneous DOM method invocations. I think it also makes the code more clear. The performance probably isn’t really an issue. Scrollable elements aren’t expected to be the primary use case of the utility anyway.

## How?
Skips iteration of children when the parent is scrollable.

## Testing Instructions

<details><summary>Scrollable block for use in reproduction/testing</summary>

```js
wp.blocks.registerBlockType( 'test/scrollable', {
    apiVersion: 3,
    title: 'Scrollable block',
    attributes: {
        isHorizontal: {
            default: false,
            type: 'boolean',
        }
    },
    edit: ( { attributes: { isHorizontal }, setAttributes } ) => {
        const { createElement: h, Fragment, useRef } = wp.element;
        const controls = h(
            wp.blockEditor.BlockControls,
            { group: 'block' },
            h(
                wp.components.ToolbarButton,
                {
                    isPressed: isHorizontal,
                    onClick: () => setAttributes( { isHorizontal: ! isHorizontal } ),
                },
                'Horizontal'
            )
        );
        const menuRef = useRef();
        const toggleMenu = ( event ) => {
            if ( menuRef.current.hasAttribute( 'hidden' ) )
                menuRef.current.removeAttribute( 'hidden' );
            else
                menuRef.current.setAttribute( 'hidden', '' );
        };
        const block = h(
            'div',
            wp.blockEditor.useBlockProps(),
            h(
                'header',
                { style: {
                    background: '#fff',
                    marginInline: '-.5em',
                    padding: '.5em',
                    borderRadius: '.5em',
                    filter: 'drop-shadow(0 0 .25em #0003)',
                    display: 'flex',
                } },
                '📜 Scroll please',
                h(
                    'button', {
                        onClick: toggleMenu,
                        style: { marginInline: 'auto 0' }
                    },
                    '⋮'
                ),
                h(
                    'div',
                    {
                        ref: menuRef,
                        style: {
                            position: 'absolute',
                            inset: '3rem 0 auto auto',
                            height: '300px',
                            fontSize: '300px',
                            lineHeight: .93,
                            overflow: 'hidden',
                            background: 'inherit',
                            borderRadius: 'inherit',
                        },
                        hidden: true,
                    },
                    '⋮'
                )
            ),
            h(
                'div', 
                {
                    style: {
                        overflow: 'auto',
                        background: 'papayawhip',
                        ...( isHorizontal
                            ? { display: 'grid', gridAutoColumns: '5em', gridAutoFlow: 'column' }
                            : { height: '200px' }
                        )
                    },
                },
                ...Array
                    .from( { length: 40 } )
                    .map(
                        ( v, i ) => h( 'p', {
                            key: 'u' + i,
                            children:'p ' + ( i + 1 )
                        } )
                    )
            )
        );
        return h( Fragment, null, controls, block );
    },
} );
```
</details>

### Verify the extraneous calls on trunk (optional)

It seems pretty clear just reading the source of the function but if your like me you want to run the experiment.

<details><summary>Diff to log iterations when the element is scrollable</summary>

```diff
diff --git a/packages/block-editor/src/utils/dom.js b/packages/block-editor/src/utils/dom.js
index 0603e9bbb1..027e81eeb0 100644
--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -167,6 +167,7 @@ export function getVisibleElementBounds( element ) {
 				let childBounds = child.getBoundingClientRect();
 				// If the parent is scrollable, use parent's scrollable bounds.
 				if ( isScrollable( currentElement ) ) {
+					console.log('using parent bounds', currentElement)
 					childBounds = currentElement.getBoundingClientRect();
 				}
 				bounds = rectUnion( bounds, childBounds );
@@ -174,6 +175,7 @@ export function getVisibleElementBounds( element ) {
 			}
 		}
 	}
+	console.log('- - - - - - - -');
 
 	/*
 	 * Take into account the outer horizontal limits of the container in which
diff --git a/packages/components/src/popover/index.tsx b/packages/components/src/popover/index.tsx
index 3005f13c95..390385091d 100644
--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -290,7 +290,7 @@ const UnforwardedPopover = (
 		whileElementsMounted: ( referenceParam, floatingParam, updateParam ) =>
 			autoUpdate( referenceParam, floatingParam, updateParam, {
 				layoutShift: false,
-				animationFrame: true,
+				animationFrame: false,
 			} ),
 	} );
 

```
</details>

1. On trunk apply the above diff
2. Open a post in the editor
3. Paste and execute the code for the scrollable block in the dev tools console
4. Insert the block
5. Check the console and verify each iteration is using the same element and therefore there’s no need to keep getting its bounds.

### Navigation block with child extending beyond the nav block's bounds

This will confirm that the original fix from https://github.com/WordPress/gutenberg/pull/62711#issuecomment-2413101197 still works.

1. Switch to EmptyTheme and navigate to Appearance > Editor
2. Click on the canvas and add a navigation block to the header 
3. Move the navigation block to the very first position in the block list to force the toolbar below the block
4. Add a submenu to the navigation if it doesn't already have one
5. Ensure that the block toolbar moves down to accomodate the submenu when it is opened i.e. the toolbar shouldn't overlap the navigation or submenu blocks
6. Confirm the toolbar behaves appropriately when adding new submenu items or scrolling the overall page

### Scrollable block toolbars

Follow the nice and detailed instructions on https://github.com/WordPress/gutenberg/issues/66112

TL;DR version

1. Edit a post, open dev tools and paste in the snippet from the issue to create some test blocks that scroll
2. Add the test blocks to a long post with several paragraphs
3. Select each of the horizontal and vertical scrolling blocks and confirm their toolbar stays in the correct location
4. Scroll down the page and ensure their toolbars disappear correctly as the block leaves the viewport

### Block Popovers and Visualizers

1. Edit a post and add blocks that have a block popover e.g. Cover block with its resizable popover
2. Add some blocks that support spacing visualizers e.g. Group block with padding and margin support
3. Confirm that the visualizers and popovers display appropriately (visualizers have some problems on trunk not matching the controls value immediately so ignore them)

## Screenshots or screencast <!-- if applicable -->

Making sure the toolbar positioning works as expected on this branch

https://github.com/user-attachments/assets/2f78eea2-0345-48c0-88c4-6ce7e2fb72cd



