### PR TITLE
Fix navigate to entity crash in Post Editor for 6.7

### DIFF
--- a/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
@@ -5,6 +5,7 @@ import { useCallback, useReducer } from '@wordpress/element';
 import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { store as coreStore } from '@wordpress/core-data';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * A hook that records the 'entity' history in the post editor as a user
@@ -56,9 +57,22 @@ export default function useNavigateToEntityRecord(
 
 	const onNavigateToEntityRecord = useCallback(
 		async ( params ) => {
-			await registry
-				.resolveSelect( coreStore )
-				.getPostType( params.postType );
+			try {
+				await registry
+					.resolveSelect( coreStore )
+					.getPostType( params.postType );
+			} catch ( err ) {
+				throw new Error(
+					sprintf(
+						// translators: %s: the name of a post type.
+						__( `Unable to fetch post type "%s" from API.` ),
+						params.postType
+					),
+					{
+						cause: err,
+					}
+				);
+			}
 			dispatch( {
 				type: 'push',
 				post: { postId: params.postId, postType: params.postType },

--- a/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
@@ -2,8 +2,9 @@
  * WordPress dependencies
  */
 import { useCallback, useReducer } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, useRegistry } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * A hook that records the 'entity' history in the post editor as a user
@@ -25,6 +26,8 @@ export default function useNavigateToEntityRecord(
 	initialPostType,
 	defaultRenderingMode
 ) {
+	const registry = useRegistry();
+
 	const [ postHistory, dispatch ] = useReducer(
 		( historyState, { type, post, previousRenderingMode } ) => {
 			if ( type === 'push' ) {
@@ -52,7 +55,10 @@ export default function useNavigateToEntityRecord(
 	const { setRenderingMode } = useDispatch( editorStore );
 
 	const onNavigateToEntityRecord = useCallback(
-		( params ) => {
+		async ( params ) => {
+			await registry
+				.resolveSelect( coreStore )
+				.getPostType( params.postType );
 			dispatch( {
 				type: 'push',
 				post: { postId: params.postId, postType: params.postType },
@@ -61,7 +67,7 @@ export default function useNavigateToEntityRecord(
 			} );
 			setRenderingMode( defaultRenderingMode );
 		},
-		[ getRenderingMode, setRenderingMode, defaultRenderingMode ]
+		[ registry, getRenderingMode, setRenderingMode, defaultRenderingMode ]
 	);
 
 	const onNavigateToPreviousEntityRecord = useCallback( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Resolves error when programmatically navigating to a custom post type in the _Post_ Editor.



Fixes https://github.com/WordPress/gutenberg/issues/64814

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- The Issue occurs in 6.6 (i.e. pre-6.7)
- The Issue was [fixed in 19.3](https://github.com/WordPress/gutenberg/pull/65062) and thus was included in WP 6.7
- The Issue reappeared due to [this PR](https://github.com/WordPress/gutenberg/pull/66101) which was backported to WP 6.7.
- This wasn’t part of a public API but it was originally working in 6.7 and now has regressed during the cycle.

Some additional context and discussion:

- [WP Slack](https://wordpress.slack.com/archives/C02QB2JS7/p1730716167643939?thread_ts=1730712757.355869&cid=C02QB2JS7) (requires sign up)
- [the Issue](https://github.com/WordPress/gutenberg/issues/64814)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Ensures all post types are loaded in the Post Editor before dispatching the request to navigate to that post type.

We load "on demand" to avoid performance overhead of loading all post types in the Post Editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->



- Follow instructions from https://github.com/WordPress/gutenberg/issues/64814#issuecomment-2453396426. To make this slightly easier you can use [this Playground instance](https://playground.wordpress.net/?blueprint-url=https%3A%2F%2Fraw.githubusercontent.com%2FTropicalista%2Fnavigate-to-entity%2Frefs%2Fheads%2Fmaster%2Fplayground%2Fblueprint.json&php=8.0&wp=beta&networking=yes&language=&multisite=no&random=95nmouu9r7i&gutenberg-pr=66709).
- On `wp/6.7` there will be an error in the console
- On this PR there will be no error

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
