### PR TITLE
Inserter: Set initial active tab ID during render

### DIFF
--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -6,7 +6,7 @@ import {
 	privateApis as componentsPrivateApis,
 	__unstableMotion as motion,
 } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -35,14 +35,13 @@ function CategoryTabs( {
 	const selectedTabId = selectedCategory ? selectedCategory.name : null;
 	const [ activeTabId, setActiveId ] = useState();
 	const firstTabId = categories?.[ 0 ]?.name;
-	useEffect( () => {
-		// If there is no active tab, make the first tab the active tab, so that
-		// when focus is moved to the tablist, the first tab will be focused
-		// despite not being selected
-		if ( selectedTabId === null && ! activeTabId && firstTabId ) {
-			setActiveId( firstTabId );
-		}
-	}, [ selectedTabId, activeTabId, firstTabId, setActiveId ] );
+
+	// If there is no active tab, make the first tab the active tab, so that
+	// when focus is moved to the tablist, the first tab will be focused
+	// despite not being selected
+	if ( selectedTabId === null && ! activeTabId && firstTabId ) {
+		setActiveId( firstTabId );
+	}
 
 	return (
 		<Tabs


### PR DESCRIPTION
## What?
PR updates the `activeTabId` logic in the `CategoryTabs` component and sets the state during render instead of using the effect.

Initially, I planned to fix the effect dependencies (`setActiveId` can be omitted, and we could also remove `activeTabId`), but I realized we could use a different pattern.

## Why?
React will re-render `CategoryTabs` immediately and not render its children or update the DOM, avoiding rendering a tab list with an undefined active tab ID.

Details:

* https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes
* https://blog.isquaredsoftware.com/2020/05/blogged-answers-a-mostly-complete-guide-to-react-rendering-behavior/#setting-state-while-rendering


## Testing Instructions
1. Open a post or page.
2. Open Inserter and switch to Patterns or Media.
3. Move focus on the tab list. Usually, two <kbd>Tab</kbd> presses when opening the pattern tab.
4. Confirm that focus correctly moves into the tab list. The first tab should be focused despite not being selected.

### Testing Instructions for Keyboard
Same.

## Screencast

https://github.com/user-attachments/assets/9cb99b34-63e1-4902-a56b-9193b6348074