### PR TITLE
Process Block Type: Copy deprecation to a new object instead of mutating when stabilizing supports

### DIFF
--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -150,10 +150,12 @@ export const processBlockType =
 		if ( settings.deprecated ) {
 			settings.deprecated = settings.deprecated.map( ( deprecation ) => {
 				// Stabilize any experimental supports before applying filters.
-				deprecation.supports = stabilizeSupports(
-					deprecation.supports
-				);
-				const filteredDeprecation = // Only keep valid deprecation keys.
+				let filteredDeprecation = {
+					...deprecation,
+					supports: stabilizeSupports( deprecation.supports ),
+				};
+
+				filteredDeprecation = // Only keep valid deprecation keys.
 					applyFilters(
 						'blocks.registerBlockType',
 						// Merge deprecation keys with pre-filter settings
@@ -163,10 +165,10 @@ export const processBlockType =
 							// Omit deprecation keys here so that deprecations
 							// can opt out of specific keys like "supports".
 							...omit( blockType, DEPRECATED_ENTRY_KEYS ),
-							...deprecation,
+							...filteredDeprecation,
 						},
 						blockType.name,
-						deprecation
+						filteredDeprecation
 					);
 				// Re-stabilize any experimental supports after applying filters.
 				// This ensures that any supports updated by filters are also stabilized.

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -71,17 +71,32 @@ function stabilizeSupports( rawSupports ) {
 		return rawSupports;
 	}
 
-	const supports = { ...rawSupports };
-	if ( supports?.typography && typeof supports.typography === 'object' ) {
-		supports.typography = Object.fromEntries(
-			Object.entries( supports.typography ).map( ( [ key, value ] ) => [
-				TYPOGRAPHY_SUPPORTS_EXPERIMENTAL_TO_STABLE[ key ] || key,
-				value,
-			] )
-		);
+	// Create a new object to avoid mutating the original. This ensures that
+	// custom block plugins that rely on immutable supports are not affected.
+	// See: https://github.com/WordPress/gutenberg/pull/66849#issuecomment-2463614281
+	const newSupports = {};
+	for ( const [ key, value ] of Object.entries( rawSupports ) ) {
+		if (
+			key === 'typography' &&
+			typeof value === 'object' &&
+			value !== null
+		) {
+			newSupports.typography = Object.fromEntries(
+				Object.entries( value ).map(
+					( [ typographyKey, typographyValue ] ) => [
+						TYPOGRAPHY_SUPPORTS_EXPERIMENTAL_TO_STABLE[
+							typographyKey
+						] || typographyKey,
+						typographyValue,
+					]
+				)
+			);
+		} else {
+			newSupports[ key ] = value;
+		}
 	}
 
-	return supports;
+	return newSupports;
 }
 
 /**

--- a/packages/blocks/src/store/test/process-block-type.js
+++ b/packages/blocks/src/store/test/process-block-type.js
@@ -215,6 +215,11 @@ describe( 'processBlockType', () => {
 			],
 		};
 
+		// Freeze the deprecated block object to ensure that the original object is not mutated.
+		// This ensures the test covers a regression where the original object was mutated.
+		// See: https://github.com/WordPress/gutenberg/pull/63401#discussion_r1832394335.
+		Object.freeze( blockSettings.deprecated[ 0 ] );
+
 		const processedBlockType = processBlockType(
 			'test/block',
 			blockSettings

--- a/packages/blocks/src/store/test/process-block-type.js
+++ b/packages/blocks/src/store/test/process-block-type.js
@@ -215,10 +215,11 @@ describe( 'processBlockType', () => {
 			],
 		};
 
-		// Freeze the deprecated block object to ensure that the original object is not mutated.
+		// Freeze the deprecated block object and its supports so that the original is not mutated.
 		// This ensures the test covers a regression where the original object was mutated.
 		// See: https://github.com/WordPress/gutenberg/pull/63401#discussion_r1832394335.
 		Object.freeze( blockSettings.deprecated[ 0 ] );
+		Object.freeze( blockSettings.deprecated[ 0 ].supports );
 
 		const processedBlockType = processBlockType(
 			'test/block',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follows #63401 and attempts a fix for the issue flagged in https://github.com/WordPress/gutenberg/pull/63401#discussion_r1832394335

When applying block supports stabilization while processing block types, try to avoid mutating the deprecation, in case the passed in object does not support setting keys. This can be the case in some plugins as was flagged in the linked comment, and in the Jetpack plugin (https://github.com/Automattic/jetpack/issues/40055 and https://github.com/Automattic/jetpack/pull/40070).

Thank you to @coder-karen for flagging this issue!

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As seen in the Jetpack plugin in https://github.com/Automattic/jetpack/pull/40070, some plugins structure their deprecations in such a way that they're _imported_ rather than constructed from ordinary JS objects. I.e. in the Jetpack plugin, it uses a pattern like the following:

```js
import * as deprecatedV1 from './v1';
import * as deprecatedV2 from './v2';
import * as deprecatedV3 from './v3';

export default [ deprecatedV3, deprecatedV2, deprecatedV1 ];
```

Where in each of those files, the keys are exported like so:

```js
export const attributes = {
  ...
};

export const supports = {
  ...
};
```

So, the object for each deprecation is not a regular JS object. Arguably the above approach isn't what's expected from the perspective of Gutenberg's code, but given that plugins are already writing things this way, let's ensure that it's supported, so as not to break plugins and websites!

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

For each deprecation, create a new object and expand the keys into the new object. This should ensure that we're updating `supports` in a safe(r) way.

Update the test for stabilizing block supports in the deprecation by calling `Object.freeze( blockSettings.deprecated[ 0 ] );` — this emulates the approach seen in the Jetpack plugin by ensuring that the `deprecated` object's keys cannot be mutated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Ensure that deprecations function as expected and/or follow the testing instructions in https://github.com/WordPress/gutenberg/pull/63401 to ensure that this doesn't cause any regressions
2. Ensure that tests pass, or test the Jetpack plugin in conjunction with this PR, using the Slideshow block.
  * For the latter, create a post and add the Slideshow block. On `trunk` I get a white screen of death with an error message, whereas with this PR, the block displays as expected in the editor.

## Screenshots or screencast <!-- if applicable -->

The following are screenshots from running the Jetpack plugin on a post that includes the Slideshow block from that plugin. (If you're testing Jetpack, you'll need to switch on Jetpack Blocks under Jetpack Plugin Settings > Writing > Composing > Jetpack Blocks.)

| Trunk (WSOD with this error) | This PR |
| --- | --- |
| <img width="1631" alt="image" src="https://github.com/user-attachments/assets/a145f5bc-8d18-453b-8e86-abc22f681e98"> | <img width="1469" alt="image" src="https://github.com/user-attachments/assets/1676f627-16e9-4d06-b3f3-3ccddb60374b"> |