### PR TITLE
ToggleGroupControl: Fix active background for `zero` value

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 -   `Popover`: Fix missing label of the headerTitle Close button ([#66813](https://github.com/WordPress/gutenberg/pull/66813)).
--   `ToggleGroupControl`: Fix active background for `zero` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
+-   `ToggleGroupControl`: Fix active background for `0` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
 
 ### Enhancements
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `Popover`: Fix missing label of the headerTitle Close button ([#66813](https://github.com/WordPress/gutenberg/pull/66813)).
+-   `ToggleGroupControl`: Fix active background for `zero` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
 
 ### Enhancements
 

--- a/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
+++ b/packages/components/src/toggle-group-control/toggle-group-control/component.tsx
@@ -52,7 +52,7 @@ function UnconnectedToggleGroupControl(
 	const [ controlElement, setControlElement ] = useState< HTMLElement >();
 	const refs = useMergeRefs( [ setControlElement, forwardedRef ] );
 	const selectedRect = useTrackElementOffsetRect(
-		value ? selectedElement : undefined
+		value || value === 0 ? selectedElement : undefined
 	);
 	useAnimatedOffsetRect( controlElement, selectedRect, {
 		prefix: 'selected',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Discovered while working on https://github.com/WordPress/gutenberg/pull/66837. 

ToggleGroupControl had a logic error that would affect the background of the active item, if its value was zero. Zero is a valid value for this component so this PR just fixes that.


## Testing Instructions
1. Test a `ToggleGroupControl` with `ToggleGroupControlOption` having `zero` value
2. Observe that in this PR the active background color is set properly.
3. (Alternatively just check out my Discovered while working on https://github.com/WordPress/gutenberg/pull/66837 and remove this line of code that was added here.

