### PR TITLE
Storybook: fix DataViews action modals

### DIFF
--- a/storybook/package-styles/config.js
+++ b/storybook/package-styles/config.js
@@ -55,8 +55,8 @@ const CONFIG = [
 	},
 	{
 		componentIdMatcher: /^dataviews-/,
-		ltr: [ dataviewsLtr, componentsLtr ],
-		rtl: [ dataviewsRtl, componentsRtl ],
+		ltr: [ componentsLtr, dataviewsLtr ],
+		rtl: [ componentsRtl, dataviewsRtl ],
 	},
 ];
 


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/56760#issuecomment-2454087159

## What?

This fixes an issue with DataViews styles in storybook. The more noticeable user-facing issue was action modals not working as expected.

<img width="1322" alt="Screenshot 2024-11-04 at 09 35 26" src="https://github.com/user-attachments/assets/db028c5e-a5f5-4d53-a394-9cb648ce3139">

https://github.com/user-attachments/assets/8e2fe07c-8c70-4efb-81b8-900403e27438

## How?

By fixing the order of styles provided to storybook.

## Testing Instructions

```sh
npm install
npm run storybook:dev
```

Go to DataViews story and verify that the action modal works as expected.
