### PR TITLE
Fix Synced Patterns non-overridden content being editable in write mode

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3071,6 +3071,10 @@ export const getBlockEditingMode = createRegistrySelector(
 				return 'disabled';
 			}
 
+			if ( state?.patternBlockEditingModes?.has( clientId ) ) {
+				return state?.patternBlockEditingModes.get( clientId );
+			}
+
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'navigation' ) {
 				const sectionRootClientId = getSectionRootClientId( state );


### PR DESCRIPTION
## What?
Fixes #66424
Alternative to https://github.com/WordPress/gutenberg/pull/65408

In Write Mode, parts of synced patterns that are supposed to be non-editable are editable.

## Why?
This happens because Write Mode overrides the `blockEditingMode` of a synced pattern's inner blocks.

Pattern blocks try calling `setBlockEditingMode` for child blocks directly, but when write mode is active a different value is returned directly from the `getBlockEditingMode` selector, one that doesn't take into account how synced patterns should work.

## How?
This PR fixes the issue by moving the pattern block editing modes to the block editor store, so that it can work harmoniously with the way Write Mode and Zoom Out mode determine the block editing mode.

Initially #65408 attempted this by adding code directly to the getBlockEditingMode` selector, but this caused a performance issue so it was reverted. That selector is called a lot, so it's sensitive to any new code that might cause some overhead.

This PR follows the suggestion of @youknowriad - https://github.com/WordPress/gutenberg/pull/65408#issuecomment-2401789726.

A higher order reducer instead calculates the block editing modes whenever there are changes to the block list. This doesn't seem to cause any noticeable performance issues. The approach taken in the higher order reducer is to first track and added/removed pattern blocks (`core/block` block types) and then build up a `Set` of editing modes for those blocks and their children.

I also have [another PR that aims to move the zoomed out/write mode code from the selector to a higher order reducer](https://github.com/WordPress/gutenberg/pull/66919), which I can follow up on if this approach looks good.

## Testing Instructions
1. Create a synced pattern (Pattern A) with two paragraphs
2. Edit the pattern and enable overrides for one of the patterns
3. Insert the pattern into a template
4. Check that you can only edit the overridden paragraph, the other paragraph should be disabled
5. Enable Zoomed Out mode, you shouldn't be able to edit any of the pattern content, since zoomed out doesn't allow content editing
6. Leave Zoomed Out mode and enable Write mode, check that you can only edit the overridden paragraph in the pattern
7. Create a second pattern (Pattern B) similar to the first one, it should have a block that's overridden and a regular block
8. Edit Pattern A and insert Pattern B into it.
9. Insert Pattern A into a template again, or go back to where you inserted it before
10. Check that you can't edit any of Pattern B from the instance of Pattern A, it should all be disabled

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/user-attachments/assets/49cd5420-aa00-4437-be43-1d1f16002514

#### After

https://github.com/user-attachments/assets/feca05d3-9fb7-404a-8e5a-406e27b4f023

