### PR TITLE
Appender: fix outside canvas styles

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -57,6 +57,19 @@
 	}
 }
 
+// The black plus that shows up on the right side of an empty paragraph block,
+// or the initial appender that exists only on empty documents.
+.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter {
+	position: absolute;
+	top: 0;
+	right: 0;
+	line-height: 0;
+
+	&:disabled {
+		display: none;
+	}
+}
+
 // Sibling inserter / "inbetweenserter".
 .block-editor-block-list__empty-block-inserter,
 .block-editor-block-list__insertion-point-inserter {

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -62,24 +62,12 @@
 	}
 }
 
-// The black plus that shows up on the right side of an empty paragraph block, or the initial appender
-// that exists only on empty documents.
-.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter,
-.block-editor-default-block-appender .block-editor-inserter {
-	position: absolute;
-	top: 0;
-	right: 0;
-	line-height: 0;
-
-	&:disabled {
-		display: none;
-	}
-}
-
 
 /**
- * Fixed position appender.
- * These styles apply to all in-canvas inserters that exist inside nesting containers.
+ * Fixed position appender (right bottom corner).
+ *
+ * These styles apply to all in-canvas inserters. All in-canvas inserters always
+ * exist within a block.
  */
 
 .block-editor-block-list__block .block-list-appender {
@@ -94,6 +82,10 @@
 	&.block-list-appender {
 		margin: 0;
 		line-height: 0;
+	}
+
+	.block-editor-inserter:disabled {
+		display: none;
 	}
 
 	.block-editor-default-block-appender {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

A misplaced CSS rule was uncovered by https://github.com/WordPress/gutenberg/pull/66432#issuecomment-2447923002.

Currently, the CSS rule that targets the empty-paragraph inserter is placed in the block editor's `content.css` file rather than its `style.css`, even though the empty-paragraph inserter is a popover that is rendered outside the canvas. Only block list appenders are rendered inside the canvas.

This was not an issue before #66432, because we were rendering all the content styles outside the iframe too!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes https://github.com/WordPress/gutenberg/pull/66432#issuecomment-2447923002.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Move the rule that targets the popover to the appropriate stylesheet.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

The change in #66432 only affects the Site Editor.

* In the Site Editor, create a new page. Test:
  * An empty paragraph; the inserter should appear on the right. (This is an outside-canvas inserter.)
  * A group block with an image (for example). Then select the group wrapper. The appender should appear on the right bottom corner. (This is an in-canvas appender.)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
