### PR TITLE
Templates: hide media field in list view

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -176,10 +176,10 @@ function ListItem< Item >( {
 	}, [ actions, item ] );
 
 	const renderedMediaField = mediaField?.render ? (
-		<mediaField.render item={ item } />
-	) : (
-		<div className="dataviews-view-list__media-placeholder"></div>
-	);
+		<div className="dataviews-view-list__media-wrapper">
+			<mediaField.render item={ item } />
+		</div>
+	) : null;
 
 	const renderedPrimaryField = primaryField?.render ? (
 		<primaryField.render item={ item } />
@@ -248,9 +248,7 @@ function ListItem< Item >( {
 					/>
 				</div>
 				<HStack spacing={ 3 } justify="start" alignment="flex-start">
-					<div className="dataviews-view-list__media-wrapper">
-						{ renderedMediaField }
-					</div>
+					{ renderedMediaField }
 					<VStack
 						spacing={ 1 }
 						className="dataviews-view-list__field-wrapper"

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -144,12 +144,6 @@ ul.dataviews-view-list {
 		}
 	}
 
-	.dataviews-view-list__media-placeholder {
-		width: $grid-unit-05 * 13;
-		height: $grid-unit-05 * 13;
-		background-color: $gray-200;
-	}
-
 	.dataviews-view-list__field-wrapper {
 		min-height: $grid-unit-05 * 13; // Ensures title is centrally aligned when all fields are hidden
 		flex-grow: 1;

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -74,7 +74,6 @@ const defaultLayouts = {
 		fields: [ 'title', 'description', 'author' ],
 		layout: {
 			primaryField: 'title',
-			mediaField: 'preview',
 		},
 	},
 };


### PR DESCRIPTION
## What?

Hide the media field in the list view of the Templates page:

| Before | After |
| --- | --- |
| <img width="2551" alt="Screenshot 2024-10-29 at 19 00 07" src="https://github.com/user-attachments/assets/ef35eb77-732d-4391-b2e7-d5f991d410c5"> | <img width="2551" alt="Screenshot 2024-10-29 at 18 59 12" src="https://github.com/user-attachments/assets/575a0375-1f1f-41c5-951c-16e74ab0fa0a"> |


## Why?

It hasn't proven very valuable to render the page preview in the little space given to the media field.


## How?

- Make `mediaField` optional for list layout ee55aa1616aade9359c83a9d24fb937b0cc84957
- Do not provide `mediaField` to the list layout a80cf3dc375b4947f3df9fdab786c0136d79e09e

## Testing Instructions

- Visit the Templates page and verify the media field is not visible and smoke test.
- Visit the Pages page and verify the media field is visible and smoke test.
