### PR TITLE
Section Styles: Fix insecure properties removal for inner block types and elements

### DIFF
--- a/backport-changelog/6.8/7759.md
+++ b/backport-changelog/6.8/7759.md
@@ -1,0 +1,4 @@
+https://github.com/WordPress/wordpress-develop/pull/7759
+
+* https://github.com/WordPress/gutenberg/pull/66896
+

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3565,26 +3565,12 @@ class WP_Theme_JSON_Gutenberg {
 
 					$variation_output = static::remove_insecure_styles( $variation_input );
 
-					// Process a variation's elements and element pseudo selector styles.
+					if ( isset( $variation_input['blocks'] ) ) {
+						$variation_output['blocks'] = static::remove_insecure_inner_block_styles( $variation_input['blocks'] );
+					}
+
 					if ( isset( $variation_input['elements'] ) ) {
-						foreach ( $valid_element_names as $element_name ) {
-							$element_input = $variation_input['elements'][ $element_name ] ?? null;
-							if ( $element_input ) {
-								$element_output = static::remove_insecure_styles( $element_input );
-
-								if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ] ) ) {
-									foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ] as $pseudo_selector ) {
-										if ( isset( $element_input[ $pseudo_selector ] ) ) {
-											$element_output[ $pseudo_selector ] = static::remove_insecure_styles( $element_input[ $pseudo_selector ] );
-										}
-									}
-								}
-
-								if ( ! empty( $element_output ) ) {
-									_wp_array_set( $variation_output, array( 'elements', $element_name ), $element_output );
-								}
-							}
-						}
+						$variation_output['elements'] = static::remove_insecure_element_styles( $variation_input['elements'] );
 					}
 
 					if ( ! empty( $variation_output ) ) {
@@ -3620,6 +3606,59 @@ class WP_Theme_JSON_Gutenberg {
 		}
 
 		return $theme_json;
+	}
+
+	/**
+	 * Remove insecure element styles within a variation or block.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param array $elements            The elements to process.
+	 * @return array The sanitized elements styles.
+	 */
+	protected static function remove_insecure_element_styles( $elements ) {
+		$sanitized           = array();
+		$valid_element_names = array_keys( static::ELEMENTS );
+
+		foreach ( $valid_element_names as $element_name ) {
+			$element_input = $elements[ $element_name ] ?? null;
+			if ( $element_input ) {
+				$element_output = static::remove_insecure_styles( $element_input );
+
+				if ( isset( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ] ) ) {
+					foreach ( static::VALID_ELEMENT_PSEUDO_SELECTORS[ $element_name ] as $pseudo_selector ) {
+						if ( isset( $element_input[ $pseudo_selector ] ) ) {
+							$element_output[ $pseudo_selector ] = static::remove_insecure_styles( $element_input[ $pseudo_selector ] );
+						}
+					}
+				}
+
+				$sanitized[ $element_name ] = $element_output;
+			}
+		}
+		return $sanitized;
+	}
+
+	/**
+	 * Remove insecure styles from inner blocks and their elements.
+	 *
+	 * @since 6.8.0
+	 *
+	 * @param array $blocks The block styles to process.
+	 * @return array Sanitized block type styles.
+	 */
+	protected static function remove_insecure_inner_block_styles( $blocks ) {
+		$sanitized = array();
+		foreach ( $blocks as $block_type => $block_input ) {
+			$block_output = static::remove_insecure_styles( $block_input );
+
+			if ( isset( $block_input['elements'] ) ) {
+				$block_output['elements'] = static::remove_insecure_element_styles( $block_input['elements'] );
+			}
+
+			$sanitized[ $block_type ] = $block_output;
+		}
+		return $sanitized;
 	}
 
 	/**

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4559,7 +4559,6 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
-
 	/**
 	 * Tests generating the spacing presets array based on the spacing scale provided.
 	 *

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4387,6 +4387,179 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		$this->assertSameSetsWithIndex( $expected, $actual );
 	}
 
+	public function test_block_style_variations_with_inner_blocks_and_elements() {
+		wp_set_current_user( static::$administrator_id );
+		gutenberg_register_block_style(
+			array( 'core/group' ),
+			array(
+				'name'  => 'custom-group',
+				'label' => 'Custom Group',
+			)
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/group' => array(
+						'color'      => array(
+							'background' => 'blue',
+						),
+						'variations' => array(
+							'custom-group' => array(
+								'color'    => array(
+									'background' => 'purple',
+								),
+								'blocks'   => array(
+									'core/paragraph' => array(
+										'color'    => array(
+											'text' => 'red',
+										),
+										'elements' => array(
+											'link' => array(
+												'color'  => array(
+													'text' => 'blue',
+												),
+												':hover' => array(
+													'color' => array(
+														'text' => 'green',
+													),
+												),
+											),
+										),
+									),
+									'core/heading'   => array(
+										'typography' => array(
+											'fontSize' => '24px',
+										),
+									),
+								),
+								'elements' => array(
+									'link' => array(
+										'color'  => array(
+											'text' => 'yellow',
+										),
+										':hover' => array(
+											'color' => array(
+												'text' => 'orange',
+											),
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $expected );
+
+		// The sanitization processes blocks in a specific order which might differ to the theme.json input.
+		$this->assertEqualsCanonicalizing(
+			$expected,
+			$actual,
+			'Block style variations data does not match when inner blocks or element styles present'
+		);
+	}
+
+	public function test_block_style_variations_with_invalid_inner_block_or_element_styles() {
+		wp_set_current_user( static::$administrator_id );
+		gutenberg_register_block_style(
+			array( 'core/group' ),
+			array(
+				'name'  => 'custom-group',
+				'label' => 'Custom Group',
+			)
+		);
+
+		$input = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/group' => array(
+						'variations' => array(
+							'custom-group' => array(
+								'blocks'   => array(
+									'core/paragraph' => array(
+										'color'      => array(
+											'text' => 'red',
+										),
+										'typography' => array(
+											'fontSize' => 'alert(1)', // Should be removed.
+										),
+										'elements'   => array(
+											'link' => array(
+												'color' => array(
+													'text' => 'blue',
+												),
+												'css'   => 'unsafe-value', // Should be removed.
+											),
+										),
+										'custom'     => 'unsafe-value', // Should be removed.
+									),
+								),
+								'elements' => array(
+									'link' => array(
+										'color'      => array(
+											'text' => 'yellow',
+										),
+										'javascript' => 'alert(1)', // Should be removed.
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$expected = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'blocks' => array(
+					'core/group' => array(
+						'variations' => array(
+							'custom-group' => array(
+								'blocks'   => array(
+									'core/paragraph' => array(
+										'color'    => array(
+											'text' => 'red',
+										),
+										'elements' => array(
+											'link' => array(
+												'color' => array(
+													'text' => 'blue',
+												),
+											),
+										),
+									),
+								),
+								'elements' => array(
+									'link' => array(
+										'color' => array(
+											'text' => 'yellow',
+										),
+									),
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$actual = WP_Theme_JSON_Gutenberg::remove_insecure_properties( $input );
+
+		// The sanitization processes blocks in a specific order which might differ to the theme.json input.
+		$this->assertEqualsCanonicalizing(
+			$expected,
+			$actual,
+			'Insecure properties were not removed from block style variation inner block types or elements'
+		);
+	}
+
+
 	/**
 	 * Tests generating the spacing presets array based on the spacing scale provided.
 	 *


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/66799

## What?

Fixes an issue where block style variations containing inner block type and element styles would have those inner styles stripped when the user attempting to save Global Styles does not have the `unfiltered_html` capability.

## Why?

The bug prevents proper saving of Global Styles with block style variations containing inner block/element styles when on multisite setups. This leads to unexpected styling when switching style variations etc.

## How?

Extends the `remove_insecure_properties` function to process the inner block type styles for variations including their nested element styles.

## Testing Instructions

### Setup

To test this fix, we need a theme that defines block style variations with inner block type styles. The easiest approach is to use an existing theme that has already done all that config. The catch with the below theme is that it uses `color-mix` styles that needs to be added to the allowed safe css atts (this is being handled separately).

1. Create a local multisite install. 
    - Alternatively, set up a user that doesn't have `unfiltered_html` caps but can access the site editor. See [linked issue](https://github.com/WordPress/gutenberg/issues/66799) for options.
2. Install and activate the [Assembler theme](https://github.com/Automattic/themes/tree/trunk/assembler).
3. Create a page or template using the following block markup:
<details>
<summary>Block markup with section style applied</summary>

```html
<!-- wp:group {"tagName":"main","metadata":{"name":"Main"},"className":"is-style-section-1","style":{"spacing":{"blockGap":"0","margin":{"top":"0"}}},"layout":{"type":"default"}} -->
<main class="wp-block-group is-style-section-1" style="margin-top:0"><!-- wp:cover {"url":"https://richptabor64.wordpress.com/wp-content/uploads/2024/11/art.png","id":13691,"alt":"art","dimRatio":50,"customOverlayColor":"#9cb1ab","isUserOverlayColor":false,"className":"alignfull is-style-default","style":{"spacing":{"padding":{"right":"var:preset|spacing|50","left":"var:preset|spacing|50"},"margin":{"top":"0","bottom":"0"}},"color":{"text":"#000000"}},"layout":{"type":"default"}} -->
<div class="wp-block-cover alignfull is-style-default has-text-color" style="color:#000000;margin-top:0;margin-bottom:0;padding-right:var(--wp--preset--spacing--50);padding-left:var(--wp--preset--spacing--50)"><img class="wp-block-cover__image-background wp-image-13691" alt="art" src="https://richptabor64.wordpress.com/wp-content/uploads/2024/11/art.png" data-object-fit="cover" /><span aria-hidden="true" class="wp-block-cover__background has-background-dim" style="background-color:#9cb1ab"></span><div class="wp-block-cover__inner-container"><!-- wp:spacer {"height":"var:preset|spacing|70"} -->
<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:group {"align":"wide","style":{"spacing":{"blockGap":"0"}},"layout":{"type":"constrained","contentSize":"1200px"}} -->
<div class="wp-block-group alignwide"><!-- wp:heading {"textAlign":"center","className":"text-balance","style":{"spacing":{"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}},"fontSize":"xx-large"} -->
<h2 class="wp-block-heading has-text-align-center text-balance has-xx-large-font-size" style="margin-top:0;margin-right:0;margin-bottom:0;margin-left:0">Experience Abstract Art</h2>
<!-- /wp:heading -->

<!-- wp:spacer {"height":"var:preset|spacing|40"} -->
<div style="height:var(--wp--preset--spacing--40)" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer -->

<!-- wp:buttons {"layout":{"type":"flex","flexWrap":"wrap","justifyContent":"center"}} -->
<div class="wp-block-buttons"><!-- wp:button {"width":50} -->
<div class="wp-block-button has-custom-width wp-block-button__width-50"><a class="wp-block-button__link wp-element-button" href="#contact-section">Get in touch</a></div>
<!-- /wp:button --></div>
<!-- /wp:buttons --></div>
<!-- /wp:group -->

<!-- wp:separator -->
<hr class="wp-block-separator has-alpha-channel-opacity" />
<!-- /wp:separator -->

<!-- wp:spacer {"height":"var:preset|spacing|70"} -->
<div style="height:var(--wp--preset--spacing--70)" aria-hidden="true" class="wp-block-spacer"></div>
<!-- /wp:spacer --></div></div>
<!-- /wp:cover --></main>
<!-- /wp:group -->
```
</details>

4. Update `kses.php` in your local WP instance to [allow `color-mix` style values](https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/kses.php?plain=1#L2658).

```diff
diff --git a/src/wp-includes/kses.php b/src/wp-includes/kses.php
index cd30d845f8..e64b5a615a 100644
--- a/src/wp-includes/kses.php
+++ b/src/wp-includes/kses.php
@@ -2655,7 +2655,7 @@ function safecss_filter_attr( $css, $deprecated = '' ) {
 			 * Nested functions and parentheses are also removed, so long as the parentheses are balanced.
 			 */
 			$css_test_string = preg_replace(
-				'/\b(?:var|calc|min|max|minmax|clamp|repeat)(\((?:[^()]|(?1))*\))/',
+				'/\b(?:var|calc|min|max|minmax|clamp|repeat|color-mix)(\((?:[^()]|(?1))*\))/',
 				'',
 				$css_test_string
 			);

