### PR TITLE
Shadow panel: Make the delete modal text translatable

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -215,8 +215,10 @@ export default function ShadowsEditPanel() {
 					size="medium"
 				>
 					{ sprintf(
-						// translators: %s: name of the shadow
-						'Are you sure you want to delete "%s"?',
+						/* translators: %s: Name of the shadow preset. */
+						__(
+							'Are you sure you want to delete "%s" shadow preset?'
+						),
 						selectedShadow.name
 					) }
 				</ConfirmDialog>


### PR DESCRIPTION
## What?

I noticed that the text inside the modal when removing the custom shadow is not translatable.

## How?

At the same time, we made some small improvements to the text. This should now match the font size presets:

https://github.com/WordPress/gutenberg/blob/b992649af2753e818639fef6e38d34de63474822/packages/edit-site/src/components/global-styles/font-sizes/confirm-delete-font-size-dialog.js#L33-L36

## Testing Instructions

Currently there is no way to ensure this is translated correctly, but at least make sure you can remove the custom shadow.

## Screenshots or screencast <!-- if applicable -->


![image](https://github.com/user-attachments/assets/da1044cd-badc-4940-aad9-69d4faa86427)
