### PR TITLE
`MenuRadioItem`: add an optional checked prefix

### DIFF
--- a/packages/components/src/menu/radio-item.tsx
+++ b/packages/components/src/menu/radio-item.tsx
@@ -29,7 +29,7 @@ export const MenuRadioItem = forwardRef<
 	HTMLDivElement,
 	WordPressComponentProps< MenuRadioItemProps, 'div', false >
 >( function MenuRadioItem(
-	{ suffix, children, onBlur, hideOnClick = false, ...props },
+	{ suffix, children, onBlur, hideOnClick = false, checkedPrefix, ...props },
 	ref
 ) {
 	// TODO: Remove when https://github.com/ariakit/ariakit/issues/4083 is fixed
@@ -51,7 +51,7 @@ export const MenuRadioItem = forwardRef<
 				// Override some ariakit inline styles
 				style={ { width: 'auto', height: 'auto' } }
 			>
-				<Icon icon={ radioCheck } size={ 24 } />
+				{ checkedPrefix || <Icon icon={ radioCheck } size={ 24 } /> }
 			</Ariakit.MenuItemCheck>
 
 			<Styled.MenuItemContentWrapper>

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -7,7 +7,7 @@ import { css } from '@emotion/react';
 /**
  * WordPress dependencies
  */
-import { customLink, formatCapitalize } from '@wordpress/icons';
+import { customLink, formatCapitalize, check } from '@wordpress/icons';
 import { useState, useMemo, useContext } from '@wordpress/element';
 
 /**
@@ -308,6 +308,29 @@ export const WithRadios: StoryFn< typeof Menu > = ( props ) => {
 					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
 				</Menu.RadioItem>
 			</Menu.Group>
+			<Menu.Group>
+				<Menu.GroupLabel>With custom checked prefix</Menu.GroupLabel>
+				<Menu.RadioItem
+					name="radio-uncontrolled-custom-checked-prefix"
+					value="one"
+					defaultChecked
+					checkedPrefix={ <Icon icon={ check } size={ 24 } /> }
+				>
+					<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
+					<Menu.ItemHelpText>
+						Checked with custom prefix
+					</Menu.ItemHelpText>
+				</Menu.RadioItem>
+				<Menu.RadioItem
+					name="radio-uncontrolled-custom-checked-prefix"
+					value="two"
+					checkedPrefix={ <Icon icon={ check } size={ 24 } /> }
+				>
+					<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
+					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
+				</Menu.RadioItem>
+			</Menu.Group>
+			<Menu.Separator />
 		</Menu>
 	);
 };

--- a/packages/components/src/menu/types.ts
+++ b/packages/components/src/menu/types.ts
@@ -173,6 +173,10 @@ export interface MenuRadioItemProps
 	 */
 	checked?: boolean;
 	/**
+	 * The contents of the checked radio menu item's prefix.
+	 */
+	checkedPrefix?: React.ReactNode;
+	/**
 	 * The checked state of the radio menu item when it is initially rendered.
 	 * Use when not wanting to control its checked state.
 	 */


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Add an optional `checkedPrefix` prop to MenuRadioItem to customize the checked icon.


## Why?

The dot may not be desirable in some designs.

## How?

Added a `checkedPrefix` react node prop to the component.

`prefix` seemed to imply permanence, so I added `checked` to the front.

## Testing Instructions

Fire up story book `npm run storybook:dev` and preview it here:

http://localhost:50240/?path=/story/components-experimental-menu--with-radios

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/97cb2e06-a774-431e-be10-5e8834566eea



