### PR TITLE
PostTaxonomiesFlatTermSelector: abstract wrapper component

### DIFF
--- a/packages/editor/src/components/post-taxonomies/flat-term-selector.js
+++ b/packages/editor/src/components/post-taxonomies/flat-term-selector.js
@@ -57,6 +57,13 @@ const termNamesToIds = ( names, terms ) => {
 		.filter( ( id ) => id !== undefined );
 };
 
+const Wrapper = ( { children, __nextHasNoMarginBottom } ) =>
+	__nextHasNoMarginBottom ? (
+		<VStack spacing={ 4 }>{ children }</VStack>
+	) : (
+		<Fragment>{ children }</Fragment>
+	);
+
 /**
  * Renders a flat term selector component.
  *
@@ -292,15 +299,8 @@ export function FlatTermSelector( { slug, __nextHasNoMarginBottom } ) {
 		singularName
 	);
 
-	const Wrapper = ( { children } ) =>
-		__nextHasNoMarginBottom ? (
-			<VStack spacing={ 4 }>{ children }</VStack>
-		) : (
-			<Fragment>{ children }</Fragment>
-		);
-
 	return (
-		<Wrapper>
+		<Wrapper __nextHasNoMarginBottom={ __nextHasNoMarginBottom }>
 			<FormTokenField
 				__next40pxDefaultSize
 				value={ values }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to:

- https://github.com/WordPress/gutenberg/pull/66566

Noticed by me and @kevin940726 while testing https://github.com/WordPress/wordpress-develop/pull/7693

Props to @kevin940726 for working out the culprit



## Why?

The controls appears to rerender when adding a tag, or at least, it loses focus.

https://github.com/user-attachments/assets/36f0ee20-495f-4e03-b38d-190edcf746cb


## How?
Extract Wrapper into an external component to avoid rerender, and therefore, blur/clearing tag control.

## Testing Instructions

1. Create a new post or page.
2. Add a tag in the post/page settings side bar.
3. Ensure that you can continue to add tags and that your input is not lost.


https://github.com/user-attachments/assets/24749b4b-10f9-48e8-a91c-6b90d6480ed0


