### PR TITLE
Cover: Show DropZone only when dragging withing the block

### DIFF
--- a/packages/block-library/src/cover/editor.scss
+++ b/packages/block-library/src/cover/editor.scss
@@ -107,10 +107,6 @@
 	}
 }
 
-// When uploading background images, show a transparent overlay.
-.wp-block-cover > .components-drop-zone .components-drop-zone__content {
-	opacity: 0.8 !important;
-}
 
 // Remove the parallax fixed background when in the patterns preview panel as it
 // doesn't work with the transforms that are applied to resize the block in that context.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/66764

>The Cover block’s DropZone auto-engages whenever any media is dragged into the editor, regardless of where it’s dragged. The DropZone renders even when media is not being dragged over the Cover block specifically.

Years ago some specific css was [introduced](https://github.com/WordPress/gutenberg/pull/33132) for:
`// When uploading background images, show a transparent overlay.`.

I tested this and didn't see any visual difference in trunk when uploading an image, even without these styles.

## Testing Instructions
1. Drag an image in the editor while having at least one Cover block
2. Observe that the DropZone doesn't seem active (blue) if you are not over the block.




#### Before
https://github.com/user-attachments/assets/04c6c3aa-5a1a-4741-8250-37312fd229f9

#### After
https://github.com/user-attachments/assets/e49aa4d7-441b-486a-802a-4022bb609ac2

