### PR TITLE
Fixed site icon does not navigate to admin dashboard in mobile view

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -15,12 +15,11 @@ import {
 import { __ } from '@wordpress/i18n';
 import { store as coreStore } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { memo, forwardRef, useContext } from '@wordpress/element';
+import { memo, forwardRef } from '@wordpress/element';
 import { search } from '@wordpress/icons';
 import { store as commandsStore } from '@wordpress/commands';
 import { displayShortcut } from '@wordpress/keycodes';
 import { filterURLForDisplay } from '@wordpress/url';
-import { privateApis as routerPrivateApis } from '@wordpress/router';
 
 /**
  * Internal dependencies
@@ -28,8 +27,6 @@ import { privateApis as routerPrivateApis } from '@wordpress/router';
 import { store as editSiteStore } from '../../store';
 import SiteIcon from '../site-icon';
 import { unlock } from '../../lock-unlock';
-const { useHistory } = unlock( routerPrivateApis );
-import { SidebarNavigationContext } from '../sidebar';
 
 const SiteHub = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
@@ -118,13 +115,13 @@ export default SiteHub;
 
 export const SiteHubMobile = memo(
 	forwardRef( ( { isTransparent }, ref ) => {
-		const history = useHistory();
-		const { navigate } = useContext( SidebarNavigationContext );
-
-		const { homeUrl, siteTitle } = useSelect( ( select ) => {
+		const { dashboardLink, homeUrl, siteTitle } = useSelect( ( select ) => {
 			const { getEntityRecord } = select( coreStore );
+			const { getSettings } = unlock( select( editSiteStore ) );
 			const _site = getEntityRecord( 'root', 'site' );
 			return {
+				dashboardLink:
+					getSettings().__experimentalDashboardLink || 'index.php',
 				homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
 				siteTitle:
 					! _site?.title && !! _site?.url
@@ -154,10 +151,7 @@ export const SiteHubMobile = memo(
 								transform: 'scale(0.5)',
 								borderRadius: 4,
 							} }
-							onClick={ () => {
-								history.push( {} );
-								navigate( 'back' );
-							} }
+							href={ dashboardLink }
 						>
 							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
 						</Button>


### PR DESCRIPTION
## What?
Fixes: https://github.com/WordPress/gutenberg/issues/66844

## Why?
This PR addresses a discrepancy in the behavior of the site icon in the WordPress admin interface when viewed on desktop versus mobile. With a classic theme active, clicking the site icon should return the user to the admin dashboard. However, on mobile screens (728px or narrower), it currently opens the Site Editor sidebar, exposing screens that aren't compatible with classic themes. This behavior creates user experience inconsistencies and may lead to navigation errors.

## How?
To resolve this, the PR adds a conditional check for classic themes on mobile screens. When a classic theme is active and the viewport is 728px or narrower, clicking the site icon will now redirect users to the admin dashboard rather than opening the Site Editor sidebar. This ensures consistent behavior across devices.

## Testing Instructions

1. Open WordPress 6.6+ on a mobile device or resize a desktop browser window to 728px width or narrower.
2. Activate a classic theme (e.g., Twenty Twenty).
3. Navigate to Appearance > Patterns.
4. Locate the site icon (usually the WordPress "W") in the upper left.
5. Click the site icon and confirm that it redirects to the admin dashboard.

## Screenshots or screencast 

https://github.com/user-attachments/assets/332b7af9-b732-42cc-aa48-0dffd690cf4c

