### PR TITLE
Image: Add `aria-haspopup` prop write mode `more` tools menu items

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -135,6 +135,7 @@ function ContentOnlyControls( {
 										setIsAltDialogOpen( true );
 										onClose();
 									} }
+									aria-haspopup="dialog"
 								>
 									{ _x(
 										'Alternative text',
@@ -146,6 +147,7 @@ function ContentOnlyControls( {
 										setIsTitleDialogOpen( true );
 										onClose();
 									} }
+									aria-haspopup="dialog"
 								>
 									{ __( 'Title text' ) }
 								</MenuItem>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/66605

Add `aria-haspopup` prop write mode `more` tools menu items (see https://github.com/WordPress/gutenberg/pull/66605#discussion_r1832270550)

