### PR TITLE
Fix: Enhance image edit responsiveness by including height in container

### DIFF
--- a/packages/block-library/src/image/edit.js
+++ b/packages/block-library/src/image/edit.js
@@ -121,10 +121,14 @@ export function ImageEdit( {
 		( parentLayout.type !== 'flex' && parentLayout.type !== 'grid' );
 	const [ maxWidthObserver, maxContentWidth ] = useMaxWidthObserver();
 
-	const [ placeholderResizeListener, { width: placeholderWidth } ] =
-		useResizeObserver();
+	const [
+		placeholderResizeListener,
+		{ width: placeholderWidth, height: placeholderHeight },
+	] = useResizeObserver();
 
-	const isSmallContainer = placeholderWidth && placeholderWidth < 160;
+	const isSmallContainer =
+		( placeholderWidth && placeholderWidth < 160 ) ||
+		( placeholderHeight && placeholderHeight < 230 );
 
 	const altRef = useRef();
 	useEffect( () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: #66983 

## What?
<!-- In a few words, what is the PR actually doing? -->
When the height value for the image placeholder is below a certain threshold, the image block still renders the options such as Upload, Media Library, and Insert from the URL. It turns out that there's a check in place to verify if the block has a certain minimum width, 160 in our case, but a similar check for height is missing which leads to an overflow of content when the height becomes less than a certain threshold and that causes the bug mentioned in the issue description.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR is necessary to eliminate the bug where the internal image controls like Upload, Media Library, and Insert from URL overflow out of the primary container. 

This PR will also bring consistency with the inclusion of height to determine whether or not the placeholder is small to further determine whether or not to render the placeholder or just allow uploading images from the toolbar of the block.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR also considers height to determine the isSmallContainer property to fix the issue.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Navigate to edit a post.
2. Create a row and add certain image blocks to it. 
3. Check if the image buttons are now overflowing out of the container.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4fde29a7-7ada-4189-a946-b2a443ef0bf4


