### PR TITLE
Revert "Set image width to `fit-content` to solve aspect ratio problems in Firefox. (#66217)"

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -10,10 +10,6 @@
 		vertical-align: bottom;
 		box-sizing: border-box;
 
-		&:not([src$=".svg"]) {
-			width: fit-content;
-		}
-
 		@media (prefers-reduced-motion: no-preference) {
 			&.hide {
 				visibility: hidden;


### PR DESCRIPTION
This reverts commit 0e65adcbe187797a536aa99f56b063a61cafdc3d.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What and Why?
<!-- In a few words, what is the PR actually doing? -->

This is an alternative to https://github.com/WordPress/gutenberg/pull/66801.

As reported both in https://github.com/WordPress/gutenberg/pull/66643 and https://github.com/WordPress/gutenberg/pull/66801. The `fit-content` rule possibly introduced too many side effects that it's safer to revert it for now.

This probably means we have to find another way to resolve [the issue with TT5 patterns](https://github.com/WordPress/gutenberg/issues/66175). (Reopen https://github.com/WordPress/gutenberg/issues/66175)

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Revert the commit in both #66217 and #66643.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Follow the instructions in https://github.com/WordPress/gutenberg/pull/66801. See https://core.trac.wordpress.org/ticket/62345 too.

## Screenshots or screencast <!-- if applicable -->
N/A
