### PR TITLE
Block Library: Fix React Compiler error for shortcuts

### DIFF
--- a/packages/block-library/src/block-keyboard-shortcuts/index.js
+++ b/packages/block-library/src/block-keyboard-shortcuts/index.js
@@ -90,22 +90,36 @@ function BlockKeyboardShortcuts() {
 				},
 			} );
 		} );
-	}, [] );
+	}, [ registerShortcut ] );
 
 	useShortcut(
 		'core/block-editor/transform-heading-to-paragraph',
 		( event ) => handleTransformHeadingAndParagraph( event, 0 )
 	);
-
-	[ 1, 2, 3, 4, 5, 6 ].forEach( ( level ) => {
-		//the loop is based off on a constant therefore
-		//the hook will execute the same way every time
-		//eslint-disable-next-line react-hooks/rules-of-hooks
-		useShortcut(
-			`core/block-editor/transform-paragraph-to-heading-${ level }`,
-			( event ) => handleTransformHeadingAndParagraph( event, level )
-		);
-	} );
+	useShortcut(
+		`core/block-editor/transform-paragraph-to-heading-1`,
+		( event ) => handleTransformHeadingAndParagraph( event, 1 )
+	);
+	useShortcut(
+		`core/block-editor/transform-paragraph-to-heading-2`,
+		( event ) => handleTransformHeadingAndParagraph( event, 2 )
+	);
+	useShortcut(
+		`core/block-editor/transform-paragraph-to-heading-3`,
+		( event ) => handleTransformHeadingAndParagraph( event, 3 )
+	);
+	useShortcut(
+		`core/block-editor/transform-paragraph-to-heading-4`,
+		( event ) => handleTransformHeadingAndParagraph( event, 4 )
+	);
+	useShortcut(
+		`core/block-editor/transform-paragraph-to-heading-5`,
+		( event ) => handleTransformHeadingAndParagraph( event, 5 )
+	);
+	useShortcut(
+		`core/block-editor/transform-paragraph-to-heading-6`,
+		( event ) => handleTransformHeadingAndParagraph( event, 6 )
+	);
 
 	return null;
 }

--- a/packages/block-library/src/block-keyboard-shortcuts/index.js
+++ b/packages/block-library/src/block-keyboard-shortcuts/index.js
@@ -97,27 +97,27 @@ function BlockKeyboardShortcuts() {
 		( event ) => handleTransformHeadingAndParagraph( event, 0 )
 	);
 	useShortcut(
-		`core/block-editor/transform-paragraph-to-heading-1`,
+		'core/block-editor/transform-paragraph-to-heading-1',
 		( event ) => handleTransformHeadingAndParagraph( event, 1 )
 	);
 	useShortcut(
-		`core/block-editor/transform-paragraph-to-heading-2`,
+		'core/block-editor/transform-paragraph-to-heading-2',
 		( event ) => handleTransformHeadingAndParagraph( event, 2 )
 	);
 	useShortcut(
-		`core/block-editor/transform-paragraph-to-heading-3`,
+		'core/block-editor/transform-paragraph-to-heading-3',
 		( event ) => handleTransformHeadingAndParagraph( event, 3 )
 	);
 	useShortcut(
-		`core/block-editor/transform-paragraph-to-heading-4`,
+		'core/block-editor/transform-paragraph-to-heading-4',
 		( event ) => handleTransformHeadingAndParagraph( event, 4 )
 	);
 	useShortcut(
-		`core/block-editor/transform-paragraph-to-heading-5`,
+		'core/block-editor/transform-paragraph-to-heading-5',
 		( event ) => handleTransformHeadingAndParagraph( event, 5 )
 	);
 	useShortcut(
-		`core/block-editor/transform-paragraph-to-heading-6`,
+		'core/block-editor/transform-paragraph-to-heading-6',
 		( event ) => handleTransformHeadingAndParagraph( event, 6 )
 	);
 


### PR DESCRIPTION
## What?
Part of #61788.

PR fixes the React Complier error for the `BlockKeyboardShortcuts` component.

## Why?
Calling hooks inside the loop breaks "Rules of Hooks".

## Testing Instructions
1. Open a post or page.
2. Insert a paragraph block.
3. Confirm you can switch it to a heading using the keyboard shortcuts - <kbd>Control</kbd>+<kbd>Alt</kbd>+<kbd>1-6</kbd>.