### PR TITLE
Global styles: resolve block style variation URIs

### DIFF
--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -102,6 +102,7 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	}
 
 	$tree       = WP_Theme_JSON_Resolver_Gutenberg::get_merged_data();
+	$tree       = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $tree );
 	$theme_json = $tree->get_raw_data();
 
 	// Only the first block style variation with data is supported.

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -172,8 +172,8 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	$styles_registry = WP_Block_Styles_Registry::get_instance();
 	$styles_registry->register( $parsed_block['blockName'], array( 'name' => $variation_instance ) );
 
-	$variation_theme_json  = new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
-    $variation_theme_json  = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $variation_theme_json );
+	$variation_theme_json = new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
+	$variation_theme_json = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $variation_theme_json );
 	$variation_styles     = $variation_theme_json->get_stylesheet(
 		array( 'styles' ),
 		array( 'custom' ),

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -172,7 +172,8 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
 	$styles_registry = WP_Block_Styles_Registry::get_instance();
 	$styles_registry->register( $parsed_block['blockName'], array( 'name' => $variation_instance ) );
 
-	$variation_theme_json = new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
+	$variation_theme_json  = new WP_Theme_JSON_Gutenberg( $config, 'blocks' );
+    $variation_theme_json  = WP_Theme_JSON_Resolver_Gutenberg::resolve_theme_file_uris( $variation_theme_json );
 	$variation_styles     = $variation_theme_json->get_stylesheet(
 		array( 'styles' ),
 		array( 'custom' ),

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2799,6 +2799,13 @@ class WP_Theme_JSON_Gutenberg {
 						$nodes[] = array(
 							'path' => array( 'styles', 'blocks', $name, 'variations', $variation ),
 						);
+						if ( isset( $node['blocks'] ) ) {
+							foreach ( $node['blocks'] as $variation_block_name => $node ) {
+								$nodes[] = array(
+									'path' => array( 'styles', 'blocks', $name, 'variations', $variation, 'blocks', $variation_block_name ),
+								);
+							}
+						}
 					}
 				}
 			} else {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2614,16 +2614,13 @@ class WP_Theme_JSON_Gutenberg {
 		$include_node_paths_only = $options['include_node_paths_only'] ?? false;
 
 		// Top-level.
-		if ( $include_node_paths_only ) {
-			$nodes[] = array(
-				'path' => array( 'styles' ),
-			);
-		} else {
-			$nodes[] = array(
-				'path'     => array( 'styles' ),
-				'selector' => static::ROOT_BLOCK_SELECTOR,
-			);
+		$node = array(
+			'path' => array( 'styles' ),
+		);
+		if ( ! $include_node_paths_only ) {
+			$node['selector'] = static::ROOT_BLOCK_SELECTOR;
 		}
+		$nodes[] = $node;
 
 		if ( isset( $theme_json['styles']['elements'] ) ) {
 			foreach ( self::ELEMENTS as $element => $selector ) {
@@ -2632,32 +2629,25 @@ class WP_Theme_JSON_Gutenberg {
 				}
 
 				// Handle element defaults.
-				if ( $include_node_paths_only ) {
-					$nodes[] = array(
-						'path' => array( 'styles', 'elements', $element ),
-					);
-				} else {
-					$nodes[] = array(
-						'path'     => array( 'styles', 'elements', $element ),
-						'selector' => static::ELEMENTS[ $element ],
-					);
+				$node = array(
+					'path' => array( 'styles', 'elements', $element ),
+				);
+				if ( ! $include_node_paths_only ) {
+					$node['selector'] = static::ELEMENTS[ $element ];
 				}
+				$nodes[] = $node;
 
 				// Handle any pseudo selectors for the element.
 				if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] ) ) {
 					foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element ] as $pseudo_selector ) {
-
 						if ( isset( $theme_json['styles']['elements'][ $element ][ $pseudo_selector ] ) ) {
-							if ( $include_node_paths_only ) {
-								$nodes[] = array(
-									'path' => array( 'styles', 'elements', $element, $pseudo_selector ),
-								);
-							} else {
-								$nodes[] = array(
-									'path'     => array( 'styles', 'elements', $element ),
-									'selector' => static::append_to_selector( static::ELEMENTS[ $element ], $pseudo_selector ),
-								);
+							$node = array(
+								'path' => array( 'styles', 'elements', $element ),
+							);
+							if ( ! $include_node_paths_only ) {
+								$node['selector'] = static::append_to_selector( static::ELEMENTS[ $element ], $pseudo_selector );
 							}
+							$nodes[] = $node;
 						}
 					}
 				}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2688,7 +2688,7 @@ class WP_Theme_JSON_Gutenberg {
 	}
 
 	/**
-	 * A public helper to get all styles nodes path in theme.json,
+	 * A public helper to get all style node paths in theme.json,
 	 * including elements and block styles variations. This is useful
 	 * when iterating over all style nodes to search for or replace any values.
 	 *

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1293,6 +1293,15 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							'url' => 'file:./example/img/image.png',
 						),
 					),
+					'elements'   => array(
+						'button' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/button.png',
+								),
+							),
+						),
+					),
 					'blocks'     => array(
 						'core/quote' => array(
 							'background' => array(
@@ -1318,7 +1327,7 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 								'button' => array(
 									'background' => array(
 										'backgroundImage' => array(
-											'url' => 'file:./example/img/button.png',
+											'url' => 'file:./example/img/group-button.png',
 										),
 									),
 								),
@@ -1334,6 +1343,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'name'   => 'file:./example/img/image.png',
 				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/image.png',
 				'target' => 'styles.background.backgroundImage.url',
+				'type'   => 'image/png',
+			),
+			array(
+				'name'   => 'file:./example/img/button.png',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/button.png',
+				'target' => 'styles.elements.button.background.backgroundImage.url',
 				'type'   => 'image/png',
 			),
 			array(
@@ -1355,8 +1370,8 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'type'   => 'image/gif',
 			),
 			array(
-				'name'   => 'file:./example/img/button.png',
-				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/button.png',
+				'name'   => 'file:./example/img/group-button.png',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/group-button.png',
 				'target' => 'styles.blocks.core/group.elements.button.background.backgroundImage.url',
 				'type'   => 'image/png',
 			),

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1405,6 +1405,15 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 							'url' => 'file:./example/img/group-twinky.png',
 						),
 					),
+					'blocks'     => array(
+						'core/group' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/group-fonzis.png',
+								),
+							),
+						),
+					),
 				),
 			)
 		);
@@ -1414,6 +1423,12 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'name'   => 'file:./example/img/group-twinky.png',
 				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/group-twinky.png',
 				'target' => 'styles.blocks.core/group.variations.group-background-twinky.background.backgroundImage.url',
+				'type'   => 'image/png',
+			),
+			array(
+				'name'   => 'file:./example/img/group-fonzis.png',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/group-fonzis.png',
+				'target' => 'styles.blocks.core/group.variations.group-background-twinky.blocks.core/group.background.backgroundImage.url',
 				'type'   => 'image/png',
 			),
 		);

--- a/phpunit/class-wp-theme-json-resolver-test.php
+++ b/phpunit/class-wp-theme-json-resolver-test.php
@@ -1308,6 +1308,22 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 								),
 							),
 						),
+						'core/group' => array(
+							'background' => array(
+								'backgroundImage' => array(
+									'url' => 'file:./example/img/group.gif',
+								),
+							),
+							'elements'   => array(
+								'button' => array(
+									'background' => array(
+										'backgroundImage' => array(
+											'url' => 'file:./example/img/button.png',
+										),
+									),
+								),
+							),
+						),
 					),
 				),
 			)
@@ -1332,6 +1348,18 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 				'target' => 'styles.blocks.core/verse.background.backgroundImage.url',
 				'type'   => 'image/gif',
 			),
+			array(
+				'name'   => 'file:./example/img/group.gif',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/group.gif',
+				'target' => 'styles.blocks.core/group.background.backgroundImage.url',
+				'type'   => 'image/gif',
+			),
+			array(
+				'name'   => 'file:./example/img/button.png',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/button.png',
+				'target' => 'styles.blocks.core/group.elements.button.background.backgroundImage.url',
+				'type'   => 'image/png',
+			),
 		);
 
 		/*
@@ -1348,6 +1376,47 @@ class WP_Theme_JSON_Resolver_Gutenberg_Test extends WP_UnitTestCase {
 		remove_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
 
 		$this->assertSame( $expected_data, $actual );
+	}
+
+	public function test_get_resolved_theme_uris_in_variations() {
+		register_block_style(
+			'core/group',
+			array(
+				'name'       => 'group-background-twinky',
+				'label'      => 'Group block twinky background',
+				'style_data' => array(
+					'background' => array(
+						'backgroundImage' => array(
+							'url' => 'file:./example/img/group-twinky.png',
+						),
+					),
+				),
+			)
+		);
+		$theme_json    = WP_Theme_JSON_Resolver_Gutenberg::get_theme_data();
+		$expected_data = array(
+			array(
+				'name'   => 'file:./example/img/group-twinky.png',
+				'href'   => 'https://example.org/wp-content/themes/example-theme/example/img/group-twinky.png',
+				'target' => 'styles.blocks.core/group.variations.group-background-twinky.background.backgroundImage.url',
+				'type'   => 'image/png',
+			),
+		);
+		/*
+		 * This filter callback normalizes the return value from `get_theme_file_uri`
+		 * to guard against changes in test environments.
+		 * The test suite otherwise returns full system dir path, e.g.,
+		 * /wordpress-phpunit/includes/../data/themedir1/default/example/img/image.png
+		 */
+		$filter_theme_file_uri_callback = function ( $file ) {
+			return 'https://example.org/wp-content/themes/example-theme/example/' . explode( 'example/', $file )[1];
+		};
+		add_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
+		$actual = WP_Theme_JSON_Resolver_Gutenberg::get_resolved_theme_uris( $theme_json );
+		remove_filter( 'theme_file_uri', $filter_theme_file_uri_callback );
+
+		$this->assertSame( $expected_data, $actual );
+		unregister_block_style( 'core/group', 'group-background-twinky' );
 	}
 
 	/**


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->


This PR:

- Introduces a new public helper method `WP_Theme_JSON->get_styles_nodes_paths()` to return the paths for all styles nodes in a theme.json tree including elements and variations.
- Uses this helper method to resolve relative URIs in theme json resolver.

## Why?

This increases support for relative path URI resolution to block style variations and elements. The latter is a side-effect, however the former is necessary because theme developers are able to add relative background images to block style variations. These URIs however do not get resolved.

## How?
By resolving all background urls, regardless of the their location in the styles tree.
Ensuring style variations are resolved in the clientside in `toStyles()`.

## Testing Instructions

Add a few images to your local theme somewhere relative to theme.json.

Now create a new a block style variation theme.json file under `/styles` that includes a background image:

```json
{
	"version": 3,
	"title": "Group pizza variation",
	"slug": "group-pizza-variation",
	"blockTypes": [ "core/group" ],
	"styles": {
		"background": {
			"backgroundImage": {
				"url": "file:./img/pizza1.jpg"
			}
		},
		"blocks": {
			"core/group": {
				"background": {
					"backgroundImage": {
						"url": "file:./img/pizza2.jpg"
					}
				}
			}
		}
	}
}

```

For good measure add a background image to an element style too. This will be in your main theme.json

```json
{
	"version": 3,
	"settings": {
		"appearanceTools": true
	},
	"styles": {
		"elements": {
			"h1": {
				"background": {
					"backgroundImage": {
						"url": "file:./img/pizza3.jpg"
					}
				}
			}
		}
	}
}

```

Ensure that style variations appear in the editor and the frontend. Pay attention to nested variation styles. They should be resolved and work as expected.

```html

<!-- wp:heading {"level":1} -->
<h1 class="wp-block-heading">heading</h1>
<!-- /wp:heading -->

<!-- wp:group {"className":"is-style-block-style-variation-a is-style-group-pizza-variation","layout":{"type":"constrained"}} -->
<div class="wp-block-group is-style-block-style-variation-a is-style-group-pizza-variation"><!-- wp:paragraph -->
<p>Love a good group block.</p>
<!-- /wp:paragraph -->

<!-- wp:group {"layout":{"type":"constrained"}} -->
<div class="wp-block-group"><!-- wp:paragraph -->
<p>Inner block</p>
<!-- /wp:paragraph --></div>
<!-- /wp:group --></div>
<!-- /wp:group -->
```