### PR TITLE
Popover: Add small size prop to close button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Enhancements
 
 -   `PaletteEdit`: use `Item` internally instead of custom styles ([#66164](https://github.com/WordPress/gutenberg/pull/66164)).
+-   `Popover`: Use small size variant for close button when `expandOnMobile` prop is enabled ([#66587](https://github.com/WordPress/gutenberg/pull/66587)).
 
 ### Experimental
 

--- a/packages/components/src/popover/index.tsx
+++ b/packages/components/src/popover/index.tsx
@@ -419,6 +419,7 @@ const UnforwardedPopover = (
 					</span>
 					<Button
 						className="components-popover__close"
+						size="small"
 						icon={ close }
 						onClick={ onClose }
 					/>


### PR DESCRIPTION
In preparation for #65751

## What?

Adds `size="small"` prop to the close Button in the Popover component, visible in mobile viewports when `expandOnMobile` is true.

## Testing Instructions

See the Default Popover story in Storybook. Enable the `expandOnMobile` prop, and set the view to a narrow viewport.

<img width="343" alt="Popover expanded on mobile" src="https://github.com/user-attachments/assets/c6502e02-3603-41f4-af7d-e6c772c722cf">

In the app, this can be seen in the quick inserter:

<img width="399" alt="Quick inserter on mobile" src="https://github.com/user-attachments/assets/1ac005d6-2433-4bd1-8cff-323108151374">
