### PR TITLE
Query Loop: Check for postTypeFromContext before using it

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -188,7 +188,7 @@ export default function PostTemplateEdit( {
 			// When we preview Query Loop blocks we should prefer the current
 			// block's postType, which is passed through block context.
 			const usedPostType =
-				postTypeFromContext !== 'page'
+				postTypeFromContext && postTypeFromContext !== 'page'
 					? postTypeFromContext
 					: previewPostType || postType;
 			return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes an issue introduced in https://github.com/WordPress/gutenberg/pull/65820, where the Query Loop block gets stuck showing the loading spinner after being inserted.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It seems to be because we're trying to use `postTypeFromContext` when it's undefined, so we should check that it exists before running logic against it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Check for `postTypeFromContext` before using it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert a Query Loop block
2. Ensure that it renders correctly in the Editor

## Screenshots or screencast <!-- if applicable -->

| trunk | This PR |
| ---- | ------ |
| <img width="1434" alt="image" src="https://github.com/user-attachments/assets/6bebe295-6787-4a69-97aa-249bf1ff506e"> | <img width="1434" alt="image" src="https://github.com/user-attachments/assets/3361cf38-6d1f-474e-a290-fdb28c9fadc6"> |