### PR TITLE
feature: add consistant illustrator to file block

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -11,6 +11,7 @@ import {
 	__unstableGetAnimateClassName as getAnimateClassName,
 	ResizableBox,
 	ToolbarButton,
+	Placeholder,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import {
@@ -24,7 +25,7 @@ import {
 	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
 import { useEffect, useState } from '@wordpress/element';
-import { useCopyToClipboard } from '@wordpress/compose';
+import { useCopyToClipboard, useResizeObserver } from '@wordpress/compose';
 import { __, _x } from '@wordpress/i18n';
 import { file as icon } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
@@ -193,6 +194,11 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 
 	const displayPreviewInEditor = browserSupportsPdfs() && displayPreview;
 
+	const [ placeholderResizeListener, { width: placeholderWidth } ] =
+		useResizeObserver();
+
+	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
+
 	if ( ! href && ! temporaryURL ) {
 		return (
 			<div { ...blockProps }>
@@ -207,6 +213,22 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					onSelect={ onSelectFile }
 					onError={ onUploadError }
 					accept="*"
+					placeholder={ ( content ) => (
+						<Placeholder
+							className="block-editor-media-placeholder"
+							icon={ icon }
+							withIllustration={
+								! isSelected || isSmallContainer
+							}
+							label={ ! isSmallContainer && __( 'File' ) }
+							instructions={ __(
+								'Upload a file or pick one from your media library.'
+							) }
+						>
+							{ content }
+							{ placeholderResizeListener }
+						</Placeholder>
+					) }
 				/>
 			</div>
 		);

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -222,7 +222,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 							}
 							label={ ! isSmallContainer && __( 'File' ) }
 							instructions={ __(
-								'Upload a file or pick one from your media library.'
+								'Drag and drop a file here, upload, or choose from your library.'
 							) }
 						>
 							{ content }


### PR DESCRIPTION
## What?
Added consistent illustrator for File block similar to the image block.

## Why?
Part of https://github.com/WordPress/gutenberg/issues/66828

## How?
- added `Placeholder` into `MediaPlaceholder` similar to image block.

## Testing Instructions
1. open the editor and insert the File block & Image block
2. select on File block and dis-select it see illustrator similar to the Image block

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3e0201c1-ff77-4268-b432-f812c5f54a2e

