### PR TITLE
Site Editor: Styles: fix inspector opening

### DIFF
--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -133,7 +133,7 @@ export default function GlobalStylesSidebar() {
 	const previousActiveAreaRef = useRef( null );
 
 	useEffect( () => {
-		if ( path.startsWith( '/wp_global_styles' ) && canvas === 'edit' ) {
+		if ( path?.startsWith( '/wp_global_styles' ) && canvas === 'edit' ) {
 			previousActiveAreaRef.current =
 				getActiveComplementaryArea( 'core' );
 			enableComplementaryArea( 'core', 'edit-site/global-styles' );

--- a/packages/edit-site/src/components/global-styles-sidebar/index.js
+++ b/packages/edit-site/src/components/global-styles-sidebar/index.js
@@ -133,7 +133,7 @@ export default function GlobalStylesSidebar() {
 	const previousActiveAreaRef = useRef( null );
 
 	useEffect( () => {
-		if ( path === '/wp_global_styles' && canvas === 'edit' ) {
+		if ( path.startsWith( '/wp_global_styles' ) && canvas === 'edit' ) {
 			previousActiveAreaRef.current =
 				getActiveComplementaryArea( 'core' );
 			enableComplementaryArea( 'core', 'edit-site/global-styles' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I noticed a small bug in #66996. When you have a nested panel open, the inspector does not open.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It should open.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Go to Site Editor > Styles. Now open a panel such as typography. Click the preview. Notice that the Global Styles inspector does not open, but it does in this PR.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
