### PR TITLE
DataViews: Fix 'aria-label' for pattern preview element

### DIFF
--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -45,7 +45,7 @@ function PreviewWrapper( { item, onClick, ariaDescribedBy, children } ) {
 			className="page-patterns-preview-field__button"
 			type="button"
 			onClick={ item.type !== PATTERN_TYPES.theme ? onClick : undefined }
-			aria-label={ item.title }
+			aria-label={ defaultGetTitle( item ) }
 			aria-describedby={ ariaDescribedBy }
 			aria-disabled={ item.type === PATTERN_TYPES.theme }
 		>


### PR DESCRIPTION
## What?
Fixes #66585.

PR fixes the `aria-label` output for `PreviewWrapper` component.

## Testing Instructions
1. Navigate to Site Editor > Patterns > Template Parts.
2. Confirm that pattern preview's `aria-label` is rendered correctly. You can use `page-patterns-preview-field__button` class for finding these elements in DOM.
3. Tests other pattern sources like, My Patterns or any other pattern category.

### Testing Instructions for Keyboard
Same.