### PR TITLE
ESLint: Fix React Compiler violations in various commands

### DIFF
--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -24,275 +24,286 @@ import {
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
-export const useTransformCommands = () => {
-	const { replaceBlocks, multiSelect } = useDispatch( blockEditorStore );
-	const {
-		blocks,
-		clientIds,
-		canRemove,
-		possibleBlockTransformations,
-		invalidSelection,
-	} = useSelect( ( select ) => {
+const getTransformCommands = () =>
+	function useTransformCommands() {
+		const { replaceBlocks, multiSelect } = useDispatch( blockEditorStore );
 		const {
-			getBlockRootClientId,
-			getBlockTransformItems,
-			getSelectedBlockClientIds,
-			getBlocksByClientId,
-			canRemoveBlocks,
-		} = select( blockEditorStore );
+			blocks,
+			clientIds,
+			canRemove,
+			possibleBlockTransformations,
+			invalidSelection,
+		} = useSelect( ( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlockTransformItems,
+				getSelectedBlockClientIds,
+				getBlocksByClientId,
+				canRemoveBlocks,
+			} = select( blockEditorStore );
 
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-		const selectedBlocks = getBlocksByClientId( selectedBlockClientIds );
+			const selectedBlockClientIds = getSelectedBlockClientIds();
+			const selectedBlocks = getBlocksByClientId(
+				selectedBlockClientIds
+			);
 
-		// selectedBlocks can have `null`s when something tries to call `selectBlock` with an inexistent clientId.
-		// These nulls will cause fatal errors down the line.
-		// In order to prevent discrepancies between selectedBlockClientIds and selectedBlocks, we effectively treat the entire selection as invalid.
-		// @see https://github.com/WordPress/gutenberg/pull/59410#issuecomment-2006304536
-		if ( selectedBlocks.filter( ( block ) => ! block ).length > 0 ) {
+			// selectedBlocks can have `null`s when something tries to call `selectBlock` with an inexistent clientId.
+			// These nulls will cause fatal errors down the line.
+			// In order to prevent discrepancies between selectedBlockClientIds and selectedBlocks, we effectively treat the entire selection as invalid.
+			// @see https://github.com/WordPress/gutenberg/pull/59410#issuecomment-2006304536
+			if ( selectedBlocks.filter( ( block ) => ! block ).length > 0 ) {
+				return {
+					invalidSelection: true,
+				};
+			}
+
+			const rootClientId = getBlockRootClientId(
+				selectedBlockClientIds[ 0 ]
+			);
 			return {
-				invalidSelection: true,
+				blocks: selectedBlocks,
+				clientIds: selectedBlockClientIds,
+				possibleBlockTransformations: getBlockTransformItems(
+					selectedBlocks,
+					rootClientId
+				),
+				canRemove: canRemoveBlocks( selectedBlockClientIds ),
+				invalidSelection: false,
+			};
+		}, [] );
+
+		if ( invalidSelection ) {
+			return {
+				isLoading: false,
+				commands: [],
 			};
 		}
+		const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
 
-		const rootClientId = getBlockRootClientId(
-			selectedBlockClientIds[ 0 ]
-		);
-		return {
-			blocks: selectedBlocks,
-			clientIds: selectedBlockClientIds,
-			possibleBlockTransformations: getBlockTransformItems(
-				selectedBlocks,
-				rootClientId
-			),
-			canRemove: canRemoveBlocks( selectedBlockClientIds ),
-			invalidSelection: false,
-		};
-	}, [] );
-
-	if ( invalidSelection ) {
-		return {
-			isLoading: false,
-			commands: [],
-		};
-	}
-	const isTemplate = blocks.length === 1 && isTemplatePart( blocks[ 0 ] );
-
-	function selectForMultipleBlocks( insertedBlocks ) {
-		if ( insertedBlocks.length > 1 ) {
-			multiSelect(
-				insertedBlocks[ 0 ].clientId,
-				insertedBlocks[ insertedBlocks.length - 1 ].clientId
-			);
-		}
-	}
-
-	// Simple block tranformation based on the `Block Transforms` API.
-	function onBlockTransform( name ) {
-		const newBlocks = switchToBlockType( blocks, name );
-		replaceBlocks( clientIds, newBlocks );
-		selectForMultipleBlocks( newBlocks );
-	}
-
-	/**
-	 * The `isTemplate` check is a stopgap solution here.
-	 * Ideally, the Transforms API should handle this
-	 * by allowing to exclude blocks from wildcard transformations.
-	 */
-	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length && canRemove && ! isTemplate;
-
-	if (
-		! clientIds ||
-		clientIds.length < 1 ||
-		! hasPossibleBlockTransformations
-	) {
-		return { isLoading: false, commands: [] };
-	}
-
-	const commands = possibleBlockTransformations.map( ( transformation ) => {
-		const { name, title, icon } = transformation;
-		return {
-			name: 'core/block-editor/transform-to-' + name.replace( '/', '-' ),
-			/* translators: %s: Block or block variation name. */
-			label: sprintf( __( 'Transform to %s' ), title ),
-			icon: <BlockIcon icon={ icon } />,
-			callback: ( { close } ) => {
-				onBlockTransform( name );
-				close();
-			},
-		};
-	} );
-
-	return { isLoading: false, commands };
-};
-
-const useQuickActionsCommands = () => {
-	const { clientIds, isUngroupable, isGroupable } = useSelect( ( select ) => {
-		const {
-			getSelectedBlockClientIds,
-			isUngroupable: _isUngroupable,
-			isGroupable: _isGroupable,
-		} = select( blockEditorStore );
-		const selectedBlockClientIds = getSelectedBlockClientIds();
-
-		return {
-			clientIds: selectedBlockClientIds,
-			isUngroupable: _isUngroupable(),
-			isGroupable: _isGroupable(),
-		};
-	}, [] );
-	const {
-		canInsertBlockType,
-		getBlockRootClientId,
-		getBlocksByClientId,
-		canRemoveBlocks,
-	} = useSelect( blockEditorStore );
-	const { getDefaultBlockName, getGroupingBlockName } =
-		useSelect( blocksStore );
-
-	const blocks = getBlocksByClientId( clientIds );
-
-	const {
-		removeBlocks,
-		replaceBlocks,
-		duplicateBlocks,
-		insertAfterBlock,
-		insertBeforeBlock,
-	} = useDispatch( blockEditorStore );
-
-	const onGroup = () => {
-		if ( ! blocks.length ) {
-			return;
+		function selectForMultipleBlocks( insertedBlocks ) {
+			if ( insertedBlocks.length > 1 ) {
+				multiSelect(
+					insertedBlocks[ 0 ].clientId,
+					insertedBlocks[ insertedBlocks.length - 1 ].clientId
+				);
+			}
 		}
 
-		const groupingBlockName = getGroupingBlockName();
-
-		// Activate the `transform` on `core/group` which does the conversion.
-		const newBlocks = switchToBlockType( blocks, groupingBlockName );
-
-		if ( ! newBlocks ) {
-			return;
-		}
-		replaceBlocks( clientIds, newBlocks );
-	};
-	const onUngroup = () => {
-		if ( ! blocks.length ) {
-			return;
+		// Simple block tranformation based on the `Block Transforms` API.
+		function onBlockTransform( name ) {
+			const newBlocks = switchToBlockType( blocks, name );
+			replaceBlocks( clientIds, newBlocks );
+			selectForMultipleBlocks( newBlocks );
 		}
 
-		const innerBlocks = blocks[ 0 ].innerBlocks;
+		/**
+		 * The `isTemplate` check is a stopgap solution here.
+		 * Ideally, the Transforms API should handle this
+		 * by allowing to exclude blocks from wildcard transformations.
+		 */
+		const hasPossibleBlockTransformations =
+			!! possibleBlockTransformations.length && canRemove && ! isTemplate;
 
-		if ( ! innerBlocks.length ) {
-			return;
+		if (
+			! clientIds ||
+			clientIds.length < 1 ||
+			! hasPossibleBlockTransformations
+		) {
+			return { isLoading: false, commands: [] };
 		}
 
-		replaceBlocks( clientIds, innerBlocks );
-	};
-
-	if ( ! clientIds || clientIds.length < 1 ) {
-		return { isLoading: false, commands: [] };
-	}
-
-	const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
-	const canInsertDefaultBlock = canInsertBlockType(
-		getDefaultBlockName(),
-		rootClientId
-	);
-	const canDuplicate = blocks.every( ( block ) => {
-		return (
-			!! block &&
-			hasBlockSupport( block.name, 'multiple', true ) &&
-			canInsertBlockType( block.name, rootClientId )
-		);
-	} );
-	const canRemove = canRemoveBlocks( clientIds );
-
-	const commands = [];
-
-	if ( canDuplicate ) {
-		commands.push( {
-			name: 'duplicate',
-			label: __( 'Duplicate' ),
-			callback: () => duplicateBlocks( clientIds, true ),
-			icon: copy,
-		} );
-	}
-
-	if ( canInsertDefaultBlock ) {
-		commands.push(
-			{
-				name: 'add-before',
-				label: __( 'Add before' ),
-				callback: () => {
-					const clientId = Array.isArray( clientIds )
-						? clientIds[ 0 ]
-						: clientId;
-					insertBeforeBlock( clientId );
-				},
-				icon: add,
-			},
-			{
-				name: 'add-after',
-				label: __( 'Add after' ),
-				callback: () => {
-					const clientId = Array.isArray( clientIds )
-						? clientIds[ clientIds.length - 1 ]
-						: clientId;
-					insertAfterBlock( clientId );
-				},
-				icon: add,
+		const commands = possibleBlockTransformations.map(
+			( transformation ) => {
+				const { name, title, icon } = transformation;
+				return {
+					name:
+						'core/block-editor/transform-to-' +
+						name.replace( '/', '-' ),
+					/* translators: %s: Block or block variation name. */
+					label: sprintf( __( 'Transform to %s' ), title ),
+					icon: <BlockIcon icon={ icon } />,
+					callback: ( { close } ) => {
+						onBlockTransform( name );
+						close();
+					},
+				};
 			}
 		);
-	}
 
-	if ( isGroupable ) {
-		commands.push( {
-			name: 'Group',
-			label: __( 'Group' ),
-			callback: onGroup,
-			icon: group,
-		} );
-	}
-
-	if ( isUngroupable ) {
-		commands.push( {
-			name: 'ungroup',
-			label: __( 'Ungroup' ),
-			callback: onUngroup,
-			icon: ungroup,
-		} );
-	}
-
-	if ( canRemove ) {
-		commands.push( {
-			name: 'remove',
-			label: __( 'Delete' ),
-			callback: () => removeBlocks( clientIds, true ),
-			icon: remove,
-		} );
-	}
-
-	return {
-		isLoading: false,
-		commands: commands.map( ( command ) => ( {
-			...command,
-			name: 'core/block-editor/action-' + command.name,
-			callback: ( { close } ) => {
-				command.callback();
-				close();
-			},
-		} ) ),
+		return { isLoading: false, commands };
 	};
-};
+
+const getQuickActionsCommands = () =>
+	function useQuickActionsCommands() {
+		const { clientIds, isUngroupable, isGroupable } = useSelect(
+			( select ) => {
+				const {
+					getSelectedBlockClientIds,
+					isUngroupable: _isUngroupable,
+					isGroupable: _isGroupable,
+				} = select( blockEditorStore );
+				const selectedBlockClientIds = getSelectedBlockClientIds();
+
+				return {
+					clientIds: selectedBlockClientIds,
+					isUngroupable: _isUngroupable(),
+					isGroupable: _isGroupable(),
+				};
+			},
+			[]
+		);
+		const {
+			canInsertBlockType,
+			getBlockRootClientId,
+			getBlocksByClientId,
+			canRemoveBlocks,
+		} = useSelect( blockEditorStore );
+		const { getDefaultBlockName, getGroupingBlockName } =
+			useSelect( blocksStore );
+
+		const blocks = getBlocksByClientId( clientIds );
+
+		const {
+			removeBlocks,
+			replaceBlocks,
+			duplicateBlocks,
+			insertAfterBlock,
+			insertBeforeBlock,
+		} = useDispatch( blockEditorStore );
+
+		const onGroup = () => {
+			if ( ! blocks.length ) {
+				return;
+			}
+
+			const groupingBlockName = getGroupingBlockName();
+
+			// Activate the `transform` on `core/group` which does the conversion.
+			const newBlocks = switchToBlockType( blocks, groupingBlockName );
+
+			if ( ! newBlocks ) {
+				return;
+			}
+			replaceBlocks( clientIds, newBlocks );
+		};
+		const onUngroup = () => {
+			if ( ! blocks.length ) {
+				return;
+			}
+
+			const innerBlocks = blocks[ 0 ].innerBlocks;
+
+			if ( ! innerBlocks.length ) {
+				return;
+			}
+
+			replaceBlocks( clientIds, innerBlocks );
+		};
+
+		if ( ! clientIds || clientIds.length < 1 ) {
+			return { isLoading: false, commands: [] };
+		}
+
+		const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
+		const canInsertDefaultBlock = canInsertBlockType(
+			getDefaultBlockName(),
+			rootClientId
+		);
+		const canDuplicate = blocks.every( ( block ) => {
+			return (
+				!! block &&
+				hasBlockSupport( block.name, 'multiple', true ) &&
+				canInsertBlockType( block.name, rootClientId )
+			);
+		} );
+		const canRemove = canRemoveBlocks( clientIds );
+
+		const commands = [];
+
+		if ( canDuplicate ) {
+			commands.push( {
+				name: 'duplicate',
+				label: __( 'Duplicate' ),
+				callback: () => duplicateBlocks( clientIds, true ),
+				icon: copy,
+			} );
+		}
+
+		if ( canInsertDefaultBlock ) {
+			commands.push(
+				{
+					name: 'add-before',
+					label: __( 'Add before' ),
+					callback: () => {
+						const clientId = Array.isArray( clientIds )
+							? clientIds[ 0 ]
+							: clientId;
+						insertBeforeBlock( clientId );
+					},
+					icon: add,
+				},
+				{
+					name: 'add-after',
+					label: __( 'Add after' ),
+					callback: () => {
+						const clientId = Array.isArray( clientIds )
+							? clientIds[ clientIds.length - 1 ]
+							: clientId;
+						insertAfterBlock( clientId );
+					},
+					icon: add,
+				}
+			);
+		}
+
+		if ( isGroupable ) {
+			commands.push( {
+				name: 'Group',
+				label: __( 'Group' ),
+				callback: onGroup,
+				icon: group,
+			} );
+		}
+
+		if ( isUngroupable ) {
+			commands.push( {
+				name: 'ungroup',
+				label: __( 'Ungroup' ),
+				callback: onUngroup,
+				icon: ungroup,
+			} );
+		}
+
+		if ( canRemove ) {
+			commands.push( {
+				name: 'remove',
+				label: __( 'Delete' ),
+				callback: () => removeBlocks( clientIds, true ),
+				icon: remove,
+			} );
+		}
+
+		return {
+			isLoading: false,
+			commands: commands.map( ( command ) => ( {
+				...command,
+				name: 'core/block-editor/action-' + command.name,
+				callback: ( { close } ) => {
+					command.callback();
+					close();
+				},
+			} ) ),
+		};
+	};
 
 export const useBlockCommands = () => {
 	useCommandLoader( {
 		name: 'core/block-editor/blockTransforms',
-		hook: useTransformCommands,
+		hook: getTransformCommands(),
 	} );
 	useCommandLoader( {
 		name: 'core/block-editor/blockQuickActions',
-		hook: useQuickActionsCommands,
+		hook: getQuickActionsCommands(),
 		context: 'block-selection-edit',
 	} );
 };

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -275,159 +275,169 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 		};
 	};
 
-const usePageNavigationCommandLoader =
-	getNavigationCommandLoaderPerPostType( 'page' );
-const usePostNavigationCommandLoader =
-	getNavigationCommandLoaderPerPostType( 'post' );
-const useTemplateNavigationCommandLoader =
-	getNavigationCommandLoaderPerTemplate( 'wp_template' );
-const useTemplatePartNavigationCommandLoader =
-	getNavigationCommandLoaderPerTemplate( 'wp_template_part' );
-
-function useSiteEditorBasicNavigationCommands() {
-	const history = useHistory();
-	const isSiteEditor = getPath( window.location.href )?.includes(
-		'site-editor.php'
-	);
-	const { isBlockBasedTheme, canCreateTemplate } = useSelect( ( select ) => {
-		return {
-			isBlockBasedTheme:
-				select( coreStore ).getCurrentTheme()?.is_block_theme,
-			canCreateTemplate: select( coreStore ).canUser( 'create', {
-				kind: 'postType',
-				name: 'wp_template',
-			} ),
-		};
-	}, [] );
-	const commands = useMemo( () => {
-		const result = [];
-
-		if ( canCreateTemplate && isBlockBasedTheme ) {
-			result.push( {
-				name: 'core/edit-site/open-navigation',
-				label: __( 'Navigation' ),
-				icon: navigation,
-				callback: ( { close } ) => {
-					const args = {
-						postType: 'wp_navigation',
-					};
-					const targetUrl = addQueryArgs( 'site-editor.php', args );
-					if ( isSiteEditor ) {
-						history.push( args );
-					} else {
-						document.location = targetUrl;
-					}
-					close();
-				},
-			} );
-
-			result.push( {
-				name: 'core/edit-site/open-styles',
-				label: __( 'Styles' ),
-				icon: styles,
-				callback: ( { close } ) => {
-					const args = {
-						path: '/wp_global_styles',
-					};
-					const targetUrl = addQueryArgs( 'site-editor.php', args );
-					if ( isSiteEditor ) {
-						history.push( args );
-					} else {
-						document.location = targetUrl;
-					}
-					close();
-				},
-			} );
-
-			result.push( {
-				name: 'core/edit-site/open-pages',
-				label: __( 'Pages' ),
-				icon: page,
-				callback: ( { close } ) => {
-					const args = {
-						postType: 'page',
-					};
-					const targetUrl = addQueryArgs( 'site-editor.php', args );
-					if ( isSiteEditor ) {
-						history.push( args );
-					} else {
-						document.location = targetUrl;
-					}
-					close();
-				},
-			} );
-
-			result.push( {
-				name: 'core/edit-site/open-templates',
-				label: __( 'Templates' ),
-				icon: layout,
-				callback: ( { close } ) => {
-					const args = {
-						postType: 'wp_template',
-					};
-					const targetUrl = addQueryArgs( 'site-editor.php', args );
-					if ( isSiteEditor ) {
-						history.push( args );
-					} else {
-						document.location = targetUrl;
-					}
-					close();
-				},
-			} );
-		}
-
-		result.push( {
-			name: 'core/edit-site/open-patterns',
-			label: __( 'Patterns' ),
-			icon: symbol,
-			callback: ( { close } ) => {
-				if ( canCreateTemplate ) {
-					const args = {
-						postType: 'wp_block',
-					};
-					const targetUrl = addQueryArgs( 'site-editor.php', args );
-					if ( isSiteEditor ) {
-						history.push( args );
-					} else {
-						document.location = targetUrl;
-					}
-					close();
-				} else {
-					// If a user cannot access the site editor
-					document.location.href = 'edit.php?post_type=wp_block';
-				}
+const getSiteEditorBasicNavigationCommands = () =>
+	function useSiteEditorBasicNavigationCommands() {
+		const history = useHistory();
+		const isSiteEditor = getPath( window.location.href )?.includes(
+			'site-editor.php'
+		);
+		const { isBlockBasedTheme, canCreateTemplate } = useSelect(
+			( select ) => {
+				return {
+					isBlockBasedTheme:
+						select( coreStore ).getCurrentTheme()?.is_block_theme,
+					canCreateTemplate: select( coreStore ).canUser( 'create', {
+						kind: 'postType',
+						name: 'wp_template',
+					} ),
+				};
 			},
-		} );
+			[]
+		);
+		const commands = useMemo( () => {
+			const result = [];
 
-		return result;
-	}, [ history, isSiteEditor, canCreateTemplate, isBlockBasedTheme ] );
+			if ( canCreateTemplate && isBlockBasedTheme ) {
+				result.push( {
+					name: 'core/edit-site/open-navigation',
+					label: __( 'Navigation' ),
+					icon: navigation,
+					callback: ( { close } ) => {
+						const args = {
+							postType: 'wp_navigation',
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					},
+				} );
 
-	return {
-		commands,
-		isLoading: false,
+				result.push( {
+					name: 'core/edit-site/open-styles',
+					label: __( 'Styles' ),
+					icon: styles,
+					callback: ( { close } ) => {
+						const args = {
+							path: '/wp_global_styles',
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					},
+				} );
+
+				result.push( {
+					name: 'core/edit-site/open-pages',
+					label: __( 'Pages' ),
+					icon: page,
+					callback: ( { close } ) => {
+						const args = {
+							postType: 'page',
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					},
+				} );
+
+				result.push( {
+					name: 'core/edit-site/open-templates',
+					label: __( 'Templates' ),
+					icon: layout,
+					callback: ( { close } ) => {
+						const args = {
+							postType: 'wp_template',
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					},
+				} );
+			}
+
+			result.push( {
+				name: 'core/edit-site/open-patterns',
+				label: __( 'Patterns' ),
+				icon: symbol,
+				callback: ( { close } ) => {
+					if ( canCreateTemplate ) {
+						const args = {
+							postType: 'wp_block',
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					} else {
+						// If a user cannot access the site editor
+						document.location.href = 'edit.php?post_type=wp_block';
+					}
+				},
+			} );
+
+			return result;
+		}, [ history, isSiteEditor, canCreateTemplate, isBlockBasedTheme ] );
+
+		return {
+			commands,
+			isLoading: false,
+		};
 	};
-}
 
 export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-pages',
-		hook: usePageNavigationCommandLoader,
+		hook: getNavigationCommandLoaderPerPostType( 'page' ),
 	} );
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-posts',
-		hook: usePostNavigationCommandLoader,
+		hook: getNavigationCommandLoaderPerPostType( 'post' ),
 	} );
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-templates',
-		hook: useTemplateNavigationCommandLoader,
+		hook: getNavigationCommandLoaderPerTemplate( 'wp_template' ),
 	} );
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-template-parts',
-		hook: useTemplatePartNavigationCommandLoader,
+		hook: getNavigationCommandLoaderPerTemplate( 'wp_template_part' ),
 	} );
 	useCommandLoader( {
 		name: 'core/edit-site/basic-navigation',
-		hook: useSiteEditorBasicNavigationCommands,
+		hook: getSiteEditorBasicNavigationCommands(),
 		context: 'site-editor',
 	} );
 }

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -28,282 +28,289 @@ import { store as editSiteStore } from '../../store';
 const { useGlobalStylesReset } = unlock( blockEditorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
-function useGlobalStylesOpenStylesCommands() {
-	const { openGeneralSidebar } = unlock( useDispatch( editSiteStore ) );
-	const { params } = useLocation();
-	const { canvas = 'view' } = params;
-	const history = useHistory();
-	const isBlockBasedTheme = useSelect( ( select ) => {
-		return select( coreStore ).getCurrentTheme().is_block_theme;
-	}, [] );
+const getGlobalStylesOpenStylesCommands = () =>
+	function useGlobalStylesOpenStylesCommands() {
+		const { openGeneralSidebar } = unlock( useDispatch( editSiteStore ) );
+		const { params } = useLocation();
+		const { canvas = 'view' } = params;
+		const history = useHistory();
+		const isBlockBasedTheme = useSelect( ( select ) => {
+			return select( coreStore ).getCurrentTheme().is_block_theme;
+		}, [] );
 
-	const commands = useMemo( () => {
-		if ( ! isBlockBasedTheme ) {
-			return [];
-		}
+		const commands = useMemo( () => {
+			if ( ! isBlockBasedTheme ) {
+				return [];
+			}
 
-		return [
-			{
-				name: 'core/edit-site/open-styles',
-				label: __( 'Open styles' ),
-				callback: ( { close } ) => {
-					close();
-					if ( ! params.postId ) {
-						history.push( {
-							path: '/wp_global_styles',
-							canvas: 'edit',
-						} );
-					}
-					if ( params.postId && canvas !== 'edit' ) {
-						history.push(
-							{ ...params, canvas: 'edit' },
-							undefined,
-							{
-								transition: 'canvas-mode-edit-transition',
-							}
-						);
-					}
-					openGeneralSidebar( 'edit-site/global-styles' );
-				},
-				icon: styles,
-			},
-		];
-	}, [ history, openGeneralSidebar, params, canvas, isBlockBasedTheme ] );
-
-	return {
-		isLoading: false,
-		commands,
-	};
-}
-
-function useGlobalStylesToggleWelcomeGuideCommands() {
-	const { openGeneralSidebar } = unlock( useDispatch( editSiteStore ) );
-	const { params } = useLocation();
-	const { canvas = 'view' } = params;
-	const { set } = useDispatch( preferencesStore );
-
-	const history = useHistory();
-	const isBlockBasedTheme = useSelect( ( select ) => {
-		return select( coreStore ).getCurrentTheme().is_block_theme;
-	}, [] );
-
-	const commands = useMemo( () => {
-		if ( ! isBlockBasedTheme ) {
-			return [];
-		}
-
-		return [
-			{
-				name: 'core/edit-site/toggle-styles-welcome-guide',
-				label: __( 'Learn about styles' ),
-				callback: ( { close } ) => {
-					close();
-					if ( ! params.postId ) {
-						history.push( {
-							path: '/wp_global_styles',
-							canvas: 'edit',
-						} );
-					}
-					if ( params.postId && canvas !== 'edit' ) {
-						history.push(
-							{
-								...params,
+			return [
+				{
+					name: 'core/edit-site/open-styles',
+					label: __( 'Open styles' ),
+					callback: ( { close } ) => {
+						close();
+						if ( ! params.postId ) {
+							history.push( {
+								path: '/wp_global_styles',
 								canvas: 'edit',
-							},
-							undefined,
-							{
-								transition: 'canvas-mode-edit-transition',
-							}
-						);
-					}
-					openGeneralSidebar( 'edit-site/global-styles' );
-					set( 'core/edit-site', 'welcomeGuideStyles', true );
-					// sometimes there's a focus loss that happens after some time
-					// that closes the modal, we need to force reopening it.
-					setTimeout( () => {
-						set( 'core/edit-site', 'welcomeGuideStyles', true );
-					}, 500 );
+							} );
+						}
+						if ( params.postId && canvas !== 'edit' ) {
+							history.push(
+								{ ...params, canvas: 'edit' },
+								undefined,
+								{
+									transition: 'canvas-mode-edit-transition',
+								}
+							);
+						}
+						openGeneralSidebar( 'edit-site/global-styles' );
+					},
+					icon: styles,
 				},
-				icon: help,
-			},
-		];
-	}, [
-		history,
-		openGeneralSidebar,
-		canvas,
-		isBlockBasedTheme,
-		set,
-		params,
-	] );
-
-	return {
-		isLoading: false,
-		commands,
-	};
-}
-
-function useGlobalStylesResetCommands() {
-	const [ canReset, onReset ] = useGlobalStylesReset();
-	const commands = useMemo( () => {
-		if ( ! canReset ) {
-			return [];
-		}
-
-		return [
-			{
-				name: 'core/edit-site/reset-global-styles',
-				label: __( 'Reset styles' ),
-				icon: isRTL() ? rotateRight : rotateLeft,
-				callback: ( { close } ) => {
-					close();
-					onReset();
-				},
-			},
-		];
-	}, [ canReset, onReset ] );
-
-	return {
-		isLoading: false,
-		commands,
-	};
-}
-
-function useGlobalStylesOpenCssCommands() {
-	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
-	const { params } = useLocation();
-	const { canvas = 'view' } = params;
-	const history = useHistory();
-	const { canEditCSS } = useSelect( ( select ) => {
-		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
-			select( coreStore );
-
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-			: undefined;
+			];
+		}, [ history, openGeneralSidebar, params, canvas, isBlockBasedTheme ] );
 
 		return {
-			canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
+			isLoading: false,
+			commands,
 		};
-	}, [] );
-
-	const commands = useMemo( () => {
-		if ( ! canEditCSS ) {
-			return [];
-		}
-
-		return [
-			{
-				name: 'core/edit-site/open-styles-css',
-				label: __( 'Customize CSS' ),
-				icon: brush,
-				callback: ( { close } ) => {
-					close();
-					if ( ! params.postId ) {
-						history.push( {
-							path: '/wp_global_styles',
-							canvas: 'edit',
-						} );
-					}
-					if ( params.postId && canvas !== 'edit' ) {
-						history.push(
-							{
-								...params,
-								canvas: 'edit',
-							},
-							undefined,
-							{
-								transition: 'canvas-mode-edit-transition',
-							}
-						);
-					}
-					openGeneralSidebar( 'edit-site/global-styles' );
-					setEditorCanvasContainerView( 'global-styles-css' );
-				},
-			},
-		];
-	}, [
-		history,
-		openGeneralSidebar,
-		setEditorCanvasContainerView,
-		canEditCSS,
-		canvas,
-		params,
-	] );
-	return {
-		isLoading: false,
-		commands,
 	};
-}
 
-function useGlobalStylesOpenRevisionsCommands() {
-	const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
-		useDispatch( editSiteStore )
-	);
-	const { params } = useLocation();
-	const { canvas = 'view' } = params;
-	const history = useHistory();
-	const hasRevisions = useSelect( ( select ) => {
-		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
-			select( coreStore );
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-			: undefined;
-		return !! globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count;
-	}, [] );
+const getGlobalStylesToggleWelcomeGuideCommands = () =>
+	function useGlobalStylesToggleWelcomeGuideCommands() {
+		const { openGeneralSidebar } = unlock( useDispatch( editSiteStore ) );
+		const { params } = useLocation();
+		const { canvas = 'view' } = params;
+		const { set } = useDispatch( preferencesStore );
 
-	const commands = useMemo( () => {
-		if ( ! hasRevisions ) {
-			return [];
-		}
+		const history = useHistory();
+		const isBlockBasedTheme = useSelect( ( select ) => {
+			return select( coreStore ).getCurrentTheme().is_block_theme;
+		}, [] );
 
-		return [
-			{
-				name: 'core/edit-site/open-global-styles-revisions',
-				label: __( 'Style revisions' ),
-				icon: backup,
-				callback: ( { close } ) => {
-					close();
-					if ( ! params.postId ) {
-						history.push( {
-							path: '/wp_global_styles',
-							canvas: 'edit',
-						} );
-					}
-					if ( params.postId && canvas !== 'edit' ) {
-						history.push(
-							{
-								...params,
+		const commands = useMemo( () => {
+			if ( ! isBlockBasedTheme ) {
+				return [];
+			}
+
+			return [
+				{
+					name: 'core/edit-site/toggle-styles-welcome-guide',
+					label: __( 'Learn about styles' ),
+					callback: ( { close } ) => {
+						close();
+						if ( ! params.postId ) {
+							history.push( {
+								path: '/wp_global_styles',
 								canvas: 'edit',
-							},
-							undefined,
-							{
-								transition: 'canvas-mode-edit-transition',
-							}
-						);
-					}
-					openGeneralSidebar( 'edit-site/global-styles' );
-					setEditorCanvasContainerView( 'global-styles-revisions' );
+							} );
+						}
+						if ( params.postId && canvas !== 'edit' ) {
+							history.push(
+								{
+									...params,
+									canvas: 'edit',
+								},
+								undefined,
+								{
+									transition: 'canvas-mode-edit-transition',
+								}
+							);
+						}
+						openGeneralSidebar( 'edit-site/global-styles' );
+						set( 'core/edit-site', 'welcomeGuideStyles', true );
+						// sometimes there's a focus loss that happens after some time
+						// that closes the modal, we need to force reopening it.
+						setTimeout( () => {
+							set( 'core/edit-site', 'welcomeGuideStyles', true );
+						}, 500 );
+					},
+					icon: help,
 				},
-			},
-		];
-	}, [
-		hasRevisions,
-		history,
-		openGeneralSidebar,
-		setEditorCanvasContainerView,
-		canvas,
-		params,
-	] );
+			];
+		}, [
+			history,
+			openGeneralSidebar,
+			canvas,
+			isBlockBasedTheme,
+			set,
+			params,
+		] );
 
-	return {
-		isLoading: false,
-		commands,
+		return {
+			isLoading: false,
+			commands,
+		};
 	};
-}
+
+const getGlobalStylesResetCommands = () =>
+	function useGlobalStylesResetCommands() {
+		const [ canReset, onReset ] = useGlobalStylesReset();
+		const commands = useMemo( () => {
+			if ( ! canReset ) {
+				return [];
+			}
+
+			return [
+				{
+					name: 'core/edit-site/reset-global-styles',
+					label: __( 'Reset styles' ),
+					icon: isRTL() ? rotateRight : rotateLeft,
+					callback: ( { close } ) => {
+						close();
+						onReset();
+					},
+				},
+			];
+		}, [ canReset, onReset ] );
+
+		return {
+			isLoading: false,
+			commands,
+		};
+	};
+
+const getGlobalStylesOpenCssCommands = () =>
+	function useGlobalStylesOpenCssCommands() {
+		const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
+			useDispatch( editSiteStore )
+		);
+		const { params } = useLocation();
+		const { canvas = 'view' } = params;
+		const history = useHistory();
+		const { canEditCSS } = useSelect( ( select ) => {
+			const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+				select( coreStore );
+
+			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+			const globalStyles = globalStylesId
+				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+				: undefined;
+
+			return {
+				canEditCSS: !! globalStyles?._links?.[ 'wp:action-edit-css' ],
+			};
+		}, [] );
+
+		const commands = useMemo( () => {
+			if ( ! canEditCSS ) {
+				return [];
+			}
+
+			return [
+				{
+					name: 'core/edit-site/open-styles-css',
+					label: __( 'Customize CSS' ),
+					icon: brush,
+					callback: ( { close } ) => {
+						close();
+						if ( ! params.postId ) {
+							history.push( {
+								path: '/wp_global_styles',
+								canvas: 'edit',
+							} );
+						}
+						if ( params.postId && canvas !== 'edit' ) {
+							history.push(
+								{
+									...params,
+									canvas: 'edit',
+								},
+								undefined,
+								{
+									transition: 'canvas-mode-edit-transition',
+								}
+							);
+						}
+						openGeneralSidebar( 'edit-site/global-styles' );
+						setEditorCanvasContainerView( 'global-styles-css' );
+					},
+				},
+			];
+		}, [
+			history,
+			openGeneralSidebar,
+			setEditorCanvasContainerView,
+			canEditCSS,
+			canvas,
+			params,
+		] );
+		return {
+			isLoading: false,
+			commands,
+		};
+	};
+
+const getGlobalStylesOpenRevisionsCommands = () =>
+	function useGlobalStylesOpenRevisionsCommands() {
+		const { openGeneralSidebar, setEditorCanvasContainerView } = unlock(
+			useDispatch( editSiteStore )
+		);
+		const { params } = useLocation();
+		const { canvas = 'view' } = params;
+		const history = useHistory();
+		const hasRevisions = useSelect( ( select ) => {
+			const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
+				select( coreStore );
+			const globalStylesId = __experimentalGetCurrentGlobalStylesId();
+			const globalStyles = globalStylesId
+				? getEntityRecord( 'root', 'globalStyles', globalStylesId )
+				: undefined;
+			return !! globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count;
+		}, [] );
+
+		const commands = useMemo( () => {
+			if ( ! hasRevisions ) {
+				return [];
+			}
+
+			return [
+				{
+					name: 'core/edit-site/open-global-styles-revisions',
+					label: __( 'Style revisions' ),
+					icon: backup,
+					callback: ( { close } ) => {
+						close();
+						if ( ! params.postId ) {
+							history.push( {
+								path: '/wp_global_styles',
+								canvas: 'edit',
+							} );
+						}
+						if ( params.postId && canvas !== 'edit' ) {
+							history.push(
+								{
+									...params,
+									canvas: 'edit',
+								},
+								undefined,
+								{
+									transition: 'canvas-mode-edit-transition',
+								}
+							);
+						}
+						openGeneralSidebar( 'edit-site/global-styles' );
+						setEditorCanvasContainerView(
+							'global-styles-revisions'
+						);
+					},
+				},
+			];
+		}, [
+			hasRevisions,
+			history,
+			openGeneralSidebar,
+			setEditorCanvasContainerView,
+			canvas,
+			params,
+		] );
+
+		return {
+			isLoading: false,
+			commands,
+		};
+	};
 
 export function useCommonCommands() {
 	const homeUrl = useSelect( ( select ) => {
@@ -324,26 +331,26 @@ export function useCommonCommands() {
 
 	useCommandLoader( {
 		name: 'core/edit-site/open-styles',
-		hook: useGlobalStylesOpenStylesCommands,
+		hook: getGlobalStylesOpenStylesCommands(),
 	} );
 
 	useCommandLoader( {
 		name: 'core/edit-site/toggle-styles-welcome-guide',
-		hook: useGlobalStylesToggleWelcomeGuideCommands,
+		hook: getGlobalStylesToggleWelcomeGuideCommands(),
 	} );
 
 	useCommandLoader( {
 		name: 'core/edit-site/reset-global-styles',
-		hook: useGlobalStylesResetCommands,
+		hook: getGlobalStylesResetCommands(),
 	} );
 
 	useCommandLoader( {
 		name: 'core/edit-site/open-styles-css',
-		hook: useGlobalStylesOpenCssCommands,
+		hook: getGlobalStylesOpenCssCommands(),
 	} );
 
 	useCommandLoader( {
 		name: 'core/edit-site/open-styles-revisions',
-		hook: useGlobalStylesOpenRevisionsCommands,
+		hook: getGlobalStylesOpenRevisionsCommands(),
 	} );
 }

--- a/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-edit-mode-commands.js
@@ -22,147 +22,152 @@ import { useLink } from '../../components/routes/link';
 
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 
-function usePageContentFocusCommands() {
-	const { record: template } = useEditedEntityRecord();
-	const { params } = useLocation();
-	const { canvas = 'view' } = params;
-	const { isPage, templateId, currentPostType } = useSelect( ( select ) => {
-		const { isPage: _isPage } = unlock( select( editSiteStore ) );
-		const { getCurrentPostType, getCurrentTemplateId } =
-			select( editorStore );
-		return {
-			isPage: _isPage(),
-			templateId: getCurrentTemplateId(),
-			currentPostType: getCurrentPostType(),
-		};
-	}, [] );
-
-	const { onClick: editTemplate } = useLink( {
-		postType: 'wp_template',
-		postId: templateId,
-	} );
-
-	const { setRenderingMode } = useDispatch( editorStore );
-
-	if ( ! isPage || canvas !== 'edit' ) {
-		return { isLoading: false, commands: [] };
-	}
-
-	const commands = [];
-
-	if ( currentPostType !== 'wp_template' ) {
-		commands.push( {
-			name: 'core/switch-to-template-focus',
-			label: sprintf(
-				/* translators: %s: template title */
-				__( 'Edit template: %s' ),
-				decodeEntities( template.title )
-			),
-			icon: layout,
-			callback: ( { close } ) => {
-				editTemplate();
-				close();
+const getPageContentFocusCommands = () =>
+	function usePageContentFocusCommands() {
+		const { record: template } = useEditedEntityRecord();
+		const { params } = useLocation();
+		const { canvas = 'view' } = params;
+		const { isPage, templateId, currentPostType } = useSelect(
+			( select ) => {
+				const { isPage: _isPage } = unlock( select( editSiteStore ) );
+				const { getCurrentPostType, getCurrentTemplateId } =
+					select( editorStore );
+				return {
+					isPage: _isPage(),
+					templateId: getCurrentTemplateId(),
+					currentPostType: getCurrentPostType(),
+				};
 			},
+			[]
+		);
+
+		const { onClick: editTemplate } = useLink( {
+			postType: 'wp_template',
+			postId: templateId,
 		} );
-	} else {
-		commands.push( {
-			name: 'core/switch-to-page-focus',
-			label: __( 'Back to page' ),
-			icon: page,
-			callback: ( { close } ) => {
-				setRenderingMode( 'template-locked' );
-				close();
-			},
-		} );
-	}
 
-	return { isLoading: false, commands };
-}
+		const { setRenderingMode } = useDispatch( editorStore );
 
-function useManipulateDocumentCommands() {
-	const { isLoaded, record: template } = useEditedEntityRecord();
-	const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
-	const history = useHistory();
-	const isEditingPage = useSelect(
-		( select ) =>
-			select( editSiteStore ).isPage() &&
-			select( editorStore ).getCurrentPostType() !== 'wp_template',
-		[]
-	);
+		if ( ! isPage || canvas !== 'edit' ) {
+			return { isLoading: false, commands: [] };
+		}
 
-	if ( ! isLoaded ) {
-		return { isLoading: true, commands: [] };
-	}
+		const commands = [];
 
-	const commands = [];
+		if ( currentPostType !== 'wp_template' ) {
+			commands.push( {
+				name: 'core/switch-to-template-focus',
+				label: sprintf(
+					/* translators: %s: template title */
+					__( 'Edit template: %s' ),
+					decodeEntities( template.title )
+				),
+				icon: layout,
+				callback: ( { close } ) => {
+					editTemplate();
+					close();
+				},
+			} );
+		} else {
+			commands.push( {
+				name: 'core/switch-to-page-focus',
+				label: __( 'Back to page' ),
+				icon: page,
+				callback: ( { close } ) => {
+					setRenderingMode( 'template-locked' );
+					close();
+				},
+			} );
+		}
 
-	if ( isTemplateRevertable( template ) && ! isEditingPage ) {
-		const label =
-			template.type === TEMPLATE_POST_TYPE
-				? sprintf(
-						/* translators: %s: template title */
-						__( 'Reset template: %s' ),
-						decodeEntities( template.title )
-				  )
-				: sprintf(
-						/* translators: %s: template part title */
-						__( 'Reset template part: %s' ),
-						decodeEntities( template.title )
-				  );
-		commands.push( {
-			name: 'core/reset-template',
-			label,
-			icon: isRTL() ? rotateRight : rotateLeft,
-			callback: ( { close } ) => {
-				revertTemplate( template );
-				close();
-			},
-		} );
-	}
-
-	if ( isTemplateRemovable( template ) && ! isEditingPage ) {
-		const label =
-			template.type === TEMPLATE_POST_TYPE
-				? sprintf(
-						/* translators: %s: template title */
-						__( 'Delete template: %s' ),
-						decodeEntities( template.title )
-				  )
-				: sprintf(
-						/* translators: %s: template part title */
-						__( 'Delete template part: %s' ),
-						decodeEntities( template.title )
-				  );
-		commands.push( {
-			name: 'core/remove-template',
-			label,
-			icon: trash,
-			callback: ( { close } ) => {
-				removeTemplate( template );
-				// Navigate to the template list
-				history.push( {
-					postType: template.type,
-				} );
-				close();
-			},
-		} );
-	}
-
-	return {
-		isLoading: ! isLoaded,
-		commands,
+		return { isLoading: false, commands };
 	};
-}
+
+const getManipulateDocumentCommands = () =>
+	function useManipulateDocumentCommands() {
+		const { isLoaded, record: template } = useEditedEntityRecord();
+		const { removeTemplate, revertTemplate } = useDispatch( editSiteStore );
+		const history = useHistory();
+		const isEditingPage = useSelect(
+			( select ) =>
+				select( editSiteStore ).isPage() &&
+				select( editorStore ).getCurrentPostType() !== 'wp_template',
+			[]
+		);
+
+		if ( ! isLoaded ) {
+			return { isLoading: true, commands: [] };
+		}
+
+		const commands = [];
+
+		if ( isTemplateRevertable( template ) && ! isEditingPage ) {
+			const label =
+				template.type === TEMPLATE_POST_TYPE
+					? sprintf(
+							/* translators: %s: template title */
+							__( 'Reset template: %s' ),
+							decodeEntities( template.title )
+					  )
+					: sprintf(
+							/* translators: %s: template part title */
+							__( 'Reset template part: %s' ),
+							decodeEntities( template.title )
+					  );
+			commands.push( {
+				name: 'core/reset-template',
+				label,
+				icon: isRTL() ? rotateRight : rotateLeft,
+				callback: ( { close } ) => {
+					revertTemplate( template );
+					close();
+				},
+			} );
+		}
+
+		if ( isTemplateRemovable( template ) && ! isEditingPage ) {
+			const label =
+				template.type === TEMPLATE_POST_TYPE
+					? sprintf(
+							/* translators: %s: template title */
+							__( 'Delete template: %s' ),
+							decodeEntities( template.title )
+					  )
+					: sprintf(
+							/* translators: %s: template part title */
+							__( 'Delete template part: %s' ),
+							decodeEntities( template.title )
+					  );
+			commands.push( {
+				name: 'core/remove-template',
+				label,
+				icon: trash,
+				callback: ( { close } ) => {
+					removeTemplate( template );
+					// Navigate to the template list
+					history.push( {
+						postType: template.type,
+					} );
+					close();
+				},
+			} );
+		}
+
+		return {
+			isLoading: ! isLoaded,
+			commands,
+		};
+	};
 
 export function useEditModeCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/page-content-focus',
-		hook: usePageContentFocusCommands,
+		hook: getPageContentFocusCommands(),
 		context: 'entity-edit',
 	} );
 
 	useCommandLoader( {
 		name: 'core/edit-site/manipulate-document',
-		hook: useManipulateDocumentCommands,
+		hook: getManipulateDocumentCommands(),
 	} );
 }


### PR DESCRIPTION
## What?
This PR fixes most of the React Compiler ESLint violations, reducing them from 24 to 8.

## Why?
We'd like to start using the React Compiler (the babel plugin) in Gutenberg, and to get there, we'd like to enable the ESLint plugin first.

## How?
This is a syntax change, introducing a wrapper function that's tricking React Compiler that rules of hooks are being correctly followed. The underlying behavior is unchanged. We're essentially changing:

```
hook: something
```

to:

```
hook: getSomething()
```

where `getSomething()` returns `something` as well.

Ideally, we would change the API to no longer need to receive and pass a hook, but this is work for another time.

This might look like a big PR, but it's quite mundane. I recommend reviewing with whitespace changes hidden as most of the changes are actually whitespace changes.

## Testing Instructions
Verify all pre-existing commands still work by pressing cmd+k in certain contexts:
* While a block is selected: Duplicate, Add before, Add after, Group, Delete
* Any context: Add new page / Add new block
* Site editor: Navigation, Patterns, Templates, Template Parts
* Site Editor: Open styles, Learn about styles
* While list view is open: Close list view. Whie list view is closed: Open list view.
* Any editor: Enter spotlight mode, Editor preferences


### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
