### PR TITLE
Allow define RadioControl label with ReactNode component

### DIFF
--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -104,7 +104,7 @@ A function that receives the value of the new option that is being selected as i
 
 An array of objects containing the value and label of the options.
 
--   `label`: `ReactNode` The label to be shown to the user. When the label is not a string, make sure that the element is accessibly labeled.
+-   `label`: `string` | `React.ReactElement` The label to be shown to the user. When the label is not a string, make sure that the element is accessibly labeled.
 - ```
 -   `value`: `string` The internal value compared against select and passed to onChange.
 

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -104,7 +104,7 @@ A function that receives the value of the new option that is being selected as i
 
 An array of objects containing the value and label of the options.
 
--   `label`: `string` The label to be shown to the user.
+-   `label`: `string` | `ReactNode` The label to be shown to the user.
 -   `value`: `string` The internal value compared against select and passed to onChange.
 
 *   Required: No

--- a/packages/components/src/radio-control/README.md
+++ b/packages/components/src/radio-control/README.md
@@ -104,7 +104,8 @@ A function that receives the value of the new option that is being selected as i
 
 An array of objects containing the value and label of the options.
 
--   `label`: `string` | `ReactNode` The label to be shown to the user.
+-   `label`: `ReactNode` The label to be shown to the user. When the label is not a string, make sure that the element is accessibly labeled.
+- ```
 -   `value`: `string` The internal value compared against select and passed to onChange.
 
 *   Required: No

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -6,13 +6,14 @@ import type { Meta, StoryFn } from '@storybook/react';
 /**
  * WordPress dependencies
  */
+import { starFilled } from '@wordpress/icons';
 import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import RadioControl from '..';
-import { Path, SVG } from '@wordpress/primitives';
+import Icon from '../../icon';
 
 const meta: Meta< typeof RadioControl > = {
 	component: RadioControl,
@@ -94,27 +95,21 @@ WithOptionDescriptions.args = {
 	],
 };
 
+/**
+ * When the label is not a string,
+ * make sure that the element is accessibly labeled.
+ */
 export const WithComponentLabels: StoryFn< typeof RadioControl > =
 	Template.bind( {} );
 
