### PR TITLE
Social Link: Add contentOnly editing support

### DIFF
--- a/packages/block-library/src/social-link/block.json
+++ b/packages/block-library/src/social-link/block.json
@@ -9,13 +9,15 @@
 	"textdomain": "default",
 	"attributes": {
 		"url": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"service": {
 			"type": "string"
 		},
 		"label": {
-			"type": "string"
+			"type": "string",
+			"role": "content"
 		},
 		"rel": {
 			"type": "string"

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -10,18 +10,22 @@ import { DELETE, BACKSPACE } from '@wordpress/keycodes';
 import { useDispatch } from '@wordpress/data';
 
 import {
+	BlockControls,
 	InspectorControls,
 	URLPopover,
 	URLInput,
+	useBlockEditingMode,
 	useBlockProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import {
 	Button,
+	Dropdown,
 	PanelBody,
 	PanelRow,
 	TextControl,
+	ToolbarButton,
 	__experimentalInputControlSuffixWrapper as InputControlSuffixWrapper,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -122,6 +126,7 @@ const SocialLinkEdit = ( {
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const isContentOnlyMode = useBlockEditingMode() === 'contentOnly';
 
 	const IconComponent = getIconBySite( service );
 	const socialLinkName = getNameBySite( service );
@@ -141,6 +146,41 @@ const SocialLinkEdit = ( {
 
 	return (
 		<>
+			{ isContentOnlyMode && showLabels && (
+				// Add an extra control to modify the label attribute when content only mode is active.
+				// With content only mode active, the inspector is hidden, so users need another way
+				// to edit this attribute.
+				<BlockControls group="other">
+					<Dropdown
+						popoverProps={ { position: 'bottom right' } }
+						renderToggle={ ( { isOpen, onToggle } ) => (
+							<ToolbarButton
+								onClick={ onToggle }
+								aria-haspopup="true"
+								aria-expanded={ isOpen }
+							>
+								{ __( 'Text' ) }
+							</ToolbarButton>
+						) }
+						renderContent={ () => (
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								className="wp-block-social-link__toolbar_content_text"
+								label={ __( 'Text' ) }
+								help={ __(
+									'Provide a text label or use the default.'
+								) }
+								value={ label }
+								onChange={ ( value ) =>
+									setAttributes( { label: value } )
+								}
+								placeholder={ socialLinkName }
+							/>
+						) }
+					/>
+				</BlockControls>
+			) }
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>
 					<PanelRow>

--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -39,3 +39,8 @@
 :root :where(.wp-block-social-links.is-style-logos-only .wp-social-link button) {
 	padding: 0;
 }
+
+.wp-block-social-link__toolbar_content_text {
+	// Corresponds to the size of the text control input in the block inspector.
+	width: 250px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds `contentOnly` editing support for the Social Link block, similar to the way we currently handle the editing mode in the Image block. 

## Why?
When content only editing is enabled via `"templateLock": "contentOnly"` any Social Link blocks within the container cannot be edited by the user. There are scenarios where the user should be able to at least edit the `url` and `label` attributes, especially when the block is distributed in a pattern that can be used in a variety of contexts. 

## How?
This PR sets `"role": "content"` on the `url` and `label` attributes in `block.json`. Doing so automatically enables the `<URLPopover>` component, so nothing more is needed for editing the icon URL. 

The icon Text, on the other hand, is only editable in the block inspector, which is completely disabled in `contentOnly` mode. Therefore, this PR applies the same approach used in the Image block, where a button/popover is added to the block toolbar that allows the user to edit the `label` attribute. This "Text" button is conditional based on whether "Show text" has been enabled on the parent Social Links block. 

## Testing Instructions
1. Test this PR using the [Playground Gutenberg PR previewer](https://playground.wordpress.net/gutenberg.html)
2. Navigate to a new page, open the Code Editor, and copy and paste the following markup

```html
<!-- wp:group {"templateLock":"contentOnly","className":"is-style-default","layout":{"type":"constrained"}} -->
<div class="wp-block-group is-style-default">
<!-- wp:social-links {"iconBackgroundColor":"contrast","iconBackgroundColorValue":"#111111"} -->
<ul class="wp-block-social-links has-icon-background-color"><!-- wp:social-link {"url":"#","service":"wordpress"} /-->
<!-- wp:social-link {"url":"#","service":"facebook"} /-->
<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
<!-- /wp:social-links -->
<!-- wp:social-links {"iconBackgroundColor":"contrast","iconBackgroundColorValue":"#111111","showLabels":true} -->
<ul class="wp-block-social-links has-visible-labels has-icon-background-color"><!-- wp:social-link {"url":"#","service":"wordpress"} /-->
<!-- wp:social-link {"url":"#","service":"facebook"} /-->
<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
<!-- /wp:social-links -->
</div>
<!-- /wp:group -->
```

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/285fa63c-0464-405a-80d1-d38f71c3f229">


3. Switch to the Visual Editor and confirm that you can edit the URL on all Social Link blocks
4. Confirm that the first set of icons does not have the "Text" button in the block toolbar since  "Show text" is disabled
5. Confirm that the second set of icons do have the "Text" button
6. Confirm that the icon text is editable when clicking on the "Text" button

## Screenshots or screencast 

|  Current (no `contentOnly` support) | 
|-|
|<img width="1444" alt="image" src="https://github.com/user-attachments/assets/5a372ea6-a04c-4f87-8326-0fd86f0ca2f6">|

|With PR (Default) | With PR (Text enabled) |
|-|-|
|<img width="1106" alt="image" src="https://github.com/user-attachments/assets/609daeff-f2d4-434e-a28c-10dcd71562f9">|<img width="1106" alt="image" src="https://github.com/user-attachments/assets/bc199b67-b02b-46b0-a869-178f76a8c2d8">|
