### PR TITLE
Feat: Storybook: Improve component organisation - Selection & Input Category - Issue #66275

### DIFF
--- a/packages/components/src/notice/stories/index.story.tsx
+++ b/packages/components/src/notice/stories/index.story.tsx
@@ -17,7 +17,8 @@ import NoticeList from '../list';
 import type { NoticeListProps } from '../types';
 
 const meta: Meta< typeof Notice > = {
-	title: 'Components/Notice',
+	title: 'Components/Feedback/Notice',
+	id: 'components-notice',
 	component: Notice,
 	// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 	subcomponents: { NoticeList },

--- a/packages/components/src/progress-bar/stories/index.story.tsx
+++ b/packages/components/src/progress-bar/stories/index.story.tsx
@@ -10,7 +10,8 @@ import { ProgressBar } from '..';
 
 const meta: Meta< typeof ProgressBar > = {
 	component: ProgressBar,
-	title: 'Components/ProgressBar',
+	title: 'Components/Feedback/ProgressBar',
+	id: 'components-progressbar',
 	argTypes: {
 		value: { control: { type: 'number', min: 0, max: 100, step: 1 } },
 	},

--- a/packages/components/src/snackbar/stories/index.story.tsx
+++ b/packages/components/src/snackbar/stories/index.story.tsx
@@ -15,7 +15,8 @@ import Icon from '../../icon';
 import Snackbar from '..';
 
 const meta: Meta< typeof Snackbar > = {
-	title: 'Components/Snackbar',
+	title: 'Components/Feedback/Snackbar',
+	id: 'components-snackbar',
 	component: Snackbar,
 	argTypes: {
 		as: { control: { type: null } },

--- a/packages/components/src/snackbar/stories/list.story.tsx
+++ b/packages/components/src/snackbar/stories/list.story.tsx
@@ -14,7 +14,8 @@ import { useState } from '@wordpress/element';
 import SnackbarList from '../list';
 
 const meta: Meta< typeof SnackbarList > = {
-	title: 'Components/SnackbarList',
+	title: 'Components/Feedback/SnackbarList',
+	id: 'components-snackbarlist',
 	component: SnackbarList,
 	argTypes: {
 		as: { control: { type: null } },

--- a/packages/components/src/spinner/stories/index.story.tsx
+++ b/packages/components/src/spinner/stories/index.story.tsx
@@ -10,7 +10,8 @@ import Spinner from '../';
 import { space } from '../../utils/space';
 
 const meta: Meta< typeof Spinner > = {
-	title: 'Components/Spinner',
+	title: 'Components/Feedback/Spinner',
+	id: 'components-spinner',
 	component: Spinner,
 	parameters: {
 		controls: {

--- a/packages/components/src/tip/stories/index.story.tsx
+++ b/packages/components/src/tip/stories/index.story.tsx
@@ -10,7 +10,8 @@ import Tip from '..';
 
 const meta: Meta< typeof Tip > = {
 	component: Tip,
-	title: 'Components/Tip',
+	title: 'Components/Feedback/Tip',
+	id: 'components-tip',
 	argTypes: {
 		children: { control: { type: 'text' } },
 	},

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -132,6 +132,7 @@ export const parameters = {
 					'Contributing Guidelines',
 					'Actions',
 					'Containers',
+					'Feedback',
 					'Utilities',
 				],
 				'Components (Experimental)',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Issue - #66275 
- Changes the componenet metadata to use the sitemap structure to ease user navigation to storybook.

## Why?
This change is part of the larger [Storybook Improvements](https://make.wordpress.org/design/2024/09/17/design-systems-storybook-improvements/) and the [shared Sitemap](https://www.figma.com/board/0ZfHa37xxWoMqy7McezUNX/WordPress.org-Storybook-Sitemap?node-id=126-5118&t=ruCtnVTDVjHTfksc-1). 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adding Categories that helps organize and group components into sections based on their role and function within the library makes our library easier to navigate and understand. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Checkout to the PR.
2. Run `npm run storybook:dev`.
3. Check for the updated components with category that are changed in PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- None

## Screenshots or screencast <!-- if applicable -->
<img width="253" alt="Screenshot 2024-11-01 at 9 37 34 AM" src="https://github.com/user-attachments/assets/fa545c23-dafb-4a0b-85b4-2fb264e0e7ad">

