### PR TITLE
Fix Editing Navigation shows small sub menu area

### DIFF
--- a/packages/editor/src/components/visual-editor/index.js
+++ b/packages/editor/src/components/visual-editor/index.js
@@ -340,7 +340,6 @@ function VisualEditor( {
 
 	useEffect( () => {
 		if ( hasNavigationBlock ) {
-			// Apply logic to set editor height to full if navigation block is present.
 			setforceFullHeight( true );
 		}
 	}, [ hasNavigationBlock ] );


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/66582

## Why?
The Editing Navigation shows small sub menu area, this PR fixes this issue.

## How?
- If in the Editor we have Navigation block then the editor will take full height.

## Testing Instructions
- Open a pattern containing Navigation.
- Edit the Navigation.
- If the navigation has sub-menu then the space is very less.

## Screenshots or screencast <!-- if applicable -->

Before:
<img width="1469" alt="Screenshot at Nov 06 14-58-45" src="https://github.com/user-attachments/assets/6be29932-78b1-4ee2-99c2-e832e7c3fb7c">

After:
<img width="1469" alt="Screenshot at Nov 06 14-57-26" src="https://github.com/user-attachments/assets/7692ffda-3818-4f47-9fa7-8e50f8220563">
