### PR TITLE
Tie zoom out availability to content post supports

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -555,6 +555,18 @@ _Returns_
 
 -   `string|undefined`: The post type label if available, otherwise undefined.
 
+### getPostTypeSupports
+
+Returns a post type support object on the current post
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `Object`: The post type supports object.
+
 ### getPreviousBlockClientId
 
 _Related_

--- a/lib/init.php
+++ b/lib/init.php
@@ -57,3 +57,27 @@ function gutenberg_menu() {
 	);
 }
 add_action( 'admin_menu', 'gutenberg_menu', 9 );
+
+
+/**
+ * This should be implemented in core as a default
+ * post type feature.
+ *
+ */
+if ( ! function_exists( 'add_content_support' ) ) {
+	/**
+	 * Add the 'content' support to core content post types.
+	 *
+	 * @since 6.8.0
+	 */
+	function add_content_support() {
+		global $wp_post_types;
+
+		foreach ( array_keys( $wp_post_types ) as $post_type ) {
+			if ( in_array( $post_type, array( 'post', 'page', 'wp_template' ), true ) ) {
+				add_post_type_support( $post_type, 'content' );
+			}
+		}
+	}
+	add_action( 'init', 'add_content_support' );
+}

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -54,7 +54,7 @@ function Header( {
 	const isLargeViewport = useViewportMatch( 'medium' );
 	const isTooNarrowForDocumentBar = useMediaQuery( '(max-width: 403px)' );
 	const {
-		postType,
+		postTypeContentSupport,
 		isTextEditor,
 		isPublishSidebarOpened,
 		showIconLabels,
@@ -66,12 +66,13 @@ function Header( {
 		const {
 			getEditorMode,
 			getEditorSettings,
-			getCurrentPostType,
 			isPublishSidebarOpened: _isPublishSidebarOpened,
+			getPostTypeSupports,
 		} = select( editorStore );
 
 		return {
-			postType: getCurrentPostType(),
+			postTypeContentSupport:
+				getPostTypeSupports().hasOwnProperty( 'content' ),
 			isTextEditor: getEditorMode() === 'text',
 			isPublishSidebarOpened: _isPublishSidebarOpened(),
 			showIconLabels: getPreference( 'core', 'showIconLabels' ),
@@ -82,10 +83,6 @@ function Header( {
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
 		};
 	}, [] );
-
-	const canBeZoomedOut = [ 'post', 'page', 'wp_template' ].includes(
-		postType
-	);
 
 	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
 		useState( true );
@@ -149,9 +146,11 @@ function Header( {
 					<PostSavedState forceIsDirty={ forceIsDirty } />
 				) }
 
-				{ canBeZoomedOut && isEditorIframed && isWideViewport && (
-					<ZoomOutToggle disabled={ forceDisableBlockTools } />
-				) }
+				{ postTypeContentSupport &&
+					isEditorIframed &&
+					isWideViewport && (
+						<ZoomOutToggle disabled={ forceDisableBlockTools } />
+					) }
 
 				<PreviewDropdown
 					forceIsAutosaveable={ forceIsDirty }

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1815,6 +1815,21 @@ export const getPostTypeLabel = createRegistrySelector(
 );
 
 /**
+ * Returns a post type support object on the current post
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {Object} The post type supports object.
+ */
+export const getPostTypeSupports = createRegistrySelector(
+	( select ) => ( state ) => {
+		const currentPostType = getCurrentPostType( state );
+		const postType = select( coreStore ).getPostType( currentPostType );
+		return postType?.supports ?? {};
+	}
+);
+
+/**
  * Returns true if the publish sidebar is opened.
  *
  * @param {Object} state Global application state


### PR DESCRIPTION
Follow up to #65732

Currently there is a hardcoded check for certain post types to see if we should offer users the zoomed out view or not. Ideally this decision should be based on an ability of the currently edited post type.

This PR adds a new post support to a few core post types, a post support named "content".

It then checks if the currently edited post has this new content support.

Context:

- move away from hardcoding post types (https://github.com/WordPress/gutenberg/pull/65732#discussion_r1780779909)
- add a content supports to post types (https://github.com/WordPress/gutenberg/pull/65732#issuecomment-2385219740)
