### PR TITLE
Block Style Variations: Fix complex variation selectors when using selectors API

### DIFF
--- a/backport-changelog/6.8/7825.md
+++ b/backport-changelog/6.8/7825.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7825
+
+* https://github.com/WordPress/gutenberg/pull/67061

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -2874,8 +2874,14 @@ class WP_Theme_JSON_Gutenberg {
 
 				// Combine selectors with style variation's selector and add to overall style variation declarations.
 				foreach ( $variation_declarations as $current_selector => $new_declarations ) {
-					// If current selector includes block classname, remove it but leave the whitespace in.
-					$shortened_selector = str_replace( $block_metadata['selector'] . ' ', ' ', $current_selector );
+					/*
+					 * Clean up any whitespace between comma separated selectors.
+					 * This prevents these spaces breaking compound selectors such as:
+					 * - `.wp-block-list:not(.wp-block-list .wp-block-list)`
+					 * - `.wp-block-image img, .wp-block-image.my-class img`
+					 */
+					$clean_current_selector = preg_replace( '/,\s+/', ',', $current_selector );
+					$shortened_selector     = str_replace( $block_metadata['selector'], '', $clean_current_selector );
 
 					// Prepend the variation selector to the current selector.
 					$split_selectors    = explode( ',', $shortened_selector );

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -4308,6 +4308,74 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_get_styles_for_block_with_style_variations_and_custom_selectors() {
+		register_block_type(
+			'test/milk',
+			array(
+				'api_version' => 3,
+				'selectors'   => array(
+					'root'  => '.milk',
+					'color' => '.wp-block-test-milk .liquid, .wp-block-test-milk:not(.spoiled), .wp-block-test-milk.in-bottle',
+				),
+			)
+		);
+
+		register_block_style(
+			'test/milk',
+			array(
+				'name'  => 'chocolate',
+				'label' => 'Chocolate',
+			)
+		);
+
+		$theme_json = new WP_Theme_JSON_Gutenberg(
+			array(
+				'version' => WP_Theme_JSON_Gutenberg::LATEST_SCHEMA,
+				'styles'  => array(
+					'blocks' => array(
+						'test/milk' => array(
+							'color'      => array(
+								'background' => 'white',
+							),
+							'variations' => array(
+								'chocolate' => array(
+									'color' => array(
+										'background' => '#35281E',
+									),
+								),
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$metadata = array(
+			'name'       => 'test/milk',
+			'path'       => array( 'styles', 'blocks', 'test/milk' ),
+			'selector'   => '.wp-block-test-milk',
+			'selectors'  => array(
+				'color' => '.wp-block-test-milk .liquid, .wp-block-test-milk:not(.spoiled), .wp-block-test-milk.in-bottle',
+			),
+			'variations' => array(
+				'chocolate' => array(
+					'path'     => array( 'styles', 'blocks', 'test/milk', 'variations', 'chocolate' ),
+					'selector' => '.is-style-chocolate.wp-block-test-milk',
+				),
+			),
+		);
+
+		$actual_styles    = $theme_json->get_styles_for_block( $metadata );
+		$default_styles   = ':root :where(.wp-block-test-milk .liquid, .wp-block-test-milk:not(.spoiled), .wp-block-test-milk.in-bottle){background-color: white;}';
+		$variation_styles = ':root :where(.is-style-chocolate.wp-block-test-milk .liquid,.is-style-chocolate.wp-block-test-milk:not(.spoiled),.is-style-chocolate.wp-block-test-milk.in-bottle){background-color: #35281E;}';
+		$expected         = $default_styles . $variation_styles;
+
+		unregister_block_style( 'test/milk', 'chocolate' );
+		unregister_block_type( 'test/milk' );
+
+		$this->assertSame( $expected, $actual_styles );
+	}
+
 	public function test_block_style_variations() {
 		wp_set_current_user( static::$administrator_id );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/66885

## What?

Fixes a bug in the manipulation of selectors for block style variations that would result in an incorrect selector and fail to match the appropriate elements on the frontend.

## Why?

- Bugs = bad
- Frontend should match editor.

## How?

Tweaks how the original block name in the block's selector is replaced so that it doesn't miss more complex selectors e.g. ones with compound classes, CSS functions etc.

## Testing Instructions

1. Confirm Theme.json unit tests are passing: 
    `npm run test:unit:php:base -- --filter WP_Theme_JSON_Gutenberg_Test`
2. Register a custom block style variation for a block that uses the Selectors API with compound selector or something with a CSS function in it. The List block sparked the original issue fixed by this PR, see snippet below for List block style.
    ```php
    register_block_style(
		'core/list',
		array(
			'name'       => 'my-list-border',
			'label'      => __( 'my list border' ),
			'style_data' => array(
				'border'  => array(
					'color' => 'green',
					'style' => 'solid',
					'width' => '2px',
				),
				'color'   => array(
					'background' => '#FBFAF3',
				),
				'spacing' => array(
					'padding' => array(
						'bottom' => 'var(--wp--preset--spacing--30)',
						'left'   => 'var(--wp--preset--spacing--50)',
						'right'  => 'var(--wp--preset--spacing--50)',
						'top'    => 'var(--wp--preset--spacing--30)',
					),
				),
			),
		),
	)
    ```
3. Edit a post, add a List block to it, and apply the custom block style from the last step.
4. Save the post and view on the frontend.
5. Confirm the List block's border styles are now reflected there as well (they still should not be recursively applied to nested lists)
6. In the site editor, add some global styles for the Image block.
   - Add a border to all images
   - Add a different border to the rounded Image block style
7. Confirm the borders for images continue to work as before.
8. Make sure other blocks using the selectors API to set custom selectors within block.json work e.g. Post Featured Image, Avatar, List Item.
9. Check blocks like Button, that still use old `__experimentalSelector` property in block.json

There might be more use cases I'm missing so bonus points for testing more than the list above 😅 

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="691" alt="Screenshot 2024-11-18 at 4 10 03 pm" src="https://github.com/user-attachments/assets/e4934f52-7731-40d6-af6e-113ca795fb8b"> | <img width="680" alt="Screenshot 2024-11-18 at 4 10 34 pm" src="https://github.com/user-attachments/assets/19822234-32b3-440b-a025-a4f310f18733"> |

_Note the missing border in the `Before` image above._