### PR TITLE
Update text case of "Starter Content"

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/utils.js
@@ -27,7 +27,7 @@ export const myPatternsCategory = {
 
 export const starterPatternsCategory = {
 	name: 'core/starter-content',
-	label: __( 'Starter Content' ),
+	label: __( 'Starter content' ),
 };
 
 export function isPatternFiltered( pattern, sourceFilter, syncFilter ) {

--- a/packages/block-library/src/button/index.js
+++ b/packages/block-library/src/button/index.js
@@ -22,7 +22,7 @@ export const settings = {
 	example: {
 		attributes: {
 			className: 'is-style-fill',
-			text: __( 'Call to Action' ),
+			text: __( 'Call to action' ),
 		},
 	},
 	edit,


### PR DESCRIPTION
## What?

Followup to #66819, changes titlecase to sentence case for "Starter content" in patterns.

It also changes a "Call to Action" to "Call to action", to match the case style for other UI.

## Testing Instructions

Use Twenty Twenty-Five, open inserter, see "Starter content" under patterns.