### PR TITLE
Feat : Slotfill for Media Toolbar Dropdown

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -709,6 +709,41 @@ _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/plain-text/README.md>
 
+### PluginMediaToolbar
+
+Renders provided option as a menu item in the block toolbar for image and cover blocks.
+
+_Usage_
+
+```jsx
+// Using ESNext syntax
+import { __ } from '@wordpress/i18n';
+import { share } from '@wordpress/icons';
+import { PluginMediaToolbar } from '@wordpress/block-editor';
+
+const MyPluginMediaToolbar = () => (
+	<PluginMediaToolbar
+		className="my-plugin-media-toolbar"
+		icon={ share }
+		onClick={ () => console.log( 'Extended Menu clicked!' ) }
+	>
+		{ __( 'Extended Menu' ) }
+	</PluginMediaToolbar>
+);
+```
+
+_Parameters_
+
+-   _props_ `Object`: Component props.
+-   _props.className_ `[string]`: Class name to be applied to the menu item.
+-   _props.icon_ `[WPBlockTypeIconRender]`: Optional icon to be rendered next to the menu item.
+-   _props.onClick_ `[Function]`: Optional click handler for the menu item.
+-   _props.children_ `Element`: The content of the menu item.
+
+_Returns_
+
+-   `Component`: The rendered menu item.
+
 ### privateApis
 
 Private @wordpress/block-editor APIs.

--- a/packages/block-editor/src/components/index.js
+++ b/packages/block-editor/src/components/index.js
@@ -74,6 +74,7 @@ export { default as __experimentalLinkControlSearchItem } from './link-control/s
 export { default as LineHeightControl } from './line-height-control';
 export { default as __experimentalListView } from './list-view';
 export { default as MediaReplaceFlow } from './media-replace-flow';
+export { default as PluginMediaToolbar } from './plugin-media-toolbar';
 export { default as MediaPlaceholder } from './media-placeholder';
 export { default as MediaUpload } from './media-upload';
 export { default as MediaUploadCheck } from './media-upload/check';

--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -35,6 +35,7 @@ import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import LinkControl from '../link-control';
 import { store as blockEditorStore } from '../../store';
+import PluginMediaToolbar from '../plugin-media-toolbar';
 
 const noop = () => {};
 let uniqueId = 0;
@@ -213,6 +214,7 @@ const MediaReplaceFlow = ( {
 								{ __( 'Reset' ) }
 							</MenuItem>
 						) }
+						<PluginMediaToolbar.Slot />
 						{ typeof children === 'function'
 							? children( { onClose } )
 							: children }

--- a/packages/block-editor/src/components/plugin-media-toolbar/index.js
+++ b/packages/block-editor/src/components/plugin-media-toolbar/index.js
@@ -1,0 +1,62 @@
+/**
+ * Defines as extensibility slot for the MediaReplaceFlow component used by Image & Cover blocks.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { createSlotFill, MenuItem } from '@wordpress/components';
+
+const { Fill, Slot } = createSlotFill( 'PluginMediaToolbar' );
+
+/**
+ * Renders provided option as a menu item in the block toolbar for image and cover blocks.
+ *
+ * @param {Object}                props             Component props.
+ * @param {string}                [props.className] Class name to be applied to the menu item.
+ * @param {WPBlockTypeIconRender} [props.icon]      Optional icon to be rendered next to the menu item.
+ * @param {Function}              [props.onClick]   Optional click handler for the menu item.
+ * @param {Element}               props.children    The content of the menu item.
+ *
+ * @example
+ * ```jsx
+ * // Using ESNext syntax
+ * import { __ } from '@wordpress/i18n';
+ * import { share } from "@wordpress/icons";
+ * import { PluginMediaToolbar } from '@wordpress/block-editor';
+ *
+ * const MyPluginMediaToolbar = () => (
+ * 	<PluginMediaToolbar
+ * 		className="my-plugin-media-toolbar"
+ * 		icon={ share }
+ * 		onClick={ () => console.log( 'Extended Menu clicked!' ) }
+ * 	>
+ *         { __( 'Extended Menu' ) }
+ * 	</PluginMediaToolbar>
+ * );
+ * ```
+ *
+ * @return {Component} The rendered menu item.
+ */
+const PluginMediaToolbar = ( {
+	children,
+	className,
+	icon,
+	onClick,
+	...props
+} ) => (
+	<Fill>
+		<MenuItem
+			className={ className }
+			icon={ icon }
+			onClick={ onClick }
+			{ ...props }
+		>
+			{ children }
+		</MenuItem>
+	</Fill>
+);
+
+PluginMediaToolbar.Slot = Slot;
+
+export default PluginMediaToolbar;

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -22,7 +22,7 @@ import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
 
 const meta: Meta< typeof Menu > = {
-	title: 'Components (Experimental)/Menu',
+	title: 'Components (Experimental)/Actions/Menu',
 	component: Menu,
 	subcomponents: {
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Allows extensibility for the Media Toolbar Dropdown for Image and Cover Blocks

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/66575

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Create a `MenuItem Slotfill` and inject its `Slot` into `MediaReplaceFlow` component
- Allow `Slotfill` to be imported from `@wordpress/block-editor`

## Testing Instructions
```jsx
import { registerPlugin } from "@wordpress/plugins";
import { PluginMediaToolbar } from "@wordpress/block-editor";
import { share } from "@wordpress/icons";

const ExtendToolbar = () => (
	<PluginMediaToolbar icon={share} onClick={() => console.log("menu-extended")}>
		Extend Menu
	</PluginMediaToolbar>
);

registerPlugin("extend-toolbar-test", {
	render: ExtendToolbar,
});
```

## Screenshots or screencast <!-- if applicable -->
| Cover Block | Image Block |
| --- | --- |
| <img width="636" alt="Screenshot 2024-11-08 at 2 12 37 PM" src="https://github.com/user-attachments/assets/2c89b52c-99ea-47be-854c-2eef41e5e295"> | <img width="635" alt="Screenshot 2024-11-08 at 2 12 28 PM" src="https://github.com/user-attachments/assets/7f002f13-6b9b-46c5-9e6d-d87196b7ea99"> |


