### PR TITLE
Resolve search block button text overlapping issue.

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -59,6 +59,8 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		flex-shrink: 0;
 		max-width: 100%;
 		box-sizing: border-box;
+		display: flex;
+		justify-content: center;
 	}
 
 	.wp-block-search__inside-wrapper {

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -58,11 +58,7 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 		// Prevent unintended text wrapping.
 		flex-shrink: 0;
 		max-width: 100%;
-	}
-
-	// Ensure minimum input field width in small viewports.
-	.wp-block-search__button[aria-expanded="true"] {
-		max-width: calc(100% - 100px);
+		box-sizing: border-box;
 	}
 
 	.wp-block-search__inside-wrapper {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR addresses an issue with the "Search Block" where the button text overlaps when the "Change button position" is set to "Button Only" and the block width is adjusted to 25% in the block settings.

https://github.com/WordPress/gutenberg/issues/66852
https://github.com/WordPress/gutenberg/issues/66871

## Why?
This PR is necessary to improve the display and functionality of the Search Block when specific settings are applied. Currently, setting the button position to "Button Only" and resizing the block width to 25% causes the button text to overflow, resulting in an inconsistent and undesirable UI.

## How?
The PR resolves the issue by removing specific CSS styling that contributed to the overlapping of the button text. The removed styles were causing the button to not resize correctly within the limited width of the block.

## Testing Instructions
1. Open a post or page.
2. Insert a Search Block.
3. Set the "Button Position" to "Button Only" in the block settings.
4. Change the block width to 25%.
5. Verify that the button text no longer overlaps and that it adjusts correctly within the resized block.

### Testing Instructions for Keyboard
1. Follow the steps above to set up the Search Block.
2. Use the keyboard to navigate to and interact with the button.
3. Ensure that the button text is visible and accessible, and no overlapping occurs when interacting with it.

## Screenshots or screencast

### Frontend in desktop Screen

| **Before**                                                                                                     | **After**                                                                                                   |
|----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| ![Tablet Before](https://github.com/user-attachments/assets/3da52cae-ebe4-49b6-bdda-d4edd0b06c4c)             | ![Tablet After](https://github.com/user-attachments/assets/cade99a0-9bb9-480e-a047-5931d0d49937)           |

### Editor in Mobile Screen

| **Before**                                                                                                     | **After**                                                                                                   |
|----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| ![Mobile Before](https://github.com/user-attachments/assets/7010ec3e-a944-47f0-88d3-f59e03f250ec)             | ![Mobile After](https://github.com/user-attachments/assets/aeeb4ca9-d25b-43c8-9f0d-8e490a3657a7)           |

### Frontend in Mobile Screen

| **Before**                                                                                                     | **After**                                                                                                   |
|----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
| ![Desktop Before](https://github.com/user-attachments/assets/a6e7e7a8-be16-4f3a-bd15-84b466bbdc33)            | ![Desktop After](https://github.com/user-attachments/assets/74e87b13-d8dc-4dac-8240-39e149070014)          |
