### PR TITLE
Guide: Use small size button for page controls

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `Guide`: Use small size button for page controls ([#66607](https://github.com/WordPress/gutenberg/pull/66607)).
+
 ## 28.11.0 (2024-10-30)
 
 ### Deprecations

--- a/packages/components/src/guide/page-control.tsx
+++ b/packages/components/src/guide/page-control.tsx
@@ -27,6 +27,7 @@ export default function PageControl( {
 					aria-current={ page === currentPage ? 'step' : undefined }
 				>
 					<Button
+						size="small"
 						key={ page }
 						icon={ <PageControlIcon /> }
 						aria-label={ sprintf(

--- a/packages/components/src/guide/style.scss
+++ b/packages/components/src/guide/style.scss
@@ -34,7 +34,7 @@
 		}
 	}
 
-	&__container {
+	.components-guide__container {
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;
@@ -42,7 +42,7 @@
 		min-height: 100%;
 	}
 
-	&__page {
+	.components-guide__page {
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
@@ -53,7 +53,7 @@
 		}
 	}
 
-	&__footer {
+	.components-guide__footer {
 		align-content: center;
 		display: flex;
 		height: $button-size;
@@ -64,7 +64,7 @@
 		width: 100%;
 	}
 
-	&__page-control {
+	.components-guide__page-control {
 		margin: 0;
 		text-align: center;
 
@@ -74,8 +74,6 @@
 		}
 
 		.components-button {
-			height: 30px;
-			min-width: 20px;
 			margin: -6px 0;
 			color: $gray-200;
 		}


### PR DESCRIPTION
In preparation for #65751

## What?

Use `small` size Buttons in the page controls for the Guide component.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

See Storybook for Guide. In the block editor, open the Options menu in the top right and open the Welcome Guide.

## Screenshots or screencast <!-- if applicable -->

@WordPress/gutenberg-design With the standard component sizing without overrides, you can see the page controls dots are a bit more spread out ([Figma specs](https://www.figma.com/design/804HN2REV2iap2ytjRQ055/Core-System-Library?node-id=15725-6552&t=Km1k2S0n23fJrjrO-4)). I _think_ this is acceptable, especially because it has more tappable surface area. Are we good with this?

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/210afc12-709b-401a-a4e4-758c23558be4" alt="Guide page controls, before" width="339">|<img src="https://github.com/user-attachments/assets/3472bd7c-8fc7-4bd1-8d0d-a1d497633541" alt="Guide page controls, after" width="339">|
