### PR TITLE
PostTaxonomiesFlatTermSelector: Restore space between tag list and most used tags

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -294,7 +294,7 @@ export function FlatTermSelector( { slug, __nextHasNoMarginBottom } ) {
 
 	const Wrapper = ( { children } ) =>
 		__nextHasNoMarginBottom ? (
-			<VStack spacing={ 3 }>{ children }</VStack>
+			<VStack spacing={ 4 }>{ children }</VStack>
 		) : (
 			<Fragment>{ children }</Fragment>
 		);

--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -2,8 +2,12 @@
  * WordPress dependencies
  */
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { useEffect, useMemo, useState } from '@wordpress/element';
-import { FormTokenField, withFilters } from '@wordpress/components';
+import { Fragment, useEffect, useMemo, useState } from '@wordpress/element';
+import {
+	FormTokenField,
+	withFilters,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { store as coreStore } from '@wordpress/core-data';
@@ -288,8 +292,15 @@ export function FlatTermSelector( { slug, __nextHasNoMarginBottom } ) {
 		singularName
 	);
 
+	const Wrapper = ( { children } ) =>
+		__nextHasNoMarginBottom ? (
+			<VStack spacing={ 3 }>{ children }</VStack>
+		) : (
+			<Fragment>{ children }</Fragment>
+		);
+
 	return (
-		<>
+		<Wrapper>
 			<FormTokenField
 				__next40pxDefaultSize
 				value={ values }
@@ -306,7 +317,7 @@ export function FlatTermSelector( { slug, __nextHasNoMarginBottom } ) {
 				__nextHasNoMarginBottom={ __nextHasNoMarginBottom }
 			/>
 			<MostUsedTerms taxonomy={ taxonomy } onSelect={ appendTerm } />
-		</>
+		</Wrapper>
 	);
 }
 


### PR DESCRIPTION
## What?

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7ac96992-57e6-4815-ab87-7b2cfeabb218) | ![image](https://github.com/user-attachments/assets/2d3f6fbe-5a4d-422d-8cb3-93eb34e59130) | 

## Why?

#63491 resets the bottom margin of the `FormTokenField` component inside the `PostTaxonomiesFlatTermSelector` component.

`PostTaxonomiesFlatTermSelector` needs space between both because most used tags may be rendered below the `FormTokenField`.

## How?

The `PostTaxonomiesFlatTermSelector` component is publicly exposed and there may be developers who have not yet opted into `__nextHasMarginBottom`. To prevent double spacing, I restore the previous spacing (`12px`) via the `VStack` component _only_ if the `__nextHasMarginBottom` prop is enabled.

## Testing Instructions

- Apply three or more tags to a post.
- Reload the post editor and you should see the "Most Used" section.
- Make sure there is space above the "Most Used" section.
