### PR TITLE
Video Block: Prevent fullscreen video cropping

### DIFF
--- a/packages/block-library/src/video/style.scss
+++ b/packages/block-library/src/video/style.scss
@@ -8,7 +8,7 @@
 
 	@supports (position: sticky) {
 		[poster] {
-			object-fit: cover;
+			object-fit: contain;
 		}
 	}
 


### PR DESCRIPTION
Fixes: #67027 


## What?

This PR resolves an issue where videos in fullscreen mode may appear cropped due to the `object-fit: cover` style applied to video elements. The style for fullscreen videos has been overridden with `object-fit: contain`, ensuring the video maintains its aspect ratio and fits the screen dimensions.


## Why?

This fix is necessary to address a usability issue where video content in fullscreen mode is partially cropped. The cropping occurs because the current styles apply `object-fit: cover` to video elements, including those displayed in fullscreen mode.


## Testing Instructions

1. Open a page or post containing a video block with a poster image.
2. Play the video and click the fullscreen button.
3. Observe that the video expands to fullscreen without being cropped, maintaining its original aspect ratio when doing   
`object-fit: contain` but gets cropped a little when doing `object-fit: cover`.

## Screencast 


### With object-fit: cover;

https://github.com/user-attachments/assets/93e2a4a2-c7c0-4e48-8081-d3611c18c5dd



### With object-fit: contain;

https://github.com/user-attachments/assets/15e83b02-9f0b-4c83-8783-ce70cedbee8f