```

### Steps

#### Easy

1. Make sure the theme.json unit tests are passing: 
    - `npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test`
    
#### Manual

On trunk:

1. Login with a user lacking the `unfiltered_html` caps and visit the site editor
3. Open the Global Styles sidebar panel and choose Browse Styles
4. Select the Noir style variation
5. Save the changes
6. Confirm the button elements hover styles match between editor and frontend
7. Now inspect the separator below the button on the frontend. Note the lack of section styles.
    - <img width="661" alt="Screenshot 2024-11-11 at 1 10 08 pm" src="https://github.com/user-attachments/assets/05b8242d-0272-49fc-a47f-8ccb80c65ab7">

This PR:

1. Reset global styles
2. Repeat the steps for trunk
3. Note that the separator's styles on the frontend now include the correct section style
    - <img width="644" alt="Screenshot 2024-11-11 at 1 12 05 pm" src="https://github.com/user-attachments/assets/66f87722-ec30-41b7-80bc-86018f3d3d2f">

4. Bonus points: If the unit tests aren't enough; add some debugging to log the variation input/output in `remove_insecure_properties` and validate the expected output is shown in error logs when attempting to save Global Styles.

<details>
<summary>Quick and dirty debug log diff</summary>

```diff
diff --git a/lib/class-wp-theme-json-gutenberg.php b/lib/class-wp-theme-json-gutenberg.php
index 7127628b63..00c64ec06e 100644
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -3563,6 +3563,10 @@ class WP_Theme_JSON_Gutenberg {
 						continue;
 					}
 
