### PR TITLE
RSS block: check for description field before rendering excerpt

### DIFF
--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -69,9 +69,10 @@ function render_block_core_rss( $attributes ) {
 			}
 		}
 
-		$excerpt = '';
-		if ( $attributes['displayExcerpt'] ) {
-			$excerpt = html_entity_decode( $item->get_description(), ENT_QUOTES, get_option( 'blog_charset' ) );
+		$excerpt     = '';
+		$description = $item->get_description();
+		if ( $attributes['displayExcerpt'] && ! empty( $description ) ) {
+			$excerpt = html_entity_decode( $description, ENT_QUOTES, get_option( 'blog_charset' ) );
 			$excerpt = esc_attr( wp_trim_words( $excerpt, $attributes['excerptLength'], ' [&hellip;]' ) );
 
 			// Change existing [...] to [&hellip;].

--- a/packages/block-library/src/rss/index.php
+++ b/packages/block-library/src/rss/index.php
@@ -61,11 +61,13 @@ function render_block_core_rss( $attributes ) {
 			$author = $item->get_author();
 			if ( is_object( $author ) ) {
 				$author = $author->get_name();
-				$author = '<span class="wp-block-rss__item-author">' . sprintf(
-					/* translators: byline. %s: author. */
-					__( 'by %s' ),
-					esc_html( strip_tags( $author ) )
-				) . '</span>';
+				if ( ! empty( $author ) ) {
+					$author = '<span class="wp-block-rss__item-author">' . sprintf(
+						/* translators: byline. %s: author. */
+						__( 'by %s' ),
+						esc_html( strip_tags( $author ) )
+					) . '</span>';
+				}
 			}
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? and How?
In the RSS block render code, check for author and description (excerpt) before passing to `strip_tags` and `html_entity_decode`.

## Why?

Some RSS feeds don't have description or author fields. 

And PHP complains:

```
Deprecated: html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated 
```

```
Deprecated: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated
```

Noticed while testing https://github.com/WordPress/gutenberg/pull/66419

## Testing Instructions

1. Insert an RSS block
2. Insert an RSS feed that doesn't have description fields, e.g., http://rss.news.yahoo.com/rss/world
3. Enable "Display excerpt" and "Display author" in the block's settings.
4. Save and check that PHP deprecation warning doesn't appear in the editor or frontend.
5. Insert an RSS feed that doesn't have author fields: https://feeds.simplecast.com/qm_9xx0g
6. Save and check that PHP deprecation warning doesn't appear in the editor or frontend.