### PR TITLE
Theme JSON: replace top-level background style objects on merge

### DIFF
--- a/backport-changelog/6.8/7697.md
+++ b/backport-changelog/6.8/7697.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7697
+
+* https://github.com/WordPress/gutenberg/pull/66656

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3297,6 +3297,10 @@ class WP_Theme_JSON_Gutenberg {
 			array(),
 			array( 'include_node_paths_only' => true )
 		);
+
+		// Add top-level styles.
+		$style_nodes[] = array( 'path' => array( 'styles' ) );
+
 		foreach ( $style_nodes as $style_node ) {
 			$path = $style_node['path'];
 			/*

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -2301,7 +2301,9 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				'styles'  => array(
 					'background' => array(
 						'backgroundImage' => array(
-							'url' => 'http://example.org/quote.png',
+							'id'     => 'uploaded',
+							'source' => 'file',
+							'url'    => 'http://example.org/quote.png',
 						),
 						'backgroundSize'  => 'cover',
 					),
@@ -2333,7 +2335,10 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
 			'styles'  => array(
 				'background' => array(
-					'backgroundSize' => 'contain',
+					'backgroundImage' => array(
+						'url' => 'http://example.org/site.png',
+					),
+					'backgroundSize'  => 'contain',
 				),
 				'blocks'     => array(
 					'core/group' => array(
@@ -2363,7 +2368,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'styles'  => array(
 				'background' => array(
 					'backgroundImage' => array(
-						'url' => 'http://example.org/quote.png',
+						'url' => 'http://example.org/site.png',
 					),
 					'backgroundSize'  => 'contain',
 				),


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR fixes an omission in the theme json merge logic where top-level background image objects are not replaced, rather they are merged, which was the state of affairs before https://github.com/WordPress/gutenberg/pull/64128

Blocks are already catered for via `::get_block_nodes()`.

## Why?

Consider the following: I want to merge existing JSON A with incoming JSON B.

```json
{
	"title" : "JSON A",
	"styles": {
		"background": {
			"backgroundImage": {
				"id": 1,
				"url": "http://example-site/wp-content/uploads/11/2024/test.jpg"
			}
		}
	}
}
```

```json
{
	"title" : "JSON B",
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "http://some-other-site/new.jpg"
			}
		}
	}
}
```

In trunk the outcome would be: 

```json
{
	"title" : "JSON A",
	"styles": {
		"background": {
			"backgroundImage": {
				"id": 1,
				"url": "http://some-other-site/new.jpg"
			}
		}
	}
}
```

Notice the `"id"` property, which does not belong to the new image. The entire object should be replaced.


## How?

Add the top-level styles path to the paths to be merged.

## Testing Instructions

Run the unit tests: `npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test`