### PR TITLE
Add border radius support in details block

### DIFF
--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -32,7 +32,12 @@
 		"__experimentalBorder": {
 			"color": true,
 			"width": true,
-			"style": true
+			"style": true,
+			"radius": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"radius": true
+			}
 		},
 		"html": false,
 		"spacing": {


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/66845

## Why?
- So that we can add Border Radius to the block.

## How?
- Adds support for border radius.

## Testing Instructions
- Add details block in the editor.
- Click on the block and in the Inspector Controls > Styles section check the Border section.

## Screenshots or screencast <!-- if applicable -->
<img width="1469" alt="Screenshot at Nov 08 11-24-57" src="https://github.com/user-attachments/assets/fd9214a5-bd41-4a11-9879-c102c19852af">

