### PR TITLE
Abstract block bindings attributes locking

### DIFF
--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -13,6 +13,10 @@ import {
 	getBlockType,
 } from '@wordpress/blocks';
 import { useContext, useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { InspectorControls, BlockControls } from '../../components';
 
 /**
  * Internal dependencies
@@ -37,12 +41,31 @@ const Edit = ( props ) => {
 		return null;
 	}
 
+	const controls = [];
+
+	if ( blockType.attributeControls?.length > 0 ) {
+		for ( const control of blockType.attributeControls ) {
+			const Wrapper =
+				control.type === 'toolbar' ? BlockControls : InspectorControls;
+
+			controls.push(
+				<Wrapper group={ control.group } key={ control.key }>
+					<control.Control { ...props } />
+				</Wrapper>
+			);
+		}
+	}
+
 	// `edit` and `save` are functions or components describing the markup
 	// with which a block is displayed. If `blockType` is valid, assign
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	return <Component { ...props } />;
+	return [
+		<Component { ...props } key="content">
+			{ controls }
+		</Component>,
+	];
 };
 
 const EditWithFilters = withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -33,6 +33,17 @@ import BlockContext from '../block-context';
  */
 const DEFAULT_BLOCK_CONTEXT = {};
 
+const AttributeWrapper = ( { control, ...props } ) => {
+	const Wrapper =
+		control.type === 'toolbar' ? BlockControls : InspectorControls;
+
+	return (
+		<Wrapper group={ control.group } key={ control.key }>
+			<control.Control { ...props } />
+		</Wrapper>
+	);
+};
+
 const Edit = ( props ) => {
 	const { name } = props;
 	const blockType = getBlockType( name );
@@ -45,13 +56,8 @@ const Edit = ( props ) => {
 
 	if ( blockType.attributeControls?.length > 0 ) {
 		for ( const control of blockType.attributeControls ) {
-			const Wrapper =
-				control.type === 'toolbar' ? BlockControls : InspectorControls;
-
 			controls.push(
-				<Wrapper group={ control.group } key={ control.key }>
-					<control.Control { ...props } />
-				</Wrapper>
+				<AttributeWrapper control={ control } { ...props } />
 			);
 		}
 	}

--- a/packages/block-editor/src/components/block-edit/edit.js
+++ b/packages/block-editor/src/components/block-edit/edit.js
@@ -61,11 +61,7 @@ const Edit = ( props ) => {
 	// them preferentially as the render value for the block.
 	const Component = blockType.edit || blockType.save;
 
-	return [
-		<Component { ...props } key="content">
-			{ controls }
-		</Component>,
-	];
+	return [ <Component { ...props } key="content" />, controls ];
 };
 
 const EditWithFilters = withFilters( 'editor.BlockEdit' )( Edit );

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -62,10 +62,9 @@ export const settings = {
 			key: 'url',
 			type: 'toolbar',
 			group: 'block',
-			Control( { isSelected, attributes, setAttributes } ) {
+			Control( { isSelected, isDisabled, attributes, setAttributes } ) {
 				const blockEditingMode = useBlockEditingMode();
 				const { linkTarget, rel, tagName, textAlign, url } = attributes;
-				const lockUrlControls = false;
 				const [ isEditingURL, setIsEditingURL ] = useState( false );
 				const isURLSet = !! url;
 				const opensInNewTab = linkTarget === NEW_TAB_TARGET;
@@ -114,7 +113,7 @@ export const settings = {
 								} }
 							/>
 						) }
-						{ ! isURLSet && isLinkTag && ! lockUrlControls && (
+						{ ! isURLSet && isLinkTag && ! isDisabled && (
 							<ToolbarButton
 								name="link"
 								icon={ link }
@@ -123,7 +122,7 @@ export const settings = {
 								onClick={ startEditing }
 							/>
 						) }
-						{ isURLSet && isLinkTag && ! lockUrlControls && (
+						{ isURLSet && isLinkTag && ! isDisabled && (
 							<ToolbarButton
 								name="link"
 								icon={ linkOff }
@@ -136,7 +135,7 @@ export const settings = {
 						{ isLinkTag &&
 							isSelected &&
 							( isEditingURL || isURLSet ) &&
-							! lockUrlControls && (
+							! isDisabled && (
 								<Popover
 									placement="bottom"
 									onClose={ () => {

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -1,17 +1,42 @@
 /**
  * WordPress dependencies
  */
+import {
+	AlignmentControl,
+	__experimentalLinkControl as LinkControl,
+	useBlockEditingMode,
+} from '@wordpress/block-editor';
+import {
+	Button,
+	ButtonGroup,
+	PanelBody,
+	TextControl,
+	ToolbarButton,
+	Popover,
+} from '@wordpress/components';
+import { useEffect, useState, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { button as icon } from '@wordpress/icons';
+import { button as icon, link, linkOff } from '@wordpress/icons';
+import { displayShortcut } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
+import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
+import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import initBlock from '../utils/init-block';
 import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+
+const LINK_SETTINGS = [
+	...LinkControl.DEFAULT_LINK_SETTINGS,
+	{
+		id: 'nofollow',
+		title: __( 'Mark as nofollow' ),
+	},
+];
 
 const { name } = metadata;
 
@@ -32,6 +57,195 @@ export const settings = {
 		...a,
 		text: ( a.text || '' ) + text,
 	} ),
+	attributeControls: [
+		{
+			key: 'url',
+			type: 'toolbar',
+			group: 'block',
+			Control( { isSelected, attributes, setAttributes } ) {
+				const blockEditingMode = useBlockEditingMode();
+				const { linkTarget, rel, tagName, textAlign, url } = attributes;
+				const lockUrlControls = false;
+				const [ isEditingURL, setIsEditingURL ] = useState( false );
+				const isURLSet = !! url;
+				const opensInNewTab = linkTarget === NEW_TAB_TARGET;
+				const nofollow = !! rel?.includes( NOFOLLOW_REL );
+				const TagName = tagName || 'a';
+				const isLinkTag = 'a' === TagName;
+
+				function startEditing( event ) {
+					event.preventDefault();
+					setIsEditingURL( true );
+				}
+
+				function unlink() {
+					setAttributes( {
+						url: undefined,
+						linkTarget: undefined,
+						rel: undefined,
+					} );
+					setIsEditingURL( false );
+				}
+
+				useEffect( () => {
+					if ( ! isSelected ) {
+						setIsEditingURL( false );
+					}
+				}, [ isSelected ] );
+
+				// Memoize link value to avoid overriding the LinkControl's internal state.
+				// This is a temporary fix. See https://github.com/WordPress/gutenberg/issues/51256.
+				const linkValue = useMemo(
+					() => ( { url, opensInNewTab, nofollow } ),
+					[ url, opensInNewTab, nofollow ]
+				);
+
+				// Use internal state instead of a ref to make sure that the component
+				// re-renders when the popover's anchor updates.
+				const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+
+				return (
+					<>
+						{ blockEditingMode === 'default' && (
+							<AlignmentControl
+								value={ textAlign }
+								onChange={ ( nextAlign ) => {
+									setAttributes( { textAlign: nextAlign } );
+								} }
+							/>
+						) }
+						{ ! isURLSet && isLinkTag && ! lockUrlControls && (
+							<ToolbarButton
+								name="link"
+								icon={ link }
+								title={ __( 'Link' ) }
+								shortcut={ displayShortcut.primary( 'k' ) }
+								onClick={ startEditing }
+							/>
+						) }
+						{ isURLSet && isLinkTag && ! lockUrlControls && (
+							<ToolbarButton
+								name="link"
+								icon={ linkOff }
+								title={ __( 'Unlink' ) }
+								shortcut={ displayShortcut.primaryShift( 'k' ) }
+								onClick={ unlink }
+								isActive
+							/>
+						) }
+						{ isLinkTag &&
+							isSelected &&
+							( isEditingURL || isURLSet ) &&
+							! lockUrlControls && (
+								<Popover
+									placement="bottom"
+									onClose={ () => {
+										setIsEditingURL( false );
+										// TODO: Check how to access the richTextRef that is not defined here.
+										richTextRef.current?.focus();
+									} }
+									anchor={ popoverAnchor }
+									focusOnMount={
+										isEditingURL ? 'firstElement' : false
+									}
+									__unstableSlotName="__unstable-block-tools-after"
+									shift
+								>
+									<LinkControl
+										value={ linkValue }
+										onChange={ ( {
+											url: newURL,
+											opensInNewTab: newOpensInNewTab,
+											nofollow: newNofollow,
+										} ) =>
+											setAttributes(
+												getUpdatedLinkAttributes( {
+													rel,
+													url: newURL,
+													opensInNewTab:
+														newOpensInNewTab,
+													nofollow: newNofollow,
+												} )
+											)
+										}
+										onRemove={ () => {
+											unlink();
+											richTextRef.current?.focus();
+										} }
+										forceIsEditingLink={ isEditingURL }
+										settings={ LINK_SETTINGS }
+									/>
+								</Popover>
+							) }
+					</>
+				);
+			},
+		},
+		{
+			key: 'width',
+			Control( { attributes, setAttributes } ) {
+				const { width: selectedWidth } = attributes;
+				function handleChange( newWidth ) {
+					// Check if we are toggling the width off
+					const width =
+						selectedWidth === newWidth ? undefined : newWidth;
+
+					// Update attributes.
+					setAttributes( { width } );
+				}
+
+				return (
+					<PanelBody title={ __( 'Settings' ) }>
+						<ButtonGroup aria-label={ __( 'Button width' ) }>
+							{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+								return (
+									<Button
+										key={ widthValue }
+										size="small"
+										variant={
+											widthValue === selectedWidth
+												? 'primary'
+												: undefined
+										}
+										onClick={ () =>
+											handleChange( widthValue )
+										}
+									>
+										{ widthValue }%
+									</Button>
+								);
+							} ) }
+						</ButtonGroup>
+					</PanelBody>
+				);
+			},
+		},
+		{
+			key: 'rel',
+			group: 'advanced',
+			Control( { attributes, setAttributes } ) {
+				const { rel, tagName } = attributes;
+				const TagName = tagName || 'a';
+				const isLinkTag = 'a' === TagName;
+
+				return (
+					<>
+						{ isLinkTag && (
+							<TextControl
+								__next40pxDefaultSize
+								__nextHasNoMarginBottom
+								label={ __( 'Link rel' ) }
+								value={ rel || '' }
+								onChange={ ( newRel ) =>
+									setAttributes( { rel: newRel } )
+								}
+							/>
+						) }
+					</>
+				);
+			},
+		},
+	],
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -6,87 +6,19 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { __, _x, isRTL } from '@wordpress/i18n';
-import {
-	ToolbarButton,
-	ToggleControl,
-	__experimentalToolsPanelItem as ToolsPanelItem,
-} from '@wordpress/components';
-import {
-	AlignmentControl,
-	BlockControls,
-	InspectorControls,
-	RichText,
-	useBlockProps,
-	useSettings,
-	useBlockEditingMode,
-} from '@wordpress/block-editor';
-import { formatLtr } from '@wordpress/icons';
 
+import { __, isRTL } from '@wordpress/i18n';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
 import { useOnEnter } from './use-enter';
 
-function ParagraphRTLControl( { direction, setDirection } ) {
-	return (
-		isRTL() && (
-			<ToolbarButton
-				icon={ formatLtr }
-				title={ _x( 'Left to right', 'editor button' ) }
-				isActive={ direction === 'ltr' }
-				onClick={ () => {
-					setDirection( direction === 'ltr' ? undefined : 'ltr' );
-				} }
-			/>
-		)
-	);
-}
+const name = 'core/paragraph';
 
 function hasDropCapDisabled( align ) {
 	return align === ( isRTL() ? 'left' : 'right' ) || align === 'center';
-}
-
-function DropCapControl( { clientId, attributes, setAttributes } ) {
-	// Please do not add a useSelect call to the paragraph block unconditionally.
-	// Every useSelect added to a (frequently used) block will degrade load
-	// and type performance. By moving it within InspectorControls, the subscription is
-	// now only added for the selected block(s).
-	const [ isDropCapFeatureEnabled ] = useSettings( 'typography.dropCap' );
-
-	if ( ! isDropCapFeatureEnabled ) {
-		return null;
-	}
-
-	const { align, dropCap } = attributes;
-
-	let helpText;
-	if ( hasDropCapDisabled( align ) ) {
-		helpText = __( 'Not available for aligned text.' );
-	} else if ( dropCap ) {
-		helpText = __( 'Showing large initial letter.' );
-	} else {
-		helpText = __( 'Toggle to show a large initial letter.' );
-	}
-
-	return (
-		<ToolsPanelItem
-			hasValue={ () => !! dropCap }
-			label={ __( 'Drop cap' ) }
-			onDeselect={ () => setAttributes( { dropCap: undefined } ) }
-			resetAllFilter={ () => ( { dropCap: undefined } ) }
-			panelId={ clientId }
-		>
-			<ToggleControl
-				__nextHasNoMarginBottom
-				label={ __( 'Drop cap' ) }
-				checked={ !! dropCap }
-				onChange={ () => setAttributes( { dropCap: ! dropCap } ) }
-				help={ helpText }
-				disabled={ hasDropCapDisabled( align ) ? true : false }
-			/>
-		</ToolsPanelItem>
-	);
 }
 
 function ParagraphBlock( {
@@ -106,63 +38,49 @@ function ParagraphBlock( {
 		} ),
 		style: { direction },
 	} );
-	const blockEditingMode = useBlockEditingMode();
-
 	return (
-		<>
-			{ blockEditingMode === 'default' && (
-				<BlockControls group="block">
-					<AlignmentControl
-						value={ align }
-						onChange={ ( newAlign ) =>
-							setAttributes( {
-								align: newAlign,
-								dropCap: hasDropCapDisabled( newAlign )
-									? false
-									: dropCap,
-							} )
-						}
-					/>
-					<ParagraphRTLControl
-						direction={ direction }
-						setDirection={ ( newDirection ) =>
-							setAttributes( { direction: newDirection } )
-						}
-					/>
-				</BlockControls>
-			) }
-			<InspectorControls group="typography">
-				<DropCapControl
-					clientId={ clientId }
-					attributes={ attributes }
-					setAttributes={ setAttributes }
-				/>
-			</InspectorControls>
-			<RichText
-				identifier="content"
-				tagName="p"
-				{ ...blockProps }
-				value={ content }
-				onChange={ ( newContent ) =>
-					setAttributes( { content: newContent } )
+		<RichText
+			identifier="content"
+			tagName="p"
+			{ ...blockProps }
+			value={ content }
+			onChange={ ( newContent ) =>
+				setAttributes( { content: newContent } )
+			}
+			onSplit={ ( value, isOriginal ) => {
+				let newAttributes;
+
+				if ( isOriginal || value ) {
+					newAttributes = {
+						...attributes,
+						content: value,
+					};
 				}
-				onMerge={ mergeBlocks }
-				onReplace={ onReplace }
-				onRemove={ onRemove }
-				aria-label={
-					RichText.isEmpty( content )
-						? __(
-								'Empty block; start writing or type forward slash to choose a block'
-						  )
-						: __( 'Block: Paragraph' )
+
+				const block = createBlock( name, newAttributes );
+
+				if ( isOriginal ) {
+					block.clientId = clientId;
 				}
-				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
-				data-custom-placeholder={ placeholder ? true : undefined }
-				__unstableEmbedURLOnPaste
-				__unstableAllowPrefixTransformations
-			/>
-		</>
+
+				return block;
+			} }
+			onMerge={ mergeBlocks }
+			onReplace={ onReplace }
+			onRemove={ onRemove }
+			aria-label={
+				RichText.isEmpty( content )
+					? __(
+							'Empty block; start writing or type forward slash to choose a block'
+					  )
+					: __( 'Block: Paragraph' )
+			}
+			data-empty={ RichText.isEmpty( content ) }
+			placeholder={ placeholder || __( 'Type / to choose a block' ) }
+			data-custom-placeholder={ placeholder ? true : undefined }
+			__unstableEmbedURLOnPaste
+			__unstableAllowPrefixTransformations
+		/>
 	);
 }
 


### PR DESCRIPTION
## What?
This PR is built on top of https://github.com/WordPress/gutenberg/pull/60779 to understand how it could help with the locking of connected attributes through block bindings. My plan is to check how it would look like for the supported blocks: Image, Button, Heading, and Paragraph.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
