### PR TITLE
Split view with meta boxes even with legacy canvas

### DIFF
--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
@@ -38,7 +33,6 @@ export function ExperimentalBlockCanvas( {
 	styles,
 	contentRef: contentRefProp,
 	iframeProps,
-	enableScroll,
 } ) {
 	useBlockCommands();
 	const isTabletViewport = useViewportMatch( 'medium', '<' );
@@ -57,16 +51,12 @@ export function ExperimentalBlockCanvas( {
 					frameSize: '40px',
 			  }
 			: {};
-	const className = clsx(
-		'block-editor-block-canvas',
-		enableScroll && 'is-scrollable'
-	);
 
 	if ( ! shouldIframe ) {
 		return (
 			<BlockTools
 				__unstableContentRef={ localRef }
-				className={ className }
+				className="block-editor-block-canvas"
 				style={ { height } }
 			>
 				<EditorStyles
@@ -88,7 +78,7 @@ export function ExperimentalBlockCanvas( {
 	return (
 		<BlockTools
 			__unstableContentRef={ localRef }
-			className={ className }
+			className="block-editor-block-canvas"
 			style={ { height, display: 'flex' } }
 		>
 			<Iframe

--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { useMergeRefs, useViewportMatch } from '@wordpress/compose';
@@ -33,6 +38,7 @@ export function ExperimentalBlockCanvas( {
 	styles,
 	contentRef: contentRefProp,
 	iframeProps,
+	enableScroll,
 } ) {
 	useBlockCommands();
 	const isTabletViewport = useViewportMatch( 'medium', '<' );
@@ -51,12 +57,17 @@ export function ExperimentalBlockCanvas( {
 					frameSize: '40px',
 			  }
 			: {};
+	const className = clsx(
+		'block-editor-block-canvas',
+		enableScroll && 'is-scrollable'
+	);
 
 	if ( ! shouldIframe ) {
 		return (
 			<BlockTools
 				__unstableContentRef={ localRef }
-				style={ { height, display: 'flex' } }
+				className={ className }
+				style={ { height } }
 			>
 				<EditorStyles
 					styles={ styles }
@@ -67,10 +78,6 @@ export function ExperimentalBlockCanvas( {
 					ref={ contentRef }
 					className="editor-styles-wrapper"
 					tabIndex={ -1 }
-					style={ {
-						height: '100%',
-						width: '100%',
-					} }
 				>
 					{ children }
 				</WritingFlow>
@@ -81,6 +88,7 @@ export function ExperimentalBlockCanvas( {
 	return (
 		<BlockTools
 			__unstableContentRef={ localRef }
+			className={ className }
 			style={ { height, display: 'flex' } }
 		>
 			<Iframe

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -1,3 +1,25 @@
+.block-editor-block-canvas.is-scrollable {
+	overflow: auto;
+
+	// Applicable only when legacy (non-iframed).
+	> .block-editor-writing-flow {
+		display: flow-root;
+		min-height: 100%;
+		box-sizing: border-box;
+	}
+
+	// Applicable only when iframed.
+	> .block-editor-iframe__container {
+		display: flex;
+		flex-direction: column;
+
+		> .block-editor-iframe__scale-container {
+			flex: 1 0 fit-content;
+			display: flow-root;
+		}
+	}
+}
+
 iframe[name="editor-canvas"] {
 	box-sizing: border-box;
 	width: 100%;

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -1,25 +1,3 @@
-.block-editor-block-canvas.is-scrollable {
-	overflow: auto;
-
-	// Applicable only when legacy (non-iframed).
-	> .block-editor-writing-flow {
-		display: flow-root;
-		min-height: 100%;
-		box-sizing: border-box;
-	}
-
-	// Applicable only when iframed.
-	> .block-editor-iframe__container {
-		display: flex;
-		flex-direction: column;
-
-		> .block-editor-iframe__scale-container {
-			flex: 1 0 fit-content;
-			display: flow-root;
-		}
-	}
-}
-
 iframe[name="editor-canvas"] {
 	box-sizing: border-box;
 	width: 100%;

--- a/packages/block-editor/src/components/use-resize-canvas/index.js
+++ b/packages/block-editor/src/components/use-resize-canvas/index.js
@@ -60,7 +60,7 @@ export default function useResizeCanvas( deviceType ) {
 					marginLeft: marginHorizontal,
 					marginRight: marginHorizontal,
 					height,
-					overflowY: 'auto',
+					maxWidth: '100%',
 				};
 			default:
 				return {

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -148,11 +148,7 @@ function useEditorStyles( ...additionalStyles ) {
 	] );
 }
 
-/**
- * @param {Object}  props
- * @param {boolean} props.isLegacy True when the editor canvas is not in an iframe.
- */
-function MetaBoxesMain( { isLegacy } ) {
+function MetaBoxesMain() {
 	const [ isOpen, openHeight, hasAnyVisible ] = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const { isMetaBoxLocationVisible } = select( editPostStore );
@@ -232,21 +228,14 @@ function MetaBoxesMain( { isLegacy } ) {
 
 	const contents = (
 		<div
-			className={ clsx(
-				// The class name 'edit-post-layout__metaboxes' is retained because some plugins use it.
-				'edit-post-layout__metaboxes',
-				! isLegacy && 'edit-post-meta-boxes-main__liner'
-			) }
-			hidden={ ! isLegacy && isShort && ! isOpen }
+			// The class name 'edit-post-layout__metaboxes' is retained because some plugins use it.
+			className="edit-post-layout__metaboxes edit-post-meta-boxes-main__liner"
+			hidden={ isShort && ! isOpen }
 		>
 			<MetaBoxes location="normal" />
 			<MetaBoxes location="advanced" />
 		</div>
 	);
-
-	if ( isLegacy ) {
-		return contents;
-	}
 
 	const isAutoHeight = openHeight === undefined;
 	let usedMax = '50%'; // Approximation before max has a value.
@@ -580,9 +569,7 @@ function Layout( {
 						}
 						extraContent={
 							! isDistractionFree &&
-							showMetaBoxes && (
-								<MetaBoxesMain isLegacy={ ! shouldIframe } />
-							)
+							showMetaBoxes && <MetaBoxesMain />
 						}
 					>
 						<PostLockedModal />

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -112,17 +112,6 @@
 
 	&:not(.is-iframed) {
 		overflow: hidden;
-
-		.editor-resizable-editor {
-			height: auto !important; // TODO: double-check this isn’t problematic or whether it can be obviated with code change to visual-editor.
-			display: flex;
-			flex-direction: column;
-		}
-
-		.editor-resizable-editor > * {
-			flex: 1 1 100%;
-			overflow: auto;
-		}
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -108,9 +108,21 @@
 
 .has-metaboxes .editor-visual-editor {
 	flex: 1;
+	isolation: isolate;
 
-	&.is-iframed {
-		isolation: isolate;
+	&:not(.is-iframed) {
+		overflow: hidden;
+
+		.editor-resizable-editor {
+			height: auto !important; // TODO: double-check this isn’t problematic or whether it can be obviated with code change to visual-editor.
+			display: flex;
+			flex-direction: column;
+		}
+
+		.editor-resizable-editor > * {
+			flex: 1 1 100%;
+			overflow: auto;
+		}
 	}
 }
 

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -107,12 +107,9 @@
 }
 
 .has-metaboxes .editor-visual-editor {
-	flex: 1;
+	// Contains z-indexes of children so that the block toolbar will appear behind
+	// the drop shadow of the meta box pane.
 	isolation: isolate;
-
-	&:not(.is-iframed) {
-		overflow: hidden;
-	}
 }
 
 // Adjust the position of the notices

--- a/packages/editor/src/components/editor-interface/style.scss
+++ b/packages/editor/src/components/editor-interface/style.scss
@@ -8,5 +8,6 @@
 }
 
 .editor-visual-editor {
-	flex: 1 0 auto;
+	// Fits the height to the parent — flex-shrink ensures it doesn’t create overflow.
+	flex: 1 1 0%;
 }

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -406,6 +406,7 @@ function VisualEditor( {
 							...deviceStyles,
 						},
 					} }
+					enableScroll={ deviceType !== 'Desktop' || disableIframe }
 				>
 					{ themeSupportsLayout &&
 						! themeHasDisabledLayoutStyles &&

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -385,6 +385,7 @@ function VisualEditor( {
 					'has-padding': isFocusedEntity || enableResizing,
 					'is-resizable': enableResizing,
 					'is-iframed': ! disableIframe,
+					'is-scrollable': disableIframe || deviceType !== 'Desktop',
 				}
 			) }
 		>
@@ -406,9 +407,6 @@ function VisualEditor( {
 							...deviceStyles,
 						},
 					} }
-					// When there’s no iframe the canvas is the scrolling context and with the
-					// iframe, device previews may overflow vertically.
-					enableScroll={ disableIframe || deviceType !== 'Desktop' }
 				>
 					{ themeSupportsLayout &&
 						! themeHasDisabledLayoutStyles &&

--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -406,7 +406,9 @@ function VisualEditor( {
 							...deviceStyles,
 						},
 					} }
-					enableScroll={ deviceType !== 'Desktop' || disableIframe }
+					// When there’s no iframe the canvas is the scrolling context and with the
+					// iframe, device previews may overflow vertically.
+					enableScroll={ disableIframe || deviceType !== 'Desktop' }
 				>
 					{ themeSupportsLayout &&
 						! themeHasDisabledLayoutStyles &&

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -2,6 +2,9 @@
 	position: relative;
 	display: flex;
 	background-color: $gray-300;
+	// Allows the height to fit the parent container and avoids parent scrolling contexts from
+	// having overflow due to popovers of block tools.
+	overflow: hidden;
 
 	// Centralize the editor horizontally (flex-direction is column).
 	align-items: center;
@@ -12,12 +15,6 @@
 
 	&.has-padding {
 		padding: $grid-unit-30 $grid-unit-30 0;
-	}
-
-	// In the iframed canvas this keeps extra scrollbars from appearing (when block toolbars overflow). In the
-	// legacy (non-iframed) canvas, overflow must not be hidden in order to maintain support for sticky positioning.
-	&.is-iframed {
-		overflow: hidden;
 	}
 
 	// The button element easily inherits styles that are meant for the editor style.

--- a/packages/editor/src/components/visual-editor/style.scss
+++ b/packages/editor/src/components/visual-editor/style.scss
@@ -30,4 +30,30 @@
 			padding: 6px;
 		}
 	}
+
+	// The cases for this are non-iframed editor canvas or previewing devices. The block canvas is
+	// made the scrolling context.
+	&.is-scrollable .block-editor-block-canvas {
+		overflow: auto;
+
+		// Applicable only when legacy (non-iframed).
+		> .block-editor-writing-flow {
+			display: flow-root;
+			min-height: 100%;
+			box-sizing: border-box; // Ensures that 100% min-height doesn’t create overflow.
+		}
+
+		// Applicable only when iframed. These styles ensure that if the the iframe is
+		// given a fixed height and it’s taller than the viewport then scrolling is
+		// allowed. This is needed for device previews.
+		> .block-editor-iframe__container {
+			display: flex;
+			flex-direction: column;
+
+			> .block-editor-iframe__scale-container {
+				flex: 1 0 fit-content;
+				display: flow-root;
+			}
+		}
+	}
 }


### PR DESCRIPTION
## What?
Brings the split view introduced in #64351 to the non-iframed canvas.

## Why?
The split view seems like a better UX since the meta boxes can be accessed without having to scroll the entire canvas. Also fixes the issues with device previews being obscured by the meta box pane—fixes #66629 (Though, a more minimal fix for 6.7 is in #66726).

Additionally:
- Incidentally, editor notices are made consistent whether or not the canvas is iframed (currently they scroll with the canvas content when not iframed but remain fixed at the top when iframed).
- Avoids unnecessary overflow in classic/hybrid themes (this is actually unrelated and may be better split off from this PR).

## How?
- Removes the condition/branching that omitted the split view when the canvas is not iframed
- Makes the private `BlockCanvas` conditionally a scrolling context with `VisualEditor` specifying it as needed:
  - With device previews because they need to be scrollable if their height is greater than the available height for the canvas
  - When the canvas is not iframed because in case meta boxes are present the scrolling area can’t be an ancestor of both—the canvas and the meta box area have to scroll independently

## Testing Instructions
These are not step-by-step but are all the things I’ve thought to test while working on this. Each one includes a screen recording to demonstrate what to test but are partial to either the iframe or non-iframe contexts. Testing should be done in both contexts and also with or without meta boxes present.

### Device preview overflow
<details><summary>With a viewport short enough so the height of the device preview does not fit the outer scrolling area should be active and include/show the bottom margin of the canvas when fully scrolled. With meta boxes present this should still be the case both when the split view is resizable or when the viewport height is less than 550 pixels and the meta box pane expands/collapses (there’s no resizable separator).</summary>

https://github.com/user-attachments/assets/010e169c-bca0-41d1-b152-95058da9a102

</details>

### Focused edit mode

<details><summary>The canvas should shrink to fit the content without overflow and become scrollable only when the content is taller than the available height for the canvas.</summary>

https://github.com/user-attachments/assets/349d7a16-ead5-4546-841a-30186d191569

</details>

### Sticky positioning

<details><summary>Sticky positioning should work as expected</summary>

https://github.com/user-attachments/assets/40d019d0-647c-4f34-8862-f23f2430f892

</details>

### Meta box toggle pane auto height

<details><summary>When the viewport height is less than 550 pixels the meta box pane should only be as tall as it needs to be to fit its content. Collapsing the pane should hide everything but the pane’s toggle button. When expanded and with overflow the toggle button should be remain visible even when the content is scrolled. With editor notices present the available height for the pane should be reduced and should not cause any extra scrollbars to appear.</summary>

https://github.com/user-attachments/assets/bcdfdbaf-fc31-4f8c-86af-69eada1906be

</details>

### Meta box resizable pane

<details><summary>The pane should be resizable from zero height to full height. While resizing the canvas should be scrollable as needed and cause no extra scrolling areas.</summary>

https://github.com/user-attachments/assets/8a1d1d83-5d18-4934-89ed-c041a20de44c

</details>

### Overflow of block toolbar

<details><summary>For all combinations of iframed/non-iframed with or without meta boxes having the block toolbar below the fold should not cause extra scrolling areas.</summary>

https://github.com/user-attachments/assets/1ff9c3a2-e7ef-4a09-a5c4-ee22a2febc27

</details>

### Editor notices

<details><summary>With notices present there should be no extra scrollbars. Now whether the canvas is iframed or not notices should push/shrink the canvas and be present above it whether or not the canvas is scrolled.</summary>

https://github.com/user-attachments/assets/cba1f599-aa9b-46b4-be89-9d6b3e14c356

</details>

### Testing Instructions for Keyboard
Test that no keyboarding changes have been introduced in any of the above scenarios.

## Screenshots or screencast <!-- if applicable -->
Each testing sub-section above has a screen recording demonstration.