### PR TITLE
Add 'grid' variant to BlockPatternsList

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -73,3 +73,24 @@
 		}
 	}
 }
+
+.block-editor-block-patterns-list {
+	&.is-variant-grid {
+		display: grid;
+		grid-template-columns: 1fr 1fr;
+		grid-gap: $grid-unit-15;
+		.block-editor-block-patterns-list__list-item {
+			margin-bottom: 0;
+		}
+		.block-editor-inserter__media-list__list-item {
+			min-height: 100px;
+		}
+
+		.block-editor-block-patterns-list__grid-row {
+			grid-column: 1 / -1;
+			box-sizing: border-box;
+			display: grid;
+			grid-gap: $grid-unit-15;
+		}
+	}
+}

--- a/packages/block-editor/src/components/block-toolbar/change-design.js
+++ b/packages/block-editor/src/components/block-toolbar/change-design.js
@@ -125,6 +125,7 @@ export default function ChangeDesign( { clientId } ) {
 						blockPatterns={ sameCategoryPatternsWithSingleWrapper }
 						onClickPattern={ onClickPattern }
 						showTitle={ false }
+						variant="grid"
 					/>
 				</DropdownContentWrapper>
 			) }

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -286,18 +286,8 @@
 	}
 }
 
+// TODO: check about the below styles..
 .block-editor-block-toolbar-change-design-content-wrapper {
 	padding: $grid-unit-15;
 	width: 320px;
-	.block-editor-block-patterns-list {
-		display: grid;
-		grid-template-columns: 1fr 1fr;
-		grid-gap: $grid-unit-15;
-		.block-editor-block-patterns-list__list-item {
-			margin-bottom: 0;
-		}
-		.block-editor-inserter__media-list__list-item {
-			min-height: 100px;
-		}
-	}
 }

--- a/packages/block-library/src/query/edit/pattern-selection-modal.js
+++ b/packages/block-library/src/query/edit/pattern-selection-modal.js
@@ -3,7 +3,11 @@
  */
 import { useState, useMemo } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { Modal, SearchControl } from '@wordpress/components';
+import {
+	Modal,
+	SearchControl,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useAsyncList } from '@wordpress/compose';
 import {
 	BlockContextProvider,
@@ -64,7 +68,7 @@ export default function PatternSelectionModal( {
 			onRequestClose={ () => setIsPatternSelectionModalOpen( false ) }
 			isFullScreen
 		>
-			<div className="block-library-query-pattern__selection-content">
+			<VStack spacing={ 0 }>
 				<div className="block-library-query-pattern__selection-search">
 					<SearchControl
 						__nextHasNoMarginBottom
@@ -79,9 +83,10 @@ export default function PatternSelectionModal( {
 						blockPatterns={ filteredBlockPatterns }
 						shownPatterns={ shownBlockPatterns }
 						onClickPattern={ onBlockPatternSelect }
+						variant="grid"
 					/>
 				</BlockContextProvider>
-			</div>
+			</VStack>
 		</Modal>
 	);
 }

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -10,34 +10,7 @@
 	padding: 0 $grid-unit-20 $grid-unit-20 52px;
 }
 
-.block-library-query__pattern-selection-content .block-editor-block-patterns-list {
-	display: grid;
-	grid-template-columns: 1fr 1fr 1fr;
-	grid-gap: $grid-unit-10;
-
-	.block-editor-block-patterns-list__list-item {
-		margin-bottom: 0;
-		.block-editor-block-preview__container {
-			max-height: 250px;
-		}
-	}
-}
-
 .block-library-query-pattern__selection-modal {
-
-	.block-editor-block-patterns-list {
-		column-count: 2;
-		column-gap: $grid-unit-30;
-
-		@include break-wide() {
-			column-count: 3;
-		}
-
-		.block-editor-block-patterns-list__list-item {
-			break-inside: avoid-column;
-		}
-	}
-
 	.block-library-query-pattern__selection-search {
 		background: $white;
 		position: sticky;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to: https://github.com/WordPress/gutenberg/issues/66549
<!-- In a few words, what is the PR actually doing? -->

The linked issue explains how we currently use `BlockPatternsList` and how we can make the UX more consistent. One thing that is obvious though is that we need to absorb the `grid` custom implementations. 

This PR tries that and will serve as a playground for all use cases for now, to see that it serves all well before merging.

For now I added the `variant=grid` prop and use that in `Change design` dialog for patterns in zoom out and the Query Loop `replace` modal. Noting that I haven't implemented dynamic columns number, but I added some proper keyboard navigation for 'grid' variants. 

