### PR TITLE
Fix: Direct import fails in block editor

### DIFF
--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -6,7 +6,7 @@ A control that lets users set values for top, right, bottom, and left. Can be us
 
 ```jsx
 import { useState } from 'react';
-import { BoxControl } from '@wordpress/components';
+import { __experimentalBoxControl as BoxControl } from '@wordpress/components';
 
 function Example() {
 	const [ values, setValues ] = useState( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`import { BoxControl } from '@wordpress/components';
`

Getting react minified error while following the above way.

## Why?
`import { __experimentalBoxControl as BoxControl } from '@wordpress/components';`

This is the correct way but information is missing in document. This solved the minify error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
1. Add the BoxControl demo in your block as shows in current documentation
2. Access your block in editor.
3. Block will fail to load and console will show error. (Error: Minified React error #130)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

