### PR TITLE
Mapping Contextual Commands: Open Styles

### DIFF
--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -332,6 +332,7 @@ export function useCommonCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/open-styles',
 		hook: getGlobalStylesOpenStylesCommands(),
+		context: 'entity-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
Part of [#50407 ](https://github.com/WordPress/gutenberg/issues/50407)

## What?
Command that will be suggested and prioritized when the Command Center is invoked from specific flows (Site Editor)

## Testing Instructions
1. Open the site editor
2. Open the Command Palette (by pressing Cmd + K on Mac).
3. Confirm that the command prompt is showing without any search
4. Also confirm that the "open styles" command is only accessible in the site editor.

## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="open-style-context" src="https://github.com/user-attachments/assets/3ea8eddb-0620-4664-803f-9e21f9dd43a5">
