### PR TITLE
Site Editor: Styles: preview template to put focus on styles

### DIFF
--- a/packages/block-editor/src/components/block-edit/index.js
+++ b/packages/block-editor/src/components/block-edit/index.js
@@ -88,7 +88,12 @@ export default function BlockEdit( {
 				]
 			) }
 		>
-			<Edit { ...props } />
+			<Edit
+				{ ...{
+					...props,
+					isSelected: isPreviewMode ? false : isSelected,
+				} }
+			/>
 			{ originalBlockClientId && (
 				<MultipleUsageWarning
 					originalBlockClientId={ originalBlockClientId }

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -611,6 +611,7 @@ function BlockListBlockProvider( props ) {
 			const blockType = getBlockType( blockName );
 			const { supportsLayout, isPreviewMode } = getSettings();
 			const hasLightBlockWrapper = blockType?.apiVersion > 1;
+			const _isSelected = isBlockSelected( clientId );
 			const previewContext = {
 				isPreviewMode,
 				blockWithoutAttributes,
@@ -627,6 +628,7 @@ function BlockListBlockProvider( props ) {
 					? getBlockDefaultClassName( blockName )
 					: undefined,
 				blockTitle: blockType?.title,
+				isSelected: _isSelected,
 			};
 
 			// When in preview mode, we can avoid a lot of selection and
@@ -635,7 +637,6 @@ function BlockListBlockProvider( props ) {
 				return previewContext;
 			}
 
-			const _isSelected = isBlockSelected( clientId );
 			const canRemove = canRemoveBlock( clientId );
 			const canMove = canMoveBlock( clientId );
 			const match = getActiveBlockVariation( blockName, attributes );
@@ -666,7 +667,6 @@ function BlockListBlockProvider( props ) {
 				isSectionBlock: _isSectionBlock( clientId ),
 				canRemove,
 				canMove,
-				isSelected: _isSelected,
 				isTemporarilyEditingAsBlocks:
 					getTemporarilyEditingAsBlocks() === clientId,
 				blockEditingMode,

--- a/packages/block-editor/src/components/block-list/use-in-between-inserter.js
+++ b/packages/block-editor/src/components/block-list/use-in-between-inserter.js
@@ -15,12 +15,14 @@ import { unlock } from '../../lock-unlock';
 
 export function useInBetweenInserter() {
 	const openRef = useContext( InsertionPointOpenRef );
-	const isInBetweenInserterDisabled = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().isDistractionFree ||
-			unlock( select( blockEditorStore ) ).isZoomOut(),
-		[]
-	);
+	const isInBetweenInserterDisabled = useSelect( ( select ) => {
+		const settings = select( blockEditorStore ).getSettings();
+		return (
+			settings.isDistractionFree ||
+			settings.isPreviewMode ||
+			unlock( select( blockEditorStore ) ).isZoomOut()
+		);
+	}, [] );
 	const {
 		getBlockListSettings,
 		getBlockIndex,

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -87,6 +87,19 @@ export default function BlockTools( {
 		expandBlock,
 	} = unlock( useDispatch( blockEditorStore ) );
 
+	const ref = useRef( false );
+	const blockToolbarRef = usePopoverScroll( __unstableContentRef );
+	const blockToolbarAfterRef = usePopoverScroll( __unstableContentRef );
+
+	const isPreviewMode = useSelect(
+		( select ) => select( blockEditorStore ).getSettings().isPreviewMode,
+		[]
+	);
+
+	if ( isPreviewMode ) {
+		return children;
+	}
+
 	function onKeyDown( event ) {
 		if ( event.defaultPrevented ) {
 			return;
@@ -193,13 +206,11 @@ export default function BlockTools( {
 			}
 		}
 	}
-	const blockToolbarRef = usePopoverScroll( __unstableContentRef );
-	const blockToolbarAfterRef = usePopoverScroll( __unstableContentRef );
 
 	return (
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div { ...props } onKeyDown={ onKeyDown }>
-			<InsertionPointOpenRef.Provider value={ useRef( false ) }>
+			<InsertionPointOpenRef.Provider value={ ref }>
 				{ ! isTyping && ! isZoomOutMode && (
 					<InsertionPoint
 						__unstableContentRef={ __unstableContentRef }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -546,6 +546,7 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 		} = removeNativeProps( props );
 		return (
 			<Tag
+				ref={ ref }
 				{ ...contentProps }
 				dangerouslySetInnerHTML={ {
 					__html: valueToHTMLString( value, multiline ),

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -86,7 +86,7 @@ const siteIconVariants = {
 export default function EditSiteEditor( { isPostsList = false } ) {
 	const disableMotion = useReducedMotion();
 	const { params } = useLocation();
-	const { canvas = 'view' } = params;
+	const { canvas = 'view', path } = params;
 	const isLoading = useIsSiteEditorLoading();
 	useAdaptEditorToCanvas( canvas );
 	const entity = useResolveEditedEntity();
@@ -209,6 +209,17 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 		duration: disableMotion ? 0 : 0.2,
 	};
 
+	const isGlobalStylesPreview = path === '/wp_global_styles';
+
+	const _settings = useMemo( () => {
+		return {
+			...settings,
+			defaultRenderingMode: isGlobalStylesPreview
+				? 'template-locked'
+				: settings.defaultRenderingMode,
+		};
+	}, [ settings, isGlobalStylesPreview ] );
+
 	return (
 		<>
 			<GlobalStylesRenderer
@@ -227,7 +238,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 					postType={ postWithTemplate ? context.postType : postType }
 					postId={ postWithTemplate ? context.postId : postId }
 					templateId={ postWithTemplate ? postId : undefined }
-					settings={ settings }
+					settings={ _settings }
 					className={ clsx( 'edit-site-editor__editor-interface', {
 						'show-icon-labels': showIconLabels,
 					} ) }
@@ -237,6 +248,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 					}
 					customSavePanel={ _isPreviewingTheme && <SavePanel /> }
 					forceDisableBlockTools={ ! hasDefaultEditorCanvasView }
+					forceRemoveBlockTools={ isGlobalStylesPreview }
 					title={ title }
 					iframeProps={ iframeProps }
 					onActionPerformed={ onActionPerformed }

--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -214,9 +214,9 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 	const _settings = useMemo( () => {
 		return {
 			...settings,
-			defaultRenderingMode: isGlobalStylesPreview
-				? 'template-locked'
-				: settings.defaultRenderingMode,
+			isPreviewMode: isGlobalStylesPreview
+				? true
+				: settings.isPreviewMode,
 		};
 	}, [ settings, isGlobalStylesPreview ] );
 
@@ -248,7 +248,7 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 					}
 					customSavePanel={ _isPreviewingTheme && <SavePanel /> }
 					forceDisableBlockTools={ ! hasDefaultEditorCanvasView }
-					forceRemoveBlockTools={ isGlobalStylesPreview }
+					showEditorFrame={ canvas === 'edit' }
 					title={ title }
 					iframeProps={ iframeProps }
 					onActionPerformed={ onActionPerformed }

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -24,7 +24,11 @@ import { store as editorStore } from '../../store';
 import EditorHistoryRedo from '../editor-history/redo';
 import EditorHistoryUndo from '../editor-history/undo';
 
-function DocumentTools( { className, disableBlockTools = false } ) {
+function DocumentTools( {
+	className,
+	disableBlockTools = false,
+	removeBlockTools = false,
+} ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
 	const {
@@ -116,7 +120,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 			variant="unstyled"
 		>
 			<div className="editor-document-tools__left">
-				{ ! isDistractionFree && (
+				{ ! isDistractionFree && ! removeBlockTools && (
 					<ToolbarItem
 						ref={ inserterSidebarToggleRef }
 						as={ Button }
@@ -134,17 +138,19 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 				) }
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
-						{ showTools && isLargeViewport && (
-							<ToolbarItem
-								as={ ToolSelector }
-								showTooltip={ ! showIconLabels }
-								variant={
-									showIconLabels ? 'tertiary' : undefined
-								}
-								disabled={ disableBlockTools }
-								size="compact"
-							/>
-						) }
+						{ showTools &&
+							isLargeViewport &&
+							! removeBlockTools && (
+								<ToolbarItem
+									as={ ToolSelector }
+									showTooltip={ ! showIconLabels }
+									variant={
+										showIconLabels ? 'tertiary' : undefined
+									}
+									disabled={ disableBlockTools }
+									size="compact"
+								/>
+							) }
 						<ToolbarItem
 							as={ EditorHistoryUndo }
 							showTooltip={ ! showIconLabels }
@@ -157,7 +163,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 							variant={ showIconLabels ? 'tertiary' : undefined }
 							size="compact"
 						/>
-						{ ! isDistractionFree && (
+						{ ! isDistractionFree && ! removeBlockTools && (
 							<ToolbarItem
 								as={ Button }
 								className="editor-document-tools__document-overview-toggle"

--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -27,7 +27,7 @@ import EditorHistoryUndo from '../editor-history/undo';
 function DocumentTools( {
 	className,
 	disableBlockTools = false,
-	removeBlockTools = false,
+	isPreviewMode,
 } ) {
 	const { setIsInserterOpened, setIsListViewOpened } =
 		useDispatch( editorStore );
@@ -120,7 +120,7 @@ function DocumentTools( {
 			variant="unstyled"
 		>
 			<div className="editor-document-tools__left">
-				{ ! isDistractionFree && ! removeBlockTools && (
+				{ ! isDistractionFree && ! isPreviewMode && (
 					<ToolbarItem
 						ref={ inserterSidebarToggleRef }
 						as={ Button }
@@ -138,19 +138,17 @@ function DocumentTools( {
 				) }
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<>
-						{ showTools &&
-							isLargeViewport &&
-							! removeBlockTools && (
-								<ToolbarItem
-									as={ ToolSelector }
-									showTooltip={ ! showIconLabels }
-									variant={
-										showIconLabels ? 'tertiary' : undefined
-									}
-									disabled={ disableBlockTools }
-									size="compact"
-								/>
-							) }
+						{ showTools && isLargeViewport && ! isPreviewMode && (
+							<ToolbarItem
+								as={ ToolSelector }
+								showTooltip={ ! showIconLabels }
+								variant={
+									showIconLabels ? 'tertiary' : undefined
+								}
+								disabled={ disableBlockTools }
+								size="compact"
+							/>
+						) }
 						<ToolbarItem
 							as={ EditorHistoryUndo }
 							showTooltip={ ! showIconLabels }
@@ -163,7 +161,7 @@ function DocumentTools( {
 							variant={ showIconLabels ? 'tertiary' : undefined }
 							size="compact"
 						/>
-						{ ! isDistractionFree && ! removeBlockTools && (
+						{ ! isDistractionFree && ! isPreviewMode && (
 							<ToolbarItem
 								as={ Button }
 								className="editor-document-tools__document-overview-toggle"

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -57,9 +57,9 @@ export default function EditorInterface( {
 	customSaveButton,
 	customSavePanel,
 	forceDisableBlockTools,
-	forceRemoveBlockTools,
 	title,
 	iframeProps,
+	showEditorFrame,
 } ) {
 	const {
 		mode,
@@ -111,6 +111,8 @@ export default function EditorInterface( {
 		[ entitiesSavedStatesCallback ]
 	);
 
+	const showFrame = ! isPreviewMode || showEditorFrame;
+
 	return (
 		<InterfaceSkeleton
 			isDistractionFree={ isDistractionFree }
@@ -123,7 +125,7 @@ export default function EditorInterface( {
 				secondarySidebar: secondarySidebarLabel,
 			} }
 			header={
-				! isPreviewMode && (
+				showFrame && (
 					<Header
 						forceIsDirty={ forceIsDirty }
 						setEntitiesSavedStatesCallback={
@@ -131,27 +133,25 @@ export default function EditorInterface( {
 						}
 						customSaveButton={ customSaveButton }
 						forceDisableBlockTools={ forceDisableBlockTools }
-						forceRemoveBlockTools={ forceRemoveBlockTools }
+						isPreviewMode={ isPreviewMode }
 						title={ title }
 					/>
 				)
 			}
 			editorNotices={ <EditorNotices /> }
 			secondarySidebar={
-				! isPreviewMode &&
+				showFrame &&
 				mode === 'visual' &&
 				( ( isInserterOpened && <InserterSidebar /> ) ||
 					( isListViewOpened && <ListViewSidebar /> ) )
 			}
 			sidebar={
-				! isPreviewMode &&
+				showFrame &&
 				! isDistractionFree && <ComplementaryArea.Slot scope="core" />
 			}
 			content={
 				<>
-					{ ! isDistractionFree && ! isPreviewMode && (
-						<EditorNotices />
-					) }
+					{ ! isDistractionFree && showFrame && <EditorNotices /> }
 
 					<EditorContentSlotFill.Slot>
 						{ ( [ editorCanvasView ] ) =>

--- a/packages/editor/src/components/editor-interface/index.js
+++ b/packages/editor/src/components/editor-interface/index.js
@@ -57,6 +57,7 @@ export default function EditorInterface( {
 	customSaveButton,
 	customSavePanel,
 	forceDisableBlockTools,
+	forceRemoveBlockTools,
 	title,
 	iframeProps,
 } ) {
@@ -130,6 +131,7 @@ export default function EditorInterface( {
 						}
 						customSaveButton={ customSaveButton }
 						forceDisableBlockTools={ forceDisableBlockTools }
+						forceRemoveBlockTools={ forceRemoveBlockTools }
 						title={ title }
 					/>
 				)

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -78,7 +78,6 @@ function Editor( {
 					<Sidebar
 						onActionPerformed={ onActionPerformed }
 						extraPanels={ extraSidebarPanels }
-						forceRemoveBlockTools={ props.forceRemoveBlockTools }
 					/>
 				</ExperimentalEditorProvider>
 			) }

--- a/packages/editor/src/components/editor/index.js
+++ b/packages/editor/src/components/editor/index.js
@@ -78,6 +78,7 @@ function Editor( {
 					<Sidebar
 						onActionPerformed={ onActionPerformed }
 						extraPanels={ extraSidebarPanels }
+						forceRemoveBlockTools={ props.forceRemoveBlockTools }
 					/>
 				</ExperimentalEditorProvider>
 			) }

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -51,9 +51,9 @@ function Header( {
 	customSaveButton,
 	forceIsDirty,
 	forceDisableBlockTools,
-	forceRemoveBlockTools,
 	setEntitiesSavedStatesCallback,
 	title,
+	isPreviewMode,
 } ) {
 	const isWideViewport = useViewportMatch( 'large' );
 	const isLargeViewport = useViewportMatch( 'medium' );
@@ -123,7 +123,7 @@ function Header( {
 			>
 				<DocumentTools
 					disableBlockTools={ forceDisableBlockTools || isTextEditor }
-					removeBlockTools={ forceRemoveBlockTools }
+					isPreviewMode={ isPreviewMode }
 				/>
 				{ hasFixedToolbar && isLargeViewport && (
 					<CollapsibleBlockToolbar

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -51,6 +51,7 @@ function Header( {
 	customSaveButton,
 	forceIsDirty,
 	forceDisableBlockTools,
+	forceRemoveBlockTools,
 	setEntitiesSavedStatesCallback,
 	title,
 } ) {
@@ -122,6 +123,7 @@ function Header( {
 			>
 				<DocumentTools
 					disableBlockTools={ forceDisableBlockTools || isTextEditor }
+					removeBlockTools={ forceRemoveBlockTools }
 				/>
 				{ hasFixedToolbar && isLargeViewport && (
 					<CollapsibleBlockToolbar

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -15,7 +15,7 @@ import { sidebars } from './constants';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-const SidebarHeader = ( { forceRemoveBlockTools }, ref ) => {
+const SidebarHeader = ( { isPreviewMode }, ref ) => {
 	const { documentLabel } = useSelect( ( select ) => {
 		const { getPostTypeLabel } = select( editorStore );
 
@@ -35,7 +35,7 @@ const SidebarHeader = ( { forceRemoveBlockTools }, ref ) => {
 			>
 				{ documentLabel }
 			</Tabs.Tab>
-			{ ! forceRemoveBlockTools && (
+			{ ! isPreviewMode && (
 				<Tabs.Tab
 					tabId={ sidebars.block }
 					// Used for focus management in the SettingsSidebar component.

--- a/packages/editor/src/components/sidebar/header.js
+++ b/packages/editor/src/components/sidebar/header.js
@@ -15,7 +15,7 @@ import { sidebars } from './constants';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
-const SidebarHeader = ( _, ref ) => {
+const SidebarHeader = ( { forceRemoveBlockTools }, ref ) => {
 	const { documentLabel } = useSelect( ( select ) => {
 		const { getPostTypeLabel } = select( editorStore );
 
@@ -35,14 +35,16 @@ const SidebarHeader = ( _, ref ) => {
 			>
 				{ documentLabel }
 			</Tabs.Tab>
-			<Tabs.Tab
-				tabId={ sidebars.block }
-				// Used for focus management in the SettingsSidebar component.
-				data-tab-id={ sidebars.block }
-			>
-				{ /* translators: Text label for the Block Settings Sidebar tab. */ }
-				{ __( 'Block' ) }
-			</Tabs.Tab>
+			{ ! forceRemoveBlockTools && (
+				<Tabs.Tab
+					tabId={ sidebars.block }
+					// Used for focus management in the SettingsSidebar component.
+					data-tab-id={ sidebars.block }
+				>
+					{ /* translators: Text label for the Block Settings Sidebar tab. */ }
+					{ __( 'Block' ) }
+				</Tabs.Tab>
+			) }
 		</Tabs.TabList>
 	);
 };

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -53,7 +53,7 @@ const SidebarContent = ( {
 	keyboardShortcut,
 	onActionPerformed,
 	extraPanels,
-	forceRemoveBlockTools,
+	isPreviewMode,
 } ) => {
 	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
@@ -95,7 +95,7 @@ const SidebarContent = ( {
 				<Tabs.Context.Provider value={ tabsContextValue }>
 					<SidebarHeader
 						ref={ tabListRef }
-						forceRemoveBlockTools={ forceRemoveBlockTools }
+						isPreviewMode={ isPreviewMode }
 					/>
 				</Tabs.Context.Provider>
 			}
@@ -124,7 +124,7 @@ const SidebarContent = ( {
 					<PatternOverridesPanel />
 					{ extraPanels }
 				</Tabs.TabPanel>
-				{ ! forceRemoveBlockTools && (
+				{ ! isPreviewMode && (
 					<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
 						<BlockInspector />
 					</Tabs.TabPanel>
@@ -134,13 +134,9 @@ const SidebarContent = ( {
 	);
 };
 
-const Sidebar = ( {
-	extraPanels,
-	onActionPerformed,
-	forceRemoveBlockTools,
-} ) => {
+const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 	useAutoSwitchEditorSidebars();
-	const { tabName, keyboardShortcut, showSummary } = useSelect(
+	const { tabName, keyboardShortcut, showSummary, isPreviewMode } = useSelect(
 		( select ) => {
 			const shortcut = select(
 				keyboardShortcutsStore
@@ -161,6 +157,8 @@ const Sidebar = ( {
 					: sidebars.document;
 			}
 
+			const { getEditorSettings, getCurrentPostType } =
+				select( editorStore );
 			return {
 				tabName: _tabName,
 				keyboardShortcut: shortcut,
@@ -168,7 +166,8 @@ const Sidebar = ( {
 					TEMPLATE_POST_TYPE,
 					TEMPLATE_PART_POST_TYPE,
 					NAVIGATION_POST_TYPE,
-				].includes( select( editorStore ).getCurrentPostType() ),
+				].includes( getCurrentPostType() ),
+				isPreviewMode: getEditorSettings().isPreviewMode,
 			};
 		},
 		[]
@@ -197,7 +196,7 @@ const Sidebar = ( {
 				showSummary={ showSummary }
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
-				forceRemoveBlockTools={ forceRemoveBlockTools }
+				isPreviewMode={ isPreviewMode }
 			/>
 		</Tabs>
 	);

--- a/packages/editor/src/components/sidebar/index.js
+++ b/packages/editor/src/components/sidebar/index.js
@@ -53,6 +53,7 @@ const SidebarContent = ( {
 	keyboardShortcut,
 	onActionPerformed,
 	extraPanels,
+	forceRemoveBlockTools,
 } ) => {
 	const tabListRef = useRef( null );
 	// Because `PluginSidebar` renders a `ComplementaryArea`, we
@@ -92,7 +93,10 @@ const SidebarContent = ( {
 			identifier={ tabName }
 			header={
 				<Tabs.Context.Provider value={ tabsContextValue }>
-					<SidebarHeader ref={ tabListRef } />
+					<SidebarHeader
+						ref={ tabListRef }
+						forceRemoveBlockTools={ forceRemoveBlockTools }
+					/>
 				</Tabs.Context.Provider>
 			}
 			closeLabel={ __( 'Close Settings' ) }
@@ -120,15 +124,21 @@ const SidebarContent = ( {
 					<PatternOverridesPanel />
 					{ extraPanels }
 				</Tabs.TabPanel>
-				<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
-					<BlockInspector />
-				</Tabs.TabPanel>
+				{ ! forceRemoveBlockTools && (
+					<Tabs.TabPanel tabId={ sidebars.block } focusable={ false }>
+						<BlockInspector />
+					</Tabs.TabPanel>
+				) }
 			</Tabs.Context.Provider>
 		</PluginSidebar>
 	);
 };
 
-const Sidebar = ( { extraPanels, onActionPerformed } ) => {
+const Sidebar = ( {
+	extraPanels,
+	onActionPerformed,
+	forceRemoveBlockTools,
+} ) => {
 	useAutoSwitchEditorSidebars();
 	const { tabName, keyboardShortcut, showSummary } = useSelect(
 		( select ) => {
@@ -187,6 +197,7 @@ const Sidebar = ( { extraPanels, onActionPerformed } ) => {
 				showSummary={ showSummary }
 				onActionPerformed={ onActionPerformed }
 				extraPanels={ extraPanels }
+				forceRemoveBlockTools={ forceRemoveBlockTools }
 			/>
 		</Tabs>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

When previewing the site through Site Editor > Styles, put the editor content in preview mode to focus on the styles rather than the content. Note that it is still possible to move on to template editing; if you double click the content you'll see a modal asking if you wish to edit the template.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When modifying global styles (through the Site Editor > Styles path), it seems beneficial to put the focus on styles rather than add all the complexities of styles AND template editing. If you edit both you might also have multiple entities to be saved.

Think about this as _distraction free style editing_, without the fear of changing other stuff.

This is an idea that came after working on #66951. We have use case there where the canvas is disabled when previewing static templates, so the props we add here are beneficial there as well.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Whenever the path is active, disable block tools and lock the template. Double click still always you to edit it.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to Site Editor > Styles.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="1464" alt="Screenshot 2024-11-14 at 13 45 49" src="https://github.com/user-attachments/assets/ed2beba4-b17d-4777-9a8e-7744c1109c32">
<img width="1464" alt="Screenshot 2024-11-14 at 13 47 23" src="https://github.com/user-attachments/assets/93051660-3f92-4fb1-9e3d-88f8613196ab">

