### PR TITLE
Core Commands: Fix add new post URL assignment

### DIFF
--- a/packages/core-commands/src/admin-navigation-commands.js
+++ b/packages/core-commands/src/admin-navigation-commands.js
@@ -97,7 +97,7 @@ export function useAdminNavigationCommands() {
 		label: __( 'Add new post' ),
 		icon: plus,
 		callback: () => {
-			document.location.href = 'post-new.php';
+			document.location.assign( 'post-new.php' );
 		},
 	} );
 


### PR DESCRIPTION
## What?
Resolves one of the last remaining violations of the React Compiler mutation rules.

## Why?
To resolve an ESLint error that's surfaced with #61788.

## How?
We're using `location.assign()` instead of `location.href = `

## Testing Instructions
- Open the site editor
- Press cmd+k
- Type "Add new post"
- Click on the single result that appears
- Verify it takes you to the screen to create a new post.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
