### PR TITLE
Inline Commenting: Disable comments on published posts for now.

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -62,6 +62,11 @@ export default function CollabSidebar() {
 		};
 	}, [] );
 
+	const postStatus = useSelect((select) => {
+		const post = select(editorStore).getCurrentPost();
+		return { postStatus: post?.status };
+	}, []);
+	
 	const threads = useSelect(
 		( select ) => {
 			if ( ! postId ) {
@@ -259,7 +264,7 @@ export default function CollabSidebar() {
 	}, [ postId, clientId ] );
 
 	// Check if the experimental flag is enabled.
-	if ( ! isBlockCommentExperimentEnabled ) {
+	if ( ! isBlockCommentExperimentEnabled || postStatus.postStatus === 'publish') {
 		return null; // or maybe return some message indicating no threads are available.
 	}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -62,11 +62,11 @@ export default function CollabSidebar() {
 		};
 	}, [] );
 
-	const postStatus = useSelect((select) => {
-		const post = select(editorStore).getCurrentPost();
+	const postStatus = useSelect( ( select ) => {
+		const post = select( editorStore ).getCurrentPost();
 		return { postStatus: post?.status };
-	}, []);
-	
+	}, [] );
+
 	const threads = useSelect(
 		( select ) => {
 			if ( ! postId ) {
@@ -264,7 +264,10 @@ export default function CollabSidebar() {
 	}, [ postId, clientId ] );
 
 	// Check if the experimental flag is enabled.
-	if ( ! isBlockCommentExperimentEnabled || postStatus.postStatus === 'publish') {
+	if (
+		! isBlockCommentExperimentEnabled ||
+		postStatus.postStatus === 'publish'
+	) {
 		return null; // or maybe return some message indicating no threads are available.
 	}
 


### PR DESCRIPTION

## What?
Part of - https://github.com/WordPress/gutenberg/issues/66377

## How?
This PR disabled the block comments feature for published posts for now.

## Testing Instructions

1. Enable experimental inline commenting option under Gutenberg -> Experiments
2. Edit any post/page which is published
3. Make sure the comments feature is not accessible for the published posts.
