### PR TITLE
Add border support to calender

### DIFF
--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -47,10 +47,10 @@
 			"width": true,
 			"style": true,
 			"__experimentalDefaultControls": {
-				"radius": true,
-				"color": true,
-				"width": true,
-				"style": true
+				"radius": false,
+				"color": false,
+				"width": false,
+				"style": false
 			}
 		}
 	},

--- a/packages/block-library/src/calendar/block.json
+++ b/packages/block-library/src/calendar/block.json
@@ -40,6 +40,18 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-calendar"

--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -1,6 +1,7 @@
 .wp-block-calendar {
 	text-align: center;
-
+	// This block has customizable borders. Border-box sizing makes that more predictable.
+	box-sizing: border-box;
 	th,
 	td {
 		padding: 0.25em;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border block support to the Calendar block.
Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Calendar block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds the border block support in block.json.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
Make sure that Calendar block's border is Configurable via Global Styles.
Edit Template/ Single Post Template & Add Calendar block and Apply the border Styles.
Verify that Calendar block styles take precedence over global Styles.
Verify that Calendar block borders display correctly in both the Editor and Frontend.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
