### PR TITLE
SelectControl: Deprecate 36px default size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Deprecations
 
 -   `Radio`: Deprecate 36px default size ([#66572](https://github.com/WordPress/gutenberg/pull/66572)).
+-   `SelectControl`: Deprecate 36px default size ([#66732](https://github.com/WordPress/gutenberg/pull/66732)).
 
 ### Enhancements
 

--- a/packages/components/src/select-control/README.md
+++ b/packages/components/src/select-control/README.md
@@ -84,6 +84,7 @@ const MySelectControl = () => {
 
 	return (
 		<SelectControl
+			__next40pxDefaultSize
 			label="Size"
 			value={ size }
 			options={ [
@@ -115,6 +116,7 @@ Render a user interface to select multiple users from a list.
 		{ value: 'c', label: 'User c' },
 	] }
 	__nextHasNoMarginBottom
+	__next40pxDefaultSize
 />
 ```
 
@@ -130,6 +132,7 @@ const [ item, setItem ] = useState( '' );
     value={ item } // e.g: value = 'a'
     onChange={ ( selection ) => { setItem( selection ) } }
     __nextHasNoMarginBottom
+    __next40pxDefaultSize
 >
 	<optgroup label="Theropods">
 		<option value="Tyrannosaurus">Tyrannosaurus</option>

--- a/packages/components/src/select-control/index.tsx
+++ b/packages/components/src/select-control/index.tsx
@@ -18,6 +18,7 @@ import type { WordPressComponentProps } from '../context';
 import type { SelectControlProps } from './types';
 import SelectControlChevronDown from './chevron-down';
 import { useDeprecated36pxDefaultSizeProp } from '../utils/use-deprecated-props';
+import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 
 function useUniqueId( idProp?: string ) {
 	const instanceId = useInstanceId( SelectControl );
@@ -69,6 +70,12 @@ function UnforwardedSelectControl< V extends string >(
 	} = useDeprecated36pxDefaultSizeProp( props );
 	const id = useUniqueId( idProp );
 	const helpId = help ? `${ id }__help` : undefined;
+
+	maybeWarnDeprecated36pxSize( {
+		componentName: 'SelectControl',
+		size,
+		__next40pxDefaultSize,
+	} );
 
 	// Disable reason: A select with an onchange throws a warning.
 	if ( ! options?.length && ! children ) {

--- a/packages/components/src/select-control/stories/index.story.tsx
+++ b/packages/components/src/select-control/stories/index.story.tsx
@@ -64,6 +64,7 @@ const SelectControlWithState: StoryFn< typeof SelectControl > = ( props ) => {
 
 export const Default = SelectControlWithState.bind( {} );
 Default.args = {
+	__next40pxDefaultSize: true,
 	__nextHasNoMarginBottom: true,
 	label: 'Label',
 	options: [


### PR DESCRIPTION
Part of #65751

## What?

Deprecate the 36px default size on SelectControl.

## Testing Instructions

- Unit tests pass
- Storybook stories should not log console warnings
- All code snippets in documentation (JSDoc, Storybook, README) should have the `__next40pxDefaultSize` prop enabled
