### PR TITLE
Relocate “View” external link to end of editor header controls

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -155,7 +155,7 @@ function Header( {
 					 */
 					<PostSavedState forceIsDirty={ forceIsDirty } />
 				) }
-
+				<PostViewLink />
 				{ canBeZoomedOut && isEditorIframed && isWideViewport && (
 					<ZoomOutToggle disabled={ forceDisableBlockTools } />
 				) }
@@ -168,7 +168,6 @@ function Header( {
 					className="editor-header__post-preview-button"
 					forceIsAutosaveable={ forceIsDirty }
 				/>
-				<PostViewLink />
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -155,19 +155,22 @@ function Header( {
 					 */
 					<PostSavedState forceIsDirty={ forceIsDirty } />
 				) }
+
 				<PostViewLink />
-				{ canBeZoomedOut && isEditorIframed && isWideViewport && (
-					<ZoomOutToggle disabled={ forceDisableBlockTools } />
-				) }
 
 				<PreviewDropdown
 					forceIsAutosaveable={ forceIsDirty }
 					disabled={ disablePreviewOption }
 				/>
+
 				<PostPreviewButton
 					className="editor-header__post-preview-button"
 					forceIsAutosaveable={ forceIsDirty }
 				/>
+
+				{ canBeZoomedOut && isEditorIframed && isWideViewport && (
+					<ZoomOutToggle disabled={ forceDisableBlockTools } />
+				) }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/66776

>The “View” external link icon currently appears between other controls when viewing a published post or page in the editor. This placement disrupts muscle memory, causing a disorienting experience as users expect consistent control positions, regardless of publish state.

> Move the “View” external link icon to the end of the list of controls. This will maintain expected positioning, allowing for a more intuitive and predictable experience.

#### Before 

![Image](https://github.com/user-attachments/assets/1a74f47a-20db-45de-8fc5-3e219d235675)

#### After 

<img width="923" alt="Screenshot 2024-11-06 at 4 05 13 PM" src="https://github.com/user-attachments/assets/b14ecc2c-9cfe-4fb4-8f21-638275f3a748">


