### PR TITLE
Style book: reduce margin selector specificity so that it doesn't override global block styles

### DIFF
--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -254,11 +254,10 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	.edit-site-style-book__example-preview .block-list-appender {
 		display: none;
 	}
-
-	.edit-site-style-book__example-preview .is-root-container > .wp-block:first-child {
+	:where(.is-root-container > .wp-block:first-child) {
 		margin-top: 0;
 	}
-	.edit-site-style-book__example-preview .is-root-container > .wp-block:last-child {
+	:where(.is-root-container > .wp-block:last-child) {
 		margin-bottom: 0;
 	}
 `;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How? Why?

Fixes the margin issue reported in

- https://github.com/WordPress/gutenberg/issues/57297

Reducing specificity of style book margin rules so that they don't override user-defined styles.


## Testing Instructions
1. Fire up the style book
2. Edit the styles for any block that has top/bottom margin controls, e.g., gallery, separator
3. Ensure that the margin values are not overridden and are reflected in the style book preview


### Before


https://github.com/user-attachments/assets/6b004efd-e757-415c-b479-e7a100d39091

### After


https://github.com/user-attachments/assets/6b46d461-84f2-4add-872c-29ab4f50dcc6




