### PR TITLE
Remove selector from list block which prohibits border changes for nested lists

### DIFF
--- a/packages/block-library/src/list/block.json
+++ b/packages/block-library/src/list/block.json
@@ -81,9 +81,6 @@
 			"clientNavigation": true
 		}
 	},
-	"selectors": {
-		"border": ".wp-block-list:not(.wp-block-list .wp-block-list)"
-	},
 	"editorStyle": "wp-block-list-editor",
 	"style": "wp-block-list"
 }


### PR DESCRIPTION
## What?
This PR resolves issue - https://github.com/WordPress/gutenberg/issues/66885

It removes a selector in list block, for not including nested lists block for applying border styles.
- Steps to reproduce bug can be found in the issue itself.

## How and why?
Because of this selector the changes in border styles are not being applied in the main list block itself. As far as I have tested there is no way to add nested list in WordPress which will emulate this behaviour.

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-11-12 at 6 43 42 PM](https://github.com/user-attachments/assets/53251ec7-a7f4-4d0b-b52e-da85e6863099)
