### PR TITLE
Fix synced pattern editing in write mode and refactor block editing mode to reducer

### DIFF
--- a/packages/block-editor/src/components/block-title/test/index.js
+++ b/packages/block-editor/src/components/block-title/test/index.js
@@ -31,7 +31,9 @@ const blockLabelMap = {
 };
 
 jest.mock( '@wordpress/blocks', () => {
+	const actualImplementation = jest.requireActual( '@wordpress/blocks' );
 	return {
+		...actualImplementation,
 		isReusableBlock( { title } ) {
 			return title === 'Reusable Block';
 		},

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1669,7 +1669,7 @@ export const setNavigationMode =
  */
 export const __unstableSetEditorMode =
 	( mode ) =>
-	( { registry } ) => {
+	( { registry, dispatch } ) => {
 		registry.dispatch( preferencesStore ).set( 'core', 'editorTool', mode );
 
 		if ( mode === 'navigation' ) {
@@ -1677,6 +1677,8 @@ export const __unstableSetEditorMode =
 		} else if ( mode === 'edit' ) {
 			speak( __( 'You are currently in Design mode.' ) );
 		}
+
+		dispatch( { type: 'SET_EDITOR_MODE', mode } );
 	};
 
 /**

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -1669,7 +1669,7 @@ export const setNavigationMode =
  */
 export const __unstableSetEditorMode =
 	( mode ) =>
-	( { registry, dispatch } ) => {
+	( { registry } ) => {
 		registry.dispatch( preferencesStore ).set( 'core', 'editorTool', mode );
 
 		if ( mode === 'navigation' ) {
@@ -1677,8 +1677,6 @@ export const __unstableSetEditorMode =
 		} else if ( mode === 'edit' ) {
 			speak( __( 'You are currently in Design mode.' ) );
 		}
-
-		dispatch( { type: 'SET_EDITOR_MODE', mode } );
 	};
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -112,6 +112,8 @@ function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
 export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
 	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
 		state.blocks.order,
+		state.defaultBlockEditingMode,
+		state.sectionBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -109,17 +109,16 @@ function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
  *
  * @return {Object[]} Tree of block objects with only clientID and innerBlocks set.
  */
-export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
-	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
+export const getEnabledClientIdsTree = createSelector(
+	getEnabledClientIdsTreeUnmemoized,
+	( state ) => [
 		state.blocks.order,
 		state.derivedBlockEditingModes,
+		state.derivedNavModeBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,
-		select( STORE_NAME ).__unstableGetEditorMode( state ),
-		state.zoomLevel,
-		getSectionRootClientId( state ),
-	] )
+	]
 );
 
 /**

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -112,7 +112,6 @@ function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
 export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
 	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
 		state.blocks.order,
-		state.defaultBlockEditingMode,
 		state.derivedBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -114,6 +114,7 @@ export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
 		state.blocks.order,
 		state.defaultBlockEditingMode,
 		state.sectionBlockEditingModes,
+		state.patternBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -113,8 +113,7 @@ export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
 	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
 		state.blocks.order,
 		state.defaultBlockEditingMode,
-		state.sectionBlockEditingModes,
-		state.patternBlockEditingModes,
+		state.derivedBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2312,6 +2312,7 @@ const withDerivedBlockEditingModes = ( reducer ) => ( state, action ) => {
 		case 'INSERT_BLOCKS':
 		case 'RECEIVE_BLOCKS':
 		case 'REPLACE_BLOCKS':
+		case 'REPLACE_INNER_BLOCKS':
 		case 'REMOVE_BLOCKS':
 		case 'MOVE_BLOCKS_TO_POSITION':
 		case 'UPDATE_SETTINGS':

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2562,6 +2562,25 @@ export function withDerivedBlockEditingModes( reducer ) {
 				}
 				break;
 			}
+			case 'SET_HAS_CONTROLLED_INNER_BLOCKS': {
+				const newControlledBlock = nextState.blocks.tree.get(
+					action.clientId
+				);
+				const nextDerivedBlockEditingModes =
+					getDerivedBlockEditingModesUpdates( {
+						prevState: state,
+						nextState,
+						addedBlocks: [ newControlledBlock ],
+					} );
+
+				if ( nextDerivedBlockEditingModes ) {
+					return {
+						...nextState,
+						derivedBlockEditingModes: nextDerivedBlockEditingModes,
+					};
+				}
+				break;
+			}
 			case 'REPLACE_BLOCKS': {
 				const nextDerivedBlockEditingModes =
 					getDerivedBlockEditingModesUpdates( {
@@ -2624,8 +2643,8 @@ export function withDerivedBlockEditingModes( reducer ) {
 			case 'UPDATE_SETTINGS': {
 				// Recompute the entire tree if the section root changes.
 				if (
-					state.settings[ sectionRootClientIdKey ] !==
-					nextState.settings[ sectionRootClientIdKey ]
+					state?.settings?.[ sectionRootClientIdKey ] !==
+					nextState?.settings?.[ sectionRootClientIdKey ]
 				) {
 					return {
 						...nextState,

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2294,6 +2294,8 @@ function getDerivedBlockEditingModeForBlock(
 		// or blocks that are inside synced patterns with bindings.
 		const block = state.blocks.tree.get( clientId );
 
+		// Handle synced pattern content so the inner blocks of a synced pattern are
+		// properly disabled.
 		if ( syncedPatternClientIds.length ) {
 			const parentPatternClientId = findParentInClientIdsList(
 				state,
@@ -2301,7 +2303,6 @@ function getDerivedBlockEditingModeForBlock(
 				syncedPatternClientIds
 			);
 
-			// There's some special handling for synced patterns, even in nav mode.
 			if ( parentPatternClientId ) {
 				// This is a pattern nested in another pattern, it should be disabled.
 				if (
@@ -2386,12 +2387,12 @@ function getDerivedBlockEditingModeForBlock(
  * This function calculates the editing modes for each block in the tree, taking into account
  * various factors such as zoom level, navigation mode, sections, and synced patterns.
  *
- * @param {Object} state            The current state object.
- * @param {string} treeRootClientId The client ID of the root block for the tree. Defaults to an empty string.
+ * @param {Object} state        The current state object.
+ * @param {string} treeClientId The client ID of the root block for the tree. Defaults to an empty string.
  *
  * @return {Map} A Map containing the derived block editing modes, keyed by block client ID.
  */
-function getDerivedBlockEditingModesForTree( state, treeRootClientId = '' ) {
+function getDerivedBlockEditingModesForTree( state, treeClientId = '' ) {
 	const isZoomedOut =
 		state?.zoomLevel < 100 || state?.zoomLevel === 'auto-scaled';
 	const isNavMode =
@@ -2410,7 +2411,7 @@ function getDerivedBlockEditingModesForTree( state, treeRootClientId = '' ) {
 			state.blocks.byClientId?.get( clientId )?.name === 'core/block'
 	);
 
-	traverseBlockTree( state, treeRootClientId, ( block ) => {
+	traverseBlockTree( state, treeClientId, ( block ) => {
 		const _blockEditingMode = getDerivedBlockEditingModeForBlock(
 			state,
 			block.clientId,
@@ -2447,7 +2448,7 @@ function getDerivedBlockEditingModesForTree( state, treeRootClientId = '' ) {
  *
  * @return {Map|undefined} The updated derived block editing modes, or undefined if no changes were made.
  */
-function updateDerivedBlockEditingModes( {
+function getDerivedBlockEditingModesUpdates( {
 	prevState,
 	nextState,
 	addedBlocks,
@@ -2530,7 +2531,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 		switch ( action.type ) {
 			case 'REMOVE_BLOCKS': {
 				const nextDerivedBlockEditingModes =
-					updateDerivedBlockEditingModes( {
+					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
 						removedClientIds: action.clientIds,
@@ -2547,7 +2548,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 			case 'RECEIVE_BLOCKS':
 			case 'INSERT_BLOCKS': {
 				const nextDerivedBlockEditingModes =
-					updateDerivedBlockEditingModes( {
+					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
 						addedBlocks: action.blocks,
@@ -2563,7 +2564,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 			}
 			case 'REPLACE_BLOCKS': {
 				const nextDerivedBlockEditingModes =
-					updateDerivedBlockEditingModes( {
+					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
 						addedBlocks: action.blocks,
@@ -2580,7 +2581,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 			}
 			case 'REPLACE_INNER_BLOCKS': {
 				const nextDerivedBlockEditingModes =
-					updateDerivedBlockEditingModes( {
+					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
 						addedBlocks: action.blocks,
@@ -2601,7 +2602,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 			}
 			case 'MOVE_BLOCKS_TO_POSITION': {
 				const nextDerivedBlockEditingModes =
-					updateDerivedBlockEditingModes( {
+					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
 						addedBlocks: action.clientIds.map( ( clientId ) => {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2347,7 +2347,6 @@ export const withDerivedBlockEditingModes =
 					}
 				}
 
-				// Handle synced patterns.
 				const syncedPatternClientIds = Object.keys(
 					state.blocks.controlledInnerBlocks
 				).filter(

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2563,14 +2563,18 @@ export function withDerivedBlockEditingModes( reducer ) {
 				break;
 			}
 			case 'SET_HAS_CONTROLLED_INNER_BLOCKS': {
-				const newControlledBlock = nextState.blocks.tree.get(
+				const updatedBlock = nextState.blocks.tree.get(
 					action.clientId
 				);
+				// The block might have been removed.
+				if ( ! updatedBlock ) {
+					break;
+				}
 				const nextDerivedBlockEditingModes =
 					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
-						addedBlocks: [ newControlledBlock ],
+						addedBlocks: [ updatedBlock ],
 					} );
 
 				if ( nextDerivedBlockEditingModes ) {

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2105,6 +2105,93 @@ export function insertionPoint( state = null, action ) {
 	return state;
 }
 
+/**
+ * Reducer that stores synced pattern client IDs.
+ *
+ * @param {boolean} state  Current state.
+ * @param {Object}  action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function syncedPatternClientIds( state = null, action ) {
+	switch ( action.type ) {
+		case 'RESET_BLOCKS': {
+			const patternClientIds = new Set();
+			recurseBlocks( action.blocks, ( block ) => {
+				if ( block.name === 'core/block' ) {
+					patternClientIds.add( block.clientId );
+				}
+			} );
+
+			return patternClientIds;
+		}
+		case 'INSERT_BLOCKS': {
+			const patternClientIds = new Set( state.syncedPatternClientIds );
+			recurseBlocks( action.blocks, ( block ) => {
+				if ( block.name === 'core/block' ) {
+					patternClientIds.add( block.clientId );
+				}
+			} );
+			return patternClientIds;
+		}
+		case 'REMOVE_BLOCKS': {
+			const patternClientIds = new Set( state.syncedPatternClientIds );
+			for ( const removedClientId of action.clientIds ) {
+				const removedTree =
+					state.blocks.tree.get(
+						`controlled||${ removedClientId }`
+					) ?? state.blocks.tree.get( removedClientId );
+				if ( removedTree ) {
+					recurseBlocks( [ removedTree ], ( block ) => {
+						patternClientIds.delete( block.clientId );
+					} );
+				}
+			}
+			return patternClientIds;
+		}
+		case 'REPLACE_INNER_BLOCKS': {
+			const patternClientIds = new Set( state.syncedPatternClientIds );
+			const rootTree =
+				state.blocks.tree.get(
+					`controlled||${ action.rootClientId }`
+				) ?? state.blocks.tree.get( action.rootClientId );
+
+			if ( rootTree ) {
+				recurseBlocks( rootTree?.innerBlocks, ( block ) => {
+					patternClientIds.delete( block.clientId );
+				} );
+			}
+			recurseBlocks( action.blocks, ( block ) => {
+				if ( block.name === 'core/block' ) {
+					patternClientIds.add( block.clientId );
+				}
+			} );
+			return syncedPatternClientIds;
+		}
+		case 'REPLACE_BLOCKS': {
+			const patternClientIds = new Set( state.syncedPatternClientIds );
+			for ( const removedClientId of action.clientIds ) {
+				const removedTree =
+					state.blocks.tree.get(
+						`controlled||${ removedClientId }`
+					) ?? state.blocks.tree.get( removedClientId );
+				if ( removedTree ) {
+					recurseBlocks( [ removedTree ], ( block ) => {
+						patternClientIds.delete( block.clientId );
+					} );
+				}
+			}
+			recurseBlocks( action.blocks, ( block ) => {
+				if ( block.name === 'core/block' ) {
+					patternClientIds.add( block.clientId );
+				}
+			} );
+			return patternClientIds;
+		}
+	}
+	return state;
+}
+
 const combinedReducers = combineReducers( {
 	blocks,
 	isDragging,
@@ -2138,6 +2225,7 @@ const combinedReducers = combineReducers( {
 	registeredInserterMediaCategories,
 	hoveredBlockClientId,
 	zoomLevel,
+	syncedPatternClientIds,
 } );
 
 function recurseBlocks( _blocks, callback ) {
@@ -2175,7 +2263,8 @@ function isWithinSection( state, clientId ) {
 	return false;
 }
 
-function getPatternBlockEditingModes( state, patternClientIds ) {
+function getPatternBlockEditingModes( state ) {
+	const patternClientIds = state.syncedPatternClientIds;
 	if ( ! patternClientIds?.size ) {
 		return new Map();
 	}
@@ -2229,132 +2318,21 @@ const withPatternBlockEditingModes = ( reducer ) => {
 		}
 
 		switch ( action.type ) {
-			case 'RESET_BLOCKS': {
-				const patternClientIds = new Set();
-				recurseBlocks( action.blocks, ( block ) => {
-					if ( block.name === 'core/block' ) {
-						patternClientIds.add( block.clientId );
-					}
-				} );
-
-				return {
-					...nextState,
-					patternBlockEditingModes: getPatternBlockEditingModes(
-						nextState,
-						patternClientIds
-					),
-					patternClientIds,
-				};
-			}
+			case 'RESET_BLOCKS':
+			case 'REMOVE_BLOCKS':
+			case 'REPLACE_INNER_BLOCKS':
+			case 'REPLACE_BLOCKS':
 			case 'INSERT_BLOCKS': {
-				const patternClientIds = state.patternClientIds
-					? new Set( state.patternClientIds )
-					: new Set();
-				recurseBlocks( action.blocks, ( block ) => {
-					if ( block.name === 'core/block' ) {
-						patternClientIds.add( block.clientId );
-					}
-				} );
-
 				return {
 					...nextState,
-					patternBlockEditingModes: getPatternBlockEditingModes(
-						nextState,
-						patternClientIds
-					),
-					patternClientIds,
-				};
-			}
-			case 'REMOVE_BLOCKS': {
-				const patternClientIds = state.patternClientIds
-					? new Set( state.patternClientIds )
-					: new Set();
-				for ( const removedClientId of action.clientIds ) {
-					const removedTree =
-						state.blocks.tree.get(
-							`controlled||${ removedClientId }`
-						) ?? state.blocks.tree.get( removedClientId );
-					if ( removedTree ) {
-						recurseBlocks( [ removedTree ], ( block ) => {
-							patternClientIds.delete( block.clientId );
-						} );
-					}
-				}
-
-				return {
-					...nextState,
-					patternBlockEditingModes: getPatternBlockEditingModes(
-						nextState,
-						patternClientIds
-					),
-					patternClientIds,
-				};
-			}
-			case 'REPLACE_INNER_BLOCKS': {
-				const patternClientIds = state.patternClientIds
-					? new Set( state.patternClientIds )
-					: new Set();
-
-				const rootTree =
-					state.blocks.tree.get(
-						`controlled||${ action.rootClientId }`
-					) ?? state.blocks.tree.get( action.rootClientId );
-
-				if ( rootTree ) {
-					recurseBlocks( rootTree?.innerBlocks, ( block ) => {
-						patternClientIds.delete( block.clientId );
-					} );
-				}
-				recurseBlocks( action.blocks, ( block ) => {
-					if ( block.name === 'core/block' ) {
-						patternClientIds.add( block.clientId );
-					}
-				} );
-
-				return {
-					...nextState,
-					patternBlockEditingModes: getPatternBlockEditingModes(
-						nextState,
-						patternClientIds
-					),
-					patternClientIds,
-				};
-			}
-			case 'REPLACE_BLOCKS': {
-				const patternClientIds = state.patternClientIds
-					? new Set( state.patternClientIds )
-					: new Set();
-				for ( const removedClientId of action.clientIds ) {
-					const removedTree =
-						state.blocks.tree.get(
-							`controlled||${ removedClientId }`
-						) ?? state.blocks.tree.get( removedClientId );
-					if ( removedTree ) {
-						recurseBlocks( [ removedTree ], ( block ) => {
-							patternClientIds.delete( block.clientId );
-						} );
-					}
-				}
-				recurseBlocks( action.blocks, ( block ) => {
-					if ( block.name === 'core/block' ) {
-						patternClientIds.add( block.clientId );
-					}
-				} );
-
-				return {
-					...nextState,
-					patternBlockEditingModes: getPatternBlockEditingModes(
-						nextState,
-						patternClientIds
-					),
-					patternClientIds,
+					patternBlockEditingModes:
+						getPatternBlockEditingModes( nextState ),
 				};
 			}
 		}
 
-		// If there's no change, the patternClientIds and patternBlockEditingModes
-		// from the previous state need to be preserved.
-		nextState.patternClientIds = state?.patternClientIds ?? new Set();
+		// If there's no change, the patternBlockEditingModes from the previous
+		// state need to be preserved.
 		nextState.patternBlockEditingModes =
 			state?.patternBlockEditingModes ?? new Map();
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2246,8 +2246,8 @@ const withDerivedBlockEditingModes = ( reducer ) => ( state, action ) => {
 						'contentOnly'
 					);
 
-					// Content is only editable in navigation mode.
-					if ( isNavMode ) {
+					// Content is only editable when not zoomed out.
+					if ( ! isZoomedOut ) {
 						recurseInnerBlocks(
 							nextState,
 							sectionClientId,
@@ -2303,10 +2303,14 @@ const withDerivedBlockEditingModes = ( reducer ) => ( state, action ) => {
 					if ( ! isZoomedOut && ! isNavMode ) {
 						derivedBlockEditingModes.set( clientId, 'contentOnly' );
 					}
+					// Zoomed out doesn't allow content editing, so don't try enabling
+					// inner blocks.
 					recurseInnerBlocks( nextState, clientId, ( block ) => {
 						// If an inner block has bindings, it should be set to contentOnly.
 						// Else it should be set to disabled.
-						if ( hasBindings( block ) ) {
+						// Also check for zoomed out - content shouldn't be editable when
+						// zoomed out, but to be rigorous, still disable inner blocks.
+						if ( ! isZoomedOut && hasBindings( block ) ) {
 							derivedBlockEditingModes.set(
 								block.clientId,
 								'contentOnly'

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3041,8 +3041,28 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
-			if ( state.derivedBlockEditingModes?.has( clientId ) ) {
+			const isNavMode =
+				select( preferencesStore )?.get( 'core', 'editorTool' ) ===
+				'navigation';
+
+			// If the editor is currently not in navigation mode, check if the clientId
+			// has an editing mode set in the regular derived map.
+			// There may be an editing mode set here for synced patterns or in zoomed out
+			// mode.
+			if (
+				! isNavMode &&
+				state.derivedBlockEditingModes?.has( clientId )
+			) {
 				return state.derivedBlockEditingModes.get( clientId );
+			}
+
+			// If the editor *is* in navigation mode, the block editing mode states
+			// are stored in the derivedNavModeBlockEditingModes map.
+			if (
+				isNavMode &&
+				state.derivedNavModeBlockEditingModes?.has( clientId )
+			) {
+				return state.derivedNavModeBlockEditingModes.get( clientId );
 			}
 
 			// In normal mode, consider that an explicitely set editing mode takes over.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3053,7 +3053,7 @@ export const getBlockEditingMode = createRegistrySelector(
 
 			// In normal mode, top level is default mode.
 			if ( clientId === '' ) {
-				return state.defaultBlockEditingMode ?? 'default';
+				return 'default';
 			}
 
 			const rootClientId = getBlockRootClientId( state, clientId );
@@ -3069,8 +3069,7 @@ export const getBlockEditingMode = createRegistrySelector(
 			}
 			// Otherwise, check if there's an ancestor that is contentOnly
 			const parentMode = getBlockEditingMode( state, rootClientId );
-			const defaultMode = state.defaultBlockEditingMode ?? 'default';
-			return parentMode === 'contentOnly' ? defaultMode : parentMode;
+			return parentMode === 'contentOnly' ? 'default' : parentMode;
 		}
 );
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3074,6 +3074,10 @@ export const getBlockEditingMode = createRegistrySelector(
 				return 'disabled';
 			}
 
+			if ( state?.patternBlockEditingModes?.has( clientId ) ) {
+				return state?.patternBlockEditingModes.get( clientId );
+			}
+
 			const editorMode = __unstableGetEditorMode( state );
 			if ( editorMode === 'navigation' ) {
 				const sectionRootClientId = getSectionRootClientId( state );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3041,15 +3041,8 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
-			if (
-				! isZoomOut( state ) &&
-				state?.patternBlockEditingModes?.has( clientId )
-			) {
-				return state?.patternBlockEditingModes.get( clientId );
-			}
-
-			if ( state.sectionBlockEditingModes?.has( clientId ) ) {
-				return state.sectionBlockEditingModes.get( clientId );
+			if ( state.derivedBlockEditingModes?.has( clientId ) ) {
+				return state.derivedBlockEditingModes.get( clientId );
 			}
 
 			// In normal mode, consider that an explicitely set editing mode takes over.

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -129,6 +129,7 @@ describe( 'private selectors', () => {
 		getBlockEditingMode.registry = {
 			select: jest.fn( () => ( {
 				hasContentRoleAttribute,
+				get,
 			} ) ),
 		};
 		__unstableGetEditorMode.registry = {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4046,7 +4046,52 @@ describe( 'state', () => {
 				'group-1': 'contentOnly', // Section root.
 				'group-2': 'contentOnly', // Section.
 				'paragraph-1': 'disabled', // Content block in section.
-				'pattern-1': 'disabled',
+				'pattern-1': 'disabled', // All other blocks outside section.
+				'paragraph-2': 'disabled',
+				'paragraph-3': 'disabled',
+				'pattern-2': 'disabled',
+				'paragraph-4': 'disabled',
+			};
+
+			Object.entries( expectedBlockEditingModes ).forEach(
+				( [ blockId, expectedMode ] ) => {
+					expect( derivedBlockEditingModes.get( blockId ) ).toBe(
+						expectedMode
+					);
+				}
+			);
+		} );
+		it( 'handles changes to the section root in navigation mode', () => {
+			select.mockImplementation( ( storeName ) => {
+				if ( storeName === preferencesStore ) {
+					return {
+						get: jest.fn( () => 'navigation' ),
+					};
+				}
+				return select( storeName );
+			} );
+
+			const action = {
+				type: 'UPDATE_SETTINGS',
+			};
+
+			function reducer() {
+				return {
+					...initialState,
+					settings: { [ sectionRootClientIdKey ]: 'group-1' },
+				};
+			}
+
+			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
+				reducer
+			)( initialState, action );
+
+			const expectedBlockEditingModes = {
+				'': 'disabled',
+				'group-1': 'contentOnly', // Section root.
+				'group-2': 'contentOnly', // Section.
+				'paragraph-1': 'contentOnly', // Content block in section.
+				'pattern-1': 'disabled', // All other blocks outside section.
 				'paragraph-2': 'disabled',
 				'paragraph-3': 'disabled',
 				'pattern-2': 'disabled',

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -12,7 +12,7 @@ import {
 	createBlock,
 	privateApis,
 } from '@wordpress/blocks';
-import { select } from '@wordpress/data';
+import { combineReducers, select } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
@@ -41,6 +41,7 @@ import {
 	blockEditingModes,
 	openedBlockSettingsMenu,
 	expandedBlock,
+	zoomLevel,
 	withDerivedBlockEditingModes,
 } from '../reducer';
 
@@ -3570,270 +3571,19 @@ describe( 'state', () => {
 	} );
 
 	describe( 'withDerivedBlockEditingModes', () => {
-		function createOrderFromTree( tree ) {
-			const order = new Map();
-			function processBlocks( _blocks, parentClientId = '' ) {
-				if ( _blocks?.length ) {
-					const innerOrder = [];
-					_blocks.forEach( ( block ) => {
-						// Add this block's clientId to parent's array
-						innerOrder.push( block.clientId );
-
-						const innerBlocks =
-							tree.get( `controlled||${ block.clientId }` )
-								?.innerBlocks ??
-							tree.get( block.clientId )?.innerBlocks;
-
-						// Process inner blocks recursively
-						processBlocks( innerBlocks, block.clientId );
-					} );
-					order.set( parentClientId, innerOrder );
-				}
-			}
-			processBlocks( tree.get( '' ).innerBlocks, '' );
-			return order;
-		}
-
-		function createByClientIdFromTree( tree ) {
-			const byClientId = new Map();
-			tree.forEach( ( block, clientId ) => {
-				if (
-					clientId.startsWith( 'controlled||' ) ||
-					clientId === ''
-				) {
-					return;
-				}
-				byClientId.set( clientId, {
-					...block,
-					innerBlocks: undefined,
-				} );
-			} );
-			return byClientId;
-		}
-
-		function createParentsFromTree( tree ) {
-			const parents = new Map();
-			function processBlock( block, parentClientId = '' ) {
-				parents.set( block.clientId, parentClientId );
-
-				const innerBlocks =
-					tree.get( `controlled||${ block.clientId }` )
-						?.innerBlocks ??
-					tree.get( block.clientId )?.innerBlocks;
-
-				// Process inner blocks recursively
-				if ( innerBlocks?.length ) {
-					innerBlocks.forEach( ( innerBlock ) => {
-						processBlock( innerBlock, block.clientId );
-					} );
-				}
-			}
-			tree.get( '' ).innerBlocks.forEach( ( block ) => {
-				processBlock( block, '' );
-			} );
-			return parents;
-		}
-
-		function createControlledInnerBlocksFromTree( tree ) {
-			const controlledInnerBlocks = {};
-			for ( const [ key ] of tree ) {
-				if ( key.startsWith( 'controlled||' ) ) {
-					// Extract the clientId from the key
-					const clientId = key.split( '||' )[ 1 ];
-					controlledInnerBlocks[ clientId ] = true;
-				}
-			}
-			return controlledInnerBlocks;
-		}
-
-		const tree = new Map(
-			Object.entries( {
-				'': {
-					innerBlocks: [
-						{
-							name: 'core/group',
-							clientId: 'group-1',
-							attributes: {},
-							innerBlocks: [
-								{
-									name: 'core/paragraph',
-									clientId: 'paragraph-1',
-									attributes: {},
-									innerBlocks: [],
-								},
-							],
-						},
-						{
-							name: 'core/block',
-							clientId: 'pattern-1',
-							attributes: {},
-							innerBlocks: [],
-						},
-					],
-				},
-				'group-1': {
-					name: 'core/group',
-					clientId: 'group-1',
-					attributes: {},
-					innerBlocks: [
-						{
-							name: 'core/group',
-							clientId: 'group-2',
-							attributes: {},
-							innerBlocks: [
-								{
-									name: 'core/paragraph',
-									clientId: 'paragraph-1',
-									attributes: {},
-									innerBlocks: [],
-								},
-							],
-						},
-					],
-				},
-				'group-2': {
-					name: 'core/group',
-					clientId: 'group-2',
-					attributes: {},
-					innerBlocks: [
-						{
-							name: 'core/paragraph',
-							clientId: 'paragraph-1',
-							attributes: {},
-							innerBlocks: [],
-						},
-					],
-				},
-				'paragraph-1': {
-					name: 'core/paragraph',
-					clientId: 'paragraph-1',
-					attributes: {},
-					innerBlocks: [],
-				},
-				'paragraph-2': {
-					name: 'core/paragraph',
-					clientId: 'paragraph-2',
-					attributes: {
-						metadata: {
-							bindings: {
-								__default: {
-									source: 'core/pattern-overrides',
-								},
-							},
-						},
-					},
-					innerBlocks: [],
-				},
-				'paragraph-3': {
-					name: 'core/paragraph',
-					clientId: 'paragraph-3',
-					attributes: {},
-					innerBlocks: [],
-				},
-				'paragraph-4': {
-					name: 'core/paragraph',
-					clientId: 'paragraph-4',
-					attributes: {
-						metadata: {
-							bindings: {
-								__default: {
-									source: 'core/pattern-overrides',
-								},
-							},
-						},
-					},
-					innerBlocks: [],
-				},
-				'pattern-1': {
-					name: 'core/block',
-					clientId: 'pattern-1',
-					attributes: {},
-					innerBlocks: [],
-				},
-				'controlled||pattern-1': {
-					innerBlocks: [
-						{
-							name: 'core/paragraph',
-							clientId: 'paragraph-2',
-							attributes: {
-								metadata: {
-									bindings: {
-										__default: {
-											source: 'core/pattern-overrides',
-										},
-									},
-								},
-							},
-							innerBlocks: [],
-						},
-						{
-							name: 'core/paragraph',
-							clientId: 'paragraph-3',
-							attributes: {},
-							innerBlocks: [],
-						},
-						{
-							name: 'core/block',
-							clientId: 'pattern-2',
-							attributes: {},
-							innerBlocks: [
-								{
-									name: 'core/paragraph',
-									clientId: 'paragraph-4',
-									attributes: {
-										metadata: {
-											bindings: {
-												__default: {
-													source: 'core/pattern-overrides',
-												},
-											},
-										},
-									},
-									innerBlocks: [],
-								},
-							],
-						},
-					],
-				},
-				'pattern-2': {
-					name: 'core/block',
-					clientId: 'pattern-2',
-					attributes: {},
-					innerBlocks: [],
-				},
-				'controlled||pattern-2': {
-					innerBlocks: [
-						{
-							name: 'core/paragraph',
-							clientId: 'paragraph-4',
-							attributes: {
-								metadata: {
-									bindings: {
-										__default: {
-											source: 'core/pattern-overrides',
-										},
-									},
-								},
-							},
-							innerBlocks: [],
-						},
-					],
-				},
+		const testReducer = withDerivedBlockEditingModes(
+			combineReducers( {
+				blocks,
+				settings,
+				zoomLevel,
 			} )
 		);
 
-		const initialState = {
-			settings: { [ sectionRootClientIdKey ]: '' },
-			zoomLevel: 100,
-			blocks: {
-				tree,
-				order: createOrderFromTree( tree ),
-				byClientId: createByClientIdFromTree( tree ),
-				parents: createParentsFromTree( tree ),
-				controlledInnerBlocks:
-					createControlledInnerBlocksFromTree( tree ),
-			},
-		};
+		function dispatchActions( actions, reducer, initialState = {} ) {
+			return actions.reduce( ( _state, action ) => {
+				return reducer( _state, action );
+			}, initialState );
+		}
 
 		beforeEach( () => {
 			isContentBlock.mockImplementation(
@@ -3845,266 +3595,590 @@ describe( 'state', () => {
 			isContentBlock.mockRestore();
 		} );
 
-		it( 'returns expected block editing modes when switching from zoomed in to zoomed out', () => {
-			select.mockImplementation( ( storeName ) => {
-				if ( storeName === preferencesStore ) {
-					return {
-						get: jest.fn( () => 'edit' ),
-					};
-				}
-				return select( storeName );
+		describe( 'edit mode', () => {
+			let initialState;
+			beforeAll( () => {
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'edit' ),
+						};
+					}
+					return select( storeName );
+				} );
+
+				initialState = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								[ sectionRootClientIdKey ]: '',
+							},
+						},
+						{
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-1',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-1',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-2',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													clientId: 'paragraph-2',
+													attributes: {},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer
+				);
 			} );
 
-			const action = {
-				type: 'SET_ZOOM_LEVEL',
-				value: 'auto-scaled',
-			};
-
-			function reducer() {
-				return {
-					...initialState,
-					zoomLevel: action.value,
-				};
-			}
-
-			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
-				reducer
-			)( initialState, action );
-
-			const expectedBlockEditingModes = {
-				'': 'contentOnly', // Section root.
-				'group-1': 'contentOnly', // Section block.
-				'group-2': 'disabled',
-				'paragraph-1': 'disabled',
-				'pattern-1': 'contentOnly', // Section block.
-				'paragraph-2': 'disabled',
-				'paragraph-3': 'disabled',
-				'pattern-2': 'disabled',
-				'paragraph-4': 'disabled',
-			};
-
-			Object.entries( expectedBlockEditingModes ).forEach(
-				( [ blockId, expectedMode ] ) => {
-					expect( derivedBlockEditingModes.get( blockId ) ).toBe(
-						expectedMode
-					);
-				}
-			);
-
-			select.mockImplementation( ( storeName ) => {
-				if ( storeName === preferencesStore ) {
-					return {
-						get: jest.fn( () => 'navigation' ),
-					};
-				}
-				return select( storeName );
+			afterAll( () => {
+				select.mockRestore();
 			} );
 
-			const {
-				derivedBlockEditingModes: navigationDerivedBlockEditingModes,
-			} = withDerivedBlockEditingModes( reducer )( initialState, action );
-
-			Object.entries( expectedBlockEditingModes ).forEach(
-				( [ blockId, expectedMode ] ) => {
-					expect(
-						navigationDerivedBlockEditingModes.get( blockId )
-					).toBe( expectedMode );
-				}
-			);
+			it( 'returns the no block editing modes when zoomed out / navigation mode are not active and there are no synced patterns', () => {
+				expect( initialState.derivedBlockEditingModes ).toEqual(
+					new Map()
+				);
+			} );
 		} );
 
-		it( 'returns expected pattern block editing modes when switching from zoomed out to zoomed in', () => {
-			select.mockImplementation( ( storeName ) => {
-				if ( storeName === preferencesStore ) {
-					return {
-						get: jest.fn( () => 'edit' ),
-					};
-				}
-				return select( storeName );
+		describe( 'synced patterns', () => {
+			let initialState;
+			beforeAll( () => {
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'edit' ),
+						};
+					}
+					return select( storeName );
+				} );
+
+				// Simulates how the editor typically inserts controlled blocks,
+				// - first the pattern is inserted with no inner blocks.
+				// - next the pattern is marked as a controlled block.
+				// - finally, once the inner blocks of the pattern are received, they're inserted.
+				// This process is repeated for the two patterns in this test.
+				initialState = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								[ sectionRootClientIdKey ]: '',
+							},
+						},
+						{
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-1',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-1',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-2',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													clientId: 'paragraph-2',
+													attributes: {},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+						{
+							type: 'INSERT_BLOCKS',
+							rootClientId: '',
+							blocks: [
+								{
+									name: 'core/block',
+									clientId: 'root-pattern',
+									attributes: {},
+									innerBlocks: [],
+								},
+							],
+						},
+						{
+							type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+							clientId: 'root-pattern',
+							hasControlledInnerBlocks: true,
+						},
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'root-pattern',
+							blocks: [
+								{
+									name: 'core/block',
+									clientId: 'nested-pattern',
+									attributes: {},
+									innerBlocks: [],
+								},
+								{
+									name: 'core/paragraph',
+									clientId: 'pattern-paragraph',
+									attributes: {},
+									innerBlocks: [],
+								},
+								{
+									name: 'core/group',
+									clientId: 'pattern-group',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId:
+												'pattern-paragraph-with-overrides',
+											attributes: {
+												metadata: {
+													bindings: {
+														__default:
+															'core/pattern-overrides',
+													},
+												},
+											},
+											innerBlocks: [],
+										},
+									],
+								},
+							],
+						},
+						{
+							type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+							clientId: 'nested-pattern',
+							hasControlledInnerBlocks: true,
+						},
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'nested-pattern',
+							blocks: [
+								{
+									name: 'core/paragraph',
+									clientId: 'nested-paragraph',
+									attributes: {},
+									innerBlocks: [],
+								},
+								{
+									name: 'core/group',
+									clientId: 'nested-group',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId:
+												'nested-paragraph-with-overrides',
+											attributes: {
+												metadata: {
+													bindings: {
+														__default:
+															'core/pattern-overrides',
+													},
+												},
+											},
+											innerBlocks: [],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer,
+					initialState
+				);
 			} );
 
-			const action = {
-				type: 'RESET_ZOOM_LEVEL',
-			};
+			afterAll( () => {
+				select.mockRestore();
+			} );
 
-			const initialStateZoomedOut = {
-				...initialState,
-				zoomLevel: 'auto-scaled',
-			};
+			it( 'returns the expected block editing modes for synced patterns', () => {
+				// Only the parent pattern and its own children that have bindings
+				// are in contentOnly mode. All other blocks are disabled.
+				expect( initialState.derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'root-pattern': 'contentOnly',
+							'pattern-paragraph': 'disabled',
+							'pattern-group': 'disabled',
+							'pattern-paragraph-with-overrides': 'contentOnly',
+							'nested-pattern': 'disabled',
+							'nested-paragraph': 'disabled',
+							'nested-group': 'disabled',
+							'nested-paragraph-with-overrides': 'disabled',
+						} )
+					)
+				);
+			} );
 
-			function reducer() {
-				return {
-					...initialStateZoomedOut,
-					zoomLevel: 100,
-				};
-			}
+			it( 'removes block editing modes when synced patterns are removed', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'REMOVE_BLOCKS',
+							clientIds: [ 'root-pattern' ],
+						},
+					],
+					testReducer,
+					initialState
+				);
 
-			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
-				reducer
-			)( initialStateZoomedOut, action );
+				expect( derivedBlockEditingModes ).toEqual( new Map() );
+			} );
 
-			const expectedBlockEditingModes = {
-				'': undefined,
-				'group-1': undefined,
-				'group-2': undefined,
-				'paragraph-1': undefined,
-				'pattern-1': 'contentOnly', // Pattern block.
-				'paragraph-2': 'contentOnly', // Pattern override.
-				'paragraph-3': 'disabled', // Non-overridden block in pattern.
-				'pattern-2': 'disabled', // Nested pattern.
-				'paragraph-4': 'disabled', // Block in nested pattern.
-			};
+			it( 'returns the expected block editing modes for synced patterns when switching to navigation mode', () => {
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'navigation' ),
+						};
+					}
+					return select( storeName );
+				} );
 
-			Object.entries( expectedBlockEditingModes ).forEach(
-				( [ blockId, expectedMode ] ) => {
-					expect( derivedBlockEditingModes.get( blockId ) ).toBe(
-						expectedMode
-					);
-				}
-			);
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'SET_EDITOR_MODE',
+							mode: 'navigation',
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section.
+							'paragraph-1': 'contentOnly', // Content block in section.
+							'group-2': 'disabled',
+							'paragraph-2': 'contentOnly', // Content block in section.
+							'root-pattern': 'contentOnly', // Pattern and section.
+							'pattern-paragraph': 'disabled',
+							'pattern-group': 'disabled',
+							'pattern-paragraph-with-overrides': 'contentOnly', // Pattern child with bindings.
+							'nested-pattern': 'disabled',
+							'nested-paragraph': 'disabled',
+							'nested-group': 'disabled',
+							'nested-paragraph-with-overrides': 'disabled',
+						} )
+					)
+				);
+
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'edit' ),
+						};
+					}
+					return select( storeName );
+				} );
+			} );
+
+			it( 'returns the expected block editing modes for synced patterns when switching to zoomed out mode', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'SET_ZOOM_LEVEL',
+							zoom: 'auto-scaled',
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section.
+							'paragraph-1': 'disabled',
+							'group-2': 'disabled',
+							'paragraph-2': 'disabled',
+							'root-pattern': 'contentOnly', // Pattern and section.
+							'pattern-paragraph': 'disabled',
+							'pattern-group': 'disabled',
+							'pattern-paragraph-with-overrides': 'disabled',
+							'nested-pattern': 'disabled',
+							'nested-paragraph': 'disabled',
+							'nested-group': 'disabled',
+							'nested-paragraph-with-overrides': 'disabled',
+						} )
+					)
+				);
+			} );
 		} );
 
-		it( 'returns expected block editing modes when switching from edit to navigation mode', () => {
-			select.mockImplementation( ( storeName ) => {
-				if ( storeName === preferencesStore ) {
-					return {
-						get: jest.fn( () => 'navigation' ),
-					};
-				}
-				return select( storeName );
+		describe( 'navigation mode', () => {
+			let initialState;
+
+			beforeAll( () => {
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'navigation' ),
+						};
+					}
+					return select( storeName );
+				} );
+
+				initialState = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								[ sectionRootClientIdKey ]: '',
+							},
+						},
+						{
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-1',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-1',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-2',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													clientId: 'paragraph-2',
+													attributes: {},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer
+				);
 			} );
 
-			const action = {
-				type: 'SET_EDITOR_MODE',
-				mode: 'navigation',
-			};
+			afterAll( () => {
+				select.mockRestore();
+			} );
 
-			function reducer() {
-				return {
-					...initialState,
-				};
-			}
+			it( 'returns the expected block editing modes', () => {
+				expect( initialState.derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'contentOnly', // Content block in section.
+							'group-2': 'disabled', // Non-content block in section.
+							'paragraph-2': 'contentOnly', // Content block in section.
+						} )
+					)
+				);
+			} );
 
-			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
-				reducer
-			)( initialState, action );
+			it( 'handles changes to the section root', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								[ sectionRootClientIdKey ]: 'group-1',
+							},
+						},
+					],
+					testReducer,
+					initialState
+				);
 
-			const expectedBlockEditingModes = {
-				'': 'contentOnly', // Section root.
-				'group-1': 'contentOnly', // Section block.
-				'group-2': 'disabled', // Non-content block in section.
-				'paragraph-1': 'contentOnly', // Content block in section.
-				'pattern-1': 'contentOnly', // Section block.
-				'paragraph-2': 'contentOnly', // Pattern override.
-				'paragraph-3': 'disabled', // Non-overridden block in pattern.
-				'pattern-2': 'disabled', // Nested pattern.
-				'paragraph-4': 'disabled', // Block in nested pattern.
-			};
-
-			Object.entries( expectedBlockEditingModes ).forEach(
-				( [ blockId, expectedMode ] ) => {
-					expect( derivedBlockEditingModes.get( blockId ) ).toBe(
-						expectedMode
-					);
-				}
-			);
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'disabled',
+							'group-1': 'contentOnly',
+							'paragraph-1': 'contentOnly',
+							'group-2': 'contentOnly',
+							'paragraph-2': 'contentOnly',
+						} )
+					)
+				);
+			} );
 		} );
 
-		it( 'handles changes to the section root in zoomed out mode', () => {
-			select.mockImplementation( ( storeName ) => {
-				if ( storeName === preferencesStore ) {
-					return {
-						get: jest.fn( () => 'edit' ),
-					};
-				}
-				return select( storeName );
+		describe( 'zoom out mode', () => {
+			let initialState;
+
+			beforeAll( () => {
+				initialState = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								[ sectionRootClientIdKey ]: '',
+							},
+						},
+						{
+							type: 'SET_ZOOM_LEVEL',
+							zoom: 'auto-scaled',
+						},
+						{
+							type: 'RESET_BLOCKS',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-1',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-1',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-2',
+											attributes: {},
+											innerBlocks: [
+												{
+													name: 'core/paragraph',
+													clientId: 'paragraph-2',
+													attributes: {},
+													innerBlocks: [],
+												},
+											],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer
+				);
 			} );
 
-			const initialZoomedOutState = {
-				...initialState,
-				zoomLevel: 'auto-scaled',
-			};
-
-			const action = {
-				type: 'UPDATE_SETTINGS',
-				mode: 'navigation',
-			};
-
-			function reducer() {
-				return {
-					...initialZoomedOutState,
-					settings: { [ sectionRootClientIdKey ]: 'group-1' },
-				};
-			}
-
-			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
-				reducer
-			)( initialZoomedOutState, action );
-
-			const expectedBlockEditingModes = {
-				'': 'disabled',
-				'group-1': 'contentOnly', // Section root.
-				'group-2': 'contentOnly', // Section.
-				'paragraph-1': 'disabled', // Content block in section.
-				'pattern-1': 'disabled', // All other blocks outside section.
-				'paragraph-2': 'disabled',
-				'paragraph-3': 'disabled',
-				'pattern-2': 'disabled',
-				'paragraph-4': 'disabled',
-			};
-
-			Object.entries( expectedBlockEditingModes ).forEach(
-				( [ blockId, expectedMode ] ) => {
-					expect( derivedBlockEditingModes.get( blockId ) ).toBe(
-						expectedMode
-					);
-				}
-			);
-		} );
-		it( 'handles changes to the section root in navigation mode', () => {
-			select.mockImplementation( ( storeName ) => {
-				if ( storeName === preferencesStore ) {
-					return {
-						get: jest.fn( () => 'navigation' ),
-					};
-				}
-				return select( storeName );
+			it( 'returns the expected block editing modes', () => {
+				expect( initialState.derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'disabled',
+							'group-2': 'disabled',
+							'paragraph-2': 'disabled',
+						} )
+					)
+				);
 			} );
 
-			const action = {
-				type: 'UPDATE_SETTINGS',
-			};
+			it( 'overrides navigation mode', () => {
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'navigation' ),
+						};
+					}
+					return select( storeName );
+				} );
 
-			function reducer() {
-				return {
-					...initialState,
-					settings: { [ sectionRootClientIdKey ]: 'group-1' },
-				};
-			}
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'SET_EDITOR_MODE',
+							mode: 'navigation',
+						},
+					],
+					testReducer,
+					initialState
+				);
 
-			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
-				reducer
-			)( initialState, action );
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'disabled',
+							'group-2': 'disabled',
+							'paragraph-2': 'disabled',
+						} )
+					)
+				);
 
-			const expectedBlockEditingModes = {
-				'': 'disabled',
-				'group-1': 'contentOnly', // Section root.
-				'group-2': 'contentOnly', // Section.
-				'paragraph-1': 'contentOnly', // Content block in section.
-				'pattern-1': 'disabled', // All other blocks outside section.
-				'paragraph-2': 'disabled',
-				'paragraph-3': 'disabled',
-				'pattern-2': 'disabled',
-				'paragraph-4': 'disabled',
-			};
+				select.mockImplementation( ( storeName ) => {
+					if ( storeName === preferencesStore ) {
+						return {
+							get: jest.fn( () => 'edit' ),
+						};
+					}
+					return select( storeName );
+				} );
+			} );
 
-			Object.entries( expectedBlockEditingModes ).forEach(
-				( [ blockId, expectedMode ] ) => {
-					expect( derivedBlockEditingModes.get( blockId ) ).toBe(
-						expectedMode
-					);
-				}
-			);
+			it( 'handles changes to the section root', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'UPDATE_SETTINGS',
+							settings: {
+								[ sectionRootClientIdKey ]: 'group-1',
+							},
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'disabled',
+							'group-1': 'contentOnly', // New section root.
+							'paragraph-1': 'contentOnly', // Section block.
+							'group-2': 'contentOnly', // Section block.
+							'paragraph-2': 'disabled',
+						} )
+					)
+				);
+			} );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3867,14 +3867,15 @@ describe( 'state', () => {
 				};
 			}
 
-			const { defaultBlockEditingMode, derivedBlockEditingModes } =
-				withDerivedBlockEditingModes( reducer )( initialState, action );
+			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
+				reducer
+			)( initialState, action );
 
 			const expectedBlockEditingModes = {
 				'': 'contentOnly', // Section root.
 				'group-1': 'contentOnly', // Section block.
-				'group-2': undefined,
-				'paragraph-1': undefined,
+				'group-2': 'disabled',
+				'paragraph-1': 'disabled',
 				'pattern-1': 'contentOnly', // Section block.
 				'paragraph-2': 'disabled',
 				'paragraph-3': 'disabled',
@@ -3889,7 +3890,6 @@ describe( 'state', () => {
 					);
 				}
 			);
-			expect( defaultBlockEditingMode ).toBe( 'disabled' );
 
 			select.mockImplementation( ( storeName ) => {
 				if ( storeName === preferencesStore ) {
@@ -3901,7 +3901,6 @@ describe( 'state', () => {
 			} );
 
 			const {
-				defaultBlockEditingMode: navigationDefaultBlockEditingMode,
 				derivedBlockEditingModes: navigationDerivedBlockEditingModes,
 			} = withDerivedBlockEditingModes( reducer )( initialState, action );
 
@@ -3912,7 +3911,6 @@ describe( 'state', () => {
 					).toBe( expectedMode );
 				}
 			);
-			expect( navigationDefaultBlockEditingMode ).toBe( 'disabled' );
 		} );
 
 		it( 'returns expected pattern block editing modes when switching from zoomed out to zoomed in', () => {
@@ -3941,11 +3939,9 @@ describe( 'state', () => {
 				};
 			}
 
-			const { defaultBlockEditingMode, derivedBlockEditingModes } =
-				withDerivedBlockEditingModes( reducer )(
-					initialStateZoomedOut,
-					action
-				);
+			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
+				reducer
+			)( initialStateZoomedOut, action );
 
 			const expectedBlockEditingModes = {
 				'': undefined,
@@ -3966,7 +3962,6 @@ describe( 'state', () => {
 					);
 				}
 			);
-			expect( defaultBlockEditingMode ).toBe( 'default' );
 		} );
 
 		it( 'returns expected block editing modes when switching from edit to navigation mode', () => {
@@ -3990,13 +3985,14 @@ describe( 'state', () => {
 				};
 			}
 
-			const { defaultBlockEditingMode, derivedBlockEditingModes } =
-				withDerivedBlockEditingModes( reducer )( initialState, action );
+			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
+				reducer
+			)( initialState, action );
 
 			const expectedBlockEditingModes = {
 				'': 'contentOnly', // Section root.
 				'group-1': 'contentOnly', // Section block.
-				'group-2': undefined, // Non-content block in section.
+				'group-2': 'disabled', // Non-content block in section.
 				'paragraph-1': 'contentOnly', // Content block in section.
 				'pattern-1': 'contentOnly', // Section block.
 				'paragraph-2': 'contentOnly', // Pattern override.
@@ -4012,7 +4008,6 @@ describe( 'state', () => {
 					);
 				}
 			);
-			expect( defaultBlockEditingMode ).toBe( 'disabled' );
 		} );
 
 		it( 'handles changes to the section root in zoomed out mode', () => {
@@ -4042,18 +4037,16 @@ describe( 'state', () => {
 				};
 			}
 
-			const { defaultBlockEditingMode, derivedBlockEditingModes } =
-				withDerivedBlockEditingModes( reducer )(
-					initialZoomedOutState,
-					action
-				);
+			const { derivedBlockEditingModes } = withDerivedBlockEditingModes(
+				reducer
+			)( initialZoomedOutState, action );
 
 			const expectedBlockEditingModes = {
-				'': undefined,
+				'': 'disabled',
 				'group-1': 'contentOnly', // Section root.
 				'group-2': 'contentOnly', // Section.
-				'paragraph-1': undefined, // Content block in section.
-				'pattern-1': undefined,
+				'paragraph-1': 'disabled', // Content block in section.
+				'pattern-1': 'disabled',
 				'paragraph-2': 'disabled',
 				'paragraph-3': 'disabled',
 				'pattern-2': 'disabled',
@@ -4067,7 +4060,6 @@ describe( 'state', () => {
 					);
 				}
 			);
-			expect( defaultBlockEditingMode ).toBe( 'disabled' );
 		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3655,7 +3655,7 @@ describe( 'state', () => {
 				select.mockRestore();
 			} );
 
-			it( 'returns the no block editing modes when zoomed out / navigation mode are not active and there are no synced patterns', () => {
+			it( 'returns no block editing modes when zoomed out / navigation mode are not active and there are no synced patterns', () => {
 				expect( initialState.derivedBlockEditingModes ).toEqual(
 					new Map()
 				);
@@ -4016,6 +4016,104 @@ describe( 'state', () => {
 				);
 			} );
 
+			it( 'removes block editing modes when blocks are removed', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'REMOVE_BLOCKS',
+							clientIds: [ 'group-2' ],
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly',
+							'group-1': 'contentOnly',
+							'paragraph-1': 'contentOnly',
+						} )
+					)
+				);
+			} );
+
+			it( 'updates block editing modes when new blocks are inserted', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'INSERT_BLOCKS',
+							rootClientId: '',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-3',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-3',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-4',
+											attributes: {},
+											innerBlocks: [],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'contentOnly', // Content block in section.
+							'group-2': 'disabled', // Non-content block in section.
+							'paragraph-2': 'contentOnly', // Content block in section.
+							'group-3': 'contentOnly', // New section block.
+							'paragraph-3': 'contentOnly', // New content block in section.
+							'group-4': 'disabled', // Non-content block in section.
+						} )
+					)
+				);
+			} );
+
+			it( 'updates block editing modes when blocks are moved to a new position', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'MOVE_BLOCKS_TO_POSITION',
+							clientIds: [ 'group-2' ],
+							fromRootClientId: 'group-1',
+							toRootClientId: '',
+						},
+					],
+					testReducer,
+					initialState
+				);
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'contentOnly', // Content block in section.
+							'group-2': 'contentOnly', // New section block.
+							'paragraph-2': 'contentOnly', // Still a content block in a section.
+						} )
+					)
+				);
+			} );
+
 			it( 'handles changes to the section root', () => {
 				const { derivedBlockEditingModes } = dispatchActions(
 					[
@@ -4151,6 +4249,104 @@ describe( 'state', () => {
 					}
 					return select( storeName );
 				} );
+			} );
+
+			it( 'removes block editing modes when blocks are removed', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'REMOVE_BLOCKS',
+							clientIds: [ 'group-2' ],
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly',
+							'group-1': 'contentOnly',
+							'paragraph-1': 'disabled',
+						} )
+					)
+				);
+			} );
+
+			it( 'updates block editing modes when new blocks are inserted', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'INSERT_BLOCKS',
+							rootClientId: '',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'group-3',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'paragraph-3',
+											attributes: {},
+											innerBlocks: [],
+										},
+										{
+											name: 'core/group',
+											clientId: 'group-4',
+											attributes: {},
+											innerBlocks: [],
+										},
+									],
+								},
+							],
+						},
+					],
+					testReducer,
+					initialState
+				);
+
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'disabled',
+							'group-2': 'disabled',
+							'paragraph-2': 'disabled',
+							'group-3': 'contentOnly', // New section block.
+							'paragraph-3': 'disabled',
+							'group-4': 'disabled',
+						} )
+					)
+				);
+			} );
+
+			it( 'updates block editing modes when blocks are moved to a new position', () => {
+				const { derivedBlockEditingModes } = dispatchActions(
+					[
+						{
+							type: 'MOVE_BLOCKS_TO_POSITION',
+							clientIds: [ 'group-2' ],
+							fromRootClientId: 'group-1',
+							toRootClientId: '',
+						},
+					],
+					testReducer,
+					initialState
+				);
+				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'': 'contentOnly', // Section root.
+							'group-1': 'contentOnly', // Section block.
+							'paragraph-1': 'disabled',
+							'group-2': 'contentOnly', // New section block.
+							'paragraph-2': 'disabled',
+						} )
+					)
+				);
 			} );
 
 			it( 'handles changes to the section root', () => {

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3866,7 +3866,10 @@ describe( 'state', () => {
 					return select( storeName );
 				} );
 
-				const { derivedBlockEditingModes } = dispatchActions(
+				const {
+					derivedBlockEditingModes,
+					derivedNavModeBlockEditingModes,
+				} = dispatchActions(
 					[
 						{
 							type: 'SET_EDITOR_MODE',
@@ -3878,6 +3881,21 @@ describe( 'state', () => {
 				);
 
 				expect( derivedBlockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'root-pattern': 'contentOnly', // Pattern and section.
+							'pattern-paragraph': 'disabled',
+							'pattern-group': 'disabled',
+							'pattern-paragraph-with-overrides': 'contentOnly', // Pattern child with bindings.
+							'nested-pattern': 'disabled',
+							'nested-paragraph': 'disabled',
+							'nested-group': 'disabled',
+							'nested-paragraph-with-overrides': 'disabled',
+						} )
+					)
+				);
+
+				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
 							'': 'contentOnly', // Section root.
@@ -4003,7 +4021,7 @@ describe( 'state', () => {
 			} );
 
 			it( 'returns the expected block editing modes', () => {
-				expect( initialState.derivedBlockEditingModes ).toEqual(
+				expect( initialState.derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
 							'': 'contentOnly', // Section root.
@@ -4017,7 +4035,7 @@ describe( 'state', () => {
 			} );
 
 			it( 'removes block editing modes when blocks are removed', () => {
-				const { derivedBlockEditingModes } = dispatchActions(
+				const { derivedNavModeBlockEditingModes } = dispatchActions(
 					[
 						{
 							type: 'REMOVE_BLOCKS',
@@ -4028,7 +4046,7 @@ describe( 'state', () => {
 					initialState
 				);
 
-				expect( derivedBlockEditingModes ).toEqual(
+				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
 							'': 'contentOnly',
@@ -4040,7 +4058,7 @@ describe( 'state', () => {
 			} );
 
 			it( 'updates block editing modes when new blocks are inserted', () => {
-				const { derivedBlockEditingModes } = dispatchActions(
+				const { derivedNavModeBlockEditingModes } = dispatchActions(
 					[
 						{
 							type: 'INSERT_BLOCKS',
@@ -4072,7 +4090,7 @@ describe( 'state', () => {
 					initialState
 				);
 
-				expect( derivedBlockEditingModes ).toEqual(
+				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
 							'': 'contentOnly', // Section root.
@@ -4089,7 +4107,7 @@ describe( 'state', () => {
 			} );
 
 			it( 'updates block editing modes when blocks are moved to a new position', () => {
-				const { derivedBlockEditingModes } = dispatchActions(
+				const { derivedNavModeBlockEditingModes } = dispatchActions(
 					[
 						{
 							type: 'MOVE_BLOCKS_TO_POSITION',
@@ -4101,7 +4119,7 @@ describe( 'state', () => {
 					testReducer,
 					initialState
 				);
-				expect( derivedBlockEditingModes ).toEqual(
+				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
 							'': 'contentOnly', // Section root.
@@ -4115,7 +4133,7 @@ describe( 'state', () => {
 			} );
 
 			it( 'handles changes to the section root', () => {
-				const { derivedBlockEditingModes } = dispatchActions(
+				const { derivedNavModeBlockEditingModes } = dispatchActions(
 					[
 						{
 							type: 'UPDATE_SETTINGS',
@@ -4128,7 +4146,7 @@ describe( 'state', () => {
 					initialState
 				);
 
-				expect( derivedBlockEditingModes ).toEqual(
+				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
 							'': 'disabled',

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -9,14 +9,12 @@ import {
 import { RawHTML } from '@wordpress/element';
 import { symbol } from '@wordpress/icons';
 import { select, dispatch } from '@wordpress/data';
-import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
  */
 import * as selectors from '../selectors';
 import { store } from '../';
-import { sectionRootClientIdKey } from '../private-keys';
 import { lock } from '../../lock-unlock';
 
 const {
@@ -4469,13 +4467,6 @@ describe( 'getBlockEditingMode', () => {
 		blockEditingModes: new Map( [] ),
 	};
 
-	const navigationModeStateWithRootSection = {
-		...baseState,
-		settings: {
-			[ sectionRootClientIdKey ]: 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', // The group is the "main" container
-		},
-	};
-
 	const hasContentRoleAttribute = jest.fn( () => false );
 
 	const fauxPrivateAPIs = {};
@@ -4487,10 +4478,6 @@ describe( 'getBlockEditingMode', () => {
 	getBlockEditingMode.registry = {
 		select: jest.fn( () => fauxPrivateAPIs ),
 	};
-
-	afterEach( () => {
-		dispatch( preferencesStore ).set( 'core', 'editorTool', undefined );
-	} );
 
 	it( 'should return default by default', () => {
 		expect(
@@ -4613,99 +4600,5 @@ describe( 'getBlockEditingMode', () => {
 		expect(
 			getBlockEditingMode( state, 'b3247f75-fd94-4fef-97f9-5bfd162cc416' )
 		).toBe( 'contentOnly' );
-	} );
-
-	describe( 'navigation mode', () => {
-		const writeModeExperiment = window.__experimentalEditorWriteMode;
-		beforeAll( () => {
-			window.__experimentalEditorWriteMode = true;
-		} );
-		afterAll( () => {
-			window.__experimentalEditorWriteMode = writeModeExperiment;
-		} );
-		it( 'in navigation mode, the root section container is default', () => {
-			dispatch( preferencesStore ).set(
-				'core',
-				'editorTool',
-				'navigation'
-			);
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337'
-				)
-			).toBe( 'default' );
-		} );
-
-		it( 'in navigation mode, anything outside the section container is disabled', () => {
-			dispatch( preferencesStore ).set(
-				'core',
-				'editorTool',
-				'navigation'
-			);
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'6cf70164-9097-4460-bcbf-200560546988'
-				)
-			).toBe( 'disabled' );
-		} );
-
-		it( 'in navigation mode, sections are contentOnly', () => {
-			dispatch( preferencesStore ).set(
-				'core',
-				'editorTool',
-				'navigation'
-			);
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'b26fc763-417d-4f01-b81c-2ec61e14a972'
-				)
-			).toBe( 'contentOnly' );
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f'
-				)
-			).toBe( 'contentOnly' );
-		} );
-
-		it( 'in navigation mode, blocks with content attributes within sections are contentOnly', () => {
-			dispatch( preferencesStore ).set(
-				'core',
-				'editorTool',
-				'navigation'
-			);
-			hasContentRoleAttribute.mockReturnValueOnce( true );
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'b3247f75-fd94-4fef-97f9-5bfd162cc416'
-				)
-			).toBe( 'contentOnly' );
-
-			hasContentRoleAttribute.mockReturnValueOnce( true );
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c'
-				)
-			).toBe( 'contentOnly' );
-		} );
-
-		it( 'in navigation mode, blocks without content attributes within sections are disabled', () => {
-			dispatch( preferencesStore ).set(
-				'core',
-				'editorTool',
-				'navigation'
-			);
-			expect(
-				getBlockEditingMode(
-					navigationModeStateWithRootSection,
-					'9b9c5c3f-2e46-4f02-9e14-9fed515b958s'
-				)
-			).toBe( 'disabled' );
-		} );
 	} );
 } );

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4468,15 +4468,16 @@ describe( 'getBlockEditingMode', () => {
 	};
 
 	const hasContentRoleAttribute = jest.fn( () => false );
+	const get = jest.fn( () => 'edit' );
 
-	const fauxPrivateAPIs = {};
+	const mockedSelectors = { get };
 
-	lock( fauxPrivateAPIs, {
+	lock( mockedSelectors, {
 		hasContentRoleAttribute,
 	} );
 
 	getBlockEditingMode.registry = {
-		select: jest.fn( () => fauxPrivateAPIs ),
+		select: jest.fn( () => mockedSelectors ),
 	};
 
 	it( 'should return default by default', () => {

--- a/packages/block-library/src/missing/test/edit.native.js
+++ b/packages/block-library/src/missing/test/edit.native.js
@@ -10,7 +10,6 @@ import { Text } from 'react-native';
 import { BottomSheet, Icon } from '@wordpress/components';
 import { help, plugins } from '@wordpress/icons';
 import { storeConfig } from '@wordpress/block-editor';
-jest.mock( '@wordpress/blocks' );
 jest.mock( '@wordpress/block-editor/src/store/selectors' );
 
 /**

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -503,6 +503,10 @@ _Returns_
 
 -   `Array|string`: A list of blocks or a string, depending on `handlerMode`.
 
+### privateApis
+
+Undocumented declaration.
+
 ### rawHandler
 
 Converts an HTML string to known blocks.

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -1,3 +1,9 @@
+/**
+ * Internal dependencies
+ */
+import { lock } from '../lock-unlock';
+import { isContentBlock } from './utils';
+
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
 // and `save`. The transforms specification allows converting one blocktype to
@@ -169,3 +175,6 @@ export {
 	__EXPERIMENTAL_ELEMENTS,
 	__EXPERIMENTAL_PATHS_WITH_OVERRIDE,
 } from './constants';
+
+export const privateApis = {};
+lock( privateApis, { isContentBlock } );

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -14,6 +14,7 @@ import {
 	getBlockLabel,
 	__experimentalSanitizeBlockAttributes,
 	getBlockAttributesNamesByRole,
+	isContentBlock,
 } from '../utils';
 
 const noop = () => {};
@@ -380,5 +381,42 @@ describe( 'getBlockAttributesNamesByRole', () => {
 		expect(
 			getBlockAttributesNamesByRole( 'core/test-block-2', 'content' )
 		).toEqual( [] );
+	} );
+} );
+
+describe( 'isContentBlock', () => {
+	it( 'returns true if the block has a content role attribute', () => {
+		registerBlockType( 'core/test-content-block', {
+			attributes: {
+				content: {
+					type: 'string',
+					role: 'content',
+				},
+				align: {
+					type: 'string',
+				},
+			},
+			save: noop,
+			category: 'text',
+			title: 'test content block',
+		} );
+		expect( isContentBlock( 'core/test-content-block' ) ).toBe( true );
+	} );
+
+	it( 'returns false if the block does not have a content role attribute', () => {
+		registerBlockType( 'core/test-non-content-block', {
+			attributes: {
+				content: {
+					type: 'string',
+				},
+				align: {
+					type: 'string',
+				},
+			},
+			save: noop,
+			category: 'text',
+			title: 'test non-content block',
+		} );
+		expect( isContentBlock( 'core/test-non-content-block' ) ).toBe( false );
 	} );
 } );

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -370,6 +370,18 @@ export const __experimentalGetBlockAttributesNamesByRole = ( ...args ) => {
 	return getBlockAttributesNamesByRole( ...args );
 };
 
+export function isContentBlock( name ) {
+	const attributes = getBlockType( name )?.attributes;
+
+	return !! Object.keys( attributes )?.some( ( attributeKey ) => {
+		const attribute = attributes[ attributeKey ];
+		return (
+			attribute?.role === 'content' ||
+			attribute?.__experimentalRole === 'content'
+		);
+	} );
+}
+
 /**
  * Return a new object with the specified keys omitted.
  *

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -227,6 +227,12 @@ test.describe( 'Pattern Overrides', () => {
 	} );
 
 	test.describe( 'block editing modes', () => {
+		test.beforeEach( async ( { page } ) => {
+			await page.addInitScript( () => {
+				window.__experimentalEditorWriteMode = true;
+			} );
+		} );
+
 		test( 'blocks with bindings in a synced pattern are editable, and all other blocks are disabled', async ( {
 			admin,
 			editor,

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -226,6 +226,315 @@ test.describe( 'Pattern Overrides', () => {
 		} );
 	} );
 
+	test.describe( 'block editing modes', () => {
+		test( 'blocks with bindings in a synced pattern are editable, and all other blocks are disabled', async ( {
+			admin,
+			editor,
+			page,
+			requestUtils,
+		} ) => {
+			const content = `
+			<!-- wp:paragraph {"metadata":{"name":"Pattern Overrides","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+			<p>Pattern Overrides</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:paragraph {"metadata":{"name":"Post Meta Binding","bindings":{"content":{"source":"core/post-meta","args":{"key":"Post Meta Binding"}}}}} -->
+			<p>Post Meta Binding</p>
+			<!-- /wp:paragraph -->
+			<!-- wp:paragraph {"metadata":{"name":"No Overrides or Binding"}} -->
+			<p>No Overrides or Binding</p>
+			<!-- /wp:paragraph -->
+			`;
+
+			const { id } = await requestUtils.createBlock( {
+				title: 'Pattern',
+				content,
+				status: 'publish',
+			} );
+
+			await admin.visitSiteEditor( {
+				postId: 'emptytheme//index',
+				postType: 'wp_template',
+				canvas: 'edit',
+			} );
+
+			await editor.setContent( '' );
+
+			await editor.insertBlock( {
+				name: 'core/block',
+				attributes: { ref: id },
+			} );
+
+			const patternBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Pattern',
+			} );
+			const paragraphs = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			const blockWithOverrides = paragraphs.filter( {
+				hasText: 'Pattern Overrides',
+			} );
+			const blockWithBindings = paragraphs.filter( {
+				hasText: 'Post Meta Binding',
+			} );
+			const blockWithoutOverridesOrBindings = paragraphs.filter( {
+				hasText: 'No Overrides or Binding',
+			} );
+
+			await test.step( 'Zoomed in / Design mode', async () => {
+				await editor.switchEditorTool( 'Design' );
+				// In zoomed in and design mode the pattern block and child blocks
+				// with bindings are editable.
+				await expect( patternBlock ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithOverrides ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			await test.step( 'Zoomed in / Write mode - pattern as a section', async () => {
+				await editor.switchEditorTool( 'Write' );
+				// The pattern block is still editable as a section.
+				await expect( patternBlock ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				// Child blocks of the pattern with bindings are editable.
+				await expect( blockWithOverrides ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			await test.step( 'Zoomed out / Write mode - pattern as a section', async () => {
+				await page.getByLabel( 'Zoom Out' ).click();
+				// In zoomed out only the pattern block is editable, as in this scenario it's a section.
+				await expect( patternBlock ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithOverrides ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			await test.step( 'Zoomed out / Design mode - pattern as a section', async () => {
+				await editor.switchEditorTool( 'Design' );
+				// In zoomed out only the pattern block is editable, as in this scenario it's a section.
+				await expect( patternBlock ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithOverrides ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			// Zoom out and group the pattern.
+			await page.getByLabel( 'Zoom Out' ).click();
+			await editor.selectBlocks( patternBlock );
+			await editor.clickBlockOptionsMenuItem( 'Group' );
+
+			await test.step( 'Zoomed in / Write mode - pattern nested in a section', async () => {
+				await editor.switchEditorTool( 'Write' );
+				// The pattern block is not inert as it has editable content, but it shouldn't be selectable.
+				// TODO: find a way to test that the block is not selectable.
+				await expect( patternBlock ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				// Child blocks of the pattern are editable as normal.
+				await expect( blockWithOverrides ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).not.toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			await test.step( 'Zoomed out / Write mode - pattern nested in a section', async () => {
+				await page.getByLabel( 'Zoom Out' ).click();
+				// None of the pattern is editable in zoomed out when nested in a section.
+				await expect( patternBlock ).toHaveAttribute( 'inert', 'true' );
+				await expect( blockWithOverrides ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			await test.step( 'Zoomed out / Design mode - pattern nested in a section', async () => {
+				await editor.switchEditorTool( 'Design' );
+				// None of the pattern is editable in zoomed out when nested in a section.
+				await expect( patternBlock ).toHaveAttribute( 'inert', 'true' );
+				await expect( blockWithOverrides ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+		} );
+
+		test( 'disables editing of nested patterns', async ( {
+			page,
+			admin,
+			requestUtils,
+			editor,
+		} ) => {
+			const paragraphName = 'Editable paragraph';
+			const headingName = 'Editable heading';
+			const innerPattern = await requestUtils.createBlock( {
+				title: 'Inner Pattern',
+				content: `<!-- wp:paragraph {"metadata":{"name":"${ paragraphName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+	<p>Inner paragraph</p>
+	<!-- /wp:paragraph -->`,
+				status: 'publish',
+			} );
+			const outerPattern = await requestUtils.createBlock( {
+				title: 'Outer Pattern',
+				content: `<!-- wp:heading {"metadata":{"name":"${ headingName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
+	<h2 class="wp-block-heading">Outer heading</h2>
+	<!-- /wp:heading -->
+	<!-- wp:block {"ref":${ innerPattern.id },"content":{"${ paragraphName }":{"content":"Inner paragraph (edited)"}}} /-->`,
+				status: 'publish',
+			} );
+
+			await admin.createNewPost();
+
+			await editor.insertBlock( {
+				name: 'core/block',
+				attributes: { ref: outerPattern.id },
+			} );
+
+			// Make an edit to the outer pattern heading.
+			await editor.canvas
+				.getByRole( 'document', { name: 'Block: Heading' } )
+				.fill( 'Outer heading (edited)' );
+
+			const postId = await editor.publishPost();
+
+			// Check the pattern has the correct attributes.
+			await expect.poll( editor.getBlocks ).toMatchObject( [
+				{
+					name: 'core/block',
+					attributes: {
+						ref: outerPattern.id,
+						content: {
+							[ headingName ]: {
+								content: 'Outer heading (edited)',
+							},
+						},
+					},
+					innerBlocks: [],
+				},
+			] );
+			// Check it renders correctly.
+			const headingBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Heading',
+			} );
+			const paragraphBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} );
+			await expect( headingBlock ).toHaveText( 'Outer heading (edited)' );
+			await expect( headingBlock ).not.toHaveAttribute( 'inert', 'true' );
+			await expect( paragraphBlock ).toHaveText(
+				'Inner paragraph (edited)'
+			);
+			await expect( paragraphBlock ).toHaveAttribute( 'inert', 'true' );
+
+			// Edit the outer pattern.
+			await editor.selectBlocks(
+				editor.canvas
+					.getByRole( 'document', { name: 'Block: Pattern' } )
+					.first()
+			);
+			await editor.showBlockToolbar();
+			await page
+				.getByRole( 'toolbar', { name: 'Block tools' } )
+				.getByRole( 'button', { name: 'Edit original' } )
+				.click();
+
+			// The inner paragraph should be editable in the pattern focus mode.
+			await editor.selectBlocks(
+				editor.canvas
+					.getByRole( 'document', { name: 'Block: Pattern' } )
+					.first()
+			);
+			await expect(
+				editor.canvas.getByRole( 'document', {
+					name: 'Block: Paragraph',
+				} ),
+				'The inner paragraph should be editable'
+			).not.toHaveAttribute( 'inert', 'true' );
+
+			// Visit the post on the frontend.
+			await page.goto( `/?p=${ postId }` );
+
+			await expect(
+				page.getByRole( 'heading', { level: 2 } )
+			).toHaveText( 'Outer heading (edited)' );
+			await expect(
+				page.getByText( 'Inner paragraph (edited)' )
+			).toBeVisible();
+		} );
+	} );
+
 	test( 'retains override values when converting a pattern block to regular blocks', async ( {
 		page,
 		admin,
@@ -423,107 +732,6 @@ test.describe( 'Pattern Overrides', () => {
 		await previewPage.reload();
 		await expect( buttonLink ).toHaveAttribute( 'target', '' );
 		await expect( buttonLink ).toHaveAttribute( 'rel', /^\s*nofollow\s*$/ );
-	} );
-
-	test( 'disables editing of nested patterns', async ( {
-		page,
-		admin,
-		requestUtils,
-		editor,
-	} ) => {
-		const paragraphName = 'Editable paragraph';
-		const headingName = 'Editable heading';
-		const innerPattern = await requestUtils.createBlock( {
-			title: 'Inner Pattern',
-			content: `<!-- wp:paragraph {"metadata":{"name":"${ paragraphName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
-<p>Inner paragraph</p>
-<!-- /wp:paragraph -->`,
-			status: 'publish',
-		} );
-		const outerPattern = await requestUtils.createBlock( {
-			title: 'Outer Pattern',
-			content: `<!-- wp:heading {"metadata":{"name":"${ headingName }","bindings":{"__default":{"source":"core/pattern-overrides"}}}} -->
-<h2 class="wp-block-heading">Outer heading</h2>
-<!-- /wp:heading -->
-<!-- wp:block {"ref":${ innerPattern.id },"content":{"${ paragraphName }":{"content":"Inner paragraph (edited)"}}} /-->`,
-			status: 'publish',
-		} );
-
-		await admin.createNewPost();
-
-		await editor.insertBlock( {
-			name: 'core/block',
-			attributes: { ref: outerPattern.id },
-		} );
-
-		// Make an edit to the outer pattern heading.
-		await editor.canvas
-			.getByRole( 'document', { name: 'Block: Heading' } )
-			.fill( 'Outer heading (edited)' );
-
-		const postId = await editor.publishPost();
-
-		// Check the pattern has the correct attributes.
-		await expect.poll( editor.getBlocks ).toMatchObject( [
-			{
-				name: 'core/block',
-				attributes: {
-					ref: outerPattern.id,
-					content: {
-						[ headingName ]: {
-							content: 'Outer heading (edited)',
-						},
-					},
-				},
-				innerBlocks: [],
-			},
-		] );
-		// Check it renders correctly.
-		const headingBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Heading',
-		} );
-		const paragraphBlock = editor.canvas.getByRole( 'document', {
-			name: 'Block: Paragraph',
-		} );
-		await expect( headingBlock ).toHaveText( 'Outer heading (edited)' );
-		await expect( headingBlock ).not.toHaveAttribute( 'inert', 'true' );
-		await expect( paragraphBlock ).toHaveText( 'Inner paragraph (edited)' );
-		await expect( paragraphBlock ).toHaveAttribute( 'inert', 'true' );
-
-		// Edit the outer pattern.
-		await editor.selectBlocks(
-			editor.canvas
-				.getByRole( 'document', { name: 'Block: Pattern' } )
-				.first()
-		);
-		await editor.showBlockToolbar();
-		await page
-			.getByRole( 'toolbar', { name: 'Block tools' } )
-			.getByRole( 'button', { name: 'Edit original' } )
-			.click();
-
-		// The inner paragraph should be editable in the pattern focus mode.
-		await editor.selectBlocks(
-			editor.canvas
-				.getByRole( 'document', { name: 'Block: Pattern' } )
-				.first()
-		);
-		await expect(
-			editor.canvas.getByRole( 'document', {
-				name: 'Block: Paragraph',
-			} ),
-			'The inner paragraph should be editable'
-		).not.toHaveAttribute( 'inert', 'true' );
-
-		// Visit the post on the frontend.
-		await page.goto( `/?p=${ postId }` );
-
-		await expect( page.getByRole( 'heading', { level: 2 } ) ).toHaveText(
-			'Outer heading (edited)'
-		);
-		await expect(
-			page.getByText( 'Inner paragraph (edited)' )
-		).toBeVisible();
 	} );
 
 	test( 'resets overrides after clicking the reset button', async ( {


### PR DESCRIPTION
## What?
Supercedes some previous attempts #66919, #66949, and #65408!
Fixes #66424

In Write Mode, parts of synced patterns that are supposed to be non-editable are editable. This PR fixes the problem, plus undertakes some refactoring of how block editing mode works due to some performance caused by so much logic being in the `getBlockEditingMode` selector.

## Why?
This bug happens because Write Mode overrides the blockEditingMode of a synced pattern's inner blocks.

Pattern blocks try calling `setBlockEditingMode` for child blocks imperatively (in the pattern block's edit function). This does set the correct block editing modes in the block editor store, but when write mode is active the `getBlockEditingMode` selector returns early with a different value.

#65408 tried to fix this by updating the `getBlockEditingMode` selector, but it cause a performance hit. 

## How?
This PR fixes the issue by moving the pattern block editing modes to the block editor store, so that it can work harmoniously with the way Write Mode and Zoom Out mode determine the block editing mode.

The PR also undertakes a refactor of how block editing mode works for zoomed out and write mode to improve performance. The `getBlockEditingMode` select is called a lot (including recursively), so any code added there can cause performance regressions.

The summary of the changes is:
- Remove the zoom out and write mode handling from the `getBlockEditingMode` selector
- Introduce a new `withDerivedBlockEditingModes` higher order reducer, it calculates a derivedBlockEditingMode state for any actions that might require this is recomputed using a few other functions:
    - `getDerivedBlockEditingModesForTree` traverses a block tree calculating the block editing modes for all the blocks in that tree, returning them in a `Map`. This can be used for the entire block tree or just a part of the block tree.
    - `getDerivedBlockEditingModeForBlock` calculates the block editing mode for a single client id. Called by `getDerivedBlockEditingModesForTree` on each block in the tree.
    - `getDerivedBlockEditingModesUpdates` used for actions that add/remove a partial subset of blocks. It should only return a value when there are block editing mode changes, meaning the store state doesn't unnecessarily change.
    - Plus a few utility functions - `traverseBlockTree`, `getBlockTreeBlock`, `findParentInClientIdsList`, `hasBindings`.
    - Also adds a new `isContentBlock` private function to the blocks package.
    
It's quite a lot of code, so I'm open to suggestions on how to structure it.
    
## Testing Instructions
1. Create a synced pattern (Pattern A) with two paragraphs
2. Edit the pattern and enable overrides for one of the patterns
3. Insert the pattern into a template
4. Check that you can only edit the overridden paragraph, the other paragraph should be disabled
5. Enable Zoomed Out mode, you shouldn't be able to edit any of the pattern content, since zoomed out doesn't allow content editing
6. Leave Zoomed Out mode and enable Write mode, check that you can only edit the overridden paragraph in the pattern
7. Create a second pattern (Pattern B) similar to the first one, it should have a block that's overridden and a regular block
8. Edit Pattern A and insert Pattern B into it.
9. Insert Pattern A into a template again, or go back to where you inserted it before
10. Check that you can't edit any of Pattern B from the instance of Pattern A, it should all be disabled

In addition to this, give a good test to both zoomed out and write mode, move blocks around, insert and remove stuff and make sure there are no issues. 😄 

## Screenshots or screencast <!-- if applicable -->
#### Before

https://github.com/user-attachments/assets/49cd5420-aa00-4437-be43-1d1f16002514

#### After

https://github.com/user-attachments/assets/feca05d3-9fb7-404a-8e5a-406e27b4f023
