### PR TITLE
Global styles revisions: move focus and active state to list item

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
@@ -12,7 +7,7 @@ import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-
+import { ENTER, SPACE } from '@wordpress/keycodes';
 /**
  * Internal dependencies
  */
@@ -120,7 +115,7 @@ function RevisionsButtons( {
 		<ol
 			className="edit-site-global-styles-screen-revisions__revisions-list"
 			aria-label={ __( 'Global styles revisions list' ) }
-			role="group"
+			role="listbox"
 		>
 			{ userRevisions.map( ( revision, index ) => {
 				const { id, author, modified } = revision;
@@ -150,27 +145,24 @@ function RevisionsButtons( {
 
 				return (
 					<li
-						className={ clsx(
-							'edit-site-global-styles-screen-revisions__revision-item',
-							{
-								'is-selected': isSelected,
-								'is-active': areStylesEqual,
-								'is-reset': isReset,
-							}
-						) }
+						className="edit-site-global-styles-screen-revisions__revision-item"
 						key={ id }
 						aria-current={ isSelected }
-					>
-						<Button
-							__next40pxDefaultSize
-							className="edit-site-global-styles-screen-revisions__revision-button"
-							accessibleWhenDisabled
-							disabled={ isSelected }
-							onClick={ () => {
+						tabIndex={ 0 }
+						role="option"
+						onKeyDown={ ( event ) => {
+							const { keyCode } = event;
+							if ( keyCode === ENTER || keyCode === SPACE ) {
 								onChange( revision );
-							} }
-							aria-label={ revisionLabel }
-						>
+							}
+						} }
+						onClick={ () => {
+							onChange( revision );
+						} }
+						aria-selected={ isSelected }
+						aria-label={ revisionLabel }
+					>
+						<span className="edit-site-global-styles-screen-revisions__revision-item-wrapper">
 							{ isReset ? (
 								<span className="edit-site-global-styles-screen-revisions__description">
 									{ __( 'Default styles' ) }
@@ -211,7 +203,7 @@ function RevisionsButtons( {
 									) }
 								</span>
 							) }
-						</Button>
+						</span>
 						{ isSelected &&
 							( areStylesEqual ? (
 								<p className="edit-site-global-styles-screen-revisions__applied-text">
@@ -225,6 +217,9 @@ function RevisionsButtons( {
 									variant="primary"
 									className="edit-site-global-styles-screen-revisions__apply-button"
 									onClick={ onApplyRevision }
+									aria-label={ __(
+										'Apply the selected revision to your site.'
+									) }
 								>
 									{ isReset
 										? __( 'Reset to defaults' )

--- a/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/revisions-buttons.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { Button } from '@wordpress/components';
+import { Button, Composite } from '@wordpress/components';
 import { dateI18n, getDate, humanTimeDiff, getSettings } from '@wordpress/date';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -112,7 +112,8 @@ function RevisionsButtons( {
 	const { datetimeAbbreviated } = getSettings().formats;
 
 	return (
-		<ol
+		<Composite
+			orientation="vertical"
 			className="edit-site-global-styles-screen-revisions__revisions-list"
 			aria-label={ __( 'Global styles revisions list' ) }
 			role="listbox"
@@ -144,11 +145,10 @@ function RevisionsButtons( {
 				);
 
 				return (
-					<li
-						className="edit-site-global-styles-screen-revisions__revision-item"
+					<Composite.Item
 						key={ id }
+						className="edit-site-global-styles-screen-revisions__revision-item"
 						aria-current={ isSelected }
-						tabIndex={ 0 }
 						role="option"
 						onKeyDown={ ( event ) => {
 							const { keyCode } = event;
@@ -156,11 +156,13 @@ function RevisionsButtons( {
 								onChange( revision );
 							}
 						} }
-						onClick={ () => {
+						onClick={ ( event ) => {
+							event.preventDefault();
 							onChange( revision );
 						} }
 						aria-selected={ isSelected }
 						aria-label={ revisionLabel }
+						render={ <div /> }
 					>
 						<span className="edit-site-global-styles-screen-revisions__revision-item-wrapper">
 							{ isReset ? (
@@ -226,10 +228,10 @@ function RevisionsButtons( {
 										: __( 'Apply' ) }
 								</Button>
 							) ) }
-					</li>
+					</Composite.Item>
 				);
 			} ) }
-		</ol>
+		</Composite>
 	);
 }
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -16,8 +16,7 @@
 
 	&[role="option"]:active,
 	&[role="option"]:focus {
-		//@include block-toolbar-button-style__focus();
-		@include input-style__focus();
+		@include button-style__focus();
 	}
 
 	&:hover {

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -14,6 +14,12 @@
 	display: flex;
 	flex-direction: column;
 
+	&[role="option"]:active,
+	&[role="option"]:focus {
+		//@include block-toolbar-button-style__focus();
+		@include input-style__focus();
+	}
+
 	&:hover {
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 		.edit-site-global-styles-screen-revisions__date {
@@ -42,7 +48,7 @@
 		border: 4px solid transparent;
 	}
 
-	&.is-selected {
+	&[aria-selected="true"] {
 		border-radius: $radius-small;
 
 		// Only visible in Windows High Contrast mode.
@@ -51,10 +57,6 @@
 
 		color: var(--wp-admin-theme-color);
 		background: rgba(var(--wp-admin-theme-color--rgb), 0.04);
-
-		.edit-site-global-styles-screen-revisions__revision-button {
-			opacity: 1;
-		}
 
 		.edit-site-global-styles-screen-revisions__date {
 			color: var(--wp-admin-theme-color);
@@ -86,23 +88,16 @@
 	&:last-child::after {
 		height: $grid-unit-20 + 2;
 	}
-
-	// Nested to override specificity of .components-button.
-	.edit-site-global-styles-screen-revisions__revision-button {
-		width: 100%;
-		height: auto;
-		display: block;
-		padding: $grid-unit-15 $grid-unit-15 $grid-unit-05 $grid-unit-50;
-		z-index: 1;
-		position: relative;
-		outline-offset: -2px;
-	}
+}
+.edit-site-global-styles-screen-revisions__revision-item-wrapper {
+	display: block;
+	padding: $grid-unit-15 $grid-unit-15 $grid-unit-05 $grid-unit-50;
 }
 
 .edit-site-global-styles-screen-revisions__apply-button.is-primary,
 .edit-site-global-styles-screen-revisions__applied-text {
 	align-self: flex-start;
-	// Left margin = left padding of .edit-site-global-styles-screen-revisions__revision-button.
+	// Left margin = left padding of .edit-site-global-styles-screen-revisions__revision-item-wrapper.
 	margin: $grid-unit-05 $grid-unit-15 $grid-unit-15 $grid-unit-50;
 }
 

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -245,7 +245,7 @@ test.describe( 'Block Style Variations', () => {
 
 		// Click on previous revision.
 		await page
-			.getByRole( 'button', {
+			.getByRole( 'option', {
 				name: /^Changes saved by /,
 			} )
 			.nth( 1 )

--- a/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
+++ b/test/e2e/specs/site-editor/user-global-styles-revisions.spec.js
@@ -50,7 +50,7 @@ test.describe( 'Style Revisions', () => {
 		// Now there should be enough revisions to show the revisions UI.
 		await page.getByRole( 'button', { name: 'Revisions' } ).click();
 
-		const revisionButtons = page.getByRole( 'button', {
+		const revisionButtons = page.getByRole( 'option', {
 			name: /^Changes saved by /,
 		} );
 
@@ -83,14 +83,14 @@ test.describe( 'Style Revisions', () => {
 
 		await page.getByRole( 'button', { name: 'Revisions' } ).click();
 
-		const unSavedButton = page.getByRole( 'button', {
+		const unSavedButton = page.getByRole( 'option', {
 			name: /^Unsaved changes/,
 		} );
 
 		await expect( unSavedButton ).toBeVisible();
 
 		await page
-			.getByRole( 'button', { name: /^Changes saved by / } )
+			.getByRole( 'option', { name: /^Changes saved by / } )
 			.last()
 			.click();
 
@@ -118,14 +118,16 @@ test.describe( 'Style Revisions', () => {
 		await editor.canvas.locator( 'body' ).click();
 		await userGlobalStylesRevisions.openStylesPanel();
 		await page.getByRole( 'button', { name: 'Revisions' } ).click();
-		const lastRevisionButton = page
+		const lastRevisionItem = page
 			.getByLabel( 'Global styles revisions list' )
-			.getByRole( 'button' )
+			.getByRole( 'option' )
 			.last();
-		await expect( lastRevisionButton ).toContainText( 'Default styles' );
-		await lastRevisionButton.click();
+		await expect( lastRevisionItem ).toContainText( 'Default styles' );
+		await lastRevisionItem.click();
 		await expect(
-			page.getByRole( 'button', { name: 'Reset to defaults' } )
+			page.getByRole( 'button', {
+				name: 'Apply the selected revision to your site.',
+			} )
 		).toBeVisible();
 	} );
 


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/66642


## What?

This PR removes the button that loads the global revision and moves it up to an accessible list item.

The result is that the list item is tabbable and selectable via keyboard, and the focus state wraps the entire item.

Thanks to @jarekmorawski for reporting.

## Why?
To shift the visible focus to the list item itself, not a child button.

To wrap the select border around the entire item.

See the UI quirk reported by: https://github.com/WordPress/gutenberg/issues/66642



## How?
Give the ordered list a role of `"listbox"` and the list items, `"option"`.

Move keyboard/click events to the `<li />`.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

Tab through the list items. You should be able to:

- select a revision using Enter or Space
- where an interactive element exists within the list item (an Apply button), you should be able to tab to it



https://github.com/user-attachments/assets/cc496758-d98b-4e69-989b-871f86a2ce18





## Screenshots or screencast <!-- if applicable -->

<img width="277" alt="Screenshot 2024-11-06 at 1 30 30 pm" src="https://github.com/user-attachments/assets/7c53ac69-0fa3-4478-ac0e-ba5c94e85fa7">

