### PR TITLE
Block toolbar: restrict visible child calculation to known blocks 

### DIFF
--- a/packages/block-editor/src/components/block-popover/index.js
+++ b/packages/block-editor/src/components/block-popover/index.js
@@ -20,7 +20,7 @@ import {
  */
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import usePopoverScroll from './use-popover-scroll';
-import { rectUnion, getVisibleElementBounds } from '../../utils/dom';
+import { rectUnion, getElementBounds } from '../../utils/dom';
 
 const MAX_POPOVER_RECOMPUTE_COUNTER = Number.MAX_SAFE_INTEGER;
 
@@ -90,10 +90,10 @@ function BlockPopover(
 			getBoundingClientRect() {
 				return lastSelectedElement
 					? rectUnion(
-							getVisibleElementBounds( selectedElement ),
-							getVisibleElementBounds( lastSelectedElement )
+							getElementBounds( selectedElement ),
+							getElementBounds( lastSelectedElement )
 					  )
-					: getVisibleElementBounds( selectedElement );
+					: getElementBounds( selectedElement );
 			},
 			contextElement: selectedElement,
 		};

--- a/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
+++ b/packages/block-editor/src/components/block-tools/use-block-toolbar-popover-props.js
@@ -17,7 +17,7 @@ import {
 import { store as blockEditorStore } from '../../store';
 import { useBlockElement } from '../block-list/use-block-props/use-block-refs';
 import { hasStickyOrFixedPositionValue } from '../../hooks/position';
-import { getVisibleElementBounds } from '../../utils/dom';
+import { getElementBounds } from '../../utils/dom';
 
 const COMMON_PROPS = {
 	placement: 'top-start',
@@ -68,7 +68,7 @@ function getProps(
 	// Get how far the content area has been scrolled.
 	const scrollTop = scrollContainer?.scrollTop || 0;
 
-	const blockRect = getVisibleElementBounds( selectedBlockElement );
+	const blockRect = getElementBounds( selectedBlockElement );
 	const contentRect = contentElement.getBoundingClientRect();
 
 	// Get the vertical position of top of the visible content area.

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -136,14 +136,12 @@ function isScrollable( element ) {
 
 export const WITH_OVERFLOW_ELEMENT_BLOCKS = [ 'core/navigation' ];
 /**
- * Returns the rect of the element.
+ * Returns the bounding rectangle of an element, with special handling for blocks
+ * that have visible overflowing children (defined in WITH_OVERFLOW_ELEMENT_BLOCKS).
  *
- * Note: the function handles special cases for blocks that contain visible,
- * nested elements that overflow the block, e.g. the Navigation block,
- * which can have overflowing submenu blocks. Such blocks are defined in
- * `WITH_OVERFLOW_ELEMENT_BLOCKS`. For such blocks,
- * the bounds of the visible children are calculated to determine
- * the full extent of the block including the visible children that overflow the parent.
+ * For blocks like Navigation that can have overflowing elements (e.g. submenus),
+ * this function calculates the combined bounds of both the parent and its visible
+ * children. The returned rect may extend beyond the viewport.
  * The returned rect represents the full extent of the element and its visible
  * children, which may extend beyond the viewport.
  *
@@ -161,9 +159,8 @@ export function getElementBounds( element ) {
 	const dataType = element.getAttribute( 'data-type' );
 
 	/*
-	 * Handle special cases for blocks that have overflow elements.
-	 * The bounds of the visible children are calculated to determine the full extent of the block
-	 * including the visible children that overflow the parent.
+	 * For blocks with overflowing elements (like Navigation), include the bounds
+	 * of visible children that extend beyond the parent container.
 	 */
 	if ( dataType && WITH_OVERFLOW_ELEMENT_BLOCKS.includes( dataType ) ) {
 		const stack = [ element ];

--- a/packages/block-editor/src/utils/dom.js
+++ b/packages/block-editor/src/utils/dom.js
@@ -134,23 +134,23 @@ function isScrollable( element ) {
 	);
 }
 
+export const WITH_OVERFLOW_ELEMENT_BLOCKS = [ 'core/navigation' ];
 /**
- * Returns the rect of the element including all visible nested elements.
+ * Returns the rect of the element.
  *
- * Visible nested elements, including elements that overflow the parent, are
- * taken into account.
- *
- * This function is useful for calculating the visible area of a block that
- * contains nested elements that overflow the block, e.g. the Navigation block,
- * which can contain overflowing Submenu blocks.
- *
+ * Note: the function handles special cases for blocks that contain visible,
+ * nested elements that overflow the block, e.g. the Navigation block,
+ * which can have overflowing submenu blocks. Such blocks are defined in
+ * `WITH_OVERFLOW_ELEMENT_BLOCKS`. For such blocks,
+ * the bounds of the visible children are calculated to determine
+ * the full extent of the block including the visible children that overflow the parent.
  * The returned rect represents the full extent of the element and its visible
  * children, which may extend beyond the viewport.
  *
  * @param {Element} element Element.
  * @return {DOMRect} Bounding client rect of the element and its visible children.
  */
-export function getVisibleElementBounds( element ) {
+export function getElementBounds( element ) {
 	const viewport = element.ownerDocument.defaultView;
 
 	if ( ! viewport ) {
@@ -158,17 +158,26 @@ export function getVisibleElementBounds( element ) {
 	}
 
 	let bounds = element.getBoundingClientRect();
-	const stack = [ element ];
-	let currentElement;
+	const dataType = element.getAttribute( 'data-type' );
 
-	while ( ( currentElement = stack.pop() ) ) {
-		// Children won’t affect bounds unless the element is not scrollable.
-		if ( ! isScrollable( currentElement ) ) {
-			for ( const child of currentElement.children ) {
-				if ( isElementVisible( child ) ) {
-					const childBounds = child.getBoundingClientRect();
-					bounds = rectUnion( bounds, childBounds );
-					stack.push( child );
+	/*
+	 * Handle special cases for blocks that have overflow elements.
+	 * The bounds of the visible children are calculated to determine the full extent of the block
+	 * including the visible children that overflow the parent.
+	 */
+	if ( dataType && WITH_OVERFLOW_ELEMENT_BLOCKS.includes( dataType ) ) {
+		const stack = [ element ];
+		let currentElement;
+
+		while ( ( currentElement = stack.pop() ) ) {
+			// Children won’t affect bounds unless the element is not scrollable.
+			if ( ! isScrollable( currentElement ) ) {
+				for ( const child of currentElement.children ) {
+					if ( isElementVisible( child ) ) {
+						const childBounds = child.getBoundingClientRect();
+						bounds = rectUnion( bounds, childBounds );
+						stack.push( child );
+					}
 				}
 			}
 		}

--- a/packages/block-editor/src/utils/test/dom.js
+++ b/packages/block-editor/src/utils/test/dom.js
@@ -39,45 +39,28 @@ describe( 'dom', () => {
 				new window.DOMRectReadOnly( 0, 0, 100, 100 )
 			);
 		} );
-		it( 'should return the child DOMRectReadOnly object if it is visible', () => {
+		it( 'should clip left and right values when an element is larger than the viewport width', () => {
 			const element = window.document.createElement( 'div' );
 			element.getBoundingClientRect = jest.fn().mockReturnValue( {
-				left: 0,
+				left: -10,
 				top: 0,
-				right: 100,
+				right: window.innerWidth + 10,
 				bottom: 100,
-				width: 100,
+				width: window.innerWidth,
 				height: 100,
 			} );
-			element.setAttribute(
-				'data-type',
-				WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
-			);
-			const childElement = window.document.createElement( 'div' );
-			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
-				left: 0,
-				top: 0,
-				right: 333,
-				bottom: 333,
-				width: 333,
-				height: 333,
-				x: 0,
-				y: 0,
-			} );
-			element.appendChild( childElement );
-
 			expect( getElementBounds( element ).toJSON() ).toEqual( {
-				left: 0,
+				left: 0, // Reset to min left bound.
 				top: 0,
-				right: 333,
-				bottom: 333,
-				width: 333,
-				height: 333,
+				right: window.innerWidth, // Reset to max right bound.
+				bottom: 100,
+				width: window.innerWidth,
+				height: 100,
 				x: 0,
 				y: 0,
 			} );
 		} );
-		it( 'should return the parent DOMRectReadOnly object if the child block type is not supported', () => {
+		it( 'should return the parent DOMRectReadOnly object if the parent block type is not supported', () => {
 			const element = window.document.createElement( 'div' );
 			element.getBoundingClientRect = jest.fn().mockReturnValue( {
 				left: 0,
@@ -112,83 +95,129 @@ describe( 'dom', () => {
 				y: 0,
 			} );
 		} );
-		it( 'should return the parent DOMRectReadOnly object if the child element is not visible', () => {
-			const element = window.document.createElement( 'div' );
-			element.getBoundingClientRect = jest.fn().mockReturnValue( {
-				left: 0,
-				top: 0,
-				right: 100,
-				bottom: 100,
-				width: 100,
-				height: 100,
-			} );
-			element.setAttribute(
-				'data-type',
-				WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
-			);
-			const childElement = window.document.createElement( 'div' );
-			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
-				left: 0,
-				top: 0,
-				right: 333,
-				bottom: 333,
-				width: 333,
-				height: 333,
-				x: 0,
-				y: 0,
-			} );
-			childElement.style.display = 'none';
-			element.appendChild( childElement );
+		describe( 'With known block type', () => {
+			it( 'should return the child DOMRectReadOnly object if it is visible and a known block type', () => {
+				const element = window.document.createElement( 'div' );
+				element.getBoundingClientRect = jest.fn().mockReturnValue( {
+					left: 0,
+					top: 0,
+					right: 100,
+					bottom: 100,
+					width: 100,
+					height: 100,
+				} );
+				element.setAttribute(
+					'data-type',
+					WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
+				);
+				const childElement = window.document.createElement( 'div' );
+				childElement.getBoundingClientRect = jest
+					.fn()
+					.mockReturnValue( {
+						left: 0,
+						top: 0,
+						right: 333,
+						bottom: 333,
+						width: 333,
+						height: 333,
+						x: 0,
+						y: 0,
+					} );
+				element.appendChild( childElement );
 
-			expect( getElementBounds( element ).toJSON() ).toEqual( {
-				left: 0,
-				top: 0,
-				right: 100,
-				bottom: 100,
-				width: 100,
-				height: 100,
-				x: 0,
-				y: 0,
+				expect( getElementBounds( element ).toJSON() ).toEqual( {
+					left: 0,
+					top: 0,
+					right: 333,
+					bottom: 333,
+					width: 333,
+					height: 333,
+					x: 0,
+					y: 0,
+				} );
 			} );
-		} );
-		it( 'should return the parent DOMRectReadOnly if the child is scrollable', () => {
-			const element = window.document.createElement( 'div' );
-			element.setAttribute(
-				'data-type',
-				WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
-			);
-			element.style.overflowX = 'auto';
-			element.style.overflowY = 'auto';
-			element.getBoundingClientRect = jest.fn().mockReturnValue( {
-				left: 0,
-				top: 0,
-				right: 100,
-				bottom: 100,
-				width: 100,
-				height: 100,
-			} );
-			const childElement = window.document.createElement( 'div' );
-			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
-				left: 0,
-				top: 0,
-				right: 333,
-				bottom: 333,
-				width: 333,
-				height: 333,
-				x: 0,
-				y: 0,
-			} );
-			element.appendChild( childElement );
+			it( 'should return the parent DOMRectReadOnly if the child is scrollable', () => {
+				const element = window.document.createElement( 'div' );
+				element.setAttribute(
+					'data-type',
+					WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
+				);
+				element.style.overflowX = 'auto';
+				element.style.overflowY = 'auto';
+				element.getBoundingClientRect = jest.fn().mockReturnValue( {
+					left: 0,
+					top: 0,
+					right: 100,
+					bottom: 100,
+					width: 100,
+					height: 100,
+				} );
+				const childElement = window.document.createElement( 'div' );
+				childElement.getBoundingClientRect = jest
+					.fn()
+					.mockReturnValue( {
+						left: 0,
+						top: 0,
+						right: 333,
+						bottom: 333,
+						width: 333,
+						height: 333,
+						x: 0,
+						y: 0,
+					} );
+				element.appendChild( childElement );
 
-			expect( getElementBounds( element ).toJSON() ).toEqual( {
-				left: 0,
-				top: 0,
-				right: 100,
-				bottom: 100,
-				width: 100,
-				height: 100,
-				x: 0,
-				y: 0,
+				expect( getElementBounds( element ).toJSON() ).toEqual( {
+					left: 0,
+					top: 0,
+					right: 100,
+					bottom: 100,
+					width: 100,
+					height: 100,
+					x: 0,
+					y: 0,
+				} );
+			} );
+			it( 'should return the parent DOMRectReadOnly object if the child element is not visible', () => {
+				const element = window.document.createElement( 'div' );
+				element.getBoundingClientRect = jest.fn().mockReturnValue( {
+					left: 0,
+					top: 0,
+					right: 100,
+					bottom: 100,
+					width: 100,
+					height: 100,
+				} );
+				element.setAttribute(
+					'data-type',
+					WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
+				);
+				const childElement = window.document.createElement( 'div' );
+				childElement.getBoundingClientRect = jest
+					.fn()
+					.mockReturnValue( {
+						left: 0,
+						top: 0,
+						right: 333,
+						bottom: 333,
+						width: 333,
+						height: 333,
+						x: 0,
+						y: 0,
+					} );
+				childElement.style.display = 'none';
+				element.appendChild( childElement );
+
+				expect( getElementBounds( element ).toJSON() ).toEqual( {
+					left: 0,
+					top: 0,
+					right: 100,
+					bottom: 100,
+					width: 100,
+					height: 100,
+					x: 0,
+					y: 0,
+				} );
 			} );
 		} );
 	} );

--- a/packages/block-editor/src/utils/test/dom.js
+++ b/packages/block-editor/src/utils/test/dom.js
@@ -1,22 +1,9 @@
 /**
  * Internal dependencies
  */
-import { getElementBounds } from '../dom';
-
+import { getElementBounds, WITH_OVERFLOW_ELEMENT_BLOCKS } from '../dom';
 describe( 'dom', () => {
 	describe( 'getElementBounds', () => {
-		const mockIsScrollable = jest.fn();
-		const mockIsElementVisible = jest.fn();
-		const mockRectUnion = jest.fn();
-		jest.mock( '../dom', () => ( {
-			isScrollable: mockIsScrollable,
-			isElementVisible: ( el ) => mockIsElementVisible( el ),
-			rectUnion: ( rect1, rect2 ) => mockRectUnion( rect1, rect2 ),
-		} ) );
-		afterEach( () => {
-			jest.clearAllMocks();
-		} );
-
 		it( 'should return a DOMRectReadOnly object if the viewport is not available', () => {
 			const element = {
 				ownerDocument: {
@@ -51,6 +38,158 @@ describe( 'dom', () => {
 			expect( getElementBounds( element ) ).toEqual(
 				new window.DOMRectReadOnly( 0, 0, 100, 100 )
 			);
+		} );
+		it( 'should return the child DOMRectReadOnly object if it is visible', () => {
+			const element = window.document.createElement( 'div' );
+			element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+			} );
+			element.setAttribute(
+				'data-type',
+				WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
+			);
+			const childElement = window.document.createElement( 'div' );
+			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 333,
+				bottom: 333,
+				width: 333,
+				height: 333,
+				x: 0,
+				y: 0,
+			} );
+			element.appendChild( childElement );
+
+			expect( getElementBounds( element ).toJSON() ).toEqual( {
+				left: 0,
+				top: 0,
+				right: 333,
+				bottom: 333,
+				width: 333,
+				height: 333,
+				x: 0,
+				y: 0,
+			} );
+		} );
+		it( 'should return the parent DOMRectReadOnly object if the child block type is not supported', () => {
+			const element = window.document.createElement( 'div' );
+			element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+			} );
+			element.setAttribute( 'data-type', 'test' );
+			const childElement = window.document.createElement( 'div' );
+			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 333,
+				bottom: 333,
+				width: 333,
+				height: 333,
+				x: 0,
+				y: 0,
+			} );
+			element.appendChild( childElement );
+
+			expect( getElementBounds( element ).toJSON() ).toEqual( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+				x: 0,
+				y: 0,
+			} );
+		} );
+		it( 'should return the parent DOMRectReadOnly object if the child element is not visible', () => {
+			const element = window.document.createElement( 'div' );
+			element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+			} );
+			element.setAttribute(
+				'data-type',
+				WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
+			);
+			const childElement = window.document.createElement( 'div' );
+			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 333,
+				bottom: 333,
+				width: 333,
+				height: 333,
+				x: 0,
+				y: 0,
+			} );
+			childElement.style.display = 'none';
+			element.appendChild( childElement );
+
+			expect( getElementBounds( element ).toJSON() ).toEqual( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+				x: 0,
+				y: 0,
+			} );
+		} );
+		it( 'should return the parent DOMRectReadOnly if the child is scrollable', () => {
+			const element = window.document.createElement( 'div' );
+			element.setAttribute(
+				'data-type',
+				WITH_OVERFLOW_ELEMENT_BLOCKS[ 0 ]
+			);
+			element.style.overflowX = 'auto';
+			element.style.overflowY = 'auto';
+			element.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+			} );
+			const childElement = window.document.createElement( 'div' );
+			childElement.getBoundingClientRect = jest.fn().mockReturnValue( {
+				left: 0,
+				top: 0,
+				right: 333,
+				bottom: 333,
+				width: 333,
+				height: 333,
+				x: 0,
+				y: 0,
+			} );
+			element.appendChild( childElement );
+
+			expect( getElementBounds( element ).toJSON() ).toEqual( {
+				left: 0,
+				top: 0,
+				right: 100,
+				bottom: 100,
+				width: 100,
+				height: 100,
+				x: 0,
+				y: 0,
+			} );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/utils/test/dom.js
+++ b/packages/block-editor/src/utils/test/dom.js
@@ -1,0 +1,56 @@
+/**
+ * Internal dependencies
+ */
+import { getElementBounds } from '../dom';
+
+describe( 'dom', () => {
+	describe( 'getElementBounds', () => {
+		const mockIsScrollable = jest.fn();
+		const mockIsElementVisible = jest.fn();
+		const mockRectUnion = jest.fn();
+		jest.mock( '../dom', () => ( {
+			isScrollable: mockIsScrollable,
+			isElementVisible: ( el ) => mockIsElementVisible( el ),
+			rectUnion: ( rect1, rect2 ) => mockRectUnion( rect1, rect2 ),
+		} ) );
+		afterEach( () => {
+			jest.clearAllMocks();
+		} );
+
+		it( 'should return a DOMRectReadOnly object if the viewport is not available', () => {
+			const element = {
+				ownerDocument: {
+					defaultView: null,
+				},
+			};
+			expect( getElementBounds( element ) ).toEqual(
+				new window.DOMRectReadOnly()
+			);
+		} );
+		it( 'should return a DOMRectReadOnly object if the viewport is available', () => {
+			const element = {
+				ownerDocument: {
+					defaultView: {
+						getComputedStyle: () => ( {
+							display: 'block',
+							visibility: 'visible',
+							opacity: '1',
+						} ),
+					},
+				},
+				getBoundingClientRect: () => ( {
+					left: 0,
+					top: 0,
+					right: 100,
+					bottom: 100,
+					width: 100,
+					height: 100,
+				} ),
+				getAttribute: ( x ) => x,
+			};
+			expect( getElementBounds( element ) ).toEqual(
+				new window.DOMRectReadOnly( 0, 0, 100, 100 )
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/66438

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Refactor `getVisibleElementBounds` to only check visible children for specific blocks that we know overflow. Rename function and update comments. Introduce rudimentary unit tests.

Props to @t-hamano and @stokesman for the ideas and testing.

## Why?

The positioning logic was rolled out to the general block population in https://github.com/WordPress/gutenberg/pull/62711 when the only use case was the navigation block. This hasn't changed.

See discussion: https://github.com/WordPress/gutenberg/issues/66438#issuecomment-2453282333

## How?
Implementing ideas discussed in https://github.com/WordPress/gutenberg/issues/66438#issuecomment-2452980588

## Testing Instructions

### Navigation block

1. Install and activate Emptytheme, or use the Create Block Theme plugin to create a new empty theme.
2. Go to Appearance → Editor and edit the default template.
3. Insert a Navigation block into the first position in the header template part.
4. Edit the Navigation block and add a submenu to one of the navigation items.
5. Try to edit the submenu. The block toolbar should not obscure your cursor.

### Scrollable block toolbars

Follow the nice and detailed instructions on https://github.com/WordPress/gutenberg/issues/66112

TL;DR

1. Edit a post, open dev tools and paste in the snippet from the issue to create some test blocks that scroll
2. Add the test blocks to a long post with several paragraphs
3. Select each of the horizontal and vertical scrolling blocks and confirm their toolbar stays in the correct location
4. Scroll down the page and ensure their toolbars disappear correctly as the block leaves the viewport

### Block Popovers and Visualizers

1. Edit a post and add blocks that have a block popover e.g. Cover block with its resizable popover
2. Add some blocks that support spacing visualizers e.g. Group block with padding and margin support
3. Confirm that the visualizers and popovers display appropriately (visualizers have some problems on trunk not matching the controls value immediately so ignore them)


`npm run test:unit packages/block-editor/src/utils/test/dom.js`

Test coverage is basic so far, just for sanity checking purposes.
