### PR TITLE
Fix TypeError when duplicating uncategorized theme patterns

### DIFF
--- a/packages/patterns/src/components/duplicate-pattern-modal.js
+++ b/packages/patterns/src/components/duplicate-pattern-modal.js
@@ -15,13 +15,11 @@ import { PATTERN_SYNC_TYPES, PATTERN_TYPES } from '../constants';
 function getTermLabels( pattern, categories ) {
 	// Theme patterns rely on core pattern categories.
 	if ( pattern.type !== PATTERN_TYPES.user ) {
-		return (
-			categories.core
-				?.filter( ( category ) =>
-					pattern.categories?.includes( category.name )
-				)
-				.map( ( category ) => category.label ) || []
-		);
+		return categories.core
+			?.filter( ( category ) =>
+				pattern.categories?.includes( category.name )
+			)
+			.map( ( category ) => category.label );
 	}
 
 	return categories.user

--- a/packages/patterns/src/components/duplicate-pattern-modal.js
+++ b/packages/patterns/src/components/duplicate-pattern-modal.js
@@ -15,11 +15,13 @@ import { PATTERN_SYNC_TYPES, PATTERN_TYPES } from '../constants';
 function getTermLabels( pattern, categories ) {
 	// Theme patterns rely on core pattern categories.
 	if ( pattern.type !== PATTERN_TYPES.user ) {
-		return categories.core
-			?.filter( ( category ) =>
-				pattern.categories.includes( category.name )
-			)
-			.map( ( category ) => category.label );
+		return (
+			categories.core
+				?.filter( ( category ) =>
+					pattern.categories?.includes( category.name )
+				)
+				.map( ( category ) => category.label ) || []
+		);
 	}
 
 	return categories.user


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What Why & How
<!-- In a few words, what is the PR actually doing? -->
When a pattern is duplicated, there is a modal with an input field that contains the labels of the pattern categories:
the information about the category is passed on to the new pattern.

The function that gets the labels compares the category from the theme pattern with the existing registered pattern categories, to make sure that the category exists and is displayed with the correct label.

However, the code did not take into account that theme patterns can be registered without the optional `categories` parameter.
This PR makes a small change to the filter and mapping using optional chaining, to avoid a TypeError when the `categories` parameter is not used.

Closes https://github.com/WordPress/gutenberg/issues/66888

## Testing Instructions
Activate a theme that registers a pattern without the `categories` parameter. This can be a classic theme or a block theme, for example Twenty Twenty-Five.
Open the Patterns screen from Appearance > Patterns or from Appearance > Editor > Patterns.
Locate the pattern that does not have a category.
Select the option to duplicate the pattern.
Confirm that the modal with the information about the duplicated pattern opens and that there are no JavaScript errors in the browser console.
Click the button at the bottom of the modal to duplicate the pattern. Confirm that there are no issues related to the category of the new pattern.

Now, select a different pattern that has a single category or multiple categories, and duplicate it.
Confirm that the category labels show correctly in the modal and that there are no new issues/ regressions.
Click the button at the bottom of the modal to duplicate the pattern. Confirm that there are no issues related to the category of the new pattern.


