### PR TITLE
Block Supports: Extend stabilization to common experimental block support flags

### DIFF
--- a/backport-changelog/6.8/7069.md
+++ b/backport-changelog/6.8/7069.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/7069
 
 * https://github.com/WordPress/gutenberg/pull/63401
 * https://github.com/WordPress/gutenberg/pull/66918
+* https://github.com/WordPress/gutenberg/pull/67018

--- a/docs/explanations/architecture/styles.md
+++ b/docs/explanations/architecture/styles.md
@@ -37,8 +37,10 @@ The user may change the state of this block by applying different styles: a text
 After some user modifications to the block, the initial markup may become something like this:
 
 ```html
-<p class="has-color has-green-color has-font-size has-small-font-size my-custom-class"
-	style="line-height: 1em"></p>
+<p
+	class="has-color has-green-color has-font-size has-small-font-size my-custom-class"
+	style="line-height: 1em"
+></p>
 ```
 
 This is what we refer to as "user-provided block styles", also know as "local styles" or "serialized styles". Essentially, each tool (font size, color, etc) ends up adding some classes and/or inline styles to the block markup. The CSS styling for these classes is part of the block, global, or theme stylesheets.
@@ -123,7 +125,7 @@ The block supports API only serializes the font size value to the wrapper, resul
 
 This is an active area of work you can follow [in the tracking issue](https://github.com/WordPress/gutenberg/issues/38167). The linked proposal is exploring a different way to serialize the user changes: instead of each block support serializing its own data (for example, classes such as `has-small-font-size`, `has-green-color`) the idea is the block would get a single class instead (for example, `wp-style-UUID`) and the CSS styling for that class will be generated in the server by WordPress.
 
-While work continues in that proposal, there's an escape hatch, an experimental option block authors can use. Any block support can skip the serialization to HTML markup by using `__experimentalSkipSerialization`. For example:
+While work continues in that proposal, there's an escape hatch, an experimental option block authors can use. Any block support can skip the serialization to HTML markup by using `skipSerialization`. For example:
 
 ```json
 {
@@ -132,7 +134,7 @@ While work continues in that proposal, there's an escape hatch, an experimental 
 	"supports": {
 		"typography": {
 			"fontSize": true,
-			"__experimentalSkipSerialization": true
+			"skipSerialization": true
 		}
 	}
 }
@@ -140,7 +142,7 @@ While work continues in that proposal, there's an escape hatch, an experimental 
 
 This means that the typography block support will do all of the things (create a UI control, bind the block attribute to the control, etc) except serializing the user values into the HTML markup. The classes and inline styles will not be automatically applied to the wrapper and it is the block author's responsibility to implement this in the `edit`, `save`, and `render_callback` functions. See [this issue](https://github.com/WordPress/gutenberg/issues/28913) for examples of how it was done for some blocks provided by WordPress.
 
-Note that, if `__experimentalSkipSerialization` is enabled for a group (typography, color, spacing) it affects _all_ block supports within this group. In the example above _all_ the properties within the `typography` group will be affected (e.g. `fontSize`, `lineHeight`, `fontFamily` .etc).
+Note that, if `skipSerialization` is enabled for a group (typography, color, spacing) it affects _all_ block supports within this group. In the example above _all_ the properties within the `typography` group will be affected (e.g. `fontSize`, `lineHeight`, `fontFamily` .etc).
 
 To enable for a _single_ property only, you may use an array to declare which properties are to be skipped. In the example below, only `fontSize` will skip serialization, leaving other items within the `typography` group (e.g. `lineHeight`, `fontFamily` .etc) unaffected.
 
@@ -152,7 +154,7 @@ To enable for a _single_ property only, you may use an array to declare which pr
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
-			"__experimentalSkipSerialization": [ "fontSize" ]
+			"skipSerialization": [ "fontSize" ]
 		}
 	}
 }
@@ -473,7 +475,7 @@ If blocks do this, they need to be registered in the server using the `block.jso
 
 Every chunk of styles can only use a single selector.
 
-This is particularly relevant if the block is using `__experimentalSkipSerialization` to serialize the different style properties to different nodes other than the wrapper. See "Current limitations of blocks supports" for more.
+This is particularly relevant if the block is using `skipSerialization` to serialize the different style properties to different nodes other than the wrapper. See "Current limitations of blocks supports" for more.
 
 #### 3. **Only a single property per block**
 

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -739,7 +739,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $origin     Optional. What source of data this object represents.
 	 *                           One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 */
-	public function __construct( $theme_json = array( 'version' => self::LATEST_SCHEMA ), $origin = 'theme' ) {
+	public function __construct( $theme_json = array( 'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA ), $origin = 'theme' ) {
 		if ( ! in_array( $origin, static::VALID_ORIGINS, true ) ) {
 			$origin = 'theme';
 		}

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -739,7 +739,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @param string $origin     Optional. What source of data this object represents.
 	 *                           One of 'blocks', 'default', 'theme', or 'custom'. Default 'theme'.
 	 */
-	public function __construct( $theme_json = array( 'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA ), $origin = 'theme' ) {
+	public function __construct( $theme_json = array( 'version' => self::LATEST_SCHEMA ), $origin = 'theme' ) {
 		if ( ! in_array( $origin, static::VALID_ORIGINS, true ) ) {
 			$origin = 'theme';
 		}

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -101,6 +101,13 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 		 * are defined in to determine the final value.
 		 *    - If config is an array, merge the arrays in their order of definition.
 		 *    - If config is not an array, use the value defined last.
+		 *
+		 * The reason for preferring the last defined key is that after filters
+		 * are applied, the last inserted key is likely the most up-to-date value.
+		 * We cannot determine with certainty which value was "last modified" so
+		 * the insertion order is the best guess. The extreme edge case of multiple
+		 * filters tweaking the same support property will become less over time as
+		 * extenders migrate existing blocks and plugins to stable keys.
 		 */
 		if ( $support !== $stable_support_key && isset( $args['supports'][ $stable_support_key ] ) ) {
 			$key_positions      = array_flip( array_keys( $args['supports'] ) );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -35,9 +35,19 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 			'__experimentalTextTransform'  => 'textTransform',
 		),
 	);
+	$done                            = array();
 
 	$updated_supports = array();
 	foreach ( $args['supports'] as $support => $config ) {
+		/*
+		 * If this support config has already been stabilized, skip it.
+		 * A stable support key occurring after an experimental key, gets
+		 * stabilized then so that the two configs can be merged effectively.
+		 */
+		if ( isset( $done[ $support ] ) ) {
+			continue;
+		}
+
 		$stable_support_key = $experimental_supports_map[ $support ] ?? $support;
 
 		/*
@@ -104,12 +114,12 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 				 * stabilized before merging to keep stabilized and experimental flags in
 				 * sync.
 				 */
-				// TODO: This could be added to a "done list", to skip in the overall loop through `$args['supports']`.
 				$args['supports'][ $stable_support_key ] = $stabilize_config( $args['supports'][ $stable_support_key ], $stable_support_key );
-
-				$stable_config = $experimental_first
+				$stable_config                           = $experimental_first
 					? array_merge( $stable_config, $args['supports'][ $stable_support_key ] )
 					: array_merge( $args['supports'][ $stable_support_key ], $stable_config );
+				// Prevents reprocessing this support as it was merged above.
+				$done[ $stable_support_key ] = true;
 			} else {
 				$stable_config = $experimental_first
 					? $args['supports'][ $stable_support_key ]

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -20,8 +20,13 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 		return $args;
 	}
 
-	$experimental_to_stable_keys = array(
-		'typography'           => array(
+	$experimental_supports_map       = array( '__experimentalBorder' => 'border' );
+	$common_experimental_properties  = array(
+		'__experimentalDefaultControls'   => 'defaultControls',
+		'__experimentalSkipSerialization' => 'skipSerialization',
+	);
+	$experimental_support_properties = array(
+		'typography' => array(
 			'__experimentalFontFamily'     => 'fontFamily',
 			'__experimentalFontStyle'      => 'fontStyle',
 			'__experimentalFontWeight'     => 'fontWeight',
@@ -29,59 +34,90 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 			'__experimentalTextDecoration' => 'textDecoration',
 			'__experimentalTextTransform'  => 'textTransform',
 		),
-		'__experimentalBorder' => 'border',
 	);
 
 	$updated_supports = array();
 	foreach ( $args['supports'] as $support => $config ) {
-		// Add the support's config as is when it's not in need of stabilization.
-		if ( empty( $experimental_to_stable_keys[ $support ] ) ) {
+		$stable_support_key = $experimental_supports_map[ $support ] ?? $support;
+
+		/*
+		 * Use the support's config as is when it's not in need of stabilization.
+		 *
+		 * A support does not need stabilization if:
+		 * - The support key doesn't need stabilization AND
+		 * - Either:
+		 *     - The config isn't an array, so can't have experimental properties OR
+		 *     - The config is an array but has no experimental properties to stabilize.
+		 */
+		if ( $support === $stable_support_key &&
+			( ! is_array( $config ) ||
+				( ! isset( $experimental_support_properties[ $stable_support_key ] ) &&
+				empty( array_intersect_key( $common_experimental_properties, $config ) )
+				)
+			)
+		) {
 			$updated_supports[ $support ] = $config;
 			continue;
 		}
 
-		// Stabilize the support's key if needed e.g. __experimentalBorder => border.
-		if ( is_string( $experimental_to_stable_keys[ $support ] ) ) {
-			$stabilized_key = $experimental_to_stable_keys[ $support ];
+		$stabilize_config = function ( $unstable_config, $stable_support_key ) use ( $experimental_support_properties, $common_experimental_properties ) {
+			$stable_config = array();
+			foreach ( $unstable_config as $key => $value ) {
+				// Get stable key from support-specific map, common properties map, or keep original.
+				$stable_key = $experimental_support_properties[ $stable_support_key ][ $key ] ??
+							$common_experimental_properties[ $key ] ??
+							$key;
 
-			// If there is no stabilized key present, use the experimental config as is.
-			if ( ! array_key_exists( $stabilized_key, $args['supports'] ) ) {
-				$updated_supports[ $stabilized_key ] = $config;
-				continue;
-			}
+				$stable_config[ $stable_key ] = $value;
 
-			// Determine the order of keys, so the last defined can be preferred.
-			$key_positions      = array_flip( array_keys( $args['supports'] ) );
-			$experimental_index = $key_positions[ $support ] ?? -1;
-			$stabilized_index   = $key_positions[ $stabilized_key ] ?? -1;
-			$experimental_first = $experimental_index < $stabilized_index;
-
-			// Update support config, prefer the last defined value.
-			if ( is_array( $config ) ) {
-				$updated_supports[ $stabilized_key ] = $experimental_first
-					? array_merge( $config, $args['supports'][ $stabilized_key ] )
-					: array_merge( $args['supports'][ $stabilized_key ], $config );
-			} else {
-				$updated_supports[ $stabilized_key ] = $experimental_first
-					? $args['supports'][ $stabilized_key ]
-					: $config;
-			}
-
-			continue;
-		}
-
-		// Stabilize individual support feature keys e.g. __experimentalFontFamily => fontFamily.
-		if ( is_array( $experimental_to_stable_keys[ $support ] ) ) {
-			$stable_support_config = array();
-			foreach ( $config as $key => $value ) {
-				if ( array_key_exists( $key, $experimental_to_stable_keys[ $support ] ) ) {
-					$stable_support_config[ $experimental_to_stable_keys[ $support ][ $key ] ] = $value;
-				} else {
-					$stable_support_config[ $key ] = $value;
+				/*
+				 * The `__experimentalSkipSerialization` key needs to be kept until
+				 * WP 6.8 becomes the minimum supported version. This is due to the
+				 * core `wp_should_skip_block_supports_serialization` function only
+				 * checking for `__experimentalSkipSerialization` in earlier versions.
+				 */
+				if ( '__experimentalSkipSerialization' === $key || 'skipSerialization' === $key ) {
+					$stable_config['__experimentalSkipSerialization'] = $value;
 				}
 			}
-			$updated_supports[ $support ] = $stable_support_config;
+			return $stable_config;
+		};
+
+		// Stabilize the config value.
+		$stable_config = is_array( $config ) ? $stabilize_config( $config, $stable_support_key ) : $config;
+
+		/*
+		 * When both experimental and stable configs are present, use the order they
+		 * are defined in to determine the final value.
+		 *    - If config is an array, merge the arrays in their order of definition.
+		 *    - If config is not an array, use the value defined last.
+		 */
+		if ( $support !== $stable_support_key && isset( $args['supports'][ $stable_support_key ] ) ) {
+			$key_positions      = array_flip( array_keys( $args['supports'] ) );
+			$experimental_first =
+				( $key_positions[ $support ] ?? PHP_INT_MAX ) <
+				( $key_positions[ $stable_support_key ] ?? PHP_INT_MAX );
+
+			if ( is_array( $args['supports'][ $stable_support_key ] ) ) {
+				/*
+				 * To merge the alternative support config effectively, it also needs to be
+				 * stabilized before merging to keep stabilized and experimental flags in
+				 * sync.
+				 */
+				// TODO: This could be added to a "done list", to skip in the overall loop through `$args['supports']`.
+				$args['supports'][ $stable_support_key ] = $stabilize_config( $args['supports'][ $stable_support_key ], $stable_support_key );
+
+				$stable_config = $experimental_first
+					? array_merge( $stable_config, $args['supports'][ $stable_support_key ] )
+					: array_merge( $args['supports'][ $stable_support_key ], $stable_config );
+			} else {
+				$stable_config = $experimental_first
+					? $args['supports'][ $stable_support_key ]
+					: $stable_config;
+			}
 		}
+
+		$updated_supports[ $stable_support_key ] = $stable_config;
 	}
 
 	$args['supports'] = $updated_supports;

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -50,16 +50,7 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 				continue;
 			}
 
-			/*
-			 * Determine the order of keys, so the last defined can be preferred.
-			 *
-			 * The reason for preferring the last defined key is that after filters
-			 * are applied, the last inserted key is likely the most up-to-date value.
-			 * We cannot determine with certainty which value was "last modified" so
-			 * the insertion order is the best guess. The extreme edge case of multiple
-			 * filters tweaking the same support property will become less over time as
-			 * extenders migrate existing blocks and plugins to stable keys.
-			 */
+			// Determine the order of keys, so the last defined can be preferred.
 			$key_positions      = array_flip( array_keys( $args['supports'] ) );
 			$experimental_index = $key_positions[ $support ] ?? -1;
 			$stabilized_index   = $key_positions[ $stabilized_key ] ?? -1;

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -97,8 +97,9 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 		$stable_config = is_array( $config ) ? $stabilize_config( $config, $stable_support_key ) : $config;
 
 		/*
-		 * When both experimental and stable configs are present, use the order they
-		 * are defined in to determine the final value.
+		 * If a plugin overrides the support config with the `register_block_type_args`
+		 * filter, both experimental and stable configs may be present. In that case,
+		 * use the order keys are defined in to determine the final value.
 		 *    - If config is an array, merge the arrays in their order of definition.
 		 *    - If config is not an array, use the value defined last.
 		 *

--- a/packages/block-editor/src/hooks/border.js
+++ b/packages/block-editor/src/hooks/border.js
@@ -161,14 +161,8 @@ export function BorderPanel( { clientId, name, setAttributes, settings } ) {
 	}
 
 	const defaultControls = {
-		...getBlockSupport( name, [
-			BORDER_SUPPORT_KEY,
-			'__experimentalDefaultControls',
-		] ),
-		...getBlockSupport( name, [
-			SHADOW_SUPPORT_KEY,
-			'__experimentalDefaultControls',
-		] ),
+		...getBlockSupport( name, [ BORDER_SUPPORT_KEY, 'defaultControls' ] ),
+		...getBlockSupport( name, [ SHADOW_SUPPORT_KEY, 'defaultControls' ] ),
 	};
 
 	return (

--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -290,7 +290,7 @@ export function ColorEdit( { clientId, name, setAttributes, settings } ) {
 
 	const defaultControls = getBlockSupport( name, [
 		COLOR_SUPPORT_KEY,
-		'__experimentalDefaultControls',
+		'defaultControls',
 	] );
 
 	const enableContrastChecking =

--- a/packages/block-editor/src/hooks/dimensions.js
+++ b/packages/block-editor/src/hooks/dimensions.js
@@ -88,11 +88,11 @@ export function DimensionsPanel( { clientId, name, setAttributes, settings } ) {
 
 	const defaultDimensionsControls = getBlockSupport( name, [
 		DIMENSIONS_SUPPORT_KEY,
-		'__experimentalDefaultControls',
+		'defaultControls',
 	] );
 	const defaultSpacingControls = getBlockSupport( name, [
 		SPACING_SUPPORT_KEY,
-		'__experimentalDefaultControls',
+		'defaultControls',
 	] );
 	const defaultControls = {
 		...defaultDimensionsControls,

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -98,22 +98,16 @@ function addAttribute( settings ) {
  * @type {Record<string, string[]>}
  */
 const skipSerializationPathsEdit = {
-	[ `${ BORDER_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [ 'border' ],
-	[ `${ COLOR_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
-		COLOR_SUPPORT_KEY,
-	],
-	[ `${ TYPOGRAPHY_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+	[ `${ BORDER_SUPPORT_KEY }.skipSerialization` ]: [ 'border' ],
+	[ `${ COLOR_SUPPORT_KEY }.skipSerialization` ]: [ COLOR_SUPPORT_KEY ],
+	[ `${ TYPOGRAPHY_SUPPORT_KEY }.skipSerialization` ]: [
 		TYPOGRAPHY_SUPPORT_KEY,
 	],
-	[ `${ DIMENSIONS_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
+	[ `${ DIMENSIONS_SUPPORT_KEY }.skipSerialization` ]: [
 		DIMENSIONS_SUPPORT_KEY,
 	],
-	[ `${ SPACING_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
-		SPACING_SUPPORT_KEY,
-	],
-	[ `${ SHADOW_SUPPORT_KEY }.__experimentalSkipSerialization` ]: [
-		SHADOW_SUPPORT_KEY,
-	],
+	[ `${ SPACING_SUPPORT_KEY }.skipSerialization` ]: [ SPACING_SUPPORT_KEY ],
+	[ `${ SHADOW_SUPPORT_KEY }.skipSerialization` ]: [ SHADOW_SUPPORT_KEY ],
 };
 
 /**

--- a/packages/block-editor/src/hooks/test/style.js
+++ b/packages/block-editor/src/hooks/test/style.js
@@ -133,8 +133,7 @@ describe( 'addSaveProps', () => {
 	const applySkipSerialization = ( features ) => {
 		const updatedSettings = { ...blockSettings };
 		Object.keys( features ).forEach( ( key ) => {
-			updatedSettings.supports[ key ].__experimentalSkipSerialization =
-				features[ key ];
+			updatedSettings.supports[ key ].skipSerialization = features[ key ];
 		} );
 		return updatedSettings;
 	};

--- a/packages/block-editor/src/hooks/typography.js
+++ b/packages/block-editor/src/hooks/typography.js
@@ -133,7 +133,7 @@ export function TypographyPanel( { clientId, name, setAttributes, settings } ) {
 
 	const defaultControls = getBlockSupport( name, [
 		TYPOGRAPHY_SUPPORT_KEY,
-		'__experimentalDefaultControls',
+		'defaultControls',
 	] );
 
 	return (

--- a/packages/block-editor/src/hooks/utils.js
+++ b/packages/block-editor/src/hooks/utils.js
@@ -124,7 +124,7 @@ export function shouldSkipSerialization(
 	feature
 ) {
 	const support = getBlockSupport( blockNameOrType, featureSet );
-	const skipSerialization = support?.__experimentalSkipSerialization;
+	const skipSerialization = support?.skipSerialization;
 
 	if ( Array.isArray( skipSerialization ) ) {
 		return skipSerialization.includes( feature );

--- a/packages/blocks/src/api/constants.js
+++ b/packages/blocks/src/api/constants.js
@@ -298,7 +298,16 @@ export const __EXPERIMENTAL_PATHS_WITH_OVERRIDE = {
 	'spacing.spacingSizes': true,
 };
 
-export const EXPERIMENTAL_TO_STABLE_KEYS = {
+export const EXPERIMENTAL_SUPPORTS_MAP = {
+	__experimentalBorder: 'border',
+};
+
+export const COMMON_EXPERIMENTAL_PROPERTIES = {
+	__experimentalDefaultControls: 'defaultControls',
+	__experimentalSkipSerialization: 'skipSerialization',
+};
+
+export const EXPERIMENTAL_SUPPORT_PROPERTIES = {
 	typography: {
 		__experimentalFontFamily: 'fontFamily',
 		__experimentalFontStyle: 'fontStyle',
@@ -307,5 +316,4 @@ export const EXPERIMENTAL_TO_STABLE_KEYS = {
 		__experimentalTextDecoration: 'textDecoration',
 		__experimentalTextTransform: 'textTransform',
 	},
-	__experimentalBorder: 'border',
 };

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -77,7 +77,7 @@ function stabilizeSupports( rawSupports ) {
 	const newSupports = {};
 
 	for ( const [ support, config ] of Object.entries( rawSupports ) ) {
-		// Add the current support's config as is if it does not need stabilization.
+		// Add the support's config as is when it's not in need of stabilization.
 		if ( ! EXPERIMENTAL_TO_STABLE_KEYS[ support ] ) {
 			newSupports[ support ] = config;
 			continue;
@@ -87,13 +87,13 @@ function stabilizeSupports( rawSupports ) {
 		if ( typeof EXPERIMENTAL_TO_STABLE_KEYS[ support ] === 'string' ) {
 			const stabilizedKey = EXPERIMENTAL_TO_STABLE_KEYS[ support ];
 
-			// If there's no stabilized key present, just use the config as is.
+			// If there is no stabilized key present, use the experimental config as is.
 			if ( ! Object.hasOwn( rawSupports, stabilizedKey ) ) {
 				newSupports[ stabilizedKey ] = config;
 				continue;
 			}
 
-			// Determine the insertion order for both key.
+			// Determine the order of keys, so the last defined can be preferred.
 			const entries = Object.entries( rawSupports );
 			const experimentalIndex = entries.findIndex(
 				( [ key ] ) => key === support
@@ -102,6 +102,7 @@ function stabilizeSupports( rawSupports ) {
 				( [ key ] ) => key === stabilizedKey
 			);
 
+			// Update support config, prefer the last defined value.
 			if ( typeof config === 'object' && config !== null ) {
 				newSupports[ stabilizedKey ] =
 					experimentalIndex < stabilizedIndex

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -77,7 +77,7 @@ function stabilizeSupports( rawSupports ) {
 	const newSupports = {};
 
 	for ( const [ support, config ] of Object.entries( rawSupports ) ) {
-		// Add the support's config as is when it's not in need of stabilization.
+		// Add the current support's config as is if it does not need stabilization.
 		if ( ! EXPERIMENTAL_TO_STABLE_KEYS[ support ] ) {
 			newSupports[ support ] = config;
 			continue;
@@ -87,22 +87,13 @@ function stabilizeSupports( rawSupports ) {
 		if ( typeof EXPERIMENTAL_TO_STABLE_KEYS[ support ] === 'string' ) {
 			const stabilizedKey = EXPERIMENTAL_TO_STABLE_KEYS[ support ];
 
-			// If there is no stabilized key present, use the experimental config as is.
+			// If there's no stabilized key present, just use the config as is.
 			if ( ! Object.hasOwn( rawSupports, stabilizedKey ) ) {
 				newSupports[ stabilizedKey ] = config;
 				continue;
 			}
 
-			/*
-			 * Determine the order of keys, so the last defined can be preferred.
-			 *
-			 * The reason for preferring the last defined key is that after filters
-			 * are applied, the last inserted key is likely the most up-to-date value.
-			 * We cannot determine with certainty which value was "last modified" so
-			 * the insertion order is the best guess. The extreme edge case of multiple
-			 * filters tweaking the same support property will become less over time as
-			 * extenders migrate existing blocks and plugins to stable keys.
-			 */
+			// Determine the insertion order for both key.
 			const entries = Object.entries( rawSupports );
 			const experimentalIndex = entries.findIndex(
 				( [ key ] ) => key === support
@@ -111,7 +102,6 @@ function stabilizeSupports( rawSupports ) {
 				( [ key ] ) => key === stabilizedKey
 			);
 
-			// Update support config, prefer the last defined value.
 			if ( typeof config === 'object' && config !== null ) {
 				newSupports[ stabilizedKey ] =
 					experimentalIndex < stabilizedIndex

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -166,6 +166,13 @@ function stabilizeSupports( rawSupports ) {
 		 * are defined in to determine the final value.
 		 *    - If config is an array, merge the arrays in their order of definition.
 		 *    - If config is not an array, use the value defined last.
+		 *
+		 * The reason for preferring the last defined key is that after filters
+		 * are applied, the last inserted key is likely the most up-to-date value.
+		 * We cannot determine with certainty which value was "last modified" so
+		 * the insertion order is the best guess. The extreme edge case of multiple
+		 * filters tweaking the same support property will become less over time as
+		 * extenders migrate existing blocks and plugins to stable keys.
 		 */
 		if (
 			support !== stableSupportKey &&

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -18,7 +18,9 @@ import { isValidIcon, normalizeIconObject, omit } from '../api/utils';
 import {
 	BLOCK_ICON_DEFAULT,
 	DEPRECATED_ENTRY_KEYS,
-	EXPERIMENTAL_TO_STABLE_KEYS,
+	EXPERIMENTAL_SUPPORTS_MAP,
+	COMMON_EXPERIMENTAL_PROPERTIES,
+	EXPERIMENTAL_SUPPORT_PROPERTIES,
 } from '../api/constants';
 
 /** @typedef {import('../api/registration').WPBlockType} WPBlockType */
@@ -66,72 +68,141 @@ function mergeBlockVariations(
 	return result;
 }
 
+/**
+ * Stabilizes a block support configuration by converting experimental properties
+ * to their stable equivalents.
+ *
+ * @param {Object} unstableConfig   The support configuration to stabilize.
+ * @param {string} stableSupportKey The stable support key for looking up properties.
+ * @return {Object} The stabilized support configuration.
+ */
+function stabilizeSupportConfig( unstableConfig, stableSupportKey ) {
+	const stableConfig = {};
+	for ( const [ key, value ] of Object.entries( unstableConfig ) ) {
+		// Get stable key from support-specific map, common properties map, or keep original.
+		const stableKey =
+			EXPERIMENTAL_SUPPORT_PROPERTIES[ stableSupportKey ]?.[ key ] ??
+			COMMON_EXPERIMENTAL_PROPERTIES[ key ] ??
+			key;
+
+		stableConfig[ stableKey ] = value;
+
+		/*
+		 * The `__experimentalSkipSerialization` key needs to be kept until
+		 * WP 6.8 becomes the minimum supported version. This is due to the
+		 * core `wp_should_skip_block_supports_serialization` function only
+		 * checking for `__experimentalSkipSerialization` in earlier versions.
+		 */
+		if (
+			key === '__experimentalSkipSerialization' ||
+			key === 'skipSerialization'
+		) {
+			stableConfig.__experimentalSkipSerialization = value;
+		}
+	}
+	return stableConfig;
+}
+
+/**
+ * Stabilizes experimental block supports by converting experimental keys and properties
+ * to their stable equivalents.
+ *
+ * @param {Object|undefined} rawSupports The block supports configuration to stabilize.
+ * @return {Object|undefined} The stabilized block supports configuration.
+ */
 function stabilizeSupports( rawSupports ) {
 	if ( ! rawSupports ) {
 		return rawSupports;
 	}
 
-	// Create a new object to avoid mutating the original. This ensures that
-	// custom block plugins that rely on immutable supports are not affected.
-	// See: https://github.com/WordPress/gutenberg/pull/66849#issuecomment-2463614281
+	/*
+	 * Create a new object to avoid mutating the original. This ensures that
+	 * custom block plugins that rely on immutable supports are not affected.
+	 * See: https://github.com/WordPress/gutenberg/pull/66849#issuecomment-2463614281
+	 */
 	const newSupports = {};
+	const done = {};
 
 	for ( const [ support, config ] of Object.entries( rawSupports ) ) {
-		// Add the support's config as is when it's not in need of stabilization.
-		if ( ! EXPERIMENTAL_TO_STABLE_KEYS[ support ] ) {
+		/*
+		 * If this support config has already been stabilized, skip it.
+		 * A stable support key occurring after an experimental key, gets
+		 * stabilized then so that the two configs can be merged effectively.
+		 */
+		if ( done[ support ] ) {
+			continue;
+		}
+
+		const stableSupportKey =
+			EXPERIMENTAL_SUPPORTS_MAP[ support ] ?? support;
+
+		/*
+		 * Use the support's config as is when it's not in need of stabilization.
+		 * A support does not need stabilization if:
+		 * - The support key doesn't need stabilization AND
+		 * - Either:
+		 *     - The config isn't an object, so can't have experimental properties OR
+		 *     - The config is an object but has no experimental properties to stabilize.
+		 */
+		if (
+			support === stableSupportKey &&
+			( ! isPlainObject( config ) ||
+				( ! EXPERIMENTAL_SUPPORT_PROPERTIES[ stableSupportKey ] &&
+					Object.keys( config ).every(
+						( key ) => ! COMMON_EXPERIMENTAL_PROPERTIES[ key ]
+					) ) )
+		) {
 			newSupports[ support ] = config;
 			continue;
 		}
 
-		// Stabilize the support's key if needed e.g. __experimentalBorder => border.
-		if ( typeof EXPERIMENTAL_TO_STABLE_KEYS[ support ] === 'string' ) {
-			const stabilizedKey = EXPERIMENTAL_TO_STABLE_KEYS[ support ];
+		// Stabilize the config value.
+		const stableConfig = isPlainObject( config )
+			? stabilizeSupportConfig( config, stableSupportKey )
+			: config;
 
-			// If there is no stabilized key present, use the experimental config as is.
-			if ( ! Object.hasOwn( rawSupports, stabilizedKey ) ) {
-				newSupports[ stabilizedKey ] = config;
-				continue;
-			}
-
-			// Determine the order of keys, so the last defined can be preferred.
-			const entries = Object.entries( rawSupports );
-			const experimentalIndex = entries.findIndex(
-				( [ key ] ) => key === support
+		/*
+		 * When both experimental and stable configs are present, use the order they
+		 * are defined in to determine the final value.
+		 *    - If config is an array, merge the arrays in their order of definition.
+		 *    - If config is not an array, use the value defined last.
+		 */
+		if (
+			support !== stableSupportKey &&
+			Object.hasOwn( rawSupports, stableSupportKey )
+		) {
+			const keyPositions = Object.keys( rawSupports ).reduce(
+				( acc, key, index ) => {
+					acc[ key ] = index;
+					return acc;
+				},
+				{}
 			);
-			const stabilizedIndex = entries.findIndex(
-				( [ key ] ) => key === stabilizedKey
-			);
+			const experimentalFirst =
+				( keyPositions[ support ] ?? Number.MAX_VALUE ) <
+				( keyPositions[ stableSupportKey ] ?? Number.MAX_VALUE );
 
-			// Update support config, prefer the last defined value.
-			if ( typeof config === 'object' && config !== null ) {
-				newSupports[ stabilizedKey ] =
-					experimentalIndex < stabilizedIndex
-						? { ...config, ...rawSupports[ stabilizedKey ] }
-						: { ...rawSupports[ stabilizedKey ], ...config };
+			if ( isPlainObject( rawSupports[ stableSupportKey ] ) ) {
+				/*
+				 * To merge the alternative support config effectively, it also needs to be
+				 * stabilized before merging to keep stabilized and experimental flags in sync.
+				 */
+				rawSupports[ stableSupportKey ] = stabilizeSupportConfig(
+					rawSupports[ stableSupportKey ],
+					stableSupportKey
+				);
+				newSupports[ stableSupportKey ] = experimentalFirst
+					? { ...stableConfig, ...rawSupports[ stableSupportKey ] }
+					: { ...rawSupports[ stableSupportKey ], ...stableConfig };
+				// Prevents reprocessing this support as it was merged above.
+				done[ stableSupportKey ] = true;
 			} else {
-				newSupports[ stabilizedKey ] =
-					experimentalIndex < stabilizedIndex
-						? rawSupports[ stabilizedKey ]
-						: config;
+				newSupports[ stableSupportKey ] = experimentalFirst
+					? rawSupports[ stableSupportKey ]
+					: stableConfig;
 			}
-			continue;
-		}
-
-		// Stabilize individual support feature keys
-		// e.g. __experimentalFontFamily => fontFamily.
-		const featureStabilizationRequired =
-			typeof EXPERIMENTAL_TO_STABLE_KEYS[ support ] === 'object' &&
-			EXPERIMENTAL_TO_STABLE_KEYS[ support ] !== null;
-		const hasConfig = typeof config === 'object' && config !== null;
-
-		if ( featureStabilizationRequired && hasConfig ) {
-			const stableConfig = {};
-			for ( const [ key, value ] of Object.entries( config ) ) {
-				const stableKey =
-					EXPERIMENTAL_TO_STABLE_KEYS[ support ][ key ] || key;
-				stableConfig[ stableKey ] = value;
-			}
-			newSupports[ support ] = stableConfig;
+		} else {
+			newSupports[ stableSupportKey ] = stableConfig;
 		}
 	}
 

--- a/packages/blocks/src/store/process-block-type.js
+++ b/packages/blocks/src/store/process-block-type.js
@@ -162,8 +162,9 @@ function stabilizeSupports( rawSupports ) {
 			: config;
 
 		/*
-		 * When both experimental and stable configs are present, use the order they
-		 * are defined in to determine the final value.
+		 * If a plugin overrides the support config with the `blocks.registerBlockType`
+		 * filter, both experimental and stable configs may be present. In that case,
+		 * use the order keys are defined in to determine the final value.
 		 *    - If config is an array, merge the arrays in their order of definition.
 		 *    - If config is not an array, use the value defined last.
 		 *

--- a/packages/blocks/src/store/test/process-block-type.js
+++ b/packages/blocks/src/store/test/process-block-type.js
@@ -26,7 +26,7 @@ describe( 'processBlockType', () => {
 		removeFilter( 'blocks.registerBlockType', 'test/filterSupports' );
 	} );
 
-	it( 'should return the block type with stabilized supports', () => {
+	it( 'should stabilize experimental block supports', () => {
 		const blockSettings = {
 			...baseBlockSettings,
 			supports: {
@@ -66,7 +66,7 @@ describe( 'processBlockType', () => {
 			blockSettings
 		)( { select } );
 
-		expect( processedBlockType.supports ).toEqual( {
+		expect( processedBlockType.supports ).toMatchObject( {
 			typography: {
 				fontSize: true,
 				lineHeight: true,
@@ -77,7 +77,7 @@ describe( 'processBlockType', () => {
 				textTransform: true,
 				textDecoration: true,
 				__experimentalWritingMode: true,
-				__experimentalDefaultControls: {
+				defaultControls: {
 					fontSize: true,
 					fontAppearance: true,
 					textTransform: true,
@@ -88,79 +88,7 @@ describe( 'processBlockType', () => {
 				radius: true,
 				style: true,
 				width: true,
-				__experimentalDefaultControls: {
-					color: true,
-					radius: true,
-					style: true,
-					width: true,
-				},
-			},
-		} );
-	} );
-
-	it( 'should return the block type with stable supports', () => {
-		const blockSettings = {
-			...baseBlockSettings,
-			supports: {
-				typography: {
-					fontSize: true,
-					lineHeight: true,
-					fontFamily: true,
-					fontStyle: true,
-					fontWeight: true,
-					letterSpacing: true,
-					textTransform: true,
-					textDecoration: true,
-					__experimentalWritingMode: true,
-					__experimentalDefaultControls: {
-						fontSize: true,
-						fontAppearance: true,
-						textTransform: true,
-					},
-				},
-				__experimentalBorder: {
-					color: true,
-					radius: true,
-					style: true,
-					width: true,
-					__experimentalDefaultControls: {
-						color: true,
-						radius: true,
-						style: true,
-						width: true,
-					},
-				},
-			},
-		};
-
-		const processedBlockType = processBlockType(
-			'test/block',
-			blockSettings
-		)( { select } );
-
-		expect( processedBlockType.supports ).toEqual( {
-			typography: {
-				fontSize: true,
-				lineHeight: true,
-				fontFamily: true,
-				fontStyle: true,
-				fontWeight: true,
-				letterSpacing: true,
-				textTransform: true,
-				textDecoration: true,
-				__experimentalWritingMode: true,
-				__experimentalDefaultControls: {
-					fontSize: true,
-					fontAppearance: true,
-					textTransform: true,
-				},
-			},
-			border: {
-				color: true,
-				radius: true,
-				style: true,
-				width: true,
-				__experimentalDefaultControls: {
+				defaultControls: {
 					color: true,
 					radius: true,
 					style: true,
@@ -227,7 +155,7 @@ describe( 'processBlockType', () => {
 			blockSettings
 		)( { select } );
 
-		expect( processedBlockType.supports ).toEqual( {
+		expect( processedBlockType.supports ).toMatchObject( {
 			typography: {
 				fontSize: true,
 				lineHeight: true,
@@ -238,7 +166,7 @@ describe( 'processBlockType', () => {
 				textTransform: true,
 				textDecoration: true,
 				__experimentalWritingMode: true,
-				__experimentalDefaultControls: {
+				defaultControls: {
 					fontSize: true,
 					fontAppearance: true,
 					textTransform: true,
@@ -249,7 +177,7 @@ describe( 'processBlockType', () => {
 				radius: false,
 				style: true,
 				width: true,
-				__experimentalDefaultControls: {
+				defaultControls: {
 					color: true,
 					radius: true,
 					style: true,
@@ -259,8 +187,8 @@ describe( 'processBlockType', () => {
 		} );
 	} );
 
-	it( 'should stabilize experimental supports within block deprecations', () => {
-		const blockSettings = {
+	describe( 'block deprecations', () => {
+		const deprecatedBlockSettings = {
 			...baseBlockSettings,
 			supports: {
 				typography: {
@@ -321,144 +249,241 @@ describe( 'processBlockType', () => {
 			],
 		};
 
-		// Freeze the deprecated block object and its supports so that the original is not mutated.
-		// This ensures the test covers a regression where the original object was mutated.
-		// See: https://github.com/WordPress/gutenberg/pull/63401#discussion_r1832394335.
-		Object.freeze( blockSettings.deprecated[ 0 ] );
-		Object.freeze( blockSettings.deprecated[ 0 ].supports );
-
-		const processedBlockType = processBlockType(
-			'test/block',
-			blockSettings
-		)( { select } );
-
-		expect( processedBlockType.deprecated[ 0 ].supports ).toEqual( {
-			typography: {
-				fontFamily: true,
-				fontStyle: true,
-				fontWeight: true,
-				letterSpacing: true,
-				textTransform: true,
-				textDecoration: true,
-				__experimentalWritingMode: true,
-			},
-			border: {
-				color: true,
-				radius: true,
-				style: true,
-				width: true,
-				__experimentalDefaultControls: {
-					color: true,
-					radius: true,
-					style: true,
-					width: true,
-				},
-			},
+		beforeEach( () => {
+			// Freeze the deprecated block object and its supports so that the original is not mutated.
+			Object.freeze( deprecatedBlockSettings.deprecated[ 0 ] );
+			Object.freeze( deprecatedBlockSettings.deprecated[ 0 ].supports );
 		} );
-	} );
 
-	it( 'should reapply transformations after supports are filtered within block deprecations', () => {
-		const blockSettings = {
-			...baseBlockSettings,
-			supports: {
-				typography: {
-					fontSize: true,
-					lineHeight: true,
-					fontFamily: true,
-					fontStyle: true,
-					fontWeight: true,
-					letterSpacing: true,
-					textTransform: true,
-					textDecoration: true,
-					__experimentalWritingMode: true,
-					__experimentalDefaultControls: {
-						fontSize: true,
-						fontAppearance: true,
+		it( 'should stabilize experimental supports', () => {
+			const processedBlockType = processBlockType(
+				'test/block',
+				deprecatedBlockSettings
+			)( { select } );
+
+			expect( processedBlockType.deprecated[ 0 ].supports ).toMatchObject(
+				{
+					typography: {
+						fontFamily: true,
+						fontStyle: true,
+						fontWeight: true,
+						letterSpacing: true,
 						textTransform: true,
+						textDecoration: true,
+						__experimentalWritingMode: true,
 					},
-				},
-				border: {
-					color: true,
-					radius: true,
-					style: true,
-					width: true,
-					__experimentalDefaultControls: {
+					border: {
 						color: true,
 						radius: true,
 						style: true,
 						width: true,
-					},
-				},
-			},
-			deprecated: [
-				{
-					supports: {
-						typography: {
-							__experimentalFontFamily: true,
-							__experimentalFontStyle: true,
-							__experimentalFontWeight: true,
-							__experimentalLetterSpacing: true,
-							__experimentalTextTransform: true,
-							__experimentalTextDecoration: true,
-							__experimentalWritingMode: true,
-						},
-						__experimentalBorder: {
+						defaultControls: {
 							color: true,
 							radius: true,
 							style: true,
 							width: true,
-							__experimentalDefaultControls: {
-								color: true,
-								radius: true,
-								style: true,
-								width: true,
-							},
 						},
 					},
-				},
-			],
-		};
-
-		addFilter(
-			'blocks.registerBlockType',
-			'test/filterSupports',
-			( settings, name ) => {
-				if ( name === 'test/block' && settings.supports.typography ) {
-					settings.supports.typography.__experimentalFontFamily = false;
-					settings.supports.typography.__experimentalFontStyle = false;
-					settings.supports.typography.__experimentalFontWeight = false;
-					settings.supports.__experimentalBorder = { radius: false };
 				}
-				return settings;
-			}
-		);
+			);
+		} );
+
+		it( 'should reapply transformations after supports are filtered', () => {
+			addFilter(
+				'blocks.registerBlockType',
+				'test/filterSupports',
+				( settings, name ) => {
+					if (
+						name === 'test/block' &&
+						settings.supports.typography
+					) {
+						settings.supports.typography.__experimentalFontFamily = false;
+						settings.supports.typography.__experimentalFontStyle = false;
+						settings.supports.typography.__experimentalFontWeight = false;
+						settings.supports.__experimentalBorder = {
+							radius: false,
+						};
+					}
+					return settings;
+				}
+			);
+
+			const processedBlockType = processBlockType(
+				'test/block',
+				deprecatedBlockSettings
+			)( { select } );
+
+			expect( processedBlockType.deprecated[ 0 ].supports ).toMatchObject(
+				{
+					typography: {
+						fontFamily: false,
+						fontStyle: false,
+						fontWeight: false,
+						letterSpacing: true,
+						textTransform: true,
+						textDecoration: true,
+						__experimentalWritingMode: true,
+					},
+					border: {
+						color: true,
+						radius: false,
+						style: true,
+						width: true,
+						defaultControls: {
+							color: true,
+							radius: true,
+							style: true,
+							width: true,
+						},
+					},
+				}
+			);
+		} );
+	} );
+
+	it( 'should stabilize common experimental properties across all supports', () => {
+		const blockSettings = {
+			...baseBlockSettings,
+			supports: {
+				typography: {
+					fontSize: true,
+					__experimentalDefaultControls: {
+						fontSize: true,
+					},
+					__experimentalSkipSerialization: true,
+				},
+				spacing: {
+					padding: true,
+					__experimentalDefaultControls: {
+						padding: true,
+					},
+					__experimentalSkipSerialization: true,
+				},
+			},
+		};
 
 		const processedBlockType = processBlockType(
 			'test/block',
 			blockSettings
 		)( { select } );
 
-		expect( processedBlockType.deprecated[ 0 ].supports ).toEqual( {
+		expect( processedBlockType.supports ).toMatchObject( {
 			typography: {
-				fontFamily: false,
-				fontStyle: false,
-				fontWeight: false,
-				letterSpacing: true,
-				textTransform: true,
-				textDecoration: true,
-				__experimentalWritingMode: true,
+				fontSize: true,
+				defaultControls: {
+					fontSize: true,
+				},
+				skipSerialization: true,
+				__experimentalSkipSerialization: true,
 			},
+			spacing: {
+				padding: true,
+				defaultControls: {
+					padding: true,
+				},
+				skipSerialization: true,
+				__experimentalSkipSerialization: true,
+			},
+		} );
+	} );
+
+	it( 'should merge experimental and stable keys in order of definition', () => {
+		const blockSettings = {
+			...baseBlockSettings,
+			supports: {
+				__experimentalBorder: {
+					color: true,
+					radius: false,
+				},
+				border: {
+					color: false,
+					style: true,
+				},
+			},
+		};
+
+		const processedBlockType = processBlockType(
+			'test/block',
+			blockSettings
+		)( { select } );
+
+		expect( processedBlockType.supports ).toMatchObject( {
+			border: {
+				color: false,
+				radius: false,
+				style: true,
+			},
+		} );
+
+		const reversedSettings = {
+			...baseBlockSettings,
+			supports: {
+				border: {
+					color: false,
+					style: true,
+				},
+				__experimentalBorder: {
+					color: true,
+					radius: false,
+				},
+			},
+		};
+
+		const reversedProcessedType = processBlockType(
+			'test/block',
+			reversedSettings
+		)( { select } );
+
+		expect( reversedProcessedType.supports ).toMatchObject( {
 			border: {
 				color: true,
 				radius: false,
 				style: true,
-				width: true,
-				__experimentalDefaultControls: {
-					color: true,
-					radius: true,
-					style: true,
-					width: true,
+			},
+		} );
+	} );
+
+	it( 'should handle non-object config values', () => {
+		const blockSettings = {
+			...baseBlockSettings,
+			supports: {
+				__experimentalBorder: true,
+				border: false,
+			},
+		};
+
+		const processedBlockType = processBlockType(
+			'test/block',
+			blockSettings
+		)( { select } );
+
+		expect( processedBlockType.supports ).toMatchObject( {
+			border: false,
+		} );
+	} );
+
+	it( 'should not modify supports that do not need stabilization', () => {
+		const blockSettings = {
+			...baseBlockSettings,
+			supports: {
+				align: true,
+				spacing: {
+					padding: true,
+					margin: true,
 				},
+			},
+		};
+
+		const processedBlockType = processBlockType(
+			'test/block',
+			blockSettings
+		)( { select } );
+
+		expect( processedBlockType.supports ).toMatchObject( {
+			align: true,
+			spacing: {
+				padding: true,
+				margin: true,
 			},
 		} );
 	} );

--- a/packages/edit-site/src/components/global-styles/screen-block.js
+++ b/packages/edit-site/src/components/global-styles/screen-block.js
@@ -113,9 +113,8 @@ function ScreenBlock( { name, variation } ) {
 	if (
 		settingsForBlockElement?.spacing?.blockGap &&
 		blockType?.supports?.spacing?.blockGap &&
-		( blockType?.supports?.spacing?.__experimentalSkipSerialization ===
-			true ||
-			blockType?.supports?.spacing?.__experimentalSkipSerialization?.some?.(
+		( blockType?.supports?.spacing?.skipSerialization === true ||
+			blockType?.supports?.spacing?.skipSerialization?.some?.(
 				( spacingType ) => spacingType === 'blockGap'
 			) )
 	) {

--- a/packages/server-side-render/README.md
+++ b/packages/server-side-render/README.md
@@ -79,7 +79,7 @@ add_filter( 'rest_endpoints', 'add_rest_method');
 
 ### skipBlockSupportAttributes
 
-Remove attributes and style properties applied by the block supports. This prevents duplication of styles in the block wrapper and the `ServerSideRender` components. Even if certain features skip serialization to HTML markup by `__experimentalSkipSerialization`, all attributes and style properties are removed.
+Remove attributes and style properties applied by the block supports. This prevents duplication of styles in the block wrapper and the `ServerSideRender` components. Even if certain features skip serialization to HTML markup by `skipSerialization`, all attributes and style properties are removed.
 
 -   Type: `Boolean`
 -   Required: No


### PR DESCRIPTION
Part of: 
- https://github.com/WordPress/gutenberg/issues/64312

Depends on:
- https://github.com/WordPress/gutenberg/pull/66918

## What?

Extends the approach to block support stabilization in #66918 to also stabilize shared/common experimental block support flags such as:
- `__experimentalSkipSerialization`
- `__experimentalDefaultControls`

## Why?

These experimental flags have been around a long time and are extensively used throughout core blocks. It's time to stabilize them to increase confidence for extenders and better document what is possible.

## How?

- Leverages the same block type args filter as #66918 and #63401.
- Updates the filter's algorithm to stabilize shared experimental keys
- Keeps `__experimentalSkipSerialization` within the filtered results due to `wp_should_skip_block_supports_serialization` in core only checking `__experimentalSkipSerialization`. It will have to stick around in the Gutenberg filter until 6.8 is the minimum supported version.

## Next Steps

- [x] ~Update uses of `__experimentalSkipSerialization` and `__experimentalDefaultControls` within Gutenberg's block supports~
- [x] Clean up and performance checks

### Future follow-ups

- [ ] Updating core blocks within block library to use the stabilized keys.

## Testing Instructions

__Warning: This is likely going to need considerable testing!__

1. Add a range of blocks to a post that use multiple types of block supports e.g. border, color, typography etc.
2. Check that all styles for these blocks display correctly when adjusted
3. Make sure that the block has appropriate controls available within Global Styles and the block inspector
4. Modify the block.json config for all the blocks to use varying combinations of experimental and stable flags.
5. Repeat steps 2 & 3 to ensure the newly modified config is reflected and styling continues to work as before
6. Add a filter to your theme that filters the block type arg in different ways and repeat the earlier checks again
7. Add multiple filters that would switch things up at each application of a filter.
8. Confirm the end result of config stabilizations and merges are as expected.



## Screenshots or screencast <!-- if applicable -->

There should be no visual differences in blocks between this PR and trunk. Any found are regressions.
