### PR TITLE
Trunk: Zoom in/out to correct location

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -7,13 +7,26 @@
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s);
+	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
-		// we only want to animate the scaling when entering zoom out. When sidebars
+		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
+		$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
+
+		position: fixed;
+		left: 0;
+		right: 0;
+		top: calc(-1 * #{$scroll-top});
+		bottom: 0;
+		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
+		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
+		// and removing the scrollbar causes the content to shift.
+		overflow-y: scroll;
+
+		// We only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
-		@include editor-canvas-resize-animation(transform 0s);
+		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
 }
 

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,7 +3,16 @@
 }
 
 .block-editor-iframe__html {
+	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
+	scale: $scale;
 	transform-origin: top center;
+	// Add the top/bottom frame size. We use scaling to account for the left/right, as
+	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+	// of the content.
+	padding-top: calc(#{$frame-size} / #{$scale});
+	padding-bottom: calc(#{$frame-size} / #{$scale});
+
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
@@ -28,43 +37,35 @@
 		// and the doubled animations cause very odd animations.
 		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
-}
 
-.block-editor-iframe__html.is-zoomed-out {
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
-	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
-	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
-	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-	// Apply an X translation to center the scaled content within the available space.
-	transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-	scale: #{$scale};
-	background-color: $gray-300;
+	&.is-zoomed-out {
+		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
+		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
+		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
+		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+		// Apply an X translation to center the scaled content within the available space.
+		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+		background-color: $gray-300;
 
-	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
-	// so we need to adjust the height of the content to match the scale by using negative margins.
-	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
-	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
-	margin-bottom: calc(-1 * #{$total-height});
-	// Add the top/bottom frame size. We use scaling to account for the left/right, as
-	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-	// of the content.
-	padding-top: calc(#{$frame-size} / #{$scale});
-	padding-bottom: calc(#{$frame-size} / #{$scale});
+		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+		// so we need to adjust the height of the content to match the scale by using negative margins.
+		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
+		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
+		margin-bottom: calc(-1 * #{$total-height});
 
-	body {
-		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+		body {
+			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 
-		> .is-root-container:not(.wp-block-post-content) {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			height: 100%;
-
-			> main {
+			> .is-root-container:not(.wp-block-post-content) {
 				flex: 1;
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+
+				> main {
+					flex: 1;
+				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -226,21 +226,6 @@ function Iframe( {
 		};
 	}, [] );
 
-	const [ windowInnerWidth, setWindowInnerWidth ] = useState();
-
-	const windowResizeRef = useRefEffect( ( node ) => {
-		const nodeWindow = node.ownerDocument.defaultView;
-
-		setWindowInnerWidth( nodeWindow.innerWidth );
-		const onResize = () => {
-			setWindowInnerWidth( nodeWindow.innerWidth );
-		};
-		nodeWindow.addEventListener( 'resize', onResize );
-		return () => {
-			nodeWindow.removeEventListener( 'resize', onResize );
-		};
-	}, [] );
-
 	const isZoomedOut = scale !== 1;
 
 	useEffect( () => {
@@ -267,7 +252,6 @@ function Iframe( {
 		iframeDocument,
 		contentHeight,
 		containerWidth,
-		windowInnerWidth,
 		isZoomedOut,
 		scaleContainerWidth,
 	} );
@@ -399,7 +383,7 @@ function Iframe( {
 	);
 
 	return (
-		<div className="block-editor-iframe__container" ref={ windowResizeRef }>
+		<div className="block-editor-iframe__container">
 			{ containerResizeListener }
 			<div
 				className={ clsx(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -272,14 +272,14 @@ function Iframe( {
 	const frameSizeValue = parseInt( frameSize );
 
 	const maxWidth = 750;
-	const scaleValue =
-		scale === 'auto-scaled'
-			? ( Math.min( containerWidth, maxWidth ) - frameSizeValue * 2 ) /
-			  scaleContainerWidth
-			: scale;
 
 	useScaleCanvas( {
-		scaleValue,
+		scale:
+			scale === 'auto-scaled'
+				? ( Math.min( containerWidth, maxWidth ) -
+						frameSizeValue * 2 ) /
+				  scaleContainerWidth
+				: scale,
 		frameSizeValue,
 		iframeDocument,
 		iframeWindowInnerHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,6 +20,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	useReducedMotion,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -130,6 +131,7 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
+	const prefersReducedMotion = useReducedMotion();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -268,6 +270,19 @@ function Iframe( {
 		containerWidth
 	);
 
+	const frameSizeValue = parseInt( frameSize );
+
+	const maxWidth = 750;
+	const scaleValue =
+		scale === 'auto-scaled'
+			? ( Math.min( containerWidth, maxWidth ) - frameSizeValue * 2 ) /
+			  scaleContainerWidth
+			: scale;
+
+	const prevScaleRef = useRef( scaleValue );
+	const prevFrameSizeRef = useRef( frameSizeValue );
+	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
+
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
 		useBubbleEvents( iframeDocument ),
@@ -320,49 +335,175 @@ function Iframe( {
 
 	useEffect( () => cleanup, [ cleanup ] );
 
-	const zoomOutAnimationClassnameRef = useRef( null );
+	useEffect( () => {
+		if (
+			! iframeDocument ||
+			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
+			// instead of the dependency array to appease the linter.
+			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
+		) {
+			return;
+		}
+
+		// Unscaled height of the current iframe container.
+		const clientHeight = iframeDocument.documentElement.clientHeight;
+
+		// Scaled height of the current iframe content.
+		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		// Previous scale value.
+		const prevScale = prevScaleRef.current;
+
+		// Unscaled size of the previous padding around the iframe content.
+		const prevFrameSize = prevFrameSizeRef.current;
+
+		// Unscaled height of the previous iframe container.
+		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
+
+		// We can't trust the set value from contentHeight, as it was measured
+		// before the zoom out mode was changed. After zoom out mode is changed,
+		// appenders may appear or disappear, so we need to get the height from
+		// the iframe at this point when we're about to animate the zoom out.
+		// The iframe scrollTop, scrollHeight, and clientHeight will all be
+		// accurate. The client height also does change when the zoom out mode
+		// is toggled, as the bottom bar about selecting the template is
+		// added/removed when toggling zoom out mode.
+		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// Step 0: Start with the current scrollTop.
+		let scrollTopNext = scrollTop;
+
+		// Step 1: Undo the effects of the previous scale and frame around the
+		// midpoint of the visible area.
+		scrollTopNext =
+			( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
+				prevScale -
+			prevClientHeight / 2;
+
+		// Step 2: Apply the new scale and frame around the midpoint of the
+		// visible area.
+		scrollTopNext =
+			( scrollTopNext + clientHeight / 2 ) * scaleValue +
+			frameSizeValue -
+			clientHeight / 2;
+
+		// Step 3: Handle an edge case so that you scroll to the top of the
+		// iframe if the top of the iframe content is visible in the container.
+		// The same edge case for the bottom is skipped because changing content
+		// makes calculating it impossible.
+		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
+
+		// This is the scrollTop value if you are scrolled to the bottom of the
+		// iframe. We can't just let the browser handle it because we need to
+		// animate the scaling.
+		const maxScrollTop =
+			scrollHeight * ( scaleValue / prevScale ) +
+			frameSizeValue * 2 -
+			clientHeight;
+
+		// Step 4: Clamp the scrollTopNext between the minimum and maximum
+		// possible scrollTop positions. Round the value to avoid subpixel
+		// truncation by the browser which sometimes causes a 1px error.
+		scrollTopNext = Math.round(
+			Math.min(
+				Math.max( 0, scrollTopNext ),
+				Math.max( 0, maxScrollTop )
+			)
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top',
+			`${ scrollTop }px`
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+			`${ scrollTopNext }px`
+		);
+
+		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
+
+		function onZoomOutTransitionEnd() {
+			// Remove the position fixed for the animation.
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+
+			// Update previous values.
+			prevClientHeightRef.current = clientHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			// Set the final scroll position that was just animated to.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}
+
+		let raf;
+		if ( prefersReducedMotion ) {
+			// Hack: Wait for the window values to recalculate.
+			raf = iframeDocument.defaultView.requestAnimationFrame(
+				onZoomOutTransitionEnd
+			);
+		} else {
+			iframeDocument.documentElement.addEventListener(
+				'transitionend',
+				onZoomOutTransitionEnd,
+				{ once: true }
+			);
+		}
+
+		return () => {
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next'
+			);
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+			if ( prefersReducedMotion ) {
+				iframeDocument.defaultView.cancelAnimationFrame( raf );
+			} else {
+				iframeDocument.documentElement.removeEventListener(
+					'transitionend',
+					onZoomOutTransitionEnd
+				);
+			}
+		};
+	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
 	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
 	// number of dependencies.
 	useEffect( () => {
-		if ( ! iframeDocument || ! isZoomedOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
 
-		const handleZoomOutAnimationClassname = () => {
-			clearTimeout( zoomOutAnimationClassnameRef.current );
-
-			iframeDocument.documentElement.classList.add(
-				'zoom-out-animation'
-			);
-
-			zoomOutAnimationClassnameRef.current = setTimeout( () => {
-				iframeDocument.documentElement.classList.remove(
-					'zoom-out-animation'
-				);
-			}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
-		};
-
-		handleZoomOutAnimationClassname();
-		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		if ( isZoomedOut ) {
+			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		} else {
+			// HACK: Since we can't remove this in the cleanup, we need to do it here.
+			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
+		}
 
 		return () => {
-			handleZoomOutAnimationClassname();
-			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
+			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
 	}, [ iframeDocument, isZoomedOut ] );
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument || ! isZoomedOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
 
-		const maxWidth = 750;
 		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
-		// initialContainerWidthRef will be smaller than the full page, and reflow will happen
+		// initialContainerWidth will be smaller than the full page, and reflow will happen
 		// when the canvas area becomes larger due to sidebars closing. This is a known but
 		// minor divergence for now.
 
@@ -371,11 +512,7 @@ function Iframe( {
 		// but calc( 100px / 2px ) is not.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scale === 'auto-scaled'
-				? ( Math.min( containerWidth, maxWidth ) -
-						parseInt( frameSize ) * 2 ) /
-						scaleContainerWidth
-				: scale
+			scaleValue
 		);
 
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
@@ -401,27 +538,29 @@ function Iframe( {
 		);
 
 		return () => {
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-content-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-inner-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-container-width'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			);
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-content-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-container-width'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
+			// );
 		};
 	}, [
-		scale,
+		scaleValue,
 		frameSize,
 		iframeDocument,
 		iframeWindowInnerHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -269,18 +269,16 @@ function Iframe( {
 		containerWidth
 	);
 
-	const frameSizeValue = parseInt( frameSize );
-
 	const maxWidth = 750;
 
 	useScaleCanvas( {
 		scale:
 			scale === 'auto-scaled'
 				? ( Math.min( containerWidth, maxWidth ) -
-						frameSizeValue * 2 ) /
+						parseInt( frameSize ) * 2 ) /
 				  scaleContainerWidth
 				: scale,
-		frameSizeValue,
+		frameSize: parseInt( frameSize ),
 		iframeDocument,
 		iframeWindowInnerHeight,
 		contentHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,7 +20,6 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
-	useReducedMotion,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -31,6 +30,7 @@ import { useSelect } from '@wordpress/data';
 import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
+import { useScaleCanvas } from './use-scale-canvas';
 import { store as blockEditorStore } from '../../store';
 
 function bubbleEvent( event, Constructor, frame ) {
@@ -131,7 +131,6 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
-	const prefersReducedMotion = useReducedMotion();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -279,9 +278,17 @@ function Iframe( {
 			  scaleContainerWidth
 			: scale;
 
-	const prevScaleRef = useRef( scaleValue );
-	const prevFrameSizeRef = useRef( frameSizeValue );
-	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
+	useScaleCanvas( {
+		scaleValue,
+		frameSizeValue,
+		iframeDocument,
+		iframeWindowInnerHeight,
+		contentHeight,
+		containerWidth,
+		windowInnerWidth,
+		isZoomedOut,
+		scaleContainerWidth,
+	} );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -334,242 +341,6 @@ function Iframe( {
 	}, [ html ] );
 
 	useEffect( () => cleanup, [ cleanup ] );
-
-	useEffect( () => {
-		if (
-			! iframeDocument ||
-			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
-			// instead of the dependency array to appease the linter.
-			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
-		) {
-			return;
-		}
-
-		// Unscaled height of the current iframe container.
-		const clientHeight = iframeDocument.documentElement.clientHeight;
-
-		// Scaled height of the current iframe content.
-		const scrollHeight = iframeDocument.documentElement.scrollHeight;
-
-		// Previous scale value.
-		const prevScale = prevScaleRef.current;
-
-		// Unscaled size of the previous padding around the iframe content.
-		const prevFrameSize = prevFrameSizeRef.current;
-
-		// Unscaled height of the previous iframe container.
-		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
-
-		// We can't trust the set value from contentHeight, as it was measured
-		// before the zoom out mode was changed. After zoom out mode is changed,
-		// appenders may appear or disappear, so we need to get the height from
-		// the iframe at this point when we're about to animate the zoom out.
-		// The iframe scrollTop, scrollHeight, and clientHeight will all be
-		// accurate. The client height also does change when the zoom out mode
-		// is toggled, as the bottom bar about selecting the template is
-		// added/removed when toggling zoom out mode.
-		const scrollTop = iframeDocument.documentElement.scrollTop;
-
-		// Step 0: Start with the current scrollTop.
-		let scrollTopNext = scrollTop;
-
-		// Step 1: Undo the effects of the previous scale and frame around the
-		// midpoint of the visible area.
-		scrollTopNext =
-			( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
-				prevScale -
-			prevClientHeight / 2;
-
-		// Step 2: Apply the new scale and frame around the midpoint of the
-		// visible area.
-		scrollTopNext =
-			( scrollTopNext + clientHeight / 2 ) * scaleValue +
-			frameSizeValue -
-			clientHeight / 2;
-
-		// Step 3: Handle an edge case so that you scroll to the top of the
-		// iframe if the top of the iframe content is visible in the container.
-		// The same edge case for the bottom is skipped because changing content
-		// makes calculating it impossible.
-		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
-
-		// This is the scrollTop value if you are scrolled to the bottom of the
-		// iframe. We can't just let the browser handle it because we need to
-		// animate the scaling.
-		const maxScrollTop =
-			scrollHeight * ( scaleValue / prevScale ) +
-			frameSizeValue * 2 -
-			clientHeight;
-
-		// Step 4: Clamp the scrollTopNext between the minimum and maximum
-		// possible scrollTop positions. Round the value to avoid subpixel
-		// truncation by the browser which sometimes causes a 1px error.
-		scrollTopNext = Math.round(
-			Math.min(
-				Math.max( 0, scrollTopNext ),
-				Math.max( 0, maxScrollTop )
-			)
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top',
-			`${ scrollTop }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-			`${ scrollTopNext }px`
-		);
-
-		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
-
-		function onZoomOutTransitionEnd() {
-			// Remove the position fixed for the animation.
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
-
-			// Update previous values.
-			prevClientHeightRef.current = clientHeight;
-			prevFrameSizeRef.current = frameSizeValue;
-			prevScaleRef.current = scaleValue;
-
-			// Set the final scroll position that was just animated to.
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-		}
-
-		let raf;
-		if ( prefersReducedMotion ) {
-			// Hack: Wait for the window values to recalculate.
-			raf = iframeDocument.defaultView.requestAnimationFrame(
-				onZoomOutTransitionEnd
-			);
-		} else {
-			iframeDocument.documentElement.addEventListener(
-				'transitionend',
-				onZoomOutTransitionEnd,
-				{ once: true }
-			);
-		}
-
-		return () => {
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top-next'
-			);
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
-			if ( prefersReducedMotion ) {
-				iframeDocument.defaultView.cancelAnimationFrame( raf );
-			} else {
-				iframeDocument.documentElement.removeEventListener(
-					'transitionend',
-					onZoomOutTransitionEnd
-				);
-			}
-		};
-	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
-
-	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
-	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
-	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
-	// number of dependencies.
-	useEffect( () => {
-		if ( ! iframeDocument ) {
-			return;
-		}
-
-		if ( isZoomedOut ) {
-			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
-		} else {
-			// HACK: Since we can't remove this in the cleanup, we need to do it here.
-			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
-		}
-
-		return () => {
-			// HACK: Skipping cleanup because it causes issues with the zoom out
-			// animation. More refactoring is needed to fix this properly.
-			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
-		};
-	}, [ iframeDocument, isZoomedOut ] );
-
-	// Calculate the scaling and CSS variables for the zoom out canvas
-	useEffect( () => {
-		if ( ! iframeDocument ) {
-			return;
-		}
-
-		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
-		// initialContainerWidth will be smaller than the full page, and reflow will happen
-		// when the canvas area becomes larger due to sidebars closing. This is a known but
-		// minor divergence for now.
-
-		// This scaling calculation has to happen within the JS because CSS calc() can
-		// only divide and multiply by a unitless value. I.e. calc( 100px / 2 ) is valid
-		// but calc( 100px / 2px ) is not.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale',
-			scaleValue
-		);
-
-		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-frame-size',
-			typeof frameSize === 'number' ? `${ frameSize }px` : frameSize
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-content-height',
-			`${ contentHeight }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ iframeWindowInnerHeight }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-container-width',
-			`${ containerWidth }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale-container-width',
-			`${ scaleContainerWidth }px`
-		);
-
-		return () => {
-			// HACK: Skipping cleanup because it causes issues with the zoom out
-			// animation. More refactoring is needed to fix this properly.
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-content-height'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-container-width'
-			// );
-			// iframeDocument.documentElement.style.removeProperty(
-			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			// );
-		};
-	}, [
-		scaleValue,
-		frameSize,
-		iframeDocument,
-		iframeWindowInnerHeight,
-		contentHeight,
-		containerWidth,
-		windowInnerWidth,
-		isZoomedOut,
-		scaleContainerWidth,
-	] );
 
 	// Make sure to not render the before and after focusable div elements in view
 	// mode. They're only needed to capture focus in edit mode.

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -226,21 +226,6 @@ function Iframe( {
 		};
 	}, [] );
 
-	const [ iframeWindowInnerHeight, setIframeWindowInnerHeight ] = useState();
-
-	const iframeResizeRef = useRefEffect( ( node ) => {
-		const nodeWindow = node.ownerDocument.defaultView;
-
-		setIframeWindowInnerHeight( nodeWindow.innerHeight );
-		const onResize = () => {
-			setIframeWindowInnerHeight( nodeWindow.innerHeight );
-		};
-		nodeWindow.addEventListener( 'resize', onResize );
-		return () => {
-			nodeWindow.removeEventListener( 'resize', onResize );
-		};
-	}, [] );
-
 	const [ windowInnerWidth, setWindowInnerWidth ] = useState();
 
 	const windowResizeRef = useRefEffect( ( node ) => {
@@ -280,7 +265,6 @@ function Iframe( {
 				: scale,
 		frameSize: parseInt( frameSize ),
 		iframeDocument,
-		iframeWindowInnerHeight,
 		contentHeight,
 		containerWidth,
 		windowInnerWidth,
@@ -295,10 +279,6 @@ function Iframe( {
 		clearerRef,
 		writingFlowRef,
 		disabledRef,
-		// Avoid resize listeners when not needed, these will trigger
-		// unnecessary re-renders when animating the iframe width, or when
-		// expanding preview iframes.
-		isZoomedOut ? iframeResizeRef : null,
 	] );
 
 	// Correct doctype is required to enable rendering in standards

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -13,7 +13,6 @@ import { useReducedMotion } from '@wordpress/compose';
  * @param {number}   root0.containerWidth      The width of the container.
  * @param {number}   root0.frameSize           The size of the frame around the content.
  * @param {Document} root0.iframeDocument      The document of the iframe.
- * @param {number}   root0.windowInnerWidth    The height of the inner window
  * @param {boolean}  root0.isZoomedOut         Whether the canvas is in zoom out mode.
  * @param {number}   root0.scale               The scale of the canvas.
  * @param {number}   root0.scaleContainerWidth The width of the container at the scaled size.
@@ -24,7 +23,6 @@ export function useScaleCanvas( {
 	iframeDocument,
 	contentHeight,
 	containerWidth,
-	windowInnerWidth,
 	isZoomedOut,
 	scaleContainerWidth,
 } ) {
@@ -263,7 +261,6 @@ export function useScaleCanvas( {
 		iframeDocument,
 		contentHeight,
 		containerWidth,
-		windowInnerWidth,
 		isZoomedOut,
 		scaleContainerWidth,
 	] );

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -11,7 +11,7 @@ import { useReducedMotion } from '@wordpress/compose';
  * @param {Object}   root0
  * @param {number}   root0.contentHeight           The height of the content in the iframe.
  * @param {number}   root0.containerWidth          The width of the container.
- * @param {number}   root0.frameSizeValue          The size of the frame around the content.
+ * @param {number}   root0.frameSize               The size of the frame around the content.
  * @param {Document} root0.iframeDocument          The document of the iframe.
  * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
  * @param {number}   root0.windowInnerWidth        The height of the inner window
@@ -21,7 +21,7 @@ import { useReducedMotion } from '@wordpress/compose';
  */
 export function useScaleCanvas( {
 	scale,
-	frameSizeValue,
+	frameSize,
 	iframeDocument,
 	iframeWindowInnerHeight,
 	contentHeight,
@@ -33,7 +33,7 @@ export function useScaleCanvas( {
 	const prefersReducedMotion = useReducedMotion();
 
 	const prevScaleRef = useRef( scale );
-	const prevFrameSizeRef = useRef( frameSizeValue );
+	const prevFrameSizeRef = useRef( frameSize );
 	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 
 	useEffect( () => {
@@ -85,7 +85,7 @@ export function useScaleCanvas( {
 		// visible area.
 		scrollTopNext =
 			( scrollTopNext + clientHeight / 2 ) * scale +
-			frameSizeValue -
+			frameSize -
 			clientHeight / 2;
 
 		// Step 3: Handle an edge case so that you scroll to the top of the
@@ -98,9 +98,7 @@ export function useScaleCanvas( {
 		// iframe. We can't just let the browser handle it because we need to
 		// animate the scaling.
 		const maxScrollTop =
-			scrollHeight * ( scale / prevScale ) +
-			frameSizeValue * 2 -
-			clientHeight;
+			scrollHeight * ( scale / prevScale ) + frameSize * 2 - clientHeight;
 
 		// Step 4: Clamp the scrollTopNext between the minimum and maximum
 		// possible scrollTop positions. Round the value to avoid subpixel
@@ -132,7 +130,7 @@ export function useScaleCanvas( {
 
 			// Update previous values.
 			prevClientHeightRef.current = clientHeight;
-			prevFrameSizeRef.current = frameSizeValue;
+			prevFrameSizeRef.current = frameSize;
 			prevScaleRef.current = scale;
 
 			// Set the final scroll position that was just animated to.
@@ -172,7 +170,7 @@ export function useScaleCanvas( {
 				);
 			}
 		};
-	}, [ iframeDocument, scale, frameSizeValue, prefersReducedMotion ] );
+	}, [ iframeDocument, scale, frameSize, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
@@ -219,7 +217,7 @@ export function useScaleCanvas( {
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-frame-size',
-			`${ frameSizeValue }px`
+			`${ frameSize }px`
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-content-height',
@@ -262,7 +260,7 @@ export function useScaleCanvas( {
 		};
 	}, [
 		scale,
-		frameSizeValue,
+		frameSize,
 		iframeDocument,
 		iframeWindowInnerHeight,
 		contentHeight,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -9,21 +9,19 @@ import { useReducedMotion } from '@wordpress/compose';
  * the states.
  *
  * @param {Object}   root0
- * @param {number}   root0.contentHeight           The height of the content in the iframe.
- * @param {number}   root0.containerWidth          The width of the container.
- * @param {number}   root0.frameSize               The size of the frame around the content.
- * @param {Document} root0.iframeDocument          The document of the iframe.
- * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
- * @param {number}   root0.windowInnerWidth        The height of the inner window
- * @param {boolean}  root0.isZoomedOut             Whether the canvas is in zoom out mode.
- * @param {number}   root0.scale                   The scale of the canvas.
- * @param {number}   root0.scaleContainerWidth     The width of the container at the scaled size.
+ * @param {number}   root0.contentHeight       The height of the content in the iframe.
+ * @param {number}   root0.containerWidth      The width of the container.
+ * @param {number}   root0.frameSize           The size of the frame around the content.
+ * @param {Document} root0.iframeDocument      The document of the iframe.
+ * @param {number}   root0.windowInnerWidth    The height of the inner window
+ * @param {boolean}  root0.isZoomedOut         Whether the canvas is in zoom out mode.
+ * @param {number}   root0.scale               The scale of the canvas.
+ * @param {number}   root0.scaleContainerWidth The width of the container at the scaled size.
  */
 export function useScaleCanvas( {
 	scale,
 	frameSize,
 	iframeDocument,
-	iframeWindowInnerHeight,
 	contentHeight,
 	containerWidth,
 	windowInnerWidth,
@@ -225,8 +223,9 @@ export function useScaleCanvas( {
 		);
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ iframeWindowInnerHeight }px`
+			`${ iframeDocument.documentElement.clientHeight }px`
 		);
+
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-container-width',
 			`${ containerWidth }px`
@@ -262,7 +261,6 @@ export function useScaleCanvas( {
 		scale,
 		frameSize,
 		iframeDocument,
-		iframeWindowInnerHeight,
 		contentHeight,
 		containerWidth,
 		windowInnerWidth,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -261,7 +261,6 @@ export function useScaleCanvas( {
 		iframeDocument,
 		contentHeight,
 		containerWidth,
-		isZoomedOut,
 		scaleContainerWidth,
 	] );
 }

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -16,11 +16,11 @@ import { useReducedMotion } from '@wordpress/compose';
  * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
  * @param {number}   root0.windowInnerWidth        The height of the inner window
  * @param {boolean}  root0.isZoomedOut             Whether the canvas is in zoom out mode.
- * @param {number}   root0.scaleValue              The scale of the canvas.
+ * @param {number}   root0.scale                   The scale of the canvas.
  * @param {number}   root0.scaleContainerWidth     The width of the container at the scaled size.
  */
 export function useScaleCanvas( {
-	scaleValue,
+	scale,
 	frameSizeValue,
 	iframeDocument,
 	iframeWindowInnerHeight,
@@ -32,7 +32,7 @@ export function useScaleCanvas( {
 } ) {
 	const prefersReducedMotion = useReducedMotion();
 
-	const prevScaleRef = useRef( scaleValue );
+	const prevScaleRef = useRef( scale );
 	const prevFrameSizeRef = useRef( frameSizeValue );
 	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 
@@ -41,7 +41,7 @@ export function useScaleCanvas( {
 			! iframeDocument ||
 			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
 			// instead of the dependency array to appease the linter.
-			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
+			( scale === 1 ) === ( prevScaleRef.current === 1 )
 		) {
 			return;
 		}
@@ -84,7 +84,7 @@ export function useScaleCanvas( {
 		// Step 2: Apply the new scale and frame around the midpoint of the
 		// visible area.
 		scrollTopNext =
-			( scrollTopNext + clientHeight / 2 ) * scaleValue +
+			( scrollTopNext + clientHeight / 2 ) * scale +
 			frameSizeValue -
 			clientHeight / 2;
 
@@ -98,7 +98,7 @@ export function useScaleCanvas( {
 		// iframe. We can't just let the browser handle it because we need to
 		// animate the scaling.
 		const maxScrollTop =
-			scrollHeight * ( scaleValue / prevScale ) +
+			scrollHeight * ( scale / prevScale ) +
 			frameSizeValue * 2 -
 			clientHeight;
 
@@ -133,7 +133,7 @@ export function useScaleCanvas( {
 			// Update previous values.
 			prevClientHeightRef.current = clientHeight;
 			prevFrameSizeRef.current = frameSizeValue;
-			prevScaleRef.current = scaleValue;
+			prevScaleRef.current = scale;
 
 			// Set the final scroll position that was just animated to.
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
@@ -172,7 +172,7 @@ export function useScaleCanvas( {
 				);
 			}
 		};
-	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
+	}, [ iframeDocument, scale, frameSizeValue, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
@@ -213,7 +213,7 @@ export function useScaleCanvas( {
 		// but calc( 100px / 2px ) is not.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scaleValue
+			scale
 		);
 
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
@@ -261,7 +261,7 @@ export function useScaleCanvas( {
 			// );
 		};
 	}, [
-		scaleValue,
+		scale,
 		frameSizeValue,
 		iframeDocument,
 		iframeWindowInnerHeight,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -1,0 +1,274 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef } from '@wordpress/element';
+import { useReducedMotion } from '@wordpress/compose';
+
+/**
+ * Handles scaling the canvas for the zoom out mode and animating between
+ * the states.
+ *
+ * @param {Object}   root0
+ * @param {number}   root0.contentHeight           The height of the content in the iframe.
+ * @param {number}   root0.containerWidth          The width of the container.
+ * @param {number}   root0.frameSizeValue          The size of the frame around the content.
+ * @param {Document} root0.iframeDocument          The document of the iframe.
+ * @param {number}   root0.iframeWindowInnerHeight The height of the inner window
+ * @param {number}   root0.windowInnerWidth        The height of the inner window
+ * @param {boolean}  root0.isZoomedOut             Whether the canvas is in zoom out mode.
+ * @param {number}   root0.scaleValue              The scale of the canvas.
+ * @param {number}   root0.scaleContainerWidth     The width of the container at the scaled size.
+ */
+export function useScaleCanvas( {
+	scaleValue,
+	frameSizeValue,
+	iframeDocument,
+	iframeWindowInnerHeight,
+	contentHeight,
+	containerWidth,
+	windowInnerWidth,
+	isZoomedOut,
+	scaleContainerWidth,
+} ) {
+	const prefersReducedMotion = useReducedMotion();
+
+	const prevScaleRef = useRef( scaleValue );
+	const prevFrameSizeRef = useRef( frameSizeValue );
+	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
+
+	useEffect( () => {
+		if (
+			! iframeDocument ||
+			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
+			// instead of the dependency array to appease the linter.
+			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
+		) {
+			return;
+		}
+
+		// Unscaled height of the current iframe container.
+		const clientHeight = iframeDocument.documentElement.clientHeight;
+
+		// Scaled height of the current iframe content.
+		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		// Previous scale value.
+		const prevScale = prevScaleRef.current;
+
+		// Unscaled size of the previous padding around the iframe content.
+		const prevFrameSize = prevFrameSizeRef.current;
+
+		// Unscaled height of the previous iframe container.
+		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
+
+		// We can't trust the set value from contentHeight, as it was measured
+		// before the zoom out mode was changed. After zoom out mode is changed,
+		// appenders may appear or disappear, so we need to get the height from
+		// the iframe at this point when we're about to animate the zoom out.
+		// The iframe scrollTop, scrollHeight, and clientHeight will all be
+		// accurate. The client height also does change when the zoom out mode
+		// is toggled, as the bottom bar about selecting the template is
+		// added/removed when toggling zoom out mode.
+		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// Step 0: Start with the current scrollTop.
+		let scrollTopNext = scrollTop;
+
+		// Step 1: Undo the effects of the previous scale and frame around the
+		// midpoint of the visible area.
+		scrollTopNext =
+			( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) /
+				prevScale -
+			prevClientHeight / 2;
+
+		// Step 2: Apply the new scale and frame around the midpoint of the
+		// visible area.
+		scrollTopNext =
+			( scrollTopNext + clientHeight / 2 ) * scaleValue +
+			frameSizeValue -
+			clientHeight / 2;
+
+		// Step 3: Handle an edge case so that you scroll to the top of the
+		// iframe if the top of the iframe content is visible in the container.
+		// The same edge case for the bottom is skipped because changing content
+		// makes calculating it impossible.
+		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
+
+		// This is the scrollTop value if you are scrolled to the bottom of the
+		// iframe. We can't just let the browser handle it because we need to
+		// animate the scaling.
+		const maxScrollTop =
+			scrollHeight * ( scaleValue / prevScale ) +
+			frameSizeValue * 2 -
+			clientHeight;
+
+		// Step 4: Clamp the scrollTopNext between the minimum and maximum
+		// possible scrollTop positions. Round the value to avoid subpixel
+		// truncation by the browser which sometimes causes a 1px error.
+		scrollTopNext = Math.round(
+			Math.min(
+				Math.max( 0, scrollTopNext ),
+				Math.max( 0, maxScrollTop )
+			)
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top',
+			`${ scrollTop }px`
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+			`${ scrollTopNext }px`
+		);
+
+		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
+
+		function onZoomOutTransitionEnd() {
+			// Remove the position fixed for the animation.
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+
+			// Update previous values.
+			prevClientHeightRef.current = clientHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			// Set the final scroll position that was just animated to.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}
+
+		let raf;
+		if ( prefersReducedMotion ) {
+			// Hack: Wait for the window values to recalculate.
+			raf = iframeDocument.defaultView.requestAnimationFrame(
+				onZoomOutTransitionEnd
+			);
+		} else {
+			iframeDocument.documentElement.addEventListener(
+				'transitionend',
+				onZoomOutTransitionEnd,
+				{ once: true }
+			);
+		}
+
+		return () => {
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top'
+			);
+			iframeDocument.documentElement.style.removeProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next'
+			);
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+			if ( prefersReducedMotion ) {
+				iframeDocument.defaultView.cancelAnimationFrame( raf );
+			} else {
+				iframeDocument.documentElement.removeEventListener(
+					'transitionend',
+					onZoomOutTransitionEnd
+				);
+			}
+		};
+	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
+
+	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
+	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
+	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
+	// number of dependencies.
+	useEffect( () => {
+		if ( ! iframeDocument ) {
+			return;
+		}
+
+		if ( isZoomedOut ) {
+			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		} else {
+			// HACK: Since we can't remove this in the cleanup, we need to do it here.
+			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
+		}
+
+		return () => {
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
+			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
+		};
+	}, [ iframeDocument, isZoomedOut ] );
+
+	// Calculate the scaling and CSS variables for the zoom out canvas
+	useEffect( () => {
+		if ( ! iframeDocument ) {
+			return;
+		}
+
+		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
+		// initialContainerWidth will be smaller than the full page, and reflow will happen
+		// when the canvas area becomes larger due to sidebars closing. This is a known but
+		// minor divergence for now.
+
+		// This scaling calculation has to happen within the JS because CSS calc() can
+		// only divide and multiply by a unitless value. I.e. calc( 100px / 2 ) is valid
+		// but calc( 100px / 2px ) is not.
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scale',
+			scaleValue
+		);
+
+		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-frame-size',
+			`${ frameSizeValue }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-content-height',
+			`${ contentHeight }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-inner-height',
+			`${ iframeWindowInnerHeight }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-container-width',
+			`${ containerWidth }px`
+		);
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scale-container-width',
+			`${ scaleContainerWidth }px`
+		);
+
+		return () => {
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-content-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-container-width'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
+			// );
+		};
+	}, [
+		scaleValue,
+		frameSizeValue,
+		iframeDocument,
+		iframeWindowInnerHeight,
+		contentHeight,
+		containerWidth,
+		windowInnerWidth,
+		isZoomedOut,
+		scaleContainerWidth,
+	] );
+}

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -3,6 +3,63 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+const EDITOR_ZOOM_OUT_CONTENT = `
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-2-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>First Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>First Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>First Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>Second Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>Second Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-2-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>Third Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>Third Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Third Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>Fourth Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>Fourth Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Fourth Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`;
+
 test.describe( 'Zoom Out', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyfour' );
@@ -46,5 +103,116 @@ test.describe( 'Zoom Out', () => {
 		} );
 		expect( htmlRect.y + paddingTop ).toBeGreaterThan( iframeRect.y );
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
+	} );
+
+	test( 'Toggling zoom state should keep content centered', async ( {
+		page,
+		editor,
+	} ) => {
+		// Add some patterns into the page.
+		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT );
+		// Find the scroll container element
+		await page.evaluate( () => {
+			const { activeElement } =
+				document.activeElement?.contentDocument ?? document;
+			window.scrollContainer =
+				window.wp.dom.getScrollContainer( activeElement );
+			return window.scrollContainer;
+		} );
+
+		// Test: Test from top of page (scrollTop 0)
+		// Enter Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+
+		const scrollTopZoomed = await page.evaluate( () => {
+			return window.scrollContainer.scrollTop;
+		} );
+
+		expect( scrollTopZoomed ).toBe( 0 );
+
+		// Exit Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+
+		const scrollTopNoZoom = await page.evaluate( () => {
+			return window.scrollContainer.scrollTop;
+		} );
+
+		expect( scrollTopNoZoom ).toBe( 0 );
+
+		// Test: Should center the scroll position when zooming out/in
+		const firstSectionEnd = editor.canvas.locator(
+			'text=First Section End'
+		);
+		const secondSectionStart = editor.canvas.locator(
+			'text=Second Section Start'
+		);
+		const secondSectionCenter = editor.canvas.locator(
+			'text=Second Section Center'
+		);
+		const secondSectionEnd = editor.canvas.locator(
+			'text=Second Section End'
+		);
+		const thirdSectionStart = editor.canvas.locator(
+			'text=Third Section Start'
+		);
+		const thirdSectionCenter = editor.canvas.locator(
+			'text=Third Section Center'
+		);
+		const thirdSectionEnd = editor.canvas.locator(
+			'text=Third Section End'
+		);
+		const fourthSectionStart = editor.canvas.locator(
+			'text=Fourth Section Start'
+		);
+
+		// Test for second section
+		// Playwright scrolls it to the center of the viewport, so this is what we scroll to.
+		await secondSectionCenter.scrollIntoViewIfNeeded();
+
+		// Because the text is spread with a group height of 100vh, they should both be visible.
+		await expect( firstSectionEnd ).not.toBeInViewport();
+		await expect( secondSectionStart ).toBeInViewport();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).not.toBeInViewport();
+
+		// After zooming, if we zoomed out with the correct central point, they should both still be visible when toggling zoom out state
+		// Enter Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( firstSectionEnd ).toBeInViewport();
+		await expect( secondSectionStart ).toBeInViewport();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+
+		// Exit Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( firstSectionEnd ).not.toBeInViewport();
+		await expect( secondSectionStart ).toBeInViewport();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).not.toBeInViewport();
+
+		// Test for third section
+		// Playwright scrolls it to the center of the viewport, so this is what we scroll to.
+		await thirdSectionCenter.scrollIntoViewIfNeeded();
+
+		// Because the text is spread with a group height of 100vh, they should both be visible.
+		await expect( secondSectionEnd ).not.toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+		await expect( thirdSectionEnd ).toBeInViewport();
+		await expect( fourthSectionStart ).not.toBeInViewport();
+
+		// After zooming, if we zoomed out with the correct central point, they should both still be visible when toggling zoom out state
+		// Enter Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+		await expect( thirdSectionEnd ).toBeInViewport();
+		await expect( fourthSectionStart ).toBeInViewport();
+
+		// Exit Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( secondSectionEnd ).not.toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+		await expect( thirdSectionEnd ).toBeInViewport();
+		await expect( fourthSectionStart ).not.toBeInViewport();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Implements work from 6.7 https://github.com/WordPress/gutenberg/pull/66618 as a `useScaleCanvas` hook.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
