### PR TITLE
Site Icon Focus fix

### DIFF
--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -22,6 +22,17 @@
 }
 
 .edit-site-editor__view-mode-toggle button:focus {
-	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) !important;
-	padding: 1px;
+	position: relative;
+
+	&::before {
+		content: "";
+		display: block;
+		position: absolute;
+		z-index: 1;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 calc(#{ $border-width } + var(--wp-admin-border-width-focus)) $white;
+	}
 }

--- a/packages/edit-site/src/components/site-icon/style.scss
+++ b/packages/edit-site/src/components/site-icon/style.scss
@@ -20,3 +20,8 @@
 		border-radius: 0;
 	}
 }
+
+.edit-site-editor__view-mode-toggle button:focus {
+	box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color), inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color) !important;
+	padding: 1px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #61339
Fixes #66375
This PR updates the SCSS file for the site icon to improve focus visibility.

## Why?
The focus ring on the site hub icon was not visible or visually appealing when using keyboard navigation, impacting accessibility.

## How?
The SCSS file gutenberg/packages/edit-site/src/components/site-icon/style.scss has been modified to add a blue border outline around the site icon when it is focused.

## Testing Instructions

1. Open the dashboard and navigate to Appearance > Editor.
2. Click anywhere in the container to close the navigation.
3. Use the keyboard to focus on the site icon in the top left corner.
4. Ensure the blue border outline appears around the site icon when focused using keyboard navigation.

### Testing Instructions for Keyboard
Ensure the blue border outline appears around the site icon when focused using keyboard navigation.

## Screenshots or screencast <!-- if applicable -->

**Screenshot:**
![site_icon_focus](https://github.com/user-attachments/assets/4de3242f-ea7f-44a1-b70c-01256814ed35)


**Video:**
https://github.com/user-attachments/assets/4a5609a0-0827-4e43-b64d-c8b27f714aaf


