### PR TITLE
Add higher order reducer for block editing modes while section editing

### DIFF
--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1669,7 +1669,7 @@ export const setNavigationMode =
  */
 export const __unstableSetEditorMode =
 	( mode ) =>
-	( { registry } ) => {
+	( { registry, dispatch } ) => {
 		registry.dispatch( preferencesStore ).set( 'core', 'editorTool', mode );
 
 		if ( mode === 'navigation' ) {
@@ -1677,6 +1677,8 @@ export const __unstableSetEditorMode =
 		} else if ( mode === 'edit' ) {
 			speak( __( 'You are currently in Design mode.' ) );
 		}
+
+		dispatch( { type: 'SET_EDITOR_MODE', mode } );
 	};
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -112,6 +112,8 @@ function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
 export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
 	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
 		state.blocks.order,
+		state.defaultBlockEditingMode,
+		state.sectionBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -390,6 +390,7 @@ const withDerivedBlockEditingMode = ( reducer ) => ( state, action ) => {
 			break;
 		}
 		case 'SET_EDITOR_MODE':
+		case 'RESET_ZOOM_LEVEL':
 		case 'SET_ZOOM_LEVEL': {
 			if ( isZoomedOut || isNavMode ) {
 				// When there are sections, the majority of blocks are disabled,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -9,12 +9,21 @@ import fastDeepEqual from 'fast-deep-equal/es6';
 import { pipe } from '@wordpress/compose';
 import { combineReducers, select } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
-import { store as blocksStore } from '@wordpress/blocks';
+import {
+	store as blocksStore,
+	privateApis as blocksPrivateApis,
+} from '@wordpress/blocks';
+import { store as preferencesStore } from '@wordpress/preferences';
+
 /**
  * Internal dependencies
  */
 import { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS } from './defaults';
 import { insertAt, moveTo } from './array';
+import { sectionRootClientIdKey } from './private-keys';
+import { unlock } from '../lock-unlock';
+
+const { isContentBlock } = unlock( blocksPrivateApis );
 
 const identity = ( x ) => x;
 
@@ -164,6 +173,243 @@ export function isUpdatingSameBlockAttribute( action, lastAction ) {
 		hasSameKeys( action.attributes, lastAction.attributes )
 	);
 }
+
+function recurseInnerBlocks( block, callback ) {
+	block.innerBlocks?.forEach( ( innerBlock ) => {
+		callback( innerBlock );
+		recurseInnerBlocks( innerBlock, callback );
+	} );
+}
+
+function isWithinSection( state, clientId ) {
+	const sectionRootClientId = state.settings?.[ sectionRootClientIdKey ];
+	const sectionClientIds = state.blocks.order.get( sectionRootClientId );
+	let parent = state.blocks.parents.get( clientId );
+	while ( !! parent ) {
+		if ( sectionClientIds.includes( parent ) ) {
+			return true;
+		}
+		parent = state.blocks.parents.get( parent );
+	}
+}
+
+function getInsertedBlocksEditingModes(
+	state,
+	rootClientId,
+	insertedBlocks,
+	{ includeContentOnlyChildren = false }
+) {
+	const editingModes = new Map();
+	const sectionRootClientId = state.settings?.[ sectionRootClientIdKey ];
+	const topLevelBlocksAreSections = rootClientId === sectionRootClientId;
+	const topLevelBlocksAreWithinSections =
+		! topLevelBlocksAreSections && isWithinSection( state, rootClientId );
+
+	for ( const block of insertedBlocks ) {
+		if ( topLevelBlocksAreSections ) {
+			editingModes.set( block.clientId, 'contentOnly' );
+		}
+
+		if ( includeContentOnlyChildren ) {
+			if (
+				topLevelBlocksAreWithinSections &&
+				isContentBlock( block.name )
+			) {
+				editingModes.set( block.clientId, 'contentOnly' );
+			}
+
+			recurseInnerBlocks( block, ( innerBlock ) => {
+				if ( isContentBlock( innerBlock.name ) ) {
+					editingModes.set( innerBlock.clientId, 'contentOnly' );
+				}
+			} );
+		}
+	}
+
+	return editingModes;
+}
+
+function getSectionBlockEditingModes(
+	state,
+	{ includeContentOnlyChildren = false }
+) {
+	const sectionBlockEditingModes = new Map();
+	const sectionRootClientId = state.settings?.[ sectionRootClientIdKey ];
+	sectionBlockEditingModes.set( sectionRootClientId, 'contentOnly' );
+
+	const sectionClientIds = state.blocks.order.get( sectionRootClientId );
+	for ( const sectionClientId of sectionClientIds ) {
+		sectionBlockEditingModes.set( sectionClientId, 'contentOnly' );
+
+		if ( includeContentOnlyChildren ) {
+			const sectionTree = state.blocks.tree.get( sectionClientId );
+
+			recurseInnerBlocks( sectionTree, ( block ) => {
+				if ( isContentBlock( block.name ) ) {
+					sectionBlockEditingModes.set(
+						block.clientId,
+						'contentOnly'
+					);
+				}
+			} );
+		}
+	}
+
+	return sectionBlockEditingModes;
+}
+
+const withDerivedBlockEditingMode = ( reducer ) => ( state, action ) => {
+	const newState = reducer( state, action );
+
+	// An exception is needed
+	// here to still recompute the block editing modes when the editor mode
+	// changes since the editor mode isn't stored within the block editor
+	// state and changing it won't trigger an altered new state.
+	if ( action.type !== 'SET_EDITOR_MODE' && newState === state ) {
+		return state;
+	}
+
+	newState.defaultBlockEditingMode =
+		state?.defaultBlockEditingMode ?? 'default';
+	newState.sectionBlockEditingModes =
+		state?.sectionBlockEditingModes ?? new Map();
+
+	const isZoomedOut =
+		newState?.zoomLevel < 100 || newState?.zoomLevel === 'auto-scaled';
+	const isNavMode =
+		select( preferencesStore )?.get( 'core', 'editorTool' ) ===
+		'navigation';
+
+	switch ( action.type ) {
+		case 'INSERT_BLOCKS':
+		case 'RECEIVE_BLOCKS': {
+			if ( isZoomedOut || isNavMode ) {
+				const rootClientId = action.rootClientId;
+				const insertedBlocks = action.blocks;
+				const insertions = getInsertedBlocksEditingModes(
+					newState,
+					rootClientId,
+					insertedBlocks,
+					{ includeContentOnlyChildren: isNavMode }
+				);
+				newState.sectionBlockEditingModes = new Map( [
+					...newState.sectionBlockEditingModes,
+					...insertions,
+				] );
+			}
+
+			break;
+		}
+		case 'REPLACE_BLOCKS': {
+			if ( isZoomedOut || isNavMode ) {
+				const removedClientIds = action.clientIds;
+
+				// Remove modes for the removed blocks.
+				for ( const clientId of removedClientIds ) {
+					newState.sectionBlockEditingModes.delete( clientId );
+
+					// It's important `state` is used here instead of `newState` because
+					// the blocks will have already been removed from the new state.
+					const tree = state.blocks.tree.get( clientId );
+					recurseInnerBlocks( tree, ( childClientId ) =>
+						newState.sectionBlockEditingModes.delete(
+							childClientId
+						)
+					);
+				}
+
+				const rootClientId = state.blocks.parents.get(
+					removedClientIds[ 0 ]
+				);
+				const insertedBlocks = action.blocks;
+
+				// Update modes for the inserted blocks.
+				const insertions = getInsertedBlocksEditingModes(
+					newState,
+					rootClientId,
+					insertedBlocks,
+					{ includeContentOnlyChildren: isNavMode }
+				);
+				newState.sectionBlockEditingModes = new Map( [
+					...newState.sectionBlockEditingModes,
+					...insertions,
+				] );
+			}
+			break;
+		}
+		case 'REMOVE_BLOCKS': {
+			if ( isZoomedOut || isNavMode ) {
+				// Remove modes for the removed blocks.
+				for ( const clientId of action.clientIds ) {
+					newState.sectionBlockEditingModes.delete( clientId );
+
+					// It's important `state` is used here instead of `newState` because
+					// the blocks will have already been removed from the new state.
+					const tree = state.blocks.tree.get( clientId );
+					recurseInnerBlocks( tree, ( childClientId ) =>
+						newState.sectionBlockEditingModes.delete(
+							childClientId
+						)
+					);
+				}
+			}
+			break;
+		}
+		case 'MOVE_BLOCKS_TO_POSITION': {
+			if ( isZoomedOut || isNavMode ) {
+				const { toRootClientId, clientIds } = action;
+
+				for ( const clientId of clientIds ) {
+					newState.sectionBlockEditingModes.delete( clientId );
+
+					// It's important `state` is used here instead of `newState` because
+					// the blocks will have already been removed from the new state.
+					const tree = state.blocks.tree.get( clientId );
+					recurseInnerBlocks( tree, ( childClientId ) =>
+						newState.sectionBlockEditingModes.delete(
+							childClientId
+						)
+					);
+				}
+
+				const insertedBlocks = clientIds.map( ( clientId ) =>
+					newState.blocks.tree.get( clientId )
+				);
+				const insertions = getInsertedBlocksEditingModes(
+					newState,
+					toRootClientId,
+					insertedBlocks,
+					{ includeContentOnlyChildren: isNavMode }
+				);
+				newState.sectionBlockEditingModes = new Map( [
+					...newState.sectionBlockEditingModes,
+					...insertions,
+				] );
+			}
+
+			break;
+		}
+		case 'SET_EDITOR_MODE':
+		case 'SET_ZOOM_LEVEL': {
+			if ( isZoomedOut || isNavMode ) {
+				// When there are sections, the majority of blocks are disabled,
+				// so the default is set to disabled, which avoids the need to iterate
+				// every through blocks that are adjacent to or ancestors of the section root.
+				newState.defaultBlockEditingMode = 'disabled';
+				newState.sectionBlockEditingModes = getSectionBlockEditingModes(
+					newState,
+					{ includeContentOnlyChildren: isNavMode }
+				);
+			} else {
+				newState.defaultBlockEditingMode = 'default';
+				newState.sectionBlockEditingModes = new Map();
+			}
+			break;
+		}
+	}
+
+	return newState;
+};
 
 function updateBlockTreeForBlocks( state, blocks ) {
 	const treeToUpdate = state.tree;
@@ -2184,4 +2430,6 @@ function withAutomaticChangeReset( reducer ) {
 	};
 }
 
-export default withAutomaticChangeReset( combinedReducers );
+export default withDerivedBlockEditingMode(
+	withAutomaticChangeReset( combinedReducers )
+);

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2997,14 +2997,6 @@ export function __unstableIsWithinBlockOverlay( state, clientId ) {
 	return false;
 }
 
-function isWithinBlock( state, clientId, parentClientId ) {
-	let parent = state.blocks.parents.get( clientId );
-	while ( !! parent && parent !== parentClientId ) {
-		parent = state.blocks.parents.get( parent );
-	}
-	return parent === parentClientId;
-}
-
 /**
  * @typedef {import('../components/block-editing-mode').BlockEditingMode} BlockEditingMode
  */
@@ -3046,68 +3038,8 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
-			// In zoom-out mode, override the behavior set by
-			// __unstableSetBlockEditingMode to only allow editing the top-level
-			// sections.
-			if ( isZoomOut( state ) ) {
-				const sectionRootClientId = getSectionRootClientId( state );
-
-				if ( clientId === '' /* ROOT_CONTAINER_CLIENT_ID */ ) {
-					return sectionRootClientId ? 'disabled' : 'contentOnly';
-				}
-				if ( clientId === sectionRootClientId ) {
-					return 'contentOnly';
-				}
-				const sectionsClientIds = getBlockOrder(
-					state,
-					sectionRootClientId
-				);
-
-				// Sections are always contentOnly.
-				if ( sectionsClientIds?.includes( clientId ) ) {
-					return 'contentOnly';
-				}
-
-				return 'disabled';
-			}
-
-			const editorMode = __unstableGetEditorMode( state );
-			if ( editorMode === 'navigation' ) {
-				const sectionRootClientId = getSectionRootClientId( state );
-
-				// The root section is "default mode"
-				if ( clientId === sectionRootClientId ) {
-					return 'default';
-				}
-
-				// Sections should always be contentOnly in navigation mode.
-				const sectionsClientIds = getBlockOrder(
-					state,
-					sectionRootClientId
-				);
-				if ( sectionsClientIds.includes( clientId ) ) {
-					return 'contentOnly';
-				}
-
-				// Blocks outside sections should be disabled.
-				const isWithinSectionRoot = isWithinBlock(
-					state,
-					clientId,
-					sectionRootClientId
-				);
-				if ( ! isWithinSectionRoot ) {
-					return 'disabled';
-				}
-
-				// The rest of the blocks depend on whether they are content blocks or not.
-				// This "flattens" the sections tree.
-				const name = getBlockName( state, clientId );
-				const { hasContentRoleAttribute } = unlock(
-					select( blocksStore )
-				);
-				const isContent = hasContentRoleAttribute( name );
-
-				return isContent ? 'contentOnly' : 'disabled';
+			if ( state.sectionBlockEditingModes?.has( clientId ) ) {
+				return state.sectionBlockEditingModes.get( clientId );
 			}
 
 			// In normal mode, consider that an explicitely set editing mode takes over.
@@ -3117,8 +3049,8 @@ export const getBlockEditingMode = createRegistrySelector(
 			}
 
 			// In normal mode, top level is default mode.
-			if ( ! clientId ) {
-				return 'default';
+			if ( clientId === '' ) {
+				return state.defaultBlockEditingMode ?? 'default';
 			}
 
 			const rootClientId = getBlockRootClientId( state, clientId );
@@ -3134,7 +3066,8 @@ export const getBlockEditingMode = createRegistrySelector(
 			}
 			// Otherwise, check if there's an ancestor that is contentOnly
 			const parentMode = getBlockEditingMode( state, rootClientId );
-			return parentMode === 'contentOnly' ? 'default' : parentMode;
+			const defaultMode = state.defaultBlockEditingMode ?? 'default';
+			return parentMode === 'contentOnly' ? defaultMode : parentMode;
 		}
 );
 

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -1,3 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { lock } from '../lock-unlock';
+import { isContentBlock } from './utils';
+
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
 // and `save`. The transforms specification allows converting one blocktype to
@@ -169,3 +175,6 @@ export {
 	__EXPERIMENTAL_ELEMENTS,
 	__EXPERIMENTAL_PATHS_WITH_OVERRIDE,
 } from './constants';
+
+export const privateApis = {};
+lock( privateApis, { isContentBlock } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -370,6 +370,18 @@ export const __experimentalGetBlockAttributesNamesByRole = ( ...args ) => {
 	return getBlockAttributesNamesByRole( ...args );
 };
 
+export function isContentBlock( name ) {
+	const attributes = getBlockType( name )?.attributes;
+
+	return !! Object.keys( attributes )?.some( ( attributeKey ) => {
+		const attribute = attributes[ attributeKey ];
+		return (
+			attribute?.role === 'content' ||
+			attribute?.__experimentalRole === 'content'
+		);
+	} );
+}
+
 /**
  * Return a new object with the specified keys omitted.
  *


### PR DESCRIPTION
## What?
Draft PR that implements the suggestion here - https://github.com/WordPress/gutenberg/pull/65408#issuecomment-2401789726

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
