### PR TITLE
resolve the button issue when only button is used

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -60,11 +60,6 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		max-width: 100%;
 	}
 
-	// Ensure minimum input field width in small viewports.
-	.wp-block-search__button[aria-expanded="true"] {
-		max-width: calc(100% - 100px);
-	}
-
 	.wp-block-search__inside-wrapper {
 		transition-property: width;
 		min-width: 0 !important;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Resolve the issue mentioned here :- #66852

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This css which i removed in this pr itself have the comment that this is for the small viewport so we should remove this css from here and if we need to target this css for small viewport so we have to use this in media-query so it may not affect the desktop design.
