### PR TITLE
Improve accessibility of the video track editor

### DIFF
--- a/packages/block-library/src/video/editor.scss
+++ b/packages/block-library/src/video/editor.scss
@@ -37,6 +37,7 @@
 	max-width: 240px;
 }
 
+.block-library-video-tracks-editor__tracks-informative-message-title,
 .block-library-video-tracks-editor__single-track-editor-edit-track-label {
 	margin-top: $grid-unit-05;
 	color: $gray-700;
@@ -54,5 +55,13 @@
 .block-library-video-tracks-editor__add-tracks-container {
 	.components-menu-group__label {
 		padding: 0;
+	}
+}
+
+.block-library-video-tracks-editor__tracks-informative-message {
+	padding: $grid-unit-10;
+
+	&-description {
+		margin-bottom: 0;
 	}
 }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -40,39 +40,29 @@ const KIND_OPTIONS = [
 ];
 
 function TrackList( { tracks, onEditPress } ) {
-	let content;
-	if ( tracks.length === 0 ) {
-		content = (
-			<p className="block-library-video-tracks-editor__tracks-informative-message">
-				{ __(
-					'Tracks can be subtitles, captions, chapters, or descriptions. They help make your content more accessible to a wider range of users.'
-				) }
-			</p>
-		);
-	} else {
-		content = tracks.map( ( track, index ) => {
-			return (
-				<HStack
-					key={ index }
-					className="block-library-video-tracks-editor__track-list-track"
+	const content = tracks.map( ( track, index ) => {
+		return (
+			<HStack
+				key={ index }
+				className="block-library-video-tracks-editor__track-list-track"
+			>
+				<span>{ track.label } </span>
+				<Button
+					__next40pxDefaultSize
+					variant="tertiary"
+					onClick={ () => onEditPress( index ) }
+					aria-label={ sprintf(
+						/* translators: %s: Label of the video text track e.g: "French subtitles" */
+						_x( 'Edit %s', 'text tracks' ),
+						track.label
+					) }
 				>
-					<span>{ track.label } </span>
-					<Button
-						__next40pxDefaultSize
-						variant="tertiary"
-						onClick={ () => onEditPress( index ) }
-						aria-label={ sprintf(
-							/* translators: %s: Label of the video text track e.g: "French subtitles" */
-							_x( 'Edit %s', 'text tracks' ),
-							track.label
-						) }
-					>
-						{ __( 'Edit' ) }
-					</Button>
-				</HStack>
-			);
-		} );
-	}
+					{ __( 'Edit' ) }
+				</Button>
+			</HStack>
+		);
+	} );
+
 	return (
 		<MenuGroup
 			label={ __( 'Text tracks' ) }
@@ -252,8 +242,21 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 						/>
 					);
 				}
+
 				return (
 					<>
+						{ tracks.length === 0 && (
+							<div className="block-library-video-tracks-editor__tracks-informative-message">
+								<h2 className="block-library-video-tracks-editor__tracks-informative-message-title">
+									{ __( 'Text tracks' ) }
+								</h2>
+								<p className="block-library-video-tracks-editor__tracks-informative-message-description">
+									{ __(
+										'Tracks can be subtitles, captions, chapters, or descriptions. They help make your content more accessible to a wider range of users.'
+									) }
+								</p>
+							</div>
+						) }
 						<NavigableMenu>
 							<TrackList
 								tracks={ tracks }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -87,7 +87,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 	const { src = '', label = '', srcLang = '', kind = DEFAULT_KIND } = track;
 	const fileName = src.startsWith( 'blob:' ) ? '' : getFilename( src ) || '';
 	return (
-		<NavigableMenu>
+		<>
 			<VStack
 				className="block-library-video-tracks-editor__single-track-editor"
 				spacing="4"
@@ -185,7 +185,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 					</HStack>
 				</VStack>
 			</VStack>
-		</NavigableMenu>
+		</>
 	);
 }
 

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -133,7 +133,15 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 				<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
 					<Button
 						__next40pxDefaultSize
-						variant="secondary"
+						isDestructive
+						variant="link"
+						onClick={ onRemove }
+					>
+						{ __( 'Remove track' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						variant="primary"
 						onClick={ () => {
 							const changes = {};
 							let hasChanges = false;
@@ -158,15 +166,7 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 							onClose();
 						} }
 					>
-						{ __( 'Close' ) }
-					</Button>
-					<Button
-						__next40pxDefaultSize
-						isDestructive
-						variant="link"
-						onClick={ onRemove }
-					>
-						{ __( 'Remove track' ) }
+						{ __( 'Apply' ) }
 					</Button>
 				</HStack>
 			</VStack>

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -77,102 +77,100 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 	const { src = '', label = '', srcLang = '', kind = DEFAULT_KIND } = track;
 	const fileName = src.startsWith( 'blob:' ) ? '' : getFilename( src ) || '';
 	return (
-		<>
-			<VStack
-				className="block-library-video-tracks-editor__single-track-editor"
-				spacing="4"
-			>
-				<span className="block-library-video-tracks-editor__single-track-editor-edit-track-label">
-					{ __( 'Edit track' ) }
-				</span>
-				<span>
-					{ __( 'File' ) }: <b>{ fileName }</b>
-				</span>
-				<Grid columns={ 2 } gap={ 4 }>
-					<TextControl
+		<VStack
+			className="block-library-video-tracks-editor__single-track-editor"
+			spacing="4"
+		>
+			<span className="block-library-video-tracks-editor__single-track-editor-edit-track-label">
+				{ __( 'Edit track' ) }
+			</span>
+			<span>
+				{ __( 'File' ) }: <b>{ fileName }</b>
+			</span>
+			<Grid columns={ 2 } gap={ 4 }>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					onChange={ ( newLabel ) =>
+						onChange( {
+							...track,
+							label: newLabel,
+						} )
+					}
+					label={ __( 'Label' ) }
+					value={ label }
+					help={ __( 'Title of track' ) }
+				/>
+				<TextControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					onChange={ ( newSrcLang ) =>
+						onChange( {
+							...track,
+							srcLang: newSrcLang,
+						} )
+					}
+					label={ __( 'Source language' ) }
+					value={ srcLang }
+					help={ __( 'Language tag (en, fr, etc.)' ) }
+				/>
+			</Grid>
+			<VStack spacing="8">
+				<SelectControl
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					className="block-library-video-tracks-editor__single-track-editor-kind-select"
+					options={ KIND_OPTIONS }
+					value={ kind }
+					label={ __( 'Kind' ) }
+					onChange={ ( newKind ) => {
+						onChange( {
+							...track,
+							kind: newKind,
+						} );
+					} }
+				/>
+				<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
+					<Button
 						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						onChange={ ( newLabel ) =>
-							onChange( {
-								...track,
-								label: newLabel,
-							} )
-						}
-						label={ __( 'Label' ) }
-						value={ label }
-						help={ __( 'Title of track' ) }
-					/>
-					<TextControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						onChange={ ( newSrcLang ) =>
-							onChange( {
-								...track,
-								srcLang: newSrcLang,
-							} )
-						}
-						label={ __( 'Source language' ) }
-						value={ srcLang }
-						help={ __( 'Language tag (en, fr, etc.)' ) }
-					/>
-				</Grid>
-				<VStack spacing="8">
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						className="block-library-video-tracks-editor__single-track-editor-kind-select"
-						options={ KIND_OPTIONS }
-						value={ kind }
-						label={ __( 'Kind' ) }
-						onChange={ ( newKind ) => {
-							onChange( {
-								...track,
-								kind: newKind,
-							} );
+						variant="secondary"
+						onClick={ () => {
+							const changes = {};
+							let hasChanges = false;
+							if ( label === '' ) {
+								changes.label = __( 'English' );
+								hasChanges = true;
+							}
+							if ( srcLang === '' ) {
+								changes.srcLang = 'en';
+								hasChanges = true;
+							}
+							if ( track.kind === undefined ) {
+								changes.kind = DEFAULT_KIND;
+								hasChanges = true;
+							}
+							if ( hasChanges ) {
+								onChange( {
+									...track,
+									...changes,
+								} );
+							}
+							onClose();
 						} }
-					/>
-					<HStack className="block-library-video-tracks-editor__single-track-editor-buttons-container">
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							onClick={ () => {
-								const changes = {};
-								let hasChanges = false;
-								if ( label === '' ) {
-									changes.label = __( 'English' );
-									hasChanges = true;
-								}
-								if ( srcLang === '' ) {
-									changes.srcLang = 'en';
-									hasChanges = true;
-								}
-								if ( track.kind === undefined ) {
-									changes.kind = DEFAULT_KIND;
-									hasChanges = true;
-								}
-								if ( hasChanges ) {
-									onChange( {
-										...track,
-										...changes,
-									} );
-								}
-								onClose();
-							} }
-						>
-							{ __( 'Close' ) }
-						</Button>
-						<Button
-							__next40pxDefaultSize
-							isDestructive
-							variant="link"
-							onClick={ onRemove }
-						>
-							{ __( 'Remove track' ) }
-						</Button>
-					</HStack>
-				</VStack>
+					>
+						{ __( 'Close' ) }
+					</Button>
+					<Button
+						__next40pxDefaultSize
+						isDestructive
+						variant="link"
+						onClick={ onRemove }
+					>
+						{ __( 'Remove track' ) }
+					</Button>
+				</HStack>
 			</VStack>
-		</>
+		</VStack>
 	);
 }
 

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -46,13 +46,13 @@ function TrackList( { tracks, onEditPress } ) {
 				key={ index }
 				className="block-library-video-tracks-editor__track-list-track"
 			>
-				<span>{ track.label } </span>
+				<span>{ track.label }</span>
 				<Button
 					__next40pxDefaultSize
 					variant="tertiary"
 					onClick={ () => onEditPress( index ) }
 					aria-label={ sprintf(
-						/* translators: %s: Label of the video text track e.g: "French subtitles" */
+						/* translators: %s: Label of the video text track e.g: "French subtitles". */
 						_x( 'Edit %s', 'text tracks' ),
 						track.label
 					) }

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -207,17 +207,28 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 			popoverProps={ {
 				ref: dropdownPopoverRef,
 			} }
-			renderToggle={ ( { isOpen, onToggle } ) => (
-				<ToolbarGroup>
-					<ToolbarButton
-						aria-expanded={ isOpen }
-						aria-haspopup="true"
-						onClick={ onToggle }
-					>
-						{ __( 'Text tracks' ) }
-					</ToolbarButton>
-				</ToolbarGroup>
-			) }
+			renderToggle={ ( { isOpen, onToggle } ) => {
+				const handleOnToggle = () => {
+					if ( ! isOpen ) {
+						// When the Popover opens make sure the initial view is
+						// always the track list rather than the edit track UI.
+						setTrackBeingEdited( null );
+					}
+					onToggle();
+				};
+
+				return (
+					<ToolbarGroup>
+						<ToolbarButton
+							aria-expanded={ isOpen }
+							aria-haspopup="true"
+							onClick={ handleOnToggle }
+						>
+							{ __( 'Text tracks' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
+				);
+			} }
 			renderContent={ () => {
 				if ( trackBeingEdited !== null ) {
 					return (

--- a/packages/block-library/src/video/tracks-editor.js
+++ b/packages/block-library/src/video/tracks-editor.js
@@ -24,7 +24,7 @@ import {
 } from '@wordpress/block-editor';
 import { upload, media } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { getFilename } from '@wordpress/url';
 
 const ALLOWED_TYPES = [ 'text/vtt' ];
@@ -102,9 +102,6 @@ function SingleTrackEditor( { track, onChange, onClose, onRemove } ) {
 					<TextControl
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom
-						/* eslint-disable jsx-a11y/no-autofocus */
-						autoFocus
-						/* eslint-enable jsx-a11y/no-autofocus */
 						onChange={ ( newLabel ) =>
 							onChange( {
 								...track,
@@ -194,6 +191,11 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 		return select( blockEditorStore ).getSettings().mediaUpload;
 	}, [] );
 	const [ trackBeingEdited, setTrackBeingEdited ] = useState( null );
+	const dropdownPopoverRef = useRef();
+
+	useEffect( () => {
+		dropdownPopoverRef.current?.focus();
+	}, [ trackBeingEdited ] );
 
 	if ( ! mediaUpload ) {
 		return null;
@@ -201,6 +203,10 @@ export default function TracksEditor( { tracks = [], onChange } ) {
 	return (
 		<Dropdown
 			contentClassName="block-library-video-tracks-editor"
+			focusOnMount
+			popoverProps={ {
+				ref: dropdownPopoverRef,
+			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<ToolbarGroup>
 					<ToolbarButton


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66717


## What?
<!-- In a few words, what is the PR actually doing? -->
- ARIA menus can only contain menu items, their variants manu item radio / checkbox, groups and separators.
- In the edit form, arrows key moved focus through focusable elements which is unexpected behavior that should be reserved to menus.
- Initial focus used to go to the first focusable element thus skipping important information rendered before it.
- The 'Close' button isn't clear and should be on the right.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- ARIA menus must not contain extraneous content.
- Focus losses must be avoided.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Moves the informative paragraph out of the navigable menu.
- Moves the edit form out of the navigable menu.
- Makes sure initial focus is on the Popover container to avoid focus losses.
- Makes sure the initial view is always the list of tracks.
- Changes the 'Close' button to primary variant, changes its label to 'Apply' and moves the button to the right, for consistency with other popovers and modal dialogs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Add a Video block and set a video.
- Click the 'Text tracks' button in the block toolbar.
- Observe initial focus is on the Popover container.
- Observe the informative paragraph is outside of the 'Add tracks' ARIA menu.
- Add a track, either from the Media Library or by uploading a video file. You can use this file (rename it to have a .vtt extension): 
[sample.txt](https://github.com/user-attachments/files/17699964/sample.txt)
- When the Popover switches to the edit view, observe initial focus is on the Popover container.
- Focus one of the input fields and enter a label or the language code.
- Use the down and arrow keys (on macOS) and observe the cursor moves at the end or beginning of the text you entered, as expected. Previously, it moved focus through the focusable elements.
- Observe the 'Close' button is now labeled 'Apply', it uses the primary variant and it's placed to the right.
- Click 'Apply': the Popover switches to the tracks list view.
- Observe initial focus is on the Popover container.
- Add more tracks, edit them delete them, and make sure there are no focus losses.
- With the Popover switched to the edit view, press the Escape key to close the Popover.
- Click 'Text tracks' in the block toolbar to reopen the Popover.
- Observe the Popover opens showing the tracks list view. Previiously, it was stuck on the edit view.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Before:

![before](https://github.com/user-attachments/assets/89e00803-cee8-42e9-b6e7-80f56b3ca2b2)


After:

![adter 03](https://github.com/user-attachments/assets/e8cf6929-ec11-4b74-a761-759ba783858b)

