### PR TITLE
fix: remove extraneous arg from `gutenberg_url()` call in `gutenberg_posts_dashboard()`

### DIFF
--- a/lib/experimental/posts/load.php
+++ b/lib/experimental/posts/load.php
@@ -51,7 +51,7 @@ function gutenberg_posts_dashboard() {
 	do_action( 'enqueue_block_editor_assets' );
 	wp_register_style(
 		'wp-gutenberg-posts-dashboard',
-		gutenberg_url( 'build/edit-site/posts.css', __FILE__ ),
+		gutenberg_url( 'build/edit-site/posts.css' ),
 		array( 'wp-components', 'wp-commands', 'wp-edit-site' )
 	);
 	wp_enqueue_style( 'wp-gutenberg-posts-dashboard' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes a call to `gutenberg_url()` with an extraneous argument in `gutenberg_posts_dashboard()`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via https://github.com/WordPress/gutenberg/pull/66693) it can be remediated independently as part of https://github.com/WordPress/gutenberg/issues/66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
