### PR TITLE
Fix: Header layout spacing in Firefox

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -7,7 +7,7 @@
 	&:has(> .editor-header__center) {
 		grid-template: auto / $header-height min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 1fr) $header-height;
+			grid-template: auto / $header-height minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {


### PR DESCRIPTION
resolves #67069 

## What?
I have adjusted the column widths to improve layout responsiveness in Firefox.

## Why?
When the browser width was reduced to approximately 1200px or lower, the "Save Draft" text began overlapping with the document bar, causing a misalignment.

## How?
To address this, I updated the styles for the .editor-header using the :has selector and modified the template widths to enhance responsiveness across different screen sizes.

```
grid-template: auto / $header-height minmax(min-content, 2fr) 2.5fr minmax(min-content, 2fr) $header-height;
```

## Testing Instructions

1. Open the Firefox browser and create a new page.
2. Resize the browser window to approximately 1200px in width.
3. Verify that the "Save Draft" text no longer appears behind the document bar, as demonstrated in the screenshot provided.
4. Repeat same for "chrome" & "safari"

## ScreenCast

https://github.com/user-attachments/assets/382047ab-9462-4bf6-a723-e9dcc64b9c2a


