### PR TITLE
WP Scripts: Make watch mode more resilient for developer errors

### DIFF
--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Make `start` script more resilient for developer errors ([#66752](https://github.com/WordPress/gutenberg/pull/66752)).
+
 ## 30.4.0 (2024-10-30)
 
 ### Enhancements

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -246,6 +246,7 @@ function getWebpackEntryPoints( buildType ) {
 							''
 						) }" due to malformed JSON.`
 					);
+					continue;
 				}
 
 				const fields =
@@ -281,7 +282,7 @@ function getWebpackEntryPoints( buildType ) {
 								) }". File is located outside of the "${ getWordPressSrcDirectory() }" directory.`
 							)
 						);
-						return;
+						continue;
 					}
 					const entryName = filepath
 						.replace( extname( filepath ), '' )
@@ -309,7 +310,7 @@ function getWebpackEntryPoints( buildType ) {
 								) }". File does not exist in the "${ getWordPressSrcDirectory() }" directory.`
 							)
 						);
-						return;
+						continue;
 					}
 					entryPoints[ entryName ] = entryFilepath;
 				}

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -239,10 +239,10 @@ function getWebpackEntryPoints( buildType ) {
 					parsedBlockJson = JSON.parse( fileContents );
 				} catch ( error ) {
 					warn(
-						`Skipping scanning "${ blockMetadataFile.replace(
+						`Not scanning "${ blockMetadataFile.replace(
 							fromProjectRoot( sep ),
 							''
-						) }" to collect entry points due to malformed JSON.`
+						) }" due to collect entry points due to malformed JSON.`
 					);
 					continue;
 				}
@@ -369,10 +369,10 @@ function getPhpFilePaths( context, props ) {
 			parsedBlockJson = JSON.parse( readFileSync( blockMetadataFile ) );
 		} catch ( error ) {
 			warn(
-				`Skipping scanning "${ blockMetadataFile.replace(
+				`Not scanning "${ blockMetadataFile.replace(
 					fromProjectRoot( sep ),
 					''
-				) }" to detect render files due to malformed JSON.`
+				) }" due to detect render files due to malformed JSON.`
 			);
 			return paths;
 		}

--- a/packages/scripts/utils/config.js
+++ b/packages/scripts/utils/config.js
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-const chalk = require( 'chalk' );
 const { readFileSync } = require( 'fs' );
 const { basename, dirname, extname, join, sep } = require( 'path' );
 const { sync: glob } = require( 'fast-glob' );
@@ -21,7 +20,8 @@ const {
 	getBlockJsonModuleFields,
 	getBlockJsonScriptFields,
 } = require( './block-json' );
-const { log } = console;
+
+const { warn } = console;
 
 // See https://babeljs.io/docs/en/config-files#configuration-file-types.
 const hasBabelConfig = () =>
@@ -209,10 +209,8 @@ function getWebpackEntryPoints( buildType ) {
 
 		// Continue only if the source directory exists.
 		if ( ! hasProjectFile( getWordPressSrcDirectory() ) ) {
-			log(
-				chalk.yellow(
-					`Source directory "${ getWordPressSrcDirectory() }" was not found. Please confirm there is a "src" directory in the root or the value passed to --webpack-src-dir is correct.`
-				)
+			warn(
+				`Source directory "${ getWordPressSrcDirectory() }" was not found. Please confirm there is a "src" directory in the root or the value passed to --webpack-src-dir is correct.`
 			);
 			return {};
 		}
@@ -240,11 +238,11 @@ function getWebpackEntryPoints( buildType ) {
 				try {
 					parsedBlockJson = JSON.parse( fileContents );
 				} catch ( error ) {
-					chalk.yellow(
-						`Skipping "${ blockMetadataFile.replace(
+					warn(
+						`Skipping scanning "${ blockMetadataFile.replace(
 							fromProjectRoot( sep ),
 							''
-						) }" due to malformed JSON.`
+						) }" to collect entry points due to malformed JSON.`
 					);
 					continue;
 				}
