### PR TITLE
Quick Edit - Slug Field: improve slug preview

### DIFF
--- a/packages/fields/src/fields/slug/slug-edit.tsx
+++ b/packages/fields/src/fields/slug/slug-edit.tsx
@@ -21,6 +21,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
+import { getSlug } from './utils';
 
 const SlugEdit = ( {
 	field,
@@ -29,7 +30,7 @@ const SlugEdit = ( {
 }: DataFormControlProps< BasePost > ) => {
 	const { id } = field;
 
-	const slug = field.getValue( { item: data } ) ?? '';
+	const slug = field.getValue( { item: data } ) || getSlug( data );
 	const permalinkTemplate = data.permalink_template || '';
 	const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 	const [ prefix, suffix ] = permalinkTemplate.split(
@@ -115,30 +116,26 @@ const SlugEdit = ( {
 							}
 						} }
 						aria-describedby={ postUrlSlugDescriptionId }
-						help={
-							<>
-								<p className="fields-controls__slug-help">
-									<span className="fields-controls__slug-help-visual-label">
-										{ __( 'Permalink:' ) }
-									</span>
-									<ExternalLink
-										className="fields-controls__slug-help-link"
-										href={ permalink }
-									>
-										<span className="fields-controls__slug-help-prefix">
-											{ permalinkPrefix }
-										</span>
-										<span className="fields-controls__slug-help-slug">
-											{ slugToDisplay }
-										</span>
-										<span className="fields-controls__slug-help-suffix">
-											{ permalinkSuffix }
-										</span>
-									</ExternalLink>
-								</p>
-							</>
-						}
 					/>
+					<div className="fields-controls__slug-help">
+						<span className="fields-controls__slug-help-visual-label">
+							{ __( 'Permalink:' ) }
+						</span>
+						<ExternalLink
+							className="fields-controls__slug-help-link"
+							href={ permalink }
+						>
+							<span className="fields-controls__slug-help-prefix">
+								{ permalinkPrefix }
+							</span>
+							<span className="fields-controls__slug-help-slug">
+								{ slugToDisplay }
+							</span>
+							<span className="fields-controls__slug-help-suffix">
+								{ permalinkSuffix }
+							</span>
+						</ExternalLink>
+					</div>
 				</VStack>
 			) }
 			{ ! isEditable && (

--- a/packages/fields/src/fields/slug/slug-view.tsx
+++ b/packages/fields/src/fields/slug/slug-view.tsx
@@ -7,9 +7,10 @@ import { useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
+import { getSlug } from './utils';
 
 const SlugView = ( { item }: { item: BasePost } ) => {
-	const slug = item.slug;
+	const slug = item ? getSlug( item ) : '';
 	const originalSlugRef = useRef( slug );
 
 	useEffect( () => {
@@ -20,7 +21,7 @@ const SlugView = ( { item }: { item: BasePost } ) => {
 
 	const slugToDisplay = slug || originalSlugRef.current;
 
-	return `/${ slugToDisplay ?? '' }`;
+	return `${ slugToDisplay ?? '' }`;
 };
 
 export default SlugView;

--- a/packages/fields/src/fields/slug/slug-view.tsx
+++ b/packages/fields/src/fields/slug/slug-view.tsx
@@ -10,7 +10,7 @@ import type { BasePost } from '../../types';
 import { getSlug } from './utils';
 
 const SlugView = ( { item }: { item: BasePost } ) => {
-	const slug = item ? getSlug( item ) : '';
+	const slug = typeof item === 'object' ? getSlug( item ) : '';
 	const originalSlugRef = useRef( slug );
 
 	useEffect( () => {
@@ -21,7 +21,7 @@ const SlugView = ( { item }: { item: BasePost } ) => {
 
 	const slugToDisplay = slug || originalSlugRef.current;
 
-	return `${ slugToDisplay ?? '' }`;
+	return `${ slugToDisplay }`;
 };
 
 export default SlugView;

--- a/packages/fields/src/fields/slug/utils.ts
+++ b/packages/fields/src/fields/slug/utils.ts
@@ -8,7 +8,7 @@ import { cleanForSlug } from '@wordpress/url';
 import type { BasePost } from '../../types';
 import { getItemTitle } from '../../actions/utils';
 
-export const getSlug = ( item: BasePost ) => {
+export const getSlug = ( item: BasePost ): string => {
 	return (
 		item.slug || cleanForSlug( getItemTitle( item ) ) || item.id.toString()
 	);

--- a/packages/fields/src/fields/slug/utils.ts
+++ b/packages/fields/src/fields/slug/utils.ts
@@ -1,0 +1,15 @@
+/**
+ * WordPress dependencies
+ */
+import { cleanForSlug } from '@wordpress/url';
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+import { getItemTitle } from '../../actions/utils';
+
+export const getSlug = ( item: BasePost ) => {
+	return (
+		item.slug || cleanForSlug( getItemTitle( item ) ) || item.id.toString()
+	);
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I noticed that the fallback logic for undefined slugs was missing, for instance draft pages. This PR implements a mechanism to provide a fallback slug when the slug is not defined.




| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/5c8b967a-648f-439a-b157-58626df0e271) | ![image](https://github.com/user-attachments/assets/2de1ad9c-b5bc-40e0-9ebf-176f4fa7a51b) | 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
Ensure that `Quick Edit in DataViews` and `Quick Edit in DataViews` are enabled.
Ensure that you have a **draft page without any title set**.

1. Visit the Site Editor.
2. Click on pages.
3. Toggle to the table view.
4. Select the draft page that you created.
5. Click on the settings.
6. Click on details panel icon.
7. Ensure that the link field is visible
8. Click on it.
9. Ensure that the slug preview is right. You should see the page ID.
10. Update the slug.
11. Save.
12. Ensure that the page is visible to the new link.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
