### PR TITLE
Global Styles: Remove unused 'Fragment' import

### DIFF
--- a/packages/edit-site/src/components/global-styles/ui.js
+++ b/packages/edit-site/src/components/global-styles/ui.js
@@ -19,7 +19,7 @@ import { __ } from '@wordpress/i18n';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { moreVertical } from '@wordpress/icons';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect, Fragment } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 import { usePrevious } from '@wordpress/compose';
 
 /**


### PR DESCRIPTION
## What?
PR removes unused `Fragment` import for Global Styles UI components. Probably a leftover from #65619.

## Testing Instructions
None. CI checks should be green.