### PR TITLE
FormTokenField: Fix token styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,7 @@
 -   `Guide`: Use small size button for page controls ([#66607](https://github.com/WordPress/gutenberg/pull/66607)).
 -   `PaletteEdit`: Add appropriate size props to Buttons ([#66590](https://github.com/WordPress/gutenberg/pull/66590)).
 -   `Notice`: Add appropriate size props to Buttons ([#66593](https://github.com/WordPress/gutenberg/pull/66593)).
+-   `FormTokenField`: Fix token styles ([#66640](https://github.com/WordPress/gutenberg/pull/66640)).
 
 ### Internal
 

--- a/packages/components/src/form-token-field/style.scss
+++ b/packages/components/src/form-token-field/style.scss
@@ -81,7 +81,12 @@
 
 		.components-form-token-field__token-text {
 			background: transparent;
-			color: $components-color-accent;
+		}
+
+		&:not(.is-disabled) {
+			.components-form-token-field__token-text {
+				color: $components-color-accent;
+			}
 		}
 
 		.components-form-token-field__remove-token {
@@ -90,7 +95,6 @@
 			position: absolute;
 			top: 1px;
 			right: 0;
-			padding: 0;
 		}
 
 		&.is-success {
@@ -112,18 +116,11 @@
 			}
 		}
 	}
-
-	&.is-disabled {
-		.components-form-token-field__remove-token {
-			cursor: default;
-		}
-	}
 }
 
 .components-form-token-field__token-text,
 .components-form-token-field__remove-token.components-button {
 	display: inline-block;
-	line-height: 24px;
 	height: auto;
 	background: $gray-300;
 	min-width: unset;
@@ -134,20 +131,19 @@
 .components-form-token-field__token-text {
 	border-radius: $radius-x-small 0 0 $radius-x-small;
 	padding: 0 0 0 8px;
+	line-height: 24px;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
 .components-form-token-field__remove-token.components-button {
-	cursor: pointer;
 	border-radius: 0 $radius-x-small $radius-x-small 0;
-	padding: 0 2px;
 	color: $gray-900;
 	line-height: 10px;
 	overflow: initial;
 
-	&:hover {
+	&:hover:not(:disabled) {
 		color: $gray-900;
 	}
 }

--- a/packages/components/src/form-token-field/token.tsx
+++ b/packages/components/src/form-token-field/token.tsx
@@ -72,6 +72,7 @@ export default function Token( {
 
 			<Button
 				className="components-form-token-field__remove-token"
+				size="small"
 				icon={ closeSmall }
 				onClick={ ! disabled ? onClick : undefined }
 				// Disable reason: Even when FormTokenField itself is accessibly disabled, token reset buttons shouldn't be in the tab sequence.


### PR DESCRIPTION
In preparation for #65751

## What?

Tweak the token component so it uses fewer style overrides, as well as fix some minor style bugs when `isBorderless`.

## Testing Instructions

See the Storybook for FormTokenField. Test for combinations of the `disabled` and `isBorderless` props.

## Screenshots or screencast <!-- if applicable -->

### Default

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/f43bb9ac-cca2-407c-aac3-c0700e8cd3c1" alt="FormTokenField, before" width="278">|<img src="https://github.com/user-attachments/assets/0e02d73f-802c-492e-9159-8e1f1bb4cb40" alt="FormTokenField, after" width="278">|

The remove button is now a nice square using the "small" variant of Button.

### Disabled

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/ca1140c6-287d-43b1-a0e1-c120a92b1ad3" alt="FormTokenField disabled, before" width="278">|<img src="https://github.com/user-attachments/assets/23b02456-a7c2-45e5-bc6d-67df14fe8c48" alt="FormTokenField disabled, after" width="278">|

No visual changes aside from right padding on the remove button.

### isBorderless & Disabled

#### Before

https://github.com/user-attachments/assets/296a006e-ea63-467f-8e6d-a7e404c7bfba

The token text and remove button both look interactive, even though they are disabled.

#### After
https://github.com/user-attachments/assets/f9648073-ee52-4da0-83b6-b07768da90a9

---

A version 2 of this component is planned, and a comprehensive design review would take place then, but cc @WordPress/gutenberg-design anyway for awareness.