### PR TITLE
Display some prompts or options in Command Palette at launch

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -88,15 +88,7 @@ const getEditorCommandLoader = () =>
 
 		const commands = [];
 
-		commands.push( {
-			name: 'core/open-shortcut-help',
-			label: __( 'Keyboard shortcuts' ),
-			icon: keyboard,
-			callback: ( { close } ) => {
-				close();
-				openModal( 'editor/keyboard-shortcut-help' );
-			},
-		} );
+		
 
 		commands.push( {
 			name: 'core/toggle-distraction-free',
@@ -109,14 +101,7 @@ const getEditorCommandLoader = () =>
 			},
 		} );
 
-		commands.push( {
-			name: 'core/open-preferences',
-			label: __( 'Editor preferences' ),
-			callback: ( { close } ) => {
-				close();
-				openModal( 'editor/preferences' );
-			},
-		} );
+		
 
 		commands.push( {
 			name: 'core/toggle-spotlight-mode',
@@ -299,6 +284,23 @@ const getEditedEntityContextualCommands = () =>
 			} );
 		}
 
+		commands.push( {
+			name: 'core/open-shortcut-help',
+			label: __( 'Keyboard shortcuts' ),
+			icon: keyboard,
+			callback: ( { close } ) => {
+				close();
+				openModal( 'editor/keyboard-shortcut-help' );
+			},
+		} );
+		commands.push( {
+			name: 'core/open-preferences',
+			label: __( 'Editor preferences' ),
+			callback: ( { close } ) => {
+				close();
+				openModal( 'editor/preferences' );
+			},
+		} );
 		return { isLoading: false, commands };
 	};
 


### PR DESCRIPTION
Part of [#53400](https://github.com/WordPress/gutenberg/issues/53400)

## What?
Display some prompts or options in the Command Palette at launch

## Why?
Currently not showing any prompts without typing.

## Testing Instructions

1. Go to Posts in the WordPress admin.
2. Open a new or existing post to enter the block editor.
3. In the block editor, open the Command Palette (by pressing Cmd + K on Mac).
4. Confirm that command prompt showing without any search

## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="command-prompts" src="https://github.com/user-attachments/assets/56536931-bc69-4bd1-ab9d-871b19a46fd1">
