### PR TITLE
DataViews: Fix primary field misalignment in grid layout

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -114,11 +114,9 @@ function GridItem< Item >( {
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
 			>
-				<HStack>
-					<div { ...clickablePrimaryItemProps }>
-						{ renderedPrimaryField }
-					</div>
-				</HStack>
+				<div { ...clickablePrimaryItemProps }>
+					{ renderedPrimaryField }
+				</div>
 				<ItemActions item={ item } actions={ actions } isCompact />
 			</HStack>
 			{ !! badgeFields?.length && (

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -17,6 +17,8 @@
 
 		.dataviews-view-grid__primary-field {
 			min-height: $grid-unit-40; // Preserve layout when there is no ellipsis button
+			display: flex;
+			align-items: center;
 
 			&--clickable {
 				width: fit-content;


### PR DESCRIPTION
Related to #66365

## What?

This PR fixes the alignment of the primary field in the grid layout.

## Why?

Because of [this change](https://github.com/WordPress/gutenberg/pull/66365/files#diff-09c5cd7b60da5d3a54fac3dfae6c6ca830f2086502edf85cfc02050f896f52e2L99-R120), the primary field no longer has flex layout.

## How?

Removed the unnecessary `HStack` wrapper and applied flex layout to the primary field.

<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions


## Screenshots or screencast <!-- if applicable -->

### Patterns

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c61f9cfa-b17c-4727-beb6-a7732a8f8ce8) | ![image](https://github.com/user-attachments/assets/33b5f9d7-4254-4afc-b382-63081ab3a5d6) |
| ![image](https://github.com/user-attachments/assets/7c29b81e-8cdd-467f-8624-a01fc7a46388) | ![image](https://github.com/user-attachments/assets/ee1607f1-c82b-47b0-9770-3c72f488fbc4) |


### Templates 

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/f77ffda0-a128-4bbc-83a6-3e8d9c8a8959) | ![image](https://github.com/user-attachments/assets/7ef04074-76cb-4242-820e-18c831a1c752) |
| ![image](https://github.com/user-attachments/assets/5643d4ed-9690-4b51-87fd-6d8af9e24583) | ![image](https://github.com/user-attachments/assets/f0511071-b67d-4a51-985e-11885f98de66) |

