### PR TITLE
Iframe: always enable for block themes, in core too

### DIFF
--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -14,36 +14,33 @@ import { unlock } from '../../lock-unlock';
 const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
 
 export function useShouldIframe() {
-	const {
-		isBlockBasedTheme,
-		hasV3BlocksOnly,
-		isEditingTemplateOrPattern,
-		isZoomOutMode,
-		deviceType,
-	} = useSelect( ( select ) => {
+	return useSelect( ( select ) => {
+		// In the Gutenberg plugin, which acts as a testing ground and is a
+		// bit more experimental than core, we always use the iframe.
+		if ( isGutenbergPlugin ) {
+			return true;
+		}
+
 		const { getEditorSettings, getCurrentPostType, getDeviceType } =
 			select( editorStore );
-		const { isZoomOut } = unlock( select( blockEditorStore ) );
-		const { getBlockTypes } = select( blocksStore );
-		const editorSettings = getEditorSettings();
-		return {
-			isBlockBasedTheme: editorSettings.__unstableIsBlockBasedTheme,
-			hasV3BlocksOnly: getBlockTypes().every( ( type ) => {
-				return type.apiVersion >= 3;
-			} ),
-			isEditingTemplateOrPattern: [ 'wp_template', 'wp_block' ].includes(
-				getCurrentPostType()
-			),
-			isZoomOutMode: isZoomOut(),
-			deviceType: getDeviceType(),
-		};
-	}, [] );
 
-	return (
-		hasV3BlocksOnly ||
-		( isGutenbergPlugin && isBlockBasedTheme ) ||
-		isEditingTemplateOrPattern ||
-		isZoomOutMode ||
-		[ 'Tablet', 'Mobile' ].includes( deviceType )
-	);
+		return (
+			// If the theme is block based, we ALWAYS use the iframe for
+			// consistency across the post and site editor. The iframe was
+			// introduced long before the sited editor and block themes, so
+			// these themes are expecting it.
+			getEditorSettings().__unstableIsBlockBasedTheme ||
+			// For classic themes, we also still want to iframe all the special
+			// editor features and modes such as device previews, zoom out, and
+			// template/pattern editing.
+			getDeviceType() !== 'Desktop' ||
+			[ 'wp_template', 'wp_block' ].includes( getCurrentPostType() ) ||
+			unlock( select( blockEditorStore ) ).isZoomOut() ||
+			// Finally, still iframe the classic editor if all blocks are v3
+			// (which means they are marked as iframe-compatible).
+			select( blocksStore )
+				.getBlockTypes()
+				.every( ( type ) => type.apiVersion >= 3 )
+		);
+	}, [] );
 }

--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -11,19 +11,10 @@ import { store as blockEditorStore } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const isGutenbergPlugin = globalThis.IS_GUTENBERG_PLUGIN ? true : false;
-
 export function useShouldIframe() {
 	return useSelect( ( select ) => {
-		// In the Gutenberg plugin, which acts as a testing ground and is a
-		// bit more experimental than core, we always use the iframe.
-		if ( isGutenbergPlugin ) {
-			return true;
-		}
-
 		const { getEditorSettings, getCurrentPostType, getDeviceType } =
 			select( editorStore );
-
 		return (
 			// If the theme is block based, we ALWAYS use the iframe for
 			// consistency across the post and site editor. The iframe was

--- a/packages/edit-post/src/components/layout/use-should-iframe.js
+++ b/packages/edit-post/src/components/layout/use-should-iframe.js
@@ -27,8 +27,8 @@ export function useShouldIframe() {
 			getDeviceType() !== 'Desktop' ||
 			[ 'wp_template', 'wp_block' ].includes( getCurrentPostType() ) ||
 			unlock( select( blockEditorStore ) ).isZoomOut() ||
-			// Finally, still iframe the classic editor if all blocks are v3
-			// (which means they are marked as iframe-compatible).
+			// Finally, still iframe the editor for classic themes if all blocks
+			// are v3 (which means they are marked as iframe-compatible).
 			select( blocksStore )
 				.getBlockTypes()
 				.every( ( type ) => type.apiVersion >= 3 )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

We already always iframe the post editor when a block theme is active with the Gutenberg plugin active. Let's do it for core too.

It's time we move forward in enabling the iframe in more scenarios. The iframe has been widely tested over the last many years in the Site Editor, device preview modes, all block, pattern and template previews, AND the post editor whenever Gutenberg is enabled with a block theme. This basically means that the iframe is always active on WordPress.com (where the GB plugin is always active and all themes are block themes).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

For greater consistency. An example complaint: https://x.com/thekevingeary/status/1803760573718397081.

We have been very cautious in enabling the iframe if there's a block that is not v3, because there's a tiny possibility it _might_ break. In most cases this is fine though, and un-iframing the editor could break more things than it fixes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We enable the iframe for block based themes, but only when the Gutenberg plugin is active.

I propose that we always enable the iframe for block based themes, also in core. The iframe has been around for a long time and it's been widely tested.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Note that for the Gutenberg plugin, nothing has changed.

* Activate a block based theme and register a v2 block. The editor should still be iframed.
* Activate a classic theme and register a v2 block. The editor iframe should be removed.
  * Also check that the iframe is still there in device preview mode and zoom-out mode.

Here's a snippet for registering a v2 block:

```js
window.wp.blocks.registerBlockType( 'test/v2', { apiVersion: 2, title: 'test' } );
```

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
