### PR TITLE
Make `BlockManager` component reusable

### DIFF
--- a/packages/editor/src/components/block-manager/checklist.js
+++ b/packages/editor/src/components/block-manager/checklist.js
@@ -17,7 +17,7 @@ function BlockTypesChecklist( { blockTypes, value, onItemChange } ) {
 						label={ blockType.title }
 						checked={ value.includes( blockType.name ) }
 						onChange={ ( ...args ) =>
-							onItemChange( blockType.name, ...args )
+							onItemChange( blockType, ...args )
 						}
 					/>
 					<BlockIcon icon={ blockType.icon } />

--- a/packages/editor/src/components/block-manager/index.js
+++ b/packages/editor/src/components/block-manager/index.js
@@ -23,18 +23,10 @@ import BlockManagerCategory from './category';
  * @param {Function} props.onChange           Function to be called when the selected blocks change.
  */
 export default function BlockManager( {
-	blockTypes: _blockTypes,
-	selectedBlockTypes: _selectedBlockTypes,
+	blockTypes,
+	selectedBlockTypes,
 	onChange,
 } ) {
-	const blockTypes = Array.isArray( _blockTypes )
-		? _blockTypes
-		: [ _blockTypes ];
-
-	const selectedBlockTypes = Array.isArray( _selectedBlockTypes )
-		? _selectedBlockTypes
-		: [ _selectedBlockTypes ];
-
 	const debouncedSpeak = useDebounce( speak, 500 );
 	const [ search, setSearch ] = useState( '' );
 	const { categories, isMatchingSearchTerm } = useSelect( ( select ) => {

--- a/packages/editor/src/components/block-manager/index.js
+++ b/packages/editor/src/components/block-manager/index.js
@@ -23,10 +23,18 @@ import BlockManagerCategory from './category';
  * @param {Function} props.onChange           Function to be called when the selected blocks change.
  */
 export default function BlockManager( {
-	blockTypes,
-	selectedBlockTypes,
+	blockTypes: _blockTypes,
+	selectedBlockTypes: _selectedBlockTypes,
 	onChange,
 } ) {
+	const blockTypes = Array.isArray( _blockTypes )
+		? _blockTypes
+		: [ _blockTypes ];
+
+	const selectedBlockTypes = Array.isArray( _selectedBlockTypes )
+		? _selectedBlockTypes
+		: [ _selectedBlockTypes ];
+
 	const debouncedSpeak = useDebounce( speak, 500 );
 	const [ search, setSearch ] = useState( '' );
 	const { categories, isMatchingSearchTerm } = useSelect( ( select ) => {

--- a/packages/editor/src/components/preferences-modal/block-visibility.js
+++ b/packages/editor/src/components/preferences-modal/block-visibility.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+import { hasBlockSupport, store as blocksStore } from '@wordpress/blocks';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+import BlockManager from '../block-manager';
+
+export default function BlockVisibility() {
+	const { showBlockTypes, hideBlockTypes } = unlock(
+		useDispatch( editorStore )
+	);
+
+	const {
+		blockTypes,
+		allowedBlockTypes: _allowedBlockTypes,
+		hiddenBlockTypes: _hiddenBlockTypes,
+	} = useSelect( ( select ) => {
+		return {
+			blockTypes: select( blocksStore ).getBlockTypes(),
+			allowedBlockTypes:
+				select( editorStore ).getEditorSettings().allowedBlockTypes,
+			hiddenBlockTypes:
+				select( preferencesStore ).get( 'core', 'hiddenBlockTypes' ) ??
+				[],
+		};
+	}, [] );
+
+	const allowedBlockTypes = useMemo( () => {
+		if ( _allowedBlockTypes === true ) {
+			return blockTypes;
+		}
+		return blockTypes.filter( ( { name } ) => {
+			return _allowedBlockTypes?.includes( name );
+		} );
+	}, [ _allowedBlockTypes, blockTypes ] );
+
+	const filteredBlockTypes = allowedBlockTypes.filter(
+		( blockType ) =>
+			hasBlockSupport( blockType, 'inserter', true ) &&
+			( ! blockType.parent ||
+				blockType.parent.includes( 'core/post-content' ) )
+	);
+
+	// Some hidden blocks become unregistered
+	// by removing for instance the plugin that registered them, yet
+	// they're still remain as hidden by the user's action.
+	// We consider "hidden", blocks which were hidden and
+	// are still registered.
+	const hiddenBlockTypes = _hiddenBlockTypes.filter( ( hiddenBlock ) => {
+		return filteredBlockTypes.some(
+			( registeredBlock ) => registeredBlock.name === hiddenBlock
+		);
+	} );
+
+	const selectedBlockTypes = filteredBlockTypes.filter(
+		( blockType ) => ! hiddenBlockTypes.includes( blockType.name )
+	);
+
+	const onChangeSelectedBlockTypes = ( newSelectedBlockTypes ) => {
+		if ( selectedBlockTypes.length > newSelectedBlockTypes.length ) {
+			const blockTypesToHide = selectedBlockTypes.filter(
+				( blockType ) =>
+					! newSelectedBlockTypes.find(
+						( { name } ) => name === blockType.name
+					)
+			);
+			hideBlockTypes( blockTypesToHide.map( ( { name } ) => name ) );
+		} else if ( selectedBlockTypes.length < newSelectedBlockTypes.length ) {
+			const blockTypesToShow = newSelectedBlockTypes.filter(
+				( blockType ) =>
+					! selectedBlockTypes.find(
+						( { name } ) => name === blockType.name
+					)
+			);
+			showBlockTypes( blockTypesToShow.map( ( { name } ) => name ) );
+		}
+	};
+
+	return (
+		<BlockManager
+			blockTypes={ filteredBlockTypes }
+			selectedBlockTypes={ selectedBlockTypes }
+			onChange={ onChangeSelectedBlockTypes }
+		/>
+	);
+}

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -18,7 +18,7 @@ import { store as interfaceStore } from '@wordpress/interface';
 import EnablePanelOption from './enable-panel';
 import EnablePluginDocumentSettingPanelOption from './enable-plugin-document-setting-panel';
 import EnablePublishSidebarOption from './enable-publish-sidebar';
-import BlockManager from '../block-manager';
+import BlockVisibility from './block-visibility';
 import PostTaxonomies from '../post-taxonomies';
 import PostFeaturedImageCheck from '../post-featured-image/check';
 import PostExcerptCheck from '../post-excerpt/check';
@@ -297,7 +297,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 									"Disable blocks that you don't want to appear in the inserter. They can always be toggled back on later."
 								) }
 							>
-								<BlockManager />
+								<BlockVisibility />
 							</PreferencesModalSection>
 						</>
 					),


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/62703#issuecomment-2385713239

## What?

This PR makes the `BlockManager` component reusable in preparation for building a UI for the allowedBlocks setting.

## Why?

The current `BlockManager` component is tightly coupled to the `showBlockTypes` and `hideBlockTypes` actions and cannot be used for other purposes.

## How?

Change the `BlockManager` component to receive the following three props.

- `blockTypes`: A list of blocks to display.
- `selectedBlockTypes`: A ​​list of currently selected blocks.
- `onChange`: Called when the selected block is changed.

Next, I reconstructed the current "Manage block visibility" settings as a `BlockVisibility` component that wraps the `BlockManager` component. The `BlockVisibility` component controls the available blocks using the `showBlockTypes` and `hideBlockTypes` via the `onChange` prop of the `BlockManager` component.

## Testing Instructions

The "Manage block visibility" setting should continue to work as before. Most of the functionality should be guaranteed by [this E2E test](https://github.com/WordPress/gutenberg/blob/865a05834d3af46a6eecd142fe6acda40642756d/test/e2e/specs/editor/various/block-visibility.spec.js).