### PR TITLE
fix: deprecated `WP_Webfonts()` constructor takes no arguments

### DIFF
--- a/lib/experimental/font-face/bc-layer/webfonts-deprecations.php
+++ b/lib/experimental/font-face/bc-layer/webfonts-deprecations.php
@@ -28,7 +28,7 @@ if ( ! function_exists( 'wp_webfonts' ) ) {
 		global $wp_webfonts;
 
 		if ( ! ( $wp_webfonts instanceof WP_Webfonts ) ) {
-			$wp_webfonts = new WP_Webfonts( wp_fonts() );
+			$wp_webfonts = new WP_Webfonts();
 		}
 
 		return $wp_webfonts;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR removes the extraneous parameter from the `new WP_Webfonts()` call in the deprecated `wp_webfonts()` function.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via https://github.com/WordPress/gutenberg/pull/66693) it can be remediated independently as part of https://github.com/WordPress/gutenberg/issues/66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
