### PR TITLE
Mapping Contextual Commands: Clear customizations for template parts

### DIFF
--- a/packages/editor/src/components/commands/index.js
+++ b/packages/editor/src/components/commands/index.js
@@ -459,5 +459,6 @@ export default function useCommands() {
 	useCommandLoader( {
 		name: 'core/edit-site/manipulate-document',
 		hook: getManipulateDocumentCommands(),
+		context: 'entity-edit',
 	} );
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/50407

## What?
Command that will be suggested and prioritized when the Command Center is invoked from specific flows (Site Editor)

## Why?
Currently not suggesting "clear customizations" command when palette launch

## Testing Instructions
1. Open the site editor
2. Open the Command Palette (by pressing Cmd + K on Mac).
3. Confirm that the command prompt for "Reset template part" is showing without any search for the current template part only if it has some customization available.

## Screenshots or screencast <!-- if applicable -->
<img width="1433" alt="reset-template-part" src="https://github.com/user-attachments/assets/cd86e2ef-9f1f-498c-a514-27f5e1b0f3fb">
