### PR TITLE
Block Bindings: Allow async call in `getValues` API

### DIFF
--- a/packages/blocks/src/store/index.js
+++ b/packages/blocks/src/store/index.js
@@ -11,6 +11,7 @@ import * as selectors from './selectors';
 import * as privateSelectors from './private-selectors';
 import * as actions from './actions';
 import * as privateActions from './private-actions';
+import * as resolvers from './resolvers';
 import { STORE_NAME } from './constants';
 import { unlock } from '../lock-unlock';
 
@@ -25,6 +26,7 @@ export const store = createReduxStore( STORE_NAME, {
 	reducer,
 	selectors,
 	actions,
+	resolvers,
 } );
 
 register( store );

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -249,9 +249,10 @@ export const hasContentRoleAttribute = ( state, blockTypeName ) => {
  *
  * @param {Object} state  Data state.
  * @param {string} source Source object.
+ * @param {Object} args   Arguments to pass to `getValues`.
  *
  * @return {Object} The values obtained from calling `getValues` asynchronously.
  */
-export function asyncBlockBindingsGetValues( state, source ) {
-	return state.asyncBlockBindingsGetValues[ source.name ];
+export function asyncBlockBindingsGetValues( state, source, args ) {
+	return state.asyncBlockBindingsGetValues[ args.clientId ]?.[ source.name ];
 }

--- a/packages/blocks/src/store/private-selectors.js
+++ b/packages/blocks/src/store/private-selectors.js
@@ -243,3 +243,15 @@ export const hasContentRoleAttribute = ( state, blockTypeName ) => {
 		}
 	);
 };
+
+/**
+ * Returns the values from `getValues` when it is called as a promise.
+ *
+ * @param {Object} state  Data state.
+ * @param {string} source Source object.
+ *
+ * @return {Object} The values obtained from calling `getValues` asynchronously.
+ */
+export function asyncBlockBindingsGetValues( state, source ) {
+	return state.asyncBlockBindingsGetValues[ source.name ];
+}

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -422,6 +422,18 @@ export function blockBindingsSources( state = {}, action ) {
 	return state;
 }
 
+export function asyncBlockBindingsGetValues( state = {}, action ) {
+	switch ( action.type ) {
+		case 'RECEIVE_BLOCK_BINDINGS_ASYNC_VALUES':
+			return {
+				...state,
+				[ action.sourceName ]: action.values,
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	bootstrappedBlockTypes,
 	unprocessedBlockTypes,
@@ -435,4 +447,5 @@ export default combineReducers( {
 	categories,
 	collections,
 	blockBindingsSources,
+	asyncBlockBindingsGetValues,
 } );

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -427,7 +427,10 @@ export function asyncBlockBindingsGetValues( state = {}, action ) {
 		case 'RECEIVE_BLOCK_BINDINGS_ASYNC_VALUES':
 			return {
 				...state,
-				[ action.sourceName ]: action.values,
+				[ action.args.clientId ]: {
+					...state[ action.args.clientId ],
+					[ action.sourceName ]: action.values,
+				},
 			};
 	}
 

--- a/packages/blocks/src/store/resolvers.js
+++ b/packages/blocks/src/store/resolvers.js
@@ -11,6 +11,7 @@ export const asyncBlockBindingsGetValues =
 		dispatch( {
 			type: 'RECEIVE_BLOCK_BINDINGS_ASYNC_VALUES',
 			sourceName: source.name,
+			args,
 			values,
 		} );
 	};

--- a/packages/blocks/src/store/resolvers.js
+++ b/packages/blocks/src/store/resolvers.js
@@ -1,0 +1,16 @@
+export const asyncBlockBindingsGetValues =
+	( source, args ) =>
+	async ( { dispatch } ) => {
+		let values;
+		try {
+			values = await source.getValues( args );
+		} catch ( error ) {
+			// Do nothing.
+			return;
+		}
+		dispatch( {
+			type: 'RECEIVE_BLOCK_BINDINGS_ASYNC_VALUES',
+			sourceName: source.name,
+			values,
+		} );
+	};


### PR DESCRIPTION
## What?
In this pull request, I'm exploring how to allow the possibility of making async calls in the `getValues` API. I can see many external sources wanting to call external APIs with `fetch`/`apiFetch`, and they need to be `async` and wait for the result to show it in the editor. Here is an example using the Gravatar API:


https://github.com/user-attachments/assets/015d5382-16f7-47cc-a3a8-7868be779e9c


In `trunk`, it was shows the fallback value because it doesn't wait for the response:

<img width="246" alt="Screenshot 2024-11-13 at 13 20 34" src="https://github.com/user-attachments/assets/fc7e2bbe-b4e5-42ef-8be3-cbc8025e3172">



## Why?
I believe async calls should be supported and we need to explore the best way to do it.

## How?
In this case, I'm creating a wrapper resolver that calls `source.getValues` asynchronously. Then, depending if the callback is async or not, we call `getValues` directly or with this new wrapper.

I am not sure if this approach is correct, but it seems to work. It seems in other scenarios we are using `resolvers` for doing async calls.

@gziolo I'd love to know your thoughts. I remember you mentioning the possibility of using [thunks](https://make.wordpress.org/core/2021/10/29/thunks-in-gutenberg/), so I'm happy to explore that if you consider it better. 

## Testing Instructions
I still need to think how tests could look like.

1. Register a source in the client with async call:
```js
import { registerBlockBindingsSource } from "@wordpress/blocks";

registerBlockBindingsSource({
  name: "santosguillamot/gravatar",
  label: "Gravatar",
  getValues: async ({ bindings }) => {
    const newValues = {};

    for (const [attributeName, source] of Object.entries(bindings)) {
      const { field } = source.args;
      // Fetch from Gravatar API.
      const response = await fetch(
        "https://api.gravatar.com/v3/profiles/santosguillamot"
      );
      const responseJson = await response.json();
      newValues[attributeName] = responseJson?.[field];
    }
    return newValues;
  },
```

2. Add some blocks connected to this source:

```html
<!-- wp:image {"width":"136px","height":"auto","metadata":{"bindings":{"url":{"source":"santosguillamot/gravatar","args":{"field":"avatar_url"}}}}} -->
<figure class="wp-block-image is-resized"><img alt="" style="width:136px;height:auto"/></figure>
<!-- /wp:image -->

<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"santosguillamot/gravatar","args":{"field":"display_name"}}}}} -->
<p>Fallback</p>
<!-- /wp:paragraph -->

<!-- wp:paragraph {"metadata":{"bindings":{"content":{"source":"santosguillamot/gravatar","args":{"field":"job_title"}}}},"style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast-2"}}}},"textColor":"contrast-2"} -->
<p class="has-contrast-2-color has-text-color has-link-color">Fallback</p>
<!-- /wp:paragraph -->
```
3. Check that it shows the values from the gravatar API.