### PR TITLE
Fix Color changes to be in sync with rest of the block for latest comment

### DIFF
--- a/packages/block-library/src/latest-comments/edit.js
+++ b/packages/block-library/src/latest-comments/edit.js
@@ -88,6 +88,13 @@ export default function LatestComments( { attributes, setAttributes } ) {
 					// the block appears on the frontend. Setting the locale
 					// explicitly prevents any middleware from setting it to 'user'.
 					urlQueryArgs={ { _locale: 'site' } }
+					/**
+					 * The `key` prop is set to a combination of `backgroundColor` and `textColor` attributes.
+					 * This forces the <ServerSideRender> component to update.
+					 */
+					key={ `${ attributes.backgroundColor || 'default' }-${
+						attributes.textColor || 'default'
+					}` }
 				/>
 			</Disabled>
 		</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR solves the following issues #66536, which address that latest comment text color doesn't change color in sync with the whole block

## Why?
Refreshing the page after adding latest comments and changing its color doesn't change text color again, Then only first line text color will change, Remaining text color will not change.

## How?
By setting the key prop and handling null values, we ensure the block behaves as expected.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
- Select Latest comments block
- Change its background color & text color from block settings.
- Save the changes and publish the page.
- View the editor side & front-end side.
- Refresh the page.
- Now, change block text color & background color again.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ee24b4be-df38-4513-9bb4-754411cef1e3



