### PR TITLE
Toolbar: Update Zoom Out toggle label to reflect current zoom state

### DIFF
--- a/packages/editor/src/components/zoom-out-toggle/index.js
+++ b/packages/editor/src/components/zoom-out-toggle/index.js
@@ -74,7 +74,7 @@ const ZoomOutToggle = ( { disabled } ) => {
 			disabled={ disabled }
 			onClick={ handleZoomOut }
 			icon={ zoomOutIcon }
-			label={ __( 'Zoom Out' ) }
+			label={ isZoomOut ? __( 'Zoom In' ) : __( 'Zoom Out' ) }
 			isPressed={ isZoomOut }
 			size="compact"
 			showTooltip={ ! showIconLabels }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: #66987 

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR updates the Toggle Label of Zoom Out to adjust based on whether the content has already been zoomed out.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR helps manage the Toggle Label appropriately thereby enhancing accessibility and user experience while using the block editor by providing a clear message about the zoom status to the user.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The existing isZoomOut state is used to keep a track of the zoom status and the label is easily adjusted based on its value to satisfy the needs and eliminate the bug.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Open a post in the block editor.
2. Hover over the zoom-out button and observe the tooltip.
3. Now, press the button and again hover over the button to observe the tooltip. The tooltip must now be changed to Zoom In instead of a misleading Zoom Out.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/153ee294-3126-4368-b9c0-604af90156ce

