### PR TITLE
WP Scripts: Revert changes that inline CSS imports early in the build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -119,7 +119,6 @@
 				"npm-run-all": "4.1.5",
 				"patch-package": "8.0.0",
 				"postcss": "8.4.38",
-				"postcss-import": "16.1.0",
 				"postcss-loader": "6.2.1",
 				"postcss-local-keyframes": "^0.0.2",
 				"prettier": "npm:wp-prettier@3.0.3",
@@ -40557,6 +40556,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
 			"integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -40835,27 +40835,6 @@
 			"peerDependencies": {
 				"postcss": "^8.2.15"
 			}
-		},
-		"node_modules/postcss-import": {
-			"version": "16.1.0",
-			"resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-16.1.0.tgz",
-			"integrity": "sha512-7hsAZ4xGXl4MW+OKEWCnF6T5jqBw80/EE9aXg1r2yyn1RsVEU8EtKXbijEODa+rg7iih4bKf7vlvTGYR4CnPNg==",
-			"dependencies": {
-				"postcss-value-parser": "^4.0.0",
-				"read-cache": "^1.0.0",
-				"resolve": "^1.1.7"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			},
-			"peerDependencies": {
-				"postcss": "^8.0.0"
-			}
-		},
-		"node_modules/postcss-import/node_modules/postcss-value-parser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
 		},
 		"node_modules/postcss-loader": {
 			"version": "6.2.1",
@@ -43335,14 +43314,6 @@
 			},
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/read-cache": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-			"dependencies": {
-				"pify": "^2.3.0"
 			}
 		},
 		"node_modules/read-cmd-shim": {
@@ -55585,7 +55556,6 @@
 				"npm-package-json-lint": "^6.4.0",
 				"npm-packlist": "^3.0.0",
 				"postcss": "^8.4.5",
-				"postcss-import": "^16.1.0",
 				"postcss-loader": "^6.2.1",
 				"prettier": "npm:wp-prettier@3.0.3",
 				"puppeteer-core": "^23.1.0",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
 		"npm-run-all": "4.1.5",
 		"patch-package": "8.0.0",
 		"postcss": "8.4.38",
-		"postcss-import": "16.1.0",
 		"postcss-loader": "6.2.1",
 		"postcss-local-keyframes": "^0.0.2",
 		"prettier": "npm:wp-prettier@3.0.3",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fix
 
 -   Make `start` script more resilient for developer errors ([#66752](https://github.com/WordPress/gutenberg/pull/66752)).
+-   Revert changes from [#61121](https://github.com/WordPress/gutenberg/pull/61121) that inlined CSS files imported from other CSS files before optimization in the `build` command.
 
 ## 30.4.0 (2024-10-30)
 

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+### Bug Fix
+
+-   Revert changes from [#61121](https://github.com/WordPress/gutenberg/pull/61121) that inlined CSS files imported from other CSS files before optimization in the `build` command.
+
 ## 30.5.0 (2024-11-16)
 
 ### Bug Fix
 
 -   Make `start` script more resilient for developer errors ([#66752](https://github.com/WordPress/gutenberg/pull/66752)).
--   Revert changes from [#61121](https://github.com/WordPress/gutenberg/pull/61121) that inlined CSS files imported from other CSS files before optimization in the `build` command.
 
 ## 30.4.0 (2024-10-30)
 

--- a/packages/scripts/config/webpack.config.js
+++ b/packages/scripts/config/webpack.config.js
@@ -75,7 +75,6 @@ const cssLoaders = [
 					plugins: isProduction
 						? [
 								...postcssPlugins,
-								require( 'postcss-import' ),
 								require( 'cssnano' )( {
 									// Provide a fallback configuration if there's not
 									// one explicitly available in the project.

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -74,7 +74,6 @@
 		"npm-package-json-lint": "^6.4.0",
 		"npm-packlist": "^3.0.0",
 		"postcss": "^8.4.5",
-		"postcss-import": "^16.1.0",
 		"postcss-loader": "^6.2.1",
 		"prettier": "npm:wp-prettier@3.0.3",
 		"puppeteer-core": "^23.1.0",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes #66503.
Reverts #61121. 

> ### Step-by-step reproduction instructions
> 
> 1. clone my test repo and install `npm` dependencies
> ```shell
> mkdir test
> cd test
> git clone https://github.com/loxK/wordpress-scripts-test.git ./ -b font-dependency
> npm i
> ``` 
> 2. build : `npm run build`
> 
> 3. notice the errors importing the font referenced in the felxslider module :
> 
> ```shell
> ERROR in ./blocks/editor.scss (./blocks/editor.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[3].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[3].use[2]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[3].use[3]!./blocks/editor.scss) 5:36-89
> Module not found: Error: Can't resolve 'fonts/flexslider-icon.eot' in '/home/www/user/Tests/wordpress-scripts-test/blocks'
> ```
> 
> 4. downgrade to wordpress/scripts v28.6.0, and build :
> 
> ```shell
> npm i -D @wordpress/scripts@28.6.0
> npm build
> ```
> 
> 5. notice that there are no errors and taht fonts are in assets/blocks/fonts :
> 
> ```bash
> # ls assets/blocks/fonts 
> flexslider-icon.0c4bb125.eot  flexslider-icon.b5aefbb7.woff  flexslider-icon.c6c9e9e5.ttf
> ```

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Import CSS files before the minification process doesn't work well with files imported from external dependencies located in `node_modules` folder.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Reverts #61121. 

## Testing instructions

### Step-by-step reproduction instructions

1. clone my test repo and install `npm` dependencies
```shell
mkdir test
cd test
git clone https://github.com/loxK/wordpress-scripts-test.git ./ -b font-dependency
npm i
``` 
2. build : `npm run build`

3. notice the errors importing the font referenced in the felxslider module :

```shell
ERROR in ./blocks/editor.scss (./blocks/editor.scss.webpack[javascript/auto]!=!./node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[3].use[1]!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[3].use[2]!./node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[3].use[3]!./blocks/editor.scss) 5:36-89
Module not found: Error: Can't resolve 'fonts/flexslider-icon.eot' in '/home/www/user/Tests/wordpress-scripts-test/blocks'
```

4. switch to this branch, and build :

```shell
npx ../gutenberg/node_modules/.bin/wp-scripts build
```

5. notice that there are no errors and taht fonts are in assets/blocks/fonts :

```bash
# ls assets/blocks/fonts 
flexslider-icon.0c4bb125.eot  flexslider-icon.b5aefbb7.woff  flexslider-icon.c6c9e9e5.ttf
```