### PR TITLE
Update placeholder text for blocks that support drag and drop

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -317,7 +317,7 @@ export function MediaPlaceholder( {
 
 			if ( instructions === undefined && mediaUpload ) {
 				instructions = __(
-					'Upload a media file or pick one from your media library.'
+					'Drag and drop an image or video here, upload, or choose from your library.'
 				);
 
 				if ( isAudio ) {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -322,7 +322,7 @@ export function MediaPlaceholder( {
 
 				if ( isAudio ) {
 					instructions = __(
-						'Upload or drag an audio file here, or pick one from your library.'
+						'Drag and drop an audio file here, upload, or choose from your library.'
 					);
 				} else if ( isImage ) {
 					instructions = __(

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -317,20 +317,20 @@ export function MediaPlaceholder( {
 
 			if ( instructions === undefined && mediaUpload ) {
 				instructions = __(
-					'Drag and drop an image or video here, upload, or choose from your library.'
+					'Drag and drop an image or video, upload, or choose from your library.'
 				);
 
 				if ( isAudio ) {
 					instructions = __(
-						'Drag and drop an audio file here, upload, or choose from your library.'
+						'Drag and drop an audio file, upload, or choose from your library.'
 					);
 				} else if ( isImage ) {
 					instructions = __(
-						'Drag and drop an image here, upload, or choose from your library.'
+						'Drag and drop an image, upload, or choose from your library.'
 					);
 				} else if ( isVideo ) {
 					instructions = __(
-						'Drag and drop a video here, upload, or choose from your library.'
+						'Drag and drop a video, upload, or choose from your library.'
 					);
 				}
 			}

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -326,11 +326,11 @@ export function MediaPlaceholder( {
 					);
 				} else if ( isImage ) {
 					instructions = __(
-						'Upload or drag an image file here, or pick one from your library.'
+						'Drag and drop an image here, upload, or choose from your library.'
 					);
 				} else if ( isVideo ) {
 					instructions = __(
-						'Upload or drag a video file here, or pick one from your library.'
+						'Drag and drop a video here, upload, or choose from your library.'
 					);
 				}
 			}

--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -24,7 +24,7 @@ export default function CoverPlaceholder( {
 			labels={ {
 				title: __( 'Cover' ),
 				instructions: __(
-					'Drag and drop onto this block, upload, or select existing media from your library.'
+					'Drag and drop an image or video here, upload, or choose from your library.'
 				),
 			} }
 			onSelect={ onSelectMedia }

--- a/packages/block-library/src/cover/edit/cover-placeholder.js
+++ b/packages/block-library/src/cover/edit/cover-placeholder.js
@@ -23,9 +23,6 @@ export default function CoverPlaceholder( {
 			icon={ <BlockIcon icon={ icon } /> }
 			labels={ {
 				title: __( 'Cover' ),
-				instructions: __(
-					'Drag and drop an image or video here, upload, or choose from your library.'
-				),
 			} }
 			onSelect={ onSelectMedia }
 			accept="image/*,video/*"

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -201,7 +201,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					labels={ {
 						title: __( 'File' ),
 						instructions: __(
-							'Drag and drop a file here, upload, or choose from your library.'
+							'Drag and drop a file, upload, or choose from your library.'
 						),
 					} }
 					onSelect={ onSelectFile }

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -201,7 +201,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 					labels={ {
 						title: __( 'File' ),
 						instructions: __(
-							'Upload a file or pick one from your media library.'
+							'Drag and drop a file here, upload, or choose from your library.'
 						),
 					} }
 					onSelect={ onSelectFile }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -96,7 +96,7 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'Add media' )
-	: __( 'Drag images, upload new ones or select files from your library.' );
+	: __( 'Drag and drop images here, upload, or choose from your library.' );
 
 const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.isNative
 	? { type: 'stepper' }

--- a/packages/block-library/src/gallery/edit.js
+++ b/packages/block-library/src/gallery/edit.js
@@ -96,7 +96,7 @@ const ALLOWED_MEDIA_TYPES = [ 'image' ];
 
 const PLACEHOLDER_TEXT = Platform.isNative
 	? __( 'Add media' )
-	: __( 'Drag and drop images here, upload, or choose from your library.' );
+	: __( 'Drag and drop images, upload, or choose from your library.' );
 
 const MOBILE_CONTROL_PROPS_RANGE_CONTROL = Platform.isNative
 	? { type: 'stepper' }

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -411,7 +411,7 @@ export function ImageEdit( {
 					! lockUrlControls &&
 					! isSmallContainer &&
 					__(
-						'Drag and drop an image here, upload, or choose from your library.'
+						'Drag and drop an image, upload, or choose from your library.'
 					)
 				}
 				style={ {

--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -411,7 +411,7 @@ export function ImageEdit( {
 					! lockUrlControls &&
 					! isSmallContainer &&
 					__(
-						'Upload or drag an image file here, or pick one from your library.'
+						'Drag and drop an image here, upload, or choose from your library.'
 					)
 				}
 				style={ {

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -141,7 +141,7 @@ function VideoEdit( {
 				icon={ icon }
 				label={ __( 'Video' ) }
 				instructions={ __(
-					'Upload a video file, pick one from your media library, or add one with a URL.'
+					'Drag and drop a video here, upload, or choose from your library.'
 				) }
 			>
 				{ content }

--- a/packages/block-library/src/video/edit.js
+++ b/packages/block-library/src/video/edit.js
@@ -141,7 +141,7 @@ function VideoEdit( {
 				icon={ icon }
 				label={ __( 'Video' ) }
 				instructions={ __(
-					'Drag and drop a video here, upload, or choose from your library.'
+					'Drag and drop a video, upload, or choose from your library.'
 				) }
 			>
 				{ content }


### PR DESCRIPTION
## What?
Update placeholder text for blocks that support drag and drop

## Why?
fixes: https://github.com/WordPress/gutenberg/issues/66828

## How?
Updating the copy text
