### PR TITLE
Fix set current category as default selected item in category list dr…

### DIFF
--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -47,6 +47,12 @@ function render_block_core_categories( $attributes, $content, $block ) {
 			$taxonomy->labels->singular_name
 		);
 
+		$current_category = get_queried_object();
+
+		if (!empty($current_category->slug)) {
+			$args['selected'] = $current_category->slug;
+		}
+
 		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 		$default_label  = $taxonomy->label;
 		$label_text     = ! empty( $attributes['label'] ) ? wp_kses_post( $attributes['label'] ) : $default_label;
@@ -104,7 +110,7 @@ function build_dropdown_script_block_core_categories( $dropdown_id ) {
 	( function() {
 		var dropdown = document.getElementById( '<?php echo esc_js( $dropdown_id ); ?>' );
 		function onCatChange() {
-			if ( dropdown.options[ dropdown.selectedIndex ].value !== -1 ) {
+			if ( dropdown.options[ dropdown.selectedIndex ].value !== '-1' ) {
 				location.href = "<?php echo esc_url( home_url() ); ?>/?" + dropdown.name + '=' + dropdown.options[ dropdown.selectedIndex ].value;
 			}
 		}

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -49,7 +49,7 @@ function render_block_core_categories( $attributes, $content, $block ) {
 
 		$current_category = get_queried_object();
 
-		if (!empty($current_category->slug)) {
+		if ( ! empty( $current_category->slug ) ) {
 			$args['selected'] = $current_category->slug;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Category List Block: Set current category as the default selected item in dropdown
Fixes #66613

When the Category List block is added to a category archive template in Gutenberg, the dropdown displays "Select Category" by default on archive pages, even though a specific category is being viewed. Ideally, the dropdown should show the active category as the selected item.

## Why?
This improvement enhances user experience by reducing confusion and making navigation clearer. Displaying the active category reinforces context for users on archive pages and aligns with expected dropdown behavior.

## How?
This PR updates the Category List block to detect the current category when used on a category archive template. By setting the active category as the default selected item in the dropdown, it aligns the block’s behavior with user expectations on archive pages. This change ensures that when users view a category archive, the dropdown automatically reflects the category they are currently browsing,

## Testing Instructions
1. Go to the Site Editor and open the template for Category Archives and add a Category List Block.
2. In the block settings, set it to Display as Dropdown.
3. Preview the Archive Page and verify the dropdown selection.
4. From the WordPress admin dashboard, go to Posts > Categories and view individual category archive pages to confirm each one displays the respective category as the default selection in the dropdown.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
[Screencast from 01-11-24 12:29:32 PM IST.webm](https://github.com/user-attachments/assets/2c5ac7ea-bb07-47bb-8205-2e8ef5589a87)

