### PR TITLE
Interactivity API: Delay block hydration to allow interactive block stores to initialize

### DIFF
--- a/packages/interactivity/src/init.ts
+++ b/packages/interactivity/src/init.ts
@@ -33,6 +33,17 @@ export const init = async () => {
 		`[data-${ directivePrefix }-interactive]`
 	);
 
+	/*
+	 * This `await` with setTimeout is required to apparently ensure that the interactive blocks have their stores
+	 * fully initialized prior to hydrating the blocks. If this is not present, then an error occurs, for example:
+	 * > view.js:46 Uncaught (in promise) ReferenceError: Cannot access 'state' before initialization
+	 * This occurs when splitTask() is implemented with scheduler.yield() as opposed to setTimeout(), as with the former
+	 * split tasks are added to the front of the task queue whereas with the latter they are added to the end of the queue.
+	 */
+	await new Promise( ( resolve ) => {
+		setTimeout( resolve, 0 );
+	} );
+
 	for ( const node of nodes ) {
 		if ( ! hydratedIslands.has( node ) ) {
 			await splitTask();

--- a/packages/interactivity/src/utils.ts
+++ b/packages/interactivity/src/utils.ts
@@ -54,7 +54,7 @@ const afterNextFrame = ( callback: () => void ) => {
 /**
  * Returns a promise that resolves after yielding to main.
  *
- * @return Promise
+ * @return Promise<void>
  */
 export const splitTask =
 	typeof window.scheduler?.yield === 'function'


### PR DESCRIPTION
Fixes #66691.

When `scheduler.yield()` is available, the `splitTask()` function is implemented to use it. When a task is split with `scheduler.yield()` it results in the tail being added to the front of the task queue. In contrast, when `splitTask()` is implemented with `setTimeout()` (when `scheduler.yield()` is not available), then the tail of the split task is added to the end of the task queue. It appears there is a race condition between the call to `init`. 

In particular, given this `init` function:

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/interactivity/src/init.ts#L30-L46

It is getting invoked _before_ the code in a block's `view.js` is invoked, for example:

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/block-library/src/image/view.js#L22

When `splitTask()` is was using `setTimeout()` then the calls to `await splitTask()` had the effect of delaying the hydration until _after_ the blocks' view modules execute. But when `splitTask()` is implemented with `scheduler.yield()` the hydration logic is executing _before_ the interactive blocks' view module (i.e. the store initialization) executes. 

Of note, the error also occurs if `await splitTask()` is eliminated from `init` function as well, indicating that it was not correctly accounting for delaying the Interactivity API's `init` until _after_ the interactive blocks have all initialized. There seems to be a dependency problem here, where hydration of an interactive block should be blocked until its corresponding view script module has loaded. This seems to be related to:

* https://github.com/WordPress/gutenberg/issues/2768
* https://github.com/WordPress/gutenberg/discussions/52723
* [Blocks: Introduce a way to enqueue view scripts only when needed for interactivity](https://core.trac.wordpress.org/ticket/59462)

In the mean time, adding a `setTimeout()` to handle the delay seems to do the trick.

# Code execution with `splitTask` implemented with `setTimeout` 

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/interactivity/src/init.ts#L31-L38

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/block-library/src/image/view.js#L22

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/interactivity/src/init.ts#L39-L46

# Code execution with `splitTask` implemented with `scheduler.yield` 

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/interactivity/src/init.ts#L30-L46

https://github.com/WordPress/gutenberg/blob/7f49b39e1e3e2eaf274b6fb03ae22508cc583d31/packages/block-library/src/image/view.js#L22