### PR TITLE
Mapping Contextual Commands: Add Custom CSS

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -240,32 +240,6 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 				} )
 			);
 
-			if (
-				orderedRecords?.length > 0 &&
-				templateType === 'wp_template_part'
-			) {
-				result.push( {
-					name: 'core/edit-site/open-template-parts',
-					label: __( 'Template parts' ),
-					icon: symbolFilled,
-					callback: ( { close } ) => {
-						const args = {
-							postType: 'wp_template_part',
-							categoryId: 'all-parts',
-						};
-						const targetUrl = addQueryArgs(
-							'site-editor.php',
-							args
-						);
-						if ( isSiteEditor ) {
-							history.push( args );
-						} else {
-							document.location = targetUrl;
-						}
-						close();
-					},
-				} );
-			}
 			return result;
 		}, [ canCreateTemplate, isBlockBasedTheme, orderedRecords, history ] );
 
@@ -274,7 +248,53 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 			isLoading,
 		};
 	};
-
+	const getTemplatePartsCommandLoader = () => {
+		function useTemplatePartsCommandLoader() {
+			const history = useHistory();
+			const isSiteEditor = getPath( window.location.href )?.includes( 'site-editor.php' );
+			const { canCreateTemplate } = useSelect(
+				( select ) => ({
+					canCreateTemplate: select( coreStore ).canUser( 'create', {
+						kind: 'postType',
+						name: 'wp_template_part',
+					} ),
+				}),
+				[]
+			);
+	
+			const commands = useMemo(() => {
+				if (!canCreateTemplate) return [];
+	
+				return [
+					{
+						name: 'core/edit-site/open-template-parts',
+						label: __( 'Template parts' ),
+						icon: symbolFilled,
+						callback: ({ close }) => {
+							const args = {
+								postType: 'wp_template_part',
+								categoryId: 'all-parts',
+							};
+							const targetUrl = addQueryArgs( 'site-editor.php', args );
+							if (isSiteEditor) {
+								history.push( args );
+							} else {
+								document.location = targetUrl;
+							}
+							close();
+						},
+					},
+				];
+			}, [ canCreateTemplate, history, isSiteEditor ]);
+	
+			return {
+				commands,
+				isLoading: false,
+			};
+		}
+	
+		return useTemplatePartsCommandLoader;
+	};
 const getSiteEditorBasicNavigationCommands = () =>
 	function useSiteEditorBasicNavigationCommands() {
 		const history = useHistory();
@@ -434,6 +454,11 @@ export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-template-parts',
 		hook: getNavigationCommandLoaderPerTemplate( 'wp_template_part' ),
+	} );
+	useCommandLoader( {
+		name: 'core/edit-site/navigate-template-parts',
+		hook: getTemplatePartsCommandLoader(), 
+		context: 'entity-edit',
 	} );
 	useCommandLoader( {
 		name: 'core/edit-site/basic-navigation',

--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -240,6 +240,32 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 				} )
 			);
 
+			if (
+				orderedRecords?.length > 0 &&
+				templateType === 'wp_template_part'
+			) {
+				result.push( {
+					name: 'core/edit-site/open-template-parts',
+					label: __( 'Template parts' ),
+					icon: symbolFilled,
+					callback: ( { close } ) => {
+						const args = {
+							postType: 'wp_template_part',
+							categoryId: 'all-parts',
+						};
+						const targetUrl = addQueryArgs(
+							'site-editor.php',
+							args
+						);
+						if ( isSiteEditor ) {
+							history.push( args );
+						} else {
+							document.location = targetUrl;
+						}
+						close();
+					},
+				} );
+			}
 			return result;
 		}, [ canCreateTemplate, isBlockBasedTheme, orderedRecords, history ] );
 
@@ -248,53 +274,7 @@ const getNavigationCommandLoaderPerTemplate = ( templateType ) =>
 			isLoading,
 		};
 	};
-	const getTemplatePartsCommandLoader = () => {
-		function useTemplatePartsCommandLoader() {
-			const history = useHistory();
-			const isSiteEditor = getPath( window.location.href )?.includes( 'site-editor.php' );
-			const { canCreateTemplate } = useSelect(
-				( select ) => ({
-					canCreateTemplate: select( coreStore ).canUser( 'create', {
-						kind: 'postType',
-						name: 'wp_template_part',
-					} ),
-				}),
-				[]
-			);
-	
-			const commands = useMemo(() => {
-				if (!canCreateTemplate) return [];
-	
-				return [
-					{
-						name: 'core/edit-site/open-template-parts',
-						label: __( 'Template parts' ),
-						icon: symbolFilled,
-						callback: ({ close }) => {
-							const args = {
-								postType: 'wp_template_part',
-								categoryId: 'all-parts',
-							};
-							const targetUrl = addQueryArgs( 'site-editor.php', args );
-							if (isSiteEditor) {
-								history.push( args );
-							} else {
-								document.location = targetUrl;
-							}
-							close();
-						},
-					},
-				];
-			}, [ canCreateTemplate, history, isSiteEditor ]);
-	
-			return {
-				commands,
-				isLoading: false,
-			};
-		}
-	
-		return useTemplatePartsCommandLoader;
-	};
+
 const getSiteEditorBasicNavigationCommands = () =>
 	function useSiteEditorBasicNavigationCommands() {
 		const history = useHistory();
@@ -454,11 +434,6 @@ export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/navigate-template-parts',
 		hook: getNavigationCommandLoaderPerTemplate( 'wp_template_part' ),
-	} );
-	useCommandLoader( {
-		name: 'core/edit-site/navigate-template-parts',
-		hook: getTemplatePartsCommandLoader(), 
-		context: 'entity-edit',
 	} );
 	useCommandLoader( {
 		name: 'core/edit-site/basic-navigation',

--- a/packages/edit-site/src/hooks/commands/use-common-commands.js
+++ b/packages/edit-site/src/hooks/commands/use-common-commands.js
@@ -347,6 +347,7 @@ export function useCommonCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/open-styles-css',
 		hook: getGlobalStylesOpenCssCommands(),
+		context: 'entity-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/50407

## What?
Command that will be suggested and prioritized when the Command Center is invoked from specific flows (Site Editor)

## Testing Instructions

1. Open the site editor
2. Open the Command Palette (by pressing Cmd + K on Mac).
3. Confirm that the command prompt is showing without any search
4. Also confirm that the "Customize css" command is only accessible in the site editor.

## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="custom-css" src="https://github.com/user-attachments/assets/4c5ce986-3649-4e02-acaf-1e9c0932d4fd">
