### PR TITLE
Add useScaleCanvas: Web Animations API for zoom in/out animation

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -41,8 +41,3 @@
 	@warn "The `edit-post__fade-in-animation` mixin is deprecated. Use `animation__fade-in` instead.";
 	@include animation__fade-in($speed, $delay);
 }
-
-@mixin editor-canvas-resize-animation($additional-transition-rules...) {
-	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96), $additional-transition-rules;
-	@include reduce-motion("transition");
-}

--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -4,6 +4,7 @@ iframe[name="editor-canvas"] {
 	height: 100%;
 	display: block;
 	// Handles transitions between device previews
-	@include editor-canvas-resize-animation;
+	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
+	@include reduce-motion("transition");
 	background-color: $gray-300;
 }

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,7 +3,16 @@
 }
 
 .block-editor-iframe__html {
+	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
+	scale: $scale;
 	transform-origin: top center;
+	// Add the top/bottom frame size. We use scaling to account for the left/right, as
+	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+	// of the content.
+	padding-top: calc(#{$frame-size} / #{$scale});
+	padding-bottom: calc(#{$frame-size} / #{$scale});
+
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
@@ -28,43 +37,35 @@
 		// and the doubled animations cause very odd animations.
 		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
-}
 
-.block-editor-iframe__html.is-zoomed-out {
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
-	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
-	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
-	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-	// Apply an X translation to center the scaled content within the available space.
-	transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-	scale: #{$scale};
-	background-color: $gray-300;
+	&.is-zoomed-out {
+		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
+		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
+		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
+		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+		// Apply an X translation to center the scaled content within the available space.
+		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+		background-color: $gray-300;
 
-	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
-	// so we need to adjust the height of the content to match the scale by using negative margins.
-	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
-	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
-	margin-bottom: calc(-1 * #{$total-height});
-	// Add the top/bottom frame size. We use scaling to account for the left/right, as
-	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-	// of the content.
-	padding-top: calc(#{$frame-size} / #{$scale});
-	padding-bottom: calc(#{$frame-size} / #{$scale});
+		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+		// so we need to adjust the height of the content to match the scale by using negative margins.
+		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
+		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
+		margin-bottom: calc(-1 * #{$total-height});
 
-	body {
-		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+		body {
+			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 
-		> .is-root-container:not(.wp-block-post-content) {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			height: 100%;
-
-			> main {
+			> .is-root-container:not(.wp-block-post-content) {
 				flex: 1;
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+
+				> main {
+					flex: 1;
+				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,68 +3,65 @@
 }
 
 .block-editor-iframe__html {
+	$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
+	$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
+	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
+
 	transform-origin: top center;
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
+	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
-		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
-		$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
-
 		position: fixed;
 		left: 0;
 		right: 0;
 		top: calc(-1 * #{$scroll-top});
 		bottom: 0;
 		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
-		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
-		// and removing the scrollbar causes the content to shift.
-		overflow-y: scroll;
-
-		// We only want to animate the scaling when entering zoom out. When sidebars
+		scale: $scale;
+		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
 		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
-}
 
-.block-editor-iframe__html.is-zoomed-out {
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
-	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
-	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
-	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-	// Apply an X translation to center the scaled content within the available space.
-	transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-	scale: #{$scale};
-	background-color: $gray-300;
+	&.is-zoomed-out {
+		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
+		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
+		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
+		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+		// Apply an X translation to center the scaled content within the available space.
+		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+		scale: $scale;
+		background-color: $gray-300;
 
-	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
-	// so we need to adjust the height of the content to match the scale by using negative margins.
-	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
-	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
-	margin-bottom: calc(-1 * #{$total-height});
-	// Add the top/bottom frame size. We use scaling to account for the left/right, as
-	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-	// of the content.
-	padding-top: calc(#{$frame-size} / #{$scale});
-	padding-bottom: calc(#{$frame-size} / #{$scale});
+		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+		// so we need to adjust the height of the content to match the scale by using negative margins.
+		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
+		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
+		margin-bottom: calc(-1 * #{$total-height});
+		// Add the top/bottom frame size. We use scaling to account for the left/right, as
+		// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+		// of the content.
+		padding-top: calc(#{$frame-size} / #{$scale});
+		padding-bottom: calc(#{$frame-size} / #{$scale});
 
-	body {
-		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+		body {
+			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 
-		> .is-root-container:not(.wp-block-post-content) {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			height: 100%;
-
-			> main {
+			> .is-root-container:not(.wp-block-post-content) {
 				flex: 1;
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+
+				> main {
+					flex: 1;
+				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -12,11 +12,8 @@
 	// of the content.
 	padding-top: calc(#{$frame-size} / #{$scale});
 	padding-bottom: calc(#{$frame-size} / #{$scale});
-
-	// We don't want to animate the transform of the translateX because it is used
-	// to "center" the canvas. Leaving it on causes the canvas to slide around in
-	// odd ways.
-	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s, translate 0s);
+	// Prevents a flash of background color change when entering/exiting zoom out
+	transition: background-color 400ms;
 
 	&.zoom-out-animation {
 		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
@@ -27,15 +24,9 @@
 		right: 0;
 		top: calc(-1 * #{$scroll-top});
 		bottom: 0;
-		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
 		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
 		// and removing the scrollbar causes the content to shift.
 		overflow-y: scroll;
-
-		// We only want to animate the scaling when entering zoom out. When sidebars
-		// are toggled, the resizing of the iframe handles scaling the canvas as well,
-		// and the doubled animations cause very odd animations.
-		@include editor-canvas-resize-animation(transform 0s, top 0s, bottom 0s, right 0s, left 0s);
 	}
 
 	&.is-zoomed-out {

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,15 +3,7 @@
 }
 
 .block-editor-iframe__html {
-	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size, 0);
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
-	scale: $scale;
 	transform-origin: top center;
-	// Add the top/bottom frame size. We use scaling to account for the left/right, as
-	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-	// of the content.
-	padding-top: calc(#{$frame-size} / #{$scale});
-	padding-bottom: calc(#{$frame-size} / #{$scale});
 	// Prevents a flash of background color change when entering/exiting zoom out
 	transition: background-color 400ms;
 
@@ -30,12 +22,15 @@
 	}
 
 	&.is-zoomed-out {
+		$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
+		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size, 0);
 		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
 		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
 		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
 		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
 		// Apply an X translation to center the scaled content within the available space.
 		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+		scale: $scale;
 		background-color: $gray-300;
 
 		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
@@ -44,6 +39,12 @@
 		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
 		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
 		margin-bottom: calc(-1 * #{$total-height});
+
+		// Add the top/bottom frame size. We use scaling to account for the left/right, as
+		// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+		// of the content.
+		padding-top: calc(#{$frame-size} / #{$scale});
+		padding-bottom: calc(#{$frame-size} / #{$scale});
 
 		body {
 			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -6,12 +6,12 @@
 	$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
 	$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
 	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
-
+	scale: $scale;
 	transform-origin: top center;
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s, translate 0s);
+	@include editor-canvas-resize-animation( transform 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
 		position: fixed;
@@ -20,7 +20,6 @@
 		top: calc(-1 * #{$scroll-top});
 		bottom: 0;
 		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
-		scale: $scale;
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
@@ -35,9 +34,7 @@
 		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
 		// Apply an X translation to center the scaled content within the available space.
 		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-		scale: $scale;
 		background-color: $gray-300;
-
 		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 		// so we need to adjust the height of the content to match the scale by using negative margins.
 		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -20,6 +20,9 @@
 		top: calc(-1 * #{$scroll-top});
 		bottom: 0;
 		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
+		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
+		// and removing the scrollbar causes the content to shift.
+		overflow-y: scroll;
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -16,7 +16,7 @@
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
+	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
 		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
@@ -35,7 +35,7 @@
 		// We only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
-		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
+		@include editor-canvas-resize-animation(transform 0s, top 0s, bottom 0s, right 0s, left 0s);
 	}
 
 	&.is-zoomed-out {

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,7 +3,7 @@
 }
 
 .block-editor-iframe__html {
-	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size, 0);
 	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
 	scale: $scale;
 	transform-origin: top center;

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,10 +3,6 @@
 }
 
 .block-editor-iframe__html {
-	$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
-	$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
-	scale: $scale;
 	transform-origin: top center;
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
@@ -14,6 +10,9 @@
 	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
+		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
+		$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
+
 		position: fixed;
 		left: 0;
 		right: 0;
@@ -23,45 +22,49 @@
 		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
 		// and removing the scrollbar causes the content to shift.
 		overflow-y: scroll;
-		// we only want to animate the scaling when entering zoom out. When sidebars
+
+		// We only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
 		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
+}
 
-	&.is-zoomed-out {
-		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
-		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
-		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-		// Apply an X translation to center the scaled content within the available space.
-		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-		background-color: $gray-300;
-		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
-		// so we need to adjust the height of the content to match the scale by using negative margins.
-		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
-		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
-		margin-bottom: calc(-1 * #{$total-height});
-		// Add the top/bottom frame size. We use scaling to account for the left/right, as
-		// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-		// of the content.
-		padding-top: calc(#{$frame-size} / #{$scale});
-		padding-bottom: calc(#{$frame-size} / #{$scale});
+.block-editor-iframe__html.is-zoomed-out {
+	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
+	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
+	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
+	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
+	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+	// Apply an X translation to center the scaled content within the available space.
+	transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+	scale: #{$scale};
+	background-color: $gray-300;
 
-		body {
-			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+	// so we need to adjust the height of the content to match the scale by using negative margins.
+	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
+	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
+	margin-bottom: calc(-1 * #{$total-height});
+	// Add the top/bottom frame size. We use scaling to account for the left/right, as
+	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+	// of the content.
+	padding-top: calc(#{$frame-size} / #{$scale});
+	padding-bottom: calc(#{$frame-size} / #{$scale});
 
-			> .is-root-container:not(.wp-block-post-content) {
+	body {
+		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+
+		> .is-root-container:not(.wp-block-post-content) {
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+
+			> main {
 				flex: 1;
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-
-				> main {
-					flex: 1;
-				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -11,7 +11,7 @@
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation( transform 0s, padding 0s, translate 0s);
+	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
 		position: fixed;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -240,15 +240,8 @@ function Iframe( {
 		containerWidth
 	);
 
-	const maxWidth = 750;
-
 	useScaleCanvas( {
-		scale:
-			scale === 'auto-scaled'
-				? ( Math.min( containerWidth, maxWidth ) -
-						parseInt( frameSize ) * 2 ) /
-				  scaleContainerWidth
-				: scale,
+		scale,
 		frameSize: parseInt( frameSize ),
 		iframeDocument,
 		contentHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -426,6 +426,7 @@ function Iframe( {
 			iframeDocument.documentElement.classList.remove(
 				'zoom-out-animation'
 			);
+
 			// Update previous values.
 			prevClientHeightRef.current = clientHeight;
 			prevFrameSizeRef.current = frameSizeValue;
@@ -435,9 +436,10 @@ function Iframe( {
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}
 
+		let raf;
 		if ( prefersReducedMotion ) {
 			// Hack: Wait for the window values to recalculate.
-			iframeDocument.defaultView.requestAnimationFrame(
+			raf = iframeDocument.defaultView.requestAnimationFrame(
 				onZoomOutTransitionEnd
 			);
 		} else {
@@ -458,10 +460,14 @@ function Iframe( {
 			iframeDocument.documentElement.classList.remove(
 				'zoom-out-animation'
 			);
-			iframeDocument.documentElement.removeEventListener(
-				'transitionend',
-				onZoomOutTransitionEnd
-			);
+			if ( prefersReducedMotion ) {
+				iframeDocument.defaultView.cancelAnimationFrame( raf );
+			} else {
+				iframeDocument.documentElement.removeEventListener(
+					'transitionend',
+					onZoomOutTransitionEnd
+				);
+			}
 		};
 	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -504,7 +504,7 @@ function Iframe( {
 		}
 
 		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
-		// initialContainerWidthRef will be smaller than the full page, and reflow will happen
+		// initialContainerWidth will be smaller than the full page, and reflow will happen
 		// when the canvas area becomes larger due to sidebars closing. This is a known but
 		// minor divergence for now.
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -129,10 +129,8 @@ function Iframe( {
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
-	const [
-		containerResizeListener,
-		{ width: containerWidth, height: containerHeight },
-	] = useResizeObserver();
+	const [ containerResizeListener, { width: containerWidth } ] =
+		useResizeObserver();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -283,7 +281,8 @@ function Iframe( {
 	const frameSizeValue = parseInt( frameSize );
 	const prevFrameSizeRef = useRef( frameSizeValue );
 
-	const prevClientHeightRef = useRef( containerHeight );
+	// Initialized in the useEffect.
+	const prevClientHeightRef = useRef();
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -346,20 +345,20 @@ function Iframe( {
 			return;
 		}
 
-		// Previous scale value.
-		const prevScale = prevScaleRef.current;
-
-		// Unscaled height of the previous iframe container.
-		const prevClientHeight = prevClientHeightRef.current;
-
-		// Unscaled size of the previous padding around the iframe content.
-		const prevFrameSize = prevFrameSizeRef.current;
-
 		// Unscaled height of the current iframe container.
 		const clientHeight = iframeDocument.documentElement.clientHeight;
 
 		// Scaled height of the current iframe content.
 		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		// Previous scale value.
+		const prevScale = prevScaleRef.current;
+
+		// Unscaled size of the previous padding around the iframe content.
+		const prevFrameSize = prevFrameSizeRef.current;
+
+		// Unscaled height of the previous iframe container.
+		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
 
 		// We can't trust the set value from contentHeight, as it was measured
 		// before the zoom out mode was changed. After zoom out mode is changed,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -414,7 +414,7 @@ function Iframe( {
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -286,7 +286,6 @@ function Iframe( {
 	const prevFrameSizeRef = useRef( frameSizeValue );
 
 	const prevClientHeightRef = useRef( containerHeight );
-	const prevScrollHeightRef = useRef( contentHeight );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -359,7 +358,6 @@ function Iframe( {
 		const scrollHeight = iframeDocument.documentElement.scrollHeight;
 
 		const prevClientHeight = prevClientHeightRef.current;
-		// const prevScrollHeight = prevScrollHeightRef.current;
 		const prevScale = prevScaleRef.current;
 		const prevFrameSize = prevFrameSizeRef.current;
 
@@ -379,18 +377,14 @@ function Iframe( {
 		);
 
 		const scaleRatio = scaleValue / prevScale;
-		const maxScrollTop = scrollHeight * scaleRatio - clientHeight;
+		const maxScrollTop =
+			scrollHeight * scaleRatio - clientHeight + frameSizeValue * 2;
 
-		// Account for differences in client height changes between zoom in and zoom out modes.
-		const edgeThreshold =
-			clientHeight / 2 + ( prevClientHeight - clientHeight );
-
-		// prettier-ignore
-		scrollTopNext = scrollTopNext - edgeThreshold <= 0 ? 0 : scrollTopNext;
-		// prettier-ignore
-		scrollTopNext = scrollTopNext + edgeThreshold >= maxScrollTop ? maxScrollTop : scrollTopNext;
-
-		scrollTopNext = Math.min( Math.max( 0, scrollTopNext ), maxScrollTop );
+		// scrollTopNext will zoom to the center point unless it would scroll past the top or bottom.
+		// In that case, it will clamp to the top or bottom.
+		scrollTopNext = Math.round(
+			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
+		);
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -418,7 +412,6 @@ function Iframe( {
 			);
 
 			prevClientHeightRef.current = clientHeight;
-			prevScrollHeightRef.current = scrollHeight;
 			prevFrameSizeRef.current = frameSizeValue;
 			prevScaleRef.current = scaleValue;
 			iframeDocument.documentElement.scrollTop = scrollTopNext;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -376,6 +376,9 @@ function Iframe( {
 				clientHeight / 2
 		);
 
+		// If we are near the top of the canvas, set the next scroll top to 0.
+		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
+
 		const scaleRatio = scaleValue / prevScale;
 		const maxScrollTop =
 			scrollHeight * scaleRatio - clientHeight + frameSizeValue * 2;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -340,11 +340,7 @@ function Iframe( {
 
 	useEffect( () => cleanup, [ cleanup ] );
 
-	const zoomOutAnimationTimeoutRef = useRef( null );
-
 	const handleZoomOutAnimation = useCallback( () => {
-		clearTimeout( zoomOutAnimationTimeoutRef.current );
-
 		// Previous scale value.
 		const prevScale = prevScaleRef.current;
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -227,21 +227,6 @@ function Iframe( {
 		};
 	}, [] );
 
-	const [ windowInnerWidth, setWindowInnerWidth ] = useState();
-
-	const windowResizeRef = useRefEffect( ( node ) => {
-		const nodeWindow = node.ownerDocument.defaultView;
-
-		setWindowInnerWidth( nodeWindow.innerWidth );
-		const onResize = () => {
-			setWindowInnerWidth( nodeWindow.innerWidth );
-		};
-		nodeWindow.addEventListener( 'resize', onResize );
-		return () => {
-			nodeWindow.removeEventListener( 'resize', onResize );
-		};
-	}, [] );
-
 	const isZoomedOut = scale !== 1;
 
 	useEffect( () => {
@@ -268,7 +253,6 @@ function Iframe( {
 		iframeDocument,
 		contentHeight,
 		containerWidth,
-		windowInnerWidth,
 		isZoomedOut,
 		scaleContainerWidth,
 	} );
@@ -400,7 +384,7 @@ function Iframe( {
 	);
 
 	return (
-		<div className="block-editor-iframe__container" ref={ windowResizeRef }>
+		<div className="block-editor-iframe__container">
 			{ containerResizeListener }
 			<div
 				className={ clsx(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,7 +20,6 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
-	useReducedMotion,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -31,6 +30,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
+import { useScaleCanvas } from './use-scale-canvas';
 import { store as blockEditorStore } from '../../store';
 
 function bubbleEvent( event, Constructor, frame ) {
@@ -132,7 +132,6 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
-	const prefersReducedMotion = useReducedMotion();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -280,9 +279,17 @@ function Iframe( {
 			  scaleContainerWidth
 			: scale;
 
-	const prevScaleRef = useRef( scaleValue );
-	const prevFrameSizeRef = useRef( frameSizeValue );
-	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
+	useScaleCanvas( {
+		scaleValue,
+		frameSizeValue,
+		iframeDocument,
+		iframeWindowInnerHeight,
+		contentHeight,
+		containerWidth,
+		windowInnerWidth,
+		isZoomedOut,
+		scaleContainerWidth,
+	} );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -335,242 +342,6 @@ function Iframe( {
 	}, [ html ] );
 
 	useEffect( () => cleanup, [ cleanup ] );
-
-	useEffect( () => {
-		if (
-			! iframeDocument ||
-			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
-			// instead of the dependency array to appease the linter.
-			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
-		) {
-			return;
-		}
-
-		// Unscaled height of the current iframe container.
-		const clientHeight = iframeDocument.documentElement.clientHeight;
-
-		// Scaled height of the current iframe content.
-		const scrollHeight = iframeDocument.documentElement.scrollHeight;
-
-		// Previous scale value.
-		const prevScale = prevScaleRef.current;
-
-		// Unscaled size of the previous padding around the iframe content.
-		const prevFrameSize = prevFrameSizeRef.current;
-
-		// Unscaled height of the previous iframe container.
-		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
-
-		// We can't trust the set value from contentHeight, as it was measured
-		// before the zoom out mode was changed. After zoom out mode is changed,
-		// appenders may appear or disappear, so we need to get the height from
-		// the iframe at this point when we're about to animate the zoom out.
-		// The iframe scrollTop, scrollHeight, and clientHeight will all be
-		// accurate. The client height also does change when the zoom out mode
-		// is toggled, as the bottom bar about selecting the template is
-		// added/removed when toggling zoom out mode.
-		const scrollTop = iframeDocument.documentElement.scrollTop;
-
-		// Step 0: Start with the current scrollTop.
-		let scrollTopNext = scrollTop;
-
-		// Step 1: Undo the effects of the previous scale and frame around the
-		// midpoint of the visible area.
-		scrollTopNext =
-			( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
-				prevScale -
-			prevClientHeight / 2;
-
-		// Step 2: Apply the new scale and frame around the midpoint of the
-		// visible area.
-		scrollTopNext =
-			( scrollTopNext + clientHeight / 2 ) * scaleValue +
-			frameSizeValue -
-			clientHeight / 2;
-
-		// Step 3: Handle an edge case so that you scroll to the top of the
-		// iframe if the top of the iframe content is visible in the container.
-		// The same edge case for the bottom is skipped because changing content
-		// makes calculating it impossible.
-		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
-
-		// This is the scrollTop value if you are scrolled to the bottom of the
-		// iframe. We can't just let the browser handle it because we need to
-		// animate the scaling.
-		const maxScrollTop =
-			scrollHeight * ( scaleValue / prevScale ) +
-			frameSizeValue * 2 -
-			clientHeight;
-
-		// Step 4: Clamp the scrollTopNext between the minimum and maximum
-		// possible scrollTop positions. Round the value to avoid subpixel
-		// truncation by the browser which sometimes causes a 1px error.
-		scrollTopNext = Math.round(
-			Math.min(
-				Math.max( 0, scrollTopNext ),
-				Math.max( 0, maxScrollTop )
-			)
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top',
-			`${ scrollTop }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-			`${ scrollTopNext }px`
-		);
-
-		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
-
-		function onZoomOutTransitionEnd() {
-			// Remove the position fixed for the animation.
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
-
-			// Update previous values.
-			prevClientHeightRef.current = clientHeight;
-			prevFrameSizeRef.current = frameSizeValue;
-			prevScaleRef.current = scaleValue;
-
-			// Set the final scroll position that was just animated to.
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-		}
-
-		let raf;
-		if ( prefersReducedMotion ) {
-			// Hack: Wait for the window values to recalculate.
-			raf = iframeDocument.defaultView.requestAnimationFrame(
-				onZoomOutTransitionEnd
-			);
-		} else {
-			iframeDocument.documentElement.addEventListener(
-				'transitionend',
-				onZoomOutTransitionEnd,
-				{ once: true }
-			);
-		}
-
-		return () => {
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top-next'
-			);
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
-			if ( prefersReducedMotion ) {
-				iframeDocument.defaultView.cancelAnimationFrame( raf );
-			} else {
-				iframeDocument.documentElement.removeEventListener(
-					'transitionend',
-					onZoomOutTransitionEnd
-				);
-			}
-		};
-	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
-
-	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
-	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
-	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
-	// number of dependencies.
-	useEffect( () => {
-		if ( ! iframeDocument ) {
-			return;
-		}
-
-		if ( isZoomedOut ) {
-			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
-		} else {
-			// HACK: Since we can't remove this in the cleanup, we need to do it here.
-			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
-		}
-
-		return () => {
-			// HACK: Skipping cleanup because it causes issues with the zoom out
-			// animation. More refactoring is needed to fix this properly.
-			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
-		};
-	}, [ iframeDocument, isZoomedOut ] );
-
-	// Calculate the scaling and CSS variables for the zoom out canvas
-	useEffect( () => {
-		if ( ! iframeDocument ) {
-			return;
-		}
-
-		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
-		// initialContainerWidth will be smaller than the full page, and reflow will happen
-		// when the canvas area becomes larger due to sidebars closing. This is a known but
-		// minor divergence for now.
-
-		// This scaling calculation has to happen within the JS because CSS calc() can
-		// only divide and multiply by a unitless value. I.e. calc( 100px / 2 ) is valid
-		// but calc( 100px / 2px ) is not.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale',
-			scaleValue
-		);
-
-		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-frame-size',
-			typeof frameSize === 'number' ? `${ frameSize }px` : frameSize
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-content-height',
-			`${ contentHeight }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ iframeWindowInnerHeight }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-container-width',
-			`${ containerWidth }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale-container-width',
-			`${ scaleContainerWidth }px`
-		);
-
-		return () => {
-			// HACK: Skipping cleanup because it causes issues with the zoom out
-			// animation. More refactoring is needed to fix this properly.
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-content-height'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-container-width'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			// );
-		};
-	}, [
-		scaleValue,
-		frameSize,
-		iframeDocument,
-		iframeWindowInnerHeight,
-		contentHeight,
-		containerWidth,
-		windowInnerWidth,
-		isZoomedOut,
-		scaleContainerWidth,
-	] );
 
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -357,13 +357,28 @@ function Iframe( {
 				prevContainerHeightRef.current / 2
 		);
 
-		// // Convert the zoomed in value to the new scale.
-		// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
-		const scrollTopNext = Math.round(
+		// Convert the zoomed in value to the new scale.
+		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+		let scrollTopNext = Math.round(
 			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
 				frameSizeValue -
 				containerHeight / 2
 		);
+
+		const edgeThreshold = prevContainerHeightRef.current / 2;
+		const maxScrollPosition =
+			contentHeight - prevContainerHeightRef.current - frameSizeValue * 2;
+
+		const scaleToTop = scrollTopOriginal - edgeThreshold <= 0;
+		const scaleToBottom =
+			scrollTopOriginal - maxScrollPosition - edgeThreshold <= 0;
+
+		if ( scaleToTop ) {
+			scrollTopNext = 0;
+		} else if ( scaleToBottom ) {
+			// Not sure on this
+			scrollTopNext = maxScrollPosition * scaleValue;
+		}
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -388,7 +403,13 @@ function Iframe( {
 
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
-	}, [ scaleValue, frameSizeValue, containerHeight, iframeDocument ] );
+	}, [
+		scaleValue,
+		frameSizeValue,
+		containerHeight,
+		iframeDocument,
+		contentHeight,
+	] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -21,7 +21,6 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
-	usePrevious,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -261,7 +260,7 @@ function Iframe( {
 	}, [] );
 
 	const isZoomedOut = scale !== 1;
-	const prevIsZoomedOut = usePrevious( isZoomedOut );
+	const prevIsZoomedOutRef = useRef( isZoomedOut );
 
 	useEffect( () => {
 		if ( ! isZoomedOut ) {
@@ -416,6 +415,9 @@ function Iframe( {
 	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
 	// number of dependencies.
 	useEffect( () => {
+		const prevIsZoomedOut = prevIsZoomedOutRef.current;
+		prevIsZoomedOutRef.current = isZoomedOut;
+
 		// If we're animating, don't re-update things.
 		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
 			return;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -437,7 +437,10 @@ function Iframe( {
 		}
 
 		if ( prefersReducedMotion ) {
-			onZoomOutTransitionEnd();
+			// Hack: Wait for the window values to recalculate.
+			iframeDocument.defaultView.requestAnimationFrame(
+				onZoomOutTransitionEnd
+			);
 		} else {
 			iframeDocument.documentElement.addEventListener(
 				'transitionend',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -359,7 +359,7 @@ function Iframe( {
 		const scrollHeight = iframeDocument.documentElement.scrollHeight;
 
 		const prevClientHeight = prevClientHeightRef.current;
-		const prevScrollHeight = prevScrollHeightRef.current;
+		// const prevScrollHeight = prevScrollHeightRef.current;
 		const prevScale = prevScaleRef.current;
 		const prevFrameSize = prevFrameSizeRef.current;
 
@@ -381,10 +381,14 @@ function Iframe( {
 		const scaleRatio = scaleValue / prevScale;
 		const maxScrollTop = scrollHeight * scaleRatio - clientHeight;
 
+		// Account for differences in client height changes between zoom in and zoom out modes.
+		const edgeThreshold =
+			clientHeight / 2 + ( prevClientHeight - clientHeight );
+
 		// prettier-ignore
-		scrollTopNext = scrollTopNext - clientHeight / 2 <= 0 ? 0 : scrollTopNext;
+		scrollTopNext = scrollTopNext - edgeThreshold <= 0 ? 0 : scrollTopNext;
 		// prettier-ignore
-		scrollTopNext = scrollTopNext + clientHeight / 2 >= maxScrollTop ? maxScrollTop : scrollTopNext;
+		scrollTopNext = scrollTopNext + edgeThreshold >= maxScrollTop ? maxScrollTop : scrollTopNext;
 
 		scrollTopNext = Math.min( Math.max( 0, scrollTopNext ), maxScrollTop );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -227,21 +227,6 @@ function Iframe( {
 		};
 	}, [] );
 
-	const [ iframeWindowInnerHeight, setIframeWindowInnerHeight ] = useState();
-
-	const iframeResizeRef = useRefEffect( ( node ) => {
-		const nodeWindow = node.ownerDocument.defaultView;
-
-		setIframeWindowInnerHeight( nodeWindow.innerHeight );
-		const onResize = () => {
-			setIframeWindowInnerHeight( nodeWindow.innerHeight );
-		};
-		nodeWindow.addEventListener( 'resize', onResize );
-		return () => {
-			nodeWindow.removeEventListener( 'resize', onResize );
-		};
-	}, [] );
-
 	const [ windowInnerWidth, setWindowInnerWidth ] = useState();
 
 	const windowResizeRef = useRefEffect( ( node ) => {
@@ -281,7 +266,6 @@ function Iframe( {
 				: scale,
 		frameSize: parseInt( frameSize ),
 		iframeDocument,
-		iframeWindowInnerHeight,
 		contentHeight,
 		containerWidth,
 		windowInnerWidth,
@@ -296,10 +280,6 @@ function Iframe( {
 		clearerRef,
 		writingFlowRef,
 		disabledRef,
-		// Avoid resize listeners when not needed, these will trigger
-		// unnecessary re-renders when animating the iframe width, or when
-		// expanding preview iframes.
-		isZoomedOut ? iframeResizeRef : null,
 	] );
 
 	// Correct doctype is required to enable rendering in standards

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -420,7 +420,7 @@ function Iframe( {
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument || ! isZoomedOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
 
@@ -458,27 +458,6 @@ function Iframe( {
 			'--wp-block-editor-iframe-zoom-out-scale-container-width',
 			`${ scaleContainerWidth }px`
 		);
-
-		return () => {
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-content-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-inner-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-container-width'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			);
-		};
 	}, [
 		scaleValue,
 		frameSize,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -483,6 +483,7 @@ function Iframe( {
 		if ( isZoomedOut ) {
 			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 		} else {
+			// HACK: Since we can't remove this in the cleanup, we need to do it here.
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		}
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -527,6 +527,28 @@ function Iframe( {
 			'--wp-block-editor-iframe-zoom-out-scale-container-width',
 			`${ scaleContainerWidth }px`
 		);
+
+		return () => {
+			// TODO: Removing this causes issues with the zoom out animation.
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-content-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-container-width'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
+			// );
+		};
 	}, [
 		scaleValue,
 		frameSize,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -271,20 +271,18 @@ function Iframe( {
 		containerWidth
 	);
 
+	const frameSizeValue = parseInt( frameSize );
+
 	const maxWidth = 750;
 	const scaleValue =
 		scale === 'auto-scaled'
-			? ( Math.min( containerWidth, maxWidth ) -
-					parseInt( frameSize ) * 2 ) /
+			? ( Math.min( containerWidth, maxWidth ) - frameSizeValue * 2 ) /
 			  scaleContainerWidth
 			: scale;
+
 	const prevScaleRef = useRef( scaleValue );
-
-	const frameSizeValue = parseInt( frameSize );
 	const prevFrameSizeRef = useRef( frameSizeValue );
-
-	// Initialized in the useEffect.
-	const prevClientHeightRef = useRef();
+	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -273,14 +273,14 @@ function Iframe( {
 	const frameSizeValue = parseInt( frameSize );
 
 	const maxWidth = 750;
-	const scaleValue =
-		scale === 'auto-scaled'
-			? ( Math.min( containerWidth, maxWidth ) - frameSizeValue * 2 ) /
-			  scaleContainerWidth
-			: scale;
 
 	useScaleCanvas( {
-		scaleValue,
+		scale:
+			scale === 'auto-scaled'
+				? ( Math.min( containerWidth, maxWidth ) -
+						frameSizeValue * 2 ) /
+				  scaleContainerWidth
+				: scale,
 		frameSizeValue,
 		iframeDocument,
 		iframeWindowInnerHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -339,7 +339,8 @@ function Iframe( {
 	useEffect( () => {
 		if (
 			! iframeDocument ||
-			// TODO: What should this condition be?
+			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
+			// instead of the dependency array to appease the linter.
 			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
 		) {
 			return;
@@ -480,7 +481,8 @@ function Iframe( {
 		}
 
 		return () => {
-			// TODO: Removing this causes issues with the zoom out animation.
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
 			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
 	}, [ iframeDocument, isZoomedOut ] );
@@ -527,7 +529,8 @@ function Iframe( {
 		);
 
 		return () => {
-			// TODO: Removing this causes issues with the zoom out animation.
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
 			// iframeDocument.documentElement.style.removeProperty(
 			// 	'--wp-block-editor-iframe-zoom-out-scale'
 			// );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -12,7 +12,6 @@ import {
 	forwardRef,
 	useMemo,
 	useEffect,
-	useRef,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -124,7 +123,6 @@ function Iframe( {
 	const { styles = '', scripts = '' } = resolvedAssets;
 	/** @type {[Document, import('react').Dispatch<Document>]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
-	const initialContainerWidthRef = useRef( 0 );
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
 	const clearerRef = useBlockSelectionClearer();
 	const [ before, writingFlowRef, after ] = useWritingFlow();
@@ -227,27 +225,12 @@ function Iframe( {
 		};
 	}, [] );
 
-	const isZoomedOut = scale !== 1;
-
-	useEffect( () => {
-		if ( ! isZoomedOut ) {
-			initialContainerWidthRef.current = containerWidth;
-		}
-	}, [ containerWidth, isZoomedOut ] );
-
-	const scaleContainerWidth = Math.max(
-		initialContainerWidthRef.current,
-		containerWidth
-	);
-
-	useScaleCanvas( {
+	const { isZoomedOut, scaleContainerWidth } = useScaleCanvas( {
 		scale,
 		frameSize: parseInt( frameSize ),
 		iframeDocument,
 		contentHeight,
 		containerWidth,
-		isZoomedOut,
-		scaleContainerWidth,
 	} );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -407,6 +407,16 @@ function Iframe( {
 			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
 		);
 
+		const reduceMotion = iframeDocument.defaultView.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		).matches;
+
+		if ( reduceMotion ) {
+			// TODO: This seems to be broken somehow.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+			return;
+		}
+
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
 			`${ scrollTop }px`
@@ -419,24 +429,24 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
 
-		// TODO: See if there's a way to wait for CSS transition to finish.
-		// 400ms should match the animation speed used in components/iframe/content.scss
-		// Ignore the delay when reduce motion is enabled.
-		const reduceMotion = iframeDocument.defaultView.matchMedia(
-			'(prefers-reduced-motion: reduce)'
-		).matches;
-		const delay = reduceMotion ? 0 : 400;
+		iframeDocument.documentElement.addEventListener(
+			'transitionend',
+			() => {
+				// Remove the position fixed for the animation.
+				iframeDocument.documentElement.classList.remove(
+					'zoom-out-animation'
+				);
 
-		zoomOutAnimationTimeoutRef.current = setTimeout( () => {
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
+				// Update previous values.
+				prevClientHeightRef.current = clientHeight;
+				prevFrameSizeRef.current = frameSizeValue;
+				prevScaleRef.current = scaleValue;
 
-			prevClientHeightRef.current = clientHeight;
-			prevFrameSizeRef.current = frameSizeValue;
-			prevScaleRef.current = scaleValue;
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-		}, delay );
+				// Set the final scroll position that was just animated to.
+				iframeDocument.documentElement.scrollTop = scrollTopNext;
+			},
+			{ once: true }
+		);
 	}, [ scaleValue, frameSizeValue, iframeDocument ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -285,7 +285,8 @@ function Iframe( {
 	const frameSizeValue = parseInt( frameSize );
 	const prevFrameSizeRef = useRef( frameSizeValue );
 
-	const prevContainerHeightRef = useRef( containerHeight );
+	const prevClientHeightRef = useRef( containerHeight );
+	const prevScrollHeightRef = useRef( contentHeight );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -344,40 +345,48 @@ function Iframe( {
 	const handleZoomOutAnimation = useCallback( () => {
 		clearTimeout( zoomOutAnimationTimeoutRef.current );
 
+		// We can't trust the set value from contentHeight, as it was measured before the zoom out mode was changed.
+		// After zoom out mode is changed, appenders may appear or disappear, so we need to get the height from the iframe
+		// at this point when we're about to animate the zoom out. The iframe scrollTop, scrollHeight, and clientHeight will all
+		// be accurate. The client height also does change when the zoom out mode is toggled, as the bottom bar about selecting
+		// the template is added/removed when toggling zoom out mode.
 		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// This is the unscaled height of the iframe content.
+		const clientHeight = iframeDocument.documentElement.clientHeight;
+
+		// This is the scaled height of the iframe content.
+		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		const prevClientHeight = prevClientHeightRef.current;
+		const prevScrollHeight = prevScrollHeightRef.current;
+		const prevScale = prevScaleRef.current;
+		const prevFrameSize = prevFrameSizeRef.current;
 
 		// Convert previous values to the zoomed in scale.
 		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
 		const scrollTopOriginal = Math.round(
-			( scrollTop +
-				prevContainerHeightRef.current / 2 -
-				prevFrameSizeRef.current ) /
-				prevScaleRef.current -
-				prevContainerHeightRef.current / 2
+			( scrollTop + prevClientHeight / 2 - prevFrameSize ) / prevScale -
+				prevClientHeight / 2
 		);
 
 		// Convert the zoomed in value to the new scale.
 		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
 		let scrollTopNext = Math.round(
-			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
+			( scrollTopOriginal + clientHeight / 2 ) * scaleValue +
 				frameSizeValue -
-				containerHeight / 2
+				clientHeight / 2
 		);
 
-		const edgeThreshold = prevContainerHeightRef.current / 2;
-		const maxScrollPosition =
-			contentHeight - prevContainerHeightRef.current - frameSizeValue * 2;
+		const scaleRatio = scaleValue / prevScale;
+		const maxScrollTop = scrollHeight * scaleRatio - clientHeight;
 
-		const scaleToTop = scrollTopOriginal - edgeThreshold <= 0;
-		const scaleToBottom =
-			scrollTopOriginal - maxScrollPosition - edgeThreshold <= 0;
+		// prettier-ignore
+		scrollTopNext = scrollTopNext - clientHeight / 2 <= 0 ? 0 : scrollTopNext;
+		// prettier-ignore
+		scrollTopNext = scrollTopNext + clientHeight / 2 >= maxScrollTop ? maxScrollTop : scrollTopNext;
 
-		if ( scaleToTop ) {
-			scrollTopNext = 0;
-		} else if ( scaleToBottom ) {
-			// Not sure on this
-			scrollTopNext = maxScrollPosition * scaleValue;
-		}
+		scrollTopNext = Math.min( Math.max( 0, scrollTopNext ), maxScrollTop );
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -404,19 +413,13 @@ function Iframe( {
 				'zoom-out-animation'
 			);
 
-			prevContainerHeightRef.current = containerHeight;
+			prevClientHeightRef.current = clientHeight;
+			prevScrollHeightRef.current = scrollHeight;
 			prevFrameSizeRef.current = frameSizeValue;
 			prevScaleRef.current = scaleValue;
-
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}, delay );
-	}, [
-		scaleValue,
-		frameSizeValue,
-		containerHeight,
-		iframeDocument,
-		contentHeight,
-	] );
+	}, [ scaleValue, frameSizeValue, iframeDocument ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -14,12 +14,7 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import {
-	useResizeObserver,
-	useMergeRefs,
-	useRefEffect,
-	useDisabled,
-} from '@wordpress/compose';
+import { useMergeRefs, useRefEffect, useDisabled } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 
@@ -126,10 +121,6 @@ function Iframe( {
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
 	const clearerRef = useBlockSelectionClearer();
 	const [ before, writingFlowRef, after ] = useWritingFlow();
-	const [ contentResizeListener, { height: contentHeight } ] =
-		useResizeObserver();
-	const [ containerResizeListener, { width: containerWidth } ] =
-		useResizeObserver();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -225,12 +216,15 @@ function Iframe( {
 		};
 	}, [] );
 
-	const { isZoomedOut, scaleContainerWidth } = useScaleCanvas( {
+	const {
+		contentResizeListener,
+		containerResizeListener,
+		isZoomedOut,
+		scaleContainerWidth,
+	} = useScaleCanvas( {
 		scale,
 		frameSize: parseInt( frameSize ),
 		iframeDocument,
-		contentHeight,
-		containerWidth,
 	} );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,6 +20,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	useReducedMotion,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -131,6 +132,7 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
+	const prefersReducedMotion = useReducedMotion();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -434,11 +436,7 @@ function Iframe( {
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}
 
-		const reduceMotion = iframeDocument.defaultView.matchMedia(
-			'(prefers-reduced-motion: reduce)'
-		).matches;
-
-		if ( reduceMotion ) {
+		if ( prefersReducedMotion ) {
 			onZoomOutTransitionEnd();
 		} else {
 			iframeDocument.documentElement.addEventListener(
@@ -463,7 +461,7 @@ function Iframe( {
 				onZoomOutTransitionEnd
 			);
 		};
-	}, [ iframeDocument, scaleValue, frameSizeValue ] );
+	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -391,6 +391,14 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
 
+		// TODO: See if there's a way to wait for CSS transition to finish.
+		// 400ms should match the animation speed used in components/iframe/content.scss
+		// Ignore the delay when reduce motion is enabled.
+		const reduceMotion = iframeDocument.defaultView.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		).matches;
+		const delay = reduceMotion ? 0 : 400;
+
 		zoomOutAnimationTimeoutRef.current = setTimeout( () => {
 			iframeDocument.documentElement.classList.remove(
 				'zoom-out-animation'
@@ -401,7 +409,7 @@ function Iframe( {
 			prevScaleRef.current = scaleValue;
 
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
-		}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
+		}, delay );
 	}, [
 		scaleValue,
 		frameSizeValue,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -270,18 +270,16 @@ function Iframe( {
 		containerWidth
 	);
 
-	const frameSizeValue = parseInt( frameSize );
-
 	const maxWidth = 750;
 
 	useScaleCanvas( {
 		scale:
 			scale === 'auto-scaled'
 				? ( Math.min( containerWidth, maxWidth ) -
-						frameSizeValue * 2 ) /
+						parseInt( frameSize ) * 2 ) /
 				  scaleContainerWidth
 				: scale,
-		frameSizeValue,
+		frameSize: parseInt( frameSize ),
 		iframeDocument,
 		iframeWindowInnerHeight,
 		contentHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -32,6 +32,7 @@ import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
 import { store as blockEditorStore } from '../../store';
+import { handle } from '@wordpress/icons';
 
 function bubbleEvent( event, Constructor, frame ) {
 	const init = {};
@@ -407,46 +408,49 @@ function Iframe( {
 			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
 		);
 
+		function handleZoomOutEnd() {
+			// Update previous values.
+			prevClientHeightRef.current = clientHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			// Set the final scroll position that was just animated to.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}
+
 		const reduceMotion = iframeDocument.defaultView.matchMedia(
 			'(prefers-reduced-motion: reduce)'
 		).matches;
 
 		if ( reduceMotion ) {
-			// TODO: This seems to be broken somehow.
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-			return;
+			handleZoomOutEnd();
+		} else {
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top',
+				`${ scrollTop }px`
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+				`${ scrollTopNext }px`
+			);
+
+			iframeDocument.documentElement.classList.add(
+				'zoom-out-animation'
+			);
+
+			iframeDocument.documentElement.addEventListener(
+				'transitionend',
+				() => {
+					// Remove the position fixed for the animation.
+					iframeDocument.documentElement.classList.remove(
+						'zoom-out-animation'
+					);
+					handleZoomOutEnd();
+				},
+				{ once: true }
+			);
 		}
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top',
-			`${ scrollTop }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-			`${ scrollTopNext }px`
-		);
-
-		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
-
-		iframeDocument.documentElement.addEventListener(
-			'transitionend',
-			() => {
-				// Remove the position fixed for the animation.
-				iframeDocument.documentElement.classList.remove(
-					'zoom-out-animation'
-				);
-
-				// Update previous values.
-				prevClientHeightRef.current = clientHeight;
-				prevFrameSizeRef.current = frameSizeValue;
-				prevScaleRef.current = scaleValue;
-
-				// Set the final scroll position that was just animated to.
-				iframeDocument.documentElement.scrollTop = scrollTopNext;
-			},
-			{ once: true }
-		);
 	}, [ scaleValue, frameSizeValue, iframeDocument ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -406,7 +406,10 @@ function Iframe( {
 		// possible scrollTop positions. Round the value to avoid subpixel
 		// truncation by the browser which sometimes causes a 1px error.
 		scrollTopNext = Math.round(
-			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
+			Math.min(
+				Math.max( 0, scrollTopNext ),
+				Math.max( 0, maxScrollTop )
+			)
 		);
 
 		iframeDocument.documentElement.style.setProperty(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -13,6 +13,7 @@ import {
 	useMemo,
 	useEffect,
 	useRef,
+	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -20,6 +21,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	usePrevious,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -259,6 +261,7 @@ function Iframe( {
 	}, [] );
 
 	const isZoomedOut = scale !== 1;
+	const prevIsZoomedOut = usePrevious( isZoomedOut );
 
 	useEffect( () => {
 		if ( ! isZoomedOut ) {
@@ -338,69 +341,66 @@ function Iframe( {
 	useEffect( () => cleanup, [ cleanup ] );
 
 	const zoomOutAnimationTimeoutRef = useRef( null );
-	const isAnimatingZoomOut = useRef( null );
+
+	const handleZoomOutAnimation = useCallback( () => {
+		clearTimeout( zoomOutAnimationTimeoutRef.current );
+
+		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// Convert previous values to the zoomed in scale.
+		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+		const scrollTopOriginal = Math.round(
+			( scrollTop +
+				prevContainerHeightRef.current / 2 -
+				prevFrameSizeRef.current ) /
+				prevScaleRef.current -
+				prevContainerHeightRef.current / 2
+		);
+
+		// // Convert the zoomed in value to the new scale.
+		// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+		const scrollTopNext = Math.round(
+			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
+				frameSizeValue -
+				containerHeight / 2
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top',
+			`${ scrollTop }px`
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+			`${ scrollTopNext }px`
+		);
+
+		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
+
+		zoomOutAnimationTimeoutRef.current = setTimeout( () => {
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+
+			prevContainerHeightRef.current = containerHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
+	}, [ scaleValue, frameSizeValue, containerHeight, iframeDocument ] );
+
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
 	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
 	// number of dependencies.
 	useEffect( () => {
 		// If we're animating, don't re-update things.
-		if ( ! iframeDocument || isAnimatingZoomOut.current ) {
+		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
 			return;
 		}
 
-		const handleZoomOutAnimation = () => {
-			clearTimeout( zoomOutAnimationTimeoutRef.current );
-			isAnimatingZoomOut.current = true;
-
-			const scrollTop = iframeDocument.documentElement.scrollTop;
-
-			// Convert previous values to the zoomed in scale.
-			// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
-			const scrollTopOriginal = Math.round(
-				( scrollTop +
-					prevContainerHeightRef.current / 2 -
-					prevFrameSizeRef.current ) /
-					prevScaleRef.current -
-					prevContainerHeightRef.current / 2
-			);
-
-			// // Convert the zoomed in value to the new scale.
-			// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
-			const scrollTopNext = Math.round(
-				( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
-					frameSizeValue -
-					containerHeight / 2
-			);
-
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top',
-				`${ scrollTop }px`
-			);
-
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-				`${ scrollTopNext }px`
-			);
-
-			iframeDocument.documentElement.classList.add(
-				'zoom-out-animation'
-			);
-
-			zoomOutAnimationTimeoutRef.current = setTimeout( () => {
-				iframeDocument.documentElement.classList.remove(
-					'zoom-out-animation'
-				);
-
-				prevContainerHeightRef.current = containerHeight;
-				prevFrameSizeRef.current = frameSizeValue;
-				prevScaleRef.current = scaleValue;
-				isAnimatingZoomOut.current = false;
-
-				iframeDocument.documentElement.scrollTop = scrollTopNext;
-			}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
-		};
-
+		// If zoom out mode is toggled, handle the animation
 		handleZoomOutAnimation();
 
 		if ( isZoomedOut ) {
@@ -410,17 +410,11 @@ function Iframe( {
 		}
 
 		return () => {};
-	}, [
-		iframeDocument,
-		isZoomedOut,
-		scaleValue,
-		frameSizeValue,
-		containerHeight,
-	] );
+	}, [ iframeDocument, isZoomedOut, handleZoomOutAnimation ] );
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument ) {
+		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -74,6 +74,30 @@ function computeScrollTopNext(
 	);
 }
 
+function getAnimationKeyframes( transitionFrom, transitionTo ) {
+	const {
+		scaleValue: prevScale,
+		frameSize: prevFrameSize,
+		scrollTopNext: scrollTop,
+	} = transitionFrom;
+	const { scaleValue, frameSize, scrollTopNext } = transitionTo;
+
+	return [
+		{
+			translate: `0 0`,
+			scale: prevScale,
+			paddingTop: `${ prevFrameSize / prevScale }px`,
+			paddingBottom: `${ prevFrameSize / prevScale }px`,
+		},
+		{
+			translate: `0 ${ scrollTop - scrollTopNext }px`,
+			scale: scaleValue,
+			paddingTop: `${ frameSize / scaleValue }px`,
+			paddingBottom: `${ frameSize / scaleValue }px`,
+		},
+	];
+}
+
 /**
  * Handles scaling the canvas for the zoom out mode and animating between
  * the states.
@@ -329,20 +353,10 @@ export function useScaleCanvas( {
 					'zoom-out-animation'
 				);
 				animationRef.current = iframeDocument.documentElement.animate(
-					[
-						{
-							translate: `0 0`,
-							scale: prevScale,
-							paddingTop: `${ prevFrameSize / prevScale }px`,
-							paddingBottom: `${ prevFrameSize / prevScale }px`,
-						},
-						{
-							translate: `0 ${ scrollTop - scrollTopNext }px`,
-							scale: scaleValue,
-							paddingTop: `${ frameSize / scaleValue }px`,
-							paddingBottom: `${ frameSize / scaleValue }px`,
-						},
-					],
+					getAnimationKeyframes(
+						transitionFrom.current,
+						transitionTo.current
+					),
 					{
 						easing: 'cubic-bezier(0.46, 0.03, 0.52, 0.96)',
 						duration: 400,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -13,7 +13,6 @@ import { useReducedMotion } from '@wordpress/compose';
  * @param {number}   root0.containerWidth      The width of the container.
  * @param {number}   root0.frameSize           The size of the frame around the content.
  * @param {Document} root0.iframeDocument      The document of the iframe.
- * @param {number}   root0.windowInnerWidth    The height of the inner window
  * @param {boolean}  root0.isZoomedOut         Whether the canvas is in zoom out mode.
  * @param {number}   root0.scale               The scale of the canvas.
  * @param {number}   root0.scaleContainerWidth The width of the container at the scaled size.
@@ -24,7 +23,6 @@ export function useScaleCanvas( {
 	iframeDocument,
 	contentHeight,
 	containerWidth,
-	windowInnerWidth,
 	isZoomedOut,
 	scaleContainerWidth,
 } ) {
@@ -263,7 +261,6 @@ export function useScaleCanvas( {
 		iframeDocument,
 		contentHeight,
 		containerWidth,
-		windowInnerWidth,
 		isZoomedOut,
 		scaleContainerWidth,
 	] );

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -11,7 +11,7 @@ import { useReducedMotion } from '@wordpress/compose';
  * @param {Object}   root0
  * @param {number}   root0.contentHeight           The height of the content in the iframe.
  * @param {number}   root0.containerWidth          The width of the container.
- * @param {number}   root0.frameSizeValue          The size of the frame around the content.
+ * @param {number}   root0.frameSize               The size of the frame around the content.
  * @param {Document} root0.iframeDocument          The document of the iframe.
  * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
  * @param {number}   root0.windowInnerWidth        The height of the inner window
@@ -21,7 +21,7 @@ import { useReducedMotion } from '@wordpress/compose';
  */
 export function useScaleCanvas( {
 	scale,
-	frameSizeValue,
+	frameSize,
 	iframeDocument,
 	iframeWindowInnerHeight,
 	contentHeight,
@@ -33,7 +33,7 @@ export function useScaleCanvas( {
 	const prefersReducedMotion = useReducedMotion();
 
 	const prevScaleRef = useRef( scale );
-	const prevFrameSizeRef = useRef( frameSizeValue );
+	const prevFrameSizeRef = useRef( frameSize );
 	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 
 	useEffect( () => {
@@ -85,7 +85,7 @@ export function useScaleCanvas( {
 		// visible area.
 		scrollTopNext =
 			( scrollTopNext + clientHeight / 2 ) * scale +
-			frameSizeValue -
+			frameSize -
 			clientHeight / 2;
 
 		// Step 3: Handle an edge case so that you scroll to the top of the
@@ -98,9 +98,7 @@ export function useScaleCanvas( {
 		// iframe. We can't just let the browser handle it because we need to
 		// animate the scaling.
 		const maxScrollTop =
-			scrollHeight * ( scale / prevScale ) +
-			frameSizeValue * 2 -
-			clientHeight;
+			scrollHeight * ( scale / prevScale ) + frameSize * 2 - clientHeight;
 
 		// Step 4: Clamp the scrollTopNext between the minimum and maximum
 		// possible scrollTop positions. Round the value to avoid subpixel
@@ -132,7 +130,7 @@ export function useScaleCanvas( {
 
 			// Update previous values.
 			prevClientHeightRef.current = clientHeight;
-			prevFrameSizeRef.current = frameSizeValue;
+			prevFrameSizeRef.current = frameSize;
 			prevScaleRef.current = scale;
 
 			// Set the final scroll position that was just animated to.
@@ -172,7 +170,7 @@ export function useScaleCanvas( {
 				);
 			}
 		};
-	}, [ iframeDocument, scale, frameSizeValue, prefersReducedMotion ] );
+	}, [ iframeDocument, scale, frameSize, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
@@ -219,7 +217,7 @@ export function useScaleCanvas( {
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ frameSizeValue }px`
+			`${ frameSize }px`
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',
@@ -262,7 +260,7 @@ export function useScaleCanvas( {
 		};
 	}, [
 		scale,
-		frameSizeValue,
+		frameSize,
 		iframeDocument,
 		iframeWindowInnerHeight,
 		contentHeight,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -9,21 +9,19 @@ import { useReducedMotion } from '@wordpress/compose';
  * the states.
  *
  * @param {Object}   root0
- * @param {number}   root0.contentHeight           The height of the content in the iframe.
- * @param {number}   root0.containerWidth          The width of the container.
- * @param {number}   root0.frameSize               The size of the frame around the content.
- * @param {Document} root0.iframeDocument          The document of the iframe.
- * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
- * @param {number}   root0.windowInnerWidth        The height of the inner window
- * @param {boolean}  root0.isZoomedOut             Whether the canvas is in zoom out mode.
- * @param {number}   root0.scale                   The scale of the canvas.
- * @param {number}   root0.scaleContainerWidth     The width of the container at the scaled size.
+ * @param {number}   root0.contentHeight       The height of the content in the iframe.
+ * @param {number}   root0.containerWidth      The width of the container.
+ * @param {number}   root0.frameSize           The size of the frame around the content.
+ * @param {Document} root0.iframeDocument      The document of the iframe.
+ * @param {number}   root0.windowInnerWidth    The height of the inner window
+ * @param {boolean}  root0.isZoomedOut         Whether the canvas is in zoom out mode.
+ * @param {number}   root0.scale               The scale of the canvas.
+ * @param {number}   root0.scaleContainerWidth The width of the container at the scaled size.
  */
 export function useScaleCanvas( {
 	scale,
 	frameSize,
 	iframeDocument,
-	iframeWindowInnerHeight,
 	contentHeight,
 	containerWidth,
 	windowInnerWidth,
@@ -225,8 +223,9 @@ export function useScaleCanvas( {
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ iframeWindowInnerHeight }px`
+			`${ iframeDocument.documentElement.clientHeight }px`
 		);
+
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-container-width',
 			`${ containerWidth }px`
@@ -262,7 +261,6 @@ export function useScaleCanvas( {
 		scale,
 		frameSize,
 		iframeDocument,
-		iframeWindowInnerHeight,
 		contentHeight,
 		containerWidth,
 		windowInnerWidth,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -29,17 +29,17 @@ function calculateScale( {
 /**
  * Compute the next scrollTop position after scaling the iframe content.
  *
- * @param {number} scrollHeight   Scaled height of the current iframe content.
  * @param {Object} transitionFrom The starting point of the transition
  * @param {Object} transitionTo   The ending state of the transition
  * @return {number} The next scrollTop position after scaling the iframe content.
  */
-function computeScrollTopNext( scrollHeight, transitionFrom, transitionTo ) {
+function computeScrollTopNext( transitionFrom, transitionTo ) {
 	const {
 		clientHeight: prevClientHeight,
 		frameSize: prevFrameSize,
 		scaleValue: prevScale,
-		scrollTop: scrollTop,
+		scrollTop,
+		scrollHeight,
 	} = transitionFrom;
 	const { clientHeight, frameSize, scaleValue } = transitionTo;
 	// Step 0: Start with the current scrollTop.
@@ -174,6 +174,7 @@ export function useScaleCanvas( {
 		frameSize,
 		clientHeight: 0,
 		scrollTop: 0,
+		scrollHeight: 0,
 	} );
 
 	/**
@@ -184,6 +185,7 @@ export function useScaleCanvas( {
 		frameSize,
 		clientHeight: 0,
 		scrollTop: 0,
+		scrollHeight: 0,
 	} );
 
 	/**
@@ -384,6 +386,8 @@ export function useScaleCanvas( {
 					transitionFrom.current.clientHeight ?? clientHeight;
 				transitionFrom.current.scrollTop =
 					iframeDocument.documentElement.scrollTop;
+				transitionFrom.current.scrollHeight =
+					iframeDocument.documentElement.scrollHeight;
 
 				transitionTo.current = {
 					scaleValue,
@@ -391,7 +395,6 @@ export function useScaleCanvas( {
 					clientHeight,
 				};
 				transitionTo.current.scrollTop = computeScrollTopNext(
-					iframeDocument.documentElement.scrollHeight,
 					transitionFrom.current,
 					transitionTo.current
 				);

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -109,26 +109,13 @@ export function useScaleCanvas( {
 			} );
 		}
 
-		if ( isAnimatingRef.current ) {
-			// Set the value that we want to animate from.
-			// We will update them after we add the animation class on next render.
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scale',
-				prevScaleRef.current
-			);
-
-			// frameSize has to be a px value for the scaling and frame size to be computed correctly.
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size',
-				`${ prevFrameSizeRef.current }px`
-			);
-		} else {
-			// We will update them after we add the animation class on next render.
+		// If we are not going to animate the transition set them directly.
+		// Example: Opening sidebars that reduce the scale of the canvas.
+		if ( ! isAnimatingRef.current ) {
 			iframeDocument.documentElement.style.setProperty(
 				'--wp-block-editor-iframe-zoom-out-scale',
 				scaleValue
 			);
-
 			// frameSize has to be a px value for the scaling and frame size to be computed correctly.
 			iframeDocument.documentElement.style.setProperty(
 				'--wp-block-editor-iframe-zoom-out-frame-size',
@@ -156,6 +143,9 @@ export function useScaleCanvas( {
 
 		let onZoomOutTransitionEnd = () => {};
 
+		/**
+		 * Handle the zoom out animation.
+		 */
 		if ( isAnimatingRef.current ) {
 			// Unscaled height of the current iframe container.
 			const clientHeight = iframeDocument.documentElement.clientHeight;
@@ -237,16 +227,6 @@ export function useScaleCanvas( {
 			iframeDocument.documentElement.classList.add(
 				'zoom-out-animation'
 			);
-			// We can change the scale and frame size here, because that's what we want to animate.
-			// We don't want to update these values until the animation class has been added.
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size',
-				`${ frameSize }px`
-			);
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scale',
-				scaleValue
-			);
 
 			const zoomOutAnimation = iframeDocument.documentElement.animate(
 				[
@@ -271,6 +251,16 @@ export function useScaleCanvas( {
 
 			onZoomOutTransitionEnd = () => {
 				isAnimatingRef.current = false;
+				// Add our final scale and frame size now that the animation is done.
+				iframeDocument.documentElement.style.setProperty(
+					'--wp-block-editor-iframe-zoom-out-scale',
+					scaleValue
+				);
+				iframeDocument.documentElement.style.setProperty(
+					'--wp-block-editor-iframe-zoom-out-frame-size',
+					`${ frameSize }px`
+				);
+
 				iframeDocument.documentElement.classList.remove(
 					'zoom-out-animation'
 				);

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -250,6 +250,27 @@ export function useScaleCanvas( {
 				scaleValue
 			);
 
+			const zoomOutAnimation = iframeDocument.documentElement.animate(
+				[
+					{
+						translate: `0 0`,
+						scale: prevScale,
+						paddingTop: `${ prevFrameSize / prevScale }px`,
+						paddingBottom: `${ prevFrameSize / prevScale }px`,
+					},
+					{
+						translate: `0 ${ scrollTop - scrollTopNext }px`,
+						scale: scaleValue,
+						paddingTop: `${ frameSize / scaleValue }px`,
+						paddingBottom: `${ frameSize / scaleValue }px`,
+					},
+				],
+				{
+					easing: 'cubic-bezier(0.46, 0.03, 0.52, 0.96)',
+					duration: 400,
+				}
+			);
+
 			onZoomOutTransitionEnd = () => {
 				isAnimatingRef.current = false;
 				iframeDocument.documentElement.classList.remove(
@@ -276,11 +297,7 @@ export function useScaleCanvas( {
 			if ( prefersReducedMotion ) {
 				onZoomOutTransitionEnd();
 			} else {
-				iframeDocument.documentElement.addEventListener(
-					'transitionend',
-					onZoomOutTransitionEnd,
-					{ once: true }
-				);
+				zoomOutAnimation.onfinish = onZoomOutTransitionEnd;
 			}
 		}
 

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -260,7 +260,7 @@ export function useScaleCanvas( {
 				// Update previous values.
 				prevClientHeightRef.current = clientHeight;
 				prevFrameSizeRef.current = frameSize;
-				prevScaleRef.current = scale;
+				prevScaleRef.current = scaleValue;
 
 				// Set the final scroll position that was just animated to.
 				iframeDocument.documentElement.scrollTop = scrollTopNext;

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -21,25 +21,35 @@ function calculateScale( {
  * the states.
  *
  * @param {Object}        root0
- * @param {number}        root0.containerWidth      The width of the container.
- * @param {number}        root0.contentHeight       The height of the content in the iframe.
- * @param {number}        root0.frameSize           The size of the frame around the content.
- * @param {Document}      root0.iframeDocument      The document of the iframe.
- * @param {boolean}       root0.isZoomedOut         Whether the canvas is in zoom out mode.
- * @param {number}        root0.maxContainerWidth   The max width of the canvas to use as the starting scale point.
- * @param {number|string} root0.scale               The scale of the canvas. Default to 'auto-scaled'.
- * @param {number}        root0.scaleContainerWidth The width of the outer container used to calculate the scale.
+ * @param {number}        root0.containerWidth    The width of the container.
+ * @param {number}        root0.contentHeight     The height of the content in the iframe.
+ * @param {number}        root0.frameSize         The size of the frame around the content.
+ * @param {Document}      root0.iframeDocument    The document of the iframe.
+ * @param {number}        root0.maxContainerWidth The max width of the canvas to use as the starting scale point.
+ * @param {number|string} root0.scale             The scale of the canvas. Can be an decimal between 0 and 1, 1, or 'auto-scaled'.
  */
 export function useScaleCanvas( {
 	containerWidth,
 	contentHeight,
 	frameSize,
 	iframeDocument,
-	isZoomedOut,
 	maxContainerWidth = 750,
 	scale,
-	scaleContainerWidth,
 } ) {
+	const initialContainerWidthRef = useRef( 0 );
+	const isZoomedOut = scale !== 1;
+
+	useEffect( () => {
+		if ( ! isZoomedOut ) {
+			initialContainerWidthRef.current = containerWidth;
+		}
+	}, [ containerWidth, isZoomedOut ] );
+
+	const scaleContainerWidth = Math.max(
+		initialContainerWidthRef.current,
+		containerWidth
+	);
+
 	const prefersReducedMotion = useReducedMotion();
 	const [ isAnimatingZoomOut, setIsAnimatingZoomOut ] = useState( false );
 	const transitionToRef = useRef( {
@@ -324,4 +334,9 @@ export function useScaleCanvas( {
 			// );
 		};
 	}, [ iframeDocument, isZoomedOut, setIsAnimatingZoomOut ] );
+
+	return {
+		isZoomedOut,
+		scaleContainerWidth,
+	};
 }

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -183,6 +183,19 @@ export function useScaleCanvas( {
 			return;
 		}
 
+		// Set the value that we want to animate from.
+		// We will update them after we add the animation class on next render.
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scale',
+			scale
+		);
+
+		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-frame-size',
+			`${ frameSize }px`
+		);
+
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',
 			`${ contentHeight }px`

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -393,6 +393,7 @@ export function useScaleCanvas( {
 		};
 	}, [
 		onZoomOutTransitionEnd,
+		prefersReducedMotion,
 		isAutoScaled,
 		scaleValue,
 		frameSize,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -5,14 +5,23 @@ import { useEffect, useRef, useCallback } from '@wordpress/element';
 import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 
 /**
+ * @typedef {Object} TransitionState
+ * @property {number} scaleValue   Scale of the canvas.
+ * @property {number} frameSize    Size of the frame/offset around the canvas.
+ * @property {number} clientHeight ClientHeight of the iframe.
+ * @property {number} scrollTop    ScrollTop of the iframe.
+ * @property {number} scrollHeight ScrollHeight of the iframe.
+ */
+
+/**
  * Calculate the scale of the canvas.
  *
- * @param {Object} root0                     Object of options
- * @param {number} root0.frameSize           The size of the frame/offset around the canvas
- * @param {number} root0.containerWidth      Actual width of the canvas container
- * @param {number} root0.maxContainerWidth   Maximum width of the container to use for the scale calculation. This locks the canvas to a maximum width when zooming out.
- * @param {number} root0.scaleContainerWidth Width the of the container wrapping the canvas container
- * @return {number} scale value between 0 and/or equal to 1
+ * @param {Object} options                     Object of options
+ * @param {number} options.frameSize           Size of the frame/offset around the canvas
+ * @param {number} options.containerWidth      Actual width of the canvas container
+ * @param {number} options.maxContainerWidth   Maximum width of the container to use for the scale calculation. This locks the canvas to a maximum width when zooming out.
+ * @param {number} options.scaleContainerWidth Width the of the container wrapping the canvas container
+ * @return {number} Scale value between 0 and/or equal to 1
  */
 function calculateScale( {
 	frameSize,
@@ -29,9 +38,9 @@ function calculateScale( {
 /**
  * Compute the next scrollTop position after scaling the iframe content.
  *
- * @param {Object} transitionFrom The starting point of the transition
- * @param {Object} transitionTo   The ending state of the transition
- * @return {number} The next scrollTop position after scaling the iframe content.
+ * @param {TransitionState} transitionFrom Starting point of the transition
+ * @param {TransitionState} transitionTo   Ending state of the transition
+ * @return {number} Next scrollTop position after scaling the iframe content.
  */
 function computeScrollTopNext( transitionFrom, transitionTo ) {
 	const {
@@ -82,9 +91,9 @@ function computeScrollTopNext( transitionFrom, transitionTo ) {
 /**
  * Generate the keyframes to use for the zoom out animation.
  *
- * @param {Object} transitionFrom Object of the starting transition state
- * @param {Object} transitionTo   Object of the ending transition state
- * @return {Object[]} An array of keyframes to use for the animation
+ * @param {TransitionState} transitionFrom Starting transition state.
+ * @param {TransitionState} transitionTo   Ending transition state.
+ * @return {Object[]} An array of keyframes to use for the animation.
  */
 function getAnimationKeyframes( transitionFrom, transitionTo ) {
 	const {
@@ -111,19 +120,23 @@ function getAnimationKeyframes( transitionFrom, transitionTo ) {
 }
 
 /**
+ * @typedef {Object} ScaleCanvasResult
+ * @property {boolean} isZoomedOut             A boolean indicating if the canvas is zoomed out.
+ * @property {number}  scaleContainerWidth     The width of the container used to calculate the scale.
+ * @property {Object}  contentResizeListener   A resize observer for the content.
+ * @property {Object}  containerResizeListener A resize observer for the container.
+ */
+
+/**
  * Handles scaling the canvas for the zoom out mode and animating between
  * the states.
  *
- * @param {Object}        root0
- * @param {number}        root0.frameSize         The size of the frame around the content.
- * @param {Document}      root0.iframeDocument    The document of the iframe.
- * @param {number}        root0.maxContainerWidth The max width of the canvas to use as the starting scale point. Defaults to 750.
- * @param {number|string} root0.scale             The scale of the canvas. Can be an decimal between 0 and 1, 1, or 'auto-scaled'.
- * @return {Object} An object containing the following properties:
- *                  isZoomedOut: A boolean indicating if the canvas is zoomed out.
- *                  scaleContainerWidth: The width of the container used to calculate the scale.
- *                  contentResizeListener: A resize observer for the content.
- *                  containerResizeListener: A resize observer for the container.
+ * @param {Object}        options                   Object of options.
+ * @param {number}        options.frameSize         Size of the frame around the content.
+ * @param {Document}      options.iframeDocument    Document of the iframe.
+ * @param {number}        options.maxContainerWidth Max width of the canvas to use as the starting scale point. Defaults to 750.
+ * @param {number|string} options.scale             Scale of the canvas. Can be an decimal between 0 and 1, 1, or 'auto-scaled'.
+ * @return {ScaleCanvasResult} Properties of the result.
  */
 export function useScaleCanvas( {
 	frameSize,
@@ -168,6 +181,7 @@ export function useScaleCanvas( {
 
 	/**
 	 * The starting transition state for the zoom out animation.
+	 * @type {import('react').RefObject<TransitionState>}
 	 */
 	const transitionFrom = useRef( {
 		scaleValue,
@@ -179,6 +193,7 @@ export function useScaleCanvas( {
 
 	/**
 	 * The ending transition state for the zoom out animation.
+	 * @type {import('react').RefObject<TransitionState>}
 	 */
 	const transitionTo = useRef( {
 		scaleValue,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -16,11 +16,11 @@ import { useReducedMotion } from '@wordpress/compose';
  * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
  * @param {number}   root0.windowInnerWidth        The height of the inner window
  * @param {boolean}  root0.isZoomedOut             Whether the canvas is in zoom out mode.
- * @param {number}   root0.scaleValue              The scale of the canvas.
+ * @param {number}   root0.scale                   The scale of the canvas.
  * @param {number}   root0.scaleContainerWidth     The width of the container at the scaled size.
  */
 export function useScaleCanvas( {
-	scaleValue,
+	scale,
 	frameSizeValue,
 	iframeDocument,
 	iframeWindowInnerHeight,
@@ -32,7 +32,7 @@ export function useScaleCanvas( {
 } ) {
 	const prefersReducedMotion = useReducedMotion();
 
-	const prevScaleRef = useRef( scaleValue );
+	const prevScaleRef = useRef( scale );
 	const prevFrameSizeRef = useRef( frameSizeValue );
 	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 
@@ -41,7 +41,7 @@ export function useScaleCanvas( {
 			! iframeDocument ||
 			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
 			// instead of the dependency array to appease the linter.
-			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
+			( scale === 1 ) === ( prevScaleRef.current === 1 )
 		) {
 			return;
 		}
@@ -84,7 +84,7 @@ export function useScaleCanvas( {
 		// Step 2: Apply the new scale and frame around the midpoint of the
 		// visible area.
 		scrollTopNext =
-			( scrollTopNext + clientHeight / 2 ) * scaleValue +
+			( scrollTopNext + clientHeight / 2 ) * scale +
 			frameSizeValue -
 			clientHeight / 2;
 
@@ -98,7 +98,7 @@ export function useScaleCanvas( {
 		// iframe. We can't just let the browser handle it because we need to
 		// animate the scaling.
 		const maxScrollTop =
-			scrollHeight * ( scaleValue / prevScale ) +
+			scrollHeight * ( scale / prevScale ) +
 			frameSizeValue * 2 -
 			clientHeight;
 
@@ -133,7 +133,7 @@ export function useScaleCanvas( {
 			// Update previous values.
 			prevClientHeightRef.current = clientHeight;
 			prevFrameSizeRef.current = frameSizeValue;
-			prevScaleRef.current = scaleValue;
+			prevScaleRef.current = scale;
 
 			// Set the final scroll position that was just animated to.
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
@@ -172,7 +172,7 @@ export function useScaleCanvas( {
 				);
 			}
 		};
-	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
+	}, [ iframeDocument, scale, frameSizeValue, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
@@ -213,7 +213,7 @@ export function useScaleCanvas( {
 		// but calc( 100px / 2px ) is not.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scaleValue
+			scale
 		);
 
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
@@ -261,7 +261,7 @@ export function useScaleCanvas( {
 			// );
 		};
 	}, [
-		scaleValue,
+		scale,
 		frameSizeValue,
 		iframeDocument,
 		iframeWindowInnerHeight,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -45,6 +45,7 @@ export function useScaleCanvas( {
 
 	const initialContainerWidthRef = useRef( 0 );
 	const isZoomedOut = scale !== 1;
+	const isAnimatingRef = useRef( false );
 
 	useEffect( () => {
 		if ( ! isZoomedOut ) {
@@ -59,13 +60,6 @@ export function useScaleCanvas( {
 
 	const prefersReducedMotion = useReducedMotion();
 	const [ isAnimatingZoomOut, setIsAnimatingZoomOut ] = useState( false );
-	const transitionToRef = useRef( {
-		scale,
-		frameSize,
-	} );
-	const prevScaleRef = useRef( scale );
-	const prevFrameSizeRef = useRef( frameSize );
-	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 	const isAutoScaled = scale === 'auto-scaled';
 
 	const scaleValue = isAutoScaled
@@ -77,159 +71,32 @@ export function useScaleCanvas( {
 		  } )
 		: scale;
 
-	// New state for isZoomedOut in the iframe component. That state is updated when the animation is completed,
-	// which causes the rerender to happen. Things that are in refs, now become state. ZoomOutAnimation is a state.
-	// ZoomOutAnimation being removed.
+	const prevScaleRef = useRef( scaleValue );
+	const prevFrameSizeRef = useRef( frameSize );
+	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
+
 	useEffect( () => {
-		if ( ! iframeDocument || ! isAnimatingZoomOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
-		const nextScale = transitionToRef.current.scale;
-		const nextFrameSize = transitionToRef.current.frameSize;
 
-		// Unscaled height of the current iframe container.
-		const clientHeight = iframeDocument.documentElement.clientHeight;
-
-		// Scaled height of the current iframe content.
-		const scrollHeight = iframeDocument.documentElement.scrollHeight;
-
-		// Previous scale value.
-		const prevScale = prevScaleRef.current;
-
-		// Unscaled size of the previous padding around the iframe content.
-		const prevFrameSize = prevFrameSizeRef.current;
-
-		// Unscaled height of the previous iframe container.
-		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
-
-		// We can't trust the set value from contentHeight, as it was measured
-		// before the zoom out mode was changed. After zoom out mode is changed,
-		// appenders may appear or disappear, so we need to get the height from
-		// the iframe at this point when we're about to animate the zoom out.
-		// The iframe scrollTop, scrollHeight, and clientHeight will all be
-		// accurate. The client height also does change when the zoom out mode
-		// is toggled, as the bottom bar about selecting the template is
-		// added/removed when toggling zoom out mode.
-		const scrollTop = iframeDocument.documentElement.scrollTop;
-
-		// Step 0: Start with the current scrollTop.
-		let scrollTopNext = scrollTop;
-
-		// Step 1: Undo the effects of the previous scale and frame around the
-		// midpoint of the visible area.
-		scrollTopNext =
-			( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
-				prevScale -
-			prevClientHeight / 2;
-
-		// Step 2: Apply the new scale and frame around the midpoint of the
-		// visible area.
-		scrollTopNext =
-			( scrollTopNext + clientHeight / 2 ) * nextScale +
-			nextFrameSize -
-			clientHeight / 2;
-
-		// Step 3: Handle an edge case so that you scroll to the top of the
-		// iframe if the top of the iframe content is visible in the container.
-		// The same edge case for the bottom is skipped because changing content
-		// makes calculating it impossible.
-		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
-
-		// This is the scrollTop value if you are scrolled to the bottom of the
-		// iframe. We can't just let the browser handle it because we need to
-		// animate the scaling.
-		const maxScrollTop =
-			scrollHeight * ( nextScale / prevScale ) +
-			nextFrameSize * 2 -
-			clientHeight;
-
-		// Step 4: Clamp the scrollTopNext between the minimum and maximum
-		// possible scrollTop positions. Round the value to avoid subpixel
-		// truncation by the browser which sometimes causes a 1px error.
-		scrollTopNext = Math.round(
-			Math.min(
-				Math.max( 0, scrollTopNext ),
-				Math.max( 0, maxScrollTop )
-			)
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top',
-			`${ scrollTop }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-			`${ scrollTopNext }px`
-		);
-
-		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ nextFrameSize }px`
-		);
-
-		// We can change the scale and frame size here, because that's what we want to animate.
-		// We don't want to update these values until the animation class has been added.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale',
-			nextScale
-		);
-
-		function onZoomOutTransitionEnd() {
-			if ( isAnimatingZoomOut ) {
-				setIsAnimatingZoomOut( false );
-
-				// Update previous values.
-				prevClientHeightRef.current = clientHeight;
-				prevFrameSizeRef.current = nextFrameSize;
-				prevScaleRef.current = nextScale;
-			}
+		if ( isZoomedOut ) {
+			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 		}
 
-		if ( prefersReducedMotion ) {
-			onZoomOutTransitionEnd();
-		} else {
-			iframeDocument.documentElement.addEventListener(
-				'transitionend',
-				onZoomOutTransitionEnd,
-				{ once: true }
-			);
-		}
+		setIsAnimatingZoomOut( true );
+		isAnimatingRef.current = true;
 
 		return () => {
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
-			// Set the final scroll position that was just animated to.
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top-next'
-			);
-
-			iframeDocument.documentElement.removeEventListener(
-				'transitionend',
-				onZoomOutTransitionEnd
-			);
+			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
-	}, [ iframeDocument, prefersReducedMotion, isAnimatingZoomOut ] );
+	}, [ iframeDocument, isZoomedOut, setIsAnimatingZoomOut ] );
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
 		if ( ! iframeDocument ) {
 			return;
 		}
-
-		// Set the value that we want to animate from.
-		// We will update them after we add the animation class on next render.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale',
-			scaleValue
-		);
 
 		if ( isAutoScaled && prevScaleRef.current !== 1 ) {
 			// We need to update the appropriate scale to exit from. If sidebars have been opened since setting the
@@ -244,11 +111,32 @@ export function useScaleCanvas( {
 			} );
 		}
 
-		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ frameSize }px`
-		);
+		if ( isAnimatingZoomOut || isAnimatingRef.current ) {
+			// Set the value that we want to animate from.
+			// We will update them after we add the animation class on next render.
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scale',
+				prevScaleRef.current
+			);
+
+			// frameSize has to be a px value for the scaling and frame size to be computed correctly.
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-frame-size',
+				`${ prevFrameSizeRef.current }px`
+			);
+		} else {
+			// We will update them after we add the animation class on next render.
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scale',
+				scaleValue
+			);
+
+			// frameSize has to be a px value for the scaling and frame size to be computed correctly.
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-frame-size',
+				`${ frameSize }px`
+			);
+		}
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',
@@ -268,10 +156,133 @@ export function useScaleCanvas( {
 			`${ scaleContainerWidth }px`
 		);
 
-		transitionToRef.current = {
-			scale: scaleValue,
-			frameSize,
-		};
+		if ( isAnimatingZoomOut ) {
+			// Unscaled height of the current iframe container.
+			const clientHeight = iframeDocument.documentElement.clientHeight;
+
+			// Scaled height of the current iframe content.
+			const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+			// Previous scale value.
+			const prevScale = prevScaleRef.current;
+
+			// Unscaled size of the previous padding around the iframe content.
+			const prevFrameSize = prevFrameSizeRef.current;
+
+			// Unscaled height of the previous iframe container.
+			const prevClientHeight =
+				prevClientHeightRef.current ?? clientHeight;
+
+			// We can't trust the set value from contentHeight, as it was measured
+			// before the zoom out mode was changed. After zoom out mode is changed,
+			// appenders may appear or disappear, so we need to get the height from
+			// the iframe at this point when we're about to animate the zoom out.
+			// The iframe scrollTop, scrollHeight, and clientHeight will all be
+			// accurate. The client height also does change when the zoom out mode
+			// is toggled, as the bottom bar about selecting the template is
+			// added/removed when toggling zoom out mode.
+			const scrollTop = iframeDocument.documentElement.scrollTop;
+
+			// Step 0: Start with the current scrollTop.
+			let scrollTopNext = scrollTop;
+
+			// Step 1: Undo the effects of the previous scale and frame around the
+			// midpoint of the visible area.
+			scrollTopNext =
+				( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
+					prevScale -
+				prevClientHeight / 2;
+
+			// Step 2: Apply the new scale and frame around the midpoint of the
+			// visible area.
+			scrollTopNext =
+				( scrollTopNext + clientHeight / 2 ) * scaleValue +
+				frameSize -
+				clientHeight / 2;
+
+			// Step 3: Handle an edge case so that you scroll to the top of the
+			// iframe if the top of the iframe content is visible in the container.
+			// The same edge case for the bottom is skipped because changing content
+			// makes calculating it impossible.
+			scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
+
+			// This is the scrollTop value if you are scrolled to the bottom of the
+			// iframe. We can't just let the browser handle it because we need to
+			// animate the scaling.
+			const maxScrollTop =
+				scrollHeight * ( scaleValue / prevScale ) +
+				frameSize * 2 -
+				clientHeight;
+
+			// Step 4: Clamp the scrollTopNext between the minimum and maximum
+			// possible scrollTop positions. Round the value to avoid subpixel
+			// truncation by the browser which sometimes causes a 1px error.
+			scrollTopNext = Math.round(
+				Math.min(
+					Math.max( 0, scrollTopNext ),
+					Math.max( 0, maxScrollTop )
+				)
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top',
+				`${ scrollTop }px`
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+				`${ scrollTopNext }px`
+			);
+
+			iframeDocument.documentElement.classList.add(
+				'zoom-out-animation'
+			);
+			// We can change the scale and frame size here, because that's what we want to animate.
+			// We don't want to update these values until the animation class has been added.
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-frame-size',
+				`${ frameSize }px`
+			);
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scale',
+				scaleValue
+			);
+
+			function onZoomOutTransitionEnd() {
+				if ( isAnimatingZoomOut ) {
+					isAnimatingRef.current = false;
+					iframeDocument.documentElement.classList.remove(
+						'zoom-out-animation'
+					);
+					setIsAnimatingZoomOut( false );
+
+					// Update previous values.
+					prevClientHeightRef.current = clientHeight;
+					prevFrameSizeRef.current = frameSize;
+					prevScaleRef.current = scale;
+
+					// Set the final scroll position that was just animated to.
+					iframeDocument.documentElement.scrollTop = scrollTopNext;
+
+					iframeDocument.documentElement.style.removeProperty(
+						'--wp-block-editor-iframe-zoom-out-scroll-top'
+					);
+					iframeDocument.documentElement.style.removeProperty(
+						'--wp-block-editor-iframe-zoom-out-scroll-top-next'
+					);
+				}
+			}
+
+			if ( prefersReducedMotion ) {
+				onZoomOutTransitionEnd();
+			} else {
+				iframeDocument.documentElement.addEventListener(
+					'transitionend',
+					onZoomOutTransitionEnd,
+					{ once: true }
+				);
+			}
+		}
 
 		return () => {
 			// HACK: Skipping cleanup because it causes issues with the zoom out
@@ -296,6 +307,7 @@ export function useScaleCanvas( {
 			// );
 		};
 	}, [
+		isAnimatingZoomOut,
 		isAutoScaled,
 		scaleValue,
 		frameSize,
@@ -305,42 +317,6 @@ export function useScaleCanvas( {
 		maxContainerWidth,
 		scaleContainerWidth,
 	] );
-
-	useEffect( () => {
-		if ( ! iframeDocument ) {
-			return;
-		}
-
-		if ( isZoomedOut ) {
-			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
-		}
-
-		setIsAnimatingZoomOut( true );
-
-		// Set the value that we want to animate from.
-		// We will update them after we add the animation class on next render.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale',
-			prevScaleRef.current
-		);
-
-		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ prevFrameSizeRef.current }px`
-		);
-
-		return () => {
-			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
-
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
-			// );
-		};
-	}, [ iframeDocument, isZoomedOut, setIsAnimatingZoomOut ] );
 
 	return {
 		isZoomedOut,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -1,0 +1,274 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useReducedMotion } from '@wordpress/compose';
+
+/**
+ * Handles scaling the canvas for the zoom out mode and animating between
+ * the states.
+ *
+ * @param {Object}   root0
+ * @param {number}   root0.contentHeight           The height of the content in the iframe.
+ * @param {number}   root0.containerWidth          The width of the container.
+ * @param {number}   root0.frameSizeValue          The size of the frame around the content.
+ * @param {Document} root0.iframeDocument          The document of the iframe.
+ * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
+ * @param {number}   root0.windowInnerWidth        The height of the inner window
+ * @param {boolean}  root0.isZoomedOut             Whether the canvas is in zoom out mode.
+ * @param {number}   root0.scaleValue              The scale of the canvas.
+ * @param {number}   root0.scaleContainerWidth     The width of the container at the scaled size.
+ */
+export function useScaleCanvas( {
+	scaleValue,
+	frameSizeValue,
+	iframeDocument,
+	iframeWindowInnerHeight,
+	contentHeight,
+	containerWidth,
+	windowInnerWidth,
+	isZoomedOut,
+	scaleContainerWidth,
+} ) {
+	const prefersReducedMotion = useReducedMotion();
+
+	const prevScaleRef = useRef( scaleValue );
+	const prevFrameSizeRef = useRef( frameSizeValue );
+	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
+
+	useEffect( () => {
+		if (
+			! iframeDocument ||
+			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
+			// instead of the dependency array to appease the linter.
+			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
+		) {
+			return;
+		}
+
+		// Unscaled height of the current iframe container.
+		const clientHeight = iframeDocument.documentElement.clientHeight;
+
+		// Scaled height of the current iframe content.
+		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		// Previous scale value.
+		const prevScale = prevScaleRef.current;
+
+		// Unscaled size of the previous padding around the iframe content.
+		const prevFrameSize = prevFrameSizeRef.current;
+
+		// Unscaled height of the previous iframe container.
+		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
+
+		// We can't trust the set value from contentHeight, as it was measured
+		// before the zoom out mode was changed. After zoom out mode is changed,
+		// appenders may appear or disappear, so we need to get the height from
+		// the iframe at this point when we're about to animate the zoom out.
+		// The iframe scrollTop, scrollHeight, and clientHeight will all be
+		// accurate. The client height also does change when the zoom out mode
+		// is toggled, as the bottom bar about selecting the template is
+		// added/removed when toggling zoom out mode.
+		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// Step 0: Start with the current scrollTop.
+		let scrollTopNext = scrollTop;
+
+		// Step 1: Undo the effects of the previous scale and frame around the
+		// midpoint of the visible area.
+		scrollTopNext =
+			( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
+				prevScale -
+			prevClientHeight / 2;
+
+		// Step 2: Apply the new scale and frame around the midpoint of the
+		// visible area.
+		scrollTopNext =
+			( scrollTopNext + clientHeight / 2 ) * scaleValue +
+			frameSizeValue -
+			clientHeight / 2;
+
+		// Step 3: Handle an edge case so that you scroll to the top of the
+		// iframe if the top of the iframe content is visible in the container.
+		// The same edge case for the bottom is skipped because changing content
+		// makes calculating it impossible.
+		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
+
+		// This is the scrollTop value if you are scrolled to the bottom of the
+		// iframe. We can't just let the browser handle it because we need to
+		// animate the scaling.
+		const maxScrollTop =
+			scrollHeight * ( scaleValue / prevScale ) +
+			frameSizeValue * 2 -
+			clientHeight;
+
+		// Step 4: Clamp the scrollTopNext between the minimum and maximum
+		// possible scrollTop positions. Round the value to avoid subpixel
+		// truncation by the browser which sometimes causes a 1px error.
+		scrollTopNext = Math.round(
+			Math.min(
+				Math.max( 0, scrollTopNext ),
+				Math.max( 0, maxScrollTop )
+			)
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top',
+			`${ scrollTop }px`
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+			`${ scrollTopNext }px`
+		);
+
+		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
+
+		function onZoomOutTransitionEnd() {
+			// Remove the position fixed for the animation.
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+
+			// Update previous values.
+			prevClientHeightRef.current = clientHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			// Set the final scroll position that was just animated to.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}
+
+		let raf;
+		if ( prefersReducedMotion ) {
+			// Hack: Wait for the window values to recalculate.
+			raf = iframeDocument.defaultView.requestAnimationFrame(
+				onZoomOutTransitionEnd
+			);
+		} else {
+			iframeDocument.documentElement.addEventListener(
+				'transitionend',
+				onZoomOutTransitionEnd,
+				{ once: true }
+			);
+		}
+
+		return () => {
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next'
+			);
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+			if ( prefersReducedMotion ) {
+				iframeDocument.defaultView.cancelAnimationFrame( raf );
+			} else {
+				iframeDocument.documentElement.removeEventListener(
+					'transitionend',
+					onZoomOutTransitionEnd
+				);
+			}
+		};
+	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
+
+	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
+	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
+	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
+	// number of dependencies.
+	useEffect( () => {
+		if ( ! iframeDocument ) {
+			return;
+		}
+
+		if ( isZoomedOut ) {
+			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		} else {
+			// HACK: Since we can't remove this in the cleanup, we need to do it here.
+			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
+		}
+
+		return () => {
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
+			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
+		};
+	}, [ iframeDocument, isZoomedOut ] );
+
+	// Calculate the scaling and CSS variables for the zoom out canvas
+	useEffect( () => {
+		if ( ! iframeDocument ) {
+			return;
+		}
+
+		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
+		// initialContainerWidth will be smaller than the full page, and reflow will happen
+		// when the canvas area becomes larger due to sidebars closing. This is a known but
+		// minor divergence for now.
+
+		// This scaling calculation has to happen within the JS because CSS calc() can
+		// only divide and multiply by a unitless value. I.e. calc( 100px / 2 ) is valid
+		// but calc( 100px / 2px ) is not.
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scale',
+			scaleValue
+		);
+
+		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-frame-size',
+			`${ frameSizeValue }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-content-height',
+			`${ contentHeight }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-inner-height',
+			`${ iframeWindowInnerHeight }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-container-width',
+			`${ containerWidth }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scale-container-width',
+			`${ scaleContainerWidth }px`
+		);
+
+		return () => {
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-content-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-container-width'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
+			// );
+		};
+	}, [
+		scaleValue,
+		frameSizeValue,
+		iframeDocument,
+		iframeWindowInnerHeight,
+		contentHeight,
+		containerWidth,
+		windowInnerWidth,
+		isZoomedOut,
+		scaleContainerWidth,
+	] );
+}

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -156,6 +156,8 @@ export function useScaleCanvas( {
 			`${ scaleContainerWidth }px`
 		);
 
+		let onZoomOutTransitionEnd = () => {};
+
 		if ( isAnimatingZoomOut ) {
 			// Unscaled height of the current iframe container.
 			const clientHeight = iframeDocument.documentElement.clientHeight;
@@ -248,30 +250,28 @@ export function useScaleCanvas( {
 				scaleValue
 			);
 
-			function onZoomOutTransitionEnd() {
-				if ( isAnimatingZoomOut ) {
-					isAnimatingRef.current = false;
-					iframeDocument.documentElement.classList.remove(
-						'zoom-out-animation'
-					);
-					setIsAnimatingZoomOut( false );
+			onZoomOutTransitionEnd = () => {
+				isAnimatingRef.current = false;
+				iframeDocument.documentElement.classList.remove(
+					'zoom-out-animation'
+				);
+				setIsAnimatingZoomOut( false );
 
-					// Update previous values.
-					prevClientHeightRef.current = clientHeight;
-					prevFrameSizeRef.current = frameSize;
-					prevScaleRef.current = scale;
+				// Update previous values.
+				prevClientHeightRef.current = clientHeight;
+				prevFrameSizeRef.current = frameSize;
+				prevScaleRef.current = scale;
 
-					// Set the final scroll position that was just animated to.
-					iframeDocument.documentElement.scrollTop = scrollTopNext;
+				// Set the final scroll position that was just animated to.
+				iframeDocument.documentElement.scrollTop = scrollTopNext;
 
-					iframeDocument.documentElement.style.removeProperty(
-						'--wp-block-editor-iframe-zoom-out-scroll-top'
-					);
-					iframeDocument.documentElement.style.removeProperty(
-						'--wp-block-editor-iframe-zoom-out-scroll-top-next'
-					);
-				}
-			}
+				iframeDocument.documentElement.style.removeProperty(
+					'--wp-block-editor-iframe-zoom-out-scroll-top'
+				);
+				iframeDocument.documentElement.style.removeProperty(
+					'--wp-block-editor-iframe-zoom-out-scroll-top-next'
+				);
+			};
 
 			if ( prefersReducedMotion ) {
 				onZoomOutTransitionEnd();
@@ -285,26 +285,29 @@ export function useScaleCanvas( {
 		}
 
 		return () => {
-			// HACK: Skipping cleanup because it causes issues with the zoom out
-			// animation. More refactoring is needed to fix this properly.
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-content-height'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-container-width'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			// );
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scale'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-frame-size'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-content-height'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-inner-height'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-container-width'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scale-container-width'
+			);
+
+			iframeDocument.documentElement.removeEventListener(
+				'transitionend',
+				onZoomOutTransitionEnd
+			);
 		};
 	}, [
 		isAnimatingZoomOut,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { useReducedMotion } from '@wordpress/compose';
+import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 
 function calculateScale( {
 	frameSize,
@@ -21,21 +21,28 @@ function calculateScale( {
  * the states.
  *
  * @param {Object}        root0
- * @param {number}        root0.containerWidth    The width of the container.
- * @param {number}        root0.contentHeight     The height of the content in the iframe.
  * @param {number}        root0.frameSize         The size of the frame around the content.
  * @param {Document}      root0.iframeDocument    The document of the iframe.
  * @param {number}        root0.maxContainerWidth The max width of the canvas to use as the starting scale point.
  * @param {number|string} root0.scale             The scale of the canvas. Can be an decimal between 0 and 1, 1, or 'auto-scaled'.
+ *
+ * @return {Object} An object containing the following properties:
+ *                  isZoomedOut: A boolean indicating if the canvas is zoomed out.
+ *                  scaleContainerWidth: The width of the container used to calculate the scale.
+ *                  contentResizeListener: A resize observer for the content.
+ *                  containerResizeListener: A resize observer for the container.
  */
 export function useScaleCanvas( {
-	containerWidth,
-	contentHeight,
 	frameSize,
 	iframeDocument,
 	maxContainerWidth = 750,
 	scale,
 } ) {
+	const [ contentResizeListener, { height: contentHeight } ] =
+		useResizeObserver();
+	const [ containerResizeListener, { width: containerWidth } ] =
+		useResizeObserver();
+
 	const initialContainerWidthRef = useRef( 0 );
 	const isZoomedOut = scale !== 1;
 
@@ -338,5 +345,7 @@ export function useScaleCanvas( {
 	return {
 		isZoomedOut,
 		scaleContainerWidth,
+		contentResizeListener,
+		containerResizeListener,
 	};
 }

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useState } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 
 function calculateScale( {
@@ -59,7 +59,6 @@ export function useScaleCanvas( {
 	);
 
 	const prefersReducedMotion = useReducedMotion();
-	const [ isAnimatingZoomOut, setIsAnimatingZoomOut ] = useState( false );
 	const isAutoScaled = scale === 'auto-scaled';
 
 	const scaleValue = isAutoScaled
@@ -84,13 +83,12 @@ export function useScaleCanvas( {
 			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 		}
 
-		setIsAnimatingZoomOut( true );
 		isAnimatingRef.current = true;
 
 		return () => {
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
-	}, [ iframeDocument, isZoomedOut, setIsAnimatingZoomOut ] );
+	}, [ iframeDocument, isZoomedOut ] );
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
@@ -111,7 +109,7 @@ export function useScaleCanvas( {
 			} );
 		}
 
-		if ( isAnimatingZoomOut || isAnimatingRef.current ) {
+		if ( isAnimatingRef.current ) {
 			// Set the value that we want to animate from.
 			// We will update them after we add the animation class on next render.
 			iframeDocument.documentElement.style.setProperty(
@@ -158,7 +156,7 @@ export function useScaleCanvas( {
 
 		let onZoomOutTransitionEnd = () => {};
 
-		if ( isAnimatingZoomOut ) {
+		if ( isAnimatingRef.current ) {
 			// Unscaled height of the current iframe container.
 			const clientHeight = iframeDocument.documentElement.clientHeight;
 
@@ -276,7 +274,6 @@ export function useScaleCanvas( {
 				iframeDocument.documentElement.classList.remove(
 					'zoom-out-animation'
 				);
-				setIsAnimatingZoomOut( false );
 
 				// Update previous values.
 				prevClientHeightRef.current = clientHeight;
@@ -327,7 +324,6 @@ export function useScaleCanvas( {
 			);
 		};
 	}, [
-		isAnimatingZoomOut,
 		isAutoScaled,
 		scaleValue,
 		frameSize,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -246,6 +246,9 @@ export function useScaleCanvas( {
 		iframeDocument.documentElement.classList.remove( 'zoom-out-animation' );
 
 		// Set the final scroll position that was just animated to.
+		// Disable reason: Eslint isn't smart enough to know that this is a
+		// DOM element. https://github.com/facebook/react/issues/31483
+		// eslint-disable-next-line react-compiler/react-compiler
 		iframeDocument.documentElement.scrollTop =
 			transitionTo.current.scrollTop;
 

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -239,12 +239,12 @@ export function useScaleCanvas( {
 
 	/**
 	 * Callback when the zoom out animation is finished.
-	 * - Cleans up animations refs
-	 * - Adds final CSS vars for scale and frame size to preserve the state
-	 * - Removes the 'zoom-out-animation' class (which has the fixed positioning)
-	 * - Sets the final scroll position after the canvas is no longer in fixed position
-	 * - Removes CSS vars related to the animation
-	 * - Sets the transitionFrom to the transitionTo state to be ready for the next animation
+	 * - Cleans up animations refs.
+	 * - Adds final CSS vars for scale and frame size to preserve the state.
+	 * - Removes the 'zoom-out-animation' class (which has the fixed positioning).
+	 * - Sets the final scroll position after the canvas is no longer in fixed position.
+	 * - Removes CSS vars related to the animation.
+	 * - Sets the transitionFrom to the transitionTo state to be ready for the next animation.
 	 */
 	const finishZoomOutAnimation = useCallback( () => {
 		startAnimationRef.current = false;
@@ -363,13 +363,13 @@ export function useScaleCanvas( {
 		/**
 		 * Handle the zoom out animation:
 		 *
-		 * - Get the current scrollTop position
-		 * - Calculate where the same scroll position is after scaling
+		 * - Get the current scrollTop position.
+		 * - Calculate where the same scroll position is after scaling.
 		 * - Apply fixed positioning to the canvas with a transform offset
-		 *   to keep the canvas centered
-		 * - Animate the scale and padding to the new scale and frame size
+		 *   to keep the canvas centered.
+		 * - Animate the scale and padding to the new scale and frame size.
 		 * - After the animation is complete, remove the fixed positioning
-		 *   and set the scroll position that keeps everything centered
+		 *   and set the scroll position that keeps everything centered.
 		 */
 		if ( startAnimationRef.current ) {
 			// Don't allow a new transition to start again unless it was started by the zoom out mode changing.

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -183,7 +183,7 @@ export function useScaleCanvas( {
 	 * The starting transition state for the zoom out animation.
 	 * @type {import('react').RefObject<TransitionState>}
 	 */
-	const transitionFrom = useRef( {
+	const transitionFromRef = useRef( {
 		scaleValue,
 		frameSize,
 		clientHeight: 0,
@@ -195,7 +195,7 @@ export function useScaleCanvas( {
 	 * The ending transition state for the zoom out animation.
 	 * @type {import('react').RefObject<TransitionState>}
 	 */
-	const transitionTo = useRef( {
+	const transitionToRef = useRef( {
 		scaleValue,
 		frameSize,
 		clientHeight: 0,
@@ -210,8 +210,8 @@ export function useScaleCanvas( {
 	 * @return {Animation} The animation object for the zoom out animation.
 	 */
 	const startZoomOutAnimation = useCallback( () => {
-		const { scrollTop } = transitionFrom.current;
-		const { scrollTop: scrollTopNext } = transitionTo.current;
+		const { scrollTop } = transitionFromRef.current;
+		const { scrollTop: scrollTopNext } = transitionToRef.current;
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -227,8 +227,8 @@ export function useScaleCanvas( {
 
 		return iframeDocument.documentElement.animate(
 			getAnimationKeyframes(
-				transitionFrom.current,
-				transitionTo.current
+				transitionFromRef.current,
+				transitionToRef.current
 			),
 			{
 				easing: 'cubic-bezier(0.46, 0.03, 0.52, 0.96)',
@@ -253,11 +253,11 @@ export function useScaleCanvas( {
 		// Add our final scale and frame size now that the animation is done.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			transitionTo.current.scaleValue
+			transitionToRef.current.scaleValue
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ transitionTo.current.frameSize }px`
+			`${ transitionToRef.current.frameSize }px`
 		);
 
 		iframeDocument.documentElement.classList.remove( 'zoom-out-animation' );
@@ -267,7 +267,7 @@ export function useScaleCanvas( {
 		// DOM element. https://github.com/facebook/react/issues/31483
 		// eslint-disable-next-line react-compiler/react-compiler
 		iframeDocument.documentElement.scrollTop =
-			transitionTo.current.scrollTop;
+			transitionToRef.current.scrollTop;
 
 		iframeDocument.documentElement.style.removeProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top'
@@ -277,7 +277,7 @@ export function useScaleCanvas( {
 		);
 
 		// Update previous values.
-		transitionFrom.current = transitionTo.current;
+		transitionFromRef.current = transitionToRef.current;
 	}, [ iframeDocument ] );
 
 	/**
@@ -314,11 +314,11 @@ export function useScaleCanvas( {
 
 		// We need to update the appropriate scale to exit from. If sidebars have been opened since setting the
 		// original scale, we will snap to a much smaller scale due to the scale container immediately changing sizes when exiting.
-		if ( isAutoScaled && transitionFrom.current.scaleValue !== 1 ) {
+		if ( isAutoScaled && transitionFromRef.current.scaleValue !== 1 ) {
 			// We use containerWidth as the divisor, as scaleContainerWidth will always match the containerWidth when
 			// exiting.
-			transitionFrom.current.scaleValue = calculateScale( {
-				frameSize: transitionFrom.current.frameSize,
+			transitionFromRef.current.scaleValue = calculateScale( {
+				frameSize: transitionFromRef.current.frameSize,
 				containerWidth,
 				maxContainerWidth,
 				scaleContainerWidth: containerWidth,
@@ -382,10 +382,10 @@ export function useScaleCanvas( {
 				animationRef.current.reverse();
 				// Swap the transition to/from refs so that we set the correct values when
 				// finishZoomOutAnimation runs.
-				const tempTransitionFrom = transitionFrom.current;
-				const tempTransitionTo = transitionTo.current;
-				transitionFrom.current = tempTransitionTo;
-				transitionTo.current = tempTransitionFrom;
+				const tempTransitionFrom = transitionFromRef.current;
+				const tempTransitionTo = transitionToRef.current;
+				transitionFromRef.current = tempTransitionTo;
+				transitionToRef.current = tempTransitionFrom;
 			} else {
 				/**
 				 * Start a new zoom animation.
@@ -397,21 +397,21 @@ export function useScaleCanvas( {
 				// the iframe at this point when we're about to animate the zoom out.
 				// The iframe scrollTop, scrollHeight, and clientHeight will all be
 				// the most accurate.
-				transitionFrom.current.clientHeight =
-					transitionFrom.current.clientHeight ?? clientHeight;
-				transitionFrom.current.scrollTop =
+				transitionFromRef.current.clientHeight =
+					transitionFromRef.current.clientHeight ?? clientHeight;
+				transitionFromRef.current.scrollTop =
 					iframeDocument.documentElement.scrollTop;
-				transitionFrom.current.scrollHeight =
+				transitionFromRef.current.scrollHeight =
 					iframeDocument.documentElement.scrollHeight;
 
-				transitionTo.current = {
+				transitionToRef.current = {
 					scaleValue,
 					frameSize,
 					clientHeight,
 				};
-				transitionTo.current.scrollTop = computeScrollTopNext(
-					transitionFrom.current,
-					transitionTo.current
+				transitionToRef.current.scrollTop = computeScrollTopNext(
+					transitionFromRef.current,
+					transitionToRef.current
 				);
 
 				animationRef.current = startZoomOutAnimation();

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -109,8 +109,6 @@ test.describe( 'Zoom Out', () => {
 		page,
 		editor,
 	} ) => {
-		// Add some patterns into the page.
-		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT );
 		// Find the scroll container element
 		await page.evaluate( () => {
 			const { activeElement } =

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -109,6 +109,8 @@ test.describe( 'Zoom Out', () => {
 		page,
 		editor,
 	} ) => {
+		// Add some patterns into the page.
+		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT );
 		// Find the scroll container element
 		await page.evaluate( () => {
 			const { activeElement } =


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Use web animation api to handle the zoom animation in a more performant way. Also allows for reversing the animation during the zoom animation if you click the zoom button twice quickly.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes zooming out scaling from wrong point when sidebars have been opened after zoom out was initiated.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Improve implementation for maintainability, performance, and fix edge cases.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When changing scale (zoom in/out):
- adds a `useScaleCanvas` hook to manage zoom level and animations
- when toggling zoom out, a useEffect:
  - adds the `is-zoomed-out` class to the iframe document html 
  - sets `startAnimationRef` to true
- Another `useEffect` runs that:
  - sets the CSS vars correctly that we need to transition _from_ (i.e. the current scale and frame size)
  - calculates the nextScrollTop position based off the current scroll top and scale so that the frame will zoom in/out to the same location
  - sets our `transitionFrom` and `transitionTo` refs with the properties of `{ scaleValue, frameSize, clientHeight, scrollTop }`. This gives the animation everything it needs to know to transition to/from the values.
  - adds the 'zoom-out-animation' class to html which:
     - sets the html to be position: fixed, with a top offset of the `transitionFrom.scrollTop` so that the canvas visually stays in the same position
     - then scaling animations happen to scale the canvas in a scrollbar-less state (due to the position: fixed)
     - when the animation finishes, we remove the 'zoom-out-animation' class and apply the `transitionTo.scrollTop` value so everything looks seamless.
- If the zoom level is toggled while the zoom animation is ongoing (such as clicking the zoom out button 2x quickly), then the `transitionFrom` and `transitionTo` refs are swapped, and the animation is reversed.

### Known bugs
- **The scaling doesn't always go to the exact center**, but at least keeps your central content visible. This is due to there being changes from zoom in/out canvas sizes from appenders being added/removed, and possibly other unintended changes to content height when switching modes.
- Images without fixed heights such as those coming from just a URL can also cause layout shift when switching modes leading to incorrect zoom positioning.
- Deeply nested images will flicker due to images wrapped in multiple groups get rerendered with new wrapping HTML when switching between modes.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Zooming from Top
- Toggle zoom state with the scroll bar at the top position
- You should always go to the top position (0 scrollTop)
- From zoomed out with frame space above the canvas, toggle zoom state. This should also set to 0 scroll top. It should set to 0 scroll top unless you have scrolled down past the top edge of the canvas, at which point it will center your zoom.


https://github.com/user-attachments/assets/b42a9307-e134-4a9e-892a-acf75a1c88df


### Zooming from below Top
- Toggle zoom state at any point beneath the top edge of the canvas
- You should be zoomed to the central point (or nearby, as the known bugs contribute to discrepancies)

https://github.com/user-attachments/assets/683cb724-6a2c-4e3a-af29-2c2d86ac99f5

### Zooming out after scale container has changed sizes
On `trunk`, this snaps to a much smaller size.

**Before**

https://github.com/user-attachments/assets/285433cd-d134-491a-acc9-cb830d3af0d8

**After**

https://github.com/user-attachments/assets/0033979f-9415-4827-886d-258dc752c1dc


### Open/close sidebar scaling animations
- When zoomed out, toggle sidebars open and closed
- Animations should be the same as on wp/6.7 branch

### Try to break it :)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/8be0d1cb-c917-4bd9-adef-002b7b5c84fe 

**After**

https://github.com/user-attachments/assets/ca221060-f6c9-4c66-9c70-631c945dc4d2




