### PR TITLE
Inline Commenting: Optimize store selector and misc changes

### DIFF
--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -84,7 +84,7 @@ export default function CollabSidebar() {
 		return {
 			clientId: _clientId,
 			blockCommentId: _clientId
-				? getBlockAttributes( _clientId ).blockCommentId
+				? getBlockAttributes( _clientId )?.blockCommentId
 				: null,
 		};
 	}, [] );

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch, resolveSelect } from '@wordpress/data';
 import { useState, useEffect, useMemo } from '@wordpress/element';
-import { comment as commentIcon } from '@wordpress/icons';
+import { comment as commentIcon, post } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -22,7 +22,7 @@ import { store as editorStore } from '../../store';
 import AddCommentButton from './comment-button';
 import AddCommentToolbarButton from './comment-button-toolbar';
 
-const threadsEmptyArray = [];
+const EMPTY_ARRAY = [];
 
 const isBlockCommentExperimentEnabled =
 	window?.__experimentalEnableBlockComment;
@@ -56,47 +56,37 @@ export default function CollabSidebar() {
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
 	const [ blockCommentID, setBlockCommentID ] = useState( null );
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
-	const { postId } = useSelect( ( select ) => {
+
+	const { postId, postStatus, threads } = useSelect( ( select ) => {
+		const { getCurrentPostId, getEditedPostAttribute } =
+			select( editorStore );
+		const _postId = getCurrentPostId();
+		const data = !! _postId
+			? select( coreStore ).getEntityRecords( 'root', 'comment', {
+					post: _postId,
+					type: 'block_comment',
+					status: 'any',
+					per_page: 100,
+			  } )
+			: null;
+
 		return {
-			postId: select( editorStore ).getCurrentPostId(),
+			postId: _postId,
+			postStatus: getEditedPostAttribute( 'status' ),
+			threads: data ?? EMPTY_ARRAY,
 		};
 	}, [] );
 
-	const postStatus = useSelect( ( select ) => {
-		const post = select( editorStore ).getCurrentPost();
-		return { postStatus: post?.status };
+	const { clientId, blockDetails } = useSelect( ( select ) => {
+		const { getBlock, getSelectedBlockClientId } =
+			select( blockEditorStore );
+		const _clientId = getSelectedBlockClientId();
+
+		return {
+			clientId: _clientId,
+			blockDetails: _clientId ? getBlock( _clientId ) : null,
+		};
 	}, [] );
-
-	const threads = useSelect(
-		( select ) => {
-			if ( ! postId ) {
-				return threadsEmptyArray;
-			}
-			const { getEntityRecords } = select( coreStore );
-			const data = getEntityRecords( 'root', 'comment', {
-				post: postId,
-				type: 'block_comment',
-				status: 'any',
-				per_page: 100,
-			} );
-			return data || threadsEmptyArray;
-		},
-		[ postId ]
-	);
-
-	const clientId = useSelect( ( select ) => {
-		const { getSelectedBlockClientId } = select( blockEditorStore );
-		return getSelectedBlockClientId();
-	}, [] );
-
-	const blockDetails = useSelect(
-		( select ) => {
-			return clientId
-				? select( blockEditorStore ).getBlock( clientId )
-				: null;
-		},
-		[ clientId ]
-	);
 
 	// Get the dispatch functions to save the comment and update the block attributes.
 	const { updateBlockAttributes } = useDispatch( blockEditorStore );
@@ -264,10 +254,7 @@ export default function CollabSidebar() {
 	}, [ postId, clientId ] );
 
 	// Check if the experimental flag is enabled.
-	if (
-		! isBlockCommentExperimentEnabled ||
-		postStatus.postStatus === 'publish'
-	) {
+	if ( ! isBlockCommentExperimentEnabled || postStatus === 'publish' ) {
 		return null; // or maybe return some message indicating no threads are available.
 	}
 

--- a/packages/editor/src/components/collab-sidebar/index.js
+++ b/packages/editor/src/components/collab-sidebar/index.js
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch, resolveSelect } from '@wordpress/data';
-import { useState, useEffect, useMemo } from '@wordpress/element';
-import { comment as commentIcon, post } from '@wordpress/icons';
+import { useState, useMemo } from '@wordpress/element';
+import { comment as commentIcon } from '@wordpress/icons';
 import { addFilter } from '@wordpress/hooks';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
@@ -54,7 +54,6 @@ export default function CollabSidebar() {
 	const { saveEntityRecord, deleteEntityRecord } = useDispatch( coreStore );
 	const { getEntityRecord } = resolveSelect( coreStore );
 	const { enableComplementaryArea } = useDispatch( interfaceStore );
-	const [ blockCommentID, setBlockCommentID ] = useState( null );
 	const [ showCommentBoard, setShowCommentBoard ] = useState( false );
 
 	const { postId, postStatus, threads } = useSelect( ( select ) => {
@@ -77,14 +76,16 @@ export default function CollabSidebar() {
 		};
 	}, [] );
 
-	const { clientId, blockDetails } = useSelect( ( select ) => {
-		const { getBlock, getSelectedBlockClientId } =
+	const { clientId, blockCommentId } = useSelect( ( select ) => {
+		const { getBlockAttributes, getSelectedBlockClientId } =
 			select( blockEditorStore );
 		const _clientId = getSelectedBlockClientId();
 
 		return {
 			clientId: _clientId,
-			blockDetails: _clientId ? getBlock( _clientId ) : null,
+			blockCommentId: _clientId
+				? getBlockAttributes( _clientId ).blockCommentId
+				: null,
 		};
 	}, [] );
 
@@ -247,12 +248,6 @@ export default function CollabSidebar() {
 		);
 	};
 
-	useEffect( () => {
-		if ( blockDetails ) {
-			setBlockCommentID( blockDetails?.attributes.blockCommentId );
-		}
-	}, [ postId, clientId ] );
-
 	// Check if the experimental flag is enabled.
 	if ( ! isBlockCommentExperimentEnabled || postStatus === 'publish' ) {
 		return null; // or maybe return some message indicating no threads are available.
@@ -260,11 +255,11 @@ export default function CollabSidebar() {
 
 	return (
 		<>
-			{ ! blockCommentID && (
+			{ ! blockCommentId && (
 				<AddCommentButton onClick={ openCollabBoard } />
 			) }
 
-			{ blockCommentID > 0 && (
+			{ blockCommentId > 0 && (
 				<AddCommentToolbarButton onClick={ openCollabBoard } />
 			) }
 			<PluginSidebar


### PR DESCRIPTION
## What?
PR updates the `CollabSidebar` component and combines store subscriptions when possible. I've also removed the side effect for setting `blockCommentID`.

I noticed multiple `useSelect` hook usages when reviewing the #66583.

## Why?
* When possible, combine the same store selectors instead of using different `useSelect` hooks. This reduces the number of store subscriptions.
* There's no need to synchronize data in the local state.

## Testing Instructions
1. Enable experimental inline commenting option under Gutenberg -> Experiments.
2. Confirm that the Inline Commenting works as before.

### Testing Instructions for Keyboard
Same.