### PR TITLE
Resize meta box pane without `ResizableBox`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Internal
 
 -   `ValidatedComboboxControl`: Expose the component under private API's. [#74891](https://github.com/WordPress/gutenberg/pull/74891)
+-   Expose `useDrag` from `@use-gesture/react` package via private API's ([#66735](https://github.com/WordPress/gutenberg/pull/66735)).
 
 ## 32.0.0 (2026-01-16)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Internal
+
+-   Expose `useDrag` from `@use-gesture/react` package via private API's ([#66735](https://github.com/WordPress/gutenberg/pull/66735)).
+
 ## 32.1.0 (2026-01-29)
 
 ### Code Quality
@@ -11,7 +15,6 @@
 ### Internal
 
 -   `ValidatedComboboxControl`: Expose the component under private API's. [#74891](https://github.com/WordPress/gutenberg/pull/74891)
--   Expose `useDrag` from `@use-gesture/react` package via private API's ([#66735](https://github.com/WordPress/gutenberg/pull/66735)).
 
 ## 32.0.0 (2026-01-16)
 

--- a/packages/components/src/private-apis.ts
+++ b/packages/components/src/private-apis.ts
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { useDrag } from '@use-gesture/react';
+
+/**
  * Internal dependencies
  */
 import { positionToPlacement as __experimentalPopoverLegacyPositionToPlacement } from './popover/utils';
@@ -42,6 +47,7 @@ lock( privateApis, {
 	DateRangeCalendar,
 	TZDate,
 	Picker,
+	useDrag,
 	ValidatedInputControl,
 	ValidatedCheckboxControl,
 	ValidatedComboboxControl,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -25,7 +25,6 @@ import { PluginArea } from '@wordpress/plugins';
 import { __, sprintf } from '@wordpress/i18n';
 import {
 	useCallback,
-	useEffect,
 	useMemo,
 	useId,
 	useRef,
@@ -48,7 +47,6 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
-	useEvent,
 	useMediaQuery,
 	useMergeRefs,
 	useRefEffect,
@@ -154,7 +152,7 @@ function MetaBoxesMain( { isLegacy } ) {
 
 	const isShort = useMediaQuery( '(max-height: 549px)' );
 
-	const [ { min, max }, setHeightConstraints ] = useState( () => ( {} ) );
+	const [ { min = 0, max }, setHeightConstraints ] = useState( () => ( {} ) );
 	// Keeps the resizable area’s size constraints updated taking into account
 	// editor notices. The constraints are also used to derive the value for the
 	// aria-valuenow attribute on the separator.
@@ -230,18 +228,10 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	};
 
-	const getRenderValues = useEvent( () => ( { isOpen, openHeight, min } ) );
-	// Sets the height to 'auto' when not resizable (isShort) and to the
-	// preferred height when resizable.
-	useEffect( () => {
-		const fresh = getRenderValues();
-		// Tests for `min` having a value to skip the first render.
-		if ( fresh.min !== undefined && metaBoxesMainRef.current ) {
-			const usedOpenHeight = isShort ? 'auto' : fresh.openHeight;
-			const usedHeight = fresh.isOpen ? usedOpenHeight : fresh.min;
-			applyHeight( usedHeight );
-		}
-	}, [ isShort ] );
+	const getContextualHeight = () => {
+		const usedOpenHeight = isShort ? 'auto' : openHeight;
+		return isOpen ? usedOpenHeight : min;
+	};
 
 	// useDrag includes keyboard support with arrow keys emulating a drag.
 	// TODO: Support more/all keyboard interactions from the window splitter pattern:
@@ -313,7 +303,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	const usedAriaValueNow =
 		max === undefined || isAutoHeight
 			? 50
-			: getAriaValueNow( isOpen ? openHeight : min );
+			: getAriaValueNow( getContextualHeight() );
 
 	const persistIsOpen = ( to = ! isOpen ) =>
 		setPreference( 'core/edit-post', 'metaBoxesMainIsOpen', to );
@@ -370,7 +360,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				'edit-post-meta-boxes-main',
 				! isShort && 'is-resizable'
 			) }
-			style={ { height: isOpen ? openHeight : min } }
+			style={ { height: getContextualHeight() } }
 		>
 			<div className="edit-post-meta-boxes-main__presenter">
 				{ toggle }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -237,26 +237,30 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	}, [ isShort ] );
 
