### PR TITLE
QuickEdit: Add password field data to the pages quick edit

### DIFF
--- a/packages/dataviews/src/components/dataform-combined-edit/style.scss
+++ b/packages/dataviews/src/components/dataform-combined-edit/style.scss
@@ -9,4 +9,8 @@
 	&__field {
 		flex: 1 1 auto;
 	}
+
+	p.components-base-control__help:has(.components-checkbox-control__help) {
+		margin-top: $grid-unit-05;
+	}
 }

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -80,30 +80,26 @@ function PostEditForm( { postType, postId } ) {
 				'parent',
 				'comment_status',
 			],
-			layout: {
-				combinedFields: [
-					{
-						id: 'status_and_visibility',
-						label: __( 'Status & Visibility' ),
-						children: [ 'status', 'password' ].filter(
-							( child ) => {
-								if (
-									child === 'password' &&
-									ids.length === 1 &&
-									record.status === 'private'
-								) {
-									return false;
-								}
-								return true;
-							}
-						),
-						direction: 'vertical',
-						render: ( { item } ) => item.status,
-					},
-				],
-			},
+			combinedFields: [
+				{
+					id: 'status_and_visibility',
+					label: __( 'Status & Visibility' ),
+					children: [ 'status', 'password' ].filter( ( child ) => {
+						if (
+							child === 'password' &&
+							ids.length === 1 &&
+							record.status === 'private'
+						) {
+							return false;
+						}
+						return true;
+					} ),
+					direction: 'vertical',
+					render: ( { item } ) => item.status,
+				},
+			],
 		} ),
-		[ ids, record.status ]
+		[ ids, record?.status ]
 	);
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -58,30 +58,6 @@ function PostEditForm( { postType, postId } ) {
 			} ),
 		[ _fields ]
 	);
