### PR TITLE
Fix TS types for editor package

### DIFF
--- a/docs/reference-guides/data/data-core-editor.md
+++ b/docs/reference-guides/data/data-core-editor.md
@@ -786,7 +786,7 @@ Return true if the current post has already been published.
 _Parameters_
 
 -   _state_ `Object`: Global application state.
--   _currentPost_ `Object?`: Explicit current post for bypassing registry selector.
+-   _currentPost_ `[Object]`: Explicit current post for bypassing registry selector.
 
 _Returns_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1631,10 +1631,6 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore>
 
-_Type_
-
--   `Object`
-
 ### storeConfig
 
 Post editor data store configuration.
@@ -1642,10 +1638,6 @@ Post editor data store configuration.
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#registerStore>
-
-_Type_
-
--   `Object`
 
 ### TableOfContents
 

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -26,6 +26,7 @@
 	"module": "build-module/index.js",
 	"react-native": "src/index",
 	"wpScript": true,
+	"types": "build-types",
 	"sideEffects": [
 		"build-style/**",
 		"src/**/*.scss",

--- a/packages/editor/src/store/constants.ts
+++ b/packages/editor/src/store/constants.ts
@@ -8,8 +8,6 @@ export const EDIT_MERGE_PROPERTIES = new Set( [ 'meta' ] );
 
 /**
  * Constant for the store module (or reducer) key.
- *
- * @type {string}
  */
 export const STORE_NAME = 'core/editor';
 

--- a/packages/editor/src/store/index.js
+++ b/packages/editor/src/store/index.js
@@ -18,8 +18,6 @@ import { unlock } from '../lock-unlock';
  * Post editor data store configuration.
  *
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#registerStore
- *
- * @type {Object}
  */
 export const storeConfig = {
 	reducer,
@@ -31,8 +29,6 @@ export const storeConfig = {
  * Store definition for the editor namespace.
  *
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/data/README.md#createReduxStore
- *
- * @type {Object}
  */
 export const store = createReduxStore( STORE_NAME, {
 	...storeConfig,

--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -442,8 +442,8 @@ export function isCurrentPostPending( state ) {
 /**
  * Return true if the current post has already been published.
  *
- * @param {Object}  state       Global application state.
- * @param {Object?} currentPost Explicit current post for bypassing registry selector.
+ * @param {Object} state         Global application state.
+ * @param {Object} [currentPost] Explicit current post for bypassing registry selector.
  *
  * @return {boolean} Whether the post has been published.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes TS types for editor package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Currentl, the types for the package are broken because of the third-party types package - [`@types/wordpress__editor`](https://www.npmjs.com/package/@types/wordpress__editor), which we can deprecate following this PR.

## How?
The problem with types was that the `store` object exported by the package was typed as `object`, which prevented the type generator from setting the types correctly. Thus this PR removes that type annotation to allow inference from imports

## Testing Instructions
- Before this PR, IDE like VS Code would tell you that it is unable to find the type declarations for the package and would suggest to install the above mentioned third-party types package, you can verify that VS Code no longer suggests that.
- When you install the third-party types package, the types for `useSelect` and `useDispatch` are broken and TS yells that the selector is not callable or the method doesn't exist. You can verify that things will work fine without the third-party types

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
