### PR TITLE
Media: add `x-wav` mime type for wav files in Firefox

### DIFF
--- a/backport-changelog/6.8/7265.md
+++ b/backport-changelog/6.8/7265.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7265
+
+* https://github.com/WordPress/gutenberg/pull/66850

--- a/lib/compat/wordpress-6.8/functions.php
+++ b/lib/compat/wordpress-6.8/functions.php
@@ -23,6 +23,6 @@ function gutenberg_get_mime_types_6_8( $mime_types ) {
 	if ( ! isset( $mime_types['x-wav'] ) && ! isset( $mime_types['wav|x-wav'] ) ) {
 		$mime_types['x-wav'] = 'audio/wav';
 	}
-    return $mime_types;
+	return $mime_types;
 }
 add_filter( 'mime_types', 'gutenberg_get_mime_types_6_8', 10, 1 );

--- a/lib/compat/wordpress-6.8/functions.php
+++ b/lib/compat/wordpress-6.8/functions.php
@@ -15,8 +15,15 @@
 */
 function gutenberg_get_mime_types_6_8( $mime_types ) {
 	/*
-	 * Given that other themes or plugins may have already
-	 * tried to add wav mime type support for Firefox, only
+	 * Only add support if there is existing support for 'wav'.
+	 * Some plugins may have deliberately disabled it.
+	*/
+	if ( ! $mime_types['wav'] && ! isset( $mime_types['wav|x-wav'] ) ) {
+		return $mime_types;
+	}
+	/*
+	 * Also, given that other themes or plugins may have already
+	 * tried to add x-wav type support, only
 	 * add the mime type if it doesn't already exist
 	 * to avoid overriding any customizations.
 	 */
@@ -25,4 +32,4 @@ function gutenberg_get_mime_types_6_8( $mime_types ) {
 	}
 	return $mime_types;
 }
-add_filter( 'mime_types', 'gutenberg_get_mime_types_6_8', 10, 1 );
+add_filter( 'mime_types', 'gutenberg_get_mime_types_6_8', 99 );

--- a/lib/compat/wordpress-6.8/functions.php
+++ b/lib/compat/wordpress-6.8/functions.php
@@ -3,6 +3,10 @@
 /**
  * Adds the x-wav mime type to the list of mime types.
  * This is necessary for Firefox as it uses the identifier for uploaded .wav files.
+ * Core backport should add the following to the default mime_types filters in
+ * `wp_get_mime_types()` in wp-includes/functions.php:
+ *
+ * `'wav|x-wav' => 'audio/wav'`
  *
  * @since 6.8.0
  *
@@ -10,10 +14,15 @@
  * @return string[] Mime types keyed by the file extension regex corresponding to those types.
 */
 function gutenberg_get_mime_types_6_8( $mime_types ) {
-	if ( isset( $mime_types['wav'] ) ) {
-		$mime_types['wav|x-wav'] = 'audio/wav';
-		unset( $mime_types['wav'] );
+	/*
+	 * Given that other themes or plugins may have already
+	 * tried to add wav mime type support for Firefox, only
+	 * add the mime type if it doesn't already exist
+	 * to avoid overriding any customizations.
+	 */
+	if ( ! isset( $mime_types['x-wav'] ) && ! isset( $mime_types['wav|x-wav'] ) ) {
+		$mime_types['x-wav'] = 'audio/wav';
 	}
-	return $mime_types;
+    return $mime_types;
 }
-add_filter( 'mime_types', 'gutenberg_get_mime_types_6_8', 10 );
+add_filter( 'mime_types', 'gutenberg_get_mime_types_6_8', 10, 1 );

--- a/lib/compat/wordpress-6.8/functions.php
+++ b/lib/compat/wordpress-6.8/functions.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Adds the x-wav mime type to the list of mime types.
+ * This is necessary for Firefox as it uses the identifier for uploaded .wav files.
+ *
+ * @since 6.8.0
+ *
+ * @param string[] $mime_types Mime types.
+ * @return string[] Mime types keyed by the file extension regex corresponding to those types.
+*/
+function gutenberg_get_mime_types_6_8( $mime_types ) {
+	if ( isset( $mime_types['wav'] ) ) {
+		$mime_types['wav|x-wav'] = 'audio/wav';
+		unset( $mime_types['wav'] );
+	}
+	return $mime_types;
+}
+add_filter( 'mime_types', 'gutenberg_get_mime_types_6_8', 10 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -119,6 +119,7 @@ require __DIR__ . '/compat/wordpress-6.7/post-formats.php';
 // WordPress 6.8 compat.
 require __DIR__ . '/compat/wordpress-6.8/preload.php';
 require __DIR__ . '/compat/wordpress-6.8/blocks.php';
+require __DIR__ . '/compat/wordpress-6.8/functions.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Adding x-wav support because Firefox uses that as a mime-type identifier for wav files.

From the core backport https://github.com/WordPress/wordpress-develop/pull/7265

Props to @Imran92 

## Why?

Uploading wav files to Firefox doesn't work.

## How?
Add the [mime_types](https://developer.wordpress.org/reference/hooks/mime_types/) hook

## Testing Instructions

In Firefox, upload a wav file.

It should work and play as expected.

It should also NOT overwrite any existing entries for hooks with a higher priority, e.g., this hook should prevail: 

```php
function test_mime_type( $mime_types ) {
    $mime_types['x-wav'] = 'audio/hello';
    return $mime_types;
}
add_filter( 'mime_types', 'test_mime_type', 9, 1 );
```

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/628dfd7a-36ad-457a-8b81-f2dd04096564

