### PR TITLE
Fix inconsistent sidebars close buttons sizes

### DIFF
--- a/packages/block-editor/src/components/tabbed-sidebar/index.js
+++ b/packages/block-editor/src/components/tabbed-sidebar/index.js
@@ -33,7 +33,7 @@ function TabbedSidebar(
 						icon={ closeSmall }
 						label={ closeButtonLabel }
 						onClick={ () => onClose() }
-						size="small"
+						size="compact"
 					/>
 
 					<Tabs.TabList

--- a/packages/block-editor/src/components/tabbed-sidebar/style.scss
+++ b/packages/block-editor/src/components/tabbed-sidebar/style.scss
@@ -11,7 +11,7 @@
 	border-bottom: $border-width solid $gray-300;
 	display: flex;
 	justify-content: space-between;
-	padding-right: $grid-unit-15;
+	padding-right: $grid-unit-10;
 }
 
 

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -94,12 +94,13 @@
 .edit-widgets-header__actions {
 	display: flex;
 	align-items: center;
-	padding-right: $grid-unit-20;
-	gap: $grid-unit-05;
+	padding-right: $grid-unit-05;
 
 	@include break-small() {
-		gap: $grid-unit-10;
+		padding-right: $grid-unit-10;
 	}
+
+	gap: $grid-unit-10;
 }
 
 .edit-widgets-header-toolbar {

--- a/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/list-view-sidebar.js
@@ -51,10 +51,10 @@ export default function ListViewSidebar() {
 			<div className="edit-widgets-editor__list-view-panel-header">
 				<strong>{ __( 'List View' ) }</strong>
 				<Button
-					__next40pxDefaultSize
 					icon={ closeSmall }
 					label={ __( 'Close' ) }
 					onClick={ closeListView }
+					size="compact"
 				/>
 			</div>
 			<div

--- a/packages/edit-widgets/src/components/secondary-sidebar/style.scss
+++ b/packages/edit-widgets/src/components/secondary-sidebar/style.scss
@@ -21,5 +21,5 @@
 	justify-content: space-between;
 	height: $grid-unit-60;
 	padding-left: $grid-unit-20;
-	padding-right: $grid-unit-05;
+	padding-right: $grid-unit-10;
 }

--- a/packages/editor/src/components/sidebar/style.scss
+++ b/packages/editor/src/components/sidebar/style.scss
@@ -1,11 +1,9 @@
 .components-panel__header.editor-sidebar__panel-tabs {
 	padding-left: 0;
-	padding-right: $grid-unit-15;
+	padding-right: $grid-unit-10;
 
 	.components-button.has-icon {
 		padding: 0;
-		min-width: $icon-size;
-		height: $icon-size;
 
 		@include break-medium() {
 			display: flex;

--- a/packages/interface/src/components/complementary-area-header/style.scss
+++ b/packages/interface/src/components/complementary-area-header/style.scss
@@ -1,7 +1,7 @@
 .interface-complementary-area-header {
 	background: $white;
-	padding-right: $grid-unit-15; // Reduced padding to account for close buttons.
-	gap: $grid-unit-10; // Always ensure space between contents and close buttons.
+	padding-right: $grid-unit-10; // Reduced padding to account for close buttons.
+	gap: $grid-unit-05; // Always ensure space between contents and close buttons.
 
 	.interface-complementary-area-header__title {
 		margin: 0 auto 0 0;

--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -308,7 +308,7 @@ function ComplementaryArea( {
 					onClose={ () => disableComplementaryArea( scope ) }
 					toggleButtonProps={ {
 						label: closeLabel,
-						size: 'small',
+						size: 'compact',
 						shortcut: toggleShortcut,
 						scope,
 						identifier,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66277

## What?
<!-- In a few words, what is the PR actually doing? -->
After https://github.com/WordPress/gutenberg/pull/61331 the size of the X close button of various sidebar panels is unnecessarily too small and inconsistent with other similar buttons.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
For better usability and accessibility, the target size should always be as big as possibile.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Increases the button size to `compact` and adjusts alignments where necessary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site editor.
- Open the Styles panel.
- Observe the size of the buttons in the panel header is now consistent and the X close button uses the 'compact' size (32 by 32 pixels).
- Observe the gap between the buttons is consistent.
- Observe the X close button is horizontally aligned with the ellipsis button in the top bar.
- Install and activate a plugin that adds a plugins panel e.g. Yoast SEO.
- Go to the Post editor.
- Open the plugin panel and observe the 'Pin / Unpin' button and the X close button use the 'compact' size (32 by 32 pixels).
- Open the post/block settings panel and observe the X close button uses the 'compact' size (32 by 32 pixels).
- Open the main inserter and observe the X close button uses the 'compact' size (32 by 32 pixels).
- Same for the List View panel.
- Set Twenty Twenty-One as the active theme.
- Go to the Widgets page.
- Observe the size and alignment of the main inserter and the List view X close buttons are consistent.
- Aside: Observe the right padding of the widgets editor top bar is now consistent with the one of the other two editors.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