@@ -271,16 +269,14 @@ function getWebpackEntryPoints( buildType ) {
 
 					// Takes the path without the file extension, and relative to the defined source directory.
 					if ( ! filepath.startsWith( srcDirectory ) ) {
-						log(
-							chalk.yellow(
-								`Skipping "${ value.replace(
-									'file:',
-									''
-								) }" listed in "${ blockMetadataFile.replace(
-									fromProjectRoot( sep ),
-									''
-								) }". File is located outside of the "${ getWordPressSrcDirectory() }" directory.`
-							)
+						warn(
+							`Skipping "${ value.replace(
+								'file:',
+								''
+							) }" listed in "${ blockMetadataFile.replace(
+								fromProjectRoot( sep ),
+								''
+							) }". File is located outside of the "${ getWordPressSrcDirectory() }" directory.`
 						);
 						continue;
 					}
@@ -299,16 +295,14 @@ function getWebpackEntryPoints( buildType ) {
 					);
 
 					if ( ! entryFilepath ) {
-						log(
-							chalk.yellow(
-								`Skipping "${ value.replace(
-									'file:',
-									''
-								) }" listed in "${ blockMetadataFile.replace(
-									fromProjectRoot( sep ),
-									''
-								) }". File does not exist in the "${ getWordPressSrcDirectory() }" directory.`
-							)
+						warn(
+							`Skipping "${ value.replace(
+								'file:',
+								''
+							) }" listed in "${ blockMetadataFile.replace(
+								fromProjectRoot( sep ),
+								''
+							) }". File does not exist in the "${ getWordPressSrcDirectory() }" directory.`
 						);
 						continue;
 					}
@@ -335,10 +329,8 @@ function getWebpackEntryPoints( buildType ) {
 		} );
 
 		if ( ! entryFile ) {
-			log(
-				chalk.yellow(
-					`No entry file discovered in the "${ getWordPressSrcDirectory() }" directory.`
-				)
+			warn(
+				`No entry file discovered in the "${ getWordPressSrcDirectory() }" directory.`
 			);
 			return {};
 		}
@@ -371,13 +363,24 @@ function getPhpFilePaths( context, props ) {
 	const srcDirectory = fromProjectRoot( context + sep );
 
 	return blockMetadataFiles.flatMap( ( blockMetadataFile ) => {
-		const blockJson = JSON.parse( readFileSync( blockMetadataFile ) );
-
 		const paths = [];
+		let parsedBlockJson;
+		try {
+			parsedBlockJson = JSON.parse( readFileSync( blockMetadataFile ) );
+		} catch ( error ) {
+			warn(
+				`Skipping scanning "${ blockMetadataFile.replace(
+					fromProjectRoot( sep ),
+					''
+				) }" to detect render files due to malformed JSON.`
+			);
+			return paths;
+		}
+
 		for ( const prop of props ) {
 			if (
-				typeof blockJson?.[ prop ] !== 'string' ||
-				! blockJson[ prop ]?.startsWith( 'file:' )
+				typeof parsedBlockJson?.[ prop ] !== 'string' ||
+				! parsedBlockJson[ prop ]?.startsWith( 'file:' )
 			) {
 				continue;
 			}
@@ -385,21 +388,19 @@ function getPhpFilePaths( context, props ) {
 			// Removes the `file:` prefix.
 			const filepath = join(
 				dirname( blockMetadataFile ),
-				blockJson[ prop ].replace( 'file:', '' )
+				parsedBlockJson[ prop ].replace( 'file:', '' )
 			);
 
 			// Takes the path without the file extension, and relative to the defined source directory.
 			if ( ! filepath.startsWith( srcDirectory ) ) {
-				log(
-					chalk.yellow(
-						`Skipping "${ blockJson[ prop ].replace(
-							'file:',
-							''
-						) }" listed in "${ blockMetadataFile.replace(
-							fromProjectRoot( sep ),
-							''
-						) }". File is located outside of the "${ context }" directory.`
-					)
+				warn(
+					`Skipping "${ parsedBlockJson[ prop ].replace(
+						'file:',
+						''
+					) }" listed in "${ blockMetadataFile.replace(
+						fromProjectRoot( sep ),
+						''
+					) }". File is located outside of the "${ context }" directory.`
 				);
 				continue;
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Extracted from https://github.com/WordPress/gutenberg/pull/66466#discussion_r1816548283:

> @sirreal, I checked the previous implementation before the function had support for `buildType` added in https://github.com/WordPress/gutenberg/pull/57461 and the `return` was inside the callback rather than loop. So it should continue execution and skip only misconfigured entries.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was useful in the watch mode when running `wp-scripts start` as it allowed developers made mistakes during development. There would be an error message displayed in the terminal that should help to resolve the issue without running the same command again.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

I created a custom block from the Gutenberg repository and put it in the watch mode with:
```bash
npx wp-create-block example-block --no-wp-scripts
cd example-block
npx ../node_modules/.bin/wp-scripts start
```

I made an error in `block.json` file to ensure it errors. I was able to see the warning coming from webpack config and the error coming from the bundler for the usage of import inside the JS code for `block.json`. The command continued to work and resumed to fully operational after I fixed the JSON file and saved it again.

Some examples after the changes applied with this PR while webpack continues to run in the watch mode:

<img width="1284" alt="Screenshot 2024-11-05 at 15 13 04" src="https://github.com/user-attachments/assets/693f6b7c-ba54-470e-8b7a-58e1c95dba9d">

<img width="1391" alt="Screenshot 2024-11-05 at 15 13 11" src="https://github.com/user-attachments/assets/aafd7b93-a41e-411a-8b16-b386a520b36f">
