### PR TITLE
DFW: reset zombie state on unmount

### DIFF
--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -42,6 +42,14 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 		}
 	}, [ blockSelectionStart, onToggle ] );
 
+	// Reset isCollapsed when the collapsible block toolbar unmounts.
+	useEffect(
+		() => () => {
+			onToggle( true );
+		},
+		[ onToggle ]
+	);
+
 	if ( ! hasBlockToolbar ) {
 		return null;
 	}

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -42,7 +42,8 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 		}
 	}, [ blockSelectionStart, onToggle ] );
 
-	// Reset isCollapsed when the collapsible block toolbar unmounts.
+	// Reset isCollapsed when the collapsible block toolbar unmounts. It is true
+	// by default.
 	useEffect(
 		() => () => {
 			onToggle( true );

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -11,7 +11,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 import { Button, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
@@ -35,6 +35,13 @@ export default function CollapsibleBlockToolbar() {
 	const [ isCollapsed, setIsCollapsed ] = useState( false );
 
 	const hasBlockSelection = !! blockSelectionStart;
+
+	useEffect( () => {
+		// If we have a new block selection, show the block tools
+		if ( blockSelectionStart ) {
+			setIsCollapsed( false );
+		}
+	}, [ blockSelectionStart ] );
 
 	if ( ! hasBlockToolbar ) {
 		return null;

--- a/packages/editor/src/components/collapsible-block-toolbar/index.js
+++ b/packages/editor/src/components/collapsible-block-toolbar/index.js
@@ -11,7 +11,7 @@ import {
 	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
-import { useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { Button, Popover } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { next, previous } from '@wordpress/icons';
@@ -24,7 +24,7 @@ import { unlock } from '../../lock-unlock';
 
 const { useHasBlockToolbar } = unlock( blockEditorPrivateApis );
 
-export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
+export default function CollapsibleBlockToolbar() {
 	const { blockSelectionStart } = useSelect( ( select ) => {
 		return {
 			blockSelectionStart:
@@ -32,24 +32,9 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 		};
 	}, [] );
 	const hasBlockToolbar = useHasBlockToolbar();
+	const [ isCollapsed, setIsCollapsed ] = useState( false );
 
 	const hasBlockSelection = !! blockSelectionStart;
-
-	useEffect( () => {
-		// If we have a new block selection, show the block tools
-		if ( blockSelectionStart ) {
-			onToggle( false );
-		}
-	}, [ blockSelectionStart, onToggle ] );
-
-	// Reset isCollapsed when the collapsible block toolbar unmounts. It is true
-	// by default.
-	useEffect(
-		() => () => {
-			onToggle( true );
-		},
-		[ onToggle ]
-	);
 
 	if ( ! hasBlockToolbar ) {
 		return null;
@@ -65,12 +50,11 @@ export default function CollapsibleBlockToolbar( { isCollapsed, onToggle } ) {
 				<BlockToolbar hideDragHandle />
 			</div>
 			<Popover.Slot name="block-toolbar" />
-
 			<Button
 				className="editor-collapsible-block-toolbar__toggle"
 				icon={ isCollapsed ? next : previous }
 				onClick={ () => {
-					onToggle( ! isCollapsed );
+					setIsCollapsed( ! isCollapsed );
 				} }
 				label={
 					isCollapsed

--- a/packages/editor/src/components/collapsible-block-toolbar/style.scss
+++ b/packages/editor/src/components/collapsible-block-toolbar/style.scss
@@ -77,3 +77,6 @@
 	}
 }
 
+.editor-header__toolbar:has(.editor-collapsible-block-toolbar:not(.is-collapsed)) + .editor-header__center {
+	display: none;
+}

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -6,7 +6,6 @@ import { useSelect } from '@wordpress/data';
 import { useMediaQuery, useViewportMatch } from '@wordpress/compose';
 import { __unstableMotion as motion } from '@wordpress/components';
 import { store as preferencesStore } from '@wordpress/preferences';
-import { useState } from '@wordpress/element';
 import { PinnedItems } from '@wordpress/interface';
 
 /**
@@ -63,7 +62,6 @@ function Header( {
 		isPublishSidebarOpened,
 		showIconLabels,
 		hasFixedToolbar,
-		hasBlockSelection,
 	} = useSelect( ( select ) => {
 		const { get: getPreference } = select( preferencesStore );
 		const {
@@ -93,12 +91,6 @@ function Header( {
 		PATTERN_POST_TYPE,
 	].includes( postType );
 
-	const [ isBlockToolsCollapsed, setIsBlockToolsCollapsed ] =
-		useState( true );
-
-	const hasCenter =
-		( ! hasBlockSelection || isBlockToolsCollapsed ) &&
-		! isTooNarrowForDocumentBar;
 	const hasBackButton = useHasBackButton();
 	/*
 	 * The edit-post-header classname is only kept for backward compatability
@@ -124,13 +116,10 @@ function Header( {
 					disableBlockTools={ forceDisableBlockTools || isTextEditor }
 				/>
 				{ hasFixedToolbar && isLargeViewport && (
-					<CollapsibleBlockToolbar
-						isCollapsed={ isBlockToolsCollapsed }
-						onToggle={ setIsBlockToolsCollapsed }
-					/>
+					<CollapsibleBlockToolbar />
 				) }
 			</motion.div>
-			{ hasCenter && (
+			{ ! isTooNarrowForDocumentBar && (
 				<motion.div
 					className="editor-header__center"
 					variants={ toolbarVariations }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Whenever exiting Distraction Free Writing, the document toolbar is gone.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It should re-appear. This also seems important because Bluesky is using DFW.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Just use CSS to hide the document toolbar.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Go to the editor demo.
* IMPORTANT: select a block!
* Enter DFW.
* Exit DFW.
* In trunk, the document toolbar is gone. With this PR is should be there.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
