### PR TITLE
Layout: Show vertical alignment toolbar with allowSwitching enabled

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -94,9 +94,6 @@ export default {
 		onChange,
 		layoutBlockSupport,
 	} ) {
-		if ( layoutBlockSupport?.allowSwitching ) {
-			return null;
-		}
 		const { allowVerticalAlignment = true } = layoutBlockSupport;
 		return (
 			<BlockControls group="block" __experimentalShareWithChildBlocks>


### PR DESCRIPTION
Fixes: #67016 

## What?
Enable vertical alignment toolbar to display when block layout has allowSwitching enabled and flex layout is active.

## Why?
Currently, the vertical alignment toolbar is hidden when allowSwitching is set to true, even when flex layout is selected.

## Testing Instructions
1. Go to any post
2. Add any block which have:
```
"supports": {
    "layout": {
        "allowSwitching": true
    }
}
```
3. Add the block and test the block toolbar
![image](https://github.com/user-attachments/assets/21bfa16c-be0f-49ca-9278-2d8553a80cc8)

## Screenshots or screencast 

### Before Fix:

![image](https://github.com/user-attachments/assets/22937499-e0ae-4723-9ddb-e3fde852cd57)

### After Fix:

![image](https://github.com/user-attachments/assets/c4d15b0f-3265-4bf0-a56a-5e90a5050d7b)



