### PR TITLE
Fix Choose menu label when a menu has been deleted.

### DIFF
--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -62,7 +62,7 @@ function NavigationMenuSelector( {
 		canUserCreateNavigationMenus,
 		canSwitchNavigationMenu,
 		isNavigationMenuMissing,
-	} = useNavigationMenu();
+	} = useNavigationMenu( currentMenuId );
 
 	const [ currentTitle ] = useEntityProp(
 		'postType',

--- a/packages/block-library/src/navigation/edit/navigation-menu-selector.js
+++ b/packages/block-library/src/navigation/edit/navigation-menu-selector.js
@@ -61,6 +61,7 @@ function NavigationMenuSelector( {
 		hasResolvedNavigationMenus,
 		canUserCreateNavigationMenus,
 		canSwitchNavigationMenu,
+		isNavigationMenuMissing,
 	} = useNavigationMenu();
 
 	const [ currentTitle ] = useEntityProp(
@@ -106,12 +107,18 @@ function NavigationMenuSelector( {
 	const noBlockMenus = ! hasNavigationMenus && hasResolvedNavigationMenus;
 	const menuUnavailable =
 		hasResolvedNavigationMenus && currentMenuId === null;
+	const navMenuHasBeenDeleted = currentMenuId && isNavigationMenuMissing;
 
 	let selectorLabel = '';
 
 	if ( isResolvingNavigationMenus ) {
 		selectorLabel = __( 'Loading…' );
-	} else if ( noMenuSelected || noBlockMenus || menuUnavailable ) {
+	} else if (
+		noMenuSelected ||
+		noBlockMenus ||
+		menuUnavailable ||
+		navMenuHasBeenDeleted
+	) {
 		// Note: classic Menus may be available.
 		selectorLabel = __( 'Choose or create a Navigation Menu' );
 	} else {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes part of https://github.com/WordPress/gutenberg/issues/59431

## What?
<!-- In a few words, what is the PR actually doing? -->
See https://github.com/WordPress/gutenberg/issues/59431#issuecomment-2475906971

When a menu has been deleted, the settings panel shows a warning Notice. In that state, the ellipsis button to choose a menu is unlabeled. The condition to set the dynamic label fails and doesn't take into account this scenario.

![Screenshot 2024-11-14 at 10 59 43](https://github.com/user-attachments/assets/0decb251-2fbf-492e-a53c-f8b80af35e8d)



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
All controls should always be properly labeled.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
It appears the condition to render the Norice:

https://github.com/WordPress/gutenberg/blob/a120f10e63e3c6eb5fa4970e8ab3690e74453fde/packages/block-library/src/navigation/edit/menu-inspector-controls.js#L96

is slightly different from the condition(s) used to determine the ellipsis button label:

https://github.com/WordPress/gutenberg/blob/a120f10e63e3c6eb5fa4970e8ab3690e74453fde/packages/block-library/src/navigation/edit/navigation-menu-selector.js#L105-L117

Specifically in this scenario, `currentMenuId && isNavigationMenuMissing` is true, while `menuUnavailable` is false.

I'm not familiar with this part to determine whether `menuUnavailable` is incorrect in the first place and whether it should be reviewed. For now, I'm just adding one more check, which is the same one used for the Notice, to render the label 'Choose or create a Navigation Menu'. Any feedback on the current `menuUnavailable` would be appreciated.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Make sure you have a navigation menu assigned to the Navigation block.
- Go to navigation panel in the Site Editor > Navigation > select the assigned menu, and delete it from the ellipsis menu.
- In the editor canvas, edit the navigation block (you'll likely have to switch the editor to template editing mode).
- Select the Navigation block.
- In the settings panel, observe a Notice is rendered.
- Hover or focus the ellipsis button above the Notice.
- Observe the ellipsis button shows a tooltip 'Choose or create a Navigation Menu'.
- Inspect the source and observe the button has an aria-label with the same text.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
