### PR TITLE
PostTitle: exit early when post type doesn't support titles

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -28,7 +28,7 @@ import usePostTitleFocus from './use-post-title-focus';
 import usePostTitle from './use-post-title';
 import PostTypeSupportCheck from '../post-type-support-check';
 
-function PostTitle( _, forwardedRef ) {
+const PostTitle = forwardRef( ( _, forwardedRef ) => {
 	const { placeholder } = useSelect( ( select ) => {
 		const { getSettings } = select( blockEditorStore );
 		const { titlePlaceholder } = getSettings();
@@ -171,23 +171,21 @@ function PostTitle( _, forwardedRef ) {
 
 	return (
 		/* eslint-disable jsx-a11y/heading-has-content, jsx-a11y/no-noninteractive-element-to-interactive-role */
-		<PostTypeSupportCheck supportKeys="title">
-			<h1
-				ref={ useMergeRefs( [ richTextRef, focusRef ] ) }
-				contentEditable
-				className={ className }
-				aria-label={ decodedPlaceholder }
-				role="textbox"
-				aria-multiline="true"
-				onFocus={ onSelect }
-				onBlur={ onUnselect }
-				onKeyDown={ onKeyDown }
-				onPaste={ onPaste }
-			/>
-		</PostTypeSupportCheck>
+		<h1
+			ref={ useMergeRefs( [ richTextRef, focusRef ] ) }
+			contentEditable
+			className={ className }
+			aria-label={ decodedPlaceholder }
+			role="textbox"
+			aria-multiline="true"
+			onFocus={ onSelect }
+			onBlur={ onUnselect }
+			onKeyDown={ onKeyDown }
+			onPaste={ onPaste }
+		/>
 		/* eslint-enable jsx-a11y/heading-has-content, jsx-a11y/no-noninteractive-element-to-interactive-role */
 	);
-}
+} );
 
 /**
  * Renders the `PostTitle` component.
@@ -197,4 +195,8 @@ function PostTitle( _, forwardedRef ) {
  *
  * @return {Component} The rendered PostTitle component.
  */
-export default forwardRef( PostTitle );
+export default forwardRef( ( _, forwardedRef ) => (
+	<PostTypeSupportCheck supportKeys="title">
+		<PostTitle ref={ forwardedRef } />
+	</PostTypeSupportCheck>
+) );


### PR DESCRIPTION
Fixes #64814, my debugging notes are in https://github.com/WordPress/gutenberg/issues/64814#issuecomment-2482818770

When the post type doesn't support `title`, exit early from rendering the `PostTitle` component. The previous version was setting up all the hooks and whistles needed to render it, but in the end it didn't render the `h1` element.

The patched version calls `useRichText` and everything else only when the post type support is really there.

Note that this patch is merely working around what I believe is a bug in `useRichText`: the `useRichText` hook fails in a subtle way when no element is rendered with the `ref` that it returns.

This patch fixes the bug for me.