### PR TITLE
Image block: Add support for "more" dropdown for additional tools in Write mode

### DIFF
--- a/packages/block-library/src/image/editor.scss
+++ b/packages/block-library/src/image/editor.scss
@@ -159,6 +159,10 @@ figure.wp-block-image:not(.wp-block) {
 	}
 }
 
+.wp-block-image__toolbar_content_textarea__container {
+	padding: $grid-unit;
+}
+
 .wp-block-image__toolbar_content_textarea {
 	// Corresponds to the size of the textarea in the block inspector.
 	width: 250px;

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -15,8 +15,11 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
 	Placeholder,
+	MenuItem,
+	ToolbarItem,
+	DropdownMenu,
 } from '@wordpress/components';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, usePrevious } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
@@ -35,7 +38,7 @@ import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { DOWN } from '@wordpress/keycodes';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
-import { crop, overlayText, upload } from '@wordpress/icons';
+import { crop, overlayText, upload, chevronDown } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore } from '@wordpress/core-data';
 
@@ -69,6 +72,11 @@ const scaleOptions = [
 	},
 ];
 
+const WRITEMODE_POPOVER_PROPS = {
+	placement: 'bottom-start',
+};
+const WRITEMODE_CONTROLS_POPOVER_PROPS = { position: 'bottom right' };
+
 // If the image has a href, wrap in an <a /> tag to trigger any inherited link element styles.
 const ImageWrapper = ( { href, children } ) => {
 	if ( ! href ) {
@@ -93,6 +101,216 @@ const ImageWrapper = ( { href, children } ) => {
 		</a>
 	);
 };
+
+function ContentOnlyControls( {
+	attributes,
+	setAttributes,
+	isContentOnlyMode,
+	lockAltControls,
+	lockAltControlsMessage,
+	lockTitleControls,
+	lockTitleControlsMessage,
+} ) {
+	const attributesToDisplayControls = [ 'alt', 'title' ];
+	const [ activeControls, setActiveControls ] = useState( () =>
+		attributesToDisplayControls.filter( ( key ) => {
+			return !! attributes[ key ];
+		} )
+	);
+	const previousActiveControls = usePrevious( activeControls );
+	if ( ! isContentOnlyMode ) {
+		return null;
+	}
+
+	// Display controls in toolbar only if they have a value set or were selected from the dropdown.
+	let controls;
+	if ( !! activeControls.length ) {
+		controls = (
+			<BlockControls group="block">
+				{ activeControls.includes( 'alt' ) && (
+					<Dropdown
+						defaultOpen={
+							! previousActiveControls?.includes( 'alt' )
+						}
+						popoverProps={ WRITEMODE_CONTROLS_POPOVER_PROPS }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarButton
+								onClick={ onToggle }
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+								onKeyDown={ ( event ) => {
+									if ( ! isOpen && event.keyCode === DOWN ) {
+										event.preventDefault();
+										onToggle();
+									}
+								} }
+							>
+								{ _x(
+									'Alternative text',
+									'Alternative text for an image. Block toolbar label, a low character count is preferred.'
+								) }
+							</ToolbarButton>
+						) }
+						renderContent={ () => (
+							<TextareaControl
+								className="wp-block-image__toolbar_content_textarea"
+								label={ __( 'Alternative text' ) }
+								value={ attributes.alt || '' }
+								onChange={ ( value ) =>
+									setAttributes( { alt: value } )
+								}
+								disabled={ lockAltControls }
+								help={
+									lockAltControls ? (
+										<>{ lockAltControlsMessage }</>
+									) : (
+										<>
+											<ExternalLink
+												href={
+													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+													__(
+														'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+													)
+												}
+											>
+												{ __(
+													'Describe the purpose of the image.'
+												) }
+											</ExternalLink>
+											<br />
+											{ __(
+												'Leave empty if decorative.'
+											) }
+										</>
+									)
+								}
+								__nextHasNoMarginBottom
+							/>
+						) }
+					/>
+				) }
+				{ activeControls.includes( 'title' ) && (
+					<Dropdown
+						defaultOpen={
+							! previousActiveControls?.includes( 'title' )
+						}
+						popoverProps={ WRITEMODE_CONTROLS_POPOVER_PROPS }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarButton
+								onClick={ onToggle }
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+								onKeyDown={ ( event ) => {
+									if ( ! isOpen && event.keyCode === DOWN ) {
+										event.preventDefault();
+										onToggle();
+									}
+								} }
+							>
+								{ __( 'Title' ) }
+							</ToolbarButton>
+						) }
+						renderContent={ () => (
+							<TextControl
+								__next40pxDefaultSize
+								className="wp-block-image__toolbar_content_textarea"
+								__nextHasNoMarginBottom
+								label={ __( 'Title attribute' ) }
+								value={ attributes.title || '' }
+								onChange={ ( value ) =>
+									setAttributes( { title: value } )
+								}
+								disabled={ lockTitleControls }
+								help={
+									lockTitleControls ? (
+										<>{ lockTitleControlsMessage }</>
+									) : (
+										<>
+											{ __(
+												'Describe the role of this image on the page.'
+											) }
+											<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
+												{ __(
+													'(Note: many devices and browsers do not display this text.)'
+												) }
+											</ExternalLink>
+										</>
+									)
+								}
+							/>
+						) }
+					/>
+				) }
+			</BlockControls>
+		);
+	}
+
+	return (
+		// Add some extra controls for content attributes when content only mode is active.
+		// With content only mode active, the inspector is hidden, so users need another way
+		// to edit these attributes.
+		<>
+			{ controls }
+			<BlockControls group="inline">
+				<ToolbarItem>
+					{ ( toggleProps ) => (
+						<DropdownMenu
+							icon={ chevronDown }
+							/* translators: button label text should, if possible, be under 16 characters. */
+							label={ __( 'More' ) }
+							toggleProps={ {
+								...toggleProps,
+								disabled:
+									activeControls.length ===
+									attributesToDisplayControls.length,
+								accessibleWhenDisabled: true,
+								// TODO: update this one..
+								description: __( 'Displays more tools…' ),
+							} }
+							popoverProps={ WRITEMODE_POPOVER_PROPS }
+						>
+							{ ( { onClose } ) => (
+								<>
+									<MenuItem
+										onClick={ () => {
+											setActiveControls( ( prev ) => [
+												...prev,
+												'alt',
+											] );
+											onClose();
+										} }
+										disabled={ activeControls.includes(
+											'alt'
+										) }
+									>
+										{ _x(
+											'Alternative text',
+											'Alternative text for an image. Block toolbar label, a low character count is preferred.'
+										) }
+									</MenuItem>
+									<MenuItem
+										onClick={ () => {
+											setActiveControls( ( prev ) => [
+												...prev,
+												'title',
+											] );
+											onClose();
+										} }
+										disabled={ activeControls.includes(
+											'title'
+										) }
+									>
+										{ __( 'Title text' ) }
+									</MenuItem>
+								</>
+							) }
+						</DropdownMenu>
+					) }
+				</ToolbarItem>
+			</BlockControls>
+		</>
+	);
+}
 
 export default function Image( {
 	temporaryURL,
@@ -621,118 +839,15 @@ export default function Image( {
 					</ToolbarGroup>
 				</BlockControls>
 			) }
-			{ isContentOnlyMode && (
-				// Add some extra controls for content attributes when content only mode is active.
-				// With content only mode active, the inspector is hidden, so users need another way
-				// to edit these attributes.
-				<BlockControls group="other">
-					<Dropdown
-						popoverProps={ { position: 'bottom right' } }
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<ToolbarButton
-								onClick={ onToggle }
-								aria-haspopup="true"
-								aria-expanded={ isOpen }
-								onKeyDown={ ( event ) => {
-									if ( ! isOpen && event.keyCode === DOWN ) {
-										event.preventDefault();
-										onToggle();
-									}
-								} }
-							>
-								{ _x(
-									'Alternative text',
-									'Alternative text for an image. Block toolbar label, a low character count is preferred.'
-								) }
-							</ToolbarButton>
-						) }
-						renderContent={ () => (
-							<TextareaControl
-								className="wp-block-image__toolbar_content_textarea"
-								label={ __( 'Alternative text' ) }
-								value={ alt || '' }
-								onChange={ updateAlt }
-								disabled={ lockAltControls }
-								help={
-									lockAltControls ? (
-										<>{ lockAltControlsMessage }</>
-									) : (
-										<>
-											<ExternalLink
-												href={
-													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-													__(
-														'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-													)
-												}
-											>
-												{ __(
-													'Describe the purpose of the image.'
-												) }
-											</ExternalLink>
-											<br />
-											{ __(
-												'Leave empty if decorative.'
-											) }
-										</>
-									)
-								}
-								__nextHasNoMarginBottom
-							/>
-						) }
-					/>
-					{ title && (
-						<Dropdown
-							popoverProps={ { position: 'bottom right' } }
-							renderToggle={ ( { isOpen, onToggle } ) => (
-								<ToolbarButton
-									onClick={ onToggle }
-									aria-haspopup="true"
-									aria-expanded={ isOpen }
-									onKeyDown={ ( event ) => {
-										if (
-											! isOpen &&
-											event.keyCode === DOWN
-										) {
-											event.preventDefault();
-											onToggle();
-										}
-									} }
-								>
-									{ __( 'Title' ) }
-								</ToolbarButton>
-							) }
-							renderContent={ () => (
-								<TextControl
-									__next40pxDefaultSize
-									className="wp-block-image__toolbar_content_textarea"
-									__nextHasNoMarginBottom
-									label={ __( 'Title attribute' ) }
-									value={ title || '' }
-									onChange={ onSetTitle }
-									disabled={ lockTitleControls }
-									help={
-										lockTitleControls ? (
-											<>{ lockTitleControlsMessage }</>
-										) : (
-											<>
-												{ __(
-													'Describe the role of this image on the page.'
-												) }
-												<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-													{ __(
-														'(Note: many devices and browsers do not display this text.)'
-													) }
-												</ExternalLink>
-											</>
-										)
-									}
-								/>
-							) }
-						/>
-					) }
-				</BlockControls>
-			) }
+			<ContentOnlyControls
+				isContentOnlyMode={ isContentOnlyMode }
+				attributes={ attributes }
+				setAttributes={ setAttributes }
+				lockAltControls={ lockAltControls }
+				lockAltControlsMessage={ lockAltControlsMessage }
+				lockTitleControls={ lockTitleControls }
+				lockTitleControlsMessage={ lockTitleControlsMessage }
+			/>
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -134,7 +134,6 @@ function ContentOnlyControls( {
 										setIsAltDialogOpen( true );
 										onClose();
 									} }
-									aria-pressed={ !! attributes.alt }
 								>
 									{ _x(
 										'Alternative text',
@@ -144,8 +143,8 @@ function ContentOnlyControls( {
 								<MenuItem
 									onClick={ () => {
 										setIsTitleDialogOpen( true );
+										onClose();
 									} }
-									aria-pressed={ !! attributes.title }
 								>
 									{ __( 'Title text' ) }
 								</MenuItem>

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -10,7 +10,6 @@ import {
 	TextControl,
 	ToolbarButton,
 	ToolbarGroup,
-	Dropdown,
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
@@ -18,8 +17,9 @@ import {
 	MenuItem,
 	ToolbarItem,
 	DropdownMenu,
+	Popover,
 } from '@wordpress/components';
-import { useViewportMatch, usePrevious } from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	BlockControls,
@@ -35,7 +35,6 @@ import {
 } from '@wordpress/block-editor';
 import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
-import { DOWN } from '@wordpress/keycodes';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
 import { crop, overlayText, upload, chevronDown } from '@wordpress/icons';
@@ -75,7 +74,6 @@ const scaleOptions = [
 const WRITEMODE_POPOVER_PROPS = {
 	placement: 'bottom-start',
 };
-const WRITEMODE_CONTROLS_POPOVER_PROPS = { position: 'bottom right' };
 
 // If the image has a href, wrap in an <a /> tag to trigger any inherited link element styles.
 const ImageWrapper = ( { href, children } ) => {
@@ -111,204 +109,144 @@ function ContentOnlyControls( {
 	lockTitleControls,
 	lockTitleControlsMessage,
 } ) {
-	const attributesToDisplayControls = [ 'alt', 'title' ];
-	const [ activeControls, setActiveControls ] = useState( () =>
-		attributesToDisplayControls.filter( ( key ) => {
-			return !! attributes[ key ];
-		} )
-	);
-	const previousActiveControls = usePrevious( activeControls );
+	// Use internal state instead of a ref to make sure that the component
+	// re-renders when the popover's anchor updates.
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const [ isAltDialogOpen, setIsAltDialogOpen ] = useState( false );
+	const [ isTitleDialogOpen, setIsTitleDialogOpen ] = useState( false );
 	if ( ! isContentOnlyMode ) {
 		return null;
 	}
-
-	// Display controls in toolbar only if they have a value set or were selected from the dropdown.
-	let controls;
-	if ( !! activeControls.length ) {
-		controls = (
-			<BlockControls group="block">
-				{ activeControls.includes( 'alt' ) && (
-					<Dropdown
-						defaultOpen={
-							! previousActiveControls?.includes( 'alt' )
-						}
-						popoverProps={ WRITEMODE_CONTROLS_POPOVER_PROPS }
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<ToolbarButton
-								onClick={ onToggle }
-								aria-haspopup="true"
-								aria-expanded={ isOpen }
-								onKeyDown={ ( event ) => {
-									if ( ! isOpen && event.keyCode === DOWN ) {
-										event.preventDefault();
-										onToggle();
-									}
-								} }
-							>
-								{ _x(
-									'Alternative text',
-									'Alternative text for an image. Block toolbar label, a low character count is preferred.'
-								) }
-							</ToolbarButton>
-						) }
-						renderContent={ () => (
-							<TextareaControl
-								className="wp-block-image__toolbar_content_textarea"
-								label={ __( 'Alternative text' ) }
-								value={ attributes.alt || '' }
-								onChange={ ( value ) =>
-									setAttributes( { alt: value } )
-								}
-								disabled={ lockAltControls }
-								help={
-									lockAltControls ? (
-										<>{ lockAltControlsMessage }</>
-									) : (
-										<>
-											<ExternalLink
-												href={
-													// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
-													__(
-														'https://www.w3.org/WAI/tutorials/images/decision-tree/'
-													)
-												}
-											>
-												{ __(
-													'Describe the purpose of the image.'
-												) }
-											</ExternalLink>
-											<br />
-											{ __(
-												'Leave empty if decorative.'
-											) }
-										</>
-									)
-								}
-								__nextHasNoMarginBottom
-							/>
-						) }
-					/>
-				) }
-				{ activeControls.includes( 'title' ) && (
-					<Dropdown
-						defaultOpen={
-							! previousActiveControls?.includes( 'title' )
-						}
-						popoverProps={ WRITEMODE_CONTROLS_POPOVER_PROPS }
-						renderToggle={ ( { isOpen, onToggle } ) => (
-							<ToolbarButton
-								onClick={ onToggle }
-								aria-haspopup="true"
-								aria-expanded={ isOpen }
-								onKeyDown={ ( event ) => {
-									if ( ! isOpen && event.keyCode === DOWN ) {
-										event.preventDefault();
-										onToggle();
-									}
-								} }
-							>
-								{ __( 'Title' ) }
-							</ToolbarButton>
-						) }
-						renderContent={ () => (
-							<TextControl
-								__next40pxDefaultSize
-								className="wp-block-image__toolbar_content_textarea"
-								__nextHasNoMarginBottom
-								label={ __( 'Title attribute' ) }
-								value={ attributes.title || '' }
-								onChange={ ( value ) =>
-									setAttributes( { title: value } )
-								}
-								disabled={ lockTitleControls }
-								help={
-									lockTitleControls ? (
-										<>{ lockTitleControlsMessage }</>
-									) : (
-										<>
-											{ __(
-												'Describe the role of this image on the page.'
-											) }
-											<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
-												{ __(
-													'(Note: many devices and browsers do not display this text.)'
-												) }
-											</ExternalLink>
-										</>
-									)
-								}
-							/>
-						) }
-					/>
-				) }
-			</BlockControls>
-		);
-	}
-
 	return (
 		// Add some extra controls for content attributes when content only mode is active.
 		// With content only mode active, the inspector is hidden, so users need another way
 		// to edit these attributes.
-		<>
-			{ controls }
-			<BlockControls group="inline">
-				<ToolbarItem>
-					{ ( toggleProps ) => (
-						<DropdownMenu
-							icon={ chevronDown }
-							/* translators: button label text should, if possible, be under 16 characters. */
-							label={ __( 'More' ) }
-							toggleProps={ {
-								...toggleProps,
-								disabled:
-									activeControls.length ===
-									attributesToDisplayControls.length,
-								accessibleWhenDisabled: true,
-								// TODO: update this one..
-								description: __( 'Displays more tools…' ),
-							} }
-							popoverProps={ WRITEMODE_POPOVER_PROPS }
-						>
-							{ ( { onClose } ) => (
-								<>
-									<MenuItem
-										onClick={ () => {
-											setActiveControls( ( prev ) => [
-												...prev,
-												'alt',
-											] );
-											onClose();
-										} }
-										disabled={ activeControls.includes(
-											'alt'
+		<BlockControls group="block">
+			<ToolbarItem ref={ setPopoverAnchor }>
+				{ ( toggleProps ) => (
+					<DropdownMenu
+						icon={ chevronDown }
+						/* translators: button label text should, if possible, be under 16 characters. */
+						label={ __( 'More' ) }
+						toggleProps={ {
+							...toggleProps,
+							description: __( 'Displays more controls.' ),
+						} }
+						popoverProps={ WRITEMODE_POPOVER_PROPS }
+					>
+						{ ( { onClose } ) => (
+							<>
+								<MenuItem
+									onClick={ () => {
+										setIsAltDialogOpen( true );
+										onClose();
+									} }
+									aria-pressed={ !! attributes.alt }
+								>
+									{ _x(
+										'Alternative text',
+										'Alternative text for an image. Block toolbar label, a low character count is preferred.'
+									) }
+								</MenuItem>
+								<MenuItem
+									onClick={ () => {
+										setIsTitleDialogOpen( true );
+									} }
+									aria-pressed={ !! attributes.title }
+								>
+									{ __( 'Title text' ) }
+								</MenuItem>
+							</>
+						) }
+					</DropdownMenu>
+				) }
+			</ToolbarItem>
+			{ isAltDialogOpen && (
+				<Popover
+					placement="bottom-start"
+					anchor={ popoverAnchor }
+					onClose={ () => setIsAltDialogOpen( false ) }
+					offset={ 13 }
+					variant="toolbar"
+				>
+					<div className="wp-block-image__toolbar_content_textarea__container">
+						<TextareaControl
+							className="wp-block-image__toolbar_content_textarea"
+							label={ __( 'Alternative text' ) }
+							value={ attributes.alt || '' }
+							onChange={ ( value ) =>
+								setAttributes( { alt: value } )
+							}
+							disabled={ lockAltControls }
+							help={
+								lockAltControls ? (
+									<>{ lockAltControlsMessage }</>
+								) : (
+									<>
+										<ExternalLink
+											href={
+												// translators: Localized tutorial, if one exists. W3C Web Accessibility Initiative link has list of existing translations.
+												__(
+													'https://www.w3.org/WAI/tutorials/images/decision-tree/'
+												)
+											}
+										>
+											{ __(
+												'Describe the purpose of the image.'
+											) }
+										</ExternalLink>
+										<br />
+										{ __( 'Leave empty if decorative.' ) }
+									</>
+								)
+							}
+							__nextHasNoMarginBottom
+						/>
+					</div>
+				</Popover>
+			) }
+			{ isTitleDialogOpen && (
+				<Popover
+					placement="bottom-start"
+					anchor={ popoverAnchor }
+					onClose={ () => setIsTitleDialogOpen( false ) }
+					offset={ 13 }
+					variant="toolbar"
+				>
+					<div className="wp-block-image__toolbar_content_textarea__container">
+						<TextControl
+							__next40pxDefaultSize
+							className="wp-block-image__toolbar_content_textarea"
+							__nextHasNoMarginBottom
+							label={ __( 'Title attribute' ) }
+							value={ attributes.title || '' }
+							onChange={ ( value ) =>
+								setAttributes( {
+									title: value,
+								} )
+							}
+							disabled={ lockTitleControls }
+							help={
+								lockTitleControls ? (
+									<>{ lockTitleControlsMessage }</>
+								) : (
+									<>
+										{ __(
+											'Describe the role of this image on the page.'
 										) }
-									>
-										{ _x(
-											'Alternative text',
-											'Alternative text for an image. Block toolbar label, a low character count is preferred.'
-										) }
-									</MenuItem>
-									<MenuItem
-										onClick={ () => {
-											setActiveControls( ( prev ) => [
-												...prev,
-												'title',
-											] );
-											onClose();
-										} }
-										disabled={ activeControls.includes(
-											'title'
-										) }
-									>
-										{ __( 'Title text' ) }
-									</MenuItem>
-								</>
-							) }
-						</DropdownMenu>
-					) }
-				</ToolbarItem>
-			</BlockControls>
-		</>
+										<ExternalLink href="https://www.w3.org/TR/html52/dom.html#the-title-attribute">
+											{ __(
+												'(Note: many devices and browsers do not display this text.)'
+											) }
+										</ExternalLink>
+									</>
+								)
+							}
+						/>
+					</div>
+				</Popover>
+			) }
+		</BlockControls>
 	);
 }
 

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -103,7 +103,6 @@ const ImageWrapper = ( { href, children } ) => {
 function ContentOnlyControls( {
 	attributes,
 	setAttributes,
-	isContentOnlyMode,
 	lockAltControls,
 	lockAltControlsMessage,
 	lockTitleControls,
@@ -114,14 +113,8 @@ function ContentOnlyControls( {
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 	const [ isAltDialogOpen, setIsAltDialogOpen ] = useState( false );
 	const [ isTitleDialogOpen, setIsTitleDialogOpen ] = useState( false );
-	if ( ! isContentOnlyMode ) {
-		return null;
-	}
 	return (
-		// Add some extra controls for content attributes when content only mode is active.
-		// With content only mode active, the inspector is hidden, so users need another way
-		// to edit these attributes.
-		<BlockControls group="block">
+		<>
 			<ToolbarItem ref={ setPopoverAnchor }>
 				{ ( toggleProps ) => (
 					<DropdownMenu
@@ -246,7 +239,7 @@ function ContentOnlyControls( {
 					</div>
 				</Popover>
 			) }
-		</BlockControls>
+		</>
 	);
 }
 
@@ -777,15 +770,21 @@ export default function Image( {
 					</ToolbarGroup>
 				</BlockControls>
 			) }
-			<ContentOnlyControls
-				isContentOnlyMode={ isContentOnlyMode }
-				attributes={ attributes }
-				setAttributes={ setAttributes }
-				lockAltControls={ lockAltControls }
-				lockAltControlsMessage={ lockAltControlsMessage }
-				lockTitleControls={ lockTitleControls }
-				lockTitleControlsMessage={ lockTitleControlsMessage }
-			/>
+			{ isContentOnlyMode && (
+				// Add some extra controls for content attributes when content only mode is active.
+				// With content only mode active, the inspector is hidden, so users need another way
+				// to edit these attributes.
+				<BlockControls group="block">
+					<ContentOnlyControls
+						attributes={ attributes }
+						setAttributes={ setAttributes }
+						lockAltControls={ lockAltControls }
+						lockAltControlsMessage={ lockAltControlsMessage }
+						lockTitleControls={ lockTitleControls }
+						lockTitleControlsMessage={ lockTitleControlsMessage }
+					/>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -1132,7 +1132,9 @@ test.describe( 'Pattern Overrides', () => {
 		);
 		await editor.showBlockToolbar();
 		await editor.clickBlockToolbarButton( 'More' );
-		await page.getByRole( 'button', { name: 'Alternative text' } ).click();
+		await page
+			.getByRole( 'menuitem', { name: 'Alternative text' } )
+			.click();
 		await page
 			.getByRole( 'textbox', { name: 'alternative text' } )
 			.fill( 'Test Image' );

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -1131,7 +1131,8 @@ test.describe( 'Pattern Overrides', () => {
 			/\/wp-content\/uploads\//
 		);
 		await editor.showBlockToolbar();
-		await editor.clickBlockToolbarButton( 'Alternative text' );
+		await editor.clickBlockToolbarButton( 'More' );
+		await page.getByRole( 'button', { name: 'Alternative text' } ).click();
 		await page
 			.getByRole( 'textbox', { name: 'alternative text' } )
 			.fill( 'Test Image' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/66455

>When writing in contentOnly mode, selecting an image block will render tools for adding a link, adding alt text, and adding title text (if there is title text present on the block already. This proposal here is oriented towards keeping the "Write" tooling simple and intuitive, leveraging the existing "More" down caret employed within text blocks, for additional controls.

>This way we can continue flexing content blocks within Write mode, without introducing further complexity.


## Testing Instructions
1. Insert an image and go to `write` mode
2. Tinker with the new 'more menu' by adding/removing values, saving, changing selected block etc..



## Screenshots or screencast <!-- if applicable -->



https://github.com/user-attachments/assets/3e6d340b-e3be-424d-95cd-76814835b55a





