### PR TITLE
chore: fix return type for `WP_Duotone_Gutenberg::get_selector()`

### DIFF
--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -640,7 +640,7 @@ class WP_Duotone_Gutenberg {
 	 *
 	 * @param string $block_name The block name.
 	 *
-	 * @return string The CSS selector or null if there is no support.
+	 * @return ?string The CSS selector or null if there is no support.
 	 */
 	private static function get_selector( $block_name ) {
 		$block_type = WP_Block_Type_Registry::get_instance()->get_registered( $block_name );
@@ -669,6 +669,8 @@ class WP_Duotone_Gutenberg {
 			// Regular filter.duotone support uses filter.duotone selectors with fallbacks.
 			return wp_get_block_css_selector( $block_type, array( 'filter', 'duotone' ), true );
 		}
+
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes the `@return` type on `WP_Duotone_Gutenberg::get_selector()` to correctly indicate that it possibly returns null.

Additionally, an explicit `return null` has been added to the end of function, instead of coercing the implicit `void` if an invalid block name is passed to the method.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via https://github.com/WordPress/gutenberg/pull/66693) it can be remediated independently as part of https://github.com/WordPress/gutenberg/issues/66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
