### PR TITLE
Fix Quote to Paragraph transform

### DIFF
--- a/packages/block-editor/src/components/block-actions/index.js
+++ b/packages/block-editor/src/components/block-actions/index.js
@@ -109,7 +109,7 @@ export default function BlockActions( {
 				groupingBlockName
 			);
 
-			if ( ! newBlocks ) {
+			if ( ! newBlocks?.length ) {
 				return;
 			}
 			replaceBlocks( clientIds, newBlocks );

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -317,7 +317,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 						block,
 						defaultBlockName
 					);
-					if ( replacement && replacement.length ) {
+					if ( replacement?.length ) {
 						replaceBlocks( clientId, replacement );
 					}
 				} else if ( isUnmodifiedDefaultBlock( block ) ) {
@@ -383,8 +383,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 							);
 
 							if (
-								replacement &&
-								replacement.length &&
+								replacement?.length &&
 								replacement.every( ( block ) =>
 									canInsertBlockType(
 										block.name,

--- a/packages/block-editor/src/components/block-list/block.native.js
+++ b/packages/block-editor/src/components/block-list/block.native.js
@@ -547,7 +547,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 								getDefaultBlockName()
 							);
 
-							if ( replacement && replacement.length ) {
+							if ( replacement?.length ) {
 								insertBlocks(
 									replacement,
 									getBlockIndex( _clientId ),
@@ -672,7 +672,7 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, registry ) => {
 						getBlock( clientId ),
 						getDefaultBlockName()
 					);
-					if ( replacement && replacement.length ) {
+					if ( replacement?.length ) {
 						replaceBlocks( clientId, replacement );
 					}
 				}

--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.native.js
@@ -56,10 +56,13 @@ const BlockTransformationsMenu = ( {
 		anchorNodeRef ? findNodeHandle( anchorNodeRef ) : undefined;
 
 	function onPickerSelect( value ) {
-		replaceBlocks(
-			selectedBlockClientId,
-			switchToBlockType( selectedBlock, value )
-		);
+		const replacement = switchToBlockType( selectedBlock, value );
+
+		if ( ! replacement?.length ) {
+			return;
+		}
+
+		replaceBlocks( selectedBlockClientId, replacement );
 
 		const selectedItem = pickerOptions().find(
 			( item ) => item.value === value

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -84,6 +84,11 @@ function BlockSwitcherDropdownMenuContents( {
 	// Simple block tranformation based on the `Block Transforms` API.
 	function onBlockTransform( name ) {
 		const newBlocks = switchToBlockType( blocks, name );
+
+		if ( ! newBlocks?.length ) {
+			return;
+		}
+
 		replaceBlocks( clientIds, newBlocks );
 		selectForMultipleBlocks( newBlocks );
 	}

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -188,6 +188,9 @@ export default function BlockTools( {
 					blocks,
 					groupingBlockName
 				);
+				if ( ! newBlocks?.length ) {
+					return;
+				}
 				replaceBlocks( clientIds, newBlocks );
 				speak( __( 'Selected blocks are grouped.' ) );
 			}

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.js
@@ -31,7 +31,7 @@ function ConvertToGroupButton( {
 			blocksSelection,
 			groupingBlockName
 		);
-		if ( newBlocks ) {
+		if ( newBlocks?.length ) {
 			replaceBlocks( clientIds, newBlocks );
 		}
 	};

--- a/packages/block-editor/src/components/convert-to-group-buttons/index.native.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/index.native.js
@@ -26,7 +26,7 @@ function useConvertToGroupButtons( {
 			blocksSelection,
 			groupingBlockName
 		);
-		if ( newBlocks ) {
+		if ( newBlocks?.length ) {
 			replaceBlocks( clientIds, newBlocks );
 		}
 	};

--- a/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
+++ b/packages/block-editor/src/components/convert-to-group-buttons/toolbar.js
@@ -51,7 +51,7 @@ function BlockGroupToolbar() {
 			layout = 'group';
 		}
 
-		if ( newBlocks && newBlocks.length > 0 ) {
+		if ( newBlocks?.length > 0 ) {
 			// Because the block is not in the store yet we can't use
 			// updateBlockAttributes so need to manually update attributes.
 			newBlocks[ 0 ].attributes.layout = layouts[ layout ];

--- a/packages/block-editor/src/components/list-view/block.js
+++ b/packages/block-editor/src/components/list-view/block.js
@@ -341,6 +341,11 @@ function ListViewBlock( {
 					blocks,
 					groupingBlockName
 				);
+
+				if ( ! newBlocks?.length ) {
+					return;
+				}
+
 				replaceBlocks( blocksToUpdate, newBlocks );
 				speak( __( 'Selected blocks are grouped.' ) );
 				const newlySelectedBlocks = getSelectedBlockClientIds();

--- a/packages/block-editor/src/components/use-block-commands/index.js
+++ b/packages/block-editor/src/components/use-block-commands/index.js
@@ -92,6 +92,11 @@ const getTransformCommands = () =>
 		// Simple block tranformation based on the `Block Transforms` API.
 		function onBlockTransform( name ) {
 			const newBlocks = switchToBlockType( blocks, name );
+
+			if ( ! newBlocks?.length ) {
+				return;
+			}
+
 			replaceBlocks( clientIds, newBlocks );
 			selectForMultipleBlocks( newBlocks );
 		}
@@ -181,7 +186,7 @@ const getQuickActionsCommands = () =>
 			// Activate the `transform` on `core/group` which does the conversion.
 			const newBlocks = switchToBlockType( blocks, groupingBlockName );
 
-			if ( ! newBlocks ) {
+			if ( ! newBlocks?.length ) {
 				return;
 			}
 			replaceBlocks( clientIds, newBlocks );

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -769,7 +769,7 @@ export const __unstableDeleteSelection =
 				: switchToBlockType( followingBlock, targetBlockType.name );
 
 		// If the block types can not match, do nothing
-		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
+		if ( ! blocksWithTheSameType?.length ) {
 			return;
 		}
 
@@ -1309,7 +1309,7 @@ export const mergeBlocks =
 				: switchToBlockType( cloneB, blockA.name );
 
 		// If the block types can not match, do nothing.
-		if ( ! blocksWithTheSameType || ! blocksWithTheSameType.length ) {
+		if ( ! blocksWithTheSameType?.length ) {
 			return;
 		}
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1143,7 +1143,7 @@ export function __unstableIsSelectionMergeable( state, isForward ) {
 	// merged into the same type of block.
 	const blocksToMerge = switchToBlockType( blockToMerge, targetBlockName );
 
-	return blocksToMerge && blocksToMerge.length;
+	return blocksToMerge?.length;
 }
 
 /**

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -515,10 +515,16 @@ export default function Image( {
 		! isContentOnlyMode;
 
 	function switchToCover() {
-		replaceBlocks(
-			clientId,
-			switchToBlockType( getBlock( clientId ), 'core/cover' )
+		const replacements = switchToBlockType(
+			getBlock( clientId ),
+			'core/cover'
 		);
+
+		if ( ! replacements?.length ) {
+			return;
+		}
+
+		replaceBlocks( clientId, replacements );
 	}
 
 	// TODO: Can allow more units after figuring out how they should interact

--- a/packages/block-library/src/quote/transforms.js
+++ b/packages/block-library/src/quote/transforms.js
@@ -122,6 +122,14 @@ const transforms = {
 		{
 			type: 'block',
 			blocks: [ 'core/paragraph' ],
+			isMatch: ( { citation }, block ) => {
+				return (
+					! RichText.isEmpty( citation ) ||
+					block.innerBlocks.some(
+						( { name } ) => name === 'core/paragraph'
+					)
+				);
+			},
 			transform: ( { citation }, innerBlocks ) =>
 				RichText.isEmpty( citation )
 					? innerBlocks


### PR DESCRIPTION
## What?
Fixes something I randomly spotted. If you try transforming a quote block that contains no paragraphs or citations to a paragraph block, an error is thrown. It happens because `switchToBlockType` (which handles transforms) requires the transformed blocks to contain one of the destination types (paragraph). The transform instead results in a heading block, so `switchToBlockType` returns `null` and `replaceBlocks` chokes on that value.

This also unearths another issue, in many places `switchToBlockType` is called followed by a call to `replaceBlocks` with the results of `switchToBlockType`. If `switchToBlockType` returns `null`, these errors can be thrown.

In this PR I'm also adding some protection against calling `replaceBlocks` with `null`.

Potentially `replaceBlocks` could handle this, but I decided not to go that route. If this were typescript we wouldn't add safety to `replaceBlocks` itself or weaken the parameter types by accepting `null`, instead it would fail to compile because the call sites try calling with the wrong type. As there may be TS consumers of this code, I decided to go with the more strongly typed approach and fix the call sites.

## How?
- Adds an `isMatch` to the Quote -> Paragraph transform to ensure it only appears when a valid transform is possible.
- Checks for null-ish or empty return values from `switchToBlockType`

## Testing Instructions
1. Add a quote
2. Delete the paragraph in the quote block and add a heading in its place
3. Re-select the quote block and check the transforms menu - it shouldn't show paragraph
4. Add a Citation - check the transform menu, it should now show paragraph and the transform works correctly
5. Undo until you're back to a quote with only a heading
6. Add a paragraph
7. Try the transform again - it should appear and work correctly.


## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="584" alt="Screenshot 2024-11-13 at 4 53 12 pm" src="https://github.com/user-attachments/assets/c23eb708-7541-4204-9d70-85a3547d62fd">
<img width="496" alt="Screenshot 2024-11-13 at 4 53 21 pm" src="https://github.com/user-attachments/assets/9bed15ec-4a6a-4985-9024-53e4942941f7">

#### After
<img width="581" alt="Screenshot 2024-11-13 at 4 52 45 pm" src="https://github.com/user-attachments/assets/0e5cbb0e-e791-4ed6-aef0-dc1ef06e55bf">

