### PR TITLE
Native CI tests: update mac os image runners from `macos-12` to `macos-13`

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-latest
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
+        runs-on: macos-latest
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-13
+        runs-on: macos-14
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-14
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-latest
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
+        runs-on: macos-latest
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['16.4']
+                xcode: ['15']
                 device: ['iPhone 14']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,11 +14,11 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-13
+        runs-on: macos-14
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['15']
+                xcode: ['15.4']
                 device: ['iPhone 14']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,11 +14,11 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-14
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['15.4']
+                xcode: ['15.0.1']
                 device: ['iPhone 14']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['14.2']
+                xcode: ['16.2']
                 device: ['iPhone 14']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -18,7 +18,7 @@ jobs:
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
-                xcode: ['16.2']
+                xcode: ['16.4']
                 device: ['iPhone 14']
                 native-test-name: [gutenberg-editor-rendering]
 

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,7 +3,7 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "16.2"
+			"platformVersion": "16.4"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,7 +3,7 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "16.4"
+			"platformVersion": "16.2"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,14 +3,14 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "16.2"
+			"platformVersion": "17.0"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",
 			"deviceTabletName": "iPad (10th generation) Simulator"
 		},
 		"buildkite": {
-			"platformVersion": "16.4"
+			"platformVersion": "17.0"
 		},
 		"pixelRatio": {
 			"iPhone": 3,

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,14 +3,14 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "17.0"
+			"platformVersion": "16.2"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",
 			"deviceTabletName": "iPad (10th generation) Simulator"
 		},
 		"buildkite": {
-			"platformVersion": "17.0"
+			"platformVersion": "16.4"
 		},
 		"pixelRatio": {
 			"iPhone": 3,

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,7 +3,7 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "17"
+			"platformVersion": "16.2"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,7 +3,7 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "16.2"
+			"platformVersion": "17.0"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",

--- a/packages/react-native-editor/__device-tests__/helpers/device-config.json
+++ b/packages/react-native-editor/__device-tests__/helpers/device-config.json
@@ -3,7 +3,7 @@
 		"local": {
 			"deviceName": "iPhone 14",
 			"deviceTabletName": "iPad (10th generation)",
-			"platformVersion": "16.2"
+			"platformVersion": "17"
 		},
 		"saucelabs": {
 			"deviceName": "iPhone 14 Simulator",


### PR DESCRIPTION
So basically I don't know what I'm doing. 

https://github.com/actions/runner-images is a source of confusion on which xcode version supports which mac os image runner. 

According to what I've found:

1. As of November 2024, the default Xcode version on macos-13 is Xcode 15.0.1 [source](https://github.com/actions/runner-images/issues/7508), and the default Xcode version on macos-14 is Xcode 15.4 [source](https://github.com/actions/runner-images/issues/10121).
2. macos-13 may default to iOS 17 runtime simulator [source](https://github.com/actions/runner-images/issues/8023). Newer runners support iOS 17 runtime simulator [source](https://github.com/actions/runner-images/issues/8023).


This PR is just a YOLO space. I'll wait for the experts.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? How?
Update mac os image runners from `macos-12` to ~latest~ `macos-13`




## Why?


> GitHub Actions is starting the deprecation process for macOS 12. While the image is being deprecated, You may experience longer queue times during peak usage hours. Deprecation will begin on 10/7/24 and the image will be fully unsupported by 12/3/24
> 
> To raise awareness of the upcoming removal, we will temporarily fail jobs using macOS 12. Builds that are scheduled to run during the brownout periods will fail. The brownouts are scheduled for the following dates and times:


See: https://github.com/actions/runner-images/issues/10721


 
## Testing Instructions

Behold! The native tests should pass 👀 🤞🏻 
