### PR TITLE
Enhancement : Hooking into command palette commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53400,6 +53400,7 @@
 				"@wordpress/components": "*",
 				"@wordpress/data": "*",
 				"@wordpress/element": "*",
+				"@wordpress/hooks": "4.11.0",
 				"@wordpress/i18n": "*",
 				"@wordpress/icons": "*",
 				"@wordpress/keyboard-shortcuts": "*",

--- a/packages/commands/package.json
+++ b/packages/commands/package.json
@@ -32,6 +32,7 @@
 		"@wordpress/components": "*",
 		"@wordpress/data": "*",
 		"@wordpress/element": "*",
+		"@wordpress/hooks": "4.11.0",
 		"@wordpress/i18n": "*",
 		"@wordpress/icons": "*",
 		"@wordpress/keyboard-shortcuts": "*",

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -26,6 +26,7 @@ import {
 	useShortcut,
 } from '@wordpress/keyboard-shortcuts';
 import { Icon, search as inputIcon } from '@wordpress/icons';
+import { doAction } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -50,7 +51,11 @@ function CommandMenuLoader( { name, search, hook, setLoader, close } ) {
 				<Command.Item
 					key={ command.name }
 					value={ command.searchLabel ?? command.label }
-					onSelect={ () => command.callback( { close } ) }
+					onSelect={ () => {
+						doAction( 'commands.beforeCommandExecution', command );
+						command.callback( { close } );
+						doAction( 'commands.afterCommandExecution', command );
+					} }
 					id={ command.name }
 				>
 					<HStack
@@ -121,7 +126,11 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 				<Command.Item
 					key={ command.name }
 					value={ command.searchLabel ?? command.label }
-					onSelect={ () => command.callback( { close } ) }
+					onSelect={ () => {
+						doAction( 'commands.beforeCommandExecution', command );
+						command.callback( { close } );
+						doAction( 'commands.afterCommandExecution', command );
+					} }
 					id={ command.name }
 				>
 					<HStack


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Allows plugin to execute custom functionality before and after command palette command execution

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/58200

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Create two `doAction` calls : `commands.beforeCommandExecution` & `commands.afterCommandExecution`
- When these actions are hooked into, they receive the `command` executed as an argument in the `callback`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Use the following snippet in a `demo` plugin to execute custom functionality
```jsx
import { addAction } from "@wordpress/hooks";

addAction(
	"commands.beforeCommandExecution",
	"demo",
	(command) => {
		console.log(command);
	}
);

addAction(
	"commands.afterCommandExecution",
	"demo",
	(command) => {
		console.log(command);
	}
);
```

## Screenshots or screencast <!-- if applicable -->
<img width="520" alt="Screenshot 2024-11-11 at 5 27 06 PM" src="https://github.com/user-attachments/assets/f37d59a7-7dfc-420e-b3d2-fb19b37fa519">

