### PR TITLE
Fix: JavaScript error when pattern category is unregistered

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -330,7 +330,7 @@ function mapUserPattern(
 		id: userPattern.id,
 		type: INSERTER_PATTERN_TYPES.user,
 		title: userPattern.title.raw,
-		categories: userPattern.wp_pattern_category.map( ( catId ) => {
+		categories: userPattern.wp_pattern_category?.map( ( catId ) => {
 			const category = __experimentalUserPatternCategories.find(
 				( { id } ) => id === catId
 			);

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -156,7 +156,7 @@ const selectPatterns = createSelector(
 				categoryId,
 				hasCategory: ( item, currentCategory ) => {
 					if ( item.type === PATTERN_TYPES.user ) {
-						return item.wp_pattern_category.some(
+						return item.wp_pattern_category?.some(
 							( catId ) =>
 								userPatternCategories.find(
 									( cat ) => cat.id === catId

--- a/packages/edit-site/src/components/page-patterns/use-patterns.js
+++ b/packages/edit-site/src/components/page-patterns/use-patterns.js
@@ -173,7 +173,7 @@ const selectPatterns = createSelector(
 						return (
 							userPatternCategories?.length &&
 							( ! item.wp_pattern_category?.length ||
-								! item.wp_pattern_category.some( ( catId ) =>
+								! item.wp_pattern_category?.some( ( catId ) =>
 									userPatternCategories.find(
 										( cat ) => cat.id === catId
 									)

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/use-pattern-categories.js
@@ -69,7 +69,7 @@ export default function usePatternCategories() {
 			// If the pattern has no categories, add it to uncategorized.
 			if (
 				! pattern.wp_pattern_category?.length ||
-				! pattern.wp_pattern_category.some( ( catId ) =>
+				! pattern.wp_pattern_category?.some( ( catId ) =>
 					userPatternCategories.find( ( cat ) => cat.id === catId )
 				)
 			) {

--- a/packages/patterns/src/components/duplicate-pattern-modal.js
+++ b/packages/patterns/src/components/duplicate-pattern-modal.js
@@ -24,7 +24,7 @@ function getTermLabels( pattern, categories ) {
 
 	return categories.user
 		?.filter( ( category ) =>
-			pattern.wp_pattern_category.includes( category.id )
+			pattern.wp_pattern_category?.includes( category.id )
 		)
 		.map( ( category ) => category.label );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Because the wp_pattern_category taxonomy can be unregistered, it needs to be used conditionally in the JavaScript code, or there may be JavaScript errors.

Closes https://github.com/WordPress/gutenberg/issues/67060

## Testing Instructions
Unregister the wp_pattern_category taxonomy.
For example, copy the following to functions.php in your active theme:

```
add_action( 'init', 'unregister' );
function unregister() {
	unregister_taxonomy_for_object_type( 'wp_pattern_category', 'wp_block' );
}
```

Please test the following and watch for any regressions or JavaScript errors:

1. Create a new post
2. Insert a paragraph block and open the Options menu in the block toolbar. 
3. In the options menu dropdown, select "Create pattern". Select synced. Do not add a category. Create the pattern.
4. Click on "Edit original" in the block toolbar.
5. Confirm that there is no category setting.

Repeat and create 3 more patterns:
Synced with custom category
Unsynced without category
Unsycned with custom category

Go to the pattern dataviews page (Appearance > Editor > Patterns or Appearance > Patterns depending on your theme)
Create the different patterns using the "Add New Pattern" button.

Confirm that the custom category you created when creating patterns is not listed in the sidebar with the other pattern categories.








