### PR TITLE
Preferences: Use hooks instead of HoC in 'EnablePublishSidebarOption'

### DIFF
--- a/packages/editor/src/components/preferences-modal/enable-publish-sidebar.js
+++ b/packages/editor/src/components/preferences-modal/enable-publish-sidebar.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { compose } from '@wordpress/compose';
-import { withSelect, withDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { privateApis as preferencesPrivateApis } from '@wordpress/preferences';
 
 /**
@@ -13,16 +12,20 @@ import { store as editorStore } from '../../store';
 
 const { PreferenceBaseOption } = unlock( preferencesPrivateApis );
 
-export default compose(
-	withSelect( ( select ) => ( {
-		isChecked: select( editorStore ).isPublishSidebarEnabled(),
-	} ) ),
-	withDispatch( ( dispatch ) => {
-		const { enablePublishSidebar, disablePublishSidebar } =
-			dispatch( editorStore );
-		return {
-			onChange: ( isEnabled ) =>
-				isEnabled ? enablePublishSidebar() : disablePublishSidebar(),
-		};
-	} )
-)( PreferenceBaseOption );
+export default function EnablePublishSidebarOption( props ) {
+	const isChecked = useSelect( ( select ) => {
+		return select( editorStore ).isPublishSidebarEnabled();
+	}, [] );
+	const { enablePublishSidebar, disablePublishSidebar } =
+		useDispatch( editorStore );
+
+	return (
+		<PreferenceBaseOption
+			isChecked={ isChecked }
+			onChange={ ( isEnabled ) =>
+				isEnabled ? enablePublishSidebar() : disablePublishSidebar()
+			}
+			{ ...props }
+		/>
+	);
+}


### PR DESCRIPTION
## What?
PR updates the `EnablePublishSidebarOption` component to use data hooks instead of HoCs.

## Why?
A micro-optimization makes the rendered component tree smaller.

Similar to #66994.

## Testing Instructions
1. Open a post or page. 
2. Open the Preferences modal.
3. Confirm you can toggle "Enable pre-publish checks".

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-14 at 12 26 20](https://github.com/user-attachments/assets/b7900c69-2e72-453c-a156-6edd4bbfa75c)
