### PR TITLE
DuotonePicker: Simplify Button styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -31,6 +31,7 @@
 -   `ComboboxControl`: Update reset button size ([#67215](https://github.com/WordPress/gutenberg/pull/67215)).
 -   `Autocomplete`: Increase option height ([#67214](https://github.com/WordPress/gutenberg/pull/67214)).
 -   `CircularOptionPicker`: Update `Button` sizes to be ready for 40px default size ([#67285](https://github.com/WordPress/gutenberg/pull/67285)).
+-   `DuotonePicker`: Simplify Button styles ([#66641](https://github.com/WordPress/gutenberg/pull/66641)).
 
 ### Experimental
 

--- a/packages/components/src/duotone-picker/color-list-picker/index.tsx
+++ b/packages/components/src/duotone-picker/color-list-picker/index.tsx
@@ -12,7 +12,6 @@ import Button from '../../button';
 import ColorPalette from '../../color-palette';
 import ColorIndicator from '../../color-indicator';
 import Icon from '../../icon';
-import { HStack } from '../../h-stack';
 import type { ColorListPickerProps, ColorOptionProps } from './types';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -32,23 +31,24 @@ function ColorOption( {
 	return (
 		<>
 			<Button
+				__next40pxDefaultSize
 				className="components-color-list-picker__swatch-button"
+				id={ labelId }
 				onClick={ () => setIsOpen( ( prev ) => ! prev ) }
 				aria-expanded={ isOpen }
 				aria-controls={ contentId }
-			>
-				<HStack justify="flex-start" spacing={ 2 }>
-					{ value ? (
+				icon={
+					value ? (
 						<ColorIndicator
 							colorValue={ value }
 							className="components-color-list-picker__swatch-color"
 						/>
 					) : (
 						<Icon icon={ swatch } />
-					) }
-					<span id={ labelId }>{ label }</span>
-				</HStack>
-			</Button>
+					)
+				}
+				text={ label }
+			/>
 			<div
 				role="group"
 				id={ contentId }

--- a/packages/components/src/duotone-picker/color-list-picker/style.scss
+++ b/packages/components/src/duotone-picker/color-list-picker/style.scss
@@ -7,12 +7,6 @@
 	margin: $grid-unit-10 0;
 }
 
-.components-color-list-picker__swatch-button {
-	// Used to simulate styles as a .button.has-icon (which this component can't
-	// opt into, because it has to show more than a simple SVG as the "icon")
-	padding: 6px;
-}
-
 .components-color-list-picker__swatch-color {
 	// Match the 24px size of the `swatch` icon (used when no color is set)
 	margin: 2px;


### PR DESCRIPTION
In preparation for #65751

## What?

Simplifies the Button styles in DuotonePicker, so there are fewer overrides and matches the [Figma specs](https://www.figma.com/design/804HN2REV2iap2ytjRQ055/Core-System-Library?node-id=15599-5870&t=Ae6lzeo6fymautbX-4) better.

## How?

Moves the button content (swatch and text) from `children` to the designated props on Button (`<Button icon={} text={} />`).

## Testing Instructions

See the Storybook for DuotonePicker.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/6a1dfad8-e90f-4852-9872-d54ffaed82d5" alt="DuotonePicker buttons, before" width="291">|<img src="https://github.com/user-attachments/assets/dc0e4ee6-961f-4a20-a87f-1227761105a8" alt="DuotonePicker buttons, after" width="291">|

The button heights are updated. The spacing between the swatch (`icon` slot) and text is now aligned with the standard spacings.