### PR TITLE
DataViews Fields API: default getValueFromId supports nested objects

### DIFF
--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -11,6 +11,22 @@ import type {
 import { getControl } from './dataform-controls';
 import DataFormCombinedEdit from './components/dataform-combined-edit';
 
+const getValueFromId =
+	( id: string ) =>
+	( { item }: { item: any } ) => {
+		const path = id.split( '.' );
+		let value = item;
+		for ( const segment of path ) {
+			if ( value.hasOwnProperty( segment ) ) {
+				value = value[ segment ];
+			} else {
+				value = undefined;
+			}
+		}
+
+		return value;
+	};
+
 /**
  * Apply default values and normalize the fields config.
  *
@@ -23,8 +39,7 @@ export function normalizeFields< Item >(
 	return fields.map( ( field ) => {
 		const fieldTypeDefinition = getFieldTypeDefinition( field.type );
 
-		const getValue =
-			field.getValue || ( ( { item } ) => ( item as any )[ field.id ] );
+		const getValue = field.getValue || getValueFromId( field.id );
 
 		const sort =
 			field.sort ??

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -14,10 +14,11 @@ import DataFormCombinedEdit from './components/dataform-combined-edit';
 const getValueFromId =
 	( id: string ) =>
 	( { item }: { item: any } ) => {
-		const path = id.split( '.' );
+		const path = id.split( /[\.\[\]]+/ ).filter( Boolean );
+
 		let value = item;
 		for ( const segment of path ) {
-			if ( value.hasOwnProperty( segment ) ) {
+			if ( !! value && value.hasOwnProperty( segment ) ) {
 				value = value[ segment ];
 			} else {
 				value = undefined;

--- a/packages/dataviews/src/normalize-fields.ts
+++ b/packages/dataviews/src/normalize-fields.ts
@@ -14,11 +14,10 @@ import DataFormCombinedEdit from './components/dataform-combined-edit';
 const getValueFromId =
 	( id: string ) =>
 	( { item }: { item: any } ) => {
-		const path = id.split( /[\.\[\]]+/ ).filter( Boolean );
-
+		const path = id.split( '.' );
 		let value = item;
 		for ( const segment of path ) {
-			if ( !! value && value.hasOwnProperty( segment ) ) {
+			if ( value.hasOwnProperty( segment ) ) {
 				value = value[ segment ];
 			} else {
 				value = undefined;

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -29,29 +29,5 @@ describe( 'normalizeFields: default getValue', () => {
 			const result = normalizedFields[ 0 ].getValue( { item } );
 			expect( result ).toBe( 'Feynmann' );
 		} );
-
-		it( 'users[0]', () => {
-			const item = { users: [ 'Feynmann' ] };
-			const fields: Field< {} >[] = [
-				{
-					id: 'users[0]',
-				},
-			];
-			const normalizedFields = normalizeFields( fields );
-			const result = normalizedFields[ 0 ].getValue( { item } );
-			expect( result ).toBe( 'Feynmann' );
-		} );
-
-		it( 'users[0].name', () => {
-			const item = { users: [ { name: 'Feynmann' } ] };
-			const fields: Field< {} >[] = [
-				{
-					id: 'users[0].name',
-				},
-			];
-			const normalizedFields = normalizeFields( fields );
-			const result = normalizedFields[ 0 ].getValue( { item } );
-			expect( result ).toBe( 'Feynmann' );
-		} );
 	} );
 } );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -6,20 +6,20 @@ import type { Field } from '../types';
 
 describe( 'normalizeFields: default getValue', () => {
 	describe( 'getValue from ID', () => {
-		it( 'name', () => {
-			const item = { name: 2 };
+		it( 'user', () => {
+			const item = { user: 'value' };
 			const fields: Field< {} >[] = [
 				{
-					id: 'name',
+					id: 'user',
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].getValue( { item } );
-			expect( result ).toBe( 2 );
+			expect( result ).toBe( 'value' );
 		} );
 
 		it( 'user.name', () => {
-			const item = { user: { name: 'Feynmann' } };
+			const item = { user: { name: 'value' } };
 			const fields: Field< {} >[] = [
 				{
 					id: 'user.name',
@@ -27,7 +27,19 @@ describe( 'normalizeFields: default getValue', () => {
 			];
 			const normalizedFields = normalizeFields( fields );
 			const result = normalizedFields[ 0 ].getValue( { item } );
-			expect( result ).toBe( 'Feynmann' );
+			expect( result ).toBe( 'value' );
+		} );
+
+		it( 'user.name.first', () => {
+			const item = { user: { name: { first: 'value' } } };
+			const fields: Field< {} >[] = [
+				{
+					id: 'user.name.first',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toBe( 'value' );
 		} );
 	} );
 } );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -34,7 +34,7 @@ describe( 'normalizeFields: default getValue', () => {
 			const item = { users: [ 'Feynmann' ] };
 			const fields: Field< {} >[] = [
 				{
-					id: 'user.name',
+					id: 'users[0]',
 				},
 			];
 			const normalizedFields = normalizeFields( fields );
@@ -46,7 +46,7 @@ describe( 'normalizeFields: default getValue', () => {
 			const item = { users: [ { name: 'Feynmann' } ] };
 			const fields: Field< {} >[] = [
 				{
-					id: 'user.name',
+					id: 'users[0].name',
 				},
 			];
 			const normalizedFields = normalizeFields( fields );

--- a/packages/dataviews/src/test/normalize-fields.ts
+++ b/packages/dataviews/src/test/normalize-fields.ts
@@ -1,0 +1,57 @@
+/**
+ * Internal dependencies
+ */
+import { normalizeFields } from '../normalize-fields';
+import type { Field } from '../types';
+
+describe( 'normalizeFields: default getValue', () => {
+	describe( 'getValue from ID', () => {
+		it( 'name', () => {
+			const item = { name: 2 };
+			const fields: Field< {} >[] = [
+				{
+					id: 'name',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toBe( 2 );
+		} );
+
+		it( 'user.name', () => {
+			const item = { user: { name: 'Feynmann' } };
+			const fields: Field< {} >[] = [
+				{
+					id: 'user.name',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toBe( 'Feynmann' );
+		} );
+
+		it( 'users[0]', () => {
+			const item = { users: [ 'Feynmann' ] };
+			const fields: Field< {} >[] = [
+				{
+					id: 'user.name',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toBe( 'Feynmann' );
+		} );
+
+		it( 'users[0].name', () => {
+			const item = { users: [ { name: 'Feynmann' } ] };
+			const fields: Field< {} >[] = [
+				{
+					id: 'user.name',
+				},
+			];
+			const normalizedFields = normalizeFields( fields );
+			const result = normalizedFields[ 0 ].getValue( { item } );
+			expect( result ).toBe( 'Feynmann' );
+		} );
+	} );
+} );


### PR DESCRIPTION
## What?

The Fields API provides a default implementation for the `getValue` function when the field doesn't provide one. It simply uses the field id as the property of the data:

```js
const item = { user: 'value' };
const field = { id: 'user' };
```

While this field doesn't provide a `getValue` function, after normalization, it'll get one such as rendering `field.getValue({ item })` would return `value`.

This PR extends what the default getValue can do by adding support for nested properties. This means `getValue` will return 'value' in this scenario:

```js
const item = { user: { name: 'value' } };
const field = { id: 'user.name' };
```

## Why?

In a recent [workshop we ran about DataViews](https://oandre.gal/talks/dataviews-core-days-roma/), three different groups of people independently thought this would work. This is a strong signal that it'd be a useful feature.

This also enables us to absorb more cases where people won't need to provide a `getValue` function, meaning that in more situations, the Fields API could be declarative (e.g.: ready to be used in the server).

## How?

- Implement tests 63571e8d82bdf7126b1f4106cc51a5bc0a202abb
- Support nested properties 82d32a2c31d23f4de9d29ec212dc115ad4b84b22
- ~Support arrays~ 962684c76759d2622859ee9323743167e7f949b1 (reverted at https://github.com/WordPress/gutenberg/pull/66890/commits/7de6e3e2fa5faa37991adc3b6683b5cd04b20864)

## Testing Instructions

Verify unit tests pass. Smoke test the site editor pages that use dataviews (pages, templates, patterns) as well as the storybook.
