### PR TITLE
Site Editor: Avoid using edited post selectors in welcome guide

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -218,7 +218,13 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 			<EditorKeyboardShortcutsRegister />
 			{ isEditMode && <BlockKeyboardShortcuts /> }
 			{ ! isReady ? <CanvasLoader id={ loadingProgressId } /> : null }
-			{ isEditMode && <WelcomeGuide /> }
+			{ isEditMode && (
+				<WelcomeGuide
+					postType={
+						postWithTemplate ? contextPostType : editedPostType
+					}
+				/>
+			) }
 			{ isReady && (
 				<Editor
 					postType={

--- a/packages/edit-site/src/components/welcome-guide/index.js
+++ b/packages/edit-site/src/components/welcome-guide/index.js
@@ -6,13 +6,13 @@ import WelcomeGuideStyles from './styles';
 import WelcomeGuidePage from './page';
 import WelcomeGuideTemplate from './template';
 
-export default function WelcomeGuide() {
+export default function WelcomeGuide( { postType } ) {
 	return (
 		<>
 			<WelcomeGuideEditor />
 			<WelcomeGuideStyles />
-			<WelcomeGuidePage />
-			<WelcomeGuideTemplate />
+			{ postType === 'page' && <WelcomeGuidePage /> }
+			{ postType === 'wp_template' && <WelcomeGuideTemplate /> }
 		</>
 	);
 }

--- a/packages/edit-site/src/components/welcome-guide/page.js
+++ b/packages/edit-site/src/components/welcome-guide/page.js
@@ -6,11 +6,6 @@ import { Guide } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 
-/**
- * Internal dependencies
- */
-import { store as editSiteStore } from '../../store';
-
 export default function WelcomeGuidePage() {
 	const { toggle } = useDispatch( preferencesStore );
 
@@ -23,8 +18,7 @@ export default function WelcomeGuidePage() {
 			'core/edit-site',
 			'welcomeGuide'
 		);
-		const { isPage } = select( editSiteStore );
-		return isPageActive && ! isEditorActive && isPage();
+		return isPageActive && ! isEditorActive;
 	}, [] );
 
 	if ( ! isVisible ) {

--- a/packages/edit-site/src/components/welcome-guide/template.js
+++ b/packages/edit-site/src/components/welcome-guide/template.js
@@ -7,16 +7,9 @@ import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { store as editorStore } from '@wordpress/editor';
 
-/**
- * Internal dependencies
- */
-import useEditedEntityRecord from '../use-edited-entity-record';
-
 export default function WelcomeGuideTemplate() {
 	const { toggle } = useDispatch( preferencesStore );
 
-	const { isLoaded, record } = useEditedEntityRecord();
-	const isPostTypeTemplate = isLoaded && record.type === 'wp_template';
 	const { isActive, hasPreviousEntity } = useSelect( ( select ) => {
 		const { getEditorSettings } = select( editorStore );
 		const { get } = select( preferencesStore );
@@ -26,7 +19,7 @@ export default function WelcomeGuideTemplate() {
 				!! getEditorSettings().onNavigateToPreviousEntityRecord,
 		};
 	}, [] );
-	const isVisible = isActive && isPostTypeTemplate && hasPreviousEntity;
+	const isVisible = isActive && hasPreviousEntity;
 
 	if ( ! isVisible ) {
 		return null;


### PR DESCRIPTION
Related #66921 

## What?

As the site editor is growing to become a multi page app, it doesn't really make sense to have an edited post type and context state in it.
That state is forcing us today to have a two synchronization mechanism between the url and the state causing some issues related to performance and some hidden bugs at times.

Ideally the routes would just pass the post type, post id to the editor component. The current PR helps to go in that direction by removing getEditedPostType usage and isPage from the welcome guides hook.
