### PR TITLE
Iframed editor: Fix relative wp-content URLs

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -272,6 +272,7 @@ function Iframe( {
 <html>
 	<head>
 		<meta charset="utf-8">
+		<base href="${ window.location.origin }">
 		<script>window.frameElement._load()</script>
 		<style>
 			html{

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -191,6 +191,22 @@ function Iframe( {
 				preventFileDropDefault,
 				false
 			);
+			// Prevent clicks on links from navigating away. Note that links
+			// inside `contenteditable` are already disabled by the browser, so
+			// this is for links in blocks outside of `contenteditable`.
+			iFrameDocument.addEventListener( 'click', ( event ) => {
+				if ( event.target.tagName === 'A' ) {
+					event.preventDefault();
+
+					// Appending a hash to the current URL will not reload the
+					// page. This is useful for e.g. footnotes.
+					const href = event.target.getAttribute( 'href' );
+					if ( href.startsWith( '#' ) ) {
+						iFrameDocument.defaultView.location.hash =
+							href.slice( 1 );
+					}
+				}
+			} );
 		}
 
 		node.addEventListener( 'load', onLoad );


### PR DESCRIPTION
## What?
Adds a `<base>` element to the iframed editor to work with relative URLs.

Fixes #54262
Rebase of #56533

## Why?
Currently the editor in the iframe does not work with relative URLs.

Relative URLs work in the editor without iframe, where the media are loaded relative to the admin URL. The <base> element restores the old behavior. In further iterations, we can make the editor even more flexible so that it can also work with other URLs.

## Testing Instructions
- Make sure your WordPress uses only blocks with version v3 to that the iframed editor is used.
- Add the constant to your wp-config.php file: 
```php
define( 'WP_CONTENT_URL', '/wp-content' );
```
- Add a new image to a post. 
- The image should be previewed in the editor.