### PR TITLE
SlotFill: remove registration API from useSlot result

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,10 @@
 -   `ToggleGroupControl`: Fix active background for `0` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
 -   `SlotFill`: Fix a bug where a stale value of `fillProps` could be used ([#67000](https://github.com/WordPress/gutenberg/pull/67000)).
 
+### Experimental
+
+-   `SlotFill`: Remove registration API methods from return value of `__experimentalUseSlot` ([#67070](https://github.com/WordPress/gutenberg/pull/67070)).
+
 ## 28.12.0 (2024-11-16)
 
 ### Deprecations

--- a/packages/components/src/slot-fill/bubbles-virtually/use-slot.ts
+++ b/packages/components/src/slot-fill/bubbles-virtually/use-slot.ts
@@ -1,42 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useMemo, useContext } from '@wordpress/element';
+import { useContext } from '@wordpress/element';
 import { useObservableValue } from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import SlotFillContext from './slot-fill-context';
-import type {
-	SlotFillBubblesVirtuallyFillRef,
-	SlotFillBubblesVirtuallySlotRef,
-	FillProps,
-	SlotKey,
-} from '../types';
+import type { SlotKey } from '../types';
 
 export default function useSlot( name: SlotKey ) {
 	const registry = useContext( SlotFillContext );
 	const slot = useObservableValue( registry.slots, name );
-
-	const api = useMemo(
-		() => ( {
-			updateSlot: (
-				ref: SlotFillBubblesVirtuallySlotRef,
-				fillProps: FillProps
-			) => registry.updateSlot( name, ref, fillProps ),
-			unregisterSlot: ( ref: SlotFillBubblesVirtuallySlotRef ) =>
-				registry.unregisterSlot( name, ref ),
-			registerFill: ( ref: SlotFillBubblesVirtuallyFillRef ) =>
-				registry.registerFill( name, ref ),
-			unregisterFill: ( ref: SlotFillBubblesVirtuallyFillRef ) =>
-				registry.unregisterFill( name, ref ),
-		} ),
-		[ name, registry ]
-	);
-
-	return {
-		...slot,
-		...api,
-	};
+	return { ...slot };
 }


### PR DESCRIPTION
Follow-up to #67000 where @youknowriad pointed out in review that the API methods (`registerSlot` etc) returned from `__experimentalUseSlot` are not used anywhere. This PR removes the API methods and leaves only the `slot` object.

I also update the `Fill` component to not use `useSlot` at all: the `register/unregisterFill` can be accessed through context and to find out if there is a registered `slot` and whether it has a DOM element, we can look at `registry.slots` directly.

I was also searching for usages of `__experimentalUseSlot`. And it seems to be not really used by plugins. Plugins like [WooCommerce](https://github.com/woocommerce/woocommerce/blob/trunk/packages/js/experimental/src/index.js#L41-L42) or [Kubio](https://wordpress.org/plugins/kubio/) want to know whether a particular slot has registered fills. If there are no fills, they usually don't render the slot at all. They use `__experimentalUseSlotFills( name ).fills.length > 0` to determine that. The `__experimentalUseSlot` function is called only for backward compatibility, because before #44642 there was only `__experimentalUseSlot` and it returned also the fills.

The only place where `__experimentalUseSlot` is really used is the `Popover` component, to determine whether a slot with given name is registered.

If we wanted to stabilize the `useSlot` API and remove the `__experimental` prefix, we need to solve these two use cases:
1. Find out whether a slot (by `name`) has any registered fills. This is _widely_ used to render slots conditionally, only if there are fills registered. Because even an empty slot renders an element and is visible in the UI, and that's often not wanted.
2. Find out whether a slot (by `name`) is registered at all.