### PR TITLE
Fix: ensure "save draft" button stays visible in editor toolbar at medium screen widths in firefox

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -7,7 +7,7 @@
 	&:has(> .editor-header__center) {
 		grid-template: auto / $header-height min-content 1fr min-content $header-height;
 		@include break-medium {
-			grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 1fr) $header-height;
+			grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 2fr) $header-height;
 		}
 	}
 	@include break-mobile {


### PR DESCRIPTION
Closes: https://github.com/WordPress/gutenberg/issues/67069

## What?

This PR resolves an issue where the "Save Draft" text in the editor toolbar starts appearing behind the document bar when the browser width is reduced to around 1200px. This issue has been specifically observed in Firefox.

## Why?

The layout issue was caused by the grid template configuration not adapting well to medium-sized screen widths in Firefox, leading to overlapping elements in the header area. This fix ensures proper alignment and visibility of toolbar elements across different screen sizes and browsers.

## How?

The grid template in the CSS was updated within the break-medium media query to better handle medium screen widths. The updated template ensures the "Save Draft" button and other toolbar elements are correctly aligned and remain visible:

`@include break-medium {
    grid-template: auto / $header-height minmax(min-content, 1fr) 2fr minmax(min-content, 2fr) $header-height;
}`

This adjustment provides a more robust and responsive layout by refining the distribution of space in the header grid.

## Testing Instructions

1. Open the WordPress editor in a browser.
2. Reduce the browser width to around 1200px.
3. Confirm that the "Save Draft" text and other toolbar elements remain visible and properly aligned in Firefox.
4. Resize the browser to various widths to ensure no overlapping issues occur.
5. Test in other browsers (e.g., Chrome, Edge, Safari) to confirm no regressions or layout issues in those environments.

## Screenshots or screencast

https://github.com/user-attachments/assets/d24c9a23-3c60-4d71-b33e-5bd490db649e
