### PR TITLE
Change button text from  'Add Media' by 'Add media' to follow sentence-case UI standards

### DIFF
--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -101,7 +101,7 @@ export default function CoverBlockControls( {
 					onSelect={ onSelectMedia }
 					onToggleFeaturedImage={ toggleUseFeaturedImage }
 					useFeaturedImage={ useFeaturedImage }
-					name={ ! url ? __( 'Add Media' ) : __( 'Replace' ) }
+					name={ ! url ? __( 'Add media' ) : __( 'Replace' ) }
 					onReset={ onClearMedia }
 				/>
 			</BlockControls>


### PR DESCRIPTION
## What?
Change button text from  'Add Media' by 'Add media' to follow sentence-case UI standards.

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/66826

## How?
By updating the text.

## Testing Instructions
See https://github.com/WordPress/gutenberg/issues/66826


## Screenshots or screencast <!-- if applicable -->

![Screenshot from 2024-11-07 16-15-31](https://github.com/user-attachments/assets/b21e7b29-01e6-423b-9f8e-ea25054aa7a8)

