### PR TITLE
Fix unexpected unlock control in block toolbar in non-default editing mode 

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -204,11 +204,13 @@ export function PrivateBlockToolbar( {
 									disabled={ ! isDefaultEditingMode }
 									isUsingBindings={ isUsingBindings }
 								/>
-								{ ! isMultiToolbar && showLockButtons && (
-									<BlockLockToolbar
-										clientId={ blockClientId }
-									/>
-								) }
+								{ ! isMultiToolbar &&
+									showLockButtons &&
+									isDefaultEditingMode && (
+										<BlockLockToolbar
+											clientId={ blockClientId }
+										/>
+									) }
 								<BlockMover
 									clientIds={ blockClientIds }
 									hideDragHandle={ hideDragHandle }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hides the Lock controls in the Block toolbar when _not_ in default editing mode.

Closes https://github.com/WordPress/gutenberg/issues/67082

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Unlocking is a advanced level action and is not required for `contentOnly` or when blocks are `disabled`.

It makes little sense in Zoom Out either.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adjust conditional to include `isDefaultEditingMode`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Site Editor
- Edit any Page with a Template
- Click on the Page Title block
- See no Lock icon in toolbar.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

#### Before
<img width="1540" alt="Screen Shot 2024-12-02 at 13 33 08" src="https://github.com/user-attachments/assets/e6e2be58-a418-4005-ab50-f73a4720f931">


#### After

<img width="1524" alt="Screen Shot 2024-12-02 at 13 33 37" src="https://github.com/user-attachments/assets/f711b0ee-b46a-4347-9135-2da1e10362e5">


