### PR TITLE
Block Inspector: Restore bottom margin for RadioControl

### DIFF
--- a/packages/block-editor/src/components/block-inspector/style.scss
+++ b/packages/block-editor/src/components/block-inspector/style.scss
@@ -10,7 +10,8 @@
 		margin-bottom: 1.5em;
 	}
 
-	.components-base-control {
+	.components-base-control,
+	.components-radio-control {
 		&:where(:not(:last-child)) {
 			margin-bottom: $grid-unit-20;
 		}

--- a/packages/block-library/src/latest-posts/edit.js
+++ b/packages/block-library/src/latest-posts/edit.js
@@ -238,7 +238,6 @@ export default function LatestPostsEdit( { attributes, setAttributes } ) {
 				/>
 				{ displayPostContent && (
 					<RadioControl
-						className="wp-block-latest-posts__post-content-radio"
 						label={ __( 'Show' ) }
 						selected={ displayPostContentRadio }
 						options={ [

--- a/packages/block-library/src/latest-posts/editor.scss
+++ b/packages/block-library/src/latest-posts/editor.scss
@@ -18,14 +18,3 @@
 		padding-left: 0;
 	}
 }
-
-// Apply the same styles that would be applied to
-// ".block-editor-block-inspector .components-base-control"
-// (see packages/block-editor/src/components/block-inspector/style.scss)
-.wp-block-latest-posts__post-content-radio {
-	margin-bottom: #{ $grid-unit-30 };
-
-	&:last-child {
-		margin-bottom: $grid-unit-10;
-	}
-}


### PR DESCRIPTION
Fixes the problem found in this comment: https://github.com/WordPress/gutenberg/pull/64582#issuecomment-2451517622

## What?

This PR restores the bottom margin for the `RadioControl` component in the block inspector.

## Why?

In #64582, the `RadioControl` component is no longer composed of the `BaseControl` component, and therefore no longer has the expected [bottom margin in the Block Inspector](https://github.com/WordPress/gutenberg/blob/49c3bf9b8791546231826feeff8681ed3d9ab153/packages/block-editor/src/components/block-inspector/style.scss#L13-L17).

This results in no space between the RadioControl component and the next control unless the developer explicitly applies space via a gap or similar.

## How?

Reapply the bottom margin to the `RadioControl` component in the block inspector. Also, remove the style for the Latest Post block, which is no longer needed.

## Testing Instructions

Run the following code in your browser console and confirm that there is a space between the two controls.

<details><summary>Details</summary>

```javascript
wp.blocks.registerBlockType( 'test/test', {
	apiVersion: 3,
	title: 'Test Block',
	edit: () => {
		return wp.element.createElement(
			'div',
			wp.blockEditor.useBlockProps(),
			wp.element.createElement( 'div', null, 'Test Block' ),
			wp.element.createElement(
				wp.blockEditor.InspectorControls,
				null,
				wp.element.createElement(
					wp.components.PanelBody,
					{
						title: 'Test',
					},
					wp.element.createElement( wp.components.RadioControl, {
						label: 'Radio 1',
						options: [
							{
								label: 'Option 1',
								value: 'option-1',
							},
							{
								label: 'Option 2',
								value: 'option-2',
							},
						],
					} ),
					wp.element.createElement( wp.components.RadioControl, {
						label: 'Radio 1',
						options: [
							{
								label: 'Option 3',
								value: 'option-3',
							},
							{
								label: 'Option 4',
								value: 'option-4',
							},
						],
					} )
				)
			)
		);
	},
} );
```

</details> 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c3921231-8afb-4c37-a6fd-dc43a2789d64) | ![image](https://github.com/user-attachments/assets/3f8f0bf1-7e1b-4413-9ed1-94c9b3f77ffc) | 

### Latest Post block

Notice that visual changes have occurred. But these visual changes should match the rules adopted in #64526:

- The bottom margin of the RadioControl has changed from `24px` to `16px`
- The bottom margin is not applied to the last `RadioControl` in the panel


| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/335a33b9-f25d-4618-9531-2c682e72eb2b) | ![image](https://github.com/user-attachments/assets/246d9394-d17a-44ca-8883-26e89b643028) |
| ![image](https://github.com/user-attachments/assets/8fb4aea6-dcb4-4e41-90be-50e99656dd34) | ![image](https://github.com/user-attachments/assets/bfcc6894-dad9-4684-aaff-ccc884ee2687) |