### PR TITLE
Fix: Set the `fit-content` width for images that are not `.svg`

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -9,7 +9,10 @@
 		max-width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
-		width: fit-content;
+
+		&:not([src$=".svg"]) {
+			width: fit-content;
+		}
 
 		@media (prefers-reduced-motion: no-preference) {
 			&.hide {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This is a follow-up of https://github.com/WordPress/gutenberg/pull/66217

In [this comment](https://github.com/WordPress/gutenberg/pull/66217#issuecomment-2450012497) reported that the fix from https://github.com/WordPress/gutenberg/pull/66217 was preventing responsive svg images to display.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

So that we don't have a regression with SVG images as they're widely used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The fix is now being applied to all images that are not SVGs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Install TT5.
2. Create a page.
3. Add the "Call to action with grid layout with products and link" pattern.
4. Add an image block with the SVG attached to this PR.
5. Save and view the page in Firefox.
6. Check that the first image of the grid has the square aspect ratio, and that the svg is also displaying.

![382009926-b29a845c-a698-48f8-a20d-29bd123a04d6](https://github.com/user-attachments/assets/f59f29af-cfd4-498f-8c1b-c54fea195817)

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/011480c2-53bf-4406-b815-efdbdfb99b1a



