### PR TITLE
Site Editor: restore block-library editor.css outside canvas

### DIFF
--- a/backport-changelog/6.8/7643.md
+++ b/backport-changelog/6.8/7643.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7643
 
 * https://github.com/WordPress/gutenberg/pull/66432
+* https://github.com/WordPress/gutenberg/pull/66556

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -368,7 +368,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		array(),
 		$version
 	);
-	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+	$styles->add_data( 'wp-block-library-editor', 'rtl', 'replace' );
 
 	gutenberg_override_style(
 		$styles,

--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -363,6 +363,15 @@ function gutenberg_register_packages_styles( $styles ) {
 
 	gutenberg_override_style(
 		$styles,
+		'wp-block-library-editor',
+		gutenberg_url( 'build/block-library/editor.css' ),
+		array(),
+		$version
+	);
+	$styles->add_data( 'wp-edit-blocks', 'rtl', 'replace' );
+
+	gutenberg_override_style(
+		$styles,
 		'wp-edit-blocks',
 		gutenberg_url( 'build/block-library/editor.css' ),
 		$wp_edit_blocks_dependencies,
@@ -410,7 +419,7 @@ function gutenberg_register_packages_styles( $styles ) {
 		$styles,
 		'wp-edit-site',
 		gutenberg_url( 'build/edit-site/style.css' ),
-		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'common', 'forms', 'wp-commands', 'wp-preferences' ),
+		array( 'wp-components', 'wp-block-editor', 'wp-editor', 'wp-block-library-editor', 'common', 'forms', 'wp-commands', 'wp-preferences' ),
 		$version
 	);
 	$styles->add_data( 'wp-edit-site', 'rtl', 'replace' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In #66544 @t-hamano observed that a bit too many styles have been removed in https://github.com/WordPress/gutenberg/pull/66432. Indeed, it should have kept loading `editor.css` files defined by blocks because they target both content and UI outside the canvas. The remaining styles should still be removed though. 

One light problem is that all the styles we want to remove are added as dependencies of `wp-edit-blocks`. So restoring `wp-edit-blocks` will add back all the styles we don't want. To fix the issue we can register a separate handle `wp-block-library-editor`, which exclusively loads the editor styles.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fix a regression from #66432.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In content only mode, select an image and click the "alternative text" button in the toolbar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
