### PR TITLE
Modal: Increase size of the Close button

### DIFF
--- a/packages/block-library/src/freeform/modal.js
+++ b/packages/block-library/src/freeform/modal.js
@@ -25,7 +25,7 @@ function ModalAuxiliaryActions( { onClick, isModalFullScreen } ) {
 
 	return (
 		<Button
-			size="small"
+			size="compact"
 			onClick={ onClick }
 			icon={ fullscreen }
 			isPressed={ isModalFullScreen }

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Bug Fixes
 
+-   `Modal`: Modal: Increase size of the Close button ([#66792](https://github.com/WordPress/gutenberg/pull/66792)).
 -   `ToggleGroupControl`: Fix active background for `0` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
 -   `SlotFill`: Fix a bug where a stale value of `fillProps` could be used ([#67000](https://github.com/WordPress/gutenberg/pull/67000)).
 -   `ColorPalette`: Disable `Clear` button if there's no color value. ([#67108](https://github.com/WordPress/gutenberg/pull/67108)).

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -338,7 +338,7 @@ function UnforwardedModal(
 											marginLeft={ 3 }
 										/>
 										<Button
-											size="small"
+											size="compact"
 											onClick={ (
 												event: React.MouseEvent< HTMLButtonElement >
 											) =>

--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -335,7 +335,7 @@ function UnforwardedModal(
 									<>
 										<Spacer
 											marginBottom={ 0 }
-											marginLeft={ 3 }
+											marginLeft={ 2 }
 										/>
 										<Button
 											size="compact"

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -111,7 +111,7 @@ export const WithHeaderActions: StoryFn< typeof Modal > = Template.bind( {} );
 WithHeaderActions.args = {
 	...Default.args,
 	headerActions: (
-		<Button icon={ fullscreen } label="Fullscreen mode" size="small" />
+		<Button icon={ fullscreen } label="Fullscreen mode" size="compact" />
 	),
 	children: <div style={ { height: '200px' } } />,
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66758

Note: as done for the previous change in https://github.com/WordPress/gutenberg/pull/65131, I guess this will warrant a dev note.

## What?
<!-- In a few words, what is the PR actually doing? -->
While using one of the new button size variants makes totally sense, the new 'small' size of 24 pixels is unnecessarily too small.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The target size of any interactive control should be as big as possible for better usability and accessibility.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Switches the size from 'small' to 'compact' (32 pixels).
- Aside: adjusts the spacing on the left of the close button to 8 pixels for consistency with the spacing between buttons used acrosso the editor. This can be seen in the Classic block modal dialog.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Open a few modal dialogs in the editor, for example:
  - The keyboard shortcuts modal dialog.
  - The modal dialog to rename a block e.g. a Group block.
  - The Classic block modal dialog.
- Observe the X close button size is now 32 pixels.
- In the Classic block modal dialog, observe the spacinf between the 'Enter fullscreen' and 'Close' buttons is now 8 pixels.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Highlighting the buttons with a red background to better illustrate:

Before:

![before](https://github.com/user-attachments/assets/bf646e71-9402-4c58-a33d-434029a0c07b)

After:

![after](https://github.com/user-attachments/assets/46db267d-f88e-424b-a04b-6d2f3ee29a63)


