### PR TITLE
VisualEditor: Always output has-global-padding classname when in post only mode

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -462,7 +462,13 @@ function VisualEditor( {
 								renderingMode !== 'post-only' ||
 									isDesignPostType
 									? 'wp-site-blocks'
-									: `${ blockListLayoutClass } wp-block-post-content` // Ensure root level blocks receive default/flow blockGap styling rules.
+									: `${ blockListLayoutClass } wp-block-post-content`, // Ensure root level blocks receive default/flow blockGap styling rules.
+								{
+									'has-global-padding':
+										renderingMode === 'post-only' &&
+										! isDesignPostType &&
+										hasRootPaddingAwareAlignments,
+								}
 							) }
 							layout={ blockListLayout }
 							dropZoneElement={


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the abstracted post editor (i.e. editing a post or page with template preview switched off), always output the `has-global-padding` classname for the post content area, irrespective of the layout type in use (but only if the theme supports it).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is kind of similar to https://github.com/WordPress/gutenberg/pull/66352 in some ways but addresses a slightly different problem.

Something that @jasmussen ran into while testing TT5 theme is that depending on the template, you can be in a situation where the template uses the global padding on a wrapper Group block, and the Content block is set to flow/default alignment. On the site frontend, this will mean that visually, there is some global padding being applied around the content area.

However in the abstracted post editor, there is no such wrapper block, and so the content can render to the very edge of the viewport, unexpectedly.

This PR proposes always applying the `has-global-padding` classname so that if the site uses the global padding it applies in the abstracted post editor. Given that folks can switch on the template preview mode if they want a more WYSIWYG look, the assumption here is that it's better to optimise for things looking good for the writing experience.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

In the `VisualEditor`, output the `has-global-padding` class name if the theme supports root padding aware alignments, we're in the post only mode, and the entity being edited is not a design one (pattern, template part, etc)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

This could be a little tricky to reproduce! It took me a while before I ran into the issue 😄

1. Set up a test site running wordpress-develop trunk or WP 6.7 RC 2
2. Activate TT5 theme
3. In the site editor, go to templates and go to Add New Template
4. From the list, select Single item: Post
5. Select to create it for All Posts
6. You should then see a list to select from patterns to create your template. For this particular case, select this one that's optimised for photos:

<img width="430" alt="image" src="https://github.com/user-attachments/assets/5e3faafd-677f-4ac2-9100-502672c98ed3">

7. Select the Content block in this template, and toggle off "Inner blocks use content width" so that the content fills the container.
8. Save the template and open up the post editor
9. Add some content to the post. On `trunk` if you use the preview in the top right and select Mobile, you'll likely see that the content unexpectedly goes edge-to-edge in the preview
10. With this PR applied, the root padding should apply so there'll be some padding

## Screenshots or screencast <!-- if applicable -->

| Before | After |
| --- | --- |
| <img width="1341" alt="image" src="https://github.com/user-attachments/assets/66ec0180-1d60-4f05-8a6a-9b87d71cf3ee"> | <img width="1339" alt="image" src="https://github.com/user-attachments/assets/904cfba1-8b65-4e7d-82a2-96456c4fcd41"> |