### PR TITLE
ComboboxControl component: Account for the value when displaying the available options

### DIFF
--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -152,19 +152,23 @@ function ComboboxControl( props: ComboboxControlProps ) {
 	const inputContainer = useRef< HTMLInputElement >( null );
 
 	const matchingSuggestions = useMemo( () => {
-		const startsWithMatch: ComboboxControlOption[] = [];
-		const containsMatch: ComboboxControlOption[] = [];
+		const startsWithMatch = new Set< ComboboxControlOption >();
+		const containsMatch = new Set< ComboboxControlOption >();
 		const match = normalizeTextString( inputValue );
 		options.forEach( ( option ) => {
-			const index = normalizeTextString( option.label ).indexOf( match );
-			if ( index === 0 ) {
-				startsWithMatch.push( option );
-			} else if ( index > 0 ) {
-				containsMatch.push( option );
-			}
+			const searchFrom = [ option.label, option.value ];
+			searchFrom.forEach( ( searchField ) => {
+				const matchIndex =
+					normalizeTextString( searchField ).indexOf( match );
+				if ( matchIndex === 0 ) {
+					startsWithMatch.add( option );
+				} else if ( matchIndex > 0 ) {
+					containsMatch.add( option );
+				}
+			} );
 		} );
-
-		return startsWithMatch.concat( containsMatch );
+		// return the content of set as array
+		return [ ...startsWithMatch, ...containsMatch ];
 	}, [ inputValue, options ] );
 
 	const onSuggestionSelected = (


### PR DESCRIPTION
## What?

When using the ComboboxControl component, the available options are filtered by what's in the label of each option, but the value is discarded. This produces some unexpected behaviors where options that should be visible disappear.

If the slug does not match the name, and you search by that slug, the option will be hidden.

## Why?
Fixes #64056

## How?
This PR adds the option value and the label in the search criteria. So whenever uses tries to search using any of those values it will work fine.

## Testing Instructions
1. Set up a ComboboxControl component with an option that has a different string in label and value. 
Example: 
```js
options = [
    {
        label: 'A label value',
        value: 'slug',
    },
];
```
2. Type slug in the text field and see the option displayed.