### PR TITLE
Try advanced heuristic to "detect" the best Section Root in Themes

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -179,15 +179,13 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 					return rootBlocks[ groupBlockIndex ].clientId;
 				}
 
-				// 4. Group or Cover block at the root.
-				const groupOrCoverBlockIndex = rootBlocks.findIndex(
-					( block ) =>
-						block.name === 'core/group' ||
-						block.name === 'core/cover'
+				// 4. Group block at the root.
+				const groupBlock = rootBlocks.find(
+					( block ) => block.name === 'core/group'
 				);
 
-				if ( groupOrCoverBlockIndex !== -1 ) {
-					return rootBlocks[ groupOrCoverBlockIndex ].clientId;
+				if ( groupBlock ) {
+					return groupBlock.clientId;
 				}
 
 				// Default to empty to indicate the root of the block editor


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Refines the algorithm for determining the section root to include common patterns found in Themes.

Closes https://github.com/WordPress/gutenberg/issues/65400

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently the algorithm optimises solely for a Group block with a `<main>` tag. That's pretty restrictive and many Themes don't optimise for this...yet.

We need to include common patterns found in Themes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Seeks the root in the following in order of priority:

- Post Content (when editing Posts/Pages only)
- Group with `<main>` tag - this can be anywhere in the block hierarchy.
- A Group block at _the root of the block tree_ (only) in between template parts named "Header" and "Footer".
- Any Group block at the root of the block tree.
- Empty - indicates there is no root and the whole editor will be treated as the section root.

Note I intentionally ommitted other types of "container" block such as 👍 

- Columns
- Cover

This is because these blocks do not behave well with drop zones in this experience. 

- Columns - it is not possible to determine which column should be the section root so we cannot use that.
- Cover - is too opinionated to allow for a good drag and drop experience in Zoom Out. It's not really a true "container".

As a result for anything other than Group we will treat the root of the editor as the root. This means if the Theme chooses to use a Columns block as the root then in Zoom Out you will be able to insert content before/after the Columns but not within them.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Easiest to test using Playground.

- https://playground.wordpress.net/?gutenberg-pr=67113&theme=Adonay - ⚠️ Adonay uses `<main>` in an unusual location. Resetting the `<main>` tag to default will be best when testing.
- https://playground.wordpress.net/?gutenberg-pr=67113&theme=Impressionist

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
