### PR TITLE
Fix: Increase the modal close button size to 32px.

### DIFF
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -25,7 +25,7 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 
 	return (
 		<Button
-			size="small"
+			size="compact"
 			onClick={ onClick }
 			icon={ fullscreen }
 			isPressed={ isModalFullScreen }

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -338,7 +338,7 @@ function UnforwardedModal(
 											marginLeft={ 3 }
 										/>
 										<Button
-											size="small"
+											size="compact"
 											onClick={ (
 												event: React.MouseEvent< HTMLButtonElement >
 											) =>

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -110,7 +110,7 @@ export const WithHeaderActions: StoryFn< typeof Modal > = Template.bind( {} );
 WithHeaderActions.args = {
 	...Default.args,
 	headerActions: (
-		<Button icon={ fullscreen } label="Fullscreen mode" size="small" />
+		<Button icon={ fullscreen } label="Fullscreen mode" size="compact" />
 	),
 	children: <div style={ { height: '200px' } } />,
 };


### PR DESCRIPTION
## What?
Fix : #66758 

## Why?
As described in #66758 the current close button size modal is too small in terms of accessibility after the recent change. So this PR updates the current "small" size to "compact" i.e, `32px`.

## Testing Instructions

- Open any modal e.g. the Preferences one, or the Keyboard shortcut one, or the one to rename a block.
- Observe the size of the `close button` of the modal should be 32 by 32 pixels.

## Screenshots or screencast 

<img width="788" alt="image" src="https://github.com/user-attachments/assets/9a3a08cd-f428-4b69-b51f-e10ca1c35978">
