### PR TITLE
Avoid using width: fit-content for images that use auto-sizes

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -10,7 +10,11 @@
 		vertical-align: bottom;
 		box-sizing: border-box;
 
-		&:not([src$=".svg"]) {
+		// `width: fit-content` is not safe to use with SVGs and with images
+		// using `sizes=auto`.
+		// See: https://github.com/WordPress/gutenberg/pull/66643
+		// See: https://core.trac.wordpress.org/ticket/62345
+		&:not(:is([src$=".svg"], [sizes="auto" i], [sizes^="auto," i])) {
 			width: fit-content;
 		}
 


### PR DESCRIPTION
Follow up to #66217 and #66643.

This fixes a bug reported in https://core.trac.wordpress.org/ticket/62345 that leads to incorrect display for images with `sizes="auto"`. See https://core.trac.wordpress.org/ticket/62345#comment:2 for details.

## What?
Exclude `width: content-fit` for images that use `sizes="auto"`.

## Why?
Having `width: content-fit` on these images leads to a visual bug on browsers that support `sizes="auto"`, per the HTML specification https://html.spec.whatwg.org/multipage/rendering.html#img-contain-size.

As this surfaces in the new Twenty Twenty-Five theme for instance and appears on heavily used browsers, I believe this is a critical visual bug and therefore needs to be fixed before the 6.7 release.

## Testing Instructions
* Use a browser that supports `sizes="auto"`, e.g. Chrome (see https://caniuse.com/mdn-html_elements_img_sizes_auto).
* Use a theme like Twenty Twenty-Five.
* Create a page where you put at least 4 `core/image` blocks, each width different images.
* Without this fix, the lazy-loaded images (which therefore also have `sizes="auto"`) will be displayed with only 300px width. With this fix, they are displayed correctly.