### PR TITLE
Fix dropping media from inserter into Cover block

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -239,7 +239,7 @@ export function MediaPlaceholder( {
 				( block.name === 'core/image' ||
 					block.name === 'core/audio' ||
 					block.name === 'core/video' ) &&
-				block.attributes.url
+				( block.attributes.url || block.attributes.src )
 					? [ block ]
 					: recursivelyFindMediaFromBlocks( block.innerBlocks )
 			);

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -252,33 +252,37 @@ export function MediaPlaceholder( {
 		}
 
 		const uploadedMediaList = await Promise.all(
-			mediaBlocks.map( ( block ) =>
-				block.attributes.id
-					? block.attributes
-					: new Promise( ( resolve, reject ) => {
-							window
-								.fetch( block.attributes.url )
-								.then( ( response ) => response.blob() )
-								.then( ( blob ) =>
-									mediaUpload( {
-										filesList: [ blob ],
-										additionalData: {
-											title: block.attributes.title,
-											alt_text: block.attributes.alt,
-											caption: block.attributes.caption,
-										},
-										onFileChange: ( [ media ] ) => {
-											if ( media.id ) {
-												resolve( media );
-											}
-										},
-										allowedTypes,
-										onError: reject,
-									} )
-								)
-								.catch( () => resolve( block.attributes.url ) );
-					  } )
-			)
+			mediaBlocks.map( ( block ) => {
+				const blockType = block.name.split( '/' )[ 1 ];
+				if ( block.attributes.id ) {
+					block.attributes.type = blockType;
+					return block.attributes;
+				}
+				return new Promise( ( resolve, reject ) => {
+					window
+						.fetch( block.attributes.url )
+						.then( ( response ) => response.blob() )
+						.then( ( blob ) =>
+							mediaUpload( {
+								filesList: [ blob ],
+								additionalData: {
+									title: block.attributes.title,
+									alt_text: block.attributes.alt,
+									caption: block.attributes.caption,
+									type: blockType,
+								},
+								onFileChange: ( [ media ] ) => {
+									if ( media.id ) {
+										resolve( media );
+									}
+								},
+								allowedTypes,
+								onError: reject,
+							} )
+						)
+						.catch( () => resolve( block.attributes.url ) );
+				} );
+			} )
 		).catch( ( err ) => onError( err ) );
 
 		if ( multiple ) {

--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -201,7 +201,7 @@ function CoverEdit( {
 			averageBackgroundColor
 		);
 
-		if ( backgroundType === IMAGE_BACKGROUND_TYPE && mediaAttributes.id ) {
+		if ( backgroundType === IMAGE_BACKGROUND_TYPE && mediaAttributes?.id ) {
 			const { imageDefaultSize } = getSettings();
 
 			// Try to use the previous selected image size if it's available

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -63,12 +63,6 @@ export function attributesFromMedia( media ) {
 			media.type === VIDEO_BACKGROUND_TYPE )
 	) {
 		mediaType = media.type;
-		// If  there's a url or src but no type, it's probably coming from the inserter so
-		// we still want to return what data we have.
-	} else if ( media.url ) {
-		mediaType = IMAGE_BACKGROUND_TYPE;
-	} else if ( media.src ) {
-		mediaType = VIDEO_BACKGROUND_TYPE;
 	} else {
 		return;
 	}

--- a/packages/block-library/src/cover/shared.js
+++ b/packages/block-library/src/cover/shared.js
@@ -35,7 +35,7 @@ export function dimRatioToClass( ratio ) {
 }
 
 export function attributesFromMedia( media ) {
-	if ( ! media || ! media.url ) {
+	if ( ! media || ( ! media.url && ! media.src ) ) {
 		return {
 			url: undefined,
 			id: undefined,
@@ -52,23 +52,29 @@ export function attributesFromMedia( media ) {
 		if ( media.media_type === IMAGE_BACKGROUND_TYPE ) {
 			mediaType = IMAGE_BACKGROUND_TYPE;
 		} else {
-			// only images and videos are accepted so if the media_type is not an image we can assume it is a video.
+			// Only images and videos are accepted so if the media_type is not an image we can assume it is a video.
 			// Videos contain the media type of 'file' in the object returned from the rest api.
 			mediaType = VIDEO_BACKGROUND_TYPE;
 		}
-	} else {
 		// For media selections originated from existing files in the media library.
-		if (
-			media.type !== IMAGE_BACKGROUND_TYPE &&
-			media.type !== VIDEO_BACKGROUND_TYPE
-		) {
-			return;
-		}
+	} else if (
+		media.type &&
+		( media.type === IMAGE_BACKGROUND_TYPE ||
+			media.type === VIDEO_BACKGROUND_TYPE )
+	) {
 		mediaType = media.type;
+		// If  there's a url or src but no type, it's probably coming from the inserter so
+		// we still want to return what data we have.
+	} else if ( media.url ) {
+		mediaType = IMAGE_BACKGROUND_TYPE;
+	} else if ( media.src ) {
+		mediaType = VIDEO_BACKGROUND_TYPE;
+	} else {
+		return;
 	}
 
 	return {
-		url: media.url,
+		url: media.url || media.src,
 		id: media.id,
 		alt: media?.alt,
 		backgroundType: mediaType,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #66824.

Fixes a bug observed while working on #66986: dropping Images or Videos from the inserter Media tab into the Cover block media placeholder doesn't add them as background to the Cover block (which would be expected).

One of the issues was the Cover block itself not recognising media from the inserter due to it not having an explicit type. I fixed that by determining the type based on block name in the media placeholder, and appending it to the block attributes.

The other issue was that the Video block uses `src` instead of `url`, and media placeholder wasn't handing that case. Updated to look for `src` attributes too.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a Cover block in a template or page;
2. Open the inserter, navigate to Media > Images and try to drag an image into the Cover block.
3. Make sure you have at least one video in the media library;
4. In the inserter, navigate to Media > Video and try to drag a video into the Cover block.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ea87233c-92dc-4ee5-b446-80f3639c4881

