### PR TITLE
Theme JSON Resolver: remove theme json merge in resolve_theme_file_uris

### DIFF
--- a/backport-changelog/6.8/7698.md
+++ b/backport-changelog/6.8/7698.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7698
+
+* https://github.com/WordPress/gutenberg/pull/66662

--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -920,18 +920,14 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			return $theme_json;
 		}
 
-		$resolved_theme_json_data = array(
-			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
-		);
+		$resolved_theme_json_data = $theme_json->get_raw_data();
 
 		foreach ( $resolved_urls as $resolved_url ) {
 			$path = explode( '.', $resolved_url['target'] );
 			_wp_array_set( $resolved_theme_json_data, $path, $resolved_url['href'] );
 		}
 
-		$theme_json->merge( new WP_Theme_JSON_Gutenberg( $resolved_theme_json_data ) );
-
-		return $theme_json;
+		return new WP_Theme_JSON_Gutenberg( $resolved_theme_json_data );
 	}
 
 	/**


### PR DESCRIPTION

## What?


The change affects `WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris()`.

When setting resolved URIs in an incoming theme json object, remove the unnecessary call to `WP_Theme_JSON_Gutenberg->merge()`.



## Why?

`WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris()` only needs to set values for paths in the raw theme json object.

It can then return a new theme object based on the updated JSON source. There's no need for a full and possibly expensive merge.


## How?
Getting the raw data from theme json, setting values, then returning a new theme json object.

## Testing Instructions

There is existing test coverage. Tests should pass.
