### PR TITLE
e2e-test-utils-playwright: Increase timeout of site-editor selector

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -54,13 +54,13 @@ export async function visitSiteEditor(
 
 		// Wait for the canvas loader to appear first, so that the locator that
 		// waits for the hidden state doesn't resolve prematurely.
-		await canvasLoader.waitFor( { state: 'visible' } );
+		await canvasLoader.waitFor( { state: 'visible', timeout: 60000 } );
 		await canvasLoader.waitFor( {
 			state: 'hidden',
 			// Bigger timeout is needed for larger entities, like the Large Post
 			// HTML fixture that we load for performance tests, which often
 			// doesn't make it under the default timeout value.
-			timeout: 60_000,
+			timeout: 60000,
 		} );
 	}
 

--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -54,13 +54,13 @@ export async function visitSiteEditor(
 
 		// Wait for the canvas loader to appear first, so that the locator that
 		// waits for the hidden state doesn't resolve prematurely.
-		await canvasLoader.waitFor( { state: 'visible', timeout: 60000 } );
+		await canvasLoader.waitFor( { state: 'visible', timeout: 60_000 } );
 		await canvasLoader.waitFor( {
 			state: 'hidden',
 			// Bigger timeout is needed for larger entities, like the Large Post
 			// HTML fixture that we load for performance tests, which often
 			// doesn't make it under the default timeout value.
-			timeout: 60000,
+			timeout: 60_000,
 		} );
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR increases the timeout of a selector in the `e2e-test-utils-playwright` package. It also fixes a typo in another timeout value

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This will hopefully solve some test flakiness that we're experiencing. The site editor loads around 500 assets. It takes around 5-6 seconds on my local machine to load just the canvas for the site editor. 10s timeout here is pretty low, so I've increased it to 60s

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
We're just increasing the timeout from 10s to 60s.

## Testing Instructions

1. Use the `visitSiteEditor` function from the `e2e-test-utils-package` in an e2e test on a slow network connection. 2. Verify that the test doesn't timeout after 10s.

### Testing Instructions for Keyboard
n/a>

## Screenshots or screencast <!-- if applicable -->
n/a