### PR TITLE
Update block integration test docks to make it clear that the helpers  can't be used externally

### DIFF
--- a/docs/contributors/code/testing-overview.md
+++ b/docs/contributors/code/testing-overview.md
@@ -291,6 +291,8 @@ test( 'fires onChange when a new value is typed', async () => {
 
 ### Integration testing for block UI
 
+**Please note that the integration test helpers are not part of the public API. They are currently experimenal and subject to change so can't be used outside of the core Gutenberg project.**
+
 Integration testing is defined as a type of testing where different parts are tested as a group. In this case, the parts that we want to test are the different components that are required to be rendered for a specific block or editor logic. In the end, they are very similar to unit tests as they are run with the same command using the Jest library. The main difference is that for the integration tests the blocks are run within a [`special instance of the block editor`](https://github.com/WordPress/gutenberg/blob/trunk/test/integration/helpers/integration-test-editor.js#L60).
 
 The advantage of this approach is that the bulk of a block editor's functionality (block toolbar and inspector panel interactions, etc.) can be tested without having to fire up the full e2e test framework. This means the tests can run much faster and more reliably. It is suggested that as much of a block's UI functionality as possible is covered with integration tests, with e2e tests used for interactions that require a full browser environment, eg. file uploads, drag and drop, etc.


### PR DESCRIPTION
## What?
Makes it clear in the docs that the integration test helpers can't currently be used outside of the GB project.

## Why?
Currently a custom block developer might think they should be able to follow the example tests in their own code, but this will fail with missing module type errors.

## How?
Adds a line to docs to explain private nature of the test helpers.

## Testing Instructions
Check the wording

