### PR TITLE
Site Editor: Pages: Preload template lookup

### DIFF
--- a/backport-changelog/6.8/7695.md
+++ b/backport-changelog/6.8/7695.md
@@ -2,3 +2,5 @@ https://github.com/WordPress/wordpress-develop/pull/7695
 
 * https://github.com/WordPress/gutenberg/pull/66631
 * https://github.com/WordPress/gutenberg/pull/67465
+* https://github.com/WordPress/gutenberg/pull/66579
+* https://github.com/WordPress/gutenberg/pull/66654

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -18,7 +18,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 			$post = get_post( (int) $matches[1] );
 		}
 
-		if (  $post ) {
+		if ( $post ) {
 			$route_for_post = rest_get_route_for_post( $post );
 			if ( $route_for_post ) {
 				$paths[] = add_query_arg( 'context', 'edit', $route_for_post );

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -10,18 +10,26 @@
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name ) {
-		$post_id = null;
+		$post = null;
 		if ( isset( $_GET['postId'] ) && is_numeric( $_GET['postId'] ) ) {
-			$post_id = (int) $_GET['postId'];
+			$post = get_post( (int) $_GET['postId'] );
 		}
 		if ( isset( $_GET['p'] ) && preg_match( '/^\/page\/(\d+)$/', $_GET['p'], $matches ) ) {
-			$post_id = (int) $matches[1];
+			$post = get_post( (int) $matches[1] );
 		}
 
-		if ( $post_id ) {
-			$route_for_post = rest_get_route_for_post( $post_id );
+		if (  $post ) {
+			$route_for_post = rest_get_route_for_post( $post );
 			if ( $route_for_post ) {
 				$paths[] = add_query_arg( 'context', 'edit', $route_for_post );
+				if ( 'page' === $post->post_type ) {
+					$paths[] = add_query_arg(
+						'slug',
+						// @see https://github.com/WordPress/gutenberg/blob/489f6067c623926bce7151a76755bb68d8e22ea7/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js#L139-L140
+						'page-' . $post->post_name,
+						'/wp/v2/templates/lookup'
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Preload the page's template when the page in the site editor is loaded directly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The lookup request blocks the loading of the whole editor (a loading indicator is shown).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Preload.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to the Sited Editor > Pages > edit a page. Check the network tab. Reload an observe no lookup request.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
