### PR TITLE
Pullquote block having design issue when text-decoration is choosen strikethrough

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -72,4 +72,5 @@
 
 .wp-block-pullquote cite {
 	color: inherit;
+	display: block;
 }


### PR DESCRIPTION
## What?
Pullquote block's cite tag has design issues when the block editor selects the text decoration. Block editor adds display block property so text decoration line-through works fine in editor and only breaks on frontend.

## Why?
Fixes: #66533 

## How?
PR adds a display property on `cite` tag to fix the issue. 

## Testing Instructions
1. Take Pullquote block.
2. Add some text
3. Choose text-ecoration line-through;
4. Now check in editor and front both side.

## Screenshots or screencast
### Before
<img width="763" alt="Screenshot 2024-11-04 at 1 46 21 PM" src="https://github.com/user-attachments/assets/98574da5-1e5b-41b4-9681-5761a2e8d6a8">

### After
<img width="734" alt="Screenshot 2024-11-04 at 1 46 49 PM" src="https://github.com/user-attachments/assets/20fc5643-59de-4d60-bf7f-521aa16aa146">


