### PR TITLE
DataViews list layout: hide actions menu when there is only one action and is primary

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -170,7 +170,7 @@ function ListItem< Item >( {
 			( action ) => action.isPrimary && !! action.icon
 		);
 		return {
-			primaryAction: _primaryActions?.[ 0 ],
+			primaryAction: _primaryActions[ 0 ],
 			eligibleActions: _eligibleActions,
 		};
 	}, [ actions, item ] );

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -175,6 +175,8 @@ function ListItem< Item >( {
 		};
 	}, [ actions, item ] );
 
+	const hasOnlyOnePrimaryAction = primaryAction && actions.length === 1;
+
 	const renderedMediaField = mediaField?.render ? (
 		<div className="dataviews-view-list__media-wrapper">
 			<mediaField.render item={ item } />
@@ -194,33 +196,35 @@ function ListItem< Item >( {
 					item={ item }
 				/>
 			) }
-			<div role="gridcell">
-				<Menu
-					trigger={
-						<Composite.Item
-							id={ generateDropdownTriggerCompositeId(
-								idPrefix
-							) }
-							render={
-								<Button
-									size="small"
-									icon={ moreVertical }
-									label={ __( 'Actions' ) }
-									accessibleWhenDisabled
-									disabled={ ! actions.length }
-									onKeyDown={ onDropdownTriggerKeyDown }
-								/>
-							}
+			{ ! hasOnlyOnePrimaryAction && (
+				<div role="gridcell">
+					<Menu
+						trigger={
+							<Composite.Item
+								id={ generateDropdownTriggerCompositeId(
+									idPrefix
+								) }
+								render={
+									<Button
+										size="small"
+										icon={ moreVertical }
+										label={ __( 'Actions' ) }
+										accessibleWhenDisabled
+										disabled={ ! actions.length }
+										onKeyDown={ onDropdownTriggerKeyDown }
+									/>
+								}
+							/>
+						}
+						placement="bottom-end"
+					>
+						<ActionsMenuGroup
+							actions={ eligibleActions }
+							item={ item }
 						/>
-					}
-					placement="bottom-end"
-				>
-					<ActionsMenuGroup
-						actions={ eligibleActions }
-						item={ item }
-					/>
-				</Menu>
-			</div>
+					</Menu>
+				</div>
+			) }
 		</HStack>
 	);
 


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/65165

## What?

This PR hides the actions menu for the DataViews list layout when there's only 1 action and is primary.

| Before | After |
| --- | --- |
| <img width="480" alt="Screenshot 2024-11-14 at 20 00 19" src="https://github.com/user-attachments/assets/a05e2597-a4df-4b36-9d1a-ec3d2233401e"> | <img width="480" alt="Screenshot 2024-11-14 at 19 59 53" src="https://github.com/user-attachments/assets/440d66dc-735e-4333-a73f-96302fd2bd63"> |

_All current core screens have more than one action. See testing instructions below._ 

## Why?

To improve UX.

## How?



## Testing Instructions

This is something we've heard from extenders. Because there's no place in core where we have this situation just yet, we have to create one for testing:

- Go to the [post-list code](https://github.com/WordPress/gutenberg/blob/hide/actions-menu-list/packages/edit-site/src/components/post-list/index.js#L350) and remove the `postTypeActions` in this line and in the line below (in both arrays).
- Visit the Pages page and verify only the edit icon is displayed.

https://github.com/user-attachments/assets/29e1f212-0195-4193-a99b-bc69025dcdce


