### PR TITLE
ColorPicker: Add accessible label for copy button

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 -   `ToggleGroupControl`: Fix active background for `0` value ([#66855](https://github.com/WordPress/gutenberg/pull/66855)).
 -   `SlotFill`: Fix a bug where a stale value of `fillProps` could be used ([#67000](https://github.com/WordPress/gutenberg/pull/67000)).
+-   `ColorPicker`: Add accessible label for copy button ([#67094](https://github.com/WordPress/gutenberg/pull/67094)).
 
 ### Experimental
 

--- a/packages/components/src/color-picker/color-copy-button.tsx
+++ b/packages/components/src/color-picker/color-copy-button.tsx
@@ -65,6 +65,11 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 		>
 			<CopyButton
 				size="small"
+				aria-label={
+					copiedColor === color.toHex()
+						? __( 'Copied!' )
+						: __( 'Copy' )
+				}
 				ref={ copyRef }
 				icon={ copy }
 				showTooltip={ false }

--- a/packages/components/src/color-picker/color-copy-button.tsx
+++ b/packages/components/src/color-picker/color-copy-button.tsx
@@ -55,21 +55,14 @@ export const ColorCopyButton = ( props: ColorCopyButtonProps ) => {
 		};
 	}, [] );
 
+	const label =
+		copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' );
+
 	return (
-		<Tooltip
-			delay={ 0 }
-			hideOnClick={ false }
-			text={
-				copiedColor === color.toHex() ? __( 'Copied!' ) : __( 'Copy' )
-			}
-		>
+		<Tooltip delay={ 0 } hideOnClick={ false } text={ label }>
 			<CopyButton
 				size="small"
-				aria-label={
-					copiedColor === color.toHex()
-						? __( 'Copied!' )
-						: __( 'Copy' )
-				}
+				aria-label={ label }
 				ref={ copyRef }
 				icon={ copy }
 				showTooltip={ false }


### PR DESCRIPTION
Alternative to #57168
Addresses ##57157 (maybe not a full fix)

## What?

Adds an accessible label for the copy button in ColorPicker.

## Why?

The icon button was only associated with an ARIA description via the Tooltip, and didn't have an ARIA label. This is a pretty big bug for which the fix was stalled in #57168, so I'm proposing we address this now in a less controversial way.

### Testing Instructions for Keyboard

See the Storybook story for ColorPicker and check that the copy button is accessibly labeled.
