### PR TITLE
Block Editor: Fix React Compiler error for 'BlockProps' util component

### DIFF
--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -562,8 +562,13 @@ export function createBlockEditFilter( features ) {
 	addFilter( 'editor.BlockEdit', 'core/editor/hooks', withBlockEditHooks );
 }
 
-function BlockProps( { index, useBlockProps, setAllWrapperProps, ...props } ) {
-	const wrapperProps = useBlockProps( props );
+function BlockProps( {
+	index,
+	useBlockProps: hook,
+	setAllWrapperProps,
+	...props
+} ) {
+	const wrapperProps = hook( props );
 	const setWrapperProps = ( next ) =>
 		setAllWrapperProps( ( prev ) => {
 			const nextAll = [ ...prev ];


### PR DESCRIPTION
## What?
Part of #61788.

PR fixes the React Compile error for the 'BlockProps' util component by renaming it during destructure. This is similar to how the commands loader avoids a similar error.

https://github.com/WordPress/gutenberg/blob/8be8e4675637726b0ff3194ccc547307c4a489bc/packages/commands/src/components/command-menu.js#L38

## Why?
> Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks  react-compiler/react-compiler

## Testing Instructions
All CI checks should be green; we're just renaming the prop.
