### PR TITLE
Tools: Add and configure PHPStan static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ junit.xml
 .wp-env.override.json
 playwright.config.override.ts
 phpcs.xml
+phpstan.neon
 phpunit.xml
 phpunit-watcher.yml
 .tool-versions

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,
-			"composer/installers": true
+			"composer/installers": true,
+			"phpstan/extension-installer": true
 		},
 		"lock": false
 	},
@@ -32,7 +33,10 @@
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
 		"spatie/phpunit-watcher": "^1.23",
 		"yoast/phpunit-polyfills": "^1.1.0",
-		"gutenberg/gutenberg-coding-standards": "@dev"
+		"gutenberg/gutenberg-coding-standards": "@dev",
+		"phpstan/extension-installer": "^1.4",
+		"phpstan/phpstan": "^1.12",
+		"szepeviktor/phpstan-wordpress": "^1.3"
 	},
 	"repositories": [
 		{
@@ -47,6 +51,7 @@
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"scripts": {
+		"analyse": "phpstan analyse -v",
 		"format": "phpcbf --standard=phpcs.xml.dist --report-summary --report-source",
 		"lint": "phpcs --standard=phpcs.xml.dist",
 		"test": "phpunit",

--- a/docs/contributors/folder-structure.md
+++ b/docs/contributors/folder-structure.md
@@ -19,6 +19,7 @@ The following snippet explains how the Gutenberg repository is structured omitti
     ├── .markdownlintignore
     ├── .npmpackagejsonlintrc.json
     ├── phpcs.xml.dist
+    ├── phpstan.neon.dist
     │   Dot files and config files used to configure the various linting tools
     │   used in the repository (PHP, JS, styles...).
     │
@@ -140,6 +141,9 @@ The following snippet explains how the Gutenberg repository is structured omitti
     │
     ├── tools/eslint
     │   Configuration files for the ESLint linter.
+    │
+    ├── tools/phpstan
+    │   Configuration files for the PHPStan analysis.
     │
     ├── tools/webpack
     │   Configuration files for the webpack build.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,34 @@
+# PHPStan configuration for Gutenberg
+#
+# To overload this configuration, copy this file to phpstan.neon and adjust as needed.
+#
+# https://phpstan.org/config-reference
+
+includes:
+  # The WordPress Core configuration file includes the base configuration for the WordPress codebase.
+  - tools/phpstan/base.neon
+  # The baseline file includes preexisting errors in the codebase that should be ignored.
+  # https://phpstan.org/user-guide/baseline
+  - tools/phpstan/baseline/level-0.php
+  - tools/phpstan/baseline/level-1.php
+  - tools/phpstan/baseline/level-2.php
+  - tools/phpstan/baseline/level-3.php
+  - tools/phpstan/baseline/level-4.php
+  - tools/phpstan/baseline/level-5.php
+  - tools/phpstan/baseline/level-6.php
+  - tools/phpstan/baseline/level-7.php
+
+parameters:
+  level: 7
+
+  treatPhpDocTypesAsCertain: false
+
+  ignoreErrors:
+    # @TODO: need to discover these symbols.
+    - '#Function gutenberg_.* not found.#'
+
+    # Level 6:
+
+    # WPCS syntax for iterable types is not supported:
+    -
+      identifier: missingType.iterableValue

--- a/tools/phpstan/base.neon
+++ b/tools/phpstan/base.neon
@@ -1,0 +1,26 @@
+# Base PHPStan configuration for Gutenberg
+#
+# This is kept separate from the main PHPStan configuration file to allow for easy overloading while baseline errors are being fixed.
+#
+# https://phpstan.org/config-reference
+
+parameters:
+  # What directories and files should be scanned.
+  paths:
+    - ../../gutenberg.php
+    - ../../post-content.php
+    - ../../lib
+  bootstrapFiles:
+    - bootstrap.php
+    - ../../gutenberg.php
+  scanFiles:
+    - ../../gutenberg.php
+    - ../../post-content.php
+  scanDirectories:
+    - ../../lib
+    - ../../packages
+  excludePaths:
+    analyse:
+      # Exclude files maintained in WordPress Core and backported to Gutenberg.
+      - ../../lib/compat/wordpress-*/html-api/*
+      - ../../packages/block-serialization-spec-parser/parser

--- a/tools/phpstan/baseline/level-0.php
+++ b/tools/phpstan/baseline/level-0.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Callback expects 1 parameter, \\$accepted_args is set to 2\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/block-style-variations.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.missing
+	'message' => '#^Function gutenberg_tinycolor_string_to_rgb\\(\\) should return array but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/duotone.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.missing
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:get_selector\\(\\) should return string but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.missing
+	'message' => '#^Method WP_Theme_JSON_Gutenberg\\:\\:should_override_preset\\(\\) should return bool but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^One or more @param tags has an invalid name or invalid syntax\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: class.notFound
+	'message' => '#^Call to static method get_stores\\(\\) on an unknown class WP_Style_Engine_CSS_Rules_Store_Gutenberg\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: new.static
+	'message' => '#^Unsafe usage of new static\\(\\)\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.missing
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_7\\:\\:get_wp_templates_author_text_field\\(\\) should return string but return statement is missing\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Callback expects 1 parameter, \\$accepted_args is set to 2\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/kses-allowed-html.php',
+];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Callback expects 1 parameter, \\$accepted_args is set to 2\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/rest-api.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-1.php
+++ b/tools/phpstan/baseline/level-1.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Function remove_filter invoked with 4 parameters, 2\\-3 required\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/../../../lib/block-supports/elements.php',
+];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Function remove_filter invoked with 4 parameters, 2\\-3 required\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Function remove_filter invoked with 4 parameters, 2\\-3 required\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/block-supports/settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: variable.undefined
+	'message' => '#^Variable \\$filter_id might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: isset.variable
+	'message' => '#^Variable \\$area in isset\\(\\) always exists and is not nullable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Class WP_Webfonts constructor invoked with 1 parameter, 0 required\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: arguments.count
+	'message' => '#^Function gutenberg_url invoked with 2 parameters, 1 required\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/posts/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: variable.undefined
+	'message' => '#^Variable \\$cache_key might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/global-styles-and-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: variable.undefined
+	'message' => '#^Variable \\$cached might not be defined\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/global-styles-and-settings.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-2.php
+++ b/tools/phpstan/baseline/level-2.php
@@ -1,0 +1,281 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: binaryOp.invalid
+	'message' => '#^Binary operation "/" between string and 255 results in an error\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/block-supports/duotone.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.void
+	'message' => '#^Result of method WP_HTML_Tag_Processor\\:\\:class_list\\(\\) \\(void\\) is used\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: binaryOp.invalid
+	'message' => '#^Binary operation "/" between string and 255 results in an error\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:compute_spacing_sizes\\(\\) through static\\:\\:\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:get_block_nodes\\(\\) through static\\:\\:\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:merge_spacing_sizes\\(\\) through static\\:\\:\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:remove_indirect_properties\\(\\) through static\\:\\:\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:resolve_custom_css_format\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:unwrap_shared_block_style_variations\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Gutenberg\\:\\:update_separator_declarations\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^PHPDoc tag @param has invalid value \\(WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data\\.\\)\\: Unexpected token "Class", expected variable at offset 148$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^PHPDoc tag @param has invalid value \\(WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data\\.\\)\\: Unexpected token "Class", expected variable at offset 154$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^PHPDoc tag @param has invalid value \\(WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data\\.\\)\\: Unexpected token "Class", expected variable at offset 155$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^PHPDoc tag @param has invalid value \\(WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data\\.\\)\\: Unexpected token "Class", expected variable at offset 156$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Resolver_Gutenberg\\:\\:inject_variations_from_block_style_variation_files\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Resolver_Gutenberg\\:\\:inject_variations_from_block_styles_registry\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Resolver_Gutenberg\\:\\:recursively_iterate_json\\(\\) through static\\:\\:\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Resolver_Gutenberg\\:\\:remove_json_comments\\(\\) through static\\:\\:\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method WP_Theme_JSON_Resolver_Gutenberg\\:\\:style_variation_has_scope\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: parameter.notFound
+	'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$source_args$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-bindings/pattern-overrides.php',
+];
+$ignoreErrors[] = [
+	// identifier: parameter.notFound
+	'message' => '#^PHPDoc tag @param references unknown parameter\\: \\$settings$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/block-bindings.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Block_Template\\:\\:\\$plugin\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Token_Map\\:\\:\\$groups\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Token_Map\\:\\:\\$key_length\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Token_Map\\:\\:\\$large_words\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Token_Map\\:\\:\\$small_mappings\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Token_Map\\:\\:\\$small_words\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Block_Template\\:\\:\\$plugin\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-wp-block-templates-registry.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Block_Template\\:\\:\\$plugin\\.$#',
+	'count' => 5,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$slug\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^PHPDoc tag @param has invalid value \\(\\[WP_Block_Template\\|null\\] \\$block_template The found block template, or null if there isn’t one\\.\\)\\: Unexpected token "\\|", expected \'\\]\' at offset 115$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: phpDoc.parseError
+	'message' => '#^PHPDoc tag @return has invalid value \\(\\[WP_Block_Template\\|null\\] The block template that was already found with the plugin property defined if it was registered by a plugin\\.\\)\\: Unexpected token "\\|", expected \'\\]\' at offset 223$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Block_Template\\:\\:\\$plugin\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.notFound
+	'message' => '#^Call to an undefined method object\\:\\:set\\(\\)\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Post\\:\\:\\$content\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Post\\:\\:\\$type\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:clean_up_old_connections\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:get_contents_and_lock_file\\(\\) through static\\:\\:\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:get_contents_from_file_descriptor\\(\\) through static\\:\\:\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:handle_ping\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:handle_publish_message\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:handle_read_pending_messages\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:handle_subscribe_to_topics\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:handle_unsubscribe_from_topics\\(\\) through static\\:\\:\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:save_contents_and_unlock_file\\(\\) through static\\:\\:\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: staticClassAccess.privateMethod
+	'message' => '#^Unsafe call to private method Gutenberg_HTTP_Signaling_Server\\:\\:save_contents_to_file_descriptor\\(\\) through static\\:\\:\\.$#',
+	'count' => 6,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-3.php
+++ b/tools/phpstan/baseline/level-3.php
@@ -1,0 +1,137 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: foreach.nonIterable
+	'message' => '#^Argument of an invalid type null supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_get_typography_value_and_unit\\(\\) should return array but returns null\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/block-supports/typography.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.empty
+	'message' => '#^Function _gutenberg_footnotes_force_filtered_html_on_import_filter\\(\\) should return string but empty return statement found\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:get_selector\\(\\) should return string but returns null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.childParameterType
+	'message' => '#^Parameter \\#1 \\$id \\(int\\) of method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:prepare_links\\(\\) should be compatible with parameter \\$post \\(WP_Post\\) of method WP_REST_Posts_Controller\\:\\:prepare_links\\(\\)$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Property WP_Theme_JSON_Data_Gutenberg\\:\\:\\$theme_json \\(WP_Theme_JSON\\) does not accept WP_Theme_JSON_Gutenberg\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-data-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method WP_Theme_JSON_Gutenberg\\:\\:get_block_selectors\\(\\) should return object but returns array\\<string, array\\<string, string\\>\\|string\\>\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$blocks \\(WP_Theme_JSON_Gutenberg\\) does not accept null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$core \\(WP_Theme_JSON_Gutenberg\\) does not accept null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$i18n_schema \\(array\\) does not accept null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$theme \\(WP_Theme_JSON_Gutenberg\\) does not accept null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$user \\(WP_Theme_JSON_Gutenberg\\) does not accept null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$user_custom_post_type_id \\(int\\) does not accept null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function _gutenberg_get_block_templates_files\\(\\) should return array but returns null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_replace_pattern_override_default_binding\\(\\) should return string but returns array\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method Gutenberg_Token_Map_6_6\\:\\:from_array\\(\\) should return WP_Token_Map\\|null but returns static\\(Gutenberg_Token_Map_6_6\\)\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method Gutenberg_Token_Map_6_6\\:\\:from_precomputed_table\\(\\) should return WP_Token_Map but returns null\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method Gutenberg_Token_Map_6_6\\:\\:from_precomputed_table\\(\\) should return WP_Token_Map but returns static\\(Gutenberg_Token_Map_6_6\\)\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAssign.dimType
+	'message' => '#^Cannot assign offset \'_fields\' to WP_REST_Request\\<array\\>\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAssign.dimType
+	'message' => '#^Cannot assign offset \'context\' to WP_REST_Request\\<array\\>\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAssign.valueType
+	'message' => '#^WP_REST_Request\\<array\\> does not accept string\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_register_block_module_id\\(\\) should return string but returns false\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-4.php
+++ b/tools/phpstan/baseline/level-4.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: booleanAnd.rightAlwaysTrue
+	'message' => '#^Right side of && is always true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: nullCoalesce.offset
+	'message' => '#^Offset 1 on array\\{array\\<int, string\\>, array\\<int, non\\-empty\\-string\\>\\} on left side of \\?\\? always exists and is not nullable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/block-style-variations.php',
+];
+$ignoreErrors[] = [
+	// identifier: booleanAnd.alwaysFalse
+	'message' => '#^Result of && is always false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/duotone.php',
+];
+$ignoreErrors[] = [
+	// identifier: identical.alwaysFalse
+	'message' => '#^Strict comparison using \\=\\=\\= between 1 and float will always evaluate to false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/duotone.php',
+];
+$ignoreErrors[] = [
+	// identifier: booleanOr.alwaysTrue
+	'message' => '#^Result of \\|\\| is always true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/position.php',
+];
+$ignoreErrors[] = [
+	// identifier: booleanAnd.leftAlwaysTrue
+	'message' => '#^Left side of && is always true\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/block-supports/shadow.php',
+];
+$ignoreErrors[] = [
+	// identifier: booleanNot.alwaysFalse
+	'message' => '#^Negated boolean expression is always false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: smallerOrEqual.alwaysTrue
+	'message' => '#^Comparison operation "\\<\\=" between 0 and int\\<0, max\\>\\|false is always true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: if.alwaysFalse
+	'message' => '#^If condition is always false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: booleanAnd.leftAlwaysTrue
+	'message' => '#^Left side of && is always true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: nullCoalesce.property
+	'message' => '#^Property WP_Post_Type\\:\\:\\$template \\(array\\<array\\>\\) on left side of \\?\\? is not nullable\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: booleanNot.alwaysTrue
+	'message' => '#^Negated boolean expression is always true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-wp-block-templates-registry.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.unusedType
+	'message' => '#^Function gutenberg_output_block_nav_menu\\(\\) never returns string so it can be removed from the return type\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: if.alwaysFalse
+	'message' => '#^If condition is always false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: if.alwaysTrue
+	'message' => '#^If condition is always true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: deadCode.unreachable
+	'message' => '#^Unreachable statement \\- code above always terminates\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-5.php
+++ b/tools/phpstan/baseline/level-5.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$separator of function explode expects string, float given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$args of function register_block_type expects array\\{api_version\\?\\: string, title\\?\\: string, category\\?\\: string\\|null, parent\\?\\: array\\<string\\>\\|null, ancestor\\?\\: array\\<string\\>\\|null, allowed_blocks\\?\\: array\\<string\\>\\|null, icon\\?\\: string\\|null, description\\?\\: string, \\.\\.\\.\\}, array\\{category\\: \'widgets\', attributes\\: array\\{url\\: array\\{type\\: \'string\'\\}, service\\: array\\{type\\: \'string\', default\\: \'amazon\'\\|\'bandcamp\'\\|\'behance\'\\|\'chain\'\\|\'codepen\'\\|\'deviantart\'\\|\'dribbble\'\\|\'dropbox\'\\|\'etsy\'\\|\'facebook\'\\|\'feed\'\\|\'fivehundredpx\'\\|\'flickr\'\\|\'foursquare\'\\|\'github\'\\|\'goodreads\'\\|\'google\'\\|\'instagram\'\\|\'lastfm\'\\|\'linkedin\'\\|\'mail\'\\|\'mastodon\'\\|\'medium\'\\|\'meetup\'\\|\'pinterest\'\\|\'pocket\'\\|\'reddit\'\\|\'skype\'\\|\'snapchat\'\\|\'soundcloud\'\\|\'spotify\'\\|\'tumblr\'\\|\'twitch\'\\|\'twitter\'\\|\'vimeo\'\\|\'vk\'\\|\'wordpress\'\\|\'yelp\'\\|\'youtube\'\\}, label\\: array\\{type\\: \'string\'\\}\\}, render_callback\\: \'gutenberg_render…\'\\} given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$value of static method WP_Duotone_Gutenberg\\:\\:colord_parse_hue\\(\\) expects float, string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$incoming of method WP_Theme_JSON\\:\\:merge\\(\\) expects WP_Theme_JSON, WP_Theme_JSON_Gutenberg given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-data-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$css of method WP_Theme_JSON_Gutenberg\\:\\:process_blocks_custom_css\\(\\) expects string, array given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$metadata of method WP_Theme_JSON_Gutenberg\\:\\:get_feature_declarations_for_node\\(\\) expects object, array given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$function_name of function _doing_it_wrong expects string, true given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#5 \\$media of function wp_register_style expects string, true given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$str of function strtoupper expects string, bool given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$value of method WP_HTTP_Response\\:\\:header\\(\\) expects string, int given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$id of method WP_REST_Templates_Controller\\:\\:prepare_links\\(\\) expects int, string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$str of function strtoupper expects string, bool given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$value of function setcookie expects string, int given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#5 \\$callback of function add_menu_page expects callable\\(\\)\\: mixed, \'\' given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/init.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-6.php
+++ b/tools/phpstan/baseline/level-6.php
@@ -1,0 +1,1103 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_build_files_notice\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_pre_init\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_wordpress_version_notice\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_background_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/background.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enqueue_block_style_variation_styles\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/block-style-variations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_block_style_variations_from_theme_json_partials\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/block-style-variations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_resolve_block_style_variation_ref_values\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/block-style-variations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_border_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/border.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_colors_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/colors.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_dimensions_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/dimensions.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_duotone_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/duotone.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_layout_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_position_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/position.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_shadow_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/shadow.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_spacing_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/spacing.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_typography_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/typography.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_footnotes_kses_init\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_footnotes_kses_init_filters\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_footnotes_remove_filters\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_defer_block_view_scripts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_legacy_wp_block_post_meta\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_legacy_social_link_blocks\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_reregister_core_block_types\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:enqueue_block_css\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:enqueue_custom_filter\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:enqueue_global_styles_preset\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:output_block_styles\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:output_footer_assets\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:output_global_styles\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:register_duotone_support\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:set_global_style_block_names\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:set_global_styles_presets\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:get_available_actions\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:get_item_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:get_theme_item\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:get_theme_item_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:get_theme_items\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:get_theme_items_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:prepare_item_for_database\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:prepare_item_for_response\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:register_routes\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Global_Styles_Controller_Gutenberg\\:\\:update_item_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Theme_JSON_Gutenberg\\:\\:do_opt_in_into_settings\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Method WP_Theme_JSON_Gutenberg\\:\\:get_layout_styles\\(\\) has parameter \\$types with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Theme_JSON_Gutenberg\\:\\:merge\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Theme_JSON_Gutenberg\\:\\:remove_indirect_properties\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Theme_JSON_Resolver_Gutenberg\\:\\:clean_cached_data\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Theme_JSON_Schema_Gutenberg\\:\\:rename_settings\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-schema-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Theme_JSON_Schema_Gutenberg\\:\\:unset_setting_by_path\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-schema-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_default_script_modules\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_override_script\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_override_style\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_packages_scripts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_packages_styles\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_vendor_scripts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_redirect_deprecated_to_new_site_editor_page\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/plugin/edit-site-routes-backwards-compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_site_editor_menu\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/plugin/edit-site-routes-backwards-compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_before_delete_font_face\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/plugin/fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_admin_bar_edit_site_menu\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/admin-bar.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_block_bindings_pattern_overrides_callback\\(\\) has parameter \\$source_attrs with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-bindings/pattern-overrides.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_block_bindings_pattern_overrides_source\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-bindings/pattern-overrides.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Global_Styles_Revisions_Controller_6_6\\:\\:prepare_item_for_response\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-global-styles-revisions-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_6\\:\\:get_item_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_6\\:\\:get_items\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_6\\:\\:get_items_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_6\\:\\:get_template_fallback\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_6\\:\\:prepare_item_for_response\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-templates-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_change_patterns_link_and_remove_template_parts_submenu_item\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_update_initial_settings\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/option.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_update_initial_settings\\(\\) has parameter \\$args with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/option.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_update_initial_settings\\(\\) has parameter \\$defaults with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/option.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_update_initial_settings\\(\\) has parameter \\$option_group with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/option.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_update_initial_settings\\(\\) has parameter \\$option_name with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/option.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_add_excerpt_support_to_wp_block\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/post.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_replace_pattern_blocks_patterns_endpoint\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/resolve-patterns.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_replace_pattern_blocks_patterns_endpoint\\(\\) has parameter \\$request with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/resolve-patterns.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_replace_pattern_blocks_patterns_endpoint\\(\\) has parameter \\$result with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/resolve-patterns.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_replace_pattern_blocks_patterns_endpoint\\(\\) has parameter \\$server with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/resolve-patterns.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_add_class_list_to_public_post_types\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_global_styles_revisions_endpoints\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_wp_rest_post_types_controller_fields\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_wp_rest_themes_stylesheet_directory_uri_field\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_wp_rest_themes_template_directory_uri_field\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_add_can_update_block_bindings_editor_setting\\(\\) has parameter \\$editor_settings with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/block-bindings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_bootstrap_server_block_bindings_sources\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/block-bindings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Posts_Controller_6_7\\:\\:get_items\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Posts_Controller_6_7\\:\\:prepare_tax_query\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_7\\:\\:get_item\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_7\\:\\:prepare_item_for_response\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Block_Templates_Registry\\:\\:get_by_query\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-wp-block-templates-registry.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.property
+	'message' => '#^Property WP_Block_Templates_Registry\\:\\:\\$registered_templates has no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-wp-block-templates-registry.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_add_block_template_plugin_attribute\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function _gutenberg_add_block_template_plugin_attribute\\(\\) has parameter \\$block_template with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/compat.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_post_format_rest_posts_controller\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/post-formats.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function gutenberg_post_format_rest_posts_controller\\(\\) has parameter \\$args with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/post-formats.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_wp_rest_templates_controller_plugin_field\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_a11y_script_module_html\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function exclude_block_comments_from_admin\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function exclude_block_comments_from_admin\\(\\) has parameter \\$query with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function update_comment_type_in_rest_api_6_8\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function update_comment_type_in_rest_api_6_8\\(\\) has parameter \\$prepared_comment with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function update_comment_type_in_rest_api_6_8\\(\\) has parameter \\$request with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function update_get_avatar_comment_type\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Function update_get_avatar_comment_type\\(\\) has parameter \\$comment_type with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/block-comments.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Comment_Controller_6_8\\:\\:create_item_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_redirect_demo\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/demo.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method _WP_Editors\\:\\:editor\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/class--wp-editors.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method _WP_Editors\\:\\:enqueue_default_editor\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/class--wp-editors.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Block_Editor_Settings_Controller\\:\\:get_items\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/class-wp-rest-block-editor-settings-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method WP_REST_Block_Editor_Settings_Controller\\:\\:get_items_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/class-wp-rest-block-editor-settings-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_REST_Block_Editor_Settings_Controller\\:\\:register_routes\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/class-wp-rest-block-editor-settings-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_register_data_views_post_type\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/data-views.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_declare_classic_block_necessary\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/disable-tinymce.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_disable_tinymce\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/disable-tinymce.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enqueue_tinymce_proxy\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/disable-tinymce.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_test_tinymce_access\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/disable-tinymce.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enable_block_experiments\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/editor-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enable_experiments\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/editor-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enable_form_input_blocks\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/editor-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Fonts_Provider\\:\\:print_styles\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-fonts-provider.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Fonts_Provider\\:\\:set_fonts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-fonts-provider.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Fonts_Resolver\\:\\:register_fonts_from_theme_json\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-fonts-resolver.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Fonts\\:\\:get_providers\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Fonts\\:\\:remove_font_family\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Fonts\\:\\:remove_variation\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Web_Fonts\\:\\:get_providers\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-web-fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Web_Fonts\\:\\:remove_font_family\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-web-fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Web_Fonts\\:\\:remove_variation\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-web-fonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Webfonts_Provider\\:\\:set_webfonts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-webfonts-provider.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method WP_Webfonts\\:\\:init\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/class-wp-webfonts.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_deregister_font_family\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_deregister_font_variation\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_deregister_webfont_variation\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_enqueue_font_variations\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_enqueue_fonts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_enqueue_webfont_variations\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function wp_enqueue_webfonts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/font-face/bc-layer/webfonts-deprecations.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_enqueue_interactivity_router\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/full-page-client-side-navigation.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function allow_filter_in_styles\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/kses.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_override_core_kses_init_filters\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/kses.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Attachments_Controller\\:\\:create_item\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.parameter
+	'message' => '#^Method Gutenberg_REST_Attachments_Controller\\:\\:filter_wp_unique_filename\\(\\) has parameter \\$attachment_filename with no type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Attachments_Controller\\:\\:prepare_item_for_response\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Attachments_Controller\\:\\:sideload_item\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.generics
+	'message' => '#^Method Gutenberg_REST_Attachments_Controller\\:\\:sideload_item_permissions_check\\(\\) has parameter \\$request with generic class WP_REST_Request but does not specify its types\\: T$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_media_processing_filter_rest_index\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_set_up_cross_origin_isolation\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_add_block_menu_item_styles_to_nav_menus\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_output_block_menu_item_custom_fields\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_update_nav_menu_item_content\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_add_post_type_arg\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/posts/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_posts_dashboard\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/posts/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_replace_posts_dashboard\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/posts/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_block_editor_settings\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_dequeue_module\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enqueue_module\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_filter_block_type_metadata_settings_register_view_module\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_module\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_view_module_ids_rest_field\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:clean_up_old_connections\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:do_wp_ajax_action\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:handle_ping\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:handle_publish_message\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:handle_read_pending_messages\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:handle_subscribe_to_topics\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:handle_unsubscribe_from_topics\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:init\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:save_contents_and_unlock_file\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Method Gutenberg_HTTP_Signaling_Server\\:\\:save_contents_to_file_descriptor\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/sync/class-gutenberg-http-signaling-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_rest_api_init_collaborative_editing\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/synchronization.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_display_experiment_field\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experiments-page.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_display_experiment_section\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experiments-page.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_initialize_experiments_settings\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experiments-page.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function the_gutenberg_experiments\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experiments-page.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_clean_theme_json_caches\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/global-styles-and-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_add_global_styles_block_custom_css\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/global-styles-and-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_menu\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/init.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_interactivity_script_module_data_hooks\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/interactivity-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_register_edit_site_export_controller_endpoints\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enqueue_global_styles_css_custom_properties\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/script-loader.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function gutenberg_enqueue_global_styles_custom_css\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/script-loader.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_migrate_database\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/upgrade.php',
+];
+$ignoreErrors[] = [
+	// identifier: missingType.return
+	'message' => '#^Function _gutenberg_migrate_remove_fse_drafts\\(\\) has no return type specified\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/upgrade.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-7.php
+++ b/tools/phpstan/baseline/level-7.php
@@ -1,0 +1,467 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$haystack of function str_ends_with expects string\\|null, string\\|true given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/background.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$haystack of function str_ends_with expects string\\|null, string\\|true given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/dimensions.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset \'hover_selector\' does not exist on array\\{selector\\: non\\-falsy\\-string, hover_selector\\?\\: non\\-falsy\\-string, skip\\: false\\}\\|array\\{selector\\: non\\-falsy\\-string, skip\\: false, elements\\: array\\{\'h1\', \'h2\', \'h3\', \'h4\', \'h5\', \'h6\'\\}\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/elements.php',
+];
+$ignoreErrors[] = [
+	// identifier: encapsedStringPart.nonString
+	'message' => '#^Part \\$process_value \\(array\\<string\\>\\|string\\) of encapsed string cannot be cast to string\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function _gutenberg_filter_post_meta_footnotes\\(\\) should return string but returns string\\|false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:get_filter_svg\\(\\) should return string but returns string\\|false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 5 does not exist on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: string, 4\\: string, 5\\?\\: string, 6\\?\\: string\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 6 does not exist on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: string, 4\\: string, 5\\: non\\-empty\\-string, 6\\?\\: string\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 6 does not exist on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: string, 4\\: string, 5\\: string, 6\\?\\: string, 7\\?\\: string, \\.\\.\\.\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 7 does not exist on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: string, 4\\: string, 5\\: string, 6\\: string, 7\\?\\: string, \\.\\.\\.\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.notFound
+	'message' => '#^Offset 8 does not exist on array\\{0\\: string, 1\\: string, 2\\: string, 3\\: string, 4\\: string, 5\\: string, 6\\: string, 7\\: non\\-empty\\-string, \\.\\.\\.\\}\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$str of function explode expects string, string\\|true\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.notFound
+	'message' => '#^Call to an undefined method WP_Error\\|WP_REST_Response\\:\\:add_links\\(\\)\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$response of method WP_REST_Controller\\:\\:prepare_response_for_collection\\(\\) expects WP_REST_Response, WP_Error\\|WP_REST_Response given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: binaryOp.invalid
+	'message' => '#^Binary operation "\\." between array\\|string and \' \' results in an error\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.nonOffsetAccessible
+	'message' => '#^Cannot access offset \'selectors\' on object\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.nonOffsetAccessible
+	'message' => '#^Cannot access offset mixed on object\\.$#',
+	'count' => 4,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function wp_get_block_css_selector expects WP_Block_Type, object given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: encapsedStringPart.nonString
+	'message' => '#^Part \\$block_gap_value \\(array\\|string\\) of encapsed string cannot be cast to string\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method WP_Theme_JSON_Resolver_Gutenberg\\:\\:translate\\(\\) should return array but returns array\\<array\\|string\\>\\|string\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$obj of function get_object_vars expects object, int\\|WP_Post given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: assign.propertyType
+	'message' => '#^Static property WP_Theme_JSON_Resolver_Gutenberg\\:\\:\\$theme \\(WP_Theme_JSON_Gutenberg\\) does not accept WP_Theme_JSON\\|WP_Theme_JSON_Gutenberg\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: foreach.nonIterable
+	'message' => '#^Argument of an invalid type array\\<int, string\\>\\|false supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$args on _WP_Dependency\\|true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$deps on _WP_Dependency\\|true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$src on _WP_Dependency\\|true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$ver on _WP_Dependency\\|true\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/client-assets.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$post of function _build_block_template_result_from_post expects WP_Post, int\\|WP_Post given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$template_type of function _build_block_template_result_from_file expects \'wp_template\'\\|\'wp_template_part\', string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Error\\|WP_Post\\:\\:\\$ID\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-global-styles-revisions-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$theme_json of static method WP_Theme_JSON_Resolver_Gutenberg\\:\\:get_resolved_theme_uris\\(\\) expects WP_Theme_JSON_Gutenberg, array\\|WP_Theme_JSON_Gutenberg given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-rest-global-styles-revisions-controller-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.nonOffsetAccessible
+	'message' => '#^Cannot access offset 1 on array\\|false\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$callback of function usort expects callable\\(int\\|string, int\\|string\\)\\: int, \'static\\:\\:longest…\' given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/class-gutenberg-token-map-6-6.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$item_updated\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.6/post.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$args of method WP_Block_Templates_Registry\\:\\:register\\(\\) expects array, array\\|string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/block-templates.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$path of function wp_normalize_path expects string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/blocks.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$item of method WP_REST_Posts_Controller\\:\\:prepare_item_for_response\\(\\) expects WP_Post, int\\|WP_Post given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$post of method WP_REST_Posts_Controller\\:\\:check_read_permission\\(\\) expects WP_Post, int\\|WP_Post given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$posts of function update_post_author_caches expects array\\<WP_Post\\>, array\\<int\\|WP_Post\\> given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$posts of function update_post_parent_caches expects array\\<WP_Post\\>, array\\<int\\|WP_Post\\> given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-posts-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#3 \\$length of function substr expects int, int\\<0, max\\>\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-server.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.notFound
+	'message' => '#^Call to an undefined method WP_Error\\|WP_REST_Response\\:\\:add_link\\(\\)\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.notFound
+	'message' => '#^Call to an undefined method WP_Error\\|WP_REST_Response\\:\\:add_links\\(\\)\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method Gutenberg_REST_Templates_Controller_6_7\\:\\:prepare_item_for_response\\(\\) should return WP_REST_Response but returns WP_Error\\|WP_REST_Response\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$template_type of function get_block_file_template expects \'wp_template\'\\|\'wp_template_part\', string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$template_type of function get_block_template expects \'wp_template\'\\|\'wp_template_part\', string given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-rest-templates-controller-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: offsetAccess.nonOffsetAccessible
+	'message' => '#^Cannot access offset 1 on array\\|false\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$callback of function usort expects callable\\(int\\|string, int\\|string\\)\\: int, \'WP_Token_Map\\:…\' given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$data of function wp_print_inline_script_tag expects string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/compat/wordpress-6.7/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_default_demo_content\\(\\) should return string but returns string\\|false\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/demo.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$var of function count expects array\\|Countable, array\\<int, string\\>\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/full-page-client-side-navigation.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_filter_global_styles_post\\(\\) should return string but returns bool\\|string\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/kses.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$content\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$db_id\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$object\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$title\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$type\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$type_label\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/navigation-theme-opt-in.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$ID\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$filter\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$post_date\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$post_name\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$post_parent\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$post_status\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$post_title\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property object\\:\\:\\$post_type\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$post of function get_permalink expects int\\|WP_Post, object given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$str of function strrev expects string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$path of function wp_normalize_path expects string, string\\|false given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$src of function wp_register_script_module expects string, string\\|false given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/script-modules.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$str of function md5 expects string, string\\|false given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/global-styles-and-settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.notFound
+	'message' => '#^Access to an undefined property WP_Error\\|WP_Term\\:\\:\\$term_id\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/upgrade.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$ID on int\\|WP_Post\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/upgrade.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/baseline/level-8.php
+++ b/tools/phpstan/baseline/level-8.php
@@ -1,0 +1,341 @@
+<?php declare(strict_types = 1);
+
+$ignoreErrors = [];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function block_has_support expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/background.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function wp_should_skip_block_supports_serialization expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/background.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function block_has_support expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/dimensions.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function wp_should_skip_block_supports_serialization expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/dimensions.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function wp_should_skip_block_supports_serialization expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 3,
+	'path' => __DIR__ . '/../../../lib/block-supports/elements.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_restore_group_inner_container\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function block_has_support expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function wp_should_skip_block_supports_serialization expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$html of class WP_HTML_Tag_Processor constructor expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/layout.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function block_has_support expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/position.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function block_has_support expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/block-supports/settings.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function gutenberg_render_typography_support\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-supports/typography.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$content of method ZipArchive\\:\\:addFromString\\(\\) expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/block-template-utils.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method WP_Duotone_Gutenberg\\:\\:get_selector\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$scope of static method WP_Theme_JSON_Gutenberg\\:\\:scope_selector\\(\\) expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#3 \\$subject of function str_replace expects array\\|string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-duotone-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$cap on WP_Post_Type\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-rest-global-styles-controller-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$block_type of function block_has_support expects WP_Block_Type, WP_Block_Type\\|null given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$input_array of function _wp_array_get expects array, array\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$root_selector of static method WP_Theme_JSON_Gutenberg\\:\\:get_block_element_selectors\\(\\) expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$scope of static method WP_Theme_JSON_Gutenberg\\:\\:scope_selector\\(\\) expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$root_selector of static method WP_Theme_JSON_Gutenberg\\:\\:get_block_selectors\\(\\) expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$obj of function get_object_vars expects object, WP_Post\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/class-wp-theme-json-resolver-gutenberg.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$subject of function preg_match_all expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/l10n.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#3 \\$subject of function preg_replace expects array\\|string, string\\|null given\\.$#',
+	'count' => 8,
+	'path' => __DIR__ . '/../../../lib/experimental/l10n.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$item of method Gutenberg_REST_Attachments_Controller\\:\\:prepare_item_for_response\\(\\) expects WP_Post, WP_Post\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/media/class-gutenberg-rest-attachments-controller.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$labels on WP_Post_Type\\|null\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../lib/experimental/posts/load.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$hierarchical on WP_Post_Type\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../lib/experimental/rest-api.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$url of function esc_url expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/comment-edit-link/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$comment_parent on WP_Comment\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/comment-reply-link/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$post of function setup_postdata expects int\\|object, WP_Post\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/comments/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function block_core_gallery_render\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/gallery/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function block_core_image_render_lightbox\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/image/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$value of method WP_HTML_Tag_Processor\\:\\:set_attribute\\(\\) expects bool\\|string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/image/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function render_block_core_media_text\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/media-text/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$html of class WP_HTML_Tag_Processor constructor expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/media-text/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$name on WP_Post\\|WP_Post_Type\\|WP_Term\\|WP_User\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/navigation-link/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$name on WP_Post\\|WP_Post_Type\\|WP_Term\\|WP_User\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/navigation-submenu/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$post of function block_core_navigation_set_ignored_hooked_blocks_metadata expects WP_Post, WP_Post\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/navigation/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: foreach.nonIterable
+	'message' => '#^Argument of an invalid type array\\|null supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/post-featured-image/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$post_content on WP_Post\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/post-featured-image/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$value of method WP_HTML_Tag_Processor\\:\\:set_attribute\\(\\) expects bool\\|string, string\\|true\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/post-featured-image/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function render_block_core_query_pagination_next\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/query-pagination-next/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Function render_block_core_query_pagination_previous\\(\\) should return string but returns string\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/query-pagination-previous/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$callback of function remove_filter expects array\\|\\(callable\\(\\)\\: mixed\\)\\|string, \\(Closure\\(mixed, mixed\\)\\: mixed\\)\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/query/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: foreach.nonIterable
+	'message' => '#^Argument of an invalid type array\\<SimplePie_Item\\>\\|null supplied for foreach, only iterables are supported\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/rss/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$str of function strip_tags expects string, string\\|null given\\.$#',
+	'count' => 2,
+	'path' => __DIR__ . '/../../../packages/block-library/src/rss/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$string of function html_entity_decode expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/rss/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$url of function esc_url expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/rss/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$str of function strtolower expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/search/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#1 \\$html of class WP_HTML_Tag_Processor constructor expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/site-logo/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: property.nonObject
+	'message' => '#^Cannot access property \\$content on WP_Block_Template\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/block-library/src/template-part/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.nonObject
+	'message' => '#^Cannot call method add_declarations\\(\\) on WP_Style_Engine_CSS_Rule\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/style-engine/class-wp-style-engine.php',
+];
+$ignoreErrors[] = [
+	// identifier: return.type
+	'message' => '#^Method WP_Style_Engine\\:\\:get_store\\(\\) should return WP_Style_Engine_CSS_Rules_Store but returns WP_Style_Engine_CSS_Rules_Store\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/style-engine/class-wp-style-engine.php',
+];
+$ignoreErrors[] = [
+	// identifier: method.nonObject
+	'message' => '#^Cannot call method render\\(\\) on WP_Block_Type\\|null\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/widgets/src/blocks/legacy-widget/index.php',
+];
+$ignoreErrors[] = [
+	// identifier: argument.type
+	'message' => '#^Parameter \\#2 \\$sidebar_id of function wp_render_widget expects string, string\\|null given\\.$#',
+	'count' => 1,
+	'path' => __DIR__ . '/../../../packages/widgets/src/blocks/legacy-widget/index.php',
+];
+
+return ['parameters' => ['ignoreErrors' => $ignoreErrors]];

--- a/tools/phpstan/bootstrap.php
+++ b/tools/phpstan/bootstrap.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Defines default WordPress constants for discovery.
+ */
+
+define( 'WPINC', 'wp-includes' );
+define( 'SITECOOKIEPATH', '/' );
+define( 'WP_TEMPLATE_PART_AREA_UNCATEGORIZED', 'uncategorized' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds a PHPStan configuration along with error baselines though Level 7.

PHPStan errors are _not_ remediated in this PR.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Mirrors efforts in https://core.trac.wordpress.org/ticket/61175 

Error baselines can be used as a list of preexisting tech debt that can be remediated independently of this PR. Baselines go up to PHPStan Level 7, as Level 8 baselines currently conflict with previous levels.

Once a decision is made regarding the PHPStan Level to target, the baselines can be merged/adjusted.

Part of #66598 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

### Run PHPStan

```bash
composer run analyse

# Generate a report
# https://phpstan.org/user-guide/output-format
composer run analyse -- --error-format=checkstyle
```

### Create a local `phpstan.neon` for remediating errors

1. Copy `phpstan.neon.dist` to `phpstan.neon`.
2. Comment out the unnecessary baselines, change the `parameters.level` to the desired level, and filter out the errors by adding them to the `parameters.ignoreErrors` list.
3. Run PHPStan as usual: `composer run analyse`.

### Remediating errors using the error baselines

While `parameters.ignoreErrors` is used to filter out "unsupported" errors, error baselines are used to suppress _preexisting_ tech debt.

This allows for the PR to be merged as is to enforce the rules on new code, while allowing contributors to remediate the existing errors at their own pace. This is in the spirit of 'Avoid unnecessary refactoring'.

To remediate a baselined error, remove the error from the `tests/phpstan/baseline/level-{%N}` file and run PHPStan again.

#### Triaging errors and regenerating baselines

If an error is found to be a false positive (or otherwise not worth fixing), it should be added to the `parameters.ignoreErrors` list in the `phpstan.neon.dist` file. When this happens, the baseline file suppressing the error will cause PHPStan to fail.

To avoid manual remediation, the baseline files can be regenerated by following the following steps:

1. Identify the baseline level that contains the error. (Search for the error in `tools/phpstan/baseline` ).
2. Change the `parameters.level` in `phpstan.neon` to the level identified in step 1.
3. Comment out the `includes` for that level _and all levels above it_.
4. Run the following command:

   ```bash
   # Replace {%N} with the level identified in step 1
   composer analyse --generate-baseline tools/phpstan/baseline/level-{%N}.php 
   ```

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Run `composer analyse` and confirm PHPStan passes.
2. Copy `phpstan.neon.dist` to `phpstan.neon`, comment out one of the baseline `includes:`, rerun `composer analyse` and confirm PHPStan fails.

## Todo

( PRs open. )

- [ ] Implement NPM scripts
- [ ] Implement GH Workflow
- [ ] Handle missing `gutenberg_*()` functions and `*_Gutenberg` classes
- [ ] Triage baselines for good `ignoreErrors` candidates.
