### PR TITLE
feature: created block transform from paragraph to button

### DIFF
--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -12,6 +12,7 @@ import deprecated from './deprecated';
 import edit from './edit';
 import metadata from './block.json';
 import save from './save';
+import transforms from './transforms';
 
 const { name } = metadata;
 
@@ -32,6 +33,7 @@ export const settings = {
 		...a,
 		text: ( a.text || '' ) + text,
 	} ),
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/button/transforms.js
+++ b/packages/block-library/src/button/transforms.js
@@ -1,0 +1,20 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+
+const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( { content } ) => {
+				return createBlock( 'core/button', {
+					text: content,
+				} );
+			},
+		},
+	],
+};
+
+export default transforms;


### PR DESCRIPTION
## What?
Added block transform from paragraph block to button block.

## Why?
Closes https://github.com/WordPress/gutenberg/issues/66846


## Testing Instructions
1. open site editor and enter any text to paragraph block
2. check paragraph block transform options, you will see button there
3. click on button transform then your paragraph block content will be converted to button block

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4c6871fe-0d93-43ca-a15a-726e1b0c016f

