### PR TITLE
Experiment: Add quick edit to any post type

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -406,8 +406,7 @@ export default function PostList( { postType } ) {
 				defaultLayouts={ defaultLayouts }
 				header={
 					window.__experimentalQuickEditDataViews &&
-					view.type !== LAYOUT_LIST &&
-					postType === 'page' && (
+					view.type !== LAYOUT_LIST && (
 						<Button
 							size="compact"
 							isPressed={ quickEdit }

--- a/packages/edit-site/src/components/posts-app/router.js
+++ b/packages/edit-site/src/components/posts-app/router.js
@@ -14,12 +14,18 @@ import SidebarNavigationScreen from '../sidebar-navigation-screen';
 import SidebarNavigationScreenMain from '../sidebar-navigation-screen-main';
 import DataViewsSidebarContent from '../sidebar-dataviews';
 import PostList from '../post-list';
+import { PostEdit } from '../post-edit';
 
 const { useLocation } = unlock( routerPrivateApis );
 
+function PostQuickEdit() {
+	const { params } = useLocation();
+	return <PostEdit postType={ params.postType } postId={ params.postId } />;
+}
+
 export default function useActiveRoute() {
 	const { params = {} } = useLocation();
-	const { postType, layout, canvas } = params;
+	const { postType, layout, canvas, quickEdit } = params;
 	const labels = useSelect(
 		( select ) => {
 			return select( coreStore ).getPostType( postType )?.labels;
@@ -28,7 +34,7 @@ export default function useActiveRoute() {
 	);
 
 	// Posts list.
-	if ( [ 'post' ].includes( postType ) ) {
+	if ( postType ) {
 		const isListLayout = layout === 'list' || ! layout;
 		return {
 			name: 'posts-list',
@@ -50,6 +56,7 @@ export default function useActiveRoute() {
 					) : (
 						<PostList postType={ postType } />
 					),
+				edit: quickEdit && <PostQuickEdit />,
 			},
 			widths: {
 				content: isListLayout ? 380 : undefined,

--- a/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
+++ b/packages/edit-site/src/components/sync-state-with-url/use-init-edited-entity-from-url.js
@@ -28,8 +28,6 @@ const postTypesWithoutParentTemplate = [
 	PATTERN_TYPES.user,
 ];
 
-const authorizedPostTypes = [ 'page', 'post' ];
-
 function useResolveEditedEntityAndContext( { postId, postType } ) {
 	const { hasLoadedAllDependencies, homepageId, postsPageId } = useSelect(
 		( select ) => {
@@ -181,11 +179,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 
 			// If we're rendering a specific page, we need to resolve its template.
 			// The site editor only supports pages for now, not other CPTs.
-			if (
-				postType &&
-				postId &&
-				authorizedPostTypes.includes( postType )
-			) {
+			if ( postType && postId ) {
 				return resolveTemplateForPostTypeAndId( postType, postId );
 			}
 
@@ -205,7 +199,7 @@ function useResolveEditedEntityAndContext( { postId, postType } ) {
 			return {};
 		}
 
-		if ( postType && postId && authorizedPostTypes.includes( postType ) ) {
+		if ( postType && postId ) {
 			return { postType, postId };
 		}
 		// TODO: for post types lists we should probably not render the front page, but maybe a placeholder


### PR DESCRIPTION
# This pull request is not intended to be merged

## What?
I wanted to take a look at how the quick edit functionality could look like for any post type:

https://github.com/user-attachments/assets/99a8e23e-2c2c-44c7-97fb-023a5f22597b

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
