### PR TITLE
Select Mode: Hide tool selector in the post editor and force design mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2764,8 +2764,11 @@ export function isNavigationMode( state ) {
  * @return {string} the editor mode.
  */
 export const __unstableGetEditorMode = createRegistrySelector(
-	( select ) => () => {
-		return select( preferencesStore ).get( 'core', 'editorTool' );
+	( select ) => ( state ) => {
+		return (
+			state.settings.editorTool ??
+			select( preferencesStore ).get( 'core', 'editorTool' )
+		);
 	}
 );
 

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -35,6 +35,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		inserterSidebarToggleRef,
 		listViewToggleRef,
 		showIconLabels,
+		showTools,
 	} = useSelect( ( select ) => {
 		const { get } = select( preferencesStore );
 		const {
@@ -42,6 +43,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			getEditorMode,
 			getInserterSidebarToggleRef,
 			getListViewToggleRef,
+			getRenderingMode,
+			getCurrentPostType,
 		} = unlock( select( editorStore ) );
 		const { getShortcutRepresentation } = select( keyboardShortcutsStore );
 
@@ -56,6 +59,9 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			showIconLabels: get( 'core', 'showIconLabels' ),
 			isDistractionFree: get( 'core', 'distractionFree' ),
 			isVisualMode: getEditorMode() === 'visual',
+			showTools:
+				getRenderingMode() !== 'post-only' ||
+				getCurrentPostType() === 'wp_template',
 		};
 	}, [] );
 
@@ -128,7 +134,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 				) }
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
-						{ isLargeViewport && (
+						{ showTools && isLargeViewport && (
 							<ToolbarItem
 								as={ ToolSelector }
 								showTooltip={ ! showIconLabels }

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -328,6 +328,10 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					: settings.template,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			[ sectionRootClientIdKey ]: sectionRootClientId,
+			editorTool:
+				renderingMode === 'post-only' && postType !== 'wp_template'
+					? 'edit'
+					: undefined,
 		};
 
 		return blockEditorSettings;
@@ -355,6 +359,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		sectionRootClientId,
 		globalStylesData,
 		globalStylesLinksData,
+		renderingMode,
 	] );
 }
 

--- a/test/e2e/specs/editor/various/write-design-mode.spec.js
+++ b/test/e2e/specs/editor/various/write-design-mode.spec.js
@@ -4,15 +4,20 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Write/Design mode', () => {
-	test.beforeEach( async ( { admin, editor } ) => {
-		await admin.createNewPost();
-		await expect(
-			editor.canvas.getByRole( 'textbox', { name: 'Add title' } )
-		).toBeFocused();
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.visitSiteEditor( {
+			postId: 'emptytheme//index',
+			postType: 'wp_template',
+			canvas: 'edit',
+		} );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.deleteAllPosts();
+		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
 	test( 'Should prevent selecting intermediary blocks', async ( {

--- a/test/e2e/specs/editor/various/write-design-mode.spec.js
+++ b/test/e2e/specs/editor/various/write-design-mode.spec.js
@@ -24,6 +24,9 @@ test.describe( 'Write/Design mode', () => {
 		editor,
 		page,
 	} ) => {
+		// Clear all content
+		await editor.setContent( '' );
+
 		// Insert a section with a nested block and an editable block.
 		await editor.insertBlock( {
 			name: 'core/group',


### PR DESCRIPTION
closes #66775

## What?

The "write/design" mode selector doesn't make a lot of sense in the post editor when only seeing posts and pages... This PR hides the tool selector and forces full design mode in this case.

An exception exists for wp_template post type.

## Testing Instructions

1- Open the post editor
2- Notice there's no tool selector
3- Toggle the "show template" in the sidebar
4- The tool selector appears and you can switch to "write" mode
5- Toggle the template off, and notice that you're back in "design" mode with the tool selector hidden.