### PR TITLE
ESLint: Bump `eslint-plugin-react-compiler` to latest beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
 				"eslint-plugin-jest": "27.2.3",
 				"eslint-plugin-jest-dom": "5.0.2",
 				"eslint-plugin-prettier": "5.0.0",
-				"eslint-plugin-react-compiler": "19.0.0-beta-8a03594-20241020",
+				"eslint-plugin-react-compiler": "19.0.0-beta-0dec889-20241115",
 				"eslint-plugin-ssr-friendly": "1.0.6",
 				"eslint-plugin-storybook": "0.6.13",
 				"eslint-plugin-testing-library": "6.0.2",
@@ -25365,9 +25365,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react-compiler": {
-			"version": "19.0.0-beta-8a03594-20241020",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-8a03594-20241020.tgz",
-			"integrity": "sha512-bYg1COih1s3r14IV/AKdQs/SN7CQmNI0ZaMtPdgZ6gp1S1Q/KGP9P43w7R6dHJ4wYpuMBvekNJHQdVu+x6UM+A==",
+			"version": "19.0.0-beta-0dec889-20241115",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-react-compiler/-/eslint-plugin-react-compiler-19.0.0-beta-0dec889-20241115.tgz",
+			"integrity": "sha512-jTjEHuE8/R6qD/CD2d+5YvWMy1q9/tX3kft4WDyg42/HktjHtHXrEToyZ6THEQf8t/YWMY1RGeCkykePbACtFA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/core": "^7.24.4",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
 		"eslint-plugin-jest": "27.2.3",
 		"eslint-plugin-jest-dom": "5.0.2",
 		"eslint-plugin-prettier": "5.0.0",
-		"eslint-plugin-react-compiler": "19.0.0-beta-8a03594-20241020",
+		"eslint-plugin-react-compiler": "19.0.0-beta-0dec889-20241115",
 		"eslint-plugin-ssr-friendly": "1.0.6",
 		"eslint-plugin-storybook": "0.6.13",
 		"eslint-plugin-testing-library": "6.0.2",

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useRef } from '@wordpress/element';
 import { create, getTextContent } from '@wordpress/rich-text';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as coreStore } from '@wordpress/core-data';
@@ -127,6 +128,8 @@ export default function DocumentOutline( {
 		};
 	} );
 
+	const prevHeadingLevelRef = useRef( 1 );
+
 	const headings = computeOutlineHeadings( blocks );
 	if ( headings.length < 1 ) {
 		return (
@@ -140,8 +143,6 @@ export default function DocumentOutline( {
 			</div>
 		);
 	}
-
-	let prevHeadingLevel = 1;
 
 	// Not great but it's the simplest way to locate the title right now.
 	const titleNode = document.querySelector( '.editor-post-title__input' );
@@ -172,7 +173,8 @@ export default function DocumentOutline( {
 				{ headings.map( ( item, index ) => {
 					// Headings remain the same, go up by one, or down by any amount.
 					// Otherwise there are missing levels.
-					const isIncorrectLevel = item.level > prevHeadingLevel + 1;
+					const isIncorrectLevel =
+						item.level > prevHeadingLevelRef.current + 1;
 
 					const isValid =
 						! item.isEmpty &&
@@ -180,7 +182,7 @@ export default function DocumentOutline( {
 						!! item.level &&
 						( item.level !== 1 ||
 							( ! hasMultipleH1 && ! hasTitle ) );
-					prevHeadingLevel = item.level;
+					prevHeadingLevelRef.current = item.level;
 
 					return (
 						<DocumentOutlineItem


### PR DESCRIPTION
## What?
Bumping `eslint-plugin-react-compiler` to the latest version and fixing a violation in the meantime.

## Why?
The ESLint plugin is in beta, so we're keeping it up to date more frequently as new beta is released every few days.

## How?
* Bumping `eslint-plugin-react-compiler` to `19.0.0-beta-0dec889-20241115`
* Fixing a violation in `DocumentOutline` by changing a local variable to a ref.

## Testing Instructions
* Open the post editor.
* Insert some heading blocks, increasing (h2, followed by h3, followed by h4) and some that break the order (h3, followed by h5).
* Verify the check for invalid blocks still works correctly.
* Verify all checks are green.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-11-19 at 11 35 31](https://github.com/user-attachments/assets/94b4b1ad-d885-4c65-a873-2cb80f22139a)
