### PR TITLE
Replace Starter Content modal with inserter panel

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
@@ -14,9 +14,8 @@ import { usePatternCategories } from '../block-patterns-tab/use-pattern-categori
 
 function PatternsExplorer( { initialCategory, rootClientId } ) {
 	const [ searchValue, setSearchValue ] = useState( '' );
-	const [ selectedCategory, setSelectedCategory ] = useState(
-		initialCategory?.name
-	);
+	const [ selectedCategory, setSelectedCategory ] =
+		useState( initialCategory );
 
 	const patternCategories = usePatternCategories( rootClientId );
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -71,7 +71,7 @@ function BlockPatternsTab( {
 			{ showPatternsExplorer && (
 				<PatternsExplorerModal
 					initialCategory={
-						selectedCategory || categories[ 0 ]?.name
+						selectedCategory?.name || categories[ 0 ]?.name
 					}
 					patternCategories={ categories }
 					onModalClose={ () => setShowPatternsExplorer( false ) }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -70,7 +70,9 @@ function BlockPatternsTab( {
 			) }
 			{ showPatternsExplorer && (
 				<PatternsExplorerModal
-					initialCategory={ selectedCategory || categories[ 0 ] }
+					initialCategory={
+						selectedCategory || categories[ 0 ]?.name
+					}
 					patternCategories={ categories }
 					onModalClose={ () => setShowPatternsExplorer( false ) }
 					rootClientId={ rootClientId }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -46,7 +46,7 @@ export function PatternCategoryPreviews( {
 	const [ allPatterns, , onClickPattern ] = usePatternsState(
 		onInsert,
 		rootClientId,
-		category?.name
+		category
 	);
 	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
@@ -69,25 +69,25 @@ export function PatternCategoryPreviews( {
 					return false;
 				}
 
-				if ( category.name === allPatternsCategory.name ) {
+				if ( category === allPatternsCategory.name ) {
 					return true;
 				}
 
 				if (
-					category.name === myPatternsCategory.name &&
+					category === myPatternsCategory.name &&
 					pattern.type === INSERTER_PATTERN_TYPES.user
 				) {
 					return true;
 				}
 
 				if (
-					category.name === starterPatternsCategory.name &&
+					category === starterPatternsCategory.name &&
 					pattern.blockTypes?.includes( 'core/post-content' )
 				) {
 					return true;
 				}
 
-				if ( category.name === 'uncategorized' ) {
+				if ( category === 'uncategorized' ) {
 					// The uncategorized category should show all the patterns without any category...
 					if ( ! pattern.categories ) {
 						return true;
@@ -99,20 +99,24 @@ export function PatternCategoryPreviews( {
 					);
 				}
 
-				return pattern.categories?.includes( category.name );
+				return pattern.categories?.includes( category );
 			} ),
 		[
 			allPatterns,
 			availableCategories,
-			category.name,
+			category,
 			patternSourceFilter,
 			patternSyncFilter,
 		]
 	);
 
+	const categoryObject = availableCategories.find(
+		( { name } ) => name === category
+	);
+
 	const pagingProps = usePatternsPaging(
 		currentCategoryPatterns,
-		category,
+		categoryObject,
 		scrollContainerRef
 	);
 	const { changePage } = pagingProps;
@@ -149,7 +153,7 @@ export function PatternCategoryPreviews( {
 							level={ 4 }
 							as="div"
 						>
-							{ category.label }
+							{ categoryObject.label }
 						</Heading>
 					</FlexBlock>
 					<PatternsFilter
@@ -158,7 +162,7 @@ export function PatternCategoryPreviews( {
 						setPatternSyncFilter={ onSetPatternSyncFilter }
 						setPatternSourceFilter={ onSetPatternSourceFilter }
 						scrollContainerRef={ scrollContainerRef }
-						category={ category }
+						category={ categoryObject }
 					/>
 				</HStack>
 				{ ! currentCategoryPatterns.length && (
@@ -184,9 +188,9 @@ export function PatternCategoryPreviews( {
 						blockPatterns={ pagingProps.categoryPatterns }
 						onClickPattern={ onClickPattern }
 						onHover={ onHover }
-						label={ category.label }
+						label={ categoryObject.label }
 						orientation="vertical"
-						category={ category.name }
+						category={ categoryObject.name }
 						isDraggable
 						showTitlesAsTooltip={ showTitlesAsTooltip }
 						patternFilter={ patternSourceFilter }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -46,7 +46,7 @@ export function PatternCategoryPreviews( {
 	const [ allPatterns, , onClickPattern ] = usePatternsState(
 		onInsert,
 		rootClientId,
-		category
+		category?.name
 	);
 	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
@@ -69,25 +69,25 @@ export function PatternCategoryPreviews( {
 					return false;
 				}
 
-				if ( category === allPatternsCategory?.name ) {
+				if ( category.name === allPatternsCategory?.name ) {
 					return true;
 				}
 
 				if (
-					category === myPatternsCategory?.name &&
+					category.name === myPatternsCategory?.name &&
 					pattern.type === INSERTER_PATTERN_TYPES.user
 				) {
 					return true;
 				}
 
 				if (
-					category === starterPatternsCategory?.name &&
+					category.name === starterPatternsCategory?.name &&
 					pattern.blockTypes?.includes( 'core/post-content' )
 				) {
 					return true;
 				}
 
-				if ( category === 'uncategorized' ) {
+				if ( category.name === 'uncategorized' ) {
 					// The uncategorized category should show all the patterns without any category...
 					if ( ! pattern.categories ) {
 						return true;
@@ -99,12 +99,12 @@ export function PatternCategoryPreviews( {
 					);
 				}
 
-				return pattern.categories?.includes( category );
+				return pattern.categories?.includes( category.name );
 			} ),
 		[
 			allPatterns,
 			availableCategories,
-			category,
+			category.name,
 			patternSourceFilter,
 			patternSyncFilter,
 		]

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -110,13 +110,9 @@ export function PatternCategoryPreviews( {
 		]
 	);
 
-	const categoryObject = availableCategories.find(
-		( { name } ) => name === category.name
-	);
-
 	const pagingProps = usePatternsPaging(
 		currentCategoryPatterns,
-		categoryObject,
+		category,
 		scrollContainerRef
 	);
 	const { changePage } = pagingProps;
@@ -153,7 +149,7 @@ export function PatternCategoryPreviews( {
 							level={ 4 }
 							as="div"
 						>
-							{ categoryObject?.label }
+							{ category?.label }
 						</Heading>
 					</FlexBlock>
 					<PatternsFilter
@@ -162,7 +158,7 @@ export function PatternCategoryPreviews( {
 						setPatternSyncFilter={ onSetPatternSyncFilter }
 						setPatternSourceFilter={ onSetPatternSourceFilter }
 						scrollContainerRef={ scrollContainerRef }
-						category={ categoryObject }
+						category={ category }
 					/>
 				</HStack>
 				{ ! currentCategoryPatterns.length && (
@@ -188,9 +184,9 @@ export function PatternCategoryPreviews( {
 						blockPatterns={ pagingProps.categoryPatterns }
 						onClickPattern={ onClickPattern }
 						onHover={ onHover }
-						label={ categoryObject.label }
+						label={ category.label }
 						orientation="vertical"
-						category={ categoryObject.name }
+						category={ category.name }
 						isDraggable
 						showTitlesAsTooltip={ showTitlesAsTooltip }
 						patternFilter={ patternSourceFilter }

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -69,19 +69,19 @@ export function PatternCategoryPreviews( {
 					return false;
 				}
 
-				if ( category === allPatternsCategory.name ) {
+				if ( category === allPatternsCategory?.name ) {
 					return true;
 				}
 
 				if (
-					category === myPatternsCategory.name &&
+					category === myPatternsCategory?.name &&
 					pattern.type === INSERTER_PATTERN_TYPES.user
 				) {
 					return true;
 				}
 
 				if (
-					category === starterPatternsCategory.name &&
+					category === starterPatternsCategory?.name &&
 					pattern.blockTypes?.includes( 'core/post-content' )
 				) {
 					return true;
@@ -111,7 +111,7 @@ export function PatternCategoryPreviews( {
 	);
 
 	const categoryObject = availableCategories.find(
-		( { name } ) => name === category
+		( { name } ) => name === category.name
 	);
 
 	const pagingProps = usePatternsPaging(
@@ -153,7 +153,7 @@ export function PatternCategoryPreviews( {
 							level={ 4 }
 							as="div"
 						>
-							{ categoryObject.label }
+							{ categoryObject?.label }
 						</Heading>
 					</FlexBlock>
 					<PatternsFilter

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -25,7 +25,7 @@ import {
 const getShouldDisableSyncFilter = ( sourceFilter ) =>
 	sourceFilter !== 'all' && sourceFilter !== 'user';
 const getShouldHideSourcesFilter = ( category ) => {
-	return category.name === myPatternsCategory.name;
+	return category?.name === myPatternsCategory.name;
 };
 
 const PATTERN_SOURCE_MENU_OPTIONS = [
@@ -60,7 +60,7 @@ export function PatternsFilter( {
 	// the user may be confused when switching to another category if the haven't explicity set
 	// this filter themselves.
 	const currentPatternSourceFilter =
-		category.name === myPatternsCategory.name
+		category?.name === myPatternsCategory.name
 			? INSERTER_PATTERN_TYPES.user
 			: patternSourceFilter;
 

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -76,13 +76,6 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 			categories.unshift( starterPatternsCategory );
 		}
 		if (
-			filteredPatterns.some( ( pattern ) =>
-				pattern.blockTypes?.includes( 'core/post-content' )
-			)
-		) {
-			categories.unshift( starterPatternsCategory );
-		}
-		if (
 			filteredPatterns.some(
 				( pattern ) => pattern.type === INSERTER_PATTERN_TYPES.user
 			)

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -68,6 +68,7 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 				label: _x( 'Uncategorized' ),
 			} );
 		}
+		categories.unshift( starterPatternsCategory );
 		if (
 			filteredPatterns.some( ( pattern ) =>
 				pattern.blockTypes?.includes( 'core/post-content' )

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -68,7 +68,13 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 				label: _x( 'Uncategorized' ),
 			} );
 		}
-		categories.unshift( starterPatternsCategory );
+		if (
+			filteredPatterns.some( ( pattern ) =>
+				pattern.blockTypes?.includes( 'core/post-content' )
+			)
+		) {
+			categories.unshift( starterPatternsCategory );
+		}
 		if (
 			filteredPatterns.some( ( pattern ) =>
 				pattern.blockTypes?.includes( 'core/post-content' )

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -32,30 +32,22 @@ function CategoryTabs( {
 
 	const previousSelectedCategory = usePrevious( selectedCategory );
 
-	const selectedTabId = selectedCategory ? selectedCategory.name : null;
 	const [ activeTabId, setActiveId ] = useState();
 	const firstTabId = categories?.[ 0 ]?.name;
 
 	// If there is no active tab, make the first tab the active tab, so that
 	// when focus is moved to the tablist, the first tab will be focused
 	// despite not being selected
-	if ( selectedTabId === null && ! activeTabId && firstTabId ) {
+	if ( selectedCategory === null && ! activeTabId && firstTabId ) {
 		setActiveId( firstTabId );
 	}
 
 	return (
 		<Tabs
 			selectOnMove={ false }
-			selectedTabId={ selectedTabId }
+			selectedTabId={ selectedCategory }
 			orientation="vertical"
-			onSelect={ ( categoryId ) => {
-				// Pass the full category object
-				onSelectCategory(
-					categories.find(
-						( category ) => category.name === categoryId
-					)
-				);
-			} }
+			onSelect={ onSelectCategory }
 			activeTabId={ activeTabId }
 			onActiveTabIdChange={ setActiveId }
 		>
@@ -66,7 +58,9 @@ function CategoryTabs( {
 						tabId={ category.name }
 						aria-label={ category.label }
 						aria-current={
-							category === selectedCategory ? 'true' : undefined
+							category.name === selectedCategory
+								? 'true'
+								: undefined
 						}
 					>
 						{ category.label }

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -66,7 +66,7 @@ function CategoryTabs( {
 						tabId={ category.name }
 						aria-label={ category.label }
 						aria-current={
-							category.name === selectedCategory
+							category.name === selectedCategory?.name
 								? 'true'
 								: undefined
 						}

--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -32,22 +32,30 @@ function CategoryTabs( {
 
 	const previousSelectedCategory = usePrevious( selectedCategory );
 
+	const selectedTabId = selectedCategory ? selectedCategory.name : null;
 	const [ activeTabId, setActiveId ] = useState();
 	const firstTabId = categories?.[ 0 ]?.name;
 
 	// If there is no active tab, make the first tab the active tab, so that
 	// when focus is moved to the tablist, the first tab will be focused
 	// despite not being selected
-	if ( selectedCategory === null && ! activeTabId && firstTabId ) {
+	if ( selectedTabId === null && ! activeTabId && firstTabId ) {
 		setActiveId( firstTabId );
 	}
 
 	return (
 		<Tabs
 			selectOnMove={ false }
-			selectedTabId={ selectedCategory }
+			selectedTabId={ selectedTabId }
 			orientation="vertical"
-			onSelect={ onSelectCategory }
+			onSelect={ ( categoryId ) => {
+				// Pass the full category object
+				onSelectCategory(
+					categories.find(
+						( category ) => category.name === categoryId
+					)
+				);
+			} }
 			activeTabId={ activeTabId }
 			onActiveTabIdChange={ setActiveId }
 		>

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -2,13 +2,14 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect, useRef } from '@wordpress/element';
+import { useEffect, useRef, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../store';
 import { unlock } from '../lock-unlock';
+import BlockContext from '../components/block-context';
 
 /**
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
@@ -19,6 +20,7 @@ import { unlock } from '../lock-unlock';
  * @param {boolean} enabled If we should enter into zoomOut mode or not
  */
 export function useZoomOut( enabled = true ) {
+	const { postId } = useContext( BlockContext );
 	const { setZoomLevel, resetZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
 	);
@@ -37,6 +39,7 @@ export function useZoomOut( enabled = true ) {
 
 	const controlZoomLevelRef = useRef( false );
 	const isEnabledRef = useRef( enabled );
+	const postIdRef = useRef( postId );
 
 	/**
 	 * This hook tracks if the zoom state was changed manually by the user via clicking
@@ -55,6 +58,11 @@ export function useZoomOut( enabled = true ) {
 	useEffect( () => {
 		isEnabledRef.current = enabled;
 
+		// If the user created a new post/page, we should take control of the zoom level.
+		if ( postIdRef.current !== postId ) {
+			controlZoomLevelRef.current = true;
+		}
+
 		if ( enabled !== isZoomOut() ) {
 			controlZoomLevelRef.current = true;
 
@@ -71,5 +79,5 @@ export function useZoomOut( enabled = true ) {
 				resetZoomLevel();
 			}
 		};
-	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
+	}, [ enabled, isZoomOut, postId, resetZoomLevel, setZoomLevel ] );
 }

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -26,7 +26,6 @@ import PageAttributesCheck from '../page-attributes/check';
 import PostTypeSupportCheck from '../post-type-support-check';
 import { store as editorStore } from '../../store';
 import { unlock } from '../../lock-unlock';
-import { useStartPatterns } from '../start-page-options';
 
 const {
 	PreferencesModal,
@@ -73,7 +72,6 @@ function PreferencesModalContents( { extraSections = {} } ) {
 	const { setIsListViewOpened, setIsInserterOpened } =
 		useDispatch( editorStore );
 	const { set: setPreference } = useDispatch( preferencesStore );
-	const hasStarterPatterns = !! useStartPatterns().length;
 
 	const sections = useMemo(
 		() =>
@@ -114,16 +112,14 @@ function PreferencesModalContents( { extraSections = {} } ) {
 										'Allow right-click contextual menus'
 									) }
 								/>
-								{ hasStarterPatterns && (
-									<PreferenceToggleControl
-										scope="core"
-										featureName="enableChoosePatternModal"
-										help={ __(
-											'Shows starter patterns when creating a new page.'
-										) }
-										label={ __( 'Show starter patterns' ) }
-									/>
-								) }
+								<PreferenceToggleControl
+									scope="core"
+									featureName="enableChoosePatternModal"
+									help={ __(
+										'Shows starter patterns when creating a new page.'
+									) }
+									label={ __( 'Show starter patterns' ) }
+								/>
 							</PreferencesModalSection>
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }
@@ -341,7 +337,6 @@ function PreferencesModalContents( { extraSections = {} } ) {
 			setIsListViewOpened,
 			setPreference,
 			isLargeViewport,
-			hasStarterPatterns,
 		]
 	);
 

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -1,16 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Modal } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { useState, useMemo } from '@wordpress/element';
-import {
-	store as blockEditorStore,
-	__experimentalBlockPatternsList as BlockPatternsList,
-} from '@wordpress/block-editor';
+import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { __unstableSerializeAndClean } from '@wordpress/blocks';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as interfaceStore } from '@wordpress/interface';
 
@@ -18,104 +10,9 @@ import { store as interfaceStore } from '@wordpress/interface';
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import { TEMPLATE_POST_TYPE } from '../../store/constants';
-
-export function useStartPatterns() {
-	// A pattern is a start pattern if it includes 'core/post-content' in its blockTypes,
-	// and it has no postTypes declared and the current post type is page or if
-	// the current post type is part of the postTypes declared.
-	const { blockPatternsWithPostContentBlockType, postType } = useSelect(
-		( select ) => {
-			const { getPatternsByBlockTypes, getBlocksByName } =
-				select( blockEditorStore );
-			const { getCurrentPostType, getRenderingMode } =
-				select( editorStore );
-			const rootClientId =
-				getRenderingMode() === 'post-only'
-					? ''
-					: getBlocksByName( 'core/post-content' )?.[ 0 ];
-			return {
-				blockPatternsWithPostContentBlockType: getPatternsByBlockTypes(
-					'core/post-content',
-					rootClientId
-				),
-				postType: getCurrentPostType(),
-			};
-		},
-		[]
-	);
-
-	return useMemo( () => {
-		if ( ! blockPatternsWithPostContentBlockType?.length ) {
-			return [];
-		}
-
-		/*
-		 * Filter patterns without postTypes declared if the current postType is page
-		 * or patterns that declare the current postType in its post type array.
-		 */
-		return blockPatternsWithPostContentBlockType.filter( ( pattern ) => {
-			return (
-				( postType === 'page' && ! pattern.postTypes ) ||
-				( Array.isArray( pattern.postTypes ) &&
-					pattern.postTypes.includes( postType ) )
-			);
-		} );
-	}, [ postType, blockPatternsWithPostContentBlockType ] );
-}
-
-function PatternSelection( { blockPatterns, onChoosePattern } ) {
-	const { editEntityRecord } = useDispatch( coreStore );
-	const { postType, postId } = useSelect( ( select ) => {
-		const { getCurrentPostType, getCurrentPostId } = select( editorStore );
-
-		return {
-			postType: getCurrentPostType(),
-			postId: getCurrentPostId(),
-		};
-	}, [] );
-	return (
-		<BlockPatternsList
-			blockPatterns={ blockPatterns }
-			onClickPattern={ ( _pattern, blocks ) => {
-				editEntityRecord( 'postType', postType, postId, {
-					blocks,
-					content: ( { blocks: blocksForSerialization = [] } ) =>
-						__unstableSerializeAndClean( blocksForSerialization ),
-				} );
-				onChoosePattern();
-			} }
-		/>
-	);
-}
-
-function StartPageOptionsModal( { onClose } ) {
-	const startPatterns = useStartPatterns();
-	const hasStartPattern = startPatterns.length > 0;
-
-	if ( ! hasStartPattern ) {
-		return null;
-	}
-
-	return (
-		<Modal
-			title={ __( 'Choose a pattern' ) }
-			isFullScreen
-			onRequestClose={ onClose }
-		>
-			<div className="editor-start-page-options__modal-content">
-				<PatternSelection
-					blockPatterns={ startPatterns }
-					onChoosePattern={ onClose }
-				/>
-			</div>
-		</Modal>
-	);
-}
 
 export default function StartPageOptions() {
-	const [ isClosed, setIsClosed ] = useState( false );
-	const shouldEnableModal = useSelect( ( select ) => {
+	const shouldEnable = useSelect( ( select ) => {
 		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
 			select( editorStore );
 		const preferencesModalActive =
@@ -129,13 +26,19 @@ export default function StartPageOptions() {
 			! preferencesModalActive &&
 			! isEditedPostDirty() &&
 			isEditedPostEmpty() &&
-			TEMPLATE_POST_TYPE !== getCurrentPostType()
+			'page' === getCurrentPostType()
 		);
 	}, [] );
+	const { setIsInserterOpened } = useDispatch( editorStore );
 
-	if ( ! shouldEnableModal || isClosed ) {
-		return null;
-	}
+	useEffect( () => {
+		if ( shouldEnable ) {
+			setIsInserterOpened( {
+				tab: 'patterns',
+				category: 'core/starter-content',
+			} );
+		}
+	}, [ shouldEnable, setIsInserterOpened ] );
 
-	return <StartPageOptionsModal onClose={ () => setIsClosed( true ) } />;
+	return null;
 }

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -12,22 +12,28 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 
 export default function StartPageOptions() {
-	const shouldEnable = useSelect( ( select ) => {
-		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
-			select( editorStore );
+	const { postId, shouldEnable } = useSelect( ( select ) => {
+		const {
+			isEditedPostDirty,
+			isEditedPostEmpty,
+			getCurrentPostId,
+			getCurrentPostType,
+		} = select( editorStore );
 		const preferencesModalActive =
 			select( interfaceStore ).isModalActive( 'editor/preferences' );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
 			'enableChoosePatternModal'
 		);
-		return (
-			choosePatternModalEnabled &&
-			! preferencesModalActive &&
-			! isEditedPostDirty() &&
-			isEditedPostEmpty() &&
-			'page' === getCurrentPostType()
-		);
+		return {
+			shouldEnable:
+				choosePatternModalEnabled &&
+				! preferencesModalActive &&
+				! isEditedPostDirty() &&
+				isEditedPostEmpty() &&
+				'page' === getCurrentPostType(),
+			postId: getCurrentPostId(),
+		};
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
@@ -38,7 +44,7 @@ export default function StartPageOptions() {
 				category: 'core/starter-content',
 			} );
 		}
-	}, [ shouldEnable, setIsInserterOpened ] );
+	}, [ postId, shouldEnable, setIsInserterOpened ] );
 
 	return null;
 }

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -12,28 +12,22 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 
 export default function StartPageOptions() {
-	const { postId, shouldEnable } = useSelect( ( select ) => {
-		const {
-			isEditedPostDirty,
-			isEditedPostEmpty,
-			getCurrentPostId,
-			getCurrentPostType,
-		} = select( editorStore );
+	const shouldEnable = useSelect( ( select ) => {
+		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
+			select( editorStore );
 		const preferencesModalActive =
 			select( interfaceStore ).isModalActive( 'editor/preferences' );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
 			'enableChoosePatternModal'
 		);
-		return {
-			shouldEnable:
-				choosePatternModalEnabled &&
-				! preferencesModalActive &&
-				! isEditedPostDirty() &&
-				isEditedPostEmpty() &&
-				'page' === getCurrentPostType(),
-			postId: getCurrentPostId(),
-		};
+		return (
+			choosePatternModalEnabled &&
+			! preferencesModalActive &&
+			! isEditedPostDirty() &&
+			isEditedPostEmpty() &&
+			'page' === getCurrentPostType()
+		);
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
@@ -44,7 +38,7 @@ export default function StartPageOptions() {
 				category: 'core/starter-content',
 			} );
 		}
-	}, [ postId, shouldEnable, setIsInserterOpened ] );
+	}, [ shouldEnable, setIsInserterOpened ] );
 
 	return null;
 }

--- a/packages/editor/src/components/start-page-options/index.js
+++ b/packages/editor/src/components/start-page-options/index.js
@@ -12,22 +12,28 @@ import { store as interfaceStore } from '@wordpress/interface';
 import { store as editorStore } from '../../store';
 
 export default function StartPageOptions() {
-	const shouldEnable = useSelect( ( select ) => {
-		const { isEditedPostDirty, isEditedPostEmpty, getCurrentPostType } =
-			select( editorStore );
+	const { postId, shouldEnable } = useSelect( ( select ) => {
+		const {
+			isEditedPostDirty,
+			isEditedPostEmpty,
+			getCurrentPostId,
+			getCurrentPostType,
+		} = select( editorStore );
 		const preferencesModalActive =
 			select( interfaceStore ).isModalActive( 'editor/preferences' );
 		const choosePatternModalEnabled = select( preferencesStore ).get(
 			'core',
 			'enableChoosePatternModal'
 		);
-		return (
-			choosePatternModalEnabled &&
-			! preferencesModalActive &&
-			! isEditedPostDirty() &&
-			isEditedPostEmpty() &&
-			'page' === getCurrentPostType()
-		);
+		return {
+			postId: getCurrentPostId(),
+			shouldEnable:
+				choosePatternModalEnabled &&
+				! preferencesModalActive &&
+				! isEditedPostDirty() &&
+				isEditedPostEmpty() &&
+				'page' === getCurrentPostType(),
+		};
 	}, [] );
 	const { setIsInserterOpened } = useDispatch( editorStore );
 
@@ -38,7 +44,7 @@ export default function StartPageOptions() {
 				category: 'core/starter-content',
 			} );
 		}
-	}, [ shouldEnable, setIsInserterOpened ] );
+	}, [ postId, shouldEnable, setIsInserterOpened ] );
 
 	return null;
 }

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -424,9 +424,6 @@ test.describe( 'Image', () => {
 		page,
 		editor,
 	} ) => {
-		// This is a temp workaround for dragging and dropping images from the inserter.
-		// This should be removed when we have the zoom out view for media categories.
-		await page.setViewportSize( { width: 1400, height: 800 } );
 		await editor.insertBlock( { name: 'core/image' } );
 		const imageBlock = editor.canvas.getByRole( 'document', {
 			name: 'Block: Image',

--- a/test/e2e/specs/editor/various/template-resolution.spec.js
+++ b/test/e2e/specs/editor/various/template-resolution.spec.js
@@ -55,12 +55,14 @@ test.describe( 'Template resolution', () => {
 				status: 'publish',
 			} );
 			await admin.editPost( newPage.id );
+			await page.locator( 'role=button[name="Block Inserter"i]' ).click();
 			await editor.openDocumentSettingsSidebar();
 			await expect(
 				page.getByRole( 'button', { name: 'Template options' } )
 			).toHaveText( 'Single Entries' );
 			await updateSiteSettings( { requestUtils, pageId: newPage.id } );
 			await page.reload();
+			await page.locator( 'role=button[name="Block Inserter"i]' ).click();
 			await expect(
 				page.getByRole( 'button', { name: 'Template options' } )
 			).toHaveText( 'Index' );
@@ -81,6 +83,7 @@ test.describe( 'Template resolution', () => {
 				postType: 'page',
 				canvas: 'edit',
 			} );
+			await page.locator( 'role=button[name="Block Inserter"i]' ).click();
 			await editor.openDocumentSettingsSidebar();
 			await expect(
 				page.getByRole( 'button', { name: 'Template options' } )

--- a/test/e2e/specs/editor/various/template-resolution.spec.js
+++ b/test/e2e/specs/editor/various/template-resolution.spec.js
@@ -63,6 +63,7 @@ test.describe( 'Template resolution', () => {
 			await updateSiteSettings( { requestUtils, pageId: newPage.id } );
 			await page.reload();
 			await page.locator( 'role=button[name="Block Inserter"i]' ).click();
+			await editor.openDocumentSettingsSidebar();
 			await expect(
 				page.getByRole( 'button', { name: 'Template options' } )
 			).toHaveText( 'Index' );

--- a/test/e2e/specs/site-editor/block-style-variations.spec.js
+++ b/test/e2e/specs/site-editor/block-style-variations.spec.js
@@ -317,9 +317,7 @@ async function draftNewPage( page ) {
 
 // Create a Group block with 2 nested Group blocks.
 async function addPageContent( editor, page ) {
-	const inserterButton = page.locator(
-		'role=button[name="Block Inserter"i]'
-	);
+	const inserterButton = page.locator( 'role=tab[name="Blocks"i]' );
 	await inserterButton.click();
 	await page.type( 'role=searchbox[name="Search"i]', 'Group' );
 	await page.click(

--- a/test/e2e/specs/site-editor/pages.spec.js
+++ b/test/e2e/specs/site-editor/pages.spec.js
@@ -272,6 +272,7 @@ test.describe( 'Pages', () => {
 
 		// Create new page that has the default template so as to swap it.
 		await draftNewPage( page );
+		await page.locator( 'role=button[name="Block Inserter"i]' ).click();
 		await editor.openDocumentSettingsSidebar();
 		const templateOptionsButton = page
 			.getByRole( 'region', { name: 'Editor settings' } )
@@ -294,6 +295,7 @@ test.describe( 'Pages', () => {
 		} );
 
 		// Now reset, and apply the default template back.
+		await editor.openDocumentSettingsSidebar();
 		await templateOptionsButton.click();
 		const resetButton = page
 			.getByRole( 'menu', { name: 'Template options' } )
@@ -308,6 +310,7 @@ test.describe( 'Pages', () => {
 		editor,
 	} ) => {
 		await draftNewPage( page );
+		await page.locator( 'role=button[name="Block Inserter"i]' ).click();
 		await editor.openDocumentSettingsSidebar();
 		const templateOptionsButton = page
 			.getByRole( 'region', { name: 'Editor settings' } )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Builds on #66819.
Previously: #61489.

Closes https://github.com/WordPress/gutenberg/issues/63865

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The modal is super annoying, let's see if the inserter + zoom out is less annoying. You can double click the canvas to exit also.

A nice side effect is also that you can inserter multiple patterns, or browser other categories.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Uses #61489.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a new page in the admin or site editor. Click patterns from this category.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


<img width="1464" alt="Screenshot 2024-11-07 at 19 12 42" src="https://github.com/user-attachments/assets/26f6e192-5d7e-4fb8-be19-db5cf6f054f9">

