### PR TITLE
Interactivity API: fix property modification from inherited context two or more levels above

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -813,7 +813,7 @@ function block_core_navigation_add_directives_to_submenu( $tags, $block_attribut
 	) ) {
 		// Add directives to the parent `<li>`.
 		$tags->set_attribute( 'data-wp-interactive', 'core/navigation' );
-		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu" }' );
+		$tags->set_attribute( 'data-wp-context', '{ "submenuOpenedBy": { "click": false, "hover": false, "focus": false }, "type": "submenu", "modal": null }' );
 		$tags->set_attribute( 'data-wp-watch', 'callbacks.initMenu' );
 		$tags->set_attribute( 'data-wp-on--focusout', 'actions.handleMenuFocusout' );
 		$tags->set_attribute( 'data-wp-on--keydown', 'actions.handleMenuKeydown' );

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix property modification from inherited context two or more levels above ([#66872](https://github.com/WordPress/gutenberg/pull/66872)).
+
 ## 6.11.0 (2024-10-30)
 
 ### Bug Fixes

--- a/packages/interactivity/src/proxies/context.ts
+++ b/packages/interactivity/src/proxies/context.ts
@@ -38,6 +38,9 @@ const contextHandlers: ProxyHandler< object > = {
 	getOwnPropertyDescriptor: ( target, key ) =>
 		descriptor( target, key ) ||
 		descriptor( contextObjectToFallback.get( target ), key ),
+	has: ( target, key ) =>
+		Reflect.has( target, key ) ||
+		Reflect.has( contextObjectToFallback.get( target ), key ),
 };
 
 /**

--- a/packages/interactivity/src/proxies/test/context-proxy.ts
+++ b/packages/interactivity/src/proxies/test/context-proxy.ts
@@ -137,6 +137,24 @@ describe( 'Interactivity API', () => {
 				expect( context.a ).toBe( 2 );
 				expect( state.a ).toBe( 2 );
 			} );
+
+			it( "should modify props inherited from fallback's ancestors", () => {
+				const ancestor: any = proxifyContext(
+					{ ancestorProp: 'ancestor' },
+					{}
+				);
+				const fallback: any = proxifyContext(
+					{ fallbackProp: 'fallback' },
+					ancestor
+				);
+				const context: any = proxifyContext( {}, fallback );
+
+				context.ancestorProp = 'modified';
+
+				expect( context.ancestorProp ).toBe( 'modified' );
+				expect( fallback.ancestorProp ).toBe( 'modified' );
+				expect( ancestor.ancestorProp ).toBe( 'modified' );
+			} );
 		} );
 
 		describe( 'computations', () => {


### PR DESCRIPTION
## What?

The Interactivity API context can be nested, and inherited properties are supposed to be modified in the contexts where they are defined. This was not the case for properties inherited from contexts defined two or more levels above.

More info at https://github.com/WordPress/gutenberg/issues/65623#issuecomment-2464519158.

Fixes #65623.

This PR also fixes a bug in the Navigation block that seems related to the bug fix; see https://github.com/WordPress/gutenberg/pull/66872#issuecomment-2470585837.

## How?

Applying the proposed fix mentioned in https://github.com/WordPress/gutenberg/issues/65623#issuecomment-2464560001.

## Testing Instructions

You can follow the "Step-by-step reproduction instructions" at https://github.com/WordPress/gutenberg/issues/65623#issue-2546194860 to reproduce the issue and check it disappears with the bug fix.

I've added unit tests to ensure the issue has been addressed and prevent it from happening again.