### PR TITLE
Media: check for `wav` mime type using isset 

### DIFF
--- a/backport-changelog/6.8/7265.md
+++ b/backport-changelog/6.8/7265.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7265
 
 * https://github.com/WordPress/gutenberg/pull/66850
+* https://github.com/WordPress/gutenberg/pull/66947

--- a/lib/compat/wordpress-6.8/functions.php
+++ b/lib/compat/wordpress-6.8/functions.php
@@ -18,7 +18,7 @@ function gutenberg_get_mime_types_6_8( $mime_types ) {
 	 * Only add support if there is existing support for 'wav'.
 	 * Some plugins may have deliberately disabled it.
 	*/
-	if ( ! $mime_types['wav'] && ! isset( $mime_types['wav|x-wav'] ) ) {
+	if ( ! isset( $mime_types['wav'] ) && ! isset( $mime_types['wav|x-wav'] ) ) {
 		return $mime_types;
 	}
 	/*


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up to https://github.com/WordPress/gutenberg/pull/66850

Add the missing `isset`. 

## Why?

It broke unit tests.

Sorry!

## How?

Is set isset?

## Testing Instructions

PHP unit tests should pass.
