### PR TITLE
Site editor: preload post if needed

### DIFF
--- a/backport-changelog/6.8/7695.md
+++ b/backport-changelog/6.8/7695.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7695
+
+* https://github.com/WordPress/gutenberg/pull/66631

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -10,6 +10,10 @@
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name ) {
+		if ( ! empty( $_GET['postId'] ) ) {
+			$paths[] = add_query_arg( 'context', 'edit', rest_get_route_for_post( $_GET['postId'] ) );
+		}
+
 		// Core already preloads both of these for `core/edit-post`.
 		$paths[] = '/wp/v2/settings';
 		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -11,7 +11,10 @@
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name ) {
 		if ( ! empty( $_GET['postId'] ) ) {
-			$paths[] = add_query_arg( 'context', 'edit', rest_get_route_for_post( $_GET['postId'] ) );
+			$route_for_post = rest_get_route_for_post( $_GET['postId'] );
+			if ( $route_for_post ) {
+				$paths[] = add_query_arg( 'context', 'edit', $route_for_post );
+			}
 		}
 
 		// Core already preloads both of these for `core/edit-post`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Whenever one directly accesses a page in the site editor, preload the page. This is a _blocking_ request: the editor will not load without it.

In the post editor, we already do this: https://github.com/WordPress/wordpress-develop/blob/1508e5bf0fa3ad2d001de08eab4dee49985bb322/src/wp-admin/edit-form-blocks.php#L52

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Users might directly access the page editor in the Site Editor.
Also, this is one of the metrics we track directly. We actually do not track Site Editor load performance for the front-page (the initial Site Editor page).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Preload it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Go to the Site Editor > Pages > edit a page (url should be something like `/wp-admin/site-editor.php?postType=page&postId=<ID>&canvas=edit`. Open the network tab. Reload the editor. Observe that the REST request for the page is gone.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
