### PR TITLE
ci: Address stalling Android E2E test tasks

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -49,26 +49,28 @@ jobs:
             - name: Gradle cache
               uses: gradle/actions/setup-gradle@d156388eb19639ec20ade50009f3d199ce1e2808 # v4.1.0
 
-            - name: AVD cache
-              uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-              id: avd-cache
-              with:
-                  path: |
-                      ~/.android/avd/*
-                      ~/.android/adb*
-                  key: avd-${{ matrix.api-level }}
-
-            - name: Create AVD and generate snapshot for caching
-              if: steps.avd-cache.outputs.cache-hit != 'true'
-              uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
-              with:
-                  api-level: ${{ matrix.api-level }}
-                  force-avd-creation: false
-                  emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-                  disable-animations: false
-                  arch: x86_64
-                  profile: Nexus 6
-                  script: echo "Generated AVD snapshot for caching."
+            # AVD cache disabled as it caused emulator termination to hang indefinitely.
+            # https://github.com/ReactiveCircus/android-emulator-runner/issues/385
+            # - name: AVD cache
+            #   uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+            #   id: avd-cache
+            #   with:
+            #       path: |
+            #           ~/.android/avd/*
+            #           ~/.android/adb*
+            #       key: avd-${{ matrix.api-level }}
+            #
+            # - name: Create AVD and generate snapshot for caching
+            #   if: steps.avd-cache.outputs.cache-hit != 'true'
+            #   uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
+            #   with:
+            #       api-level: ${{ matrix.api-level }}
+            #       force-avd-creation: false
+            #       emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+            #       disable-animations: false
+            #       arch: x86_64
+            #       profile: Nexus 6
+            #       script: echo "Generated AVD snapshot for caching."
 
             - name: Run tests
               uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -20,6 +20,8 @@ jobs:
             matrix:
                 native-test-name: [gutenberg-editor-rendering]
                 api-level: [29]
+                target: [default, google_apis]
+                arch: [x86_64]
 
         steps:
             - name: checkout
@@ -56,17 +58,18 @@ jobs:
                   path: |
                       ~/.android/avd/*
                       ~/.android/adb*
-                  key: avd-${{ matrix.api-level }}
+                  key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
 
             - name: Create AVD and generate snapshot for caching
               if: steps.avd-cache.outputs.cache-hit != 'true'
               uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
               with:
                   api-level: ${{ matrix.api-level }}
+                  target: ${{ matrix.target }}
                   force-avd-creation: false
                   emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   disable-animations: false
-                  arch: x86_64
+                  arch: ${{ matrix.arch }}
                   profile: Nexus 6
                   script: echo "Generated AVD snapshot for caching."
 
@@ -74,10 +77,11 @@ jobs:
               uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
               with:
                   api-level: ${{ matrix.api-level }}
+                  target: ${{ matrix.target }}
                   force-avd-creation: false
                   emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   disable-animations: true
-                  arch: x86_64
+                  arch: ${{ matrix.arch }}
                   profile: Nexus 6
                   script: npm run native test:e2e:android:local ${{ matrix.native-test-name }}
 

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -20,8 +20,6 @@ jobs:
             matrix:
                 native-test-name: [gutenberg-editor-rendering]
                 api-level: [29]
-                target: [default, google_apis]
-                arch: [x86_64]
 
         steps:
             - name: checkout
@@ -58,18 +56,17 @@ jobs:
                   path: |
                       ~/.android/avd/*
                       ~/.android/adb*
-                  key: avd-${{ matrix.api-level }}-${{ matrix.target }}-${{ matrix.arch }}
+                  key: avd-${{ matrix.api-level }}
 
             - name: Create AVD and generate snapshot for caching
               if: steps.avd-cache.outputs.cache-hit != 'true'
               uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
               with:
                   api-level: ${{ matrix.api-level }}
-                  target: ${{ matrix.target }}
                   force-avd-creation: false
                   emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   disable-animations: false
-                  arch: ${{ matrix.arch }}
+                  arch: x86_64
                   profile: Nexus 6
                   script: echo "Generated AVD snapshot for caching."
 
@@ -77,11 +74,10 @@ jobs:
               uses: reactivecircus/android-emulator-runner@62dbb605bba737720e10b196cb4220d374026a6d # v2.33.0
               with:
                   api-level: ${{ matrix.api-level }}
-                  target: ${{ matrix.target }}
                   force-avd-creation: false
                   emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
                   disable-animations: true
-                  arch: ${{ matrix.arch }}
+                  arch: x86_64
                   profile: Nexus 6
                   script: npm run native test:e2e:android:local ${{ matrix.native-test-name }}
 

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-13
+        runs-on: macos-12
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Address [recently](https://github.com/WordPress/gutenberg/actions/workflows/rnmobile-android-runner.yml) indefinite hanging that occurs while terminating the emulator for the Android end-to-end test CI tasks. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The CI tasks never complete, so a successful test suite run is never reported, which blocks the pull request status and causes confusion. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove the [recommended](https://github.com/ReactiveCircus/android-emulator-runner/blob/c77bfe7c0bb57698e777375b61762daf9d578400/README.md#usage--examples) AVD cache, as it appears its presence can cause indefinite hangs while terminating the emulator, as referenced several times in the `reactivecircus/android-emulator-runner` issue tracker: 

* https://github.com/ReactiveCircus/android-emulator-runner/issues/385
* https://github.com/ReactiveCircus/android-emulator-runner/issues/362
* https://github.com/ReactiveCircus/android-emulator-runner/issues/373
* https://github.com/ReactiveCircus/android-emulator-runner/issues/381

It is possible that removing the AVD cache is somewhat of an ineffective fix—temporarily solving the issue in the form of removing a problematic cache—but, given numerous other people report the AVD cache as problematic, I figure removing the AVD cache is worth a try. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
N/A, no user-facing changes.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
N/A, no user-facing changes.

## Screenshots or screencast <!-- if applicable -->
N/A, no user-facing changes.
