### PR TITLE
Site Hub: Fix height in mobile layout

### DIFF
--- a/packages/edit-site/src/components/site-hub/style.scss
+++ b/packages/edit-site/src/components/site-hub/style.scss
@@ -4,7 +4,7 @@
 	justify-content: space-between;
 	gap: $grid-unit-10;
 	margin-right: $grid-unit-15;
-	height: $grid-unit-70;
+	height: $header-height;
 }
 
 .edit-site-site-hub__actions {


### PR DESCRIPTION
Related to #66171

## What?

This PR changes the height of the site hub from `56px` to `60px`. This fixes the appearance of a vertical scrollbar in mobile layouts.

| Before | After |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/39376eb4-4fe8-4361-9ba7-f4b8f9b35d4f)| ![image](https://github.com/user-attachments/assets/6f7deb41-613b-439a-970a-4245538c14a7) | 

## Why?

This is because the site hub is 56px tall, while the toggle icon inside is 60px tall:

![image](https://github.com/user-attachments/assets/d0897b6b-cf53-4b2d-a898-df8dd4c8b9bb)

## Testing Instructions

- Narrow your browser width.
- Go to Site Editor > Patterns.
- The site hub should no longer have a scrollbar.

