### PR TITLE
Enable zoom out mode for non-iframe editor

### DIFF
--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -131,7 +131,6 @@ export default function EditorInterface( {
 						customSaveButton={ customSaveButton }
 						forceDisableBlockTools={ forceDisableBlockTools }
 						title={ title }
-						isEditorIframed={ ! disableIframe }
 					/>
 				)
 			}

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -53,7 +53,6 @@ function Header( {
 	forceDisableBlockTools,
 	setEntitiesSavedStatesCallback,
 	title,
-	isEditorIframed,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -168,7 +167,7 @@ function Header( {
 					forceIsAutosaveable={ forceIsDirty }
 				/>
 
-				{ canBeZoomedOut && isEditorIframed && isWideViewport && (
+				{ canBeZoomedOut && isWideViewport && (
 					<ZoomOutToggle disabled={ forceDisableBlockTools } />
 				) }
 


### PR DESCRIPTION
Fixes #66671

## What?

This PR re-enables the zoom out toggle for the non-iframe editor that was disabled in #65452.

## Why?

Selecting the Pattern tab forces the zoom out mode. This is correct behavior, but creates a contradiction because the non-iframe editor doesn't have the zoom out toggle button in the first place. The zoom out toggle button suddenly appears, but when you press it, it disappears.

This PR simply reverts #65452. When #65452 was submitted, zoom out mode didn't work in non-iframe editors. But now it seems to work correctly. The introduction of the `useZoomout()` hook or #66141 might be related.

## Testing Instructions

- To make it work as a non-iframe editor:
  - Enable a plugin that includes Blocks API version 2, e.g. [CoBlocks](https://wordpress.org/plugins/coblocks/).
  - Enable a classic theme.
- Ensure that the zoom out toggle works.
- Additional test:
  - Enable custom fields.
  - Meta boxes are not resizable.
  - When you click the zoom out button, the meta boxes become resizable. However, in the `wp/6.7` branch, the meta boxes are not displayed in the zoom out mode (See #66742). There is a discussion in #66718 about whether to implement this specification in trunk as well.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/1160ac53-d605-4a13-bbf1-4e73c61003e3


