### PR TITLE
Pullquote: Ensure spacing consistency between editor and frontend

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -11,6 +11,10 @@
 		color: inherit;
 	}
 
+	cite {
+		display: block;
+	}
+
 	blockquote {
 		margin: 0;
 	}
@@ -68,8 +72,4 @@
 			font-style: normal;
 		}
 	}
-}
-
-.wp-block-pullquote cite {
-	color: inherit;
 }


### PR DESCRIPTION
Fixes: #67067

## What?
This PR fixes a spacing inconsistency between the editor and frontend in the Pullquote block by adjusting the `<cite>` tag styling.

## Why?
In the editor, the spacing inside the `<blockquote>` tag was correctly set to `--wp--preset--spacing--30` (Twenty Twenty Five Theme). However, on the frontend, there was additional unintended spacing applied to the <cite> tag, leading to a mismatch in appearance. This fix ensures consistency between the editor and frontend, providing a seamless user experience.

## How?
The issue was resolved by adding a display: block rule to the `<cite>` tag in the frontend. This adjustment removes the unintended extra space, aligning the spacing with the editor’s design. Additionally, a redundant color: inherit rule was removed for cleaner code.

## Testing Instructions
1.  Open a post or page in the editor.
2.	Insert a Pullquote block.
3.	Set the style and content for the Pullquote block.
4.	View the post or page on the frontend.
5.	Verify that the spacing inside the `<blockquote>` tag matches between the editor and the frontend.
6.	Confirm that there is no additional spacing in the frontend beyond the expected spacing.

## Screenshots or screencast <!-- if applicable -->
### Before changes:
#### Editor:
<img width="668" alt="image" src="https://github.com/user-attachments/assets/555e39f7-fa6e-409f-acc6-9fd4fc9c1750">

#### Front end:
<img width="798" alt="image" src="https://github.com/user-attachments/assets/d43ea73c-8801-4884-803f-7bd406ac7d30">

### After changes:
#### Editor:
<img width="657" alt="image" src="https://github.com/user-attachments/assets/8e0db634-3478-4bbc-bd00-1c6e5eb94e7f">

#### Frontend:
<img width="778" alt="image" src="https://github.com/user-attachments/assets/8f355d56-e48f-4d75-bbc2-51df1b9a78f9">

