### PR TITLE
Added enableAlpha prop to CustomGradientPicker and GradientPicker components

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+-   `GradientPicker`: Add enableAlpha prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))
+-   `CustomGradientPicker`: Add enableAlpha prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))
+
 ### Deprecations
 
 -   `DimensionControl`: Deprecate 36px default size ([#66705](https://github.com/WordPress/gutenberg/pull/66705)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## Unreleased
 
--   `GradientPicker`: Add enableAlpha prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))
--   `CustomGradientPicker`: Add enableAlpha prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))
+### Enhancements
+
+-   `GradientPicker`: Add `enableAlpha` prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))
+-   `CustomGradientPicker`: Add `enableAlpha` prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))
 
 ### Deprecations
 

--- a/packages/components/src/custom-gradient-picker/index.tsx
+++ b/packages/components/src/custom-gradient-picker/index.tsx
@@ -140,6 +140,7 @@ const GradientTypePicker = ( {
 export function CustomGradientPicker( {
 	value,
 	onChange,
+	enableAlpha = true,
 	__experimentalIsRenderedInSidebar = false,
 }: CustomGradientPickerProps ) {
 	const { gradientAST, hasGradient } = getGradientAstWithDefault( value );
@@ -167,6 +168,7 @@ export function CustomGradientPicker( {
 				__experimentalIsRenderedInSidebar={
 					__experimentalIsRenderedInSidebar
 				}
+				disableAlpha={ ! enableAlpha }
 				background={ background }
 				hasGradient={ hasGradient }
 				value={ controlPoints }

--- a/packages/components/src/custom-gradient-picker/types.ts
+++ b/packages/components/src/custom-gradient-picker/types.ts
@@ -27,7 +27,7 @@ export type CustomGradientPickerProps = {
 	 */
 	onChange: ( currentGradient: string ) => void;
 	/**
-	 * Whether to disable alpha transparency options in the picker.
+	 * Whether to enable alpha transparency options in the picker.
 	 *
 	 * @default true
 	 */

--- a/packages/components/src/custom-gradient-picker/types.ts
+++ b/packages/components/src/custom-gradient-picker/types.ts
@@ -27,6 +27,12 @@ export type CustomGradientPickerProps = {
 	 */
 	onChange: ( currentGradient: string ) => void;
 	/**
+	 * Whether to disable alpha transparency options in the picker.
+	 *
+	 * @default true
+	 */
+	enableAlpha?: boolean;
+	/**
 	 * Whether this is rendered in the sidebar.
 	 *
 	 * @default false

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -102,7 +102,7 @@ gradients from `gradients` will be shown.
 
 ### `enableAlpha`
 
-Whether to disable alpha transparency options in the picker.
+Whether to enable alpha transparency options in the picker.
 
  - Type: `boolean`
  - Required: No

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -100,6 +100,14 @@ gradients from `gradients` will be shown.
  - Required: No
  - Default: `false`
 
+### `enableAlpha`
+
+Whether to disable alpha transparency options in the picker.
+
+ - Type: `boolean`
+ - Required: No
+ - Default: `true`
+
 ### `gradients`
 
 An array of objects as predefined gradients displayed above the gradient

--- a/packages/components/src/gradient-picker/index.tsx
+++ b/packages/components/src/gradient-picker/index.tsx
@@ -213,6 +213,7 @@ export function GradientPicker( {
 	onChange,
 	value,
 	clearable = true,
+	enableAlpha = true,
 	disableCustomGradients = false,
 	__experimentalIsRenderedInSidebar,
 	headingLevel = 2,
@@ -230,6 +231,7 @@ export function GradientPicker( {
 					__experimentalIsRenderedInSidebar={
 						__experimentalIsRenderedInSidebar
 					}
+					enableAlpha={ enableAlpha }
 					value={ value }
 					onChange={ onChange }
 				/>

--- a/packages/components/src/gradient-picker/types.ts
+++ b/packages/components/src/gradient-picker/types.ts
@@ -56,6 +56,12 @@ type GradientPickerBaseProps = {
 	 * @default true
 	 */
 	loop?: boolean;
+	/**
+	 * Whether to disable alpha transparency options in the picker.
+	 *
+	 * @default true
+	 */
+	enableAlpha?: boolean;
 } & (
 	| {
 			// TODO: [#54055] Either this or `aria-labelledby` should be required

--- a/packages/components/src/gradient-picker/types.ts
+++ b/packages/components/src/gradient-picker/types.ts
@@ -57,7 +57,7 @@ type GradientPickerBaseProps = {
 	 */
 	loop?: boolean;
 	/**
-	 * Whether to disable alpha transparency options in the picker.
+	 * Whether to enable alpha transparency options in the picker.
 	 *
 	 * @default true
 	 */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds enableAlpha prop to GradientPicker component, which is already supported within CustomGradientBar subcomponent.

## Why?
Firstly, both ColorPicker and ColorPalette component's have this feature under enableAlppha prop, so adding it to GradientPicker would only be consistent. Secondly, I have found a use for this feature within my own project, where a block can not be allowed transparency, but wants to utilize other features of the GradientPicker component.

## How?
The GradientPicker's subcomponent's subcomponent "CustomGradientBar" already supports disabling alpha for custom gradients. All i did was add enableAlpha prop to GradientPicker and its subcomponent, CustomGradientPicker, in order to take advantage of the feature within CustomGradientBar component.

This is my first attempt at contributing, and I do not expect it to be free of faults.

## Testing Instructions
When using GradientPicker component, simply add the enableAlpha prop with 'false' as the value, or omit the prop to let it resort to default value of 'true'.

