### PR TITLE
Prevent duplicate post format taxonomy queries

### DIFF
--- a/lib/compat/wordpress-6.7/blocks.php
+++ b/lib/compat/wordpress-6.7/blocks.php
@@ -59,6 +59,16 @@ function gutenberg_add_format_query_vars_to_query_loop_block( $query, $block ) {
 		return $query;
 	}
 
+	// Return early if the query already contains a post format. This is to avoid duplication if the
+	// WordPress core filter is already applied.
+	if ( ! empty( $query['tax_query'] ) ) {
+		foreach ( $query['tax_query'] as $taxquery ) {
+			if ( isset( $taxquery['taxonomy'] ) && 'post_format' === $taxquery['taxonomy'] ) {
+				return $query;
+			}
+		}
+	}
+
 	$formats = $block->context['query']['format'];
 	/*
 	 * Validate that the format is either `standard` or a supported post format.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
If Gutenberg is active on WordPress 6.7 or later, the filter that adds the post format to the taxonomy query should not run twice.
This PR adds an early return to gutenberg_add_format_query_vars_to_query_loop_block if the post format is already in the taxonomy query.

Closes https://github.com/WordPress/gutenberg/issues/66071

## Testing Instructions
I tested this by doing the following:

First I activated Gutenberg with this PR on WordPress 6.7 nightly.
I created a post with a post format and set the query loop to show this format.
Then I edited `gutenberg_add_format_query_vars_to_query_loop_block` and added a temporary `echo` inside the new if-statement, to confirm that the early return was triggered on the front of the website.
I also confirmed that the correct post was still shown.

Then I ran the Gutenberg PHP tests without issues. _I have not ran the core tests!_

Then I activated Gutenberg with the PR on WordPress 6.6.2 and re-did the manual test of the query loop with the post format filter applied, and confirmed that the filter still worked.
