### PR TITLE
Site Editor: fix template for page-on-front option

### DIFF
--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -116,8 +116,8 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 							return id;
 						}
 
-						// If not front page template is found, continue with
-						// the logic below (fetching the page template).
+						// If no front page template is found, continue with the
+						// logic below (fetching the page template).
 					} else {
 						// Still resolving `templates`.
 						return undefined;

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -96,7 +96,32 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 					postTypeToResolve === 'page' &&
 					homepageId === postIdToResolve
 				) {
-					return getDefaultTemplateId( { slug: 'front-page' } );
+					// The /lookup endpoint cannot currently handle a lookup
+					// when a page is set as the front page, so specifically in
+					// that case, we want to check if there is a front page
+					// template, and instead of falling back to the home
+					// template, we want to fall back to the page template.
+					const templates = getEntityRecords(
+						'postType',
+						TEMPLATE_POST_TYPE,
+						{
+							per_page: -1,
+						}
+					);
+					if ( templates ) {
+						const id = templates?.find(
+							( { slug } ) => slug === 'front-page'
+						)?.id;
+						if ( id ) {
+							return id;
+						}
+
+						// If not front page template is found, continue with
+						// the logic below (fetching the page template).
+					} else {
+						// Still resolving `templates`.
+						return undefined;
+					}
 				}
 
 				const editedEntity = getEditedEntityRecord(

--- a/test/e2e/specs/site-editor/template-hierarchy.spec.js
+++ b/test/e2e/specs/site-editor/template-hierarchy.spec.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Template hierarchy', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyfour' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'shows correct template with page on front option', async ( {
+		admin,
+		page,
+		editor,
+	} ) => {
+		await admin.visitAdminPage( 'options-reading.php' );
+		await page.click( 'input[name="show_on_front"][value="page"]' );
+		await page.selectOption( 'select[name="page_on_front"]', '2' );
+		await page.click( 'input[type="submit"]' );
+		await admin.visitSiteEditor();
+
+		// Title block should contain "Sample Page"
+		await expect(
+			editor.canvas.locator( 'role=document[name="Block: Title"]' )
+		).toContainText( 'Sample Page' );
+
+		await admin.visitAdminPage( 'options-reading.php' );
+		await page.click( 'input[name="show_on_front"][value="posts"]' );
+		await page.click( 'input[type="submit"]' );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I removed a bit too much logic in #66579. I thought the `/lookup` REST API request could handle fetching the front-page template when the page-on-front option is set, but it can't. Ideally we should fix the endpoint, but in the meantime, I'll restore the previous logic (and add more inline comments).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fixes #66687.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Restores logic from #66579, closer to where it's needed and with more comments.

When a front page ID is set, the correct front-page hierarchy is first the `front-page` template, then the specific page template for the front page ID. This was previously manually checked in JS. It looked specifically for the front page template and if it doesn't exist, continue with the remaining logic to find the page template.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Set a page to be the front page in Reading settings. The front-end's front page should have changed. Check that it's the same in the site editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
