### PR TITLE
Controlled useZoomOut

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -20,42 +20,51 @@ export function useZoomOut( zoomOut = true ) {
 		useDispatch( blockEditorStore )
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
+
 	const programmaticZoomOutChange = useRef( null );
 
+	const toggleZoomOut = ( isZoomedOut ) => {
+		if ( isZoomedOut ) {
+			resetZoomLevel();
+		} else {
+			setZoomLevel( 'auto-scaled' );
+		}
+	};
+
 	useEffect( () => {
-		const isZoomOutOnMount = isZoomOut();
+		const matchedZoomOutStateOnMount = zoomOut === isZoomOut();
 
 		return () => {
-			// No mode change was made for the user, so no action is needed.
-			if ( programmaticZoomOutChange.current === null ) {
+			const isZoomedOut = isZoomOut();
+			// If the zoomOut state matched on mount and the current zoom state
+			// matches on unmount, then no action is needed.
+			if ( matchedZoomOutStateOnMount && isZoomedOut === zoomOut ) {
 				return;
 			}
 
-			// If zoom out mode was exited for the user and they were originally in zoom out mode, re-enter zoom out mode.
-			if (
-				programmaticZoomOutChange.current === false &&
-				isZoomOutOnMount
-			) {
-				setZoomLevel( 'auto-scaled' );
+			// The modes matched during a hook rerender (zoomOut === isZoomOut()),
+			// so we should not invert zoom states. This catches manual zoom out
+			// changes while the hook was mounted.
+			if ( ! programmaticZoomOutChange.current ) {
+				return;
 			}
-			// Zoom out was activated for the user, and they were not originally in zoom out mode, so reset the zoom level.
-			else if (
-				programmaticZoomOutChange.current === true &&
-				isZoomOut() &&
-				! isZoomOutOnMount
-			) {
-				resetZoomLevel();
-			}
+
+			// Zoom Out mode was changed by this hook, so we need to invert the state.
+			toggleZoomOut( isZoomedOut );
 		};
 	}, [] );
 
 	useEffect( () => {
-		if ( zoomOut && ! isZoomOut() ) {
+		const isZoomedOut = isZoomOut();
+
+		// Requested zoom and current zoom states are different, so toggle the state.
+		if ( zoomOut !== isZoomedOut ) {
 			programmaticZoomOutChange.current = true;
-			setZoomLevel( 'auto-scaled' );
-		} else if ( ! zoomOut && isZoomOut() ) {
+
+			toggleZoomOut( isZoomedOut );
+		} else {
+			// Reset the flag if the zoom state is the same as requested.
 			programmaticZoomOutChange.current = false;
-			resetZoomLevel();
 		}
-	}, [ zoomOut, setZoomLevel, isZoomOut, resetZoomLevel ] );
+	}, [ zoomOut, isZoomOut, toggleZoomOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -27,9 +27,10 @@ export function useZoomOut( zoomOut = true ) {
 		const matchedZoomOutStateOnMount = zoomOut === isZoomOut();
 
 		return () => {
+			const isZoomedOut = isZoomOut();
 			// If the zoomOut state matched on mount and the current zoom state
 			// matches on unmount, then no action is needed.
-			if ( matchedZoomOutStateOnMount && isZoomOut() === zoomOut ) {
+			if ( matchedZoomOutStateOnMount && isZoomedOut === zoomOut ) {
 				return;
 			}
 
@@ -41,9 +42,11 @@ export function useZoomOut( zoomOut = true ) {
 			}
 
 			// Zoom Out mode was toggled by this hook, so we need to invert the state.
-			return isZoomOut()
-				? resetZoomLevel()
-				: setZoomLevel( 'auto-scaled' );
+			if ( isZoomedOut ) {
+				resetZoomLevel();
+			} else {
+				setZoomLevel( 'auto-scaled' );
+			}
 		};
 	}, [] );
 

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -26,7 +26,7 @@ export function useZoomOut( zoomOut = true ) {
 		const isZoomOutOnMount = isZoomOut();
 
 		return () => {
-			// We never changed modes for them, so there is nothing to do.
+			// No mode change was made for the user, so no action is needed.
 			if ( programmaticZoomOutChange.current === null ) {
 				return;
 			}

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -20,27 +20,27 @@ export function useZoomOut( zoomOut = true ) {
 		useDispatch( blockEditorStore )
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
-	const programatticEnterZoomOut = useRef( null );
+	const programmaticZoomOutChange = useRef( null );
 
 	useEffect( () => {
 		const isZoomOutOnMount = isZoomOut();
 
 		return () => {
 			// We never changed modes for them, so there is nothing to do.
-			if ( programatticEnterZoomOut.current === null ) {
+			if ( programmaticZoomOutChange.current === null ) {
 				return;
 			}
 
 			// If we exited zoom out for them and they were originally in zoom out mode, enter zoom out again.
 			if (
-				programatticEnterZoomOut.current === false &&
+				programmaticZoomOutChange.current === false &&
 				isZoomOutOnMount
 			) {
 				setZoomLevel( 'auto-scaled' );
 			}
 			// We entered zoom out for them, and they were not originally in zoom out mode, so reset the zoom level.
 			else if (
-				programatticEnterZoomOut.current === true &&
+				programmaticZoomOutChange.current === true &&
 				isZoomOut() &&
 				! isZoomOutOnMount
 			) {
@@ -51,10 +51,10 @@ export function useZoomOut( zoomOut = true ) {
 
 	useEffect( () => {
 		if ( zoomOut && ! isZoomOut() ) {
-			programatticEnterZoomOut.current = true;
+			programmaticZoomOutChange.current = true;
 			setZoomLevel( 'auto-scaled' );
 		} else if ( ! zoomOut && isZoomOut() ) {
-			programatticEnterZoomOut.current = false;
+			programmaticZoomOutChange.current = false;
 			resetZoomLevel();
 		}
 	}, [ zoomOut, setZoomLevel, isZoomOut, resetZoomLevel ] );

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -27,23 +27,11 @@ export function useZoomOut( zoomOut = true ) {
 	const manualIsZoomOutCheck = isZoomOut();
 
 	useEffect( () => {
-		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
-		// state (zoomOut), then it means they manually changed the zoom state and we should
-		// not toggle the zoom level on unmount.
-		if ( manualIsZoomOutCheck !== zoomOut ) {
-			toggleZoomOnUnmount.current = false;
-		}
-	}, [ manualIsZoomOutCheck ] );
-	// Intentionally excluding zoomOut from the dependency array. We want to catch instances where
-	// the zoom out state changes due to user interaction and not due to the hook.
-
-	useEffect( () => {
 		return () => {
 			if ( ! toggleZoomOnUnmount.current ) {
 				return;
 			}
 
-			// Zoom Out mode was toggled by this hook, so we need to invert the state.
 			if ( isZoomOut() ) {
 				resetZoomLevel();
 			} else {
@@ -52,6 +40,8 @@ export function useZoomOut( zoomOut = true ) {
 		};
 	}, [] );
 
+	// This hook should only run when zoomOut changes, so we check for isZoomOut() within the
+	// hook rather than passing in
 	useEffect( () => {
 		const isZoomedOut = isZoomOut();
 
@@ -66,4 +56,15 @@ export function useZoomOut( zoomOut = true ) {
 			}
 		}
 	}, [ zoomOut, setZoomLevel, isZoomOut, resetZoomLevel ] );
+
+	useEffect( () => {
+		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
+		// state (zoomOut), then it means the user manually changed the zoom state and we should
+		// not toggle the zoom level on unmount.
+		if ( manualIsZoomOutCheck !== zoomOut ) {
+			toggleZoomOnUnmount.current = false;
+		}
+	}, [ manualIsZoomOutCheck ] );
+	// Intentionally excluding zoomOut from the dependency array. We want to catch instances where
+	// the zoom out state changes due to user interaction and not due to the hook.
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -20,24 +20,42 @@ export function useZoomOut( zoomOut = true ) {
 		useDispatch( blockEditorStore )
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
+	const programatticEnterZoomOut = useRef( null );
 
 	useEffect( () => {
 		const isZoomOutOnMount = isZoomOut();
 
 		return () => {
-			if ( isZoomOutOnMount ) {
+			// We never changed modes for them, so there is nothing to do.
+			if ( programatticEnterZoomOut.current === null ) {
+				return;
+			}
+
+			// If we exited zoom out for them and they were originally in zoom out mode, enter zoom out again.
+			if (
+				programatticEnterZoomOut.current === false &&
+				isZoomOutOnMount
+			) {
 				setZoomLevel( 'auto-scaled' );
-			} else {
+			}
+			// We entered zoom out for them, and they were not originally in zoom out mode, so reset the zoom level.
+			else if (
+				programatticEnterZoomOut.current === true &&
+				isZoomOut() &&
+				! isZoomOutOnMount
+			) {
 				resetZoomLevel();
 			}
 		};
 	}, [] );
 
 	useEffect( () => {
-		if ( zoomOut ) {
+		if ( zoomOut && ! isZoomOut() ) {
+			programatticEnterZoomOut.current = true;
 			setZoomLevel( 'auto-scaled' );
-		} else {
+		} else if ( ! zoomOut && isZoomOut() ) {
+			programatticEnterZoomOut.current = false;
 			resetZoomLevel();
 		}
-	}, [ zoomOut, setZoomLevel, resetZoomLevel ] );
+	}, [ zoomOut, setZoomLevel, isZoomOut, resetZoomLevel ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -25,7 +25,7 @@ export function useZoomOut( zoomOut = true ) {
 	const zoomStateOnMount = useRef( null );
 
 	// Let this hook know if the zoom state was changed manually.
-	const manualIsZoomOutCheck = isZoomOut();
+	const userZoomOutState = isZoomOut();
 
 	useEffect( () => {
 		zoomStateOnMount.current = isZoomOut();
@@ -73,13 +73,13 @@ export function useZoomOut( zoomOut = true ) {
 		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
 		// state (zoomOut), then it means the user manually changed the zoom state and we should
 		// not toggle the zoom level on unmount.
-		if ( manualIsZoomOutCheck !== zoomOut ) {
+		if ( userZoomOutState !== zoomOut ) {
 			toggleZoomOnUnmount.current = false;
 			// We no longer care about the zoom state on mount.
 			// We are tracking the toggle on unmount based on if this hook changes.
 			zoomStateOnMount.current = null;
 		}
-	}, [ manualIsZoomOutCheck ] );
+	}, [ userZoomOutState ] );
 	// Intentionally excluding zoomOut from the dependency array. We want to catch instances where
 	// the zoom out state changes due to user interaction and not due to the hook.
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -38,7 +38,7 @@ export function useZoomOut( zoomOut = true ) {
 			) {
 				setZoomLevel( 'auto-scaled' );
 			}
-			// We entered zoom out for them, and they were not originally in zoom out mode, so reset the zoom level.
+			// Zoom out was activated for the user, and they were not originally in zoom out mode, so reset the zoom level.
 			else if (
 				programmaticZoomOutChange.current === true &&
 				isZoomOut() &&

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -23,22 +23,13 @@ export function useZoomOut( zoomOut = true ) {
 
 	const programmaticZoomOutChange = useRef( null );
 
-	const toggleZoomOut = ( isZoomedOut ) => {
-		if ( isZoomedOut ) {
-			resetZoomLevel();
-		} else {
-			setZoomLevel( 'auto-scaled' );
-		}
-	};
-
 	useEffect( () => {
 		const matchedZoomOutStateOnMount = zoomOut === isZoomOut();
 
 		return () => {
-			const isZoomedOut = isZoomOut();
 			// If the zoomOut state matched on mount and the current zoom state
 			// matches on unmount, then no action is needed.
-			if ( matchedZoomOutStateOnMount && isZoomedOut === zoomOut ) {
+			if ( matchedZoomOutStateOnMount && isZoomOut() === zoomOut ) {
 				return;
 			}
 
@@ -49,8 +40,10 @@ export function useZoomOut( zoomOut = true ) {
 				return;
 			}
 
-			// Zoom Out mode was changed by this hook, so we need to invert the state.
-			toggleZoomOut( isZoomedOut );
+			// Zoom Out mode was toggled by this hook, so we need to invert the state.
+			return isZoomOut()
+				? resetZoomLevel()
+				: setZoomLevel( 'auto-scaled' );
 		};
 	}, [] );
 
@@ -61,10 +54,14 @@ export function useZoomOut( zoomOut = true ) {
 		if ( zoomOut !== isZoomedOut ) {
 			programmaticZoomOutChange.current = true;
 
-			toggleZoomOut( isZoomedOut );
+			if ( isZoomedOut ) {
+				resetZoomLevel();
+			} else {
+				setZoomLevel( 'auto-scaled' );
+			}
 		} else {
 			// Reset the flag if the zoom state is the same as requested.
 			programmaticZoomOutChange.current = false;
 		}
-	}, [ zoomOut, isZoomOut, toggleZoomOut ] );
+	}, [ zoomOut, setZoomLevel, isZoomOut, resetZoomLevel ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -79,7 +79,9 @@ export function useZoomOut( zoomOut = true ) {
 			// We are tracking the toggle on unmount based on if this hook changes.
 			zoomStateOnMount.current = null;
 		}
+
+		// Intentionally excluding zoomOut from the dependency array. We want to catch instances where
+		// the zoom out state changes due to user interaction and not due to the hook.
+		// eslint-disable-next-line react-hooks/rules-of-hooks
 	}, [ userZoomOutState ] );
-	// Intentionally excluding zoomOut from the dependency array. We want to catch instances where
-	// the zoom out state changes due to user interaction and not due to the hook.
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -31,7 +31,7 @@ export function useZoomOut( zoomOut = true ) {
 				return;
 			}
 
-			// If we exited zoom out for them and they were originally in zoom out mode, enter zoom out again.
+			// If zoom out mode was exited for the user and they were originally in zoom out mode, re-enter zoom out mode.
 			if (
 				programmaticZoomOutChange.current === false &&
 				isZoomOutOnMount

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -27,7 +27,7 @@ test.describe( 'Site Editor Inserter', () => {
 		},
 	} );
 
-	test.skip( 'inserter toggle button should toggle global inserter', async ( {
+	test( 'inserter toggle button should toggle global inserter', async ( {
 		InserterUtils,
 	} ) => {
 		const inserterButton = InserterUtils.getInserterButton();
@@ -44,7 +44,7 @@ test.describe( 'Site Editor Inserter', () => {
 	} );
 
 	// A test for https://github.com/WordPress/gutenberg/issues/43090.
-	test.skip( 'should close the inserter when clicking on the toggle button', async ( {
+	test( 'should close the inserter when clicking on the toggle button', async ( {
 		editor,
 		InserterUtils,
 	} ) => {
@@ -66,7 +66,7 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( blockLibrary ).toBeHidden();
 	} );
 
-	test.skip( 'should open the inserter to patterns tab if using zoom out', async ( {
+	test( 'should open the inserter to patterns tab if using zoom out', async ( {
 		InserterUtils,
 	} ) => {
 		const zoomOutButton = InserterUtils.getZoomOutButton();

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -119,7 +119,7 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 	} );
 
-	test( 'should return you to zoom out if starting from zoom out', async ( {
+	test( 'should not toggle zoom state between tabs if starting from zoom out', async ( {
 		InserterUtils,
 	} ) => {
 		const zoomOutButton = InserterUtils.getZoomOutButton();
@@ -147,16 +147,14 @@ test.describe( 'Site Editor Inserter', () => {
 		await blocksTab.click();
 		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
 
-		// Zoom out should disengage
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		// Zoom out should still be egnaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 
 		// Close the inserter
 		await inserterButton.click();
 		await expect( blockLibrary ).toBeHidden();
 
-		// We should return to zoom out since the inserter was opened with
-		// zoom out engaged, and it was automatically disengaged when selecting
-		// the blocks tab
+		// We should stay in zoom out state since it was manually engaged from the start
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 	} );
 
@@ -224,47 +222,6 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( blockLibrary ).toBeHidden();
 
 		// We should stay in zoomed out state since it was manually engaged
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
-	} );
-
-	// Covers bug found in https://github.com/WordPress/gutenberg/pull/66381#issuecomment-2441540851
-	test( 'should return to initial zoom out state after switching between multiple tabs', async ( {
-		InserterUtils,
-	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
-
-		await inserterButton.click();
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		const mediaTab = InserterUtils.getBlockLibraryTab( 'Media' );
-
-		// Should start with pattern tab selected in zoom out state
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
-
-		// Go to blocks tab which should exit zoom out
-		await blocksTab.click();
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
-
-		// Go to media tab which should enter zoom out again since that's the starting state
-		await mediaTab.click();
-		await expect( mediaTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
-
-		// Close the inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeHidden();
-
-		// We should re-enter zoomed out state since it was the starting point
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -126,6 +126,47 @@ test.describe( 'Site Editor Inserter', () => {
 		const inserterButton = InserterUtils.getInserterButton();
 		const blockLibrary = InserterUtils.getBlockLibrary();
 
+		// Manually enter zoom out
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Open inserter
+		await inserterButton.click();
+
+		// Patterns tab should be active
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		// Canvas should be zoomed
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Select blocks tab
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		// Zoom out should disengage
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Close the inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should return to zoom out since the inserter was opened with
+		// zoom out engaged, and it was automatically disengaged when selecting
+		// the blocks tab
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
+
+	// Test for https://github.com/WordPress/gutenberg/issues/66328
+	test( 'should not return you to zoom out if manually disengaged', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
 		await zoomOutButton.click();
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 
@@ -137,10 +178,7 @@ test.describe( 'Site Editor Inserter', () => {
 		);
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await blocksTab.click();
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-
+		await zoomOutButton.click();
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 
 		// Close the inserter
@@ -148,8 +186,8 @@ test.describe( 'Site Editor Inserter', () => {
 
 		await expect( blockLibrary ).toBeHidden();
 
-		// We should return to zoom out since we started from there
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		// We should not return to zoom out since it was manually disengaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 	} );
 } );
 

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -189,6 +189,38 @@ test.describe( 'Site Editor Inserter', () => {
 		// We should not return to zoom out since it was manually disengaged
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 	} );
+
+	// Similar test to the above but starting from not zoomed in
+	test( 'should not toggle zoom state when closing the inserter if the user manually changed zoom state', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await inserterButton.click();
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await patternsTab.click();
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		// Toggle again to return to zoom state
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close the inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should stay in zoomed out state since it was manually engaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
 } );
 
 class InserterUtils {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -146,6 +146,7 @@ test.describe( 'Site Editor Inserter', () => {
 		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
 		await blocksTab.click();
 		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+
 		// Zoom out should disengage
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 
@@ -199,6 +200,8 @@ test.describe( 'Site Editor Inserter', () => {
 		const blockLibrary = InserterUtils.getBlockLibrary();
 
 		await inserterButton.click();
+
+		// Go to patterns tab which should enter zoom out
 		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
 		await patternsTab.click();
 		await expect( patternsTab ).toHaveAttribute(
@@ -207,9 +210,11 @@ test.describe( 'Site Editor Inserter', () => {
 		);
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 
+		// Manually toggle zoom out off
 		await zoomOutButton.click();
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
-		// Toggle again to return to zoom state
+
+		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
 		await zoomOutButton.click();
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -91,6 +91,33 @@ test.describe( 'Site Editor Inserter', () => {
 		// We should still be in Zoom Out
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 	} );
+
+	test( 'should enter zoom out from patterns tab and exit zoom out when closing the inserter', async ( {
+		InserterUtils,
+	} ) => {
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await inserterButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await patternsTab.click();
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
 } );
 
 class InserterUtils {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -27,7 +27,7 @@ test.describe( 'Site Editor Inserter', () => {
 		},
 	} );
 
-	test( 'inserter toggle button should toggle global inserter', async ( {
+	test.skip( 'inserter toggle button should toggle global inserter', async ( {
 		InserterUtils,
 	} ) => {
 		const inserterButton = InserterUtils.getInserterButton();
@@ -44,7 +44,7 @@ test.describe( 'Site Editor Inserter', () => {
 	} );
 
 	// A test for https://github.com/WordPress/gutenberg/issues/43090.
-	test( 'should close the inserter when clicking on the toggle button', async ( {
+	test.skip( 'should close the inserter when clicking on the toggle button', async ( {
 		editor,
 		InserterUtils,
 	} ) => {
@@ -66,7 +66,7 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( blockLibrary ).toBeHidden();
 	} );
 
-	test( 'should open the inserter to patterns tab if using zoom out', async ( {
+	test.skip( 'should open the inserter to patterns tab if using zoom out', async ( {
 		InserterUtils,
 	} ) => {
 		const zoomOutButton = InserterUtils.getZoomOutButton();
@@ -219,6 +219,47 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( blockLibrary ).toBeHidden();
 
 		// We should stay in zoomed out state since it was manually engaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
+
+	// Covers bug found in https://github.com/WordPress/gutenberg/pull/66381#issuecomment-2441540851
+	test( 'should return to initial zoom out state after switching between multiple tabs', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		const mediaTab = InserterUtils.getBlockLibraryTab( 'Media' );
+
+		// Should start with pattern tab selected in zoom out state
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Go to blocks tab which should exit zoom out
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Go to media tab which should enter zoom out again since that's the starting state
+		await mediaTab.click();
+		await expect( mediaTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close the inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should re-enter zoomed out state since it was the starting point
 		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 	} );
 } );

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -118,6 +118,39 @@ test.describe( 'Site Editor Inserter', () => {
 
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 	} );
+
+	test( 'should return you to zoom out if starting from zoom out', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Close the inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should return to zoom out since we started from there
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
 } );
 
 class InserterUtils {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Only control zoom level in useZoomOut if starting from non-zoomed state.

Fixes https://github.com/WordPress/gutenberg/issues/66328

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This modifies the idea of the useZoomOut state to allow for a controlled mode. If the user begins in zoom out or manually toggles the zoom level, then we assume they are a user who understands the zoom levels and doesn't need this toggled for them. If they begin from a non-zoomed state, we can zoom in when they reach the patterns tab and remove the zoom level when they exit the inserter. If they use the zoom button when the inserter is open, this also removes the control mode, as they understand how to enter and exit zoom out.
    
The idea here is:

- it is jarring to have the zoom level automatically change for you, so default to not changing it unless it seems like the user doesn't know how to use the zoom button.
- have a smart default, but allow overrides

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add controlZoomLevel ref to track if we should be controlling the zoom level for the user or not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

#### Starting from Zoom Out
- Enter Zoom Out
- Open Inserter
- Should be on patterns tab
- Should still be zoomed out
- Click to blocks tab
- Should stay in zoomed out state
- Close inserter 
- Should stay in zoomed out state

#### Starting from Zoom In (zoom level === 100)
- Open Inserter
- Should be on blocks tab
- Switch to patterns tab
- Should be zoomed out
- Click to blocks tab
- Should be zoomed back in
- Switch to media tab
- Should be zoomed out
- Close inserter 
- Should zoomed in

#### Starting from Zoom In (zoom level === 100) and manually toggle zoom mode via header (exit control mode)
- Open Inserter
- Should be on blocks tab
- Switch to patterns tab
- Should be zoomed out
- Click to blocks tab
- Should be zoomed back in
- Click header zoom button toggle. You are no longer in the controlled mode and clicking the blocks, patterns, or media tabs will not change your zoom level.
- Should be zoomed out
- Click to Patterns tab, Blocks tab, etc.
- You should stay zoomed out
- Close inserter 
- Should stay zoomed out


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