-	const form = {
-		type: 'panel',
-		fields: [
-			'featured_media',
-			'title',
-			'status_and_visibility',
-			'author',
-			'date',
-			'slug',
-			'parent',
-			'comment_status',
-		],
-		layout: {
-			combinedFields: [
-				{
-					id: 'status_and_visibility',
-					label: 'Status & Visibility',
-					children: [ 'status', 'password' ],
-					direction: 'vertical',
-					render: ( { item } ) => item.status,
-				},
-			],
-		},
-	};
 
 	const fieldsWithBulkEditSupport = [
 		'title',
@@ -91,6 +67,44 @@ function PostEditForm( { postType, postId } ) {
 		'comment_status',
 	];
 
+	const form = useMemo(
+		() => ( {
+			type: 'panel',
+			fields: [
+				'featured_media',
+				'title',
+				'status_and_visibility',
+				'author',
+				'date',
+				'slug',
+				'parent',
+				'comment_status',
+			],
+			layout: {
+				combinedFields: [
+					{
+						id: 'status_and_visibility',
+						label: 'Status & Visibility',
+						children: [ 'status', 'password' ].filter(
+							( child ) => {
+								if (
+									child === 'password' &&
+									ids.length === 1 &&
+									record.status === 'private'
+								) {
+									return false;
+								}
+								return true;
+							}
+						),
+						direction: 'vertical',
+						render: ( { item } ) => item.status,
+					},
+				],
+			},
+		} ),
+		[ ids, record.status ]
+	);
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {
 			if (

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -79,7 +79,11 @@ function PostEditForm( { postType, postId } ) {
 				'slug',
 				'parent',
 				'comment_status',
-			],
+			].filter(
+				( field ) =>
+					ids.length === 1 ||
+					fieldsWithBulkEditSupport.includes( field )
+			),
 			combinedFields: [
 				{
 					id: 'status_and_visibility',
@@ -139,16 +143,7 @@ function PostEditForm( { postType, postId } ) {
 			<DataForm
 				data={ ids.length === 1 ? record : multiEdits }
 				fields={ fields }
-				form={
-					ids.length === 1
-						? form
-						: {
-								...form,
-								fields: form.fields.filter( ( field ) =>
-									fieldsWithBulkEditSupport.includes( field )
-								),
-						  }
-				}
+				form={ form }
 				onChange={ onChange }
 			/>
 		</VStack>

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -84,7 +84,7 @@ function PostEditForm( { postType, postId } ) {
 				combinedFields: [
 					{
 						id: 'status_and_visibility',
-						label: 'Status & Visibility',
+						label: __( 'Status & Visibility' ),
 						children: [ 'status', 'password' ].filter(
 							( child ) => {
 								if (

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -63,12 +63,24 @@ function PostEditForm( { postType, postId } ) {
 		fields: [
 			'featured_media',
 			'title',
+			'status_and_visibility',
 			'author',
 			'date',
 			'slug',
 			'parent',
 			'comment_status',
 		],
+		layout: {
+			combinedFields: [
+				{
+					id: 'status_and_visibility',
+					label: 'Status & Visibility',
+					children: [ 'status', 'password' ],
+					direction: 'vertical',
+					render: ( { item } ) => item.status,
+				},
+			],
+		},
 	};
 
 	const fieldsWithBulkEditSupport = [

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -23,6 +23,14 @@ import { unlock } from '../../lock-unlock';
 
 const { PostCardPanel } = unlock( editorPrivateApis );
 
+const fieldsWithBulkEditSupport = [
+	'title',
+	'status',
+	'date',
+	'author',
+	'comment_status',
+];
+
 function PostEditForm( { postType, postId } ) {
 	const ids = useMemo( () => postId.split( ',' ), [ postId ] );
 	const { record } = useSelect(
@@ -59,14 +67,6 @@ function PostEditForm( { postType, postId } ) {
 		[ _fields ]
 	);
 
-	const fieldsWithBulkEditSupport = [
-		'title',
-		'status',
-		'date',
-		'author',
-		'comment_status',
-	];
-
 	const form = useMemo(
 		() => ( {
 			type: 'panel',
@@ -88,22 +88,13 @@ function PostEditForm( { postType, postId } ) {
 				{
 					id: 'status_and_visibility',
 					label: __( 'Status & Visibility' ),
-					children: [ 'status', 'password' ].filter( ( child ) => {
-						if (
-							child === 'password' &&
-							ids.length === 1 &&
-							record.status === 'private'
-						) {
-							return false;
-						}
-						return true;
-					} ),
+					children: [ 'status', 'password' ],
 					direction: 'vertical',
 					render: ( { item } ) => item.status,
 				},
 			],
 		} ),
-		[ ids, record?.status ]
+		[ ids ]
 	);
 	const onChange = ( edits ) => {
 		for ( const id of ids ) {

--- a/packages/edit-site/src/components/post-edit/style.scss
+++ b/packages/edit-site/src/components/post-edit/style.scss
@@ -7,3 +7,10 @@
 		justify-content: center;
 	}
 }
+
+.dataforms-layouts-panel__field-dropdown {
+	.fields-controls__password {
+		border-top: $border-width solid $gray-200;
+		padding-top: $grid-unit-20;
+	}
+}

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -27,6 +27,7 @@ import {
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
+import { passwordField } from '@wordpress/fields';
 
 /**
  * Internal dependencies
@@ -348,6 +349,7 @@ function usePostFields( viewType ) {
 					},
 				],
 			},
+			passwordField,
 		],
 		[ authors, viewType, frontPageId, postsPageId ]
 	);

--- a/packages/edit-site/src/components/post-fields/index.js
+++ b/packages/edit-site/src/components/post-fields/index.js
@@ -8,7 +8,12 @@ import clsx from 'clsx';
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { decodeEntities } from '@wordpress/html-entities';
-import { featuredImageField, slugField, parentField } from '@wordpress/fields';
+import {
+	featuredImageField,
+	slugField,
+	parentField,
+	passwordField,
+} from '@wordpress/fields';
 import {
 	createInterpolateElement,
 	useMemo,
@@ -27,7 +32,6 @@ import {
 import { __experimentalHStack as HStack, Icon } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEntityRecords, store as coreStore } from '@wordpress/core-data';
-import { passwordField } from '@wordpress/fields';
 
 /**
  * Internal dependencies

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -52,7 +52,7 @@ This field is used to display the post parent.
 
 ### passwordField
 
-Undocumented declaration.
+This field is used to display the post password.
 
 ### permanentlyDeletePost
 

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -50,6 +50,10 @@ Undocumented declaration.
 
 This field is used to display the post parent.
 
+### passwordField
+
+Undocumented declaration.
+
 ### permanentlyDeletePost
 
 Undocumented declaration.

--- a/packages/fields/src/fields/index.ts
+++ b/packages/fields/src/fields/index.ts
@@ -3,3 +3,4 @@ export { default as titleField } from './title';
 export { default as orderField } from './order';
 export { default as featuredImageField } from './featured-image';
 export { default as parentField } from './parent';
+export { default as passwordField } from './password';

--- a/packages/fields/src/fields/password/edit.tsx
+++ b/packages/fields/src/fields/password/edit.tsx
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	CheckboxControl,
+	__experimentalVStack as VStack,
+	TextControl,
+	BaseControl,
+	VisuallyHidden,
+} from '@wordpress/components';
+import type { DataFormControlProps } from '@wordpress/dataviews';
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+
+function PasswordEdit( {
+	data,
+	onChange,
+	field,
+	hideLabelFromVision,
+}: DataFormControlProps< BasePost > ) {
+	const { label } = field;
+	const [ showPassword, setShowPassword ] = useState( !! data.password );
+
+	const handleTogglePassword = ( value: boolean ) => {
+		setShowPassword( value );
+		if ( ! value ) {
+			onChange( { password: '' } );
+		}
+	};
+
+	return (
+		<VStack
+			as="fieldset"
+			spacing={ 4 }
+			className="dataviews-controls__password"
+		>
+			{ ! hideLabelFromVision && (
+				<BaseControl.VisualLabel as="legend">
+					{ label }
+				</BaseControl.VisualLabel>
+			) }
+			{ hideLabelFromVision && (
+				<VisuallyHidden as="legend">{ label }</VisuallyHidden>
+			) }
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={ __( 'Password protected' ) }
+				help={ __( 'Only visible to those who know the password' ) }
+				checked={ showPassword }
+				onChange={ handleTogglePassword }
+			/>
+			{ showPassword && (
+				<div className="editor-change-status__password-input">
+					<TextControl
+						label={ __( 'Password' ) }
+						onChange={ ( value ) =>
+							onChange( {
+								password: value,
+							} )
+						}
+						value={ data.password || '' }
+						placeholder={ __( 'Use a secure password' ) }
+						type="text"
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						maxLength={ 255 }
+					/>
+				</div>
+			) }
+		</VStack>
+	);
+}
+export default PasswordEdit;

--- a/packages/fields/src/fields/password/edit.tsx
+++ b/packages/fields/src/fields/password/edit.tsx
@@ -15,8 +15,14 @@ import { __ } from '@wordpress/i18n';
  */
 import type { BasePost } from '../../types';
 
-function PasswordEdit( { data, onChange }: DataFormControlProps< BasePost > ) {
-	const [ showPassword, setShowPassword ] = useState( !! data.password );
+function PasswordEdit( {
+	data,
+	onChange,
+	field,
+}: DataFormControlProps< BasePost > ) {
+	const [ showPassword, setShowPassword ] = useState(
+		!! field.getValue( { item: data } )
+	);
 
 	const handleTogglePassword = ( value: boolean ) => {
 		setShowPassword( value );
@@ -47,7 +53,7 @@ function PasswordEdit( { data, onChange }: DataFormControlProps< BasePost > ) {
 								password: value,
 							} )
 						}
-						value={ data.password || '' }
+						value={ field.getValue( { item: data } ) || '' }
 						placeholder={ __( 'Use a secure password' ) }
 						type="text"
 						__next40pxDefaultSize

--- a/packages/fields/src/fields/password/edit.tsx
+++ b/packages/fields/src/fields/password/edit.tsx
@@ -37,7 +37,7 @@ function PasswordEdit( {
 		<VStack
 			as="fieldset"
 			spacing={ 4 }
-			className="dataviews-controls__password"
+			className="fields-controls__password"
 		>
 			{ ! hideLabelFromVision && (
 				<BaseControl.VisualLabel as="legend">
@@ -55,7 +55,7 @@ function PasswordEdit( {
 				onChange={ handleTogglePassword }
 			/>
 			{ showPassword && (
-				<div className="editor-change-status__password-input">
+				<div className="fields-controls__password-input">
 					<TextControl
 						label={ __( 'Password' ) }
 						onChange={ ( value ) =>

--- a/packages/fields/src/fields/password/edit.tsx
+++ b/packages/fields/src/fields/password/edit.tsx
@@ -5,8 +5,6 @@ import {
 	CheckboxControl,
 	__experimentalVStack as VStack,
 	TextControl,
-	BaseControl,
-	VisuallyHidden,
 } from '@wordpress/components';
 import type { DataFormControlProps } from '@wordpress/dataviews';
 import { useState } from '@wordpress/element';
@@ -17,13 +15,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { BasePost } from '../../types';
 
-function PasswordEdit( {
-	data,
-	onChange,
-	field,
-	hideLabelFromVision,
-}: DataFormControlProps< BasePost > ) {
-	const { label } = field;
+function PasswordEdit( { data, onChange }: DataFormControlProps< BasePost > ) {
 	const [ showPassword, setShowPassword ] = useState( !! data.password );
 
 	const handleTogglePassword = ( value: boolean ) => {
@@ -39,14 +31,6 @@ function PasswordEdit( {
 			spacing={ 4 }
 			className="fields-controls__password"
 		>
-			{ ! hideLabelFromVision && (
-				<BaseControl.VisualLabel as="legend">
-					{ label }
-				</BaseControl.VisualLabel>
-			) }
-			{ hideLabelFromVision && (
-				<VisuallyHidden as="legend">{ label }</VisuallyHidden>
-			) }
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ __( 'Password protected' ) }

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import type { BasePost } from '../../types';
+import PasswordEdit from './edit';
+
+const passwordField: Field< BasePost > = {
+	id: 'password',
+	label: __( 'Password' ),
+	getValue: ( { item } ) => item.password,
+	isValid: ( { status } ) => status !== 'private',
+	Edit: PasswordEdit,
+};
+
+export default passwordField;

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -15,6 +15,8 @@ const passwordField: Field< BasePost > = {
 	label: __( 'Password' ),
 	getValue: ( { item } ) => item.password,
 	Edit: PasswordEdit,
+	enableSorting: false,
+	enableHiding: false,
 };
 
 export default passwordField;

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import type { Field } from '@wordpress/dataviews';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,7 +11,7 @@ import PasswordEdit from './edit';
 
 const passwordField: Field< BasePost > = {
 	id: 'password',
-	label: __( 'Password' ),
+	type: 'text',
 	getValue: ( { item } ) => item.password,
 	Edit: PasswordEdit,
 	enableSorting: false,

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -19,4 +19,7 @@ const passwordField: Field< BasePost > = {
 	isVisible: ( item ) => item.status !== 'private',
 };
 
+/**
+ * This field is used to display the post password.
+ */
 export default passwordField;

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -17,6 +17,7 @@ const passwordField: Field< BasePost > = {
 	Edit: PasswordEdit,
 	enableSorting: false,
 	enableHiding: false,
+	isVisible: ( item ) => item.status !== 'private',
 };
 
 export default passwordField;

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -14,7 +14,6 @@ const passwordField: Field< BasePost > = {
 	id: 'password',
 	label: __( 'Password' ),
 	getValue: ( { item } ) => item.password,
-	isValid: ( { status } ) => status !== 'private',
 	Edit: PasswordEdit,
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This adds a password field to the `@wordpress/fields` package for use within the DataForm component. In particular the page quick edit.
Related issue https://github.com/WordPress/gutenberg/issues/64519.

## Why?

The password field was missing from the page quick edit.

## How?

A new password field is added to the `@wordpress/fields` component, which can be imported by using `passwordField`.
The field it-self is mimicked from the current implementation in the site editor sidebar: https://github.com/WordPress/gutenberg/blob/2943dd3adfa4e1ad33b980760277377df9ac0f91/packages/editor/src/components/post-status/index.js#L222-L263
Class names have just been updated.

The password field is displayed within the status dropdown as part of the combined fields API.

## Testing Instructions

1. Enable the DataViews specific experiments under **Gutenberg > Experiments**
2. Make sure you have a block themed theme enabled.
3. Go to **Appearance > Editor** and click **Pages**
4. Switch the page view to the table view
5. Select a page and select the **Details** icon
6. A **Status & Visibility** field should now be displayed
7. Click on the visibility field and toggle the statuses, a password field should be shown if the status is not private
8. Add a password and update the page ( it should update correctly )
9. Select multiple pages, the **Status & Visibility** field should dissapear.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1512" alt="Screenshot 2024-10-29 at 2 42 21 PM" src="https://github.com/user-attachments/assets/e283057b-577f-4474-8a33-f84e17a7aec5">

<img width="1506" alt="Screenshot 2024-10-29 at 2 46 27 PM" src="https://github.com/user-attachments/assets/df9855e0-ee17-4940-9481-f729de1b75f6">
