### PR TITLE
getDefaultTemplateId: ensure entity config is loaded

### DIFF
--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -17,10 +17,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 			}
 		}
 
-		// Core already preloads both of these for `core/edit-post`.
-		// To do: investigate why adding this preload path breaks the site
-		// editor in Safari ("template not found"). Perhaps a race condition?
-		// $paths[] = '/wp/v2/settings';
+		$paths[] = '/wp/v2/settings';
 		$paths[] = array( '/wp/v2/settings', 'OPTIONS' );
 		$paths[] = '/?_fields=' . implode(
 			',',

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -25,13 +25,6 @@ import {
 import { getSyncProvider } from './sync';
 import { fetchBlockPatterns } from './fetch';
 
-async function getConfig( resolveSelect, kind, name ) {
-	const configs = await resolveSelect.getEntitiesConfig( kind );
-	return configs.find(
-		( config ) => config.name === name && config.kind === kind
-	);
-}
-
 /**
  * Requests authors from the REST API.
  *
@@ -72,7 +65,10 @@ export const getCurrentUser =
 export const getEntityRecord =
 	( kind, name, key = '', query ) =>
 	async ( { select, dispatch, registry, resolveSelect } ) => {
-		const entityConfig = await getConfig( resolveSelect, kind, name );
+		const configs = await resolveSelect.getEntitiesConfig( kind );
+		const entityConfig = configs.find(
+			( config ) => config.name === name && config.kind === kind
+		);
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -235,7 +231,10 @@ export const getEditedEntityRecord = forwardResolver( 'getEntityRecord' );
 export const getEntityRecords =
 	( kind, name, query = {} ) =>
 	async ( { dispatch, registry, resolveSelect } ) => {
-		const entityConfig = await getConfig( resolveSelect, kind, name );
+		const configs = await resolveSelect.getEntitiesConfig( kind );
+		const entityConfig = configs.find(
+			( config ) => config.name === name && config.kind === kind
+		);
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -460,10 +459,13 @@ export const canUser =
 				throw new Error( 'The entity resource object is not valid.' );
 			}
 
-			const entityConfig = await getConfig(
-				resolveSelect,
-				resource.kind,
-				resource.name
+			const configs = await resolveSelect.getEntitiesConfig(
+				resource.kind
+			);
+			const entityConfig = configs.find(
+				( config ) =>
+					config.name === resource.name &&
+					config.kind === resource.kind
 			);
 			if ( ! entityConfig ) {
 				return;
@@ -747,28 +749,27 @@ export const getNavigationFallbackId =
 
 export const getDefaultTemplateId =
 	( query ) =>
-	async ( { dispatch, registry, resolveSelect } ) => {
-		const kind = 'postType';
-		const name = 'wp_template';
-		if ( ! ( await getConfig( resolveSelect, kind, name ) ) ) {
-			return;
-		}
+	async ( { dispatch, registry } ) => {
 		const template = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
 		} );
-		// Endpoint may return an empty object if no template is found.
-		if ( template?.id ) {
-			registry.batch( () => {
-				dispatch.receiveDefaultTemplateId( query, template.id );
-				dispatch.receiveEntityRecords( kind, name, [ template ] );
-				// Avoid further network requests.
-				dispatch.finishResolution( 'getEntityRecord', [
-					kind,
-					name,
-					template.id,
-				] );
-			} );
-		}
+		setTimeout( () => {
+			// Endpoint may return an empty object if no template is found.
+			if ( template?.id ) {
+				registry.batch( () => {
+					dispatch.receiveDefaultTemplateId( query, template.id );
+					dispatch.receiveEntityRecords( 'postType', 'wp_template', [
+						template,
+					] );
+					// Avoid further network requests.
+					dispatch.finishResolution( 'getEntityRecord', [
+						'postType',
+						'wp_template',
+						template.id,
+					] );
+				} );
+			}
+		}, 100 );
 	};
 
 /**
@@ -784,7 +785,11 @@ export const getDefaultTemplateId =
 export const getRevisions =
 	( kind, name, recordKey, query = {} ) =>
 	async ( { dispatch, registry, resolveSelect } ) => {
-		const entityConfig = await getConfig( resolveSelect, kind, name );
+		const configs = await resolveSelect.getEntitiesConfig( kind );
+		const entityConfig = configs.find(
+			( config ) => config.name === name && config.kind === kind
+		);
+
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -901,7 +906,10 @@ getRevisions.shouldInvalidate = ( action, kind, name, recordKey ) =>
 export const getRevision =
 	( kind, name, recordKey, revisionKey, query ) =>
 	async ( { dispatch, resolveSelect } ) => {
-		const entityConfig = await getConfig( resolveSelect, kind, name );
+		const configs = await resolveSelect.getEntitiesConfig( kind );
+		const entityConfig = configs.find(
+			( config ) => config.name === name && config.kind === kind
+		);
 
 		if ( ! entityConfig ) {
 			return;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -25,6 +25,13 @@ import {
 import { getSyncProvider } from './sync';
 import { fetchBlockPatterns } from './fetch';
 
+async function getConfig( resolveSelect, kind, name ) {
+	const configs = await resolveSelect.getEntitiesConfig( kind );
+	return configs.find(
+		( config ) => config.name === name && config.kind === kind
+	);
+}
+
 /**
  * Requests authors from the REST API.
  *
@@ -65,10 +72,7 @@ export const getCurrentUser =
 export const getEntityRecord =
 	( kind, name, key = '', query ) =>
 	async ( { select, dispatch, registry, resolveSelect } ) => {
-		const configs = await resolveSelect.getEntitiesConfig( kind );
-		const entityConfig = configs.find(
-			( config ) => config.name === name && config.kind === kind
-		);
+		const entityConfig = await getConfig( resolveSelect, kind, name );
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -231,10 +235,7 @@ export const getEditedEntityRecord = forwardResolver( 'getEntityRecord' );
 export const getEntityRecords =
 	( kind, name, query = {} ) =>
 	async ( { dispatch, registry, resolveSelect } ) => {
-		const configs = await resolveSelect.getEntitiesConfig( kind );
-		const entityConfig = configs.find(
-			( config ) => config.name === name && config.kind === kind
-		);
+		const entityConfig = await getConfig( resolveSelect, kind, name );
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -459,13 +460,10 @@ export const canUser =
 				throw new Error( 'The entity resource object is not valid.' );
 			}
 
-			const configs = await resolveSelect.getEntitiesConfig(
-				resource.kind
-			);
-			const entityConfig = configs.find(
-				( config ) =>
-					config.name === resource.name &&
-					config.kind === resource.kind
+			const entityConfig = await getConfig(
+				resolveSelect,
+				resource.kind,
+				resource.name
 			);
 			if ( ! entityConfig ) {
 				return;
@@ -749,27 +747,28 @@ export const getNavigationFallbackId =
 
 export const getDefaultTemplateId =
 	( query ) =>
-	async ( { dispatch, registry } ) => {
+	async ( { dispatch, registry, resolveSelect } ) => {
+		const kind = 'postType';
+		const name = 'wp_template';
+		if ( ! ( await getConfig( resolveSelect, kind, name ) ) ) {
+			return;
+		}
 		const template = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
 		} );
-		setTimeout( () => {
-			// Endpoint may return an empty object if no template is found.
-			if ( template?.id ) {
-				registry.batch( () => {
-					dispatch.receiveDefaultTemplateId( query, template.id );
-					dispatch.receiveEntityRecords( 'postType', 'wp_template', [
-						template,
-					] );
-					// Avoid further network requests.
-					dispatch.finishResolution( 'getEntityRecord', [
-						'postType',
-						'wp_template',
-						template.id,
-					] );
-				} );
-			}
-		}, 100 );
+		// Endpoint may return an empty object if no template is found.
+		if ( template?.id ) {
+			registry.batch( () => {
+				dispatch.receiveDefaultTemplateId( query, template.id );
+				dispatch.receiveEntityRecords( kind, name, [ template ] );
+				// Avoid further network requests.
+				dispatch.finishResolution( 'getEntityRecord', [
+					kind,
+					name,
+					template.id,
+				] );
+			} );
+		}
 	};
 
 /**
@@ -785,11 +784,7 @@ export const getDefaultTemplateId =
 export const getRevisions =
 	( kind, name, recordKey, query = {} ) =>
 	async ( { dispatch, registry, resolveSelect } ) => {
-		const configs = await resolveSelect.getEntitiesConfig( kind );
-		const entityConfig = configs.find(
-			( config ) => config.name === name && config.kind === kind
-		);
-
+		const entityConfig = await getConfig( resolveSelect, kind, name );
 		if ( ! entityConfig ) {
 			return;
 		}
@@ -906,10 +901,7 @@ getRevisions.shouldInvalidate = ( action, kind, name, recordKey ) =>
 export const getRevision =
 	( kind, name, recordKey, revisionKey, query ) =>
 	async ( { dispatch, resolveSelect } ) => {
-		const configs = await resolveSelect.getEntitiesConfig( kind );
-		const entityConfig = configs.find(
-			( config ) => config.name === name && config.kind === kind
-		);
+		const entityConfig = await getConfig( resolveSelect, kind, name );
 
 		if ( ! entityConfig ) {
 			return;

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -753,6 +753,8 @@ export const getDefaultTemplateId =
 		const template = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
 		} );
+		// Wait for the the entities config to be loaded, otherwise receiving
+		// the template as an entity will not work.
 		await resolveSelect.getEntitiesConfig( 'postType' );
 		// Endpoint may return an empty object if no template is found.
 		if ( template?.id ) {

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -750,26 +750,26 @@ export const getNavigationFallbackId =
 export const getDefaultTemplateId =
 	( query ) =>
 	async ( { dispatch, registry } ) => {
-		const response = await apiFetch( {
+		const template = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
-			parse: false,
 		} );
-		const template = await response.json();
-		// Endpoint may return an empty object if no template is found.
-		if ( template?.id ) {
-			registry.batch( () => {
-				dispatch.receiveDefaultTemplateId( query, template.id );
-				dispatch.receiveEntityRecords( 'postType', 'wp_template', [
-					template,
-				] );
-				// Avoid further network requests.
-				dispatch.finishResolution( 'getEntityRecord', [
-					'postType',
-					'wp_template',
-					template.id,
-				] );
-			} );
-		}
+		setTimeout( () => {
+			// Endpoint may return an empty object if no template is found.
+			if ( template?.id ) {
+				registry.batch( () => {
+					dispatch.receiveDefaultTemplateId( query, template.id );
+					dispatch.receiveEntityRecords( 'postType', 'wp_template', [
+						template,
+					] );
+					// Avoid further network requests.
+					dispatch.finishResolution( 'getEntityRecord', [
+						'postType',
+						'wp_template',
+						template.id,
+					] );
+				} );
+			}
+		}, 100 );
 	};
 
 /**

--- a/packages/core-data/src/resolvers.js
+++ b/packages/core-data/src/resolvers.js
@@ -749,27 +749,26 @@ export const getNavigationFallbackId =
 
 export const getDefaultTemplateId =
 	( query ) =>
-	async ( { dispatch, registry } ) => {
+	async ( { dispatch, registry, resolveSelect } ) => {
 		const template = await apiFetch( {
 			path: addQueryArgs( '/wp/v2/templates/lookup', query ),
 		} );
-		setTimeout( () => {
-			// Endpoint may return an empty object if no template is found.
-			if ( template?.id ) {
-				registry.batch( () => {
-					dispatch.receiveDefaultTemplateId( query, template.id );
-					dispatch.receiveEntityRecords( 'postType', 'wp_template', [
-						template,
-					] );
-					// Avoid further network requests.
-					dispatch.finishResolution( 'getEntityRecord', [
-						'postType',
-						'wp_template',
-						template.id,
-					] );
-				} );
-			}
-		}, 100 );
+		await resolveSelect.getEntitiesConfig( 'postType' );
+		// Endpoint may return an empty object if no template is found.
+		if ( template?.id ) {
+			registry.batch( () => {
+				dispatch.receiveDefaultTemplateId( query, template.id );
+				dispatch.receiveEntityRecords( 'postType', 'wp_template', [
+					template,
+				] );
+				// Avoid further network requests.
+				dispatch.finishResolution( 'getEntityRecord', [
+					'postType',
+					'wp_template',
+					template.id,
+				] );
+			} );
+		}
 	};
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See https://github.com/WordPress/gutenberg/pull/66579#issuecomment-2450378831.
See https://github.com/WordPress/gutenberg/pull/66647.

The problem was the the entities configs were not loaded when the template was received as an entity.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The Site Editor would not load in Safari without the temporary fix. See https://github.com/WordPress/gutenberg/pull/66579#issuecomment-2450378831.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Ensure we wait for the entities config to be loaded.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the Site Editor in Safari.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
