### PR TITLE
Storybook: fix DataViews layout

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -65,6 +65,7 @@ export const Default = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
 		fields: [ 'title', 'description', 'categories' ],
+		layout: defaultLayouts[ DEFAULT_VIEW.type ].layout,
 	} );
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );


### PR DESCRIPTION
## What?

The `layout` prop for the story didn't have the data defined in default layouts.

## Why?

The styles defined in `layout.styles` wouldn't work.

## Testing Instructions

`npm install && npm run storybook:dev`

Change the styles provided via `defaultLayouts.table.layout.styles.description` and verify that they are applied (`max-width`, etc. are inline styles of the table cell).