### PR TITLE
Manage controlled inner blocks in content only

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -262,6 +262,8 @@ const BlockInspectorSingleBlock = ( {
 				),
 			};
 		} );
+	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
+	const editorMode = __unstableGetEditorMode();
 
 	return (
 		<div className="block-editor-block-inspector">
@@ -311,6 +313,20 @@ const BlockInspectorSingleBlock = ( {
 
 					{ ! isSectionBlock && (
 						<>
+							{ editorMode === 'navigation' &&
+								isSelectedContentClientIdControlling && (
+									<PanelBody title={ __( 'Content' ) }>
+										<PrivateListView
+											rootClientId={
+												selectedContentClientId
+											}
+											ignoreRenderingMode
+											isExpanded
+											description={ __( 'Inner blocks' ) }
+											showAppender={ false }
+										/>
+									</PanelBody>
+								) }
 							<InspectorControls.Slot />
 							<InspectorControls.Slot group="list" />
 							<InspectorControls.Slot

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -29,8 +29,10 @@ import useBlockInspectorAnimationSettings from './useBlockInspectorAnimationSett
 import BlockInfo from '../block-info-slot-fill';
 import BlockQuickNavigation from '../block-quick-navigation';
 import { useBorderPanelLabel } from '../../hooks/border';
+import { privateApis as blockEditorPrivateApis } from '../../private-apis';
 
 import { unlock } from '../../lock-unlock';
+const { PrivateListView } = unlock( blockEditorPrivateApis );
 
 function BlockStylesPanel( { clientId } ) {
 	return (
@@ -223,6 +225,7 @@ const BlockInspectorSingleBlock = ( {
 		},
 		[ blockName ]
 	);
+
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const borderPanelLabel = useBorderPanelLabel( { blockName } );
 	const contentClientIds = useSelect(
@@ -246,6 +249,20 @@ const BlockInspectorSingleBlock = ( {
 		[ isSectionBlock, clientId ]
 	);
 
+	const { selectedContentClientId, isSelectedContentClientIdControlling } =
+		useSelect( ( select ) => {
+			const { getSelectedBlockClientId, areInnerBlocksControlled } =
+				select( blockEditorStore );
+
+			const _selectedBlockClientId = getSelectedBlockClientId();
+			return {
+				selectedContentClientId: _selectedBlockClientId,
+				isSelectedContentClientIdControlling: areInnerBlocksControlled(
+					_selectedBlockClientId
+				),
+			};
+		} );
+
 	return (
 		<div className="block-editor-block-inspector">
 			<BlockCard
@@ -268,13 +285,29 @@ const BlockInspectorSingleBlock = ( {
 						<BlockStylesPanel clientId={ clientId } />
 					) }
 
-					{ contentClientIds && contentClientIds?.length > 0 && (
-						<PanelBody title={ __( 'Content' ) }>
-							<BlockQuickNavigation
-								clientIds={ contentClientIds }
-							/>
-						</PanelBody>
-					) }
+					{ ! isSelectedContentClientIdControlling &&
+						contentClientIds &&
+						contentClientIds?.length > 0 && (
+							<PanelBody title={ __( 'Content' ) }>
+								<BlockQuickNavigation
+									clientIds={ contentClientIds }
+								/>
+							</PanelBody>
+						) }
+
+					{ isSelectedContentClientIdControlling &&
+						contentClientIds &&
+						contentClientIds?.length > 0 && (
+							<PanelBody title={ __( 'Content' ) }>
+								<PrivateListView
+									rootClientId={ selectedContentClientId }
+									ignoreRenderingMode
+									isExpanded
+									description={ __( 'Inner blocks' ) }
+									showAppender={ false }
+								/>
+							</PanelBody>
+						) }
 
 					{ ! isSectionBlock && (
 						<>

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -249,19 +249,38 @@ const BlockInspectorSingleBlock = ( {
 		[ isSectionBlock, clientId ]
 	);
 
-	const { selectedContentClientId, isSelectedContentClientIdControlling } =
-		useSelect( ( select ) => {
-			const { getSelectedBlockClientId, areInnerBlocksControlled } =
-				select( blockEditorStore );
+	const {
+		selectedContentClientId,
+		isSelectedContentClientIdControlling,
+		isSelectedBlockInContentOnlyContainer,
+	} = useSelect( ( select ) => {
+		const {
+			getSelectedBlockClientId,
+			areInnerBlocksControlled,
+			getBlockRootClientId,
+			getTemplateLock,
+		} = select( blockEditorStore );
 
-			const _selectedBlockClientId = getSelectedBlockClientId();
-			return {
-				selectedContentClientId: _selectedBlockClientId,
-				isSelectedContentClientIdControlling: areInnerBlocksControlled(
-					_selectedBlockClientId
-				),
-			};
-		} );
+		const _selectedBlockClientId = getSelectedBlockClientId();
+		const _isSelectedContentClientIdControlling = areInnerBlocksControlled(
+			_selectedBlockClientId
+		);
+
+		const rootClientId = getBlockRootClientId( _selectedBlockClientId );
+		const templateLock = getTemplateLock( rootClientId );
+
+		const _isSelectedBlockInContentOnlyContainer =
+			templateLock === 'contentOnly';
+
+		return {
+			selectedContentClientId: _selectedBlockClientId,
+			isSelectedContentClientIdControlling:
+				_isSelectedContentClientIdControlling,
+			isSelectedBlockInContentOnlyContainer:
+				_isSelectedBlockInContentOnlyContainer,
+			hasContentLockedParent: false,
+		};
+	} );
 	const { __unstableGetEditorMode } = useSelect( blockEditorStore );
 	const editorMode = __unstableGetEditorMode();
 
@@ -298,6 +317,7 @@ const BlockInspectorSingleBlock = ( {
 						) }
 
 					{ isSelectedContentClientIdControlling &&
+						isSelectedBlockInContentOnlyContainer &&
 						contentClientIds &&
 						contentClientIds?.length > 0 && (
 							<PanelBody title={ __( 'Content' ) }>
@@ -314,6 +334,7 @@ const BlockInspectorSingleBlock = ( {
 					{ ! isSectionBlock && (
 						<>
 							{ editorMode === 'navigation' &&
+								isSelectedBlockInContentOnlyContainer &&
 								isSelectedContentClientIdControlling && (
 									<PanelBody title={ __( 'Content' ) }>
 										<PrivateListView

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -215,6 +215,7 @@ const BlockInspectorSingleBlock = ( {
 	isSectionBlock,
 } ) => {
 	const availableTabs = useInspectorControlsTabs( blockName );
+
 	const showTabs = ! isSectionBlock && availableTabs?.length > 1;
 
 	const hasBlockStyles = useSelect(

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -78,6 +78,7 @@ export const BLOCK_LIST_ITEM_HEIGHT = 32;
  * @param {?HTMLElement}   props.dropZoneElement        Optional element to be used as the drop zone.
  * @param {?boolean}       props.showBlockMovers        Flag to enable block movers. Defaults to `false`.
  * @param {?boolean}       props.isExpanded             Flag to determine whether nested levels are expanded by default. Defaults to `false`.
+ * @param {?boolean}       props.ignoreRenderingMode    Flag to ignore rendering mode and always show the block. Defaults to `false`.
  * @param {?boolean}       props.showAppender           Flag to show or hide the block appender. Defaults to `false`.
  * @param {?ComponentType} props.blockSettingsMenu      Optional more menu substitution. Defaults to the standard `BlockSettingsDropdown` component.
  * @param {string}         props.rootClientId           The client id of the root block from which we determine the blocks to show in the list.
@@ -93,6 +94,7 @@ function ListViewComponent(
 		dropZoneElement,
 		showBlockMovers = false,
 		isExpanded = false,
+		ignoreRenderingMode = false,
 		showAppender = false,
 		blockSettingsMenu: BlockSettingsMenu = BlockSettingsDropdown,
 		rootClientId,
@@ -115,7 +117,7 @@ function ListViewComponent(
 
 	const instanceId = useInstanceId( ListViewComponent );
 	const { clientIdsTree, draggedClientIds, selectedClientIds } =
-		useListViewClientIds( { blocks, rootClientId } );
+		useListViewClientIds( { blocks, rootClientId, ignoreRenderingMode } );
 	const blockIndexes = useListViewBlockIndexes( clientIdsTree );
 
 	const { getBlock } = useSelect( blockEditorStore );

--- a/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-client-ids.js
@@ -10,22 +10,29 @@ import { useSelect } from '@wordpress/data';
 import { store as blockEditorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
 
-export default function useListViewClientIds( { blocks, rootClientId } ) {
+export default function useListViewClientIds( {
+	blocks,
+	rootClientId,
+	ignoreRenderingMode,
+} ) {
 	return useSelect(
 		( select ) => {
 			const {
 				getDraggedBlockClientIds,
 				getSelectedBlockClientIds,
 				getEnabledClientIdsTree,
+				__unstableGetClientIdsTree: getClientIdsTree,
 			} = unlock( select( blockEditorStore ) );
 
 			return {
 				selectedClientIds: getSelectedBlockClientIds(),
 				draggedClientIds: getDraggedBlockClientIds(),
 				clientIdsTree:
-					blocks ?? getEnabledClientIdsTree( rootClientId ),
+					blocks ?? ignoreRenderingMode
+						? getClientIdsTree( rootClientId )
+						: getEnabledClientIdsTree( rootClientId ),
 			};
 		},
-		[ blocks, rootClientId ]
+		[ blocks, rootClientId, ignoreRenderingMode ]
 	);
 }

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -90,6 +90,7 @@ function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
 			state,
 			clientId
 		);
+
 		if ( getBlockEditingMode( state, clientId ) !== 'disabled' ) {
 			result.push( { clientId, innerBlocks } );
 		} else {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3046,6 +3046,12 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
+			// All controlling blocks are treated as content only
+			// by default.
+			if ( areInnerBlocksControlled( state, clientId ) ) {
+				return 'contentOnly';
+			}
+
 			// In zoom-out mode, override the behavior set by
 			// __unstableSetBlockEditingMode to only allow editing the top-level
 			// sections.
@@ -3074,10 +3080,6 @@ export const getBlockEditingMode = createRegistrySelector(
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'navigation' ) {
 				const sectionRootClientId = getSectionRootClientId( state );
-
-				if ( areInnerBlocksControlled( state, clientId ) ) {
-					return 'contentOnly';
-				}
 
 				// The root section is "default mode"
 				if ( clientId === sectionRootClientId ) {

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3046,12 +3046,6 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
-			// All controlling blocks are treated as content only
-			// by default.
-			if ( areInnerBlocksControlled( state, clientId ) ) {
-				return 'contentOnly';
-			}
-
 			// In zoom-out mode, override the behavior set by
 			// __unstableSetBlockEditingMode to only allow editing the top-level
 			// sections.
@@ -3071,6 +3065,12 @@ export const getBlockEditingMode = createRegistrySelector(
 
 				// Sections are always contentOnly.
 				if ( sectionsClientIds?.includes( clientId ) ) {
+					return 'contentOnly';
+				}
+
+				// All controlling blocks are treated as content only
+				// by default.
+				if ( areInnerBlocksControlled( state, clientId ) ) {
 					return 'contentOnly';
 				}
 
@@ -3113,6 +3113,15 @@ export const getBlockEditingMode = createRegistrySelector(
 				);
 				const isContent = hasContentRoleAttribute( name );
 
+				// All controlling blocks are treated as content only
+				// by default.
+				if (
+					! isContent &&
+					areInnerBlocksControlled( state, clientId )
+				) {
+					return 'contentOnly';
+				}
+
 				return isContent ? 'contentOnly' : 'disabled';
 			}
 
@@ -3136,6 +3145,16 @@ export const getBlockEditingMode = createRegistrySelector(
 					select( blocksStore )
 				);
 				const isContent = hasContentRoleAttribute( name );
+
+				// All controlling blocks are treated as content only
+				// by default.
+				if (
+					! isContent &&
+					areInnerBlocksControlled( state, clientId )
+				) {
+					return 'contentOnly';
+				}
+
 				return isContent ? 'contentOnly' : 'disabled';
 			}
 			// Otherwise, check if there's an ancestor that is contentOnly

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3046,6 +3046,10 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
+			if ( areInnerBlocksControlled( state, clientId ) ) {
+				return 'contentOnly';
+			}
+
 			// In zoom-out mode, override the behavior set by
 			// __unstableSetBlockEditingMode to only allow editing the top-level
 			// sections.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3046,10 +3046,6 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
-			if ( areInnerBlocksControlled( state, clientId ) ) {
-				return 'contentOnly';
-			}
-
 			// In zoom-out mode, override the behavior set by
 			// __unstableSetBlockEditingMode to only allow editing the top-level
 			// sections.
@@ -3078,6 +3074,10 @@ export const getBlockEditingMode = createRegistrySelector(
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'navigation' ) {
 				const sectionRootClientId = getSectionRootClientId( state );
+
+				if ( areInnerBlocksControlled( state, clientId ) ) {
+					return 'contentOnly';
+				}
 
 				// The root section is "default mode"
 				if ( clientId === sectionRootClientId ) {

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -73,6 +73,11 @@ export default function NavigationInnerBlocks( {
 	const showPlaceholder =
 		! hasCustomPlaceholder && ! hasMenuItems && ! isSelected;
 
+	const defaultRenderingMode = useSelect( ( select ) => {
+		const { getBlockEditingMode } = select( blockEditorStore );
+		return getBlockEditingMode( clientId ) === 'default';
+	} );
+
 	const innerBlocksProps = useInnerBlocksProps(
 		{
 			className: 'wp-block-navigation__container',
@@ -93,13 +98,14 @@ export default function NavigationInnerBlocks( {
 			// the sibling inserter.
 			// See https://github.com/WordPress/gutenberg/issues/37572.
 			renderAppender:
-				isSelected ||
+				defaultRenderingMode &&
+				( isSelected ||
 				( isImmediateParentOfSelectedBlock &&
 					! selectedBlockHasChildren ) ||
 				// Show the appender while dragging to allow inserting element between item and the appender.
 				parentOrChildHasSelection
 					? InnerBlocks.ButtonBlockAppender
-					: false,
+					: false ),
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
 			__unstableDisableLayoutClassNames: true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Deeply nested blocks are hard to edit in design mode already. In write mode they become even more complicated to reach and reliably update.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Follow-up from a discussion with @youknowriad we can update content only to:

- enable blocks with controlled inner blocks to expose these inner blocks in the block inspector via a list view
  - this list view auto engages when a block with controlled inner blocks is selected in content only mode
  - the block inspector will support drilldown for blocks that show this list view of inner blocks
- make blocks with controlled inner blocks in content only are selectable but not editable in the canvas

Briefly:

- Use an off canvas list view as an affordance for editing controlled inner blocks in the block inspector.
- Treat all blocks that have controlled inner blocks the same when they're the children of content only locking parents.
- Update the list view to be able to show full tree independent of the editing mode
- Refine the display and interaction to enable drill down editing of attributes for controlled inner blocks

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- in a page
- add a pattern (simple, not synced!) from the pattern library
- add a navigation block in the pattern
- go to the code editor and edit the containing group to have content only locking by adding `"templateLock": "contentOnly"` to the outermost `<!-- wp:group`
- exit code editor
- select the patten - **notice the navigation block shows in the quick block navigation in the inspector**
- select the navigation block - **notice there is a list view rendered in the inspector**

**Open questions**


- Where should this list view appear? Does it appear on its own, or do we squish it bethween parent styles and block quick navigation?
- How is this redefining content only? If all blocks with controlled inner blocks become editable via the inspector, we break the contract that only role="content" is editable in content only.
- How much can we bloat the list view with? To implement the ideas above we'll need a new flag in the list view that tells it to disregard content only and list the full block tree not the flattened editable one.
- How much can we bifurcate the implementation of the block inspector? To add drill down just for this list view but not for other blocks may be a very specific execution path with lots of code serving a single small UX surface.
- Is this UX actually good? Having some exploratory PR will allow hands on interaction.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d143488c-88c4-41eb-8a98-d81149a40a44



