### PR TITLE
Adds Command: Deactivate All Plugins to Command Palette

### DIFF
--- a/backport-changelog/6.8/7775.md
+++ b/backport-changelog/6.8/7775.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7775
+
+* https://github.com/WordPress/gutenberg/pull/66913

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -160,14 +160,14 @@ add_filter( 'register_post_type_args', 'gutenberg_register_post_type_args_for_wp
 // Add the custom REST API endpoint to deactivate all plugins.
 add_action(
 	'rest_api_init',
-	function() {
+	function () {
 		register_rest_route(
 			'custom/v1',
 			'/deactivate-plugins',
 			array(
 				'methods'             => 'POST',
 				'callback'            => 'deactivate_all_plugins',
-				'permission_callback' => function() {
+				'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
 				},
 			)
@@ -175,28 +175,43 @@ add_action(
 	}
 );
 
-/**
- * Deactivates all plugins on the WordPress site.
- *
- * This function ensures that only users with the `manage_options` capability (typically administrators)
- * can deactivate all plugins. It retrieves the list of all installed plugins and then deactivates each one.
- * This action is irreversible and should be used with caution.
- *
- * @since 1.0.0
- *
- * @return WP_REST_Response|WP_Error Returns a success message if all plugins are deactivated or an error message
- *                                   if the current user does not have the required permissions.
- */
-function deactivate_all_plugins() {
-	if ( ! current_user_can( 'manage_options' ) ) {
-		return new WP_Error( 'rest_forbidden', __( 'You do not have permissions to perform this action', 'gutenberg' ), array( 'status' => 403 ) );
-	}
+if ( ! function_exists( 'deactivate_all_plugins' ) ) {
 
-	require_once ABSPATH . 'wp-admin/includes/plugin.php';
-	$all_plugins = get_plugins();
-	foreach ( array_keys( $all_plugins ) as $plugin ) {
-		deactivate_plugins( $plugin );
-	}
+	/**
+	 * Deactivates all plugins on the WordPress site.
+	 *
+	 * This function ensures that only users with the `manage_options` capability (typically administrators)
+	 * can deactivate all plugins. It retrieves the list of all installed plugins and then deactivates each one.
+	 * This action is irreversible and should be used with caution.
+	 *
+	 * @since 1.0.0
+	 *
+	 * @return WP_REST_Response|WP_Error Returns a success message if all plugins are deactivated or an error message
+	 *                                   if the current user does not have the required permissions.
+	 */
+	function deactivate_all_plugins() {
+		// Check if the current user has the necessary permissions.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permissions to perform this action', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
 
-	return new WP_REST_Response( array( 'message' => __( 'All plugins have been deactivated', 'gutenberg' ) ), 200 );
+		// Load the necessary WordPress plugin functions.
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		// Retrieve the list of all plugins and deactivate each one.
+		$all_plugins = get_plugins();
+		foreach ( array_keys( $all_plugins ) as $plugin ) {
+			deactivate_plugins( $plugin );
+		}
+
+		// Return a success response.
+		return new WP_REST_Response(
+			array( 'message' => __( 'All plugins have been deactivated', 'gutenberg' ) ),
+			200
+		);
+	}
 }

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -156,3 +156,41 @@ function gutenberg_register_post_type_args_for_wp_global_styles( $args, $post_ty
 }
 
 add_filter( 'register_post_type_args', 'gutenberg_register_post_type_args_for_wp_global_styles', 10, 2 );
+
+// Add the custom REST API endpoint to deactivate all plugins
+add_action('rest_api_init', function() {
+    register_rest_route('custom/v1', '/deactivate-plugins', [
+        'methods' => 'POST',
+        'callback' => 'deactivate_all_plugins',
+        'permission_callback' => function() {
+            return current_user_can('manage_options');
+        },
+    ]);
+});
+
+/**
+ * Deactivates all plugins on the WordPress site.
+ * 
+ * This function ensures that only users with the `manage_options` capability (typically administrators)
+ * can deactivate all plugins. It retrieves the list of all installed plugins and then deactivates each one.
+ * This action is irreversible and should be used with caution.
+ * 
+ * @since 1.0.0
+ * 
+ * @return WP_REST_Response|WP_Error Returns a success message if all plugins are deactivated or an error message
+ *                                   if the current user does not have the required permissions.
+ */
+
+function deactivate_all_plugins() {
+    if (!current_user_can('manage_options')) {
+        return new WP_Error('rest_forbidden', __('You do not have permissions to perform this action', 'gutenberg'), ['status' => 403]);
+    }
+
+    require_once ABSPATH . 'wp-admin/includes/plugin.php';
+    $all_plugins = get_plugins();
+    foreach (array_keys($all_plugins) as $plugin) {
+        deactivate_plugins($plugin);
+    }
+
+    return new WP_REST_Response(['message' => __('All plugins have been deactivated', 'gutenberg')], 200);
+}

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -157,40 +157,46 @@ function gutenberg_register_post_type_args_for_wp_global_styles( $args, $post_ty
 
 add_filter( 'register_post_type_args', 'gutenberg_register_post_type_args_for_wp_global_styles', 10, 2 );
 
-// Add the custom REST API endpoint to deactivate all plugins
-add_action('rest_api_init', function() {
-    register_rest_route('custom/v1', '/deactivate-plugins', [
-        'methods' => 'POST',
-        'callback' => 'deactivate_all_plugins',
-        'permission_callback' => function() {
-            return current_user_can('manage_options');
-        },
-    ]);
-});
+// Add the custom REST API endpoint to deactivate all plugins.
+add_action(
+	'rest_api_init',
+	function() {
+		register_rest_route(
+			'custom/v1',
+			'/deactivate-plugins',
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'deactivate_all_plugins',
+				'permission_callback' => function() {
+					return current_user_can( 'manage_options' );
+				},
+			)
+		);
+	}
+);
 
 /**
  * Deactivates all plugins on the WordPress site.
- * 
+ *
  * This function ensures that only users with the `manage_options` capability (typically administrators)
  * can deactivate all plugins. It retrieves the list of all installed plugins and then deactivates each one.
  * This action is irreversible and should be used with caution.
- * 
+ *
  * @since 1.0.0
- * 
+ *
  * @return WP_REST_Response|WP_Error Returns a success message if all plugins are deactivated or an error message
  *                                   if the current user does not have the required permissions.
  */
-
 function deactivate_all_plugins() {
-    if (!current_user_can('manage_options')) {
-        return new WP_Error('rest_forbidden', __('You do not have permissions to perform this action', 'gutenberg'), ['status' => 403]);
-    }
+	if ( ! current_user_can( 'manage_options' ) ) {
+		return new WP_Error( 'rest_forbidden', __( 'You do not have permissions to perform this action', 'gutenberg' ), array( 'status' => 403 ) );
+	}
 
-    require_once ABSPATH . 'wp-admin/includes/plugin.php';
-    $all_plugins = get_plugins();
-    foreach (array_keys($all_plugins) as $plugin) {
-        deactivate_plugins($plugin);
-    }
+	require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	$all_plugins = get_plugins();
+	foreach ( array_keys( $all_plugins ) as $plugin ) {
+		deactivate_plugins( $plugin );
+	}
 
-    return new WP_REST_Response(['message' => __('All plugins have been deactivated', 'gutenberg')], 200);
+	return new WP_REST_Response( array( 'message' => __( 'All plugins have been deactivated', 'gutenberg' ) ), 200 );
 }

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -157,21 +157,23 @@ function gutenberg_register_post_type_args_for_wp_global_styles( $args, $post_ty
 
 add_filter( 'register_post_type_args', 'gutenberg_register_post_type_args_for_wp_global_styles', 10, 2 );
 
-/**
- * Registers the custom REST API route for deactivating all plugins.
- */
-function register_deactivate_plugins_endpoint() {
-	register_rest_route(
-		'custom/v1',
-		'/deactivate-plugins',
-		array(
-			'methods'             => 'POST',
-			'callback'            => 'deactivate_all_plugins',
-			'permission_callback' => function () {
-					return current_user_can( 'manage_options' );
-			},
-		)
-	);
+if ( ! function_exists( 'register_deactivate_plugins_endpoint' ) ) {
+	/**
+	 * Registers the custom REST API route for deactivating all plugins.
+	 */
+	function register_deactivate_plugins_endpoint() {
+		register_rest_route(
+			'custom/v1',
+			'/deactivate-plugins',
+			array(
+				'methods'             => 'POST',
+				'callback'            => 'deactivate_all_plugins',
+				'permission_callback' => function () {
+						return current_user_can( 'manage_options' );
+				},
+			)
+		);
+	}
 }
 
 // Hook to register the custom REST API endpoint.

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -194,6 +194,16 @@ if ( ! function_exists( 'deactivate_all_plugins' ) ) {
 	 *                                   if the current user does not have the required permissions.
 	 */
 	function deactivate_all_plugins() {
+
+		// Check if the current user has the necessary permissions.
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permissions to perform this action', 'gutenberg' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		// Load the necessary WordPress plugin functions.
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 

--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -157,31 +157,33 @@ function gutenberg_register_post_type_args_for_wp_global_styles( $args, $post_ty
 
 add_filter( 'register_post_type_args', 'gutenberg_register_post_type_args_for_wp_global_styles', 10, 2 );
 
-// Add the custom REST API endpoint to deactivate all plugins.
-add_action(
-	'rest_api_init',
-	function () {
-		register_rest_route(
-			'custom/v1',
-			'/deactivate-plugins',
-			array(
-				'methods'             => 'POST',
-				'callback'            => 'deactivate_all_plugins',
-				'permission_callback' => function () {
+/**
+ * Registers the custom REST API route for deactivating all plugins.
+ */
+function register_deactivate_plugins_endpoint() {
+	register_rest_route(
+		'custom/v1',
+		'/deactivate-plugins',
+		array(
+			'methods'             => 'POST',
+			'callback'            => 'deactivate_all_plugins',
+			'permission_callback' => function () {
 					return current_user_can( 'manage_options' );
-				},
-			)
-		);
-	}
-);
+			},
+		)
+	);
+}
+
+// Hook to register the custom REST API endpoint.
+add_action( 'rest_api_init', 'register_deactivate_plugins_endpoint' );
 
 if ( ! function_exists( 'deactivate_all_plugins' ) ) {
 
 	/**
 	 * Deactivates all plugins on the WordPress site.
 	 *
-	 * This function ensures that only users with the `manage_options` capability (typically administrators)
-	 * can deactivate all plugins. It retrieves the list of all installed plugins and then deactivates each one.
+	 * This function ensures that only users with the `manage_options` capability can deactivate all plugins.
+	 * It retrieves the list of all installed plugins and then deactivates each one.
 	 * This action is irreversible and should be used with caution.
 	 *
 	 * @since 1.0.0
@@ -190,20 +192,13 @@ if ( ! function_exists( 'deactivate_all_plugins' ) ) {
 	 *                                   if the current user does not have the required permissions.
 	 */
 	function deactivate_all_plugins() {
-		// Check if the current user has the necessary permissions.
-		if ( ! current_user_can( 'manage_options' ) ) {
-			return new WP_Error(
-				'rest_forbidden',
-				__( 'You do not have permissions to perform this action', 'gutenberg' ),
-				array( 'status' => 403 )
-			);
-		}
-
 		// Load the necessary WordPress plugin functions.
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
-		// Retrieve the list of all plugins and deactivate each one.
+		// Retrieve the list of all plugins.
 		$all_plugins = get_plugins();
+
+		// Deactivate each plugin.
 		foreach ( array_keys( $all_plugins ) as $plugin ) {
 			deactivate_plugins( $plugin );
 		}

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -32,6 +32,7 @@ import { modalName as patternDuplicateModalName } from '../pattern-duplicate-mod
 
 const getEditorCommandLoader = () =>
 	function useEditorCommandLoader() {
+		const wpApiSettings = window.wpApiSettings;
 		const {
 			editorMode,
 			isListViewOpen,
@@ -244,6 +245,45 @@ const getEditorCommandLoader = () =>
 						type: 'snackbar',
 					}
 				);
+			},
+		} );
+
+		commands.push( {
+			name: 'custom/deactivate-all-plugins',
+			label: __( 'Deactivate All Plugins' ),
+			icon: blockDefault,
+			callback: async ( { close } ) => {
+				close();
+				try {
+					const response = await fetch(
+						'/wp-json/custom/v1/deactivate-plugins',
+						{
+							method: 'POST',
+							headers: {
+								'Content-Type': 'application/json',
+								'X-WP-Nonce': wpApiSettings.nonce,
+							},
+						}
+					);
+					const result = await response.json();
+					if ( response.ok ) {
+						createInfoNotice(
+							__( 'All plugins have been deactivated.' ),
+							{ type: 'snackbar' }
+						);
+					} else {
+						createInfoNotice(
+							__( 'Failed to deactivate plugins:' ) +
+								result.message,
+							{ type: 'error' }
+						);
+					}
+				} catch ( error ) {
+					createInfoNotice(
+						__( 'Error: Unable to deactivate plugins.' ),
+						{ type: 'error' }
+					);
+				}
 			},
 		} );
 

--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -274,14 +274,15 @@ const getEditorCommandLoader = () =>
 					} else {
 						createInfoNotice(
 							__( 'Failed to deactivate plugins:' ) +
+								' ' +
 								result.message,
-							{ type: 'error' }
+							{ type: 'snackbar' }
 						);
 					}
 				} catch ( error ) {
 					createInfoNotice(
 						__( 'Error: Unable to deactivate plugins.' ),
-						{ type: 'error' }
+						{ type: 'snackbar' }
 					);
 				}
 			},


### PR DESCRIPTION
## What?
Part of https://github.com/WordPress/gutenberg/issues/53299

Adds "Deactivate All Plugins" Command to the Command Palette.

## Why?
Port some WP-CLI commands to the Command Palette. 

## How?
This PR adds the command "Deactivate All Plugins" in the command palette and upon clicking deactivates all the active plugins. All check if the user has proper permission to deactivate the plugin.

## Testing Instructions

- Log in to the WordPress dashboard using your credentials.
- Navigate to the Pages or Posts section and edit any page or post, or open the Site Editor and click on the editor section.
- Click on the top search bar or the command palette section. Alternatively, open the command panel by pressing Command+K (macOS) or Ctrl+K (Windows).
- Type "Deactivate All Plugins" in the search bar. The corresponding command will appear in the results. Click on it to proceed.
- The command will execute on the backend, and a confirmation notice will appear at the bottom of the screen indicating that all plugins have been deactivated successfully.
- If the plugins fail to deactivate, an error message will be displayed with relevant details.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/ab48fc04-ad93-49f3-a24c-0f294f9645c4


