### PR TITLE
Theme JSON: include block style variations in path only output of get_block_nodes

### DIFF
--- a/backport-changelog/6.8/7784.md
+++ b/backport-changelog/6.8/7784.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7784
+
+* https://github.com/WordPress/gutenberg/pull/66948

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2749,9 +2749,21 @@ class WP_Theme_JSON_Gutenberg {
 		foreach ( $theme_json['styles']['blocks'] as $name => $node ) {
 			$node_path = array( 'styles', 'blocks', $name );
 			if ( $include_node_paths_only ) {
-				$nodes[] = array(
+				$variation_paths = array();
+				if ( $include_variations && isset( $node['variations'] ) ) {
+					foreach ( $node['variations'] as $variation => $node ) {
+						$variation_paths[] = array(
+							'path' => array( 'styles', 'blocks', $name, 'variations', $variation ),
+						);
+					}
+				}
+				$node = array(
 					'path' => $node_path,
 				);
+				if ( ! empty( $variation_paths ) ) {
+					$node['variations'] = $variation_paths;
+				}
+				$nodes[] = $node;
 			} else {
 				$selector = null;
 				if ( isset( $selectors[ $name ]['selector'] ) ) {

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2751,7 +2751,7 @@ class WP_Theme_JSON_Gutenberg {
 			if ( $include_node_paths_only ) {
 				$variation_paths = array();
 				if ( $include_variations && isset( $node['variations'] ) ) {
-					foreach ( $node['variations'] as $variation => $node ) {
+					foreach ( $node['variations'] as $variation => $variation_node ) {
 						$variation_paths[] = array(
 							'path' => array( 'styles', 'blocks', $name, 'variations', $variation ),
 						);

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5927,7 +5927,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					'core/group'  => array(
-						'elements' => array(
+						'elements'   => array(
 							'link' => array(
 								'color' => array(
 									'background' => 'blue',
@@ -5950,6 +5950,83 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			),
 			array(
 				'path' => array( 'styles', 'blocks', 'core/group', 'elements', 'link' ),
+			),
+		);
+
+		$this->assertEquals( $expected, $block_nodes );
+	}
+
+	/**
+	 * This test covers `get_block_nodes` with the `$include_node_paths_only`
+	 * and `include_block_style_variations` options.
+	 */
+	public function test_return_block_node_paths_with_variations() {
+		$theme_json = new ReflectionClass( 'WP_Theme_JSON_Gutenberg' );
+
+		$func = $theme_json->getMethod( 'get_block_nodes' );
+		$func->setAccessible( true );
+
+		$theme_json = array(
+			'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+			'styles'  => array(
+				'typography' => array(
+					'fontSize' => '16px',
+				),
+				'blocks'     => array(
+					'core/button' => array(
+						'color'      => array(
+							'background' => 'red',
+						),
+						'variations' => array(
+							'cheese' => array(
+								'color' => array(
+									'background' => 'cheese',
+								),
+							),
+						),
+					),
+					'core/group'  => array(
+						'color'      => array(
+							'background' => 'blue',
+						),
+						'variations' => array(
+							'apricot' => array(
+								'color' => array(
+									'background' => 'apricot',
+								),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		$block_nodes = $func->invoke(
+			null,
+			$theme_json,
+			array(),
+			array(
+				'include_node_paths_only'        => true,
+				'include_block_style_variations' => true,
+			)
+		);
+
+		$expected = array(
+			array(
+				'path' => array( 'styles', 'blocks', 'core/button' ),
+				'variations' => array(
+					array(
+						'path' => array( 'styles', 'blocks', 'core/button', 'variations', 'cheese' ),
+					),
+				),
+			),
+			array(
+				'path' => array( 'styles', 'blocks', 'core/group' ),
+				'variations' => array(
+					array(
+						'path' => array( 'styles', 'blocks', 'core/group', 'variations', 'apricot' ),
+					),
+				),
 			),
 		);
 

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -5927,7 +5927,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 						),
 					),
 					'core/group'  => array(
-						'elements'   => array(
+						'elements' => array(
 							'link' => array(
 								'color' => array(
 									'background' => 'blue',
@@ -6013,7 +6013,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 
 		$expected = array(
 			array(
-				'path' => array( 'styles', 'blocks', 'core/button' ),
+				'path'       => array( 'styles', 'blocks', 'core/button' ),
 				'variations' => array(
 					array(
 						'path' => array( 'styles', 'blocks', 'core/button', 'variations', 'cheese' ),
@@ -6021,7 +6021,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 				),
 			),
 			array(
-				'path' => array( 'styles', 'blocks', 'core/group' ),
+				'path'       => array( 'styles', 'blocks', 'core/group' ),
 				'variations' => array(
 					array(
 						'path' => array( 'styles', 'blocks', 'core/group', 'variations', 'apricot' ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Follow up to https://github.com/WordPress/gutenberg/pull/66002

Including variations in the nodes array when `'include_node_paths_only' => true`

Discussed here: https://github.com/WordPress/gutenberg/pull/66731/files#r1830311575

cc @mukeshpanchal27 

## Why?
https://github.com/WordPress/gutenberg/pull/66002 added and  `$include_node_paths_only` option to `get_block_nodes()` to improve performance.

When `true` this option tells the function to only return paths, and not selectors, for consumers that only needed paths to style values.

For [one of the conditional blocks](https://github.com/WordPress/gutenberg/pull/66002/files#diff-b03597cc3da199e5aa5a94950e8241135904853e7c3b82d758e42744878afae7R2751), block style variations wasn't included. 

This PR adds them to the array of paths following the existing model `$node[]['path' => [], 'variations' => ['path' => []]]`

## How?
Just adding the same loop but in the `$include_node_paths_only` condition block.

## Testing Instructions

PHP unit tests should pass.
Smoke test the editor.  Should be all 👍🏻 