-function Rating( { stars, ariaLabel }: { stars: number; ariaLabel: string } ) {
-	const starPath =
-		'M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z';
+function Rating( {
+	stars,
+	...restProps
+}: { stars: number } & JSX.IntrinsicElements[ 'div' ] ) {
 	return (
-		<div
-			style={ { display: 'flex' } }
-			aria-label={ ariaLabel }
-			title={ ariaLabel }
-		>
+		<div style={ { display: 'flex' } } { ...restProps }>
 			{ Array.from( { length: stars }, ( _, index ) => (
-				<SVG
-					key={ index }
-					width={ 24 }
-					height={ 24 }
-					viewBox="0 0 24 24"
-				>
-					<Path d={ starPath } />
-				</SVG>
+				<Icon key={ index } icon={ starFilled } />
 			) ) }
 		</div>
 	);
@@ -124,23 +119,15 @@ WithComponentLabels.args = {
 	label: 'Rating',
 	options: [
 		{
-			label: <Rating stars={ 5 } ariaLabel="Five Stars" />,
-			value: '5',
-		},
-		{
-			label: <Rating stars={ 4 } ariaLabel="Four Stars" />,
-			value: '4',
-		},
-		{
-			label: <Rating stars={ 3 } ariaLabel="Three Stars" />,
+			label: <Rating stars={ 3 } aria-label="Three Stars" />,
 			value: '3',
 		},
 		{
-			label: <Rating stars={ 2 } ariaLabel="Two Stars" />,
+			label: <Rating stars={ 2 } aria-label="Two Stars" />,
 			value: '2',
 		},
 		{
-			label: <Rating stars={ 1 } ariaLabel="One Star" />,
+			label: <Rating stars={ 1 } aria-label="One Star" />,
 			value: '1',
 		},
 	],

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -101,7 +101,11 @@ function Rating( { stars, ariaLabel }: { stars: number; ariaLabel: string } ) {
 	const starPath =
 		'M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z';
 	return (
-		<div style={ { display: 'flex' } } aria-label={ ariaLabel }>
+		<div
+			style={ { display: 'flex' } }
+			aria-label={ ariaLabel }
+			title={ ariaLabel }
+		>
 			{ Array.from( { length: stars }, ( _, index ) => (
 				<SVG
 					key={ index }

--- a/packages/components/src/radio-control/stories/index.story.tsx
+++ b/packages/components/src/radio-control/stories/index.story.tsx
@@ -12,6 +12,7 @@ import { useState } from '@wordpress/element';
  * Internal dependencies
  */
 import RadioControl from '..';
+import { Path, SVG } from '@wordpress/primitives';
 
 const meta: Meta< typeof RadioControl > = {
 	component: RadioControl,
@@ -89,6 +90,54 @@ WithOptionDescriptions.args = {
 			label: 'Password Protected',
 			value: 'password',
 			description: 'Protected by a password',
+		},
+	],
+};
+
+export const WithComponentLabels: StoryFn< typeof RadioControl > =
+	Template.bind( {} );
+
+function Rating( { stars, ariaLabel }: { stars: number; ariaLabel: string } ) {
+	const starPath =
+		'M12 17.27L18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z';
+	return (
+		<div style={ { display: 'flex' } } aria-label={ ariaLabel }>
+			{ Array.from( { length: stars }, ( _, index ) => (
+				<SVG
+					key={ index }
+					width={ 24 }
+					height={ 24 }
+					viewBox="0 0 24 24"
+				>
+					<Path d={ starPath } />
+				</SVG>
+			) ) }
+		</div>
+	);
+}
+
+WithComponentLabels.args = {
+	label: 'Rating',
+	options: [
+		{
+			label: <Rating stars={ 5 } ariaLabel="Five Stars" />,
+			value: '5',
+		},
+		{
+			label: <Rating stars={ 4 } ariaLabel="Four Stars" />,
+			value: '4',
+		},
+		{
+			label: <Rating stars={ 3 } ariaLabel="Three Stars" />,
+			value: '3',
+		},
+		{
+			label: <Rating stars={ 2 } ariaLabel="Two Stars" />,
+			value: '2',
+		},
+		{
+			label: <Rating stars={ 1 } ariaLabel="One Star" />,
+			value: '1',
 		},
 	],
 };

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -17,9 +17,9 @@ export type RadioControlProps = Pick<
 	 */
 	options?: {
 		/**
-		 * The label to be shown to the user
+		 * The label to be shown to the user.
 		 */
-		label: string;
+		label: string | React.ReactNode;
 		/**
 		 * The internal value compared against select and passed to onChange
 		 */

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -19,7 +19,7 @@ export type RadioControlProps = Pick<
 		/**
 		 * The label to be shown to the user.
 		 */
-		label: string | React.ReactNode;
+		label: React.ReactNode;
 		/**
 		 * The internal value compared against select and passed to onChange
 		 */

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -21,7 +21,7 @@ export type RadioControlProps = Pick<
 		 *
 		 * When the label is not a string, make sure that the element is accessibly labeled.
 		 */
-		label: React.ReactNode;
+		label: string | React.ReactElement;
 		/**
 		 * The internal value compared against select and passed to onChange
 		 */

--- a/packages/components/src/radio-control/types.ts
+++ b/packages/components/src/radio-control/types.ts
@@ -18,6 +18,8 @@ export type RadioControlProps = Pick<
 	options?: {
 		/**
 		 * The label to be shown to the user.
+		 *
+		 * When the label is not a string, make sure that the element is accessibly labeled.
 		 */
 		label: React.ReactNode;
 		/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR allows using a `ReactNode` element for label in the RadioControl component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because sometimes it's desired to render not only text for the radio control label

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

* Allow to define `ReactNode` for radio label

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Run storybook

```
npm run storybook:dev
```

2. Go to the new [With Component Labels](http://localhost:50240/?path=/story/components-radiocontrol--with-component-labels) story
3. Confirm the story works as expected

<img width="623" alt="image" src="https://github.com/user-attachments/assets/d662e0d1-2d33-482a-9992-568edd8d65a1">

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
