### PR TITLE
Feature: Rename "Edit site" to "Design" and make it consistently visible in the admin bar

### DIFF
--- a/lib/compat/wordpress-6.7/admin-bar.php
+++ b/lib/compat/wordpress-6.7/admin-bar.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Changes to the WordPress admin bar.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Adds the "Design" link to the Toolbar.
+ *
+ * @since 6.7.0
+ *
+ * @param WP_Admin_Bar $wp_admin_bar The WP_Admin_Bar instance.
+ */
+function gutenberg_admin_bar_design_menu( $wp_admin_bar ) {
+
+	// Don't show if a block theme is not activated.
+	if ( ! wp_is_block_theme() ) {
+		return;
+	}
+
+	// Don't show for users who can't edit theme options.
+	if ( ! current_user_can( 'edit_theme_options' ) ) {
+		return;
+	}
+
+	$wp_admin_bar->add_node(
+		array(
+			'id'    => 'site-editor',
+			'title' => __( 'Edit site' ),
+			'href'  => admin_url( 'site-editor.php' ),
+		)
+	);
+}
+remove_action( 'admin_bar_menu', 'wp_admin_bar_edit_site_menu', 42 );
+add_action( 'admin_bar_menu', 'gutenberg_admin_bar_design_menu', 43 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -108,6 +108,7 @@ require __DIR__ . '/compat/wordpress-6.6/option.php';
 require __DIR__ . '/compat/wordpress-6.6/post.php';
 
 // WordPress 6.7 compat.
+require __DIR__ . '/compat/wordpress-6.7/admin-bar.php';
 require __DIR__ . '/compat/wordpress-6.7/block-templates.php';
 require __DIR__ . '/compat/wordpress-6.7/blocks.php';
 require __DIR__ . '/compat/wordpress-6.7/block-bindings.php';


### PR DESCRIPTION


## What?
-  Rename "Edit site" to "Design" 
- Make it consistently visible in the admin (including admin and multisite admin)
- Consistently redirect to the site editor main view.

## Why?
Fixes: #63785 
![Screenshot 2024-11-10 at 21 17 33](https://github.com/user-attachments/assets/d896fc7b-79ef-4a44-982b-c7c41ece505a)

![Screenshot 2024-11-10 at 21 17 41](https://github.com/user-attachments/assets/498ad326-14cd-44a6-874b-bf966201d6fe)

