### PR TITLE
Stabilize the Experimental block supports property

### DIFF
--- a/docs/reference-guides/data/data-core-blocks.md
+++ b/docs/reference-guides/data/data-core-blocks.md
@@ -123,7 +123,7 @@ _Parameters_
 
 -   _state_ `Object`: Data state.
 -   _nameOrType_ `(string|Object)`: Block name or type object
--   _feature_ `Array|string`: Feature to retrieve
+-   _features_ `Array|string`: Feature to retrieve
 -   _defaultSupports_ `*`: Default value to return if not explicitly defined
 
 _Returns_

--- a/packages/blocks/src/store/selectors.js
+++ b/packages/blocks/src/store/selectors.js
@@ -597,7 +597,7 @@ export const getChildBlockNames = createSelector(
  *
  * @param {Object}          state           Data state.
  * @param {(string|Object)} nameOrType      Block name or type object
- * @param {Array|string}    feature         Feature to retrieve
+ * @param {Array|string}    features        Feature to retrieve
  * @param {*}               defaultSupports Default value to return if not
  *                                          explicitly defined
  *
@@ -629,7 +629,7 @@ export const getChildBlockNames = createSelector(
 export const getBlockSupport = (
 	state,
 	nameOrType,
-	feature,
+	features,
 	defaultSupports
 ) => {
 	const blockType = getNormalizedBlockType( state, nameOrType );
@@ -637,11 +637,31 @@ export const getBlockSupport = (
 		return defaultSupports;
 	}
 
-	return getValueFromObjectPath(
-		blockType.supports,
-		feature,
-		defaultSupports
-	);
+	const featuresArray = Array.isArray( features ) ? features : [ features ];
+
+	let supportValue;
+	for ( const feature of featuresArray ) {
+		// Check for the feature directly
+		supportValue = getValueFromObjectPath( blockType.supports, feature );
+
+		// Check for `defaultControls` if the feature has it
+		if ( supportValue?.defaultControls ) {
+			return supportValue.defaultControls;
+		}
+
+		// Check for `__experimentalDefaultControls` if `defaultControls` is not found
+		if ( supportValue?.__experimentalDefaultControls ) {
+			return supportValue.__experimentalDefaultControls;
+		}
+
+		// If a value is found, return it
+		if ( supportValue !== undefined ) {
+			return supportValue;
+		}
+	}
+
+	// Return the default value if none of the features are found
+	return defaultSupports;
 };
 
 /**


### PR DESCRIPTION
## What?
Split from https://github.com/WordPress/gutenberg/issues/64314

## Why?
The __experimentalDefaultControls property developers can choose which settings are displayed by default in the Editor for each block support. The __experimental prefix removed and now make it easier for third-party developers to confidently use this defaultControls property. Also, falling back to the __experimental prefix if available.

__experimentalDefaultControls → defaultControls

I have added the supports for those hooks:

Color
Typography
Spacing
Border
Now both are workable __experimentalDefaultControls & defaultControls

## How?
This PR adds support for __experimentalDefaultControls & defaultControls in the blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

1. Open block.json file or area.
2. If you have already used for block support __experimentalDefaultControls instead of we can use it defaultControls only.
3. Block support default controls now managing by using this defaultControls property

Note: Here we need to update the WP core blocks' block.json files to use the non __experimental prefixes.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f0314e84-a1cd-430f-88bf-27e1a7ba3b5b


