### PR TITLE
DataViews: Reduce the size of action button in Grid layout

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -57,6 +57,7 @@ interface ItemActionsProps< Item > {
 interface CompactItemActionsProps< Item > {
 	item: Item;
 	actions: Action< Item >[];
+	isSmall?: boolean;
 }
 
 interface PrimaryActionsProps< Item > {
@@ -214,7 +215,13 @@ export default function ItemActions< Item >( {
 	}, [ actions, item ] );
 
 	if ( isCompact ) {
-		return <CompactItemActions item={ item } actions={ eligibleActions } />;
+		return (
+			<CompactItemActions
+				item={ item }
+				actions={ eligibleActions }
+				isSmall
+			/>
+		);
 	}
 
 	if ( hasOnlyOneActionAndIsPrimary( primaryActions, actions ) ) {
@@ -250,12 +257,13 @@ export default function ItemActions< Item >( {
 function CompactItemActions< Item >( {
 	item,
 	actions,
+	isSmall,
 }: CompactItemActionsProps< Item > ) {
 	return (
 		<Menu
 			trigger={
 				<Button
-					size="compact"
+					size={ isSmall ? 'small' : 'compact' }
 					icon={ moreVertical }
 					label={ __( 'Actions' ) }
 					accessibleWhenDisabled

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -16,7 +16,7 @@
 		}
 
 		.dataviews-view-grid__primary-field {
-			min-height: $grid-unit-40; // Preserve layout when there is no ellipsis button
+			min-height: $grid-unit-30; // Preserve layout when there is no ellipsis button
 			display: flex;
 			align-items: center;
 


### PR DESCRIPTION
Related to #65200

## What?

This PR changes the size of the action button in Grid layout from 32px to 24px.

## Why?

In #65200, an attempt is made to display long pattern titles in two lines in Grid layout. As part of this, an attempt is also made to reduce the size of the action buttons. However, the current Actions button is hard-coded to a compact (32px) size, so they cannot be resized unless we use CSS.

## How?

Add `isSmall` prop to the `CompactItemActions` component to change the button size.

## Testing Instructions

Check the size of the action button in Grid layout.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c8f434c7-7eba-4317-93d2-6253fe2c0dca) | ![image](https://github.com/user-attachments/assets/26db1a5e-91a4-406a-805a-cca53005f7b7) |
| ![image](https://github.com/user-attachments/assets/8da45e56-4963-4652-a55e-0854125ceb6b) | ![image](https://github.com/user-attachments/assets/3c51ee4a-7d42-4c99-910d-4220a850e5ef) |
| ![image](https://github.com/user-attachments/assets/e0358e21-76cf-4dc1-bc01-c3066f287ab8) | ![image](https://github.com/user-attachments/assets/87581b1f-24c4-4209-8659-3cee81af770f) |
| ![image](https://github.com/user-attachments/assets/8791a9ee-be10-40b6-a1ab-40069e51342f) | ![image](https://github.com/user-attachments/assets/98915cc1-9e8b-41ca-8b5a-8cfeb92ec83a) |

