### PR TITLE
Appender: fix initial position

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -57,8 +57,7 @@
 	}
 }
 
-// The black plus that shows up on the right side of an empty paragraph block,
-// or the initial appender that exists only on empty documents.
+// The black plus that shows up on the right side of an empty paragraph block.
 .block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter {
 	position: absolute;
 	top: 0;

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -62,6 +62,17 @@
 	}
 }
 
+// The initial appender that exists only on empty documents.
+.block-editor-default-block-appender .block-editor-inserter {
+	position: absolute;
+	top: 0;
+	right: 0;
+	line-height: 0;
+
+	&:disabled {
+		display: none;
+	}
+}
 
 /**
  * Fixed position appender (right bottom corner).


### PR DESCRIPTION
Fixes #66708
Follow up #66630 (See [this comment](https://github.com/WordPress/gutenberg/pull/66630/files#r1825365222):)

## What?

Fixes the position of the "fake" appender that is rendered when the document is empty.

## Why?

As I understand it, the initial appender (`.block-editor-default-block-appender .block-editor-inserter`) is rendered outside the canvas, and the default appender (`.block-editor-block-list__empty-block-inserter.block-editor-block-list__empty-block-inserter`) after clicking on the block is rendered inside the canvas.

I think this is because #66630 removed the CSS related to the initial appender from `content.css`.

## How?

Re-add only the initial appender's CSS to `content.css`. At the same time, improve the comments about the appender.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

- Create a post with empty content.
- Reload your browser.
- Initial appender: should be positioned to the far right.
- Click on an empty paragraph block.
- Default appender: should be positioned to the far right.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![Image](https://github.com/user-attachments/assets/76d64e05-e9a5-49d5-b17b-50cf30e23abb) | ![Image](https://github.com/user-attachments/assets/573a005a-8fd1-47d9-803f-3cc4f499c730)| 
