### PR TITLE
Site Hub Mobile: Return to dashboard correctly in classic theme

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -121,17 +121,24 @@ export const SiteHubMobile = memo(
 		const history = useHistory();
 		const { navigate } = useContext( SidebarNavigationContext );
 
-		const { homeUrl, siteTitle } = useSelect( ( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			const _site = getEntityRecord( 'root', 'site' );
-			return {
-				homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
-				siteTitle:
-					! _site?.title && !! _site?.url
-						? filterURLForDisplay( _site?.url )
-						: _site?.title,
-			};
-		}, [] );
+		const { dashboardLink, homeUrl, siteTitle, isBlockBasedTheme } =
+			useSelect( ( select ) => {
+				const { getSettings } = unlock( select( editSiteStore ) );
+				const { getEntityRecord, getCurrentTheme } =
+					select( coreStore );
+				const _site = getEntityRecord( 'root', 'site' );
+				return {
+					dashboardLink:
+						getSettings().__experimentalDashboardLink ||
+						'index.php',
+					homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
+					siteTitle:
+						! _site?.title && !! _site?.url
+							? filterURLForDisplay( _site?.url )
+							: _site?.title,
+					isBlockBasedTheme: getCurrentTheme()?.is_block_theme,
+				};
+			}, [] );
 		const { open: openCommandCenter } = useDispatch( commandsStore );
 
 		return (
@@ -147,16 +154,25 @@ export const SiteHubMobile = memo(
 					>
 						<Button
 							__next40pxDefaultSize
+							href={
+								! isBlockBasedTheme ? dashboardLink : undefined
+							}
 							ref={ ref }
-							label={ __( 'Go to Site Editor' ) }
+							label={
+								isBlockBasedTheme
+									? __( 'Go to Site Editor' )
+									: __( 'Go to the Dashboard' )
+							}
 							className="edit-site-layout__view-mode-toggle"
 							style={ {
 								transform: 'scale(0.5)',
 								borderRadius: 4,
 							} }
 							onClick={ () => {
-								history.push( {} );
-								navigate( 'back' );
+								if ( isBlockBasedTheme ) {
+									history.push( {} );
+									navigate( 'back' );
+								}
 							} }
 						>
 							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />


### PR DESCRIPTION
Fixes #66844

## What?

This PR makes sure that in mobile layouts and classic themes, when you click on the site hub icon, it will take you back to the dashboard instead of the Design screen.

## Why?

Classic themes should not have access to anything other than the Patterns screen.

## Testing Instructions

- Enable Twenty Twenty-One and narrow your browser width.
- Go to Appearance > Patterns.
- Click the Site Hub icon.
  - trunk: The Design screen should appear.
  - This PR: The Dashboard should appear.
