### PR TITLE
Improve the featured image UI when it cannot retrieve the image file and data

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -15,6 +15,7 @@ import {
 	withNotices,
 	withFilters,
 	__experimentalHStack as HStack,
+	Notice,
 } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
 import { useState, useRef } from '@wordpress/element';
@@ -184,11 +185,14 @@ function PostFeaturedImage( {
 						render={ ( { open } ) => (
 							<div className="editor-post-featured-image__container">
 								{ isMissingMedia ? (
-									<p>
+									<Notice
+										status="warning"
+										isDismissible={ false }
+									>
 										{ __(
 											'Could not retrieve the featured image data.'
 										) }
-									</p>
+									</Notice>
 								) : (
 									<Button
 										__next40pxDefaultSize

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -18,7 +18,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
-import { useState, useRef } from '@wordpress/element';
+import { useState, useRef, useEffect } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { useSelect, withDispatch, withSelect } from '@wordpress/data';
 import {
@@ -106,6 +106,13 @@ function PostFeaturedImage( {
 	const [ isLoading, setIsLoading ] = useState( false );
 	const { getSettings } = useSelect( blockEditorStore );
 	const { mediaSourceUrl } = getMediaDetails( media, currentPostId );
+	const toggleFocusTimerRef = useRef();
+
+	useEffect( () => {
+		return () => {
+			clearTimeout( toggleFocusTimerRef.current );
+		};
+	}, [] );
 
 	function onDropFiles( filesList ) {
 		getSettings().mediaUpload( {
@@ -269,7 +276,12 @@ function PostFeaturedImage( {
 											className="editor-post-featured-image__action"
 											onClick={ () => {
 												onRemoveImage();
-												toggleRef.current.focus();
+												// The toggle button is rendered conditionally, we need
+												// to wait it is rendered before moving focus to it.
+												toggleFocusTimerRef.current =
+													setTimeout( () => {
+														toggleRef.current?.focus();
+													} );
 											} }
 											variant={
 												isMissingMedia
@@ -294,15 +306,10 @@ function PostFeaturedImage( {
 }
 
 const applyWithSelect = withSelect( ( select ) => {
-	const { getMedia, getPostType } = select( coreStore );
+	const { getMedia, getPostType, hasFinishedResolution } =
+		select( coreStore );
 	const { getCurrentPostId, getEditedPostAttribute } = select( editorStore );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
-	const isRequestingFeaturedImageMedia =
-		!! featuredImageId &&
-		! select( coreStore ).hasFinishedResolution( 'getMedia', [
-			featuredImageId,
-			{ context: 'view' },
-		] );
 
 	return {
 		media: featuredImageId
@@ -311,7 +318,12 @@ const applyWithSelect = withSelect( ( select ) => {
 		currentPostId: getCurrentPostId(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		featuredImageId,
-		isRequestingFeaturedImageMedia,
+		isRequestingFeaturedImageMedia:
+			!! featuredImageId &&
+			! hasFinishedResolution( 'getMedia', [
+				featuredImageId,
+				{ context: 'view' },
+			] ),
 	};
 } );
 

--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -99,6 +99,7 @@ function PostFeaturedImage( {
 	postType,
 	noticeUI,
 	noticeOperations,
+	isRequestingFeaturedImageMedia,
 } ) {
 	const toggleRef = useRef();
 	const [ isLoading, setIsLoading ] = useState( false );
@@ -155,23 +156,7 @@ function PostFeaturedImage( {
 		);
 	}
 
-	const { isRequestingFeaturedImageMedia } = useSelect(
-		( select ) => {
-			const _isRequestingFeaturedImageMedia =
-				!! featuredImageId &&
-				! select( coreStore ).hasFinishedResolution( 'getMedia', [
-					featuredImageId,
-					{ context: 'view' },
-				] );
-
-			return {
-				isRequestingFeaturedImageMedia: _isRequestingFeaturedImageMedia,
-			};
-		},
-		[ featuredImageId ]
-	);
-
-	const noImageData =
+	const isMissingMedia =
 		! isRequestingFeaturedImageMedia && !! featuredImageId && ! media;
 
 	return (
@@ -198,7 +183,7 @@ function PostFeaturedImage( {
 						modalClass="editor-post-featured-image__media-modal"
 						render={ ( { open } ) => (
 							<div className="editor-post-featured-image__container">
-								{ noImageData ? (
+								{ isMissingMedia ? (
 									<p>
 										{ __(
 											'Could not retrieve the featured image data.'
@@ -256,7 +241,7 @@ function PostFeaturedImage( {
 											'editor-post-featured-image__actions',
 											{
 												'editor-post-featured-image__actions-missing-image':
-													noImageData,
+													isMissingMedia,
 												'editor-post-featured-image__actions-is-requesting-image':
 													isRequestingFeaturedImageMedia,
 											}
@@ -268,7 +253,7 @@ function PostFeaturedImage( {
 											onClick={ open }
 											aria-haspopup="dialog"
 											variant={
-												noImageData
+												isMissingMedia
 													? 'secondary'
 													: undefined
 											}
@@ -283,11 +268,11 @@ function PostFeaturedImage( {
 												toggleRef.current.focus();
 											} }
 											variant={
-												noImageData
+												isMissingMedia
 													? 'secondary'
 													: undefined
 											}
-											isDestructive={ noImageData }
+											isDestructive={ isMissingMedia }
 										>
 											{ __( 'Remove' ) }
 										</Button>
@@ -308,6 +293,12 @@ const applyWithSelect = withSelect( ( select ) => {
 	const { getMedia, getPostType } = select( coreStore );
 	const { getCurrentPostId, getEditedPostAttribute } = select( editorStore );
 	const featuredImageId = getEditedPostAttribute( 'featured_media' );
+	const isRequestingFeaturedImageMedia =
+		!! featuredImageId &&
+		! select( coreStore ).hasFinishedResolution( 'getMedia', [
+			featuredImageId,
+			{ context: 'view' },
+		] );
 
 	return {
 		media: featuredImageId
@@ -316,6 +307,7 @@ const applyWithSelect = withSelect( ( select ) => {
 		currentPostId: getCurrentPostId(),
 		postType: getPostType( getEditedPostAttribute( 'type' ) ),
 		featuredImageId,
+		isRequestingFeaturedImageMedia,
 	};
 } );
 

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -16,9 +16,13 @@
 	&:hover,
 	&:focus,
 	&:focus-within {
-		.editor-post-featured-image__actions {
+		.editor-post-featured-image__actions:not(.editor-post-featured-image__actions-is-requesting-image) {
 			opacity: 1;
 		}
+	}
+
+	.editor-post-featured-image__actions.editor-post-featured-image__actions-missing-image {
+		opacity: 1;
 	}
 
 	.components-drop-zone__content {
@@ -72,17 +76,22 @@
 }
 
 .editor-post-featured-image__actions {
-	@include reduce-motion("transition");
-	bottom: 0;
-	opacity: 0; // Use opacity instead of visibility so that the buttons remain in the tab order.
-	padding: $grid-unit-10;
-	position: absolute;
-	transition: opacity 50ms ease-out;
-}
+	&:not(.editor-post-featured-image__actions-missing-image) {
+		@include reduce-motion("transition");
+		bottom: 0;
+		opacity: 0; // Use opacity instead of visibility so that the buttons remain in the tab order.
+		padding: $grid-unit-10;
+		position: absolute;
+		transition: opacity 50ms ease-out;
 
-.editor-post-featured-image__action {
-	backdrop-filter: blur(16px) saturate(180%);
-	background: rgba(255, 255, 255, 0.75);
-	flex-grow: 1;
-	justify-content: center;
+		.editor-post-featured-image__action {
+			backdrop-filter: blur(16px) saturate(180%);
+			background: rgba(255, 255, 255, 0.75);
+		}
+	}
+
+	.editor-post-featured-image__action {
+		flex-grow: 1;
+		justify-content: center;
+	}
 }

--- a/packages/editor/src/components/post-featured-image/style.scss
+++ b/packages/editor/src/components/post-featured-image/style.scss
@@ -23,6 +23,7 @@
 
 	.editor-post-featured-image__actions.editor-post-featured-image__actions-missing-image {
 		opacity: 1;
+		margin-top: $grid-unit-20;
 	}
 
 	.components-drop-zone__content {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/66005

## What?
<!-- In a few words, what is the PR actually doing? -->
The Post featured image UI doesn't take into account the edge case when there is an attachment ID stored in the database but no actual image file and no image meta data. For example, this may happen when importing posts via the WordPress Importer and skipping to import the attachments. It may happen in other cases as well as migrating the database etc.

In these cases, the UI only shows an empty button. See https://github.com/WordPress/gutenberg/issues/66005#issuecomment-2470490093

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The UI should always be clearly operable and provide feedback on the current state including errors or missing attachment / data.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Introduces logic to determine whether the request for the featured image media data has completed.
- When the request has completed and there is an attachment ID but no media data:
  - Shows a paragraph with an informative message instead of the image preview.
  - Shows the Replace and Remove buttons, with a secondary variant and `isDestructive` styling for the remove button.
- When the image is correctly retrieved and rendered, there are no visual changes.
- Added bonus: shows the  loading Spinner also when the request to retrieve the image data is pending. Previously, the Spinner was only shown after dragging an image into the UI, when the upload was pending.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Rename this file to have an `xml` extension: 
[featured image broken.txt](https://github.com/user-attachments/files/17718377/featured.image.broken.txt)
- Import the file via the WordPress Importer under Tools > Import > WordPress importer.
- Do not check the `Download and import file attachments` checkbox.
- At this point you should have a new post with title `Broken featured image`.
- Edit: an easier way to reproduce, as @mamaduka suggested, is by using WP CLI. You need to set a post with a featured image ID that points to a non-existing attachment e.g. `wp post meta update your_post_id_here _thumbnail_id 999999`.
- Edit the post.
- Observe the Featured image UI shows the Spinner while attempting to retrieve the image data.
- When the request completes, observe the UI shows an informative message in a paragraph.
- Observe the Replace and Remove buttons are visible by default (no need to hover or focus) so that the UI is clearly operable.
- Try to remove / replace the image and check everything works as expected.
- Observe that when the image is correctly set there are no visual changes and the buttons only appear on hover or focus, as expected based on the current design.


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

This is the UI when the attachment ID exists but no other data exist:

![Screenshot 2024-11-12 at 15 23 49](https://github.com/user-attachments/assets/9a2b9a0a-e147-424c-bb04-c0061d69a985)

I have no strong opinions on whether the informative message in the paragraph should have some specific styling e.g. like a warning. I'd lean towards keeping it simple. Cc @WordPress/gutenberg-design 

This is the UI with an image correctly set. No changes here:

![Screenshot 2024-11-12 at 15 29 30](https://github.com/user-attachments/assets/04a9bb70-359b-43f8-9781-cb3e5ab9067c)


It's worth noting the case covered here is different from another edge case:
- The featured image ID and all its media data exist in the database.
- The image is later deleted from the filesystem but all its data are still available.

In this case, the UI will show a 'broken image' as browsers do by default, with the alternative text / fallback text displayed. Screenshot:

![Screenshot 2024-11-12 at 15 24 24](https://github.com/user-attachments/assets/09a2d5b6-6bb2-40e4-8f1b-f6a73c993c5a)

That is the current behavior of this UI. Hovering or focusing will show the Replace and Remove buttons but they don't look that great on a white background. I'd tend to think the styling for this case should be improved but it's out of the scope of this PR.