### PR TITLE
fix: wrong number of `$accepted_args` on `add_filter()` calls

### DIFF
--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -273,7 +273,7 @@ if ( function_exists( 'wp_enqueue_block_style_variation_styles' ) ) {
 }
 
 // Add Gutenberg filters and action.
-add_filter( 'render_block_data', 'gutenberg_render_block_style_variation_support_styles', 10, 2 );
+add_filter( 'render_block_data', 'gutenberg_render_block_style_variation_support_styles', 10, 1 );
 add_filter( 'render_block', 'gutenberg_render_block_style_variation_class_name', 10, 2 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_block_style_variation_styles', 1 );
 

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -273,7 +273,7 @@ if ( function_exists( 'wp_enqueue_block_style_variation_styles' ) ) {
 }
 
 // Add Gutenberg filters and action.
-add_filter( 'render_block_data', 'gutenberg_render_block_style_variation_support_styles', 10, 1 );
+add_filter( 'render_block_data', 'gutenberg_render_block_style_variation_support_styles' );
 add_filter( 'render_block', 'gutenberg_render_block_style_variation_class_name', 10, 2 );
 add_action( 'wp_enqueue_scripts', 'gutenberg_enqueue_block_style_variation_styles', 1 );
 

--- a/lib/experimental/kses-allowed-html.php
+++ b/lib/experimental/kses-allowed-html.php
@@ -40,4 +40,4 @@ function gutenberg_kses_allowed_html( $allowedtags ) {
 	);
 	return $allowedtags;
 }
-add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowed_html', 10, 2 );
+add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowed_html', 10, 1 );

--- a/lib/experimental/kses-allowed-html.php
+++ b/lib/experimental/kses-allowed-html.php
@@ -40,4 +40,4 @@ function gutenberg_kses_allowed_html( $allowedtags ) {
 	);
 	return $allowedtags;
 }
-add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowed_html', 10, 1 );
+add_filter( 'wp_kses_allowed_html', 'gutenberg_kses_allowed_html' );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -27,7 +27,7 @@ function gutenberg_override_global_styles_endpoint( array $args ): array {
 
 	return $args;
 }
-add_filter( 'register_wp_global_styles_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 2 );
+add_filter( 'register_wp_global_styles_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 1 );
 
 /**
  * Registers the Edit Site Export REST API routes.

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -27,7 +27,7 @@ function gutenberg_override_global_styles_endpoint( array $args ): array {
 
 	return $args;
 }
-add_filter( 'register_wp_global_styles_post_type_args', 'gutenberg_override_global_styles_endpoint', 10, 1 );
+add_filter( 'register_wp_global_styles_post_type_args', 'gutenberg_override_global_styles_endpoint' );
 
 /**
  * Registers the Edit Site Export REST API routes.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes several instances of the wrong number of `$accepted_args` being passed to `add_filter()`, so the match the correct number of args taken by their callbacks.

As the correct `$accepted_args` and `$priority` are the defaults once corrected, the explicit args have been removed entirely.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