+	// useDrag includes keyboard support with arrow keys emulating a drag.
+	// TODO: Support more/all keyboard interactions from the window splitter pattern:
+	// https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
 	const bindDragGesture = useDrag(
 		( { movement, first, last, memo } ) => {
 			const pane = metaBoxesMainRef.current;
+			const [ , yMovement ] = movement;
 			if ( first ) {
 				pane.classList.add( 'is-resizing' );
 				didDragGestureRef.current = true;
-
-				if ( heightRef.current === undefined ) {
-					const fromHeight = metaBoxesMainRef.current.offsetHeight;
-					return { fromHeight };
-				}
-				if ( heightRef.current > max ) {
+				let fromHeight = heightRef.current ?? pane.offsetHeight;
+				if ( isOpen ) {
 					// Starts from max in case shortening the window has imposed it.
-					return { fromHeight: max };
+					if ( fromHeight > max ) {
+						fromHeight = max;
+					}
+				} else {
+					fromHeight = min;
 				}
-				return { fromHeight: isOpen ? heightRef.current : min };
+				applyHeight( fromHeight - yMovement );
+				return { fromHeight };
 			}
 
 			if ( ! first && ! last ) {
-				const [ , yMovement ] = movement;
 				applyHeight( memo.fromHeight - yMovement );
 				return memo;
 			}
@@ -271,7 +275,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			// separator won’t set the persisted height to the closed height.
 			applyHeight( heightRef.current, nextIsOpen );
 		},
-		{ delay: 200, threshold: 5 }
+		{ delay: 200, threshold: 5, keyboardDisplacement: 20 }
 	);
 
 	if ( ! hasAnyVisible ) {
@@ -303,24 +307,6 @@ function MetaBoxesMain( { isLegacy } ) {
 	const persistIsOpen = ( to = ! isOpen ) =>
 		setPreference( 'core/edit-post', 'metaBoxesMainIsOpen', to );
 
-	// TODO: Support more/all keyboard interactions from the window splitter pattern:
-	// https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
-	const onSeparatorKeyDown = ( event ) => {
-		const delta = { ArrowUp: 20, ArrowDown: -20 }[ event.key ];
-		if ( delta ) {
-			const pane = metaBoxesMainRef.current;
-			let fromHeight;
-			if ( isOpen ) {
-				fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
-			} else {
-				fromHeight = min;
-			}
-			const nextHeight = delta + fromHeight;
-			applyHeight( nextHeight, true );
-			persistIsOpen( nextHeight > min );
-			event.preventDefault();
-		}
-	};
 	const paneLabel = __( 'Meta Boxes' );
 
 	let toggleDragProps;
@@ -366,9 +352,6 @@ function MetaBoxesMain( { isLegacy } ) {
 					aria-label={ __( 'Drag to resize' ) }
 					aria-describedby={ separatorHelpId }
 					{ ...bindDragGesture() }
-					// The drag gesture handlers include one for key down but it doesn’t seem necessary
-					// to call that handler (for now) so it’s simply overriden.
-					onKeyDown={ onSeparatorKeyDown }
 				/>
 			</Tooltip>
 			<VisuallyHidden id={ separatorHelpId }>

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -228,11 +228,6 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	};
 
-	const getContextualHeight = () => {
-		const usedOpenHeight = isShort ? 'auto' : openHeight;
-		return isOpen ? usedOpenHeight : min;
-	};
-
 	// useDrag includes keyboard support with arrow keys emulating a drag.
 	// TODO: Support more/all keyboard interactions from the window splitter pattern:
 	// https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
@@ -297,13 +292,13 @@ function MetaBoxesMain( { isLegacy } ) {
 	}
 
 	const isAutoHeight = openHeight === undefined;
+	const usedOpenHeight = isShort ? 'auto' : openHeight;
+	const usedHeight = isOpen ? usedOpenHeight : min;
 
 	const getAriaValueNow = ( height ) =>
 		Math.round( ( ( height - min ) / ( max - min ) ) * 100 );
 	const usedAriaValueNow =
-		max === undefined || isAutoHeight
-			? 50
-			: getAriaValueNow( getContextualHeight() );
+		max === undefined || isAutoHeight ? 50 : getAriaValueNow( usedHeight );
 
 	const persistIsOpen = ( to = ! isOpen ) =>
 		setPreference( 'core/edit-post', 'metaBoxesMainIsOpen', to );
@@ -360,7 +355,7 @@ function MetaBoxesMain( { isLegacy } ) {
 				'edit-post-meta-boxes-main',
 				! isShort && 'is-resizable'
 			) }
-			style={ { height: getContextualHeight() } }
+			style={ { height: usedHeight } }
 		>
 			<div className="edit-post-meta-boxes-main__presenter">
 				{ toggle }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -308,7 +308,9 @@ function MetaBoxesMain( { isLegacy } ) {
 	const getAriaValueNow = ( height ) =>
 		Math.round( ( ( height - min ) / ( max - min ) ) * 100 );
 	const usedAriaValueNow =
-		max === undefined || isAutoHeight ? 50 : getAriaValueNow( openHeight );
+		max === undefined || isAutoHeight
+			? 50
+			: getAriaValueNow( isOpen ? openHeight : min );
 
 	const persistIsOpen = ( to = ! isOpen ) =>
 		setPreference( 'core/edit-post', 'metaBoxesMainIsOpen', to );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -219,10 +219,11 @@ function MetaBoxesMain( { isLegacy } ) {
 				'metaBoxesMainOpenHeight',
 				candidateHeight
 			);
-		} else {
+		}
+		// Applies imperative DOM updates only when not persisting the value
+		// because otherwise it's done by the subsequent render.
+		else {
 			metaBoxesMainRef.current.style.height = styleHeight;
-			// Updates aria-valuenow only when not persisting the value because otherwise
-			// it's done by the render that persisting the value causes.
 			if ( ! isShort ) {
 				separatorRef.current.ariaValueNow =
 					getAriaValueNow( candidateHeight );

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -196,7 +196,6 @@ function MetaBoxesMain( { isLegacy } ) {
 	const separatorRef = useRef();
 	const separatorHelpId = useId();
 
-	const didDragGestureRef = useRef( false );
 	const heightRef = useRef();
 
 	/**
@@ -248,12 +247,11 @@ function MetaBoxesMain( { isLegacy } ) {
 	// TODO: Support more/all keyboard interactions from the window splitter pattern:
 	// https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
 	const bindDragGesture = useDrag(
-		( { movement, first, last, memo } ) => {
+		( { movement, first, last, memo, tap, args } ) => {
 			const pane = metaBoxesMainRef.current;
 			const [ , yMovement ] = movement;
 			if ( first ) {
 				pane.classList.add( 'is-resizing' );
-				didDragGestureRef.current = true;
 				let fromHeight = heightRef.current ?? pane.offsetHeight;
 				if ( isOpen ) {
 					// Starts from max in case shortening the window has imposed it.
@@ -267,13 +265,18 @@ function MetaBoxesMain( { isLegacy } ) {
 				return { fromHeight };
 			}
 
-			if ( ! first && ! last ) {
+			if ( ! first && ! last && ! tap ) {
 				applyHeight( memo.fromHeight - yMovement );
 				return memo;
 			}
 			// Here, `last === true` – it’s the final event of the gesture.
 
 			pane.classList.remove( 'is-resizing' );
+			if ( tap ) {
+				const [ onTap ] = args;
+				onTap?.();
+				return;
+			}
 			const nextIsOpen = heightRef.current > min;
 			persistIsOpen( nextIsOpen );
 			// Persists height only if still open. This is so that when closed by a drag the
@@ -281,7 +284,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			// the pane open again.
 			applyHeight( heightRef.current, nextIsOpen );
 		},
-		{ delay: 200, threshold: 5, keyboardDisplacement: 20 }
+		{ keyboardDisplacement: 20, filterTaps: true }
 	);
 
 	if ( ! hasAnyVisible ) {
@@ -317,32 +320,21 @@ function MetaBoxesMain( { isLegacy } ) {
 
 	const paneLabel = __( 'Meta Boxes' );
 
-	let toggleDragProps;
-	// Allows resizing from the toggle only in tall viewports.
-	if ( ! isShort ) {
-		toggleDragProps = bindDragGesture();
-		const gesturePointerDown = toggleDragProps.onPointerDown;
-		// Clears the flag `didDragGestureRef` when the toggle is pressed and
-		// passes the event along the to the gesture handler.
-		toggleDragProps.onPointerDown = ( event ) => {
-			didDragGestureRef.current = false;
-			gesturePointerDown( event );
-		};
-	}
 	// The toggle button. It also resizes when the viewport is tall to provide
 	// a larger hit area than the small separator button.
 	const toggle = (
 		<button
 			aria-expanded={ isOpen }
+			// Toggles for all clicks when short and only keyboard “clicks” when
+			// resizable because pointer input is handled by the drag gesture.
 			onClick={ ( { detail } ) => {
-				const isToggleInferred = ! didDragGestureRef.current;
-				const isKeyboard = ! detail;
-				// Toggles only if a resize couldn’t or didn’t happen.
-				if ( isShort || isKeyboard || isToggleInferred ) {
+				if ( isShort || ! detail ) {
 					persistIsOpen();
 				}
 			} }
-			{ ...toggleDragProps }
+			// Passes a toggle callback that the drag gesture handler calls when
+			// it interprets the input as a click/tap.
+			{ ...( ! isShort && bindDragGesture( persistIsOpen ) ) }
 		>
 			{ paneLabel }
 			<Icon icon={ isOpen ? chevronUp : chevronDown } />

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -50,6 +50,7 @@ import {
 import {
 	useEvent,
 	useMediaQuery,
+	useMergeRefs,
 	useRefEffect,
 	useViewportMatch,
 } from '@wordpress/compose';
@@ -150,7 +151,7 @@ function MetaBoxesMain( { isLegacy } ) {
 		];
 	}, [] );
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const metaBoxesMainRef = useRef();
+
 	const isShort = useMediaQuery( '(max-height: 549px)' );
 
 	const [ { min, max }, setHeightConstraints ] = useState( () => ( {} ) );
@@ -186,6 +187,11 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 		return () => observer.disconnect();
 	}, [] );
+	const metaBoxesMainRef = useRef();
+	const setMainRefs = useMergeRefs( [
+		metaBoxesMainRef,
+		effectSizeConstraints,
+	] );
 
 	const separatorRef = useRef();
 	const separatorHelpId = useId();
@@ -365,14 +371,13 @@ function MetaBoxesMain( { isLegacy } ) {
 	return (
 		<NavigableRegion
 			aria-label={ paneLabel }
-			ref={ metaBoxesMainRef }
+			ref={ setMainRefs }
 			className={ clsx(
 				'edit-post-meta-boxes-main',
 				! isShort && 'is-resizable'
 			) }
 			style={ { height: isOpen ? openHeight : min } }
 		>
-			<meta ref={ effectSizeConstraints } />
 			<div className="edit-post-meta-boxes-main__presenter">
 				{ toggle }
 				{ separator }

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -41,11 +41,11 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { store as coreStore } from '@wordpress/core-data';
 import {
 	Icon,
-	ResizableBox,
 	SlotFillProvider,
 	Tooltip,
 	VisuallyHidden,
 	__unstableUseNavigateRegions as useNavigateRegions,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import {
 	useEvent,
@@ -73,6 +73,8 @@ import useNavigateToEntityRecord from '../../hooks/use-navigate-to-entity-record
 import { useMetaBoxInitialization } from '../meta-boxes/use-meta-box-initialization';
 
 const { useCommandContext } = unlock( commandsPrivateApis );
+/** @type {{} & {useDrag: import('@use-gesture/react').useDrag}} */
+const { useDrag } = unlock( componentsPrivateApis );
 const { Editor, FullscreenMode } = unlock( editorPrivateApis );
 const { BlockKeyboardShortcuts } = unlock( blockLibraryPrivateApis );
 const DESIGN_POST_TYPES = [
@@ -185,24 +187,25 @@ function MetaBoxesMain( { isLegacy } ) {
 		return () => observer.disconnect();
 	}, [] );
 
-	const resizeDataRef = useRef( {} );
 	const separatorRef = useRef();
 	const separatorHelpId = useId();
+
+	const didDragGestureRef = useRef( false );
+	const heightRef = useRef();
 
 	/**
 	 * @param {number|'auto'} [candidateHeight] Height in pixels or 'auto'.
 	 * @param {boolean}       isPersistent      Whether to persist the height in preferences.
-	 * @param {boolean}       isInstant         Whether to update the height in the DOM.
 	 */
-	const applyHeight = (
-		candidateHeight = 'auto',
-		isPersistent,
-		isInstant
-	) => {
+	const applyHeight = ( candidateHeight = 'auto', isPersistent ) => {
+		let styleHeight;
 		if ( candidateHeight === 'auto' ) {
 			isPersistent = false; // Just in case — “auto” should never persist.
+			styleHeight = candidateHeight;
 		} else {
 			candidateHeight = Math.min( max, Math.max( min, candidateHeight ) );
+			heightRef.current = candidateHeight;
+			styleHeight = `${ candidateHeight }px`;
 		}
 		if ( isPersistent ) {
 			setPreference(
@@ -210,24 +213,17 @@ function MetaBoxesMain( { isLegacy } ) {
 				'metaBoxesMainOpenHeight',
 				candidateHeight
 			);
-		}
-		// Updates aria-valuenow only when not persisting the value because otherwise
-		// it's done by the render that persisting the value causes.
-		else if ( ! isShort ) {
-			separatorRef.current.ariaValueNow =
-				getAriaValueNow( candidateHeight );
-		}
-		if ( isInstant ) {
-			metaBoxesMainRef.current.updateSize( {
-				height: candidateHeight,
-				// Oddly, when the event that triggered this was not from the mouse (e.g. keydown),
-				// if `width` is left unspecified a subsequent drag gesture applies a fixed
-				// width and the pane fails to widen/narrow with parent width changes from
-				// sidebars opening/closing or window resizes.
-				width: 'auto',
-			} );
+		} else {
+			metaBoxesMainRef.current.style.height = styleHeight;
+			// Updates aria-valuenow only when not persisting the value because otherwise
+			// it's done by the render that persisting the value causes.
+			if ( ! isShort ) {
+				separatorRef.current.ariaValueNow =
+					getAriaValueNow( candidateHeight );
+			}
 		}
 	};
+
 	const getRenderValues = useEvent( () => ( { isOpen, openHeight, min } ) );
 	// Sets the height to 'auto' when not resizable (isShort) and to the
 	// preferred height when resizable.
@@ -237,9 +233,46 @@ function MetaBoxesMain( { isLegacy } ) {
 		if ( fresh.min !== undefined && metaBoxesMainRef.current ) {
 			const usedOpenHeight = isShort ? 'auto' : fresh.openHeight;
 			const usedHeight = fresh.isOpen ? usedOpenHeight : fresh.min;
-			applyHeight( usedHeight, false, true );
+			applyHeight( usedHeight );
 		}
 	}, [ isShort ] );
+
+	const bindDragGesture = useDrag(
+		( { movement, first, last, memo } ) => {
+			const pane = metaBoxesMainRef.current;
+			if ( first ) {
+				pane.classList.add( 'is-resizing' );
+				didDragGestureRef.current = true;
+
+				if ( heightRef.current === undefined ) {
+					const fromHeight = metaBoxesMainRef.current.offsetHeight;
+					return { fromHeight };
+				}
+				if ( heightRef.current > max ) {
+					// Starts from max in case shortening the window has imposed it.
+					return { fromHeight: max };
+				}
+				return { fromHeight: isOpen ? heightRef.current : min };
+			}
+
+			if ( ! first && ! last ) {
+				const [ , yMovement ] = movement;
+				applyHeight( memo.fromHeight - yMovement );
+				return memo;
+			}
+			// Here, `last === true` – it’s the final event of the gesture.
+
+			pane.classList.remove( 'is-resizing' );
+			const nextIsOpen = heightRef.current > min;
+			persistIsOpen( nextIsOpen );
+			// Persists height only if still open. This is so that when closed by a drag the
+			// prior height can be restored by the toggle button instead of having to drag
+			// the pane open again. Also, if already at minimum height, a click on the
+			// separator won’t set the persisted height to the closed height.
+			applyHeight( heightRef.current, nextIsOpen );
+		},
+		{ delay: 200, threshold: 5 }
+	);
 
 	if ( ! hasAnyVisible ) {
 		return;
@@ -261,6 +294,7 @@ function MetaBoxesMain( { isLegacy } ) {
 	}
 
 	const isAutoHeight = openHeight === undefined;
+
 	const getAriaValueNow = ( height ) =>
 		Math.round( ( ( height - min ) / ( max - min ) ) * 100 );
 	const usedAriaValueNow =
@@ -274,39 +308,54 @@ function MetaBoxesMain( { isLegacy } ) {
 	const onSeparatorKeyDown = ( event ) => {
 		const delta = { ArrowUp: 20, ArrowDown: -20 }[ event.key ];
 		if ( delta ) {
-			const pane = metaBoxesMainRef.current.resizable;
-			const fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
+			const pane = metaBoxesMainRef.current;
+			let fromHeight;
+			if ( isOpen ) {
+				fromHeight = isAutoHeight ? pane.offsetHeight : openHeight;
+			} else {
+				fromHeight = min;
+			}
 			const nextHeight = delta + fromHeight;
-			applyHeight( nextHeight, true, true );
+			applyHeight( nextHeight, true );
 			persistIsOpen( nextHeight > min );
 			event.preventDefault();
 		}
 	};
 	const paneLabel = __( 'Meta Boxes' );
 
+	let toggleDragProps;
+	// Allows resizing from the toggle only in tall viewports.
+	if ( ! isShort ) {
+		toggleDragProps = bindDragGesture();
+		const gesturePointerDown = toggleDragProps.onPointerDown;
+		// Clears the flag `didDragGestureRef` when the toggle is pressed and
+		// passes the event along the to the gesture handler.
+		toggleDragProps.onPointerDown = ( event ) => {
+			didDragGestureRef.current = false;
+			gesturePointerDown( event );
+		};
+	}
+	// The toggle button. It also resizes when the viewport is tall to provide
+	// a larger hit area than the small separator button.
 	const toggle = (
 		<button
 			aria-expanded={ isOpen }
 			onClick={ ( { detail } ) => {
-				const { isToggleInferred } = resizeDataRef.current;
-				if ( isShort || ! detail || isToggleInferred ) {
+				const isToggleInferred = ! didDragGestureRef.current;
+				const isKeyboard = ! detail;
+				// Toggles only if a resize couldn’t or didn’t happen.
+				if ( isShort || isKeyboard || isToggleInferred ) {
 					persistIsOpen();
-					const usedOpenHeight = isShort ? 'auto' : openHeight;
-					const usedHeight = isOpen ? min : usedOpenHeight;
-					applyHeight( usedHeight, false, true );
 				}
 			} }
-			// Prevents resizing in short viewports.
-			{ ...( isShort && {
-				onMouseDown: ( event ) => event.stopPropagation(),
-				onTouchStart: ( event ) => event.stopPropagation(),
-			} ) }
+			{ ...toggleDragProps }
 		>
 			{ paneLabel }
 			<Icon icon={ isOpen ? chevronUp : chevronDown } />
 		</button>
 	);
 
+	// The separator button that provides a11y for resizing.
 	const separator = ! isShort && (
 		<>
 			<Tooltip text={ __( 'Drag to resize' ) }>
@@ -316,86 +365,37 @@ function MetaBoxesMain( { isLegacy } ) {
 					aria-valuenow={ usedAriaValueNow }
 					aria-label={ __( 'Drag to resize' ) }
 					aria-describedby={ separatorHelpId }
+					{ ...bindDragGesture() }
+					// The drag gesture handlers include one for key down but it doesn’t seem necessary
+					// to call that handler (for now) so it’s simply overriden.
 					onKeyDown={ onSeparatorKeyDown }
 				/>
 			</Tooltip>
 			<VisuallyHidden id={ separatorHelpId }>
 				{ __(
-					'Use up and down arrow keys to resize the meta box panel.'
+					'Use up and down arrow keys to resize the meta box pane.'
 				) }
 			</VisuallyHidden>
 		</>
 	);
 
-	const paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
-		as: NavigableRegion,
-		ref: metaBoxesMainRef,
-		className: 'edit-post-meta-boxes-main',
-		defaultSize: { height: isOpen ? openHeight : 0 },
-		minHeight: min,
-		maxHeight: max,
-		enable: { top: true },
-		handleClasses: { top: 'edit-post-meta-boxes-main__presenter' },
-		handleComponent: {
-			top: (
-				<>
-					{ toggle }
-					{ separator }
-				</>
-			),
-		},
-		// Avoids hiccups while dragging over objects like iframes and ensures that
-		// the event to end the drag is captured by the target (resize handle)
-		// whether or not it’s under the pointer.
-		onPointerDown: ( { pointerId, target } ) => {
-			if ( separatorRef.current?.parentElement.contains( target ) ) {
-				target.setPointerCapture( pointerId );
-			}
-		},
-		onResizeStart: ( { timeStamp }, direction, elementRef ) => {
-			if ( isAutoHeight ) {
-				// Sets the starting height to avoid visual jumps in height and
-				// aria-valuenow being `NaN` for the first (few) resize events.
-				applyHeight( elementRef.offsetHeight, false, true );
-			}
-			elementRef.classList.add( 'is-resizing' );
-			resizeDataRef.current = { timeStamp, maxDelta: 0 };
-		},
-		onResize: ( event, direction, elementRef, delta ) => {
-			const { maxDelta } = resizeDataRef.current;
-			const newDelta = Math.abs( delta.height );
-			resizeDataRef.current.maxDelta = Math.max( maxDelta, newDelta );
-			applyHeight( metaBoxesMainRef.current.state.height );
-		},
-		onResizeStop: ( event, direction, elementRef ) => {
-			elementRef.classList.remove( 'is-resizing' );
-			const duration = event.timeStamp - resizeDataRef.current.timeStamp;
-			const wasSeparator = event.target === separatorRef.current;
-			const { maxDelta } = resizeDataRef.current;
-			const isToggleInferred =
-				maxDelta < 1 || ( duration < 144 && maxDelta < 5 );
-			if ( isShort || ( ! wasSeparator && isToggleInferred ) ) {
-				resizeDataRef.current.isToggleInferred = true;
-			} else {
-				const { height } = metaBoxesMainRef.current.state;
-				const nextIsOpen = height > min;
-				persistIsOpen( nextIsOpen );
-				// Persists height only if still open. This is so that when closed by a drag the
-				// prior height can be restored by the toggle button instead of having to drag
-				// the pane open again. Also, if already closed, a click on the separator won’t
-				// persist the height as the minimum.
-				if ( nextIsOpen ) {
-					applyHeight( height, true );
-				}
-			}
-		},
-	} );
-
 	return (
-		<ResizableBox aria-label={ paneLabel } { ...paneProps }>
+		<NavigableRegion
+			aria-label={ paneLabel }
+			ref={ metaBoxesMainRef }
+			className={ clsx(
+				'edit-post-meta-boxes-main',
+				! isShort && 'is-resizable'
+			) }
+			style={ { height: isOpen ? openHeight : min } }
+		>
 			<meta ref={ effectSizeConstraints } />
+			<div className="edit-post-meta-boxes-main__presenter">
+				{ toggle }
+				{ separator }
+			</div>
 			{ contents }
-		</ResizableBox>
+		</NavigableRegion>
 	);
 }
 

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -278,8 +278,7 @@ function MetaBoxesMain( { isLegacy } ) {
 			persistIsOpen( nextIsOpen );
 			// Persists height only if still open. This is so that when closed by a drag the
 			// prior height can be restored by the toggle button instead of having to drag
-			// the pane open again. Also, if already at minimum height, a click on the
-			// separator won’t set the persisted height to the closed height.
+			// the pane open again.
 			applyHeight( heightRef.current, nextIsOpen );
 		},
 		{ delay: 200, threshold: 5, keyboardDisplacement: 20 }

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -79,7 +79,9 @@
 			width: inherit;
 			height: $grid-unit-05;
 			border-radius: $radius-small;
-			transition: width 0.3s ease-out;
+			@media not (prefers-reduced-motion) {
+				transition: width 0.3s ease-out;
+			}
 		}
 
 		&:is(:hover, :focus)::before {

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -10,20 +10,22 @@
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
-	padding-block-start: $button-size-compact;
 }
 
 .edit-post-meta-boxes-main__presenter {
+	flex-shrink: 0;
 	display: flex;
+	justify-content: center;
 	box-shadow: 0 $border-width $gray-300;
 	// Windows High Contrast mode will show this outline, but not the shadow.
 	outline: 1px solid transparent;
 	position: relative;
-	// Re-resizable adds an invisible overlay during resizes (apparently meant to avoid text selections)
-	// and this has to appear in front of it or else click events will be blocked on touch devices.
-	z-index: 10000;
-	inset: 0 0 auto;
+	z-index: 1;
 	height: $button-size-compact;
+	// Enlarge the toggle/resizable hit area on touch devices.
+	@media (pointer: coarse) {
+		height: $button-size;
+	}
 
 	// Style reset for both toggle and separator buttons.
 	> button {
@@ -32,6 +34,8 @@
 		border: none;
 		outline: none;
 		background-color: transparent;
+		// Ensure the drag gesture behaves as expected for touch input.
+		touch-action: none;
 	}
 
 	> button[aria-expanded] {
@@ -56,12 +60,12 @@
 		}
 	}
 
-	button[role="separator"] {
+	// This button is only present when resizable.
+	> button[role="separator"] {
 		cursor: row-resize;
-		width: $grid-unit-80;
-		margin: auto;
 		position: absolute;
-		inset: 0;
+		width: $grid-unit-80;
+		height: inherit;
 
 		&::before {
 			content: "";
@@ -75,25 +79,13 @@
 			width: inherit;
 			height: $grid-unit-05;
 			border-radius: $radius-small;
-			@media not (prefers-reduced-motion) {
-				transition: width 0.3s ease-out;
-			}
+			transition: width 0.3s ease-out;
 		}
 
-		&:is(:hover, :focus-visible)::before {
+		&:is(:hover, :focus)::before {
 			background-color: var(--wp-admin-theme-color);
 			width: $grid-unit-80 + $grid-unit-20;
 		}
-	}
-}
-
-// Enlarge the toggle/resizable hit area on touch devices.
-@media (pointer: coarse) {
-	.edit-post-meta-boxes-main {
-		padding-block-start: $button-size;
-	}
-	.edit-post-meta-boxes-main__presenter {
-		height: $button-size;
 	}
 }
 


### PR DESCRIPTION
## What?
Makes meta box pane resizing implementation based on `@use-gesture/react`’s drag hook.

## Why?
- To fix the focus order so it matches the visual order
- For improved dragging feels – this performs better in my testing

Fixes #66436

## How?
Privately exports `useDrag` from the components package and uses it for resizing the meta box pane.

## Testing Instructions
1. In the Post Editor with meta boxes present
2. Resize the meta box pane and ensure it works as before

### Testing Instructions for Keyboard
1. In the Post Editor with meta boxes present
2. Tab through the interface and note that the "Drag to resize" separator/button matches the visual order (i.e. it comes after the editor canvas but before any of the meta box tab stops)
3. With the separator focused use the up and down arrows keys to resize the pane

## Screenshots or screencast <!-- if applicable -->

### Dragging performance

| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/bf80ef85-44ab-49ab-829e-66b79c835372"></video>|<video src="https://github.com/user-attachments/assets/56852864-2b57-4863-866c-9259adbe122d"></video>| 

> [!NOTE]
> The recordings above are with Chrome and the browser dev tools open. On trunk, the combination of dev tools being open and the Yoast plugin reliably makes the dragging chunky on my machine. On this branch, with the same conditions it’s much better.

