### PR TITLE
Add Left, Right, and Full-Width Alignment Options to Code Block (Issue #66960)

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -87,7 +87,7 @@ Display code snippets that respect your spacing and tabs. ([Source](https://gith
 
 -	**Name:** core/code
 -	**Category:** text
--	**Supports:** align (wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
+-	**Supports:** align (full, left, right, wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
 -	**Attributes:** content
 
 ## Column

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -15,7 +15,7 @@
 		}
 	},
 	"supports": {
-		"align": [ "wide" ],
+		"align": [ "left", "right", "wide", "full" ],
 		"anchor": true,
 		"typography": {
 			"fontSize": true,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Added alignment options for the Code Block: left, right, and full-width. Fixes : #66960 

## Why?
To provide users with more flexibility and control over the layout and positioning of the Code Block within their content, enhancing the overall editing experience

## How?
Updated the block's alignment control to support the new options.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/333c2c0c-07f7-4904-aa34-fa83068f9a6c
