### PR TITLE
Style book: remove styles from examples

### DIFF
--- a/packages/block-library/src/cover/index.js
+++ b/packages/block-library/src/cover/index.js
@@ -26,6 +26,14 @@ export const settings = {
 			customOverlayColor: '#065174',
 			dimRatio: 40,
 			url: 'https://s.w.org/images/core/5.3/Windbuchencom.jpg',
+			style: {
+				typography: {
+					fontSize: 48,
+				},
+				color: {
+					text: 'white',
+				},
+			},
 		},
 		innerBlocks: [
 			{
@@ -33,14 +41,6 @@ export const settings = {
 				attributes: {
 					content: __( '<strong>Snow Patrol</strong>' ),
 					align: 'center',
-					style: {
-						typography: {
-							fontSize: 48,
-						},
-						color: {
-							text: 'white',
-						},
-					},
 				},
 			},
 		],

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -27,16 +27,6 @@ export const settings = {
 				type: 'constrained',
 				justifyContent: 'center',
 			},
-			style: {
-				spacing: {
-					padding: {
-						top: '4em',
-						right: '3em',
-						bottom: '4em',
-						left: '3em',
-					},
-				},
-			},
 		},
 		innerBlocks: [
 			{

--- a/packages/block-library/src/group/index.js
+++ b/packages/block-library/src/group/index.js
@@ -27,6 +27,16 @@ export const settings = {
 				type: 'constrained',
 				justifyContent: 'center',
 			},
+			style: {
+				spacing: {
+					padding: {
+						top: '4em',
+						right: '3em',
+						bottom: '4em',
+						left: '3em',
+					},
+				},
+			},
 		},
 		innerBlocks: [
 			{

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -150,6 +150,11 @@ function getOverviewBlockExamples(
 				name: blockName,
 				title: blockType.title,
 				category: 'overview',
+				/*
+				 * CSS generated from style attributes will take precedence over global styles CSS,
+				 * so remove the style attribute from the example to ensure the example
+				 * demonstrates changes to global styles.
+				 */
 				blocks: getBlockFromExample( blockName, {
 					...blockType.example,
 					attributes: {
@@ -185,6 +190,11 @@ export function getExamples( colors: MultiOriginPalettes ): BlockExample[] {
 			name: blockType.name,
 			title: blockType.title,
 			category: blockType.category,
+			/*
+			 * CSS generated from style attributes will take precedence over global styles CSS,
+			 * so remove the style attribute from the example to ensure the example
+			 * demonstrates changes to global styles.
+			 */
 			blocks: getBlockFromExample( blockType.name, {
 				...blockType.example,
 				attributes: {

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -150,7 +150,13 @@ function getOverviewBlockExamples(
 				name: blockName,
 				title: blockType.title,
 				category: 'overview',
-				blocks: getBlockFromExample( blockName, blockType.example ),
+				blocks: getBlockFromExample( blockName, {
+					...blockType.example,
+					attributes: {
+						...blockType.example.attributes,
+						style: undefined,
+					},
+				} ),
 			};
 			examples.push( blockExample );
 		}
@@ -179,7 +185,13 @@ export function getExamples( colors: MultiOriginPalettes ): BlockExample[] {
 			name: blockType.name,
 			title: blockType.title,
 			category: blockType.category,
-			blocks: getBlockFromExample( blockType.name, blockType.example ),
+			blocks: getBlockFromExample( blockType.name, {
+				...blockType.example,
+				attributes: {
+					...blockType.example.attributes,
+					style: undefined,
+				},
+			} ),
 		} ) );
 	const isHeadingBlockRegistered = !! getBlockType( 'core/heading' );
 


### PR DESCRIPTION
## What? How? Why?

Resolves https://github.com/WordPress/gutenberg/issues/67092

In the style book, remove block example styles because they prevent global styles from being tested/previewed.

For the cover block example, move the styles up to the container block.


## Testing Instructions

1. Fire up the site editor.
2. Open the style book and head to the "Themes" tab.
3. Find the group block, select it, then edit the group block's global padding styles.
4. You should see the padding changes represented on the canvas.
5. Do the same for the cover block, but edit its font size and text color. The changes should appear!
6. Know that your time is valuable and appreciated.

### Group block
https://github.com/user-attachments/assets/03fe90d0-cfbd-4edf-a538-4cf96f147f62

Also check what the group example looks like in the preview - it's example padding should be preserved:

<img width="672" alt="Screenshot 2024-11-20 at 12 40 26 pm" src="https://github.com/user-attachments/assets/eb6f2f45-7c4a-4303-9421-6b6b99cb78c2">

### Cover block


https://github.com/user-attachments/assets/9f8218fa-4a6c-45d9-aa32-e8c54fdf2109


The cover block preview should look the same as before:

| Trunk | This PR |
|--------|--------|
| <img width="300" alt="Screenshot 2024-11-20 at 12 48 45 pm" src="https://github.com/user-attachments/assets/f478fe89-6c31-4132-a097-bcb1da885ad7"> | <img width="300" alt="Screenshot 2024-11-20 at 12 47 27 pm" src="https://github.com/user-attachments/assets/35c14cff-4725-4824-a38a-0b804c11824a"> | 





