### PR TITLE
Block Editor: Fix ESLint warning for 'useBlockTypesState' hook

### DIFF
--- a/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
+++ b/packages/block-editor/src/components/inserter/hooks/use-block-types-state.js
@@ -94,7 +94,12 @@ const useBlockTypesState = ( rootClientId, onInsert, isQuick ) => {
 				destinationClientId
 			);
 		},
-		[ onInsert, getClosestAllowedInsertionPoint, rootClientId ]
+		[
+			getClosestAllowedInsertionPoint,
+			rootClientId,
+			onInsert,
+			createErrorNotice,
+		]
 	);
 
 	return [ items, categories, collections, onSelectItem ];


### PR DESCRIPTION
## What?
PR fixes the ESLint warning for the 'useBlockTypesState' hook.

```
React Hook useCallback has a missing dependency: 'createErrorNotice'. Either include it or remove the dependency array.
```

Discovered while debugging https://github.com/WordPress/gutenberg/issues/65687#issuecomment-2457204111.

## Testing Instructions
None. CI checks should be green.