### PR TITLE
Data: Rename useSelect internals to fix React Compiler violations

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -209,11 +209,11 @@ function Store( registry, suspense ) {
 	};
 }
 
-function useStaticSelect( storeName ) {
+function _useStaticSelect( storeName ) {
 	return useRegistry().select( storeName );
 }
 
-function useMappingSelect( suspense, mapSelect, deps ) {
+function _useMappingSelect( suspense, mapSelect, deps ) {
 	const registry = useRegistry();
 	const isAsync = useAsyncMode();
 	const store = useMemo(
@@ -308,13 +308,11 @@ export default function useSelect( mapSelect, deps ) {
 		);
 	}
 
-	/* eslint-disable react-hooks/rules-of-hooks */
 	// `staticSelectMode` is not allowed to change during the hook instance's,
 	// lifetime, so the rules of hooks are not really violated.
 	return staticSelectMode
-		? useStaticSelect( mapSelect )
-		: useMappingSelect( false, mapSelect, deps );
-	/* eslint-enable react-hooks/rules-of-hooks */
+		? _useStaticSelect( mapSelect )
+		: _useMappingSelect( false, mapSelect, deps );
 }
 
 /**
@@ -337,5 +335,5 @@ export default function useSelect( mapSelect, deps ) {
  * @return {ReturnType<T>} Data object returned by the `mapSelect` function.
  */
 export function useSuspenseSelect( mapSelect, deps ) {
-	return useMappingSelect( true, mapSelect, deps );
+	return _useMappingSelect( true, mapSelect, deps );
 }


### PR DESCRIPTION
## What?
Fixing the React Compiler violations in `useSelect`. See #61788

## Why?
We want to introduce the React Compiler ESLint plugin, and we need to fix all violations first.

## How?
We rename a couple of internal functions that `useSelect` uses in order to allow for the compiler to work on this file. We were breaking the rules of hooks anyway, so we're willing to make this compromise. The alternative would have been disabling the rule completely on that file, which isn't better IMHO.

## Testing Instructions
All checks should be green. This is just a naming change.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None