### PR TITLE
fix: remove extraneous param from `remove_filter()` calls

### DIFF
--- a/lib/block-supports/elements.php
+++ b/lib/block-supports/elements.php
@@ -255,12 +255,12 @@ function gutenberg_render_elements_class_name( $block_content, $block ) {
 }
 
 // Remove deprecated WordPress core filters.
-remove_filter( 'render_block', 'wp_render_elements_support', 10, 2 );
-remove_filter( 'pre_render_block', 'wp_render_elements_support_styles', 10, 2 );
+remove_filter( 'render_block', 'wp_render_elements_support', 10 );
+remove_filter( 'pre_render_block', 'wp_render_elements_support_styles', 10 );
 
 // Remove WordPress core filters to avoid rendering duplicate elements stylesheet & attaching classes twice.
-remove_filter( 'render_block', 'wp_render_elements_class_name', 10, 2 );
-remove_filter( 'render_block_data', 'wp_render_elements_support_styles', 10, 1 );
+remove_filter( 'render_block', 'wp_render_elements_class_name', 10 );
+remove_filter( 'render_block_data', 'wp_render_elements_support_styles', 10 );
 
 add_filter( 'render_block', 'gutenberg_render_elements_class_name', 10, 2 );
 add_filter( 'render_block_data', 'gutenberg_render_elements_support_styles', 10, 1 );

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1055,8 +1055,8 @@ function gutenberg_restore_group_inner_container( $block_content, $block ) {
 }
 
 if ( function_exists( 'wp_restore_group_inner_container' ) ) {
-	remove_filter( 'render_block', 'wp_restore_group_inner_container', 10, 2 );
-	remove_filter( 'render_block_core/group', 'wp_restore_group_inner_container', 10, 2 );
+	remove_filter( 'render_block', 'wp_restore_group_inner_container', 10 );
+	remove_filter( 'render_block_core/group', 'wp_restore_group_inner_container', 10 );
 }
 add_filter( 'render_block_core/group', 'gutenberg_restore_group_inner_container', 10, 2 );
 
@@ -1118,6 +1118,6 @@ function gutenberg_restore_image_outer_container( $block_content, $block ) {
 }
 
 if ( function_exists( 'wp_restore_image_outer_container' ) ) {
-	remove_filter( 'render_block_core/image', 'wp_restore_image_outer_container', 10, 2 );
+	remove_filter( 'render_block_core/image', 'wp_restore_image_outer_container', 10 );
 }
 add_filter( 'render_block_core/image', 'gutenberg_restore_image_outer_container', 10, 2 );

--- a/lib/block-supports/settings.php
+++ b/lib/block-supports/settings.php
@@ -128,7 +128,7 @@ function _gutenberg_add_block_level_preset_styles( $pre_render, $block ) {
 	return null;
 }
 // Remove WordPress core filter to avoid rendering duplicate settings style blocks.
-remove_filter( 'render_block', '_wp_add_block_level_presets_class', 10, 2 );
-remove_filter( 'pre_render_block', '_wp_add_block_level_preset_styles', 10, 2 );
+remove_filter( 'render_block', '_wp_add_block_level_presets_class', 10 );
+remove_filter( 'pre_render_block', '_wp_add_block_level_preset_styles', 10 );
 add_filter( 'render_block', '_gutenberg_add_block_level_presets_class', 10, 2 );
 add_filter( 'pre_render_block', '_gutenberg_add_block_level_preset_styles', 10, 2 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes several calls to `remove_filter()`, where an invalid 4th parameter is passed.

(Unlike `add_filter()`, `remove_filter()` does not take `$accepted_args` )

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via https://github.com/WordPress/gutenberg/pull/66693) it can be remediated independently as part of https://github.com/WordPress/gutenberg/issues/66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
