### PR TITLE
[Bug ] Fixed Spacer block, when used as Grow(Fill) or Fit, will prompt a user about unsaved changes

### DIFF
--- a/packages/block-library/src/spacer/edit.js
+++ b/packages/block-library/src/spacer/edit.js
@@ -299,7 +299,8 @@ const SpacerEdit = ( {
 			}
 		} else if (
 			isFlexLayout &&
-			( selfStretch === 'fill' || selfStretch === 'fit' )
+			( selfStretch === 'fill' || selfStretch === 'fit' ) &&
+			width !== undefined
 		) {
 			if ( inheritedOrientation === 'horizontal' ) {
 				setAttributes( {


### PR DESCRIPTION
Fixes #67041 

## What?
This pull request resolves #67041 by adding additional checks before updating attributes on page load. Specifically, it ensures that the width attribute is not reset to undefined if it is already undefined.
 
## Why?
Currently, when a user reloads a page containing a Spacer Block set to "Fill" or "Grow," WordPress identifies unsaved changes, even when no edits were made. This can lead to confusion and disrupt the editing experience.

## How?
This update introduces a condition in the useEffect hook to verify if width is already undefined. If so, the value remains unchanged. This prevents unnecessary updates that cause WordPress to flag the post as modified.

## Testing Instructions

1. Create a new post.
2. Insert a Stack block.
3. Add a Spacer block within the Stack.
4. Set the Spacer to Grow.
5. Publish the post.
6. Navigate to the All Posts list.
7. Reopen the post for editing.
8. Make no changes and navigate away or reload.
   -  Before the update: You would be prompted with a warning about unsaved changes.
   - After the update: No such prompt appears, confirming that attributes are not incorrectly updated.

## Screenshots 
NA
