### PR TITLE
Edit Site: Remove leftover 'priority-queue' dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54310,7 +54310,6 @@
 				"@wordpress/plugins": "*",
 				"@wordpress/preferences": "*",
 				"@wordpress/primitives": "*",
-				"@wordpress/priority-queue": "*",
 				"@wordpress/private-apis": "*",
 				"@wordpress/reusable-blocks": "*",
 				"@wordpress/router": "*",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -61,7 +61,6 @@
 		"@wordpress/plugins": "*",
 		"@wordpress/preferences": "*",
 		"@wordpress/primitives": "*",
-		"@wordpress/priority-queue": "*",
 		"@wordpress/private-apis": "*",
 		"@wordpress/reusable-blocks": "*",
 		"@wordpress/router": "*",


### PR DESCRIPTION
## What?
This is a follow-up to #66744.

PR removes `@wordpress/priority-queue` from dependencies, as the `edit-site` app no longer uses it.

## Testing Instructions
None.
