### PR TITLE
Safari: fix site editor template error

### DIFF
--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -19,7 +19,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 
 		// Core already preloads both of these for `core/edit-post`.
 		// To do: investigate why adding this preload path breaks the site
-		// editor in Safair ("template not found"). Perhaps a race condition?
+		// editor in Safari ("template not found"). Perhaps a race condition?
 		// $paths[] = '/wp/v2/settings';
 		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
 		$paths[] = '/?_fields=' . implode(

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -18,7 +18,9 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		}
 
 		// Core already preloads both of these for `core/edit-post`.
-		$paths[] = '/wp/v2/settings';
+		// To do: investigate why adding this preload path breaks the site
+		// editor in Safair ("template not found"). Perhaps a race condition?
+		// $paths[] = '/wp/v2/settings';
 		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
 		$paths[] = '/?_fields=' . implode(
 			',',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See https://github.com/WordPress/gutenberg/pull/66579#issuecomment-2450378831.

There must be some kind of race condition that that PR surfaced in Safari, so this serves as a temporary fix while I investigate the issue.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
