### PR TITLE
Fix: registerPlugin width issue

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 -   `Snackbar`: Use link variant for action Button ([#66560](https://github.com/WordPress/gutenberg/pull/66560)).
 
+### Bug Fixes
+
+-   `Components`: Fix width issue for sidebar panel ([#66725](https://github.com/WordPress/gutenberg/pull/66725))
+
 ## 28.11.0 (2024-10-30)
 
 ### Deprecations

--- a/packages/components/src/panel/style.scss
+++ b/packages/components/src/panel/style.scss
@@ -154,6 +154,11 @@
 	&:first-of-type {
 		margin-top: 0;
 	}
+
+	.components-base-control {
+		width: 100%;
+	}
+
 }
 
 .components-panel .circle-picker {


### PR DESCRIPTION
## What?
Fix the width issue for custom dropdown meta fields.

## Why?
closes #66724 

## How?
added `100%` width to `components-panel__row` child `components-base-control` class.

## Testing Instructions
1. add this code to `gutenberg.php` file
```php
add_action( 'init', function() {
	register_post_meta( 'post', 'blog_date_info', array(
		'show_in_rest' => true,
		'single' => true,
		'type' => 'string',
		'default' => 'default',
	) );
} );

add_action( 'enqueue_block_editor_assets', function(){
	wp_enqueue_script( 'date-info', plugin_dir_url( __FILE__ ) . 'test.js', array( 'wp-plugins', 'wp-edit-post', 'wp-element', 'wp-components', 'wp-data' ) );
} );
```

2. create `test.js` file in same directory of `gutenberg.php` file and add this build JS code
```js
(()=>{var e={686:()=>{var e=wp.data,t=e.useSelect,a=e.useDispatch,r=wp.components.SelectControl,o=wp.editPost.PluginPostStatusInfo,n=wp.plugins.registerPlugin,__=wp.i18n.__,l=function(){var e=t((function(e){var t=e("core/editor").getEditedPostAttribute("meta");return{blogDateInfo:(null==t?void 0:t.blog_date_info)||"default"}})).blogDateInfo,o=a("core/editor").editPost;return React.createElement(r,{label:__("Display Date Format","rtcamp-features"),value:e,options:[{label:__("Default","rtcamp-features"),value:"default"},{label:__("Last updated on","rtcamp-features"),value:"updated"},{label:__("Published on","rtcamp-features"),value:"published"}],onChange:function(e){o({meta:{blog_date_info:e}})}})};n("blog-date-info-sidebar",{render:function(){return React.createElement(o,null,React.createElement(l,null))},icon:null})}},t={};function a(r){var o=t[r];if(void 0!==o)return o.exports;var n=t[r]={exports:{}};return e[r](n,n.exports,a),n.exports}a.n=e=>{var t=e&&e.__esModule?()=>e.default:()=>e;return a.d(t,{a:t}),t},a.d=(e,t)=>{for(var r in t)a.o(t,r)&&!a.o(e,r)&&Object.defineProperty(e,r,{enumerable:!0,get:t[r]})},a.o=(e,t)=>Object.prototype.hasOwnProperty.call(e,t),(()=>{"use strict";a(686)})()})();

```

3. notice without `width: 100%` on `components-base-control` its cropping text and dropdown component is shrinked


## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| <img width="322" alt="Screenshot 2024-11-04 at 23 31 03" src="https://github.com/user-attachments/assets/8bd3ebd7-a619-472f-83db-984afe907964"> | <img width="322" alt="Screenshot 2024-11-04 at 23 37 40" src="https://github.com/user-attachments/assets/d79648d0-3805-4860-b9a0-89aefb2f89aa"> |

