### PR TITLE
Query Loop: Remove postTypeFromContext

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -100,7 +100,6 @@ export default function PostTemplateEdit( {
 		} = {},
 		templateSlug,
 		previewPostType,
-		postType: postTypeFromContext,
 	},
 	attributes: { layout },
 	__unstableLayoutClassNames,
@@ -187,10 +186,7 @@ export default function PostTemplateEdit( {
 			}
 			// When we preview Query Loop blocks we should prefer the current
 			// block's postType, which is passed through block context.
-			const usedPostType =
-				postTypeFromContext && postTypeFromContext !== 'page'
-					? postTypeFromContext
-					: previewPostType || postType;
+			const usedPostType = previewPostType || postType;
 			return {
 				posts: getEntityRecords( 'postType', usedPostType, {
 					...query,

--- a/packages/block-library/src/query/block.json
+++ b/packages/block-library/src/query/block.json
@@ -42,7 +42,7 @@
 			"default": false
 		}
 	},
-	"usesContext": [ "postType", "templateSlug" ],
+	"usesContext": [ "templateSlug" ],
 	"providesContext": {
 		"queryId": "queryId",
 		"query": "query",

--- a/packages/block-library/src/query/edit/inspector-controls/index.js
+++ b/packages/block-library/src/query/edit/inspector-controls/index.js
@@ -45,15 +45,9 @@ import { useToolsPanelDropdownMenuProps } from '../../../utils/hooks';
 const { BlockInfo } = unlock( blockEditorPrivateApis );
 
 export default function QueryInspectorControls( props ) {
-	const {
-		attributes,
-		setQuery,
-		setDisplayLayout,
-		postTypeFromContext,
-		isSingular,
-	} = props;
+	const { attributes, setQuery, setDisplayLayout, isSingular } = props;
 	const { query, displayLayout } = attributes;
-	let {
+	const {
 		order,
 		orderBy,
 		author: authorIds,
@@ -67,16 +61,6 @@ export default function QueryInspectorControls( props ) {
 		parents,
 		format,
 	} = query;
-	// If a post type is set in context, update `postType` to match it,
-	// unless the post type is `page`, as it usually doesn't make sense to loop
-	// through pages.
-	if (
-		postTypeFromContext &&
-		postTypeFromContext !== 'page' &&
-		postTypeFromContext !== postType
-	) {
-		postType = postTypeFromContext;
-	}
 	const allowedControls = useAllowedControls( attributes );
 	const showSticky = postType === 'post';
 	const {

--- a/packages/block-library/src/query/edit/query-content.js
+++ b/packages/block-library/src/query/edit/query-content.js
@@ -43,7 +43,7 @@ export default function QueryContent( {
 		tagName: TagName = 'div',
 		query: { inherit } = {},
 	} = attributes;
-	const { templateSlug, postType } = context;
+	const { templateSlug } = context;
 	const { isSingular } = getQueryContextFromTemplate( templateSlug );
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
@@ -159,7 +159,6 @@ export default function QueryContent( {
 					setDisplayLayout={ updateDisplayLayout }
 					setAttributes={ setAttributes }
 					clientId={ clientId }
-					postTypeFromContext={ postType }
 					isSingular={ isSingular }
 				/>
 			</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes a recently added context variable, `postTypeFromContext`, as it is causing a bug with the Query Loop block settings.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
See more details in [this comment](https://github.com/WordPress/gutenberg/pull/65820#discussion_r1825748953).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes `postTypeFromContext`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Insert a Query Loop block into a post.
2. Ensure that the post type can be changed via the block settings.
