### PR TITLE
Editor: Correctly select post title support in 'DocumentOutline'

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -279,8 +279,7 @@ Renders a document outline component.
 _Parameters_
 
 -   _props_ `Object`: Props.
--   _props.onSelect_ `Function`: Function to be called when an outline item is selected.
--   _props.isTitleSupported_ `boolean`: Indicates whether the title is supported.
+-   _props.onSelect_ `Function`: Function to be called when an outline item is selected
 -   _props.hasOutlineItemsDisabled_ `boolean`: Indicates whether the outline items are disabled.
 
 _Returns_

--- a/packages/editor/src/components/document-outline/check.js
+++ b/packages/editor/src/components/document-outline/check.js
@@ -19,7 +19,7 @@ export default function DocumentOutlineCheck( { children } ) {
 		return getGlobalBlockCount( 'core/heading' ) > 0;
 	} );
 
-	if ( hasHeadings ) {
+	if ( ! hasHeadings ) {
 		return null;
 	}
 

--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -102,19 +102,17 @@ const isEmptyHeading = ( heading ) =>
  * Renders a document outline component.
  *
  * @param {Object}   props                         Props.
- * @param {Function} props.onSelect                Function to be called when an outline item is selected.
- * @param {boolean}  props.isTitleSupported        Indicates whether the title is supported.
+ * @param {Function} props.onSelect                Function to be called when an outline item is selected
  * @param {boolean}  props.hasOutlineItemsDisabled Indicates whether the outline items are disabled.
  *
  * @return {Component} The component to be rendered.
  */
 export default function DocumentOutline( {
 	onSelect,
-	isTitleSupported,
 	hasOutlineItemsDisabled,
 } ) {
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const { blocks, title } = useSelect( ( select ) => {
+	const { blocks, title, isTitleSupported } = useSelect( ( select ) => {
 		const { getBlocks } = select( blockEditorStore );
 		const { getEditedPostAttribute } = select( editorStore );
 		const { getPostType } = select( coreStore );


### PR DESCRIPTION
## What?
PR fixes two obvious mistakes I missed in #59209 😞

Note: The title selection currently isn't working correctly and is being tracked in #47624. I've some ideas on how to fix it; I'll push it separately.

## Testing Instructions
1. Switch to one of the classic default themes - 2012.
2. Open a post or a page.
3. View the document outline.
4. Confirm that the title is rendered.

### Testing Instructions for Keyboard
Same.
