### PR TITLE
Media & Text: Set `.wp-block-media-text__media a` display to block

### DIFF
--- a/packages/block-library/src/media-text/style.scss
+++ b/packages/block-library/src/media-text/style.scss
@@ -69,7 +69,7 @@
 }
 
 .wp-block-media-text__media a {
-	display: inline-block;
+	display: block;
 }
 
 .wp-block-media-text__media img,


### PR DESCRIPTION
Fixes: #66914 

## What?
Ajusted the display property from `inline-block` to `block` to resolve layout issues in the Media & Text block anchor link.

## Why?
This PR is necessary address a display issue when an anchor link is added to the Media & Text block. The current inline-block display style results in reduced and inconsistent media sizes.

## Testing Instructions
1. Go to any post
2. Add Media & Text Block
3. Select an image
4. Add an anchor link to block and save
5. Check frontend

## Screenshots or screencast 

### Issue
![FRONTEND](https://github.com/user-attachments/assets/014c32b4-8885-44bc-8dd7-f24e09f1c04d)

### After Fix
![FRONTEND (1)](https://github.com/user-attachments/assets/b11be183-254f-42d4-83bd-6fb40f57d77f)
