### PR TITLE
FIX: Adding top margin to `Full Content` post view in the `latest-pos…

### DIFF
--- a/packages/block-library/src/latest-posts/style.scss
+++ b/packages/block-library/src/latest-posts/style.scss
@@ -57,7 +57,8 @@
 	font-size: 0.8125em;
 }
 
-.wp-block-latest-posts__post-excerpt {
+.wp-block-latest-posts__post-excerpt,
+.wp-block-latest-posts__post-full-content {
 	margin-top: 0.5em;
 	margin-bottom: 1em;
 }


### PR DESCRIPTION
## What?
- Updated styles on the `latest-posts` block to add space between title and post content in `Full Post` toggle.

## Why?
Spacing issue was found in the `latest-post` block between content and title. Which doesn't not look good on the. REF: https://github.com/WordPress/gutenberg/issues/66412

## How?
Added styles to add top margin on the post content on the `latest-post` block.

## Testing Instructions
- Type / to choose a block
- Select Latest post block
- Change its post content from "Excerpt" to "Full Post"
- Save the changes and publish the page.
- View the editor side & front-end side.

### Testing Instructions for Keyboard
N/A

## Screenshots or screencast
![image](https://github.com/user-attachments/assets/68770328-2208-4ea0-9091-4a8b1ba46a31)