+					$debug_variations = true;
+					if ( $debug_variations && $metadata['name'] === 'core/group' ) {
+						error_log( json_encode( $variation_input, JSON_PRETTY_PRINT ) );
+					}
 					$variation_output = static::remove_insecure_styles( $variation_input );
 
 					if ( isset( $variation_input['blocks'] ) ) {
@@ -3573,6 +3577,11 @@ class WP_Theme_JSON_Gutenberg {
 						$variation_output['elements'] = static::remove_insecure_element_styles( $variation_input['elements'] );
 					}
 
+					if ( $debug_variations && $metadata['name'] === 'core/group' ) {
+						error_log( json_encode( $variation_output, JSON_PRETTY_PRINT ) );
+						exit();
+					}
+
 					if ( ! empty( $variation_output ) ) {
 						_wp_array_set( $sanitized, $variation['path'], $variation_output );
 					}

```
</details>

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="661" alt="Screenshot 2024-11-11 at 1 10 08 pm" src="https://github.com/user-attachments/assets/ad8346ad-a66f-4844-95e9-7b9df29a8127"> | <img width="644" alt="Screenshot 2024-11-11 at 1 12 05 pm" src="https://github.com/user-attachments/assets/8cbf27b1-573a-4bcb-a671-274b2ec32f65"> |

