### PR TITLE
feature: add consistant illustrator to audio block

### DIFF
--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -13,6 +13,7 @@ import {
 	SelectControl,
 	Spinner,
 	ToggleControl,
+	Placeholder,
 } from '@wordpress/components';
 import {
 	BlockControls,
@@ -27,6 +28,7 @@ import { useDispatch } from '@wordpress/data';
 import { audio as icon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useState } from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -127,6 +129,11 @@ function AudioEdit( {
 		className: classes,
 	} );
 
+	const [ placeholderResizeListener, { width: placeholderWidth } ] =
+		useResizeObserver();
+
+	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
+
 	if ( ! src && ! temporaryURL ) {
 		return (
 			<div { ...blockProps }>
@@ -138,6 +145,22 @@ function AudioEdit( {
 					allowedTypes={ ALLOWED_MEDIA_TYPES }
 					value={ attributes }
 					onError={ onUploadError }
+					placeholder={ ( content ) => (
+						<Placeholder
+							className="block-editor-media-placeholder"
+							icon={ icon }
+							withIllustration={
+								! isSingleSelected || isSmallContainer
+							}
+							label={ ! isSmallContainer && __( 'Audio' ) }
+							instructions={ __(
+								'Upload or drag an audio file here, or pick one from your library.'
+							) }
+						>
+							{ content }
+							{ placeholderResizeListener }
+						</Placeholder>
+					) }
 				/>
 			</div>
 		);

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -46,6 +46,7 @@ function AudioEdit( {
 	onReplace,
 	isSelected: isSingleSelected,
 	insertBlocksAfter,
+	blockEditingMode,
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
@@ -134,35 +135,57 @@ function AudioEdit( {
 
 	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
 
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+
+	const autioReplaceFlow = isSingleSelected && (
+		<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
+			<MediaReplaceFlow
+				name={ ! src ? __( 'Add audio' ) : __( 'Replace' ) }
+				mediaId={ id }
+				mediaURL={ src }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				accept="audio/*"
+				onSelect={ onSelectAudio }
+				onSelectURL={ onSelectURL }
+				onError={ onUploadError }
+				onReset={ () => onSelectAudio( undefined ) }
+			/>
+		</BlockControls>
+	);
+
+	console.log( 'testing', isContentOnlyMode, isSingleSelected );
+
 	if ( ! src && ! temporaryURL ) {
 		return (
-			<div { ...blockProps }>
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					onSelect={ onSelectAudio }
-					onSelectURL={ onSelectURL }
-					accept="audio/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ attributes }
-					onError={ onUploadError }
-					placeholder={ ( content ) => (
-						<Placeholder
-							className="block-editor-media-placeholder"
-							icon={ icon }
-							withIllustration={
-								! isSingleSelected || isSmallContainer
-							}
-							label={ ! isSmallContainer && __( 'Audio' ) }
-							instructions={ __(
-								'Upload or drag an audio file here, or pick one from your library.'
-							) }
-						>
-							{ content }
-							{ placeholderResizeListener }
-						</Placeholder>
-					) }
-				/>
-			</div>
+			<>
+				{ autioReplaceFlow }
+				<div { ...blockProps }>
+					<MediaPlaceholder
+						onSelect={ onSelectAudio }
+						onSelectURL={ onSelectURL }
+						accept="audio/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ attributes }
+						onError={ onUploadError }
+						placeholder={ ( content ) => (
+							<Placeholder
+								className="block-editor-media-placeholder"
+								icon={ <BlockIcon icon={ icon } /> }
+								withIllustration={
+									! isSingleSelected || isSmallContainer
+								}
+								label={ ! isSmallContainer && __( 'Audio' ) }
+								instructions={ __(
+									'Upload or drag an audio file here, or pick one from your library.'
+								) }
+							>
+								{ content }
+								{ placeholderResizeListener }
+							</Placeholder>
+						) }
+					/>
+				</div>
+			</>
 		);
 	}
 

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -46,7 +46,6 @@ function AudioEdit( {
 	onReplace,
 	isSelected: isSingleSelected,
 	insertBlocksAfter,
-	blockEditingMode,
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
@@ -135,57 +134,35 @@ function AudioEdit( {
 
 	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
 
-	const isContentOnlyMode = blockEditingMode === 'contentOnly';
-
-	const autioReplaceFlow = isSingleSelected && (
-		<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
-			<MediaReplaceFlow
-				name={ ! src ? __( 'Add audio' ) : __( 'Replace' ) }
-				mediaId={ id }
-				mediaURL={ src }
-				allowedTypes={ ALLOWED_MEDIA_TYPES }
-				accept="audio/*"
-				onSelect={ onSelectAudio }
-				onSelectURL={ onSelectURL }
-				onError={ onUploadError }
-				onReset={ () => onSelectAudio( undefined ) }
-			/>
-		</BlockControls>
-	);
-
-	console.log( 'testing', isContentOnlyMode, isSingleSelected );
-
 	if ( ! src && ! temporaryURL ) {
 		return (
-			<>
-				{ autioReplaceFlow }
-				<div { ...blockProps }>
-					<MediaPlaceholder
-						onSelect={ onSelectAudio }
-						onSelectURL={ onSelectURL }
-						accept="audio/*"
-						allowedTypes={ ALLOWED_MEDIA_TYPES }
-						value={ attributes }
-						onError={ onUploadError }
-						placeholder={ ( content ) => (
-							<Placeholder
-								className="block-editor-media-placeholder"
-								icon={ <BlockIcon icon={ icon } /> }
-								withIllustration={
-									! isSingleSelected || isSmallContainer
-								}
-								label={ ! isSmallContainer && __( 'Audio' ) }
-								instructions={ __(
-									'Upload or drag an audio file here, or pick one from your library.'
-								) }
-							>
-								{ content }
-								{ placeholderResizeListener }
-							</Placeholder>
-						) }
-					/>
-				</div>
-			</>
+			<div { ...blockProps }>
+				<MediaPlaceholder
+					icon={ <BlockIcon icon={ icon } /> }
+					onSelect={ onSelectAudio }
+					onSelectURL={ onSelectURL }
+					accept="audio/*"
+					allowedTypes={ ALLOWED_MEDIA_TYPES }
+					value={ attributes }
+					onError={ onUploadError }
+					placeholder={ ( content ) => (
+						<Placeholder
+							className="block-editor-media-placeholder"
+							icon={ icon }
+							withIllustration={
+								! isSingleSelected || isSmallContainer
+							}
+							label={ ! isSmallContainer && __( 'Audio' ) }
+							instructions={ __(
+								'Upload or drag an audio file here, or pick one from your library.'
+							) }
+						>
+							{ content }
+							{ placeholderResizeListener }
+						</Placeholder>
+					) }
+				/>
+			</div>
 		);
 	}
 

--- a/packages/block-library/src/audio/edit.js
+++ b/packages/block-library/src/audio/edit.js
@@ -17,7 +17,6 @@ import {
 } from '@wordpress/components';
 import {
 	BlockControls,
-	BlockIcon,
 	InspectorControls,
 	MediaPlaceholder,
 	MediaReplaceFlow,
@@ -46,6 +45,7 @@ function AudioEdit( {
 	onReplace,
 	isSelected: isSingleSelected,
 	insertBlocksAfter,
+	blockEditingMode,
 } ) {
 	const { id, autoplay, loop, preload, src } = attributes;
 	const [ temporaryURL, setTemporaryURL ] = useState( attributes.blob );
@@ -134,35 +134,55 @@ function AudioEdit( {
 
 	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
 
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
+
+	const autioReplaceFlow = isSingleSelected && (
+		<BlockControls group={ isContentOnlyMode ? 'inline' : 'other' }>
+			<MediaReplaceFlow
+				name={ ! src ? __( 'Add audio' ) : __( 'Replace' ) }
+				mediaId={ id }
+				mediaURL={ src }
+				allowedTypes={ ALLOWED_MEDIA_TYPES }
+				accept="audio/*"
+				onSelect={ onSelectAudio }
+				onSelectURL={ onSelectURL }
+				onError={ onUploadError }
+				onReset={ () => onSelectAudio( undefined ) }
+			/>
+		</BlockControls>
+	);
+
 	if ( ! src && ! temporaryURL ) {
 		return (
-			<div { ...blockProps }>
-				<MediaPlaceholder
-					icon={ <BlockIcon icon={ icon } /> }
-					onSelect={ onSelectAudio }
-					onSelectURL={ onSelectURL }
-					accept="audio/*"
-					allowedTypes={ ALLOWED_MEDIA_TYPES }
-					value={ attributes }
-					onError={ onUploadError }
-					placeholder={ ( content ) => (
-						<Placeholder
-							className="block-editor-media-placeholder"
-							icon={ icon }
-							withIllustration={
-								! isSingleSelected || isSmallContainer
-							}
-							label={ ! isSmallContainer && __( 'Audio' ) }
-							instructions={ __(
-								'Upload or drag an audio file here, or pick one from your library.'
-							) }
-						>
-							{ content }
-							{ placeholderResizeListener }
-						</Placeholder>
-					) }
-				/>
-			</div>
+			<>
+				{ autioReplaceFlow }
+				<div { ...blockProps }>
+					<MediaPlaceholder
+						onSelect={ onSelectAudio }
+						onSelectURL={ onSelectURL }
+						accept="audio/*"
+						allowedTypes={ ALLOWED_MEDIA_TYPES }
+						value={ attributes }
+						onError={ onUploadError }
+						placeholder={ ( content ) => (
+							<Placeholder
+								className="block-editor-media-placeholder"
+								icon={ ! isSmallContainer && icon }
+								withIllustration={
+									! isSingleSelected || isSmallContainer
+								}
+								label={ ! isSmallContainer && __( 'Audio' ) }
+								instructions={ __(
+									'Upload or drag an audio file here, or pick one from your library.'
+								) }
+							>
+								{ ! isSmallContainer && content }
+								{ placeholderResizeListener }
+							</Placeholder>
+						) }
+					/>
+				</div>
+			</>
 		);
 	}
 

--- a/packages/block-library/src/audio/editor.scss
+++ b/packages/block-library/src/audio/editor.scss
@@ -16,4 +16,8 @@
 		margin-top: -9px;
 		margin-left: -9px;
 	}
+
+	.components-placeholder.has-illustration {
+		min-height: 60px;
+	}
 }


### PR DESCRIPTION
## What?
Added consistent illustrator for Audio block similar to the image block.

## Why?
Part of https://github.com/WordPress/gutenberg/issues/66828

## How?
- added `Placeholder` into `MediaPlaceholder` similar to image block.

## Testing Instructions
1. open the editor and insert the `Audio` block & `Image` block
2. select on `Audio` block and dis-select it see illustrator similar to the `Image` block


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d6fdc947-03aa-43f1-b1e8-87227e8388ef

