### PR TITLE
DataViews: Fix focus loss when removing all filters or resetting

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   Fix focus loss when removing all filters or resetting ([#67003](https://github.com/WordPress/gutenberg/pull/67003)).
+
 ## 4.7.0 (2024-10-30)
 
 ## 4.6.0 (2024-10-16)
@@ -23,8 +27,7 @@
 ## Internal
 
 -   The "move left/move right" controls in the table layout (popup displayed on cliking header) are always visible. ([#64646](https://github.com/WordPress/gutenberg/pull/64646)). Before this, its visibility depending on filters, enableSorting, and enableHiding.
-- Filters no longer display the elements' description. ([#64674](https://github.com/WordPress/gutenberg/pull/64674))
-
+-   Filters no longer display the elements' description. ([#64674](https://github.com/WordPress/gutenberg/pull/64674))
 
 ## Enhancements
 

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -139,13 +139,11 @@ export function FiltersToggle( {
 					trigger={ buttonComponent }
 				/>
 			) : (
-				<FilterVisibilityToggle buttonRef={ buttonRef }>
+				<FilterVisibilityToggle
+					buttonRef={ buttonRef }
+					filtersCount={ view.filters?.length }
+				>
 					{ buttonComponent }
-					{ hasVisibleFilters && !! view.filters?.length && (
-						<span className="dataviews-filters-toggle__count">
-							{ view.filters?.length }
-						</span>
-					) }
 				</FilterVisibilityToggle>
 			) }
 		</div>
@@ -154,9 +152,11 @@ export function FiltersToggle( {
 
 function FilterVisibilityToggle( {
 	buttonRef,
+	filtersCount,
 	children,
 }: {
 	buttonRef: React.RefObject< HTMLButtonElement >;
+	filtersCount?: number;
 	children: React.ReactNode;
 } ) {
 	// Focus the `add filter` button when unmounts.
@@ -166,7 +166,16 @@ function FilterVisibilityToggle( {
 		},
 		[ buttonRef ]
 	);
-	return children;
+	return (
+		<>
+			{ children }
+			{ !! filtersCount && (
+				<span className="dataviews-filters-toggle__count">
+					{ filtersCount }
+				</span>
+			) }
+		</>
+	);
 }
 
 function Filters() {

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -7,6 +7,7 @@ import {
 	useRef,
 	useMemo,
 	useCallback,
+	useEffect,
 } from '@wordpress/element';
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import { funnel } from '@wordpress/icons';
@@ -70,7 +71,7 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 	}, [ fields, view ] );
 }
 
-export function FilterVisibilityToggle( {
+export function FiltersToggle( {
 	filters,
 	view,
 	onChangeView,
@@ -85,6 +86,7 @@ export function FilterVisibilityToggle( {
 	isShowingFilter: boolean;
 	setIsShowingFilter: React.Dispatch< React.SetStateAction< boolean > >;
 } ) {
+	const buttonRef = useRef< HTMLButtonElement >( null );
 	const onChangeViewWithFilterVisibility = useCallback(
 		( _view: View ) => {
 			onChangeView( _view );
@@ -98,6 +100,34 @@ export function FilterVisibilityToggle( {
 	if ( filters.length === 0 ) {
 		return null;
 	}
+
+	const addFilterButtonProps = {
+		label: __( 'Add filter' ),
+		'aria-expanded': false,
+		isPressed: false,
+	};
+	const toggleFiltersButtonProps = {
+		label: _x( 'Filter', 'verb' ),
+		'aria-expanded': isShowingFilter,
+		isPressed: isShowingFilter,
+		onClick: () => {
+			if ( ! isShowingFilter ) {
+				setOpenedFilter( null );
+			}
+			setIsShowingFilter( ! isShowingFilter );
+		},
+	};
+	const buttonComponent = (
+		<Button
+			ref={ buttonRef }
+			className="dataviews-filters__visibility-toggle"
+			size="compact"
+			icon={ funnel }
+			{ ...( hasVisibleFilters
+				? toggleFiltersButtonProps
+				: addFilterButtonProps ) }
+		/>
+	);
 	if ( ! hasVisibleFilters ) {
 		return (
 			<AddFilterMenu
@@ -105,40 +135,39 @@ export function FilterVisibilityToggle( {
 				view={ view }
 				onChangeView={ onChangeViewWithFilterVisibility }
 				setOpenedFilter={ setOpenedFilter }
-				trigger={
-					<Button
-						className="dataviews-filters__visibility-toggle"
-						size="compact"
-						icon={ funnel }
-						label={ __( 'Add filter' ) }
-						isPressed={ false }
-						aria-expanded={ false }
-					/>
-				}
+				trigger={ buttonComponent }
 			/>
 		);
 	}
 	return (
-		<div className="dataviews-filters__container-visibility-toggle">
-			<Button
-				className="dataviews-filters__visibility-toggle"
-				size="compact"
-				icon={ funnel }
-				label={ _x( 'Filter', 'verb' ) }
-				onClick={ () => {
-					if ( ! isShowingFilter ) {
-						setOpenedFilter( null );
-					}
-					setIsShowingFilter( ! isShowingFilter );
-				} }
-				isPressed={ isShowingFilter }
-				aria-expanded={ isShowingFilter }
-			/>
+		<FilterVisibilityToggle buttonRef={ buttonRef }>
+			{ buttonComponent }
 			{ hasVisibleFilters && !! view.filters?.length && (
 				<span className="dataviews-filters-toggle__count">
 					{ view.filters?.length }
 				</span>
 			) }
+		</FilterVisibilityToggle>
+	);
+}
+
+function FilterVisibilityToggle( {
+	buttonRef,
+	children,
+}: {
+	buttonRef: React.RefObject< HTMLButtonElement >;
+	children: React.ReactNode;
+} ) {
+	// Focus the `add filter` button when unmounts.
+	useEffect(
+		() => () => {
+			buttonRef.current?.focus();
+		},
+		[ buttonRef ]
+	);
+	return (
+		<div className="dataviews-filters__container-visibility-toggle">
+			{ children }
 		</div>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -128,26 +128,27 @@ export function FiltersToggle( {
 				: addFilterButtonProps ) }
 		/>
 	);
-	if ( ! hasVisibleFilters ) {
-		return (
-			<AddFilterMenu
-				filters={ filters }
-				view={ view }
-				onChangeView={ onChangeViewWithFilterVisibility }
-				setOpenedFilter={ setOpenedFilter }
-				trigger={ buttonComponent }
-			/>
-		);
-	}
 	return (
-		<FilterVisibilityToggle buttonRef={ buttonRef }>
-			{ buttonComponent }
-			{ hasVisibleFilters && !! view.filters?.length && (
-				<span className="dataviews-filters-toggle__count">
-					{ view.filters?.length }
-				</span>
+		<div className="dataviews-filters__container-visibility-toggle">
+			{ ! hasVisibleFilters ? (
+				<AddFilterMenu
+					filters={ filters }
+					view={ view }
+					onChangeView={ onChangeViewWithFilterVisibility }
+					setOpenedFilter={ setOpenedFilter }
+					trigger={ buttonComponent }
+				/>
+			) : (
+				<FilterVisibilityToggle buttonRef={ buttonRef }>
+					{ buttonComponent }
+					{ hasVisibleFilters && !! view.filters?.length && (
+						<span className="dataviews-filters-toggle__count">
+							{ view.filters?.length }
+						</span>
+					) }
+				</FilterVisibilityToggle>
 			) }
-		</FilterVisibilityToggle>
+		</div>
 	);
 }
 
@@ -165,11 +166,7 @@ function FilterVisibilityToggle( {
 		},
 		[ buttonRef ]
 	);
-	return (
-		<div className="dataviews-filters__container-visibility-toggle">
-			{ children }
-		</div>
-	);
+	return children;
 }
 
 function Filters() {

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -16,7 +16,7 @@ import DataViewsContext from '../dataviews-context';
 import {
 	default as DataViewsFilters,
 	useFilters,
-	FilterVisibilityToggle,
+	FiltersToggle,
 } from '../dataviews-filters';
 import DataViewsLayout from '../dataviews-layout';
 import DataViewsFooter from '../dataviews-footer';
@@ -135,7 +135,7 @@ export default function DataViews< Item >( {
 						className="dataviews__search"
 					>
 						{ search && <DataViewsSearch label={ searchLabel } /> }
-						<FilterVisibilityToggle
+						<FiltersToggle
 							filters={ filters }
 							view={ view }
 							onChangeView={ onChangeView }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/64697

In DataViews when we remove the last visible filter or resetting the filters the focus is lost.
This PR fixes that by focusing the `add filter` toggle when we do the above. I'm reusing the same Button for the filters toggle to have the same `ref`, because based on the visible filters we either render an `add filter` button or a toggle visibility of current filters one.

## Testing Instructions
1. In any list using DataViews add some filters and then:
   1. remove all of the visible filters
   2. reset filters
3. Observe that in both cases the focus is not lost and is added back to the `add filter` button
4. You can try the above with keyboard navigation too.

