### PR TITLE
URLInput: Fix incorrect classname for suggestions

### DIFF
--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -533,10 +533,9 @@ class URLInput extends Component {
 			<Popover placement="bottom" focusOnMount={ false }>
 				<div
 					{ ...suggestionsListProps }
-					className={ clsx(
-						'block-editor-url-input__suggestions',
-						`${ className }__suggestions`
-					) }
+					className={ clsx( 'block-editor-url-input__suggestions', {
+						[ `${ className }__suggestions` ]: className,
+					} ) }
 				>
 					{ suggestions.map( ( suggestion, index ) => (
 						<Button


### PR DESCRIPTION
## What?

Fixes the invalid 'undefined__suggestions' CSS class that was generated when no `className` prop was passed to the `URLInput` component.

![suggestions](https://github.com/user-attachments/assets/0467f782-7f66-412a-b76a-479756370dd6)

## Why?

We need to check if the class name exists.

## Testing Instructions

It's a little difficult to test the `URLInput` component directly, so please test it with the `ImageURLInputUI` component, which uses it internally.

- Insert an Image block.
- Click the Link button from the block toolbar.
- Type "sa".
- A suggestion will be displayed. Open the browser console and confirm that a class name called `undefined__suggestions` does not exist.

Additionally, make the following changes and test that the class name is applied as before.

```diff
diff --git a/packages/block-editor/src/components/url-popover/link-editor.js b/packages/block-editor/src/components/url-popover/link-editor.js
index e7d39eed76..97b5ed9c34 100644
--- a/packages/block-editor/src/components/url-popover/link-editor.js
+++ b/packages/block-editor/src/components/url-popover/link-editor.js
@@ -31,6 +31,7 @@ export default function LinkEditor( {
                        { ...props }
                >
                        <URLInput
+                               className="test"
                                value={ value }
                                onChange={ onChangeInputValue }
                                autocompleteRef={ autocompleteRef }
```

If you perform the same operation, the suggestion should have the CSS class `test__suggestions` applied.
