### PR TITLE
Heading: Hide border controls by default

### DIFF
--- a/packages/block-library/src/heading/block.json
+++ b/packages/block-library/src/heading/block.json
@@ -37,13 +37,7 @@
 			"color": true,
 			"radius": true,
 			"style": true,
-			"width": true,
-			"__experimentalDefaultControls": {
-				"color": true,
-				"radius": true,
-				"style": true,
-				"width": true
-			}
+			"width": true
 		},
 		"color": {
 			"gradients": true,


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/issues/43247

## What?

Makes border support controls for the heading block optional, i.e. not displayed by default.

## Why?

The general consensus through work on https://github.com/WordPress/gutenberg/issues/43247 is that default display of border controls should match the display of margin and padding controls.

The heading block makes margin and padding optional controls so they have to be toggled on via the Dimension panel's ToolsPanel button. This PR makes the border controls consistent with that.

## How?

Removes default controls config for border controls in the Heading block.json.

## Testing Instructions

1. Edit a post and add a heading block
2. Ensure that the border controls are hidden by default
3. Toggle on the border controls and make sure they work as expected.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|---|---|
| <img width="282" alt="Screenshot 2024-11-19 at 7 44 12 pm" src="https://github.com/user-attachments/assets/190b74e7-eb18-4f35-8364-df3e2719c8a9"> | <img width="282" alt="Screenshot 2024-11-19 at 7 43 37 pm" src="https://github.com/user-attachments/assets/ecaf608c-087a-44ed-bc4d-3934e53b56fd"> |

