### PR TITLE
Data: upgrade Redux to v5.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,7 +135,7 @@
 				"react-scanner": "1.2.0",
 				"react-test-renderer": "18.3.1",
 				"reassure": "0.7.1",
-				"redux": "4.1.2",
+				"redux": "5.0.1",
 				"resize-observer-polyfill": "1.5.1",
 				"rimraf": "3.0.2",
 				"rtlcss": "4.0.0",
@@ -43764,12 +43764,9 @@
 			}
 		},
 		"node_modules/redux": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-			"integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
-			"dependencies": {
-				"@babel/runtime": "^7.9.2"
-			}
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+			"integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="
 		},
 		"node_modules/regenerate": {
 			"version": "1.4.2",
@@ -53963,7 +53960,7 @@
 				"equivalent-key-map": "^0.2.2",
 				"is-plain-object": "^5.0.0",
 				"is-promise": "^4.0.0",
-				"redux": "^4.1.2",
+				"redux": "^5.0.1",
 				"rememo": "^4.0.2",
 				"use-memo-one": "^1.1.1"
 			},

--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
 		"react-scanner": "1.2.0",
 		"react-test-renderer": "18.3.1",
 		"reassure": "0.7.1",
-		"redux": "4.1.2",
+		"redux": "5.0.1",
 		"resize-observer-polyfill": "1.5.1",
 		"rimraf": "3.0.2",
 		"rtlcss": "4.0.0",

--- a/packages/data/package.json
+++ b/packages/data/package.json
@@ -42,7 +42,7 @@
 		"equivalent-key-map": "^0.2.2",
 		"is-plain-object": "^5.0.0",
 		"is-promise": "^4.0.0",
-		"redux": "^4.1.2",
+		"redux": "^5.0.1",
 		"rememo": "^4.0.2",
 		"use-memo-one": "^1.1.1"
 	},


### PR DESCRIPTION
Let's upgrade Redux to the latest version 5.0.1. There are [apps](https://github.com/Automattic/wp-calypso/pull/85379) that use both `@wordpress/data` and plain `redux` and the fact that we still use the old 4.x version causes unnecessary `node_modules` conflicts.

There shouldn't be any visible changes, after all, the `redux` API surface is very small. Maybe only the TS types might have some incompatible changes, but I don't see any.