### PR TITLE
Fix: Rename 'Details panel' to 'Quick Edit' in Data Views (#66612)

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -412,7 +412,7 @@ export default function PostList( { postType } ) {
 							size="compact"
 							isPressed={ quickEdit }
 							icon={ drawerRight }
-							label={ __( 'Details' ) }
+							label={ __( 'Quick Edit' ) }
 							onClick={ () => {
 								history.push( {
 									...location.params,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Renames "Details panel" to "Quick Edit" in Data Views for improved clarity and consistency.



## Why?
This PR addresses issue #66612 by aligning terminology to be more intuitive for users. The change enhances usability by using familiar terms in WordPress admin panel.


## Testing Instructions

1. Step-by-step reproduce instructions
2. Go to the WordPress admin > Gutenberg > Experiments and enable the 'Quick Edit in DataViews' experiment.
3. Go to the Site editor > Pages.
4. Switch to the Table view or Grid view.
5. In the data views top bar, observe the label of the button to toggle this panel is 'Details'.
6. Open the panel.
7. Observe there's no heading at the top of the panel to communicate what this panel is about.


## Screenshots or screencast <!-- if applicable -->
