### PR TITLE
Perf metrics: update select and other metrics to use non-empty paragraphs

### DIFF
--- a/test/performance/fixtures/perf-utils.ts
+++ b/test/performance/fixtures/perf-utils.ts
@@ -150,7 +150,7 @@ export class PerfUtils {
 	}
 
 	/**
-	 * Generates and loads a 1000 empty paragraphs into the editor canvas.
+	 * Generates and loads a 1000 paragraphs into the editor canvas.
 	 */
 	async load1000Paragraphs() {
 		await this.page.waitForFunction(
@@ -161,7 +161,7 @@ export class PerfUtils {
 			const { createBlock } = window.wp.blocks;
 			const { dispatch } = window.wp.data;
 			const blocks = Array.from( { length: 1000 } ).map( () =>
-				createBlock( 'core/paragraph' )
+				createBlock( 'core/paragraph', { content: 'paragraph' } )
 			);
 			dispatch( 'core/block-editor' ).resetBlocks( blocks );
 		} );

--- a/test/performance/specs/post-editor.spec.js
+++ b/test/performance/specs/post-editor.spec.js
@@ -270,7 +270,7 @@ test.describe( 'Post Editor Performance', () => {
 			const canvas = await perfUtils.getCanvas();
 
 			const paragraphs = canvas.getByRole( 'document', {
-				name: /Empty block/i,
+				name: /Block: Paragraph/i,
 			} );
 
 			const samples = 10;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

https://github.com/WordPress/gutenberg/pull/66636 caused an increase in the "select" metric simply be restoring the empty paragraph inserter. This made me realise that the paragraphs used in the test are all empty!

Why would this be a real scenario? Most blocks that someone will select will NOT be empty. The empty paragraph (default block) is actually an exception in many ways: we do not render the block toolbar, and we do render the inserter. Why would we want to test an exception? 

I don't see how a 1000 empty paragraphs a good scenario for any perf test, so I changed the util. 

## Why?


Unrealistic performance test.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
