### PR TITLE
Block editor: exclude wp- styles from iframe compat styles

### DIFF
--- a/packages/block-editor/src/components/iframe/get-compatibility-styles.js
+++ b/packages/block-editor/src/components/iframe/get-compatibility-styles.js
@@ -37,15 +37,10 @@ export function getCompatibilityStyles() {
 				return accumulator;
 			}
 
-			// Don't try to add the reset styles, which were removed as a dependency
-			// from `edit-blocks` for the iframe since we don't need to reset admin
-			// styles.
-			if (
-				[
-					'wp-reset-editor-styles-css',
-					'wp-reset-editor-styles-rtl-css',
-				].includes( ownerNode.id )
-			) {
+			// Don't try to add core WP styles. We are responsible for adding
+			// them. This compatibility layer is only meant to add styles added
+			// by plugins or themes.
+			if ( ownerNode.id.startsWith( 'wp-' ) ) {
 				return accumulator;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes https://github.com/WordPress/gutenberg/pull/66556#issuecomment-2449268452.

This PR skips over `wp-` core styles when looking for "compatibility" styles (that contain rules that target the canvas).

Not only does this fix the warning, but it should also speed up load a tiny bit because there's less styles to parse.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because we are responsible for adding our own styles to the iframed canvas. Note that we would be seeing warnings for all the styles not added, so we know that all of them are correctly added.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We skip them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load the site editor and make sure there's no compat styles warning.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
