### PR TITLE
Allow flex justification controls to be disabled at the block level

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -71,14 +71,14 @@ export default {
 		return (
 			<>
 				<Flex>
-					<FlexItem>
-						{ allowJustification && (
+					{ allowJustification && (
+						<FlexItem>
 							<FlexLayoutJustifyContentControl
 								layout={ layout }
 								onChange={ onChange }
 							/>
-						) }
-					</FlexItem>
+						</FlexItem>
+					) }
 					<FlexItem>
 						{ allowOrientation && (
 							<OrientationControl

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -79,14 +79,14 @@ export default {
 							/>
 						</FlexItem>
 					) }
-					<FlexItem>
-						{ allowOrientation && (
+					{ allowOrientation && (
+						<FlexItem>
 							<OrientationControl
 								layout={ layout }
 								onChange={ onChange }
 							/>
-						) }
-					</FlexItem>
+						</FlexItem>
+					) }
 				</Flex>
 				<FlexWrapControl layout={ layout } onChange={ onChange } />
 			</>

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -66,15 +66,18 @@ export default {
 		onChange,
 		layoutBlockSupport = {},
 	} ) {
-		const { allowOrientation = true } = layoutBlockSupport;
+		const { allowOrientation = true, allowJustification = true } =
+			layoutBlockSupport;
 		return (
 			<>
 				<Flex>
 					<FlexItem>
-						<FlexLayoutJustifyContentControl
-							layout={ layout }
-							onChange={ onChange }
-						/>
+						{ allowJustification && (
+							<FlexLayoutJustifyContentControl
+								layout={ layout }
+								onChange={ onChange }
+							/>
+						) }
 					</FlexItem>
 					<FlexItem>
 						{ allowOrientation && (
@@ -94,14 +97,22 @@ export default {
 		onChange,
 		layoutBlockSupport,
 	} ) {
-		const { allowVerticalAlignment = true } = layoutBlockSupport;
+		const { allowVerticalAlignment = true, allowJustification = true } =
+			layoutBlockSupport;
+
+		if ( ! allowJustification && ! allowVerticalAlignment ) {
+			return null;
+		}
+
 		return (
 			<BlockControls group="block" __experimentalShareWithChildBlocks>
-				<FlexLayoutJustifyContentControl
-					layout={ layout }
-					onChange={ onChange }
-					isToolbar
-				/>
+				{ allowJustification && (
+					<FlexLayoutJustifyContentControl
+						layout={ layout }
+						onChange={ onChange }
+						isToolbar
+					/>
+				) }
 				{ allowVerticalAlignment && (
 					<FlexLayoutVerticalAlignmentControl
 						layout={ layout }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes an issue noticed while reviewing #67022.

The `allowJustification` property of layout support should, per [the docs](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-supports/#layout-allowjustification) allow disabling justification controls for the block in constrained or flex layouts, but currently flex justification controls are being rendered regardless of that property.

This PR updates the controls so they are only output when `allowJustification` is `true`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Either create a custom block with layout for testing, or update the layout property of one of the core blocks in its block.json. E.g. in `buttons/block.json` update the layout support to:

```
"layout": {
			"allowSwitching": false,
			"allowInheriting": false,
                         "allowJustification": false,
			"default": {
				"type": "flex"
			}
		},
```

2. Check the block in the editor. The justification controls shouldn't show in the toolbar or in the sidebar.

Note that if orientation controls are enabled (which they are by default), the sidebar will look a bit empty:

<img width="278" alt="Screenshot 2024-11-18 at 4 46 34 pm" src="https://github.com/user-attachments/assets/79da451c-dbea-4e3e-9b53-b609b8349cb2">


But that's already the case when justification is enabled and orientation is disabled (which has been a working feature for a while now):

<img width="276" alt="Screenshot 2024-11-18 at 4 31 06 pm" src="https://github.com/user-attachments/assets/99d5fe0f-0598-4a07-b595-8cfa212b22e3">



