### PR TITLE
Keep meta boxes in the interface content’s scrolling context for device previews

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -417,6 +417,7 @@ function Layout( {
 		hasHistory,
 		isWelcomeGuideVisible,
 		templateId,
+		isDevicePreview,
 	} = useSelect(
 		( select ) => {
 			const { get } = select( preferencesStore );
@@ -424,6 +425,8 @@ function Layout( {
 				select( editPostStore )
 			);
 			const { canUser, getPostType } = select( coreStore );
+			const { getDeviceType, getEditorMode, getRenderingMode } =
+				select( editorStore );
 
 			const supportsTemplateMode = settings.supportsTemplateMode;
 			const isViewable =
@@ -434,7 +437,7 @@ function Layout( {
 			} );
 
 			return {
-				mode: select( editorStore ).getEditorMode(),
+				mode: getEditorMode(),
 				isFullscreenActive:
 					select( editPostStore ).isFeatureActive( 'fullscreenMode' ),
 				hasActiveMetaboxes: select( editPostStore ).hasMetaBoxes(),
@@ -444,7 +447,7 @@ function Layout( {
 				isDistractionFree: get( 'core', 'distractionFree' ),
 				showMetaBoxes:
 					! DESIGN_POST_TYPES.includes( currentPostType ) &&
-					select( editorStore ).getRenderingMode() === 'post-only',
+					getRenderingMode() === 'post-only',
 				isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 				templateId:
 					supportsTemplateMode &&
@@ -453,6 +456,7 @@ function Layout( {
 					! isEditingTemplate
 						? getEditedPostTemplateId()
 						: null,
+				isDevicePreview: getDeviceType() !== 'Desktop',
 			};
 		},
 		[ currentPostType, isEditingTemplate, settings.supportsTemplateMode ]
@@ -594,7 +598,11 @@ function Layout( {
 						extraContent={
 							! isDistractionFree &&
 							showMetaBoxes && (
-								<MetaBoxesMain isLegacy={ ! shouldIframe } />
+								<MetaBoxesMain
+									isLegacy={
+										! shouldIframe || isDevicePreview
+									}
+								/>
 							)
 						}
 					>

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -106,12 +106,15 @@
 	clear: both;
 }
 
-.has-metaboxes .editor-visual-editor {
-	flex: 1;
+// Only when the split view is active the visual editor should allow shrinking and
+// its main size should be zero.
+.has-metaboxes .interface-interface-skeleton__content:has(.edit-post-meta-boxes-main) .editor-visual-editor {
+	flex-shrink: 1;
+	flex-basis: 0%;
+}
 
-	&.is-iframed {
-		isolation: isolate;
-	}
+.has-metaboxes .editor-visual-editor.is-iframed {
+	isolation: isolate;
 }
 
 // Adjust the position of the notices


### PR DESCRIPTION
## What?
Avoids obscured device previews when meta boxes are present in the Post editor.

## Why?
Fixes #66629 minimally with the solution proposed by Aki from the issue.

## How?
Makes device previews a condition for displaying the meta boxes as they are when the canvas is not iframed and revises styling so there’s a no clipping of the fixed canvas height of device previews. 

## Testing Instructions

### Device previews
1. In the Post editor with meta boxes present
2. Switch to either Tablet/Mobile device preview
3. If your viewport is not short enough that the device preview overflows shorten your browser’s window until it does
4. Verify the entire height of the device preview is scrollable whether or not the meta boxes are collapsed

### Desktop view
Ensure the split view works as before:
1. Resizing still works as expected (can be resized from zero to full height)
2. With a viewport of less than 550 pixels the meta box pane is only as tall as needed to fit its content (collapsing a individual meta boxes should shorten the whole pane given no other meta boxes are expanded or there are so many meta boxes present that even with all collapsed this is inapplicable)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ed5fee0d-e2fe-45a7-baad-8e37a9576b79
