### PR TITLE
SlotFill: fix a bug with storing stale fillProps

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 -   `Popover`: Fix missing label of the headerTitle Close button ([#66813](https://github.com/WordPress/gutenberg/pull/66813)).
 -   `ToggleGroupControl`: Fix active background for `0` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
+-   `SlotFill`: Fix a bug where a stale value of `fillProps` could be used ([#67000](https://github.com/WordPress/gutenberg/pull/67000)).
 
 ### Enhancements
 

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
@@ -34,11 +34,18 @@ function createSlotRegistry(): SlotFillBubblesVirtuallyContext {
 
 	const unregisterSlot: SlotFillBubblesVirtuallyContext[ 'unregisterSlot' ] =
 		( name, ref ) => {
+			const slot = slots.get( name );
+			if ( ! slot ) {
+				return;
+			}
+
 			// Make sure we're not unregistering a slot registered by another element
 			// See https://github.com/WordPress/gutenberg/pull/19242#issuecomment-590295412
-			if ( slots.get( name )?.ref === ref ) {
-				slots.delete( name );
+			if ( slot.ref !== ref ) {
+				return;
 			}
+
+			slots.delete( name );
 		};
 
 	const updateSlot: SlotFillBubblesVirtuallyContext[ 'updateSlot' ] = (
@@ -74,20 +81,18 @@ function createSlotRegistry(): SlotFillBubblesVirtuallyContext {
 		fills.set( name, [ ...( fills.get( name ) || [] ), ref ] );
 	};
 
-	const unregisterFill: SlotFillBubblesVirtuallyContext[ 'registerFill' ] = (
-		name,
-		ref
-	) => {
-		const fillsForName = fills.get( name );
-		if ( ! fillsForName ) {
-			return;
-		}
+	const unregisterFill: SlotFillBubblesVirtuallyContext[ 'unregisterFill' ] =
+		( name, ref ) => {
+			const fillsForName = fills.get( name );
+			if ( ! fillsForName ) {
+				return;
+			}
 
-		fills.set(
-			name,
-			fillsForName.filter( ( fillRef ) => fillRef !== ref )
-		);
-	};
+			fills.set(
+				name,
+				fillsForName.filter( ( fillRef ) => fillRef !== ref )
+			);
+		};
 
 	return {
 		slots,

--- a/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot-fill-provider.tsx
@@ -43,10 +43,15 @@ function createSlotRegistry(): SlotFillBubblesVirtuallyContext {
 
 	const updateSlot: SlotFillBubblesVirtuallyContext[ 'updateSlot' ] = (
 		name,
+		ref,
 		fillProps
 	) => {
 		const slot = slots.get( name );
 		if ( ! slot ) {
+			return;
+		}
+
+		if ( slot.ref !== ref ) {
 			return;
 		}
 

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.tsx
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.tsx
@@ -57,7 +57,7 @@ function Slot(
 	// fillProps may be an update that interacts with the layout, so we
 	// useLayoutEffect.
 	useLayoutEffect( () => {
-		registry.updateSlot( name, fillProps );
+		registry.updateSlot( name, ref, fillProps );
 	} );
 
 	return (

--- a/packages/components/src/slot-fill/bubbles-virtually/slot.tsx
+++ b/packages/components/src/slot-fill/bubbles-virtually/slot.tsx
@@ -35,29 +35,33 @@ function Slot(
 		as,
 		// `children` is not allowed. However, if it is passed,
 		// it will be displayed as is, so remove `children`.
-		// @ts-ignore
 		children,
 		...restProps
 	} = props;
 
 	const { registerSlot, unregisterSlot, ...registry } =
 		useContext( SlotFillContext );
+
 	const ref = useRef< HTMLElement >( null );
 
+	// We don't want to unregister and register the slot whenever
+	// `fillProps` change, which would cause the fill to be re-mounted. Instead,
+	// we can just update the slot (see hook below).
+	// For more context, see https://github.com/WordPress/gutenberg/pull/44403#discussion_r994415973
+	const fillPropsRef = useRef( fillProps );
 	useLayoutEffect( () => {
-		registerSlot( name, ref, fillProps );
+		fillPropsRef.current = fillProps;
+	}, [ fillProps ] );
+
+	useLayoutEffect( () => {
+		registerSlot( name, ref, fillPropsRef.current );
 		return () => {
 			unregisterSlot( name, ref );
 		};
-		// We don't want to unregister and register the slot whenever
-		// `fillProps` change, which would cause the fill to be re-mounted. Instead,
-		// we can just update the slot (see hook below).
-		// For more context, see https://github.com/WordPress/gutenberg/pull/44403#discussion_r994415973
 	}, [ registerSlot, unregisterSlot, name ] );
-	// fillProps may be an update that interacts with the layout, so we
-	// useLayoutEffect.
+
 	useLayoutEffect( () => {
-		registry.updateSlot( name, ref, fillProps );
+		registry.updateSlot( name, ref, fillPropsRef.current );
 	} );
 
 	return (

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot.ts
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot.ts
@@ -21,8 +21,10 @@ export default function useSlot( name: SlotKey ) {
 
 	const api = useMemo(
 		() => ( {
-			updateSlot: ( fillProps: FillProps ) =>
-				registry.updateSlot( name, fillProps ),
+			updateSlot: (
+				ref: SlotFillBubblesVirtuallySlotRef,
+				fillProps: FillProps
+			) => registry.updateSlot( name, ref, fillProps ),
 			unregisterSlot: ( ref: SlotFillBubblesVirtuallySlotRef ) =>
 				registry.unregisterSlot( name, ref ),
 			registerFill: ( ref: SlotFillBubblesVirtuallyFillRef ) =>

--- a/packages/components/src/slot-fill/types.ts
+++ b/packages/components/src/slot-fill/types.ts
@@ -131,7 +131,11 @@ export type SlotFillBubblesVirtuallyContext = {
 		name: SlotKey,
 		ref: SlotFillBubblesVirtuallySlotRef
 	) => void;
-	updateSlot: ( name: SlotKey, fillProps: FillProps ) => void;
+	updateSlot: (
+		name: SlotKey,
+		ref: SlotFillBubblesVirtuallySlotRef,
+		fillProps: FillProps
+	) => void;
 	registerFill: (
 		name: SlotKey,
 		ref: SlotFillBubblesVirtuallyFillRef


### PR DESCRIPTION
Fixes a `SlotFill` bug where a slot is sometimes rendered with old stale `fillProps`. It's described and discussed here: https://github.com/WordPress/gutenberg/pull/65907#issuecomment-2461140952. In short, the `updateSlot` method needs to check a `ref` value to determine if it's still the current registered slot. When an old slot is unregistered and new slot is registered, there is a short period of time where both are semi-registered and special care is needed.

~~That's the first commit in this PR. In addition, I'm doing a series of refactorings of `SlotFill` in order to put it in a better shape:~~
