### PR TITLE
Inline Commenting: Avoid querying comments on editor load

### DIFF
--- a/packages/editor/src/components/collab-sidebar/add-comment.js
+++ b/packages/editor/src/components/collab-sidebar/add-comment.js
@@ -35,25 +35,22 @@ export function AddComment( {
 	// State to manage the comment thread.
 	const [ inputComment, setInputComment ] = useState( '' );
 
-	const {
-		defaultAvatar,
-		clientId,
-		blockCommentId,
-		showAddCommentBoard,
-		currentUser,
-	} = useSelect( ( select ) => {
-		const { getSettings } = select( blockEditorStore );
-		const { __experimentalDiscussionSettings } = getSettings();
-		const selectedBlock = select( blockEditorStore ).getSelectedBlock();
-		const userData = select( coreStore ).getCurrentUser();
-		return {
-			defaultAvatar: __experimentalDiscussionSettings?.avatarURL,
-			clientId: selectedBlock?.clientId,
-			blockCommentId: selectedBlock?.attributes?.blockCommentId,
-			showAddCommentBoard: showCommentBoard,
-			currentUser: userData,
-		};
-	} );
+	const { defaultAvatar, clientId, blockCommentId, currentUser } = useSelect(
+		( select ) => {
+			const { getSettings, getSelectedBlock } =
+				select( blockEditorStore );
+			const { __experimentalDiscussionSettings } = getSettings();
+			const selectedBlock = getSelectedBlock();
+			const userData = select( coreStore ).getCurrentUser();
+			return {
+				defaultAvatar: __experimentalDiscussionSettings?.avatarURL,
+				clientId: selectedBlock?.clientId,
+				blockCommentId: selectedBlock?.attributes?.blockCommentId,
+				currentUser: userData,
+			};
+		},
+		[]
+	);
 
 	const userAvatar =
 		currentUser && currentUser.avatar_urls && currentUser.avatar_urls[ 48 ]
@@ -69,7 +66,7 @@ export function AddComment( {
 		setInputComment( '' );
 	};
 
-	if ( ! showAddCommentBoard || ! clientId || undefined !== blockCommentId ) {
+	if ( ! showCommentBoard || ! clientId || undefined !== blockCommentId ) {
 		return null;
 	}
 


### PR DESCRIPTION
## What?
I've updated the collab sidebar to only load comments when it's displayed instead of fetching them when opening the editor. Previously, a query was also made even when the experiment was disabled.

## Why?
Unnecessary queries can negatively affect the editor's performance.

## How?
* Extract sidebar contents into a separate component.
* I've also made small cleanups to the components. I'll try to leave comments inline as needed.

## Testing Instructions
1. Enable experimental inline commenting option under Gutenberg -> Experiments.
2. Confirm that the REST API request isn't made for Block Comment when opening the editor.
3. Opening the sidebar should load the comments.
4. Everything else should work as before.

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2024-11-01 at 13 30 38](https://github.com/user-attachments/assets/1ea5f688-eb7d-4dca-9ac2-372fce924100)
