### PR TITLE
update: Add Media to Add media in cover block

### DIFF
--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -101,7 +101,7 @@ export default function CoverBlockControls( {
 					onSelect={ onSelectMedia }
 					onToggleFeaturedImage={ toggleUseFeaturedImage }
 					useFeaturedImage={ useFeaturedImage }
-					name={ ! url ? __( 'Add Media' ) : __( 'Replace' ) }
+					name={ ! url ? __( 'Add media' ) : __( 'Replace' ) }
 					onReset={ onClearMedia }
 				/>
 			</BlockControls>


### PR DESCRIPTION

## What?
Updated `Add Media` text to `Add media` in cover block toolbar.

## Why?
fixes https://github.com/WordPress/gutenberg/issues/66826

## Screenshots or screencast <!-- if applicable -->
<img width="859" alt="Screenshot 2024-11-07 at 23 42 44" src="https://github.com/user-attachments/assets/ff3dee26-f23d-4d83-8e7f-6a8b83bba6c7">
