### PR TITLE
Block Bindings: Add server sources to bindings UI

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -49,6 +49,7 @@ const useToolsPanelDropdownMenuProps = () => {
 
 function BlockBindingsPanelDropdown( { attribute, binding } ) {
 	const blockContext = useContext( BlockContext );
+	const { updateBlockBindings } = useBlockBindingsUtils();
 	const registeredSources = getBlockBindingsSources();
 	// Get a new object with the rendered components to check if they are null.
 	const sourcesComponents = Object.entries( registeredSources ).reduce(
@@ -70,6 +71,9 @@ function BlockBindingsPanelDropdown( { attribute, binding } ) {
 				if ( SourceComponent ) {
 					acc[ name ] = SourceComponent;
 				}
+			} else if ( name !== 'core/pattern-overrides' ) {
+				// TODO: Look for a proper way to opt-in/opt-out for this.
+				acc[ name ] = null;
 			}
 
 			return acc;
@@ -84,6 +88,20 @@ function BlockBindingsPanelDropdown( { attribute, binding } ) {
 
 	return Object.entries( sourcesComponents ).map(
 		( [ sourceName, SourceComponent ] ) => {
+			if ( ! SourceComponent ) {
+				return (
+					<DropdownMenuV2.Item
+						onClick={ () => {
+							updateBlockBindings( {
+								[ attribute ]: { source: sourceName },
+							} );
+						} }
+					>
+						{ registeredSources[ sourceName ].label }
+					</DropdownMenuV2.Item>
+				);
+			}
+
 			return (
 				<DropdownMenuV2
 					key={ sourceName }


### PR DESCRIPTION
This exploration is made on top of https://github.com/WordPress/gutenberg/pull/65994

## What?
In this pull request, I'm exploring how server sources could automatically appear in block bindings UI and how they should opt-in for this.

https://github.com/user-attachments/assets/581ba53e-1a53-4e5a-94be-93cd92681991


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
