### PR TITLE
Block Editor: Fix color contrast checker

### DIFF
--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -13,40 +13,90 @@ function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
+function detectColors( blockEl ) {
+	if ( ! blockEl ) {
+		return;
+	}
+
+	const firstLinkElement = blockEl.querySelector( 'a' );
+	const linkColor =
+		firstLinkElement && !! firstLinkElement.innerText
+			? getComputedStyle( firstLinkElement ).color
+			: null;
+
+	const textColor = getComputedStyle( blockEl ).color;
+
+	let backgroundColorNode = blockEl;
+	let backgroundColor =
+		getComputedStyle( backgroundColorNode ).backgroundColor;
+	while (
+		backgroundColor === 'rgba(0, 0, 0, 0)' &&
+		backgroundColorNode.parentNode &&
+		backgroundColorNode.parentNode.nodeType ===
+			backgroundColorNode.parentNode.ELEMENT_NODE
+	) {
+		backgroundColorNode = backgroundColorNode.parentNode;
+		backgroundColor =
+			getComputedStyle( backgroundColorNode ).backgroundColor;
+	}
+
+	return {
+		textColor,
+		backgroundColor,
+		linkColor,
+	};
+}
+
+function createStyleObserver( node, callback ) {
+	// Watch for changes to style-related attributes
+	const observer = new MutationObserver( ( mutations ) => {
+		const hasStyleChanges = mutations.some(
+			( mutation ) => mutation.attributeName === 'style'
+		);
+
+		if ( hasStyleChanges ) {
+			const computedStyle =
+				node.ownerDocument.defaultView.getComputedStyle( node );
+			callback( computedStyle );
+		}
+	} );
+
+	// Observe style-related changes
+	observer.observe( node, {
+		attributeFilter: [ 'style' ],
+	} );
+
+	return observer;
+}
+
 export default function BlockColorContrastChecker( { clientId } ) {
 	const [ detectedBackgroundColor, setDetectedBackgroundColor ] = useState();
 	const [ detectedColor, setDetectedColor ] = useState();
 	const [ detectedLinkColor, setDetectedLinkColor ] = useState();
 	const blockEl = useBlockElement( clientId );
 
-	// There are so many things that can change the color of a block
-	// So we perform this check on every render.
 	useEffect( () => {
 		if ( ! blockEl ) {
 			return;
 		}
-		setDetectedColor( getComputedStyle( blockEl ).color );
 
-		const firstLinkElement = blockEl.querySelector( 'a' );
-		if ( firstLinkElement && !! firstLinkElement.innerText ) {
-			setDetectedLinkColor( getComputedStyle( firstLinkElement ).color );
+		let colors = detectColors( blockEl );
+		setDetectedColor( colors.textColor );
+		setDetectedBackgroundColor( colors.backgroundColor );
+		if ( colors.linkColor ) {
+			setDetectedLinkColor( colors.linkColor );
 		}
 
-		let backgroundColorNode = blockEl;
-		let backgroundColor =
-			getComputedStyle( backgroundColorNode ).backgroundColor;
-		while (
-			backgroundColor === 'rgba(0, 0, 0, 0)' &&
-			backgroundColorNode.parentNode &&
-			backgroundColorNode.parentNode.nodeType ===
-				backgroundColorNode.parentNode.ELEMENT_NODE
-		) {
-			backgroundColorNode = backgroundColorNode.parentNode;
-			backgroundColor =
-				getComputedStyle( backgroundColorNode ).backgroundColor;
-		}
-
-		setDetectedBackgroundColor( backgroundColor );
+		const observer = createStyleObserver( blockEl, () => {
+			colors = detectColors( blockEl );
+			setDetectedColor( colors.textColor );
+			setDetectedBackgroundColor( colors.backgroundColor );
+			if ( colors.linkColor ) {
+				setDetectedLinkColor( colors.linkColor );
+			}
+		} );
+		// Cleanup
+		return () => observer.disconnect();
 	}, [ blockEl ] );
 
 	return (

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -13,7 +13,7 @@ function getComputedStyle( node ) {
 	return node.ownerDocument.defaultView.getComputedStyle( node );
 }
 
-function detectColors( blockEl ) {
+function getBlockColors( blockEl ) {
 	if ( ! blockEl ) {
 		return;
 	}
@@ -48,22 +48,21 @@ function detectColors( blockEl ) {
 }
 
 function createStyleObserver( node, callback ) {
-	// Watch for changes to style-related attributes
+	// Watch for changes to style-related attributes.
 	const observer = new window.MutationObserver( ( mutations ) => {
 		const hasStyleChanges = mutations.some(
-			( mutation ) => mutation.attributeName === 'style'
+			( mutation ) =>
+				mutation.attributeName === 'style' ||
+				mutation.attributeName === 'class'
 		);
 
 		if ( hasStyleChanges ) {
-			const computedStyle =
-				node.ownerDocument.defaultView.getComputedStyle( node );
-			callback( computedStyle );
+			callback();
 		}
 	} );
 
-	// Observe style-related changes
 	observer.observe( node, {
-		attributeFilter: [ 'style' ],
+		attributeFilter: [ 'style', 'class' ],
 	} );
 
 	return observer;
@@ -80,22 +79,20 @@ export default function BlockColorContrastChecker( { clientId } ) {
 			return;
 		}
 
-		let colors = detectColors( blockEl );
-		setDetectedColor( colors.textColor );
-		setDetectedBackgroundColor( colors.backgroundColor );
-		if ( colors.linkColor ) {
-			setDetectedLinkColor( colors.linkColor );
-		}
-
-		const observer = createStyleObserver( blockEl, () => {
-			colors = detectColors( blockEl );
+		function updateContrastChecker() {
+			const colors = getBlockColors( blockEl );
 			setDetectedColor( colors.textColor );
 			setDetectedBackgroundColor( colors.backgroundColor );
 			if ( colors.linkColor ) {
 				setDetectedLinkColor( colors.linkColor );
 			}
-		} );
-		// Cleanup
+		}
+
+		// Check colors on mount.
+		updateContrastChecker();
+
+		const observer = createStyleObserver( blockEl, updateContrastChecker );
+
 		return () => observer.disconnect();
 	}, [ blockEl ] );
 

--- a/packages/block-editor/src/hooks/contrast-checker.js
+++ b/packages/block-editor/src/hooks/contrast-checker.js
@@ -49,7 +49,7 @@ function detectColors( blockEl ) {
 
 function createStyleObserver( node, callback ) {
 	// Watch for changes to style-related attributes
-	const observer = new MutationObserver( ( mutations ) => {
+	const observer = new window.MutationObserver( ( mutations ) => {
 		const hasStyleChanges = mutations.some(
 			( mutation ) => mutation.attributeName === 'style'
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes https://github.com/WordPress/gutenberg/issues/67035

Adding an observer to the contrast checker with the objective of checking the styles changes in real-time, so that we show the correct messaging.

## Why?

Right now, the contrast checker only runs when you change the block focus. This means if you’re adjusting colors for a block, the contrast issue message only appears after you switch to another element and then come back to the block controls. As a result, many users might miss the contrast warning entirely, defeating its purpose.

## How?

Adding the observer, so the check runs when there are style changes for the block.

## Testing Instructions

1. Create a page
2. Add a paragraph.
3. Change the paragraph color, text color and background color and confirm that you see the contrast notice when you're selecting problematic colors.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/a0f90a3c-1cef-44f6-a5f0-eefe3ffee97a


