### PR TITLE
Post Editor: Set the default value of the editorTool to edit

### DIFF
--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -40,7 +40,9 @@ export function useShowBlockTools() {
 		const _showEmptyBlockSideInserter =
 			clientId &&
 			! isTyping() &&
-			editorMode === 'edit' &&
+			// Hide the block inserter on the navigation mode.
+			// See https://github.com/WordPress/gutenberg/pull/66636#discussion_r1824728483.
+			editorMode !== 'navigation' &&
 			isEmptyDefaultBlock;
 		const _showBlockToolbarPopover =
 			! getSettings().hasFixedToolbar &&

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -62,6 +62,7 @@ export function initializeEditor(
 	dispatch( preferencesStore ).setDefaults( 'core', {
 		allowRightClickOverrides: true,
 		editorMode: 'visual',
+		editorTool: 'edit',
 		fixedToolbar: false,
 		hiddenBlockTypes: [],
 		inactivePanels: [],

--- a/packages/edit-post/src/index.native.js
+++ b/packages/edit-post/src/index.native.js
@@ -29,6 +29,7 @@ export function initializeEditor( id, postType, postId ) {
 		welcomeGuide: true,
 	} );
 	dispatch( preferencesStore ).setDefaults( 'core', {
+		editorTool: 'edit',
 		hiddenBlockTypes: [],
 		inactivePanels: [],
 		openPanels: [ 'post-status' ],

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -68,6 +68,7 @@ export function initializeEditor( id, settings ) {
 		allowRightClickOverrides: true,
 		distractionFree: false,
 		editorMode: 'visual',
+		editorTool: 'edit',
 		fixedToolbar: false,
 		focusMode: false,
 		inactivePanels: [],

--- a/packages/edit-site/src/posts.js
+++ b/packages/edit-site/src/posts.js
@@ -65,6 +65,7 @@ export function initializePostsDashboard( id, settings ) {
 		allowRightClickOverrides: true,
 		distractionFree: false,
 		editorMode: 'visual',
+		editorTool: 'edit',
 		fixedToolbar: false,
 		focusMode: false,
 		inactivePanels: [],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #66632.

Fix the `editorTool` might not be initialized on the post editor. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Referring to https://github.com/WordPress/gutenberg/issues/66632, the block inserter is missing because the `editorMode` is not `edit`

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Initialize the default value of the `editorTool` to the `edit` on the post editor. Note that the site editor initializes the value [here](https://github.com/WordPress/gutenberg/blob/78385ff93b36c43fcd16026b9105d7d205c910cd/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js#L258), and [the tool selector just checks whether the value is navigation](https://github.com/WordPress/gutenberg/blob/78385ff93b36c43fcd16026b9105d7d205c910cd/packages/block-editor/src/components/tool-selector/index.js#L68).

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

0. Apply following changes to [here](https://github.com/WordPress/gutenberg/blob/fc2bf3a0c5369d5ee4f94ee73aed1feb32c357ad/packages/preferences/src/store/reducer.js#L50) if you have configured the editor mode before
  ```js
  delete persistedData.core.editorTool;
  ```
2. Open up the post editor
3. Notice the paragraph block has a plus icon to open the block inserter menu
4. Click on the paragraph block
5. Notice that the plus icon is still there

## Screenshots or screencast <!-- if applicable -->
