### PR TITLE
Storybook: Log `warning()` when in dev mode

### DIFF
--- a/storybook/main.js
+++ b/storybook/main.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 const path = require( 'path' );
+const DefinePlugin = require( 'webpack' ).DefinePlugin;
 
 /**
  * WordPress dependencies
@@ -107,6 +108,15 @@ module.exports = {
 					},
 				],
 			},
+			plugins: [
+				...config.plugins,
+				new DefinePlugin( {
+					// Ensures that `@wordpress/warning` can properly detect dev mode.
+					'globalThis.SCRIPT_DEBUG': JSON.stringify(
+						process.env.NODE_ENV === 'development'
+					),
+				} ),
+			],
 		};
 	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Ensure that console warnings using `@wordpress/warning` are also properly logged in Storybook when in dev mode.

## Why?

`warning()` messages were not logged in Storybook, even when in dev mode. This is inconvenient because we often check for these things using Storybook.

## How?

`warning()` checks for dev mode using the `SCRIPT_DEBUG` global.

https://github.com/WordPress/gutenberg/blob/7714bce8d9356707a020b5d7df84797832c423f8/packages/warning/src/index.ts#L6-L9

We should inject this with Webpack, similar to how the wp packages are built:

https://github.com/WordPress/gutenberg/blob/7714bce8d9356707a020b5d7df84797832c423f8/tools/webpack/shared.js#L75

## Testing Instructions

See the "With Actions" story for Snackbar. Adding multiple actions to the `actions` array should log a console warning.

https://github.com/WordPress/gutenberg/blob/7714bce8d9356707a020b5d7df84797832c423f8/packages/components/src/snackbar/index.tsx#L119-L123

Alter the story args here so there are multiple actions:

https://github.com/WordPress/gutenberg/blob/7714bce8d9356707a020b5d7df84797832c423f8/packages/components/src/snackbar/stories/index.story.tsx#L59-L64