### PR TITLE
Hide metaboxes in Zoom Out

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -424,6 +424,9 @@ function Layout( {
 				select( editPostStore )
 			);
 			const { canUser, getPostType } = select( coreStore );
+			const { __unstableGetEditorMode } = unlock(
+				select( blockEditorStore )
+			);
 
 			const supportsTemplateMode = settings.supportsTemplateMode;
 			const isViewable =
@@ -432,6 +435,8 @@ function Layout( {
 				kind: 'postType',
 				name: 'wp_template',
 			} );
+
+			const isZoomOut = __unstableGetEditorMode() === 'zoom-out';
 
 			return {
 				mode: select( editorStore ).getEditorMode(),
@@ -444,7 +449,8 @@ function Layout( {
 				isDistractionFree: get( 'core', 'distractionFree' ),
 				showMetaBoxes:
 					! DESIGN_POST_TYPES.includes( currentPostType ) &&
-					select( editorStore ).getRenderingMode() === 'post-only',
+					select( editorStore ).getRenderingMode() === 'post-only' &&
+					! isZoomOut,
 				isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 				templateId:
 					supportsTemplateMode &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hides metaboxes in Zoom Out mode.

Closes https://github.com/WordPress/gutenberg/issues/66718

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Meta boxes don't belong in Zoom Out which is designed for composing content.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionalise based on Zoom Out state.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Install Plugin that registers metaboxes (e.g. Yoast SEO)
- New Post
- See Metaboxes
- Enable Zoom Out
- See Metaboxes are hidden.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/fb855404-378d-44d8-8751-e3bf754ac04e


