### PR TITLE
ComplementaryArea: Fix button position

### DIFF
--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -4,6 +4,6 @@
 	gap: $grid-unit-10; // Always ensure space between contents and close buttons.
 
 	.interface-complementary-area-header__title {
-		margin: 0;
+		margin: 0 auto 0 0;
 	}
 }


### PR DESCRIPTION
Follow-up #63243

## What?

This PR fixes the button misalignment in the `ComplementaryArea` component.

## Why?

I suggested [here](https://github.com/WordPress/gutenberg/pull/63243#issuecomment-2422641020) to remove some margins, which weren't needed in the global styles, but were needed for the plugin sidebar.


## How?

Rather than restoring the left margin on the buttons, I added a right auto-margin to the title instead. This is also to avoid using selectors with the `.components-` prefix. Since [the `title` prop is required](https://github.com/WordPress/gutenberg/blob/ec3d2c17f36199f7e57fb792a84d778fc2b0e57f/packages/interface/src/components/complementary-area/README.md#title), this should ensure that the buttons are always positioned on the right.

## Testing Instructions

- Activate the Yoast SEO plugin.
- Open the post editor.
- Click on the button in the header.
- Check the position of the pin button.
- (Optional) The layout of the global style sidebar header should not be affected.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c97b49b7-a2da-4702-89f4-98da0aea542c) | ![image](https://github.com/user-attachments/assets/6a17d68a-4c31-4c12-9409-b293a1816c64)| 