### PR TITLE
Fix Paragraph appender layout shift (building on 66061)

### DIFF
--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -25,24 +25,10 @@
 		// Set the opacity of the initial block appender to the same as placeholder text in an empty Paragraph block.
 		opacity: 0.62;
 
-		// The following prevent user agent styles from applying margins to the appender's inner paragraph.
-		// Prevents Layout shift in the editor when single post's content block's inner block content width is unset.
+		// The following prevents user agent styles from applying margins to the appender's inner paragraph.
+		// This in turn prevents layout shift due to layout styles removing margins from first and last children.
 		margin-block-start: 0;
 		margin-block-end: 0;
-	}
-
-	// In "constrained" layout containers, the first and last paragraphs have their margins zeroed out.
-	// In the case of this appender, it needs to apply those same rules to avoid layout shifts.
-	// Such shifts happen when the bottom margin of the Title block has been set to less than the default 1em margin of paragraphs.
-	:where(body .is-layout-constrained) &,
-	:where(.wp-site-blocks) & {
-		> :first-child {
-			margin-block-start: 0;
-			margin-block-end: 0;
-		}
-
-		// Since this appender will only ever appear on an entirely empty document, we don't account for last-child.
-		// This is also because it will never be the last child, the block inserter that sits in this appender is the last child.
 	}
 
 	// Dropzone.

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -24,6 +24,11 @@
 	.block-editor-default-block-appender__content {
 		// Set the opacity of the initial block appender to the same as placeholder text in an empty Paragraph block.
 		opacity: 0.62;
+
+		// The following prevent user agent styles from applying margins to the appender's inner paragraph.
+		// Prevents Layout shift in the editor when single post's content block's inner block content width is unset.
+		margin-block-start: 0;
+		margin-block-end: 0;
 	}
 
 	// In "constrained" layout containers, the first and last paragraphs have their margins zeroed out.
@@ -158,15 +163,6 @@
 	.block-editor-inserter__toggle.components-button.has-icon,
 	.block-list-appender__toggle {
 		display: flex;
-	}
-}
-
-// Prevent appender layout shift when default placeholder is clicked and replaced with insertDefaultBlock( undefined, rootClientId );
-.is-root-container.wp-block-post-content-is-layout-flow .block-list-appender {
-
-	p.block-editor-default-block-appender__content {
-		margin-block-start: 0;
-		margin-block-end: 0;
 	}
 }
 

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -161,6 +161,15 @@
 	}
 }
 
+// Prevent appender layout shift when default placeholder is clicked and replaced with insertDefaultBlock( undefined, rootClientId );
+.is-root-container.wp-block-post-content-is-layout-flow .block-list-appender {
+
+	p.block-editor-default-block-appender__content {
+		margin-block-start: 0;
+		margin-block-end: 0;
+	}
+}
+
 .block-editor-default-block-appender__content {
 	cursor: text;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes: #65969 

This PR is forked from #66061 (kudos @Vrishabhsk for the work here!)

Set the default block appender to have top and bottom margins of `0`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in #66061 and #65969, the layout rules used in the post content block means that the first and last child of the post content area will have a `0` margin at the top and bottom. The (fake) default paragraph appender therefore needs to have similar rules applied to it in order to override user agent styles that cause a layout shift when a user interacts with the default appender and creates the first block in a post or page.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Always apply `0` top and bottom margins on the default appender, rather than only for particular layouts.

A question for reviewers: does this rule seem safe enough to always be applied? So far in testing, it _seems_ to feel safer to me to apply this reset-like style than not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Note: in order to test the original issue in #65969 you might need to update the single post template's post content block to use the flow/default layout by switching off "Inner blocks use content width" on that block:

<img width="287" alt="image" src="https://github.com/user-attachments/assets/83aefb33-4cbe-411f-b9dc-964bcb530fa0">

1. While running TT5 theme go to create a new post or page
2. Click on the default appender to create the first paragraph block
3. Notice that there shouldn't be any layout shift when the paragraph block is inserted
4. Test across a range of themes that this doesn't cause any issues (it's working well for me so far in all the Twenty-something core themes)

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/545729c0-965a-400f-a9b5-85ed8d224047

