### PR TITLE
Post fields: clean up

### DIFF
--- a/packages/fields/src/fields/featured-image/featured-image-edit.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-edit.tsx
@@ -9,11 +9,12 @@ import { MediaUpload } from '@wordpress/media-utils';
 import { lineSolid } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
 import type { DataFormControlProps } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import { __ } from '@wordpress/i18n';
 
 export const FeaturedImageEdit = ( {
 	data,

--- a/packages/fields/src/fields/featured-image/featured-image-view.tsx
+++ b/packages/fields/src/fields/featured-image/featured-image-view.tsx
@@ -3,12 +3,12 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 
 export const FeaturedImageView = ( {
 	item,

--- a/packages/fields/src/fields/featured-image/index.ts
+++ b/packages/fields/src/fields/featured-image/index.ts
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import { __ } from '@wordpress/i18n';
 import { FeaturedImageEdit } from './featured-image-edit';
 import { FeaturedImageView } from './featured-image-view';
 
@@ -15,7 +15,6 @@ const featuredImageField: Field< BasePost > = {
 	id: 'featured_media',
 	type: 'text',
 	label: __( 'Featured Image' ),
-	getValue: ( { item } ) => item.featured_media,
 	Edit: FeaturedImageEdit,
 	render: FeaturedImageView,
 	enableSorting: false,

--- a/packages/fields/src/fields/order/index.ts
+++ b/packages/fields/src/fields/order/index.ts
@@ -3,14 +3,15 @@
  */
 import type { Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
+
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
 
 const orderField: Field< BasePost > = {
-	type: 'integer',
 	id: 'menu_order',
+	type: 'integer',
 	label: __( 'Order' ),
 	description: __( 'Determines the order of pages.' ),
 };

--- a/packages/fields/src/fields/parent/index.ts
+++ b/packages/fields/src/fields/parent/index.ts
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import { __ } from '@wordpress/i18n';
 import { ParentEdit } from './parent-edit';
 import { ParentView } from './parent-view';
 
@@ -15,7 +15,6 @@ const parentField: Field< BasePost > = {
 	id: 'parent',
 	type: 'text',
 	label: __( 'Parent' ),
-	getValue: ( { item } ) => item.parent,
 	Edit: ParentEdit,
 	render: ParentView,
 	enableSorting: true,

--- a/packages/fields/src/fields/parent/parent-edit.tsx
+++ b/packages/fields/src/fields/parent/parent-edit.tsx
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import removeAccents from 'remove-accents';
+
+/**
  * WordPress dependencies
  */
 import { ComboboxControl, ExternalLink } from '@wordpress/components';
@@ -12,21 +17,16 @@ import {
 // @ts-ignore
 import { store as coreStore } from '@wordpress/core-data';
 import type { DataFormControlProps } from '@wordpress/dataviews';
-
-/**
- * External dependencies
- */
-import removeAccents from 'remove-accents';
+import { debounce } from '@wordpress/compose';
+import { decodeEntities } from '@wordpress/html-entities';
+import { __, sprintf } from '@wordpress/i18n';
+import { filterURLForDisplay } from '@wordpress/url';
 
 /**
  * Internal dependencies
  */
-import { debounce } from '@wordpress/compose';
-import { decodeEntities } from '@wordpress/html-entities';
-import { __, sprintf } from '@wordpress/i18n';
 import type { BasePost } from '../../types';
 import { getTitleWithFallbackName } from './utils';
-import { filterURLForDisplay } from '@wordpress/url';
 
 type TreeBase = {
 	id: number;

--- a/packages/fields/src/fields/parent/parent-view.tsx
+++ b/packages/fields/src/fields/parent/parent-view.tsx
@@ -3,14 +3,14 @@
  */
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
+import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import type { DataViewRenderFieldProps } from '@wordpress/dataviews';
 import { getTitleWithFallbackName } from './utils';
-import { __ } from '@wordpress/i18n';
 
 export const ParentView = ( {
 	item,

--- a/packages/fields/src/fields/password/index.tsx
+++ b/packages/fields/src/fields/password/index.tsx
@@ -12,7 +12,6 @@ import PasswordEdit from './edit';
 const passwordField: Field< BasePost > = {
 	id: 'password',
 	type: 'text',
-	getValue: ( { item } ) => item.password,
 	Edit: PasswordEdit,
 	enableSorting: false,
 	enableHiding: false,

--- a/packages/fields/src/fields/slug/index.ts
+++ b/packages/fields/src/fields/slug/index.ts
@@ -2,12 +2,12 @@
  * WordPress dependencies
  */
 import type { Field } from '@wordpress/dataviews';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import type { BasePost } from '../../types';
-import { __ } from '@wordpress/i18n';
 import SlugEdit from './slug-edit';
 import SlugView from './slug-view';
 
@@ -15,7 +15,6 @@ const slugField: Field< BasePost > = {
 	id: 'slug',
 	type: 'text',
 	label: __( 'Slug' ),
-	getValue: ( { item } ) => item.slug,
 	Edit: SlugEdit,
 	render: SlugView,
 };


### PR DESCRIPTION
## What?

Reorder imports & remove unnecessary `getValue` functions.

## Why?

To keep things tidy.

## Testing Instructions

Smoke test that all fields work as before.