### PR TITLE
Date/Time: Use Site Timezone in RSS Block

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -48,6 +48,12 @@ function render_block_core_rss( $attributes ) {
 			$date = $item->get_date( 'U' );
 
 			if ( $date ) {
+				$gmt_offset = get_option( 'gmt_offset' );
+
+				$date = is_numeric( $gmt_offset )
+					? $date + (int) ( (float) $gmt_offset * HOUR_IN_SECONDS )
+					: $date;
+
 				$date = sprintf(
 					'<time datetime="%1$s" class="wp-block-rss__item-publish-date">%2$s</time> ',
 					esc_attr( date_i18n( 'c', $date ) ),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes: #66970

## What?
This PR fixes an issue where the RSS Block displays dates in UTC instead of the site’s configured timezone. The date is now correctly adjusted based on the site’s gmt_offset setting.

## Why?
This PR is necessary because the RSS Block was displaying dates in UTC, ignoring the site’s configured timezone in the WordPress settings. This resulted in incorrect date displays for users whose sites are set to timezones other than UTC. The problem was initially identified in [trac](https://core.trac.wordpress.org/ticket/62400)

## How?
The issue is addressed by adding logic to adjust the date based on the site’s `gmt_offset` option. This ensures that the displayed date corresponds to the site’s local timezone rather than UTC.

## Testing Instructions
1. Go to Settings > General in the WordPress dashboard and set the site timezone to something other than UTC, such as UTC+9.
2. Add an RSS Block to a post or page.
3. Link the RSS Block to an RSS feed where pubDate includes a timezone offset (e.g., [MixOnline](https://www.mixonline.jp/DesktopModules/MixOnline_Rss/MixOnlinerss.aspx?rssmode=3), which uses +0900).
4. Enable “Display date” in the RSS Block settings.
5. Preview or publish the post.
6. Verify that the displayed date corresponds to the site’s timezone, not UTC.

## Screenshots or screencast <!-- if applicable -->
### RSS feed:
<img width="500" src="https://github.com/user-attachments/assets/3321488f-2569-4576-96c4-a8d5aa27f90a" />

### Block:
<img width="500" src="https://github.com/user-attachments/assets/e49c2adc-465b-4571-a3e0-9f6b8f6bb9d1" />

### Settings > General
<img width="590" alt="image" src="https://github.com/user-attachments/assets/f8cbd5c4-4466-4da4-9908-47ad2b4fa5cf">


