### PR TITLE
feature: add consistant illustrator to media text block

### DIFF
--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -106,7 +106,7 @@ function PlaceholderContainer( {
 					withIllustration={ ! isSelected || isSmallContainer }
 					label={ ! isSmallContainer && __( 'Media area' ) }
 					instructions={ __(
-						'Upload a media file or pick one from your media library.'
+						'Drag and drop an image or video here, upload, or choose from your library.'
 					) }
 				>
 					{ content }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -15,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
@@ -76,7 +76,6 @@ function PlaceholderContainer( {
 	mediaUrl,
 	onSelectMedia,
 	toggleUseFeaturedImage,
-	isSelected,
 } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
@@ -84,14 +83,12 @@ function PlaceholderContainer( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
-	const [ placeholderResizeListener, { width: placeholderWidth } ] =
-		useResizeObserver();
-
-	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
-
 	return (
 		<MediaPlaceholder
 			icon={ <BlockIcon icon={ icon } /> }
+			labels={ {
+				title: __( 'Media area' ),
+			} }
 			className={ className }
 			onSelect={ onSelectMedia }
 			accept="image/*,video/*"
@@ -99,20 +96,6 @@ function PlaceholderContainer( {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			onError={ onUploadError }
 			disableMediaButtons={ mediaUrl }
-			placeholder={ ( content ) => (
-				<Placeholder
-					className="block-editor-media-placeholder"
-					icon={ icon }
-					withIllustration={ ! isSelected || isSmallContainer }
-					label={ ! isSmallContainer && __( 'Media area' ) }
-					instructions={ __(
-						'Upload a media file or pick one from your media library.'
-					) }
-				>
-					{ content }
-					{ placeholderResizeListener }
-				</Placeholder>
-			) }
 		/>
 	);
 }

--- a/packages/block-library/src/media-text/media-container.js
+++ b/packages/block-library/src/media-text/media-container.js
@@ -15,7 +15,7 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useViewportMatch } from '@wordpress/compose';
+import { useViewportMatch, useResizeObserver } from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 import { forwardRef } from '@wordpress/element';
 import { isBlobURL } from '@wordpress/blob';
@@ -76,6 +76,7 @@ function PlaceholderContainer( {
 	mediaUrl,
 	onSelectMedia,
 	toggleUseFeaturedImage,
+	isSelected,
 } ) {
 	const { createErrorNotice } = useDispatch( noticesStore );
 
@@ -83,12 +84,14 @@ function PlaceholderContainer( {
 		createErrorNotice( message, { type: 'snackbar' } );
 	};
 
+	const [ placeholderResizeListener, { width: placeholderWidth } ] =
+		useResizeObserver();
+
+	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
+
 	return (
 		<MediaPlaceholder
 			icon={ <BlockIcon icon={ icon } /> }
-			labels={ {
-				title: __( 'Media area' ),
-			} }
 			className={ className }
 			onSelect={ onSelectMedia }
 			accept="image/*,video/*"
@@ -96,6 +99,20 @@ function PlaceholderContainer( {
 			allowedTypes={ ALLOWED_MEDIA_TYPES }
 			onError={ onUploadError }
 			disableMediaButtons={ mediaUrl }
+			placeholder={ ( content ) => (
+				<Placeholder
+					className="block-editor-media-placeholder"
+					icon={ icon }
+					withIllustration={ ! isSelected || isSmallContainer }
+					label={ ! isSmallContainer && __( 'Media area' ) }
+					instructions={ __(
+						'Upload a media file or pick one from your media library.'
+					) }
+				>
+					{ content }
+					{ placeholderResizeListener }
+				</Placeholder>
+			) }
 		/>
 	);
 }


### PR DESCRIPTION
## What?
Added consistent illustrator for Media text block similar to the image block.

## Why?
Part of https://github.com/WordPress/gutenberg/issues/66828

## How?
- added `Placeholder` into `MediaPlaceholder` similar to image block.

## Testing Instructions
1. open the editor and insert the `Media text` block & Image block
2. select on `Media text` block and dis-select it see illustrator similar to the Image block


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0717ca06-a279-4226-868e-17f98963c6e4

