### PR TITLE
Add command: Manage Template Parts

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -18,6 +18,7 @@ import {
 	layout,
 	rotateRight,
 	rotateLeft,
+	category,
 } from '@wordpress/icons';
 import { useCommandLoader } from '@wordpress/commands';
 import { store as preferencesStore } from '@wordpress/preferences';
@@ -278,6 +279,54 @@ const getEditorCommandLoader = () =>
 		};
 	};
 
+const getSiteEditorTemplatePartCommands = () =>
+	function useSiteEditorCategoryCommands() {
+		if ( typeof window.goBack !== 'function' ) {
+			window.goBack = function () {
+				if ( window.history.length > 1 ) {
+					window.history.back();
+				} else {
+					// If no history is available, navigate to a default page
+					window.location.href = '/';
+				}
+			};
+		}
+
+		// Fetch the current template slug
+		const templateSlug = useSelect( ( select ) => {
+			const { getCurrentPost } = select( editorStore );
+			const currentTemplate = getCurrentPost();
+
+			// Check if we have the current post and it's of type 'wp_template_part'
+			return currentTemplate?.type === 'wp_template_part'
+				? currentTemplate.slug
+				: null;
+		}, [] );
+
+		const commands = [];
+
+		// Check if we are in the Site Editor and editing a category-related template
+		const isSiteEditor = window.location.href.includes( 'site-editor.php' );
+		if ( isSiteEditor && templateSlug ) {
+			commands.push( {
+				name: 'core/manage-categories',
+				label: __( 'Manage Template Parts' ),
+				icon: category,
+				callback: ( { close } ) => {
+					if ( typeof window.goBack === 'function' ) {
+						window.goBack();
+					} else {
+						window.history.back();
+					}
+					close();
+				},
+				isDefault: true,
+			} );
+		}
+
+		return { isLoading: false, commands };
+	};
+
 const getEditedEntityContextualCommands = () =>
 	function useEditedEntityContextualCommands() {
 		const { postType } = useSelect( ( select ) => {
@@ -442,6 +491,12 @@ export default function useCommands() {
 	useCommandLoader( {
 		name: 'core/editor/edit-ui',
 		hook: getEditorCommandLoader(),
+	} );
+
+	useCommandLoader( {
+		name: 'core/editor/category-commands',
+		hook: getSiteEditorTemplatePartCommands(),
+		context: 'entity-edit',
 	} );
 
 	useCommandLoader( {


### PR DESCRIPTION
## What?
Enhancement for the **Manage Template Parts** mentioned in https://github.com/WordPress/gutenberg/issues/50407

## Why?
Currently there is no command to manage template parts while editing template parts.

## How?
This PR adds adds "Manage Template Parts" command by default when the command palette is opened while editing any template parts.

## Testing Instructions

- Log in to your WordPress dashboard.
- Navigate to the Site Editor.
- Click on Patterns from the left panel.
- Click on "All templates parts" from the left panel.
- The main section will display a list of all available template parts.
- Select any template part, you wish to edit.
- The editor panel for the selected template will open.
- Open the Command Palette by either pressing Cmd + K (on macOS) or using the command palette icon at the top.
- The "Manage Template Parts" command will appear by default.
- Click on the displayed command to be redirected to the previous page or the manage template parts page.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3fa52c3f-786d-44a9-861c-deed31f7fc41

