### PR TITLE
Query block: remove incorrect selector call

### DIFF
--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -50,16 +50,7 @@ export default function QueryContent( {
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 	} );
-	const isTemplate = useSelect(
-		( select ) => {
-			const currentTemplate =
-				select( coreStore ).__experimentalGetTemplateForLink()?.type;
-			const isInTemplate = 'wp_template' === currentTemplate;
-			const isInSingularContent = postType !== undefined;
-			return isInTemplate && ! isInSingularContent;
-		},
-		[ postType ]
-	);
+	const isTemplate = postType === undefined;
 	const { postsPerPage } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { getEntityRecord, getEntityRecordEdits, canUser } =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

* `__experimentalGetTemplateForLink` _requires_ a first argument (the link) to work. Without the link argument the resolver will fail. The only reason this returns anything right now is because `__experimentalGetTemplateForLink` has already been called, and the resolver already triggered.
* Without the `link` argument, this selector essentially test if we're in the Site Editor or not. The Site Editor is the only place where `__experimentalGetTemplateForLink` will ever (and always) return a result without an argument.
* I removed the other calls in #66579, which causes this selector call to always return `null`.
* The correct way to check for the Site Editor in blocks seems to be checking `postType` or `postId` from the context. See [here](https://github.com/WordPress/gutenberg/blob/828868d680a4f052c35854d0ed0fb217179664b8/packages/block-library/src/comments-title/edit.js#L39) and [here](https://github.com/WordPress/gutenberg/blob/828868d680a4f052c35854d0ed0fb217179664b8/packages/block-library/src/post-comments-form/form.js#L69). That check is already here, so this code actually seems to be checking for the Site Editor twice?
* Since it's here twice, I removed the selector.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Remove an incorrect call, which in turn causes an incorrect request (`/wp-admin/site-editor.php?_wp-find-template=true`).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Remove it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It was originally added in https://github.com/WordPress/gutenberg/pull/65067/files#r1821498758, so I assume the same testing instructions:

> 1. Insert a Query Loop block inside a single page, post, or CPT.
> 2. Ensure that the Default query ("inherit") shows posts from the 'post' post type in both the Editor and the front-end.
> 3. Insert a Query Loop block inside a template.
> 4. Ensure that the "Query Type" control is only shown when editing a template and that it is hidden when editing a single page, post, or CPT.

* ✅ I do not see the query type option in the Post Editor.
* ✅ I do not see the query type option when editing pages in the Site Editor.
* ✅ I DO see the query type option when editing templates in the Site Editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
