### PR TITLE
Home Link: Add `border`, `color` and `spacing`

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -369,7 +369,7 @@ Create a link that always points to the homepage of the site. Usually not necess
 -	**Name:** core/home-link
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** border (radius), color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Custom HTML

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -369,7 +369,7 @@ Create a link that always points to the homepage of the site. Usually not necess
 -	**Name:** core/home-link
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** border (radius), color (background, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** border (radius), color (background, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Custom HTML

--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -24,6 +24,25 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
+		"__experimentalBorder": {
+			"color": true,
+			"width": true,
+			"style": true,
+			"radius": true,
+			"__experimentalDefaultControls": {
+				"width": true,
+				"radius": true
+			}
+		},
+		"color": {
+			"text": true,
+			"background": true,
+			"link": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
@@ -39,6 +58,9 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"border": {
+			"radius": true
 		}
 	},
 	"editorStyle": "wp-block-home-link-editor",

--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -35,9 +35,10 @@
 			}
 		},
 		"color": {
-			"text": true,
-			"background": true,
-			"link": true
+			"__experimentalDefaultControls": {
+				"background": true,
+				"text": true
+			}
 		},
 		"spacing": {
 			"padding": true,

--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -29,8 +29,12 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 			[ `has-${ backgroundColor }-background-color` ]: !! backgroundColor,
 		} ),
 		style: {
-			color: style?.color?.text,
-			backgroundColor: style?.color?.background,
+			...( ! attributes?.style?.color?.text && {
+				color: style?.color?.text,
+			} ),
+			...( ! attributes?.style?.color?.background && {
+				backgroundColor: style?.color?.background,
+			} ),
 		},
 	} );
 


### PR DESCRIPTION
Fixes: #66901 
Part of: #43247

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Added the support for Border Radius, Color ( Background, Text ), and Spacing ( Margin and Padding ) to the Home Link Block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It will enhance the customizability of the Home Link Block by letting the users add border-radius, custom colors and spacings.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
block.json corresponding to the Home Link block is updated with above mentioned configurations.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a page.
2. Add a navigation component.
3. Insert a Home Link block inside it.
4. Try customizing the Home Link block.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4a4841be-dc5d-4d9e-b2f2-fda79d95ca8e


