### PR TITLE
Feat: Remove default background from theme.json when applying solid color to Buttons

### DIFF
--- a/packages/block-editor/src/hooks/color.js
+++ b/packages/block-editor/src/hooks/color.js
@@ -183,6 +183,8 @@ export function addSaveProps( props, blockNameOrType, attributes ) {
 		'has-background': serializeHasBackground && hasBackground,
 		'has-link-color':
 			shouldSerialize( 'link' ) && style?.elements?.link?.color,
+		// If there exists a background color, remove the background property from the gradient.
+		'no-background-gradient': backgroundColor || style?.color?.background,
 	} );
 	props.className = newClassName ? newClassName : undefined;
 

--- a/packages/block-editor/src/hooks/use-color-props.js
+++ b/packages/block-editor/src/hooks/use-color-props.js
@@ -61,6 +61,8 @@ export function getColorClassesAndStyles( attributes ) {
 			gradient ||
 			style?.color?.gradient,
 		'has-link-color': style?.elements?.link?.color,
+		// If there exists a background color, remove the background property from the gradient.
+		'no-background-gradient': backgroundColor,
 	} );
 
 	// Collect inline styles for colors.

--- a/packages/block-editor/src/hooks/use-color-props.js
+++ b/packages/block-editor/src/hooks/use-color-props.js
@@ -62,7 +62,7 @@ export function getColorClassesAndStyles( attributes ) {
 			style?.color?.gradient,
 		'has-link-color': style?.elements?.link?.color,
 		// If there exists a background color, remove the background property from the gradient.
-		'no-background-gradient': backgroundColor,
+		'no-background-gradient': backgroundColor || style?.color?.background,
 	} );
 
 	// Collect inline styles for colors.

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -74,6 +74,11 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
+// no-background-gradient class is used to remove the default gradient background from the button.
+.wp-block-buttons .wp-block-button .no-background-gradient {
+	background: none;
+}
+
 // For vertical buttons, gap is not factored into width calculations.
 .wp-block-buttons.is-vertical > .wp-block-button {
 	&.wp-block-button__width-25 {

--- a/packages/block-library/src/button/style.scss
+++ b/packages/block-library/src/button/style.scss
@@ -74,11 +74,6 @@ $blocks-block__margin: 0.5em;
 	}
 }
 
-// no-background-gradient class is used to remove the default gradient background from the button.
-.wp-block-buttons .wp-block-button .no-background-gradient {
-	background: none;
-}
-
 // For vertical buttons, gap is not factored into width calculations.
 .wp-block-buttons.is-vertical > .wp-block-button {
 	&.wp-block-button__width-25 {

--- a/packages/block-library/src/common.scss
+++ b/packages/block-library/src/common.scss
@@ -101,6 +101,10 @@
 	z-index: 100000;
 }
 
+.no-background-gradient {
+	background-image: none !important;
+}
+
 /**
  * The following provide a simple means of applying a default border style when
  * a user first makes a selection in the border block support panel.


### PR DESCRIPTION
Fixes: #67055 

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Issue Summary:
As per the issue and my testing, it was found that when we apply a default gradient to the button using theme.json, the user becomes ineligible for changing the gradient to any solid color thereafter giving rise the bug mentioned in the issue.

Proposed Approach:
Introduce a new class name that contains the `background: none;` property which can be applied whenever we have a `backgroundColor`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This PR is necessary to resolve the bug mentioned above.

## How? ( Approach )
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Normally, the gradient is applied using the `background` property, if we generalize the background property in `theme.json` then this property gets applied by default to the buttons, when we change the background color, the backgroundColor property changes, but `background` property is still derived from the parent leading to this bug.

This approach adds `background` property as null to the button whenever a backgroundColor value is set. This way, the rest of the buttons can by default inherit the default background color from `theme.json` while allowing users to override it from the editor.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Override the default theme.json and add default gradient styles for button.

```
"button": {
        "color": {
	        "text": "#fff",
	        "gradient": "linear-gradient(135deg,rgba(6,147,227,1) 0%,rgb(155,81,224) 100%)"
        }
}
```

2. Create a post and add buttons to it.
3. Try to change the default gradient to any solid color, observe the color being changed on the editor.
4. Save the post and observe the change being reflected in the permalink of the post.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/9653cd62-0a0a-4f77-8b7f-95a839228263



https://github.com/user-attachments/assets/161dae4a-c3d8-4c0f-94de-7223e3a87bee

