### PR TITLE
Block Editor: Fix 'useZoomOut' hook conflicts

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -13,31 +13,24 @@ import { unlock } from '../lock-unlock';
 /**
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
  *
- * @param {boolean} zoomOut If we should enter into zoomOut mode or not
+ * @param {boolean} enabled If we should enter into zoomOut mode or not
  */
-export function useZoomOut( zoomOut = true ) {
+export function useZoomOut( enabled = true ) {
 	const { setZoomLevel, resetZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	useEffect( () => {
-		const isZoomOutOnMount = isZoomOut();
-
-		return () => {
-			if ( isZoomOutOnMount ) {
-				setZoomLevel( 'auto-scaled' );
-			} else {
-				resetZoomLevel();
-			}
-		};
-	}, [] );
-
-	useEffect( () => {
-		if ( zoomOut ) {
-			setZoomLevel( 'auto-scaled' );
-		} else {
-			resetZoomLevel();
+		if ( ! enabled ) {
+			return;
 		}
-	}, [ zoomOut, setZoomLevel, resetZoomLevel ] );
+
+		const isAlreadyInZoomOut = isZoomOut();
+		if ( ! isAlreadyInZoomOut ) {
+			setZoomLevel( 'auto-scaled' );
+		}
+
+		return () => ! isAlreadyInZoomOut && resetZoomLevel();
+	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
 }


### PR DESCRIPTION
## What?
Fixes #66328.
Alternative to #66381 and #66574.

PR fixes a bug when Zoom out mode is incorrectly enabled/disabled based on the inserter's mounting state and if the user has already manually enabled it.

## Testing Instructions
Borrowed from #66381.

1. Enter Zoom out manually
2. Open the inserter.
3. The pattern tab should be selected.
4. Exit zoom out manually.
5. Close the inserter.
6. Editor should remain in non-zoomed state (regular editing)

From full screen mode
1. Open inserter
2. Click patterns tab
3. Zoom out should engage
4. Close inserter
5. Zoom out should disengage

From full screen mode, exit zoom out manually
1. Open inserter
2. Click patterns tab
3. Zoom out should engage
4. Manually exit zoom out
5. Close inserter
6. Zoom out should not engage (remain in full screen mode)

~~From zoom out, re-engage after unmount~~

The fix doesn't handle this case. If the user enables zoom-out mode manually, the visual editor should stay in zoom-out mode until it's disabled again.

1. Enter Zoom out manually
2. Open the inserter.
3. The pattern tab should be selected.
4. Click blocks tab
5. Zoom out should reset to full screen
6. Close inserter
7. Zoom out should re-engage since that's the point that we started

### Testing Instructions for Keyboard
Same.