### PR TITLE
Block Editor: Fix 'useSelect' dependencies for the 'RichText' component

### DIFF
--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -233,7 +233,14 @@ export function RichTextWrapper(
 				bindingsLabel: _bindingsLabel,
 			};
 		},
-		[ blockBindings, identifier, blockName, blockContext, adjustedValue ]
+		[
+			blockBindings,
+			identifier,
+			blockName,
+			adjustedValue,
+			clientId,
+			blockContext,
+		]
 	);
 
 	const shouldDisableEditing = readOnly || disableBoundBlock;


### PR DESCRIPTION
## What?

PR fixes the `useSelect` dependencies warning for the `RichText` component.

```
React Hook useSelect has a missing dependency: 'clientId'. Either include it or remove the dependency array.
```

## Why?
We should fix similar warnings whenever possible.

## Testing Instructions
None. CI checks should be green.
