### PR TITLE
Fix uncategorized pattern browsing when pattern has no categories 

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/pattern-list.js
@@ -85,10 +85,10 @@ function PatternList( {
 				return true;
 			}
 			if ( selectedCategory === 'uncategorized' ) {
-				const hasKnownCategory = pattern.categories.some(
-					( category ) =>
+				const hasKnownCategory =
+					pattern.categories?.some( ( category ) =>
 						registeredPatternCategories.includes( category )
-				);
+					) ?? false;
 
 				return ! pattern.categories?.length || ! hasKnownCategory;
 			}


### PR DESCRIPTION
## What?
Fix uncategorized pattern browsing when pattern has no categories. 

## Why?
Fixes: https://github.com/WordPress/gutenberg/issues/66944


## Testing Instructions
Follow instructions in  https://github.com/WordPress/gutenberg/issues/66944
