### PR TITLE
Comments controller: fix issue where comments are allowed when closed

### DIFF
--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php
@@ -10,6 +10,10 @@
 class Gutenberg_REST_Comment_Controller_6_8 extends WP_REST_Comments_Controller {
 
 	public function create_item_permissions_check( $request ) {
+		if ( 'comment' === $request['type'] ) {
+			return parent::create_item_permissions_check( $request );
+		}
+
 		if ( ! is_user_logged_in() ) {
 			if ( get_option( 'comment_registration' ) ) {
 				return new WP_Error(
@@ -90,14 +94,6 @@ class Gutenberg_REST_Comment_Controller_6_8 extends WP_REST_Comments_Controller 
 			);
 		}
 
-		if ( 'draft' === $post->post_status && 'comment' === $request['comment_type'] ) {
-			return new WP_Error(
-				'rest_comment_draft_post',
-				__( 'Sorry, you are not allowed to create a comment on this post.' ),
-				array( 'status' => 403 )
-			);
-		}
-
 		if ( 'trash' === $post->post_status ) {
 			return new WP_Error(
 				'rest_comment_trash_post',
@@ -111,14 +107,6 @@ class Gutenberg_REST_Comment_Controller_6_8 extends WP_REST_Comments_Controller 
 				'rest_cannot_read_post',
 				__( 'Sorry, you are not allowed to read the post for this comment.' ),
 				array( 'status' => rest_authorization_required_code() )
-			);
-		}
-
-		if ( ! comments_open( $post->ID ) && 'comment' === $request['comment_type'] ) {
-			return new WP_Error(
-				'rest_comment_closed',
-				__( 'Sorry, comments are closed for this item.' ),
-				array( 'status' => 403 )
 			);
 		}
 

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-comment-controller-6-8.php
@@ -10,7 +10,7 @@
 class Gutenberg_REST_Comment_Controller_6_8 extends WP_REST_Comments_Controller {
 
 	public function create_item_permissions_check( $request ) {
-		if ( 'comment' === $request['type'] ) {
+		if ( empty( $request['comment_type'] ) || 'comment' === $request['comment_type'] ) {
 			return parent::create_item_permissions_check( $request );
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

The comments endpoint allows no type to be specified, in which case `comment` should be assumed.

https://github.com/WordPress/wordpress-develop/blob/a27e6a8ecd5279a45e47ef88d048643740d07b5a/src/wp-includes/rest-api/endpoints/class-wp-rest-comments-controller.php#L591

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Comments can be submitted even if comments are closed.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
