### PR TITLE
Cover: Fix media library image selection

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -211,7 +211,8 @@ function CoverEdit( {
 				mediaAttributes.url = newMedia?.sizes?.[ sizeSlug ]?.url;
 			} else if ( newMedia?.sizes?.[ imageDefaultSize ] ) {
 				mediaAttributes.sizeSlug = imageDefaultSize;
-				mediaAttributes.url = newMedia?.sizes?.[ sizeSlug ]?.url;
+				mediaAttributes.url =
+					newMedia?.sizes?.[ imageDefaultSize ]?.url;
 			} else {
 				mediaAttributes.sizeSlug = DEFAULT_MEDIA_SIZE_SLUG;
 			}

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -206,13 +206,24 @@ function CoverEdit( {
 
 			// Try to use the previous selected image size if it's available
 			// otherwise try the default image size or fallback to full size.
-			if ( sizeSlug && newMedia?.sizes?.[ sizeSlug ] ) {
+			if (
+				sizeSlug &&
+				( newMedia?.sizes?.[ sizeSlug ] ||
+					newMedia?.media_details?.sizes?.[ sizeSlug ] )
+			) {
 				mediaAttributes.sizeSlug = sizeSlug;
-				mediaAttributes.url = newMedia?.sizes?.[ sizeSlug ]?.url;
-			} else if ( newMedia?.sizes?.[ imageDefaultSize ] ) {
+				mediaAttributes.url =
+					newMedia?.sizes?.[ sizeSlug ]?.url ||
+					newMedia?.media_details?.sizes?.[ sizeSlug ]?.source_url;
+			} else if (
+				newMedia?.sizes?.[ imageDefaultSize ] ||
+				newMedia?.media_details?.sizes?.[ imageDefaultSize ]
+			) {
 				mediaAttributes.sizeSlug = imageDefaultSize;
 				mediaAttributes.url =
-					newMedia?.sizes?.[ imageDefaultSize ]?.url;
+					newMedia?.sizes?.[ imageDefaultSize ]?.url ||
+					newMedia?.media_details?.sizes?.[ imageDefaultSize ]
+						?.source_url;
 			} else {
 				mediaAttributes.sizeSlug = DEFAULT_MEDIA_SIZE_SLUG;
 			}


### PR DESCRIPTION
## What?
Fixes #66765.
A regression after #62926.

PR fixes a regression when selecting an image from the Media Library didn't set the `url` attribute for the cover block. I've also fixed the logic for deriving `sizeSlug` and `url` attributes during direct uploads.

Re 9b09c91e41a32242daca5df3aa10cd83e9cb898d - The media object returned by Library selection and REST API upload have different shapes.

The fixes are in atomic commits, which should make reviewing easier.

## Testing Instructions
1. Open a post or page.
2. Insert a Cover block.
3. Select an image from the media library with an available `imageDefaultSize` (default: `large`) size.
4. Confirm that it's correctly displayed.
5. Insert another Cover block.
6. Uplade an image that could be resized to smaller resolutions (at least `large`).
7. Confirm that the Settings control panel sets the correct resolution value.

### Testing Instructions for Keyboard
Same.
