### PR TITLE
Omit "design" controls from Cover block toolbar while in Write mode

### DIFF
--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -74,11 +74,12 @@ export default function CoverBlockControls( {
 		} );
 	};
 
+	const hasNonContentControls = blockEditingMode === 'default';
 	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 
 	return (
 		<>
-			{ ! isContentOnlyMode && (
+			{ ! isContentOnlyMode && hasNonContentControls && (
 				<BlockControls group="block">
 					<>
 						<BlockAlignmentMatrixControl

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -9,8 +9,10 @@ import {
 	__experimentalBlockAlignmentMatrixControl as BlockAlignmentMatrixControl,
 	__experimentalBlockFullHeightAligmentControl as FullHeightAlignmentControl,
 	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -73,25 +75,34 @@ export default function CoverBlockControls( {
 		} );
 	};
 
+	const mode = useSelect(
+		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
+		[]
+	);
+
 	return (
 		<>
-			<BlockControls group="block">
-				<BlockAlignmentMatrixControl
-					label={ __( 'Change content position' ) }
-					value={ contentPosition }
-					onChange={ ( nextPosition ) =>
-						setAttributes( {
-							contentPosition: nextPosition,
-						} )
-					}
-					isDisabled={ ! hasInnerBlocks }
-				/>
-				<FullHeightAlignmentControl
-					isActive={ isMinFullHeight }
-					onToggle={ toggleMinFullHeight }
-					isDisabled={ ! hasInnerBlocks }
-				/>
-			</BlockControls>
+			{ 'navigation' !== mode && (
+				<BlockControls group="block">
+					<>
+						<BlockAlignmentMatrixControl
+							label={ __( 'Change content position' ) }
+							value={ contentPosition }
+							onChange={ ( nextPosition ) =>
+								setAttributes( {
+									contentPosition: nextPosition,
+								} )
+							}
+							isDisabled={ ! hasInnerBlocks }
+						/>
+						<FullHeightAlignmentControl
+							isActive={ isMinFullHeight }
+							onToggle={ toggleMinFullHeight }
+							isDisabled={ ! hasInnerBlocks }
+						/>
+					</>
+				</BlockControls>
+			) }
 			<BlockControls group="other">
 				<MediaReplaceFlow
 					mediaId={ id }

--- a/packages/block-library/src/cover/edit/block-controls.js
+++ b/packages/block-library/src/cover/edit/block-controls.js
@@ -9,10 +9,8 @@ import {
 	__experimentalBlockAlignmentMatrixControl as BlockAlignmentMatrixControl,
 	__experimentalBlockFullHeightAligmentControl as FullHeightAlignmentControl,
 	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -29,6 +27,7 @@ export default function CoverBlockControls( {
 	currentSettings,
 	toggleUseFeaturedImage,
 	onClearMedia,
+	blockEditingMode,
 } ) {
 	const { contentPosition, id, useFeaturedImage, minHeight, minHeightUnit } =
 		attributes;
@@ -75,14 +74,11 @@ export default function CoverBlockControls( {
 		} );
 	};
 
-	const mode = useSelect(
-		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),
-		[]
-	);
+	const isContentOnlyMode = blockEditingMode === 'contentOnly';
 
 	return (
 		<>
-			{ 'navigation' !== mode && (
+			{ ! isContentOnlyMode && (
 				<BlockControls group="block">
 					<>
 						<BlockAlignmentMatrixControl

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -437,6 +437,7 @@ function CoverEdit( {
 			currentSettings={ currentSettings }
 			toggleUseFeaturedImage={ toggleUseFeaturedImage }
 			onClearMedia={ onClearMedia }
+			blockEditingMode={ blockEditingMode }
 		/>
 	);
 


### PR DESCRIPTION
## What?
Based on editor mode updating cover block toolbar controls.

## Why?
closes https://github.com/WordPress/gutenberg/issues/66823

## How?
- get mode from the editor and based on that render or skip cover block toolbar controls.

## Testing Instructions
1. select write mode in editor
2. add cover block and check its toolbar
3. full screen & matrix controls won't be visible if write mode is selected.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a4841c56-8beb-44cc-b9a2-c56b35c91f74

