### PR TITLE
Fix the search button overflow in the search block

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -33,9 +33,9 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	max-width: 100%;
 	min-width: 220px;
 
-	.wp-block-search__button {
-		padding-left: 18px;
-		padding-right: 18px;
+	button.wp-block-search__button {
+		padding-left: 16px;
+		padding-right: 16px;
 		max-width: 87.5px;
 	}
 }

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -34,9 +34,11 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	min-width: 220px;
 
 	button.wp-block-search__button {
-		padding-left: 16px;
-		padding-right: 16px;
-		max-width: 87.5px;
+		// !important used to forcibly prevent undesired padding of
+		// various different active themes.
+		padding-left: 10px !important;
+		padding-right: 10px !important;
+		max-width: 7vw;
 	}
 }
 

--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -31,6 +31,13 @@ $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 	flex: auto;
 	flex-wrap: nowrap;
 	max-width: 100%;
+	min-width: 220px;
+
+	.wp-block-search__button {
+		padding-left: 18px;
+		padding-right: 18px;
+		max-width: 87.5px;
+	}
 }
 
 .wp-block-search__label {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR addresses the issue of the search button overflow when using `button inside` at `width=25%`.

Closes: #66906

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR is necessary to ensure the UI doesn't break when selecting different editor options.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR resolves the issue by matching the appearance of the block on frontend with that of the appearance in the editor

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Add/Create a post.
2. Insert a Search Block.
3. Set "Button Position" to "button inside".
4. Set the block width to 25%.
5. Verify that the search button's appearance is same as that of the editor on the frontend and the button is contained in the search box.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
Verify button appearance: Use Tab and Shift confirming that the search button looks consistent and is contained within the search box in both the editor and on the frontend.

## Screenshots or screencast <!-- if applicable -->

| Frontend before | Frontend after | Editor |
| -------|----- | -------|
|<img width="210" alt="Screenshot 2024-11-11 at 6 17 16 PM" src="https://github.com/user-attachments/assets/aae1adb7-2e3f-4061-8bd6-eac6a136fe9d">|<img width="235" alt="Screenshot 2024-11-11 at 6 17 38 PM" src="https://github.com/user-attachments/assets/9b407cf4-8c6f-4d78-9e33-d0d233dbe6ab">| <img width="234" alt="Screenshot 2024-11-11 at 6 51 38 PM" src="https://github.com/user-attachments/assets/9df58927-c70c-49a4-b6bc-ed5ac16dfc9a"> |