### PR TITLE
Fix: Navigate to entity breaks when `postType` is not loaded

### DIFF
--- a/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
@@ -3,7 +3,7 @@
  */
 import { useCallback, useReducer } from '@wordpress/element';
 import { store as coreStore } from '@wordpress/core-data';
-import { resolveSelect, useSelect, useDispatch } from '@wordpress/data';
+import { useRegistry, useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -51,10 +51,13 @@ export default function useNavigateToEntityRecord(
 
 	const { getRenderingMode } = useSelect( editorStore );
 	const { setRenderingMode } = useDispatch( editorStore );
+	const registry = useRegistry();
 
 	const onNavigateToEntityRecord = useCallback(
 		async ( params ) => {
-			await resolveSelect( coreStore ).getPostType( params.postType );
+			await registry
+				.resolveSelect( coreStore )
+				.getPostType( params.postType );
 			dispatch( {
 				type: 'push',
 				post: { postId: params.postId, postType: params.postType },
@@ -63,12 +66,7 @@ export default function useNavigateToEntityRecord(
 			} );
 			setRenderingMode( defaultRenderingMode );
 		},
-		[
-			resolveSelect,
-			getRenderingMode,
-			setRenderingMode,
-			defaultRenderingMode,
-		]
+		[ registry, getRenderingMode, setRenderingMode, defaultRenderingMode ]
 	);
 
 	const onNavigateToPreviousEntityRecord = useCallback( () => {

--- a/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
+++ b/packages/edit-post/src/hooks/use-navigate-to-entity-record.js
@@ -2,7 +2,8 @@
  * WordPress dependencies
  */
 import { useCallback, useReducer } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { store as coreStore } from '@wordpress/core-data';
+import { resolveSelect, useSelect, useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
 /**
@@ -52,7 +53,8 @@ export default function useNavigateToEntityRecord(
 	const { setRenderingMode } = useDispatch( editorStore );
 
 	const onNavigateToEntityRecord = useCallback(
-		( params ) => {
+		async ( params ) => {
+			await resolveSelect( coreStore ).getPostType( params.postType );
 			dispatch( {
 				type: 'push',
 				post: { postId: params.postId, postType: params.postType },
@@ -61,7 +63,12 @@ export default function useNavigateToEntityRecord(
 			} );
 			setRenderingMode( defaultRenderingMode );
 		},
-		[ getRenderingMode, setRenderingMode, defaultRenderingMode ]
+		[
+			resolveSelect,
+			getRenderingMode,
+			setRenderingMode,
+			defaultRenderingMode,
+		]
 	);
 
 	const onNavigateToPreviousEntityRecord = useCallback( () => {


### PR DESCRIPTION
## What?
Attemp to fix: https://github.com/WordPress/gutenberg/issues/64814

According to that issue and from different tests, it seems calling `onNavigateToEntityRecord` breaks the editor if the `postType` hasn't loaded yet.

## Why?
It breaks the editor experience.

## How?
As suggested by @getdave [here](https://github.com/WordPress/gutenberg/issues/64814#issuecomment-2454471392), I'm calling `getPostType` with `resolveSelect` just before doing the navigation to ensure it is available.

## Testing Instructions
It should fix the mentioned issue with its reproduction steps.
