### PR TITLE
Block Locking: Remove edit locking for Synced Patterns

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -24,7 +24,7 @@ import useBlockDisplayInformation from '../use-block-display-information';
 import { store as blockEditorStore } from '../../store';
 
 // Entity based blocks which allow edit locking
-const ALLOWS_EDIT_LOCKING = [ 'core/block', 'core/navigation' ];
+const ALLOWS_EDIT_LOCKING = [ 'core/navigation' ];
 
 function getTemplateLockValue( lock ) {
 	// Prevents all operations.


### PR DESCRIPTION
## What?
PR removes the edit locking option for Synced Patterns.

## Why?
Synced Patterns are no longer editable in the editor canvas, so the option does nothing.

## Testing Instructions
1. Open a post or page.
2. Insert a Synced Pattern.
3. Open the block locking modal.
4. Confirm that "Restrict editing" isn't visible.

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2024-11-15 at 11 08 42](https://github.com/user-attachments/assets/c08d324f-34b7-48e2-a676-434514aaeade)

