### PR TITLE
Remove unnecessary tooltip from Video block Text tracks button.

### DIFF
--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -204,8 +204,6 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<ToolbarGroup>
 					<ToolbarButton
-						label={ __( 'Text tracks' ) }
-						showTooltip
 						aria-expanded={ isOpen }
 						aria-haspopup="true"
 						onClick={ onToggle }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66715

## What?
<!-- In a few words, what is the PR actually doing? -->
The 'Text tracks' button of the Video block renders unnecessary aria-label and tooltip.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Buttons with visible text don't need an aria-label attribute that just repeats the visible text.
Same for the tooltip.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the Button `label` and `showTooltip` props.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a Video block.
- Hover or focus the 'Text tracks' button in the block toolbar.
- Observe the button doesn't show a tooltip any longer.
- Inspect the source and obseve the button dos not have an aria-lable attribute any longer.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
