### PR TITLE
Fix: Image block - Lightbox Button position

### DIFF
--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -403,8 +403,11 @@ const { state, actions, callbacks } = store(
 				const buttonOffsetTop = figureHeight - offsetHeight;
 				const buttonOffsetRight = figureWidth - offsetWidth;
 
-				let imageButtonTop = buttonOffsetTop + 16;
-				let imageButtonRight = buttonOffsetRight + 16;
+				// The button should be at most 16px from the top and right and inside the image.
+				// For extremely small images take the minimum of 16px or 20% of the image size.
+				let imageButtonTop = Math.min( offsetHeight * 0.2, 16 );
+				let imageButtonRight =
+					buttonOffsetRight + Math.min( offsetWidth * 0.2, 16 );
 
 				// In the case of an image with object-fit: contain, the size of the
 				// <img> element can be larger than the image itself, so it needs to

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -985,9 +985,11 @@ test.describe( 'Image - lightbox', () => {
 			const postId = await editor.publishPost();
 			await page.goto( `/?p=${ postId }` );
 
-			const lightboxImage = page.locator( '.wp-lightbox-container img' );
-			await expect( lightboxImage ).toBeVisible();
-			await lightboxImage.click();
+			const imageLightboxTrigger = page.locator(
+				'.wp-lightbox-container .lightbox-trigger'
+			);
+			await expect( imageLightboxTrigger ).toBeVisible();
+			await imageLightboxTrigger.click();
 
 			const figure = page
 				.locator( '.wp-lightbox-overlay .wp-block-image' )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/66958
## Why?
The button's absolute positioning, determined by top and right values, is influenced by several factors. However, in some scenarios, the resulting position can be suboptimal.

For a standard Image block, the positioning generally works well. But when the Image block adopts a non-default layout, especially within nested containers, the positioning becomes inconsistent and erratic.

## How?
This PR adds on to the logic of calculating the buttons's position relatively to the size of the image inside the figure tag and sets default minimum positions of the button.
 
## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a post and add a Group block and set to a Grid variant.
2. inside the group block add 6 images with varying sizes/ratio and with and without captions.
3. Publish and view the front end.
4. Hover on the images.
5. Observe the placement of the trigger button.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/87aa7623-d5dc-4e6f-a332-9336626da785

