### PR TITLE
Image: Ensure consistent image block rendering between editor and frontend

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -6,7 +6,7 @@
 
 	img {
 		height: auto;
-		max-width: 100%;
+		width: 100%;
 		vertical-align: bottom;
 		box-sizing: border-box;
 


### PR DESCRIPTION
Fixes: #67088 

## What?
Changes the CSS property of image blocks from `max-width: 100%` to `width: 100%` to ensure consistent rendering between editor and frontend.

## Why?
- Low-resolution images were displaying inconsistently between editor and frontend
- This broke the WYSIWYG (What You See Is What You Get) experience
- Users were getting confused by different image sizes in editor vs published view
- Prior implementation with `max-width` allowed images to shrink below their container width


## How?
- Modified the CSS for `.wp-block-image img` selector
- Changed `max-width: 100%` to `width: 100%`
- Maintained `height: auto` for proper aspect ratio
- Preserved existing animation and visibility state styles

## Testing Instructions
1. In the site editor, Add an image block
2. Upload or select a low-resolution image (e.g., 300x200px)
3. Observe the image size in editor
4. Save and preview/publish the post
5. Compare the image dimensions between editor and frontend


## Screencast 

### Before fix:

https://github.com/user-attachments/assets/90260efe-fb97-4e12-8218-ba76649e68ef

### After fix:

https://github.com/user-attachments/assets/744b8c9b-524f-4838-93a3-51acb70a7e99


