### PR TITLE
Site Editor: Avoid using edited entity state in site editor loading hook

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -47,7 +47,6 @@ import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
 import useEditorTitle from './use-editor-title';
-import { useIsSiteEditorLoading } from '../layout/hooks';
 import { useAdaptEditorToCanvas } from './use-adapt-editor-to-canvas';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
@@ -82,7 +81,6 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 	const disableMotion = useReducedMotion();
 	const { params } = useLocation();
 	const { canvas = 'view' } = params;
-	const isLoading = useIsSiteEditorLoading();
 	useAdaptEditorToCanvas( canvas );
 	const {
 		editedPostType,
@@ -206,8 +204,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 
 	// Replace the title and icon displayed in the DocumentBar when there's an overlay visible.
 	const title = getEditorCanvasContainerTitle( editorCanvasView );
-
-	const isReady = ! isLoading;
+	const isReady = postWithTemplate ? !! contextPostId : !! editedPostId;
 	const transition = {
 		duration: disableMotion ? 0 : 0.2,
 	};

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -47,6 +47,7 @@ import SiteEditorMoreMenu from '../more-menu';
 import SiteIcon from '../site-icon';
 import useEditorIframeProps from '../block-editor/use-editor-iframe-props';
 import useEditorTitle from './use-editor-title';
+import { useIsSiteEditorLoading } from '../layout/hooks';
 import { useAdaptEditorToCanvas } from './use-adapt-editor-to-canvas';
 
 const { Editor, BackButton } = unlock( editorPrivateApis );
@@ -81,6 +82,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 	const disableMotion = useReducedMotion();
 	const { params } = useLocation();
 	const { canvas = 'view' } = params;
+	const isLoading = useIsSiteEditorLoading();
 	useAdaptEditorToCanvas( canvas );
 	const {
 		editedPostType,
@@ -204,7 +206,8 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 
 	// Replace the title and icon displayed in the DocumentBar when there's an overlay visible.
 	const title = getEditorCanvasContainerTitle( editorCanvasView );
-	const isReady = postWithTemplate ? !! contextPostId : !! editedPostId;
+
+	const isReady = ! isLoading;
 	const transition = {
 		duration: disableMotion ? 0 : 0.2,
 	};

--- a/packages/edit-site/src/components/layout/hooks.js
+++ b/packages/edit-site/src/components/layout/hooks.js
@@ -5,15 +5,9 @@ import { useEffect, useState } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
-/**
- * Internal dependencies
- */
-import useEditedEntityRecord from '../use-edited-entity-record';
-
 const MAX_LOADING_TIME = 10000; // 10 seconds
 
 export function useIsSiteEditorLoading() {
-	const { isLoaded: hasLoadedPost } = useEditedEntityRecord();
 	const [ loaded, setLoaded ] = useState( false );
 	const inLoadingPause = useSelect(
 		( select ) => {
@@ -64,5 +58,5 @@ export function useIsSiteEditorLoading() {
 		}
 	}, [ inLoadingPause ] );
 
-	return ! loaded || ! hasLoadedPost;
+	return ! loaded;
 }


### PR DESCRIPTION
Related #66921 

## What?

As the site editor is growing to become a multi page app, it doesn't really make sense to have an edited post type and context state in it.
That state is forcing us today to have a two synchronization mechanism between the url and the state causing some issues related to performance and some hidden bugs at times.

Ideally the routes would just pass the post type, post id to the editor component. The current PR helps to go in that direction by removing getEditedPostType usage from the isLoading hook.

## Testing Instructions

- Load the site editor, the loading should behave exactly like trunk. 