### PR TITLE
Style engine: wrap array_merge in conditionals to prevent unnecessary merging

### DIFF
--- a/packages/style-engine/class-wp-style-engine.php
+++ b/packages/style-engine/class-wp-style-engine.php
@@ -424,8 +424,15 @@ if ( ! class_exists( 'WP_Style_Engine' ) ) {
 						continue;
 					}
 
-					$parsed_styles['classnames']   = array_merge( $parsed_styles['classnames'], static::get_classnames( $style_value, $style_definition ) );
-					$parsed_styles['declarations'] = array_merge( $parsed_styles['declarations'], static::get_css_declarations( $style_value, $style_definition, $options ) );
+					$classnames = static::get_classnames( $style_value, $style_definition );
+					if ( ! empty( $classnames ) ) {
+						$parsed_styles['classnames'] = array_merge( $parsed_styles['classnames'], $classnames );
+					}
+
+					$css_declarations = static::get_css_declarations( $style_value, $style_definition, $options );
+					if ( ! empty( $css_declarations ) ) {
+						$parsed_styles['declarations'] = array_merge( $parsed_styles['declarations'], $css_declarations );
+					}
 				}
 			}
 


### PR DESCRIPTION
Backport changes from Core patch: https://github.com/WordPress/wordpress-develop/pull/7670

Wrap `array_merge` in a conditional to prevent unnecessary firing.

Props to @mukeshpanchal27 

## Testing

CI tests should pass


