### PR TITLE
Site Hub: Fixed navigation redirect on mobile devices for classic themes

### DIFF
--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -121,17 +121,27 @@ export const SiteHubMobile = memo(
 		const history = useHistory();
 		const { navigate } = useContext( SidebarNavigationContext );
 
-		const { homeUrl, siteTitle } = useSelect( ( select ) => {
-			const { getEntityRecord } = select( coreStore );
-			const _site = getEntityRecord( 'root', 'site' );
-			return {
-				homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
-				siteTitle:
-					! _site?.title && !! _site?.url
-						? filterURLForDisplay( _site?.url )
-						: _site?.title,
-			};
-		}, [] );
+		const { dashboardLink, isBlockTheme, homeUrl, siteTitle } = useSelect(
+			( select ) => {
+				const { getSettings } = unlock( select( editSiteStore ) );
+
+				const { getEntityRecord, getCurrentTheme } =
+					select( coreStore );
+				const _site = getEntityRecord( 'root', 'site' );
+				return {
+					dashboardLink:
+						getSettings().__experimentalDashboardLink ||
+						'index.php',
+					isBlockTheme: getCurrentTheme()?.is_block_theme ?? false,
+					homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
+					siteTitle:
+						! _site?.title && !! _site?.url
+							? filterURLForDisplay( _site?.url )
+							: _site?.title,
+				};
+			},
+			[]
+		);
 		const { open: openCommandCenter } = useDispatch( commandsStore );
 
 		return (
@@ -148,16 +158,23 @@ export const SiteHubMobile = memo(
 						<Button
 							__next40pxDefaultSize
 							ref={ ref }
-							label={ __( 'Go to Site Editor' ) }
 							className="edit-site-layout__view-mode-toggle"
 							style={ {
 								transform: 'scale(0.5)',
 								borderRadius: 4,
 							} }
-							onClick={ () => {
-								history.push( {} );
-								navigate( 'back' );
-							} }
+							{ ...( dashboardLink && ! isBlockTheme
+								? {
+										href: dashboardLink,
+										label: __( 'Go to the Dashboard' ),
+								  }
+								: {
+										onClick: () => {
+											history.push( {} );
+											navigate( 'back' );
+										},
+										label: __( 'Go to Site Editor' ),
+								  } ) }
 						>
 							<SiteIcon className="edit-site-layout__view-mode-toggle-icon" />
 						</Button>

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -163,7 +163,7 @@ export const SiteHubMobile = memo(
 								transform: 'scale(0.5)',
 								borderRadius: 4,
 							} }
-							{ ...( dashboardLink && ! isBlockTheme
+							{ ...( ! isBlockTheme
 								? {
 										href: dashboardLink,
 										label: __( 'Go to the Dashboard' ),

--- a/packages/edit-site/src/components/site-hub/index.js
+++ b/packages/edit-site/src/components/site-hub/index.js
@@ -132,7 +132,7 @@ export const SiteHubMobile = memo(
 					dashboardLink:
 						getSettings().__experimentalDashboardLink ||
 						'index.php',
-					isBlockTheme: getCurrentTheme()?.is_block_theme ?? false,
+					isBlockTheme: getCurrentTheme()?.is_block_theme,
 					homeUrl: getEntityRecord( 'root', '__unstableBase' )?.home,
 					siteTitle:
 						! _site?.title && !! _site?.url


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Resolves: #66844 

## What?
The PR addresses a UI bug that doesn't let the users get redirected to the dashboard from mobile devices on classic themes.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
1. The user would otherwise need to double-click on the site logo from mobile devices to navigate to the dashboard page.
2. The PR retains the functionality to open the Design panel on the new theme and retains the functionality to navigate to the dashboard from mobile devices in classic themes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I've used the dashboard link and a condition to determine if the block theme is activated or not and based on that am rendering onClick and href attributes of the button which can then redirect the user to the Dashboard if using the classic theme or can open the Design panel when using the Block Theme.

## Testing Instructions
1. Open WordPress 6.6+ on a mobile device, OR on desktop, shrink the viewport to 728px width or less.
2. Activate a classic theme, such as twentytwenty.
3. Navigate to Appearance > Patterns.
3. Inspect the site icon (typically the WordPress "W") in the upper left, and observe that it is the "Go to Site Editor" button (via aria-label attribute).
4. Click the site icon and observe that the left site editor panel opens.


https://github.com/user-attachments/assets/b0138d47-518c-49d6-ac03-e57b2351e679


