### PR TITLE
Editor: Restore the 'PluginPostStatusInfo' slot position

### DIFF
--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -87,11 +87,11 @@ export default function PostSummary( { onActionPerformed } ) {
 										<PostsPerPage />
 										<SiteDiscussion />
 										<PostFormatPanel />
+										{ fills }
 									</VStack>
 									<PostTrash
 										onActionPerformed={ onActionPerformed }
 									/>
-									{ fills }
 								</VStack>
 							) }
 						</VStack>


### PR DESCRIPTION
## What?
Fixes #66652.

PR restores the 'PluginPostStatusInfo' slot position and moves it before the "Move to Trash" button.

We missed this detail in #65087.

## Why?
Matches the original behavior.

## Testing Instructions
1. Open a post or page.
2. Run the snippet to add the `PluginPostStatusInfo` slot.
3. Confirm it's now positioned before the trash button.

<details><summary>Test Snippet</summary>
<p>

```javascript
const {createElement: el, useState} = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const PluginPostStatusInfo = wp.editor.PluginPostStatusInfo;
const ToggleControl = wp.components.ToggleControl;

function TestPluginPostStatusInfo() {
    const [enabled,setEnabled] = useState(false);

    return el(PluginPostStatusInfo, {}, el(ToggleControl, {
        __nextHasNoMarginBottom: true,
        label: 'Has fixed background?',
        checked: enabled,
        onChange: (newValue) => setEnabled(newValue)
    }));
}

registerPlugin('post-status-info-test', {
    render: TestPluginPostStatusInfo,
});
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-01 at 09 35 07](https://github.com/user-attachments/assets/a50f704d-df96-4c74-83bb-edd3efc9b4c0)
