### PR TITLE
Align placeholder and iIllustration states between Cover and Image blocks

### DIFF
--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -4,6 +4,8 @@
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { cover as icon } from '@wordpress/icons';
+import { Placeholder } from '@wordpress/components';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -17,16 +19,16 @@ export default function CoverPlaceholder( {
 	onError,
 	style,
 	toggleUseFeaturedImage,
+	isSelected,
 } ) {
+	const [ placeholderResizeListener, { width: placeholderWidth } ] =
+		useResizeObserver();
+
+	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
+
 	return (
 		<MediaPlaceholder
 			icon={ <BlockIcon icon={ icon } /> }
-			labels={ {
-				title: __( 'Cover' ),
-				instructions: __(
-					'Drag and drop onto this block, upload, or select existing media from your library.'
-				),
-			} }
 			onSelect={ onSelectMedia }
 			accept="image/*,video/*"
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
@@ -34,8 +36,21 @@ export default function CoverPlaceholder( {
 			onToggleFeaturedImage={ toggleUseFeaturedImage }
 			onError={ onError }
 			style={ style }
-		>
-			{ children }
-		</MediaPlaceholder>
+			placeholder={ ( content ) => (
+				<Placeholder
+					className="block-editor-media-placeholder"
+					icon={ icon }
+					withIllustration={ ! isSelected || isSmallContainer }
+					label={ ! isSmallContainer && __( 'Cover' ) }
+					instructions={ __(
+						'Drag and drop onto this block, upload, or select existing media from your library.'
+					) }
+				>
+					{ content }
+					{ isSelected && children }
+					{ placeholderResizeListener }
+				</Placeholder>
+			) }
+		/>
 	);
 }

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -485,6 +485,7 @@ function CoverEdit( {
 						onSelectMedia={ onSelectMedia }
 						onError={ onUploadError }
 						toggleUseFeaturedImage={ toggleUseFeaturedImage }
+						isSelected={ isSelected }
 					>
 						<div className="wp-block-cover__placeholder-background-options">
 							<ColorPalette

--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -2,6 +2,7 @@
 	// Override default cover styles
 	// because we're not ready yet to show the cover block.
 	&.is-placeholder {
+		color: var(--wp--preset--color--contrast);
 		padding: 0 !important;
 		display: flex;
 		align-items: stretch;


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/66768

## Why?
- Add functionality in Cover Block for displaying the placeholder state only when selected, and the illustration state when not selected—like the Image block does so that we have consistent User Experience.

## How?
- Add Placeholder in MediaPlaceholder in Cover Block.

## Testing Instructions
- Add Cover Block in the editor.
- Select the Cover block then we should see the placeholder state, and when Cover block is not selected then we should see the illustration state.

## Screenshots or screencast <!-- if applicable -->

When Cover Block is Selected (Placeholder state):
<img width="1469" alt="Screenshot at Nov 07 16-00-35" src="https://github.com/user-attachments/assets/07db9727-f121-4995-a348-d0bee099f018">

When Cover Block is not Selected (Illustration State):
<img width="1469" alt="Screenshot at Nov 07 16-00-47" src="https://github.com/user-attachments/assets/16a23bd1-01a4-493f-b08b-806dbc438a1c">


