### PR TITLE
Zoom in/out to correct location

### DIFF
--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,55 +3,65 @@
 }
 
 .block-editor-iframe__html {
+	$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
+	$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
+	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
+
 	transform-origin: top center;
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s);
+	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
+		position: fixed;
+		left: 0;
+		right: 0;
+		top: calc(-1 * #{$scroll-top});
+		bottom: 0;
+		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
+		scale: $scale;
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
-		@include editor-canvas-resize-animation(transform 0s);
+		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
-}
 
-.block-editor-iframe__html.is-zoomed-out {
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
-	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
-	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
-	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-	// Apply an X translation to center the scaled content within the available space.
-	transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-	scale: #{$scale};
-	background-color: $gray-300;
+	&.is-zoomed-out {
+		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
+		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
+		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
+		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+		// Apply an X translation to center the scaled content within the available space.
+		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+		scale: $scale;
+		background-color: $gray-300;
 
-	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
-	// so we need to adjust the height of the content to match the scale by using negative margins.
-	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
-	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
-	margin-bottom: calc(-1 * #{$total-height});
-	// Add the top/bottom frame size. We use scaling to account for the left/right, as
-	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-	// of the content.
-	padding-top: calc(#{$frame-size} / #{$scale});
-	padding-bottom: calc(#{$frame-size} / #{$scale});
+		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+		// so we need to adjust the height of the content to match the scale by using negative margins.
+		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
+		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
+		margin-bottom: calc(-1 * #{$total-height});
+		// Add the top/bottom frame size. We use scaling to account for the left/right, as
+		// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+		// of the content.
+		padding-top: calc(#{$frame-size} / #{$scale});
+		padding-bottom: calc(#{$frame-size} / #{$scale});
 
-	body {
-		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+		body {
+			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
 
-		> .is-root-container:not(.wp-block-post-content) {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-			height: 100%;
-
-			> main {
+			> .is-root-container:not(.wp-block-post-content) {
 				flex: 1;
+				display: flex;
+				flex-direction: column;
+				height: 100%;
+
+				> main {
+					flex: 1;
+				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -6,12 +6,12 @@
 	$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
 	$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
 	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
-
+	scale: $scale;
 	transform-origin: top center;
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation(transform 0s, scale 0s, padding 0s, translate 0s);
+	@include editor-canvas-resize-animation( transform 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
 		position: fixed;
@@ -20,7 +20,6 @@
 		top: calc(-1 * #{$scroll-top});
 		bottom: 0;
 		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
-		scale: $scale;
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
@@ -35,9 +34,7 @@
 		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
 		// Apply an X translation to center the scaled content within the available space.
 		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-		scale: $scale;
 		background-color: $gray-300;
-
 		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
 		// so we need to adjust the height of the content to match the scale by using negative margins.
 		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -20,6 +20,9 @@
 		top: calc(-1 * #{$scroll-top});
 		bottom: 0;
 		translate: 0 calc(#{$scroll-top} - #{$scroll-top-next});
+		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
+		// and removing the scrollbar causes the content to shift.
+		overflow-y: scroll;
 		// we only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -3,10 +3,6 @@
 }
 
 .block-editor-iframe__html {
-	$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
-	$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
-	$scale: var(--wp-block-editor-iframe-zoom-out-scale, 1);
-	scale: $scale;
 	transform-origin: top center;
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
@@ -14,6 +10,9 @@
 	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
+		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);
+		$scroll-top-next: var(--wp-block-editor-iframe-zoom-out-scroll-top-next, 0);
+
 		position: fixed;
 		left: 0;
 		right: 0;
@@ -23,45 +22,49 @@
 		// Force preserving a scrollbar gutter as scrollbar-gutter isn't supported in all browsers yet,
 		// and removing the scrollbar causes the content to shift.
 		overflow-y: scroll;
-		// we only want to animate the scaling when entering zoom out. When sidebars
+
+		// We only want to animate the scaling when entering zoom out. When sidebars
 		// are toggled, the resizing of the iframe handles scaling the canvas as well,
 		// and the doubled animations cause very odd animations.
 		@include editor-canvas-resize-animation( transform 0s, top 0s, bottom 0s, right 0s, left 0s );
 	}
+}
 
-	&.is-zoomed-out {
-		$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
-		$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
-		$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
-		$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
-		$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
-		// Apply an X translation to center the scaled content within the available space.
-		transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
-		background-color: $gray-300;
-		// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
-		// so we need to adjust the height of the content to match the scale by using negative margins.
-		$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
-		$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
-		$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
-		margin-bottom: calc(-1 * #{$total-height});
-		// Add the top/bottom frame size. We use scaling to account for the left/right, as
-		// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
-		// of the content.
-		padding-top: calc(#{$frame-size} / #{$scale});
-		padding-bottom: calc(#{$frame-size} / #{$scale});
+.block-editor-iframe__html.is-zoomed-out {
+	$scale: var(--wp-block-editor-iframe-zoom-out-scale);
+	$frame-size: var(--wp-block-editor-iframe-zoom-out-frame-size);
+	$inner-height: var(--wp-block-editor-iframe-zoom-out-inner-height);
+	$content-height: var(--wp-block-editor-iframe-zoom-out-content-height);
+	$scale-container-width: var(--wp-block-editor-iframe-zoom-out-scale-container-width);
+	$container-width: var(--wp-block-editor-iframe-zoom-out-container-width, 100vw);
+	// Apply an X translation to center the scaled content within the available space.
+	transform: translateX(calc((#{$scale-container-width} - #{$container-width}) / 2 / #{$scale}));
+	scale: #{$scale};
+	background-color: $gray-300;
 
-		body {
-			min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+	// Chrome seems to respect that transform scale shouldn't affect the layout size of the element,
+	// so we need to adjust the height of the content to match the scale by using negative margins.
+	$extra-content-height: calc(#{$content-height} * (1 - #{$scale}));
+	$total-frame-height: calc(2 * #{$frame-size} / #{$scale});
+	$total-height: calc(#{$extra-content-height} + #{$total-frame-height} + 2px);
+	margin-bottom: calc(-1 * #{$total-height});
+	// Add the top/bottom frame size. We use scaling to account for the left/right, as
+	// the padding left/right causes the contents to reflow, which breaks the 1:1 scaling
+	// of the content.
+	padding-top: calc(#{$frame-size} / #{$scale});
+	padding-bottom: calc(#{$frame-size} / #{$scale});
 
-			> .is-root-container:not(.wp-block-post-content) {
+	body {
+		min-height: calc((#{$inner-height} - #{$total-frame-height}) / #{$scale});
+
+		> .is-root-container:not(.wp-block-post-content) {
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+
+			> main {
 				flex: 1;
-				display: flex;
-				flex-direction: column;
-				height: 100%;
-
-				> main {
-					flex: 1;
-				}
 			}
 		}
 	}

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -11,7 +11,7 @@
 	// We don't want to animate the transform of the translateX because it is used
 	// to "center" the canvas. Leaving it on causes the canvas to slide around in
 	// odd ways.
-	@include editor-canvas-resize-animation( transform 0s, padding 0s, translate 0s);
+	@include editor-canvas-resize-animation( transform 0s, scale 0s, padding 0s, translate 0s);
 
 	&.zoom-out-animation {
 		position: fixed;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -426,6 +426,7 @@ function Iframe( {
 			iframeDocument.documentElement.classList.remove(
 				'zoom-out-animation'
 			);
+
 			// Update previous values.
 			prevClientHeightRef.current = clientHeight;
 			prevFrameSizeRef.current = frameSizeValue;
@@ -435,9 +436,10 @@ function Iframe( {
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}
 
+		let raf;
 		if ( prefersReducedMotion ) {
 			// Hack: Wait for the window values to recalculate.
-			iframeDocument.defaultView.requestAnimationFrame(
+			raf = iframeDocument.defaultView.requestAnimationFrame(
 				onZoomOutTransitionEnd
 			);
 		} else {
@@ -458,10 +460,14 @@ function Iframe( {
 			iframeDocument.documentElement.classList.remove(
 				'zoom-out-animation'
 			);
-			iframeDocument.documentElement.removeEventListener(
-				'transitionend',
-				onZoomOutTransitionEnd
-			);
+			if ( prefersReducedMotion ) {
+				iframeDocument.defaultView.cancelAnimationFrame( raf );
+			} else {
+				iframeDocument.documentElement.removeEventListener(
+					'transitionend',
+					onZoomOutTransitionEnd
+				);
+			}
 		};
 	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -129,10 +129,8 @@ function Iframe( {
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
-	const [
-		containerResizeListener,
-		{ width: containerWidth, height: containerHeight },
-	] = useResizeObserver();
+	const [ containerResizeListener, { width: containerWidth } ] =
+		useResizeObserver();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -283,7 +281,8 @@ function Iframe( {
 	const frameSizeValue = parseInt( frameSize );
 	const prevFrameSizeRef = useRef( frameSizeValue );
 
-	const prevClientHeightRef = useRef( containerHeight );
+	// Initialized in the useEffect.
+	const prevClientHeightRef = useRef();
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -346,20 +345,20 @@ function Iframe( {
 			return;
 		}
 
-		// Previous scale value.
-		const prevScale = prevScaleRef.current;
-
-		// Unscaled height of the previous iframe container.
-		const prevClientHeight = prevClientHeightRef.current;
-
-		// Unscaled size of the previous padding around the iframe content.
-		const prevFrameSize = prevFrameSizeRef.current;
-
 		// Unscaled height of the current iframe container.
 		const clientHeight = iframeDocument.documentElement.clientHeight;
 
 		// Scaled height of the current iframe content.
 		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		// Previous scale value.
+		const prevScale = prevScaleRef.current;
+
+		// Unscaled size of the previous padding around the iframe content.
+		const prevFrameSize = prevFrameSizeRef.current;
+
+		// Unscaled height of the previous iframe container.
+		const prevClientHeight = prevClientHeightRef.current ?? clientHeight;
 
 		// We can't trust the set value from contentHeight, as it was measured
 		// before the zoom out mode was changed. After zoom out mode is changed,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -286,7 +286,6 @@ function Iframe( {
 	const prevFrameSizeRef = useRef( frameSizeValue );
 
 	const prevClientHeightRef = useRef( containerHeight );
-	const prevScrollHeightRef = useRef( contentHeight );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -359,7 +358,6 @@ function Iframe( {
 		const scrollHeight = iframeDocument.documentElement.scrollHeight;
 
 		const prevClientHeight = prevClientHeightRef.current;
-		// const prevScrollHeight = prevScrollHeightRef.current;
 		const prevScale = prevScaleRef.current;
 		const prevFrameSize = prevFrameSizeRef.current;
 
@@ -379,18 +377,14 @@ function Iframe( {
 		);
 
 		const scaleRatio = scaleValue / prevScale;
-		const maxScrollTop = scrollHeight * scaleRatio - clientHeight;
+		const maxScrollTop =
+			scrollHeight * scaleRatio - clientHeight + frameSizeValue * 2;
 
-		// Account for differences in client height changes between zoom in and zoom out modes.
-		const edgeThreshold =
-			clientHeight / 2 + ( prevClientHeight - clientHeight );
-
-		// prettier-ignore
-		scrollTopNext = scrollTopNext - edgeThreshold <= 0 ? 0 : scrollTopNext;
-		// prettier-ignore
-		scrollTopNext = scrollTopNext + edgeThreshold >= maxScrollTop ? maxScrollTop : scrollTopNext;
-
-		scrollTopNext = Math.min( Math.max( 0, scrollTopNext ), maxScrollTop );
+		// scrollTopNext will zoom to the center point unless it would scroll past the top or bottom.
+		// In that case, it will clamp to the top or bottom.
+		scrollTopNext = Math.round(
+			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
+		);
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -418,7 +412,6 @@ function Iframe( {
 			);
 
 			prevClientHeightRef.current = clientHeight;
-			prevScrollHeightRef.current = scrollHeight;
 			prevFrameSizeRef.current = frameSizeValue;
 			prevScaleRef.current = scaleValue;
 			iframeDocument.documentElement.scrollTop = scrollTopNext;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -376,6 +376,9 @@ function Iframe( {
 				clientHeight / 2
 		);
 
+		// If we are near the top of the canvas, set the next scroll top to 0.
+		scrollTopNext = scrollTop <= prevFrameSize ? 0 : scrollTopNext;
+
 		const scaleRatio = scaleValue / prevScale;
 		const maxScrollTop =
 			scrollHeight * scaleRatio - clientHeight + frameSizeValue * 2;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -340,11 +340,7 @@ function Iframe( {
 
 	useEffect( () => cleanup, [ cleanup ] );
 
-	const zoomOutAnimationTimeoutRef = useRef( null );
-
 	const handleZoomOutAnimation = useCallback( () => {
-		clearTimeout( zoomOutAnimationTimeoutRef.current );
-
 		// Previous scale value.
 		const prevScale = prevScaleRef.current;
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -437,7 +437,10 @@ function Iframe( {
 		}
 
 		if ( prefersReducedMotion ) {
-			onZoomOutTransitionEnd();
+			// Hack: Wait for the window values to recalculate.
+			iframeDocument.defaultView.requestAnimationFrame(
+				onZoomOutTransitionEnd
+			);
 		} else {
 			iframeDocument.documentElement.addEventListener(
 				'transitionend',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -359,7 +359,7 @@ function Iframe( {
 		const scrollHeight = iframeDocument.documentElement.scrollHeight;
 
 		const prevClientHeight = prevClientHeightRef.current;
-		const prevScrollHeight = prevScrollHeightRef.current;
+		// const prevScrollHeight = prevScrollHeightRef.current;
 		const prevScale = prevScaleRef.current;
 		const prevFrameSize = prevFrameSizeRef.current;
 
@@ -381,10 +381,14 @@ function Iframe( {
 		const scaleRatio = scaleValue / prevScale;
 		const maxScrollTop = scrollHeight * scaleRatio - clientHeight;
 
+		// Account for differences in client height changes between zoom in and zoom out modes.
+		const edgeThreshold =
+			clientHeight / 2 + ( prevClientHeight - clientHeight );
+
 		// prettier-ignore
-		scrollTopNext = scrollTopNext - clientHeight / 2 <= 0 ? 0 : scrollTopNext;
+		scrollTopNext = scrollTopNext - edgeThreshold <= 0 ? 0 : scrollTopNext;
 		// prettier-ignore
-		scrollTopNext = scrollTopNext + clientHeight / 2 >= maxScrollTop ? maxScrollTop : scrollTopNext;
+		scrollTopNext = scrollTopNext + edgeThreshold >= maxScrollTop ? maxScrollTop : scrollTopNext;
 
 		scrollTopNext = Math.min( Math.max( 0, scrollTopNext ), maxScrollTop );
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -483,6 +483,7 @@ function Iframe( {
 		if ( isZoomedOut ) {
 			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 		} else {
+			// HACK: Since we can't remove this in the cleanup, we need to do it here.
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		}
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -527,6 +527,28 @@ function Iframe( {
 			'--wp-block-editor-iframe-zoom-out-scale-container-width',
 			`${ scaleContainerWidth }px`
 		);
+
+		return () => {
+			// TODO: Removing this causes issues with the zoom out animation.
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-frame-size'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-content-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-inner-height'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-container-width'
+			// );
+			// iframeDocument.documentElement.style.removeProperty(
+			// 	'--wp-block-editor-iframe-zoom-out-scale-container-width'
+			// );
+		};
 	}, [
 		scaleValue,
 		frameSize,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -271,20 +271,18 @@ function Iframe( {
 		containerWidth
 	);
 
+	const frameSizeValue = parseInt( frameSize );
+
 	const maxWidth = 750;
 	const scaleValue =
 		scale === 'auto-scaled'
-			? ( Math.min( containerWidth, maxWidth ) -
-					parseInt( frameSize ) * 2 ) /
+			? ( Math.min( containerWidth, maxWidth ) - frameSizeValue * 2 ) /
 			  scaleContainerWidth
 			: scale;
+
 	const prevScaleRef = useRef( scaleValue );
-
-	const frameSizeValue = parseInt( frameSize );
 	const prevFrameSizeRef = useRef( frameSizeValue );
-
-	// Initialized in the useEffect.
-	const prevClientHeightRef = useRef();
+	const prevClientHeightRef = useRef( /* Initialized in the useEffect. */ );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -339,7 +339,8 @@ function Iframe( {
 	useEffect( () => {
 		if (
 			! iframeDocument ||
-			// TODO: What should this condition be?
+			// HACK: Checking if isZoomedOut differs from prevIsZoomedOut here
+			// instead of the dependency array to appease the linter.
 			( scaleValue === 1 ) === ( prevScaleRef.current === 1 )
 		) {
 			return;
@@ -480,7 +481,8 @@ function Iframe( {
 		}
 
 		return () => {
-			// TODO: Removing this causes issues with the zoom out animation.
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
 			// iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
 	}, [ iframeDocument, isZoomedOut ] );
@@ -527,7 +529,8 @@ function Iframe( {
 		);
 
 		return () => {
-			// TODO: Removing this causes issues with the zoom out animation.
+			// HACK: Skipping cleanup because it causes issues with the zoom out
+			// animation. More refactoring is needed to fix this properly.
 			// iframeDocument.documentElement.style.removeProperty(
 			// 	'--wp-block-editor-iframe-zoom-out-scale'
 			// );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -407,6 +407,16 @@ function Iframe( {
 			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
 		);
 
+		const reduceMotion = iframeDocument.defaultView.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		).matches;
+
+		if ( reduceMotion ) {
+			// TODO: This seems to be broken somehow.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+			return;
+		}
+
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
 			`${ scrollTop }px`
@@ -419,24 +429,24 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
 
-		// TODO: See if there's a way to wait for CSS transition to finish.
-		// 400ms should match the animation speed used in components/iframe/content.scss
-		// Ignore the delay when reduce motion is enabled.
-		const reduceMotion = iframeDocument.defaultView.matchMedia(
-			'(prefers-reduced-motion: reduce)'
-		).matches;
-		const delay = reduceMotion ? 0 : 400;
+		iframeDocument.documentElement.addEventListener(
+			'transitionend',
+			() => {
+				// Remove the position fixed for the animation.
+				iframeDocument.documentElement.classList.remove(
+					'zoom-out-animation'
+				);
 
-		zoomOutAnimationTimeoutRef.current = setTimeout( () => {
-			iframeDocument.documentElement.classList.remove(
-				'zoom-out-animation'
-			);
+				// Update previous values.
+				prevClientHeightRef.current = clientHeight;
+				prevFrameSizeRef.current = frameSizeValue;
+				prevScaleRef.current = scaleValue;
 
-			prevClientHeightRef.current = clientHeight;
-			prevFrameSizeRef.current = frameSizeValue;
-			prevScaleRef.current = scaleValue;
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-		}, delay );
+				// Set the final scroll position that was just animated to.
+				iframeDocument.documentElement.scrollTop = scrollTopNext;
+			},
+			{ once: true }
+		);
 	}, [ scaleValue, frameSizeValue, iframeDocument ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -20,6 +20,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	useReducedMotion,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -131,6 +132,7 @@ function Iframe( {
 		useResizeObserver();
 	const [ containerResizeListener, { width: containerWidth } ] =
 		useResizeObserver();
+	const prefersReducedMotion = useReducedMotion();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -434,11 +436,7 @@ function Iframe( {
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}
 
-		const reduceMotion = iframeDocument.defaultView.matchMedia(
-			'(prefers-reduced-motion: reduce)'
-		).matches;
-
-		if ( reduceMotion ) {
+		if ( prefersReducedMotion ) {
 			onZoomOutTransitionEnd();
 		} else {
 			iframeDocument.documentElement.addEventListener(
@@ -463,7 +461,7 @@ function Iframe( {
 				onZoomOutTransitionEnd
 			);
 		};
-	}, [ iframeDocument, scaleValue, frameSizeValue ] );
+	}, [ iframeDocument, scaleValue, frameSizeValue, prefersReducedMotion ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -32,6 +32,7 @@ import { useBlockSelectionClearer } from '../block-selection-clearer';
 import { useWritingFlow } from '../writing-flow';
 import { getCompatibilityStyles } from './get-compatibility-styles';
 import { store as blockEditorStore } from '../../store';
+import { handle } from '@wordpress/icons';
 
 function bubbleEvent( event, Constructor, frame ) {
 	const init = {};
@@ -407,46 +408,49 @@ function Iframe( {
 			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
 		);
 
+		function handleZoomOutEnd() {
+			// Update previous values.
+			prevClientHeightRef.current = clientHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			// Set the final scroll position that was just animated to.
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}
+
 		const reduceMotion = iframeDocument.defaultView.matchMedia(
 			'(prefers-reduced-motion: reduce)'
 		).matches;
 
 		if ( reduceMotion ) {
-			// TODO: This seems to be broken somehow.
-			iframeDocument.documentElement.scrollTop = scrollTopNext;
-			return;
+			handleZoomOutEnd();
+		} else {
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top',
+				`${ scrollTop }px`
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+				`${ scrollTopNext }px`
+			);
+
+			iframeDocument.documentElement.classList.add(
+				'zoom-out-animation'
+			);
+
+			iframeDocument.documentElement.addEventListener(
+				'transitionend',
+				() => {
+					// Remove the position fixed for the animation.
+					iframeDocument.documentElement.classList.remove(
+						'zoom-out-animation'
+					);
+					handleZoomOutEnd();
+				},
+				{ once: true }
+			);
 		}
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top',
-			`${ scrollTop }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-			`${ scrollTopNext }px`
-		);
-
-		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
-
-		iframeDocument.documentElement.addEventListener(
-			'transitionend',
-			() => {
-				// Remove the position fixed for the animation.
-				iframeDocument.documentElement.classList.remove(
-					'zoom-out-animation'
-				);
-
-				// Update previous values.
-				prevClientHeightRef.current = clientHeight;
-				prevFrameSizeRef.current = frameSizeValue;
-				prevScaleRef.current = scaleValue;
-
-				// Set the final scroll position that was just animated to.
-				iframeDocument.documentElement.scrollTop = scrollTopNext;
-			},
-			{ once: true }
-		);
 	}, [ scaleValue, frameSizeValue, iframeDocument ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -406,7 +406,10 @@ function Iframe( {
 		// possible scrollTop positions. Round the value to avoid subpixel
 		// truncation by the browser which sometimes causes a 1px error.
 		scrollTopNext = Math.round(
-			Math.min( Math.max( 0, scrollTopNext ), maxScrollTop )
+			Math.min(
+				Math.max( 0, scrollTopNext ),
+				Math.max( 0, maxScrollTop )
+			)
 		);
 
 		iframeDocument.documentElement.style.setProperty(

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -21,7 +21,6 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
-	usePrevious,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -260,7 +259,7 @@ function Iframe( {
 	}, [] );
 
 	const isZoomedOut = scale !== 1;
-	const prevIsZoomedOut = usePrevious( isZoomedOut );
+	const prevIsZoomedOutRef = useRef( isZoomedOut );
 
 	useEffect( () => {
 		if ( ! isZoomedOut ) {
@@ -415,6 +414,9 @@ function Iframe( {
 	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
 	// number of dependencies.
 	useEffect( () => {
+		const prevIsZoomedOut = prevIsZoomedOutRef.current;
+		prevIsZoomedOutRef.current = isZoomedOut;
+
 		// If we're animating, don't re-update things.
 		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
 			return;

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -413,7 +413,7 @@ function Iframe( {
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -122,6 +122,7 @@ function Iframe( {
 		};
 	}, [] );
 	const { styles = '', scripts = '' } = resolvedAssets;
+	/** @type {[Document, any]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const initialContainerWidthRef = useRef( 0 );
 	const [ bodyClasses, setBodyClasses ] = useState( [] );
@@ -284,7 +285,8 @@ function Iframe( {
 	const frameSizeValue = parseInt( frameSize );
 	const prevFrameSizeRef = useRef( frameSizeValue );
 
-	const prevContainerHeightRef = useRef( containerHeight );
+	const prevClientHeightRef = useRef( containerHeight );
+	const prevScrollHeightRef = useRef( contentHeight );
 
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
@@ -343,40 +345,48 @@ function Iframe( {
 	const handleZoomOutAnimation = useCallback( () => {
 		clearTimeout( zoomOutAnimationTimeoutRef.current );
 
+		// We can't trust the set value from contentHeight, as it was measured before the zoom out mode was changed.
+		// After zoom out mode is changed, appenders may appear or disappear, so we need to get the height from the iframe
+		// at this point when we're about to animate the zoom out. The iframe scrollTop, scrollHeight, and clientHeight will all
+		// be accurate. The client height also does change when the zoom out mode is toggled, as the bottom bar about selecting
+		// the template is added/removed when toggling zoom out mode.
 		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// This is the unscaled height of the iframe content.
+		const clientHeight = iframeDocument.documentElement.clientHeight;
+
+		// This is the scaled height of the iframe content.
+		const scrollHeight = iframeDocument.documentElement.scrollHeight;
+
+		const prevClientHeight = prevClientHeightRef.current;
+		const prevScrollHeight = prevScrollHeightRef.current;
+		const prevScale = prevScaleRef.current;
+		const prevFrameSize = prevFrameSizeRef.current;
 
 		// Convert previous values to the zoomed in scale.
 		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
 		const scrollTopOriginal = Math.round(
-			( scrollTop +
-				prevContainerHeightRef.current / 2 -
-				prevFrameSizeRef.current ) /
-				prevScaleRef.current -
-				prevContainerHeightRef.current / 2
+			( scrollTop + prevClientHeight / 2 - prevFrameSize ) / prevScale -
+				prevClientHeight / 2
 		);
 
 		// Convert the zoomed in value to the new scale.
 		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
 		let scrollTopNext = Math.round(
-			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
+			( scrollTopOriginal + clientHeight / 2 ) * scaleValue +
 				frameSizeValue -
-				containerHeight / 2
+				clientHeight / 2
 		);
 
-		const edgeThreshold = prevContainerHeightRef.current / 2;
-		const maxScrollPosition =
-			contentHeight - prevContainerHeightRef.current - frameSizeValue * 2;
+		const scaleRatio = scaleValue / prevScale;
+		const maxScrollTop = scrollHeight * scaleRatio - clientHeight;
 
-		const scaleToTop = scrollTopOriginal - edgeThreshold <= 0;
-		const scaleToBottom =
-			scrollTopOriginal - maxScrollPosition - edgeThreshold <= 0;
+		// prettier-ignore
+		scrollTopNext = scrollTopNext - clientHeight / 2 <= 0 ? 0 : scrollTopNext;
+		// prettier-ignore
+		scrollTopNext = scrollTopNext + clientHeight / 2 >= maxScrollTop ? maxScrollTop : scrollTopNext;
 
-		if ( scaleToTop ) {
-			scrollTopNext = 0;
-		} else if ( scaleToBottom ) {
-			// Not sure on this
-			scrollTopNext = maxScrollPosition * scaleValue;
-		}
+		scrollTopNext = Math.min( Math.max( 0, scrollTopNext ), maxScrollTop );
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -403,19 +413,13 @@ function Iframe( {
 				'zoom-out-animation'
 			);
 
-			prevContainerHeightRef.current = containerHeight;
+			prevClientHeightRef.current = clientHeight;
+			prevScrollHeightRef.current = scrollHeight;
 			prevFrameSizeRef.current = frameSizeValue;
 			prevScaleRef.current = scaleValue;
-
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}, delay );
-	}, [
-		scaleValue,
-		frameSizeValue,
-		containerHeight,
-		iframeDocument,
-		contentHeight,
-	] );
+	}, [ scaleValue, frameSizeValue, iframeDocument ] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -121,7 +121,7 @@ function Iframe( {
 		};
 	}, [] );
 	const { styles = '', scripts = '' } = resolvedAssets;
-	/** @type {[Document, any]} */
+	/** @type {[Document, import('react').Dispatch<Document>]} */
 	const [ iframeDocument, setIframeDocument ] = useState();
 	const initialContainerWidthRef = useRef( 0 );
 	const [ bodyClasses, setBodyClasses ] = useState( [] );

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -419,7 +419,7 @@ function Iframe( {
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument || ! isZoomedOut ) {
+		if ( ! iframeDocument ) {
 			return;
 		}
 
@@ -457,27 +457,6 @@ function Iframe( {
 			'--wp-block-editor-iframe-zoom-out-scale-container-width',
 			`${ scaleContainerWidth }px`
 		);
-
-		return () => {
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-content-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-inner-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-container-width'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			);
-		};
 	}, [
 		scaleValue,
 		frameSize,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -128,8 +128,10 @@ function Iframe( {
 	const [ before, writingFlowRef, after ] = useWritingFlow();
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
-	const [ containerResizeListener, { width: containerWidth } ] =
-		useResizeObserver();
+	const [
+		containerResizeListener,
+		{ width: containerWidth, height: containerHeight },
+	] = useResizeObserver();
 
 	const setRef = useRefEffect( ( node ) => {
 		node._load = () => {
@@ -268,6 +270,20 @@ function Iframe( {
 		containerWidth
 	);
 
+	const maxWidth = 750;
+	const scaleValue =
+		scale === 'auto-scaled'
+			? ( Math.min( containerWidth, maxWidth ) -
+					parseInt( frameSize ) * 2 ) /
+			  scaleContainerWidth
+			: scale;
+	const prevScaleRef = useRef( scaleValue );
+
+	const frameSizeValue = parseInt( frameSize );
+	const prevFrameSizeRef = useRef( frameSizeValue );
+
+	const prevContainerHeightRef = useRef( containerHeight );
+
 	const disabledRef = useDisabled( { isDisabled: ! readonly } );
 	const bodyRef = useMergeRefs( [
 		useBubbleEvents( iframeDocument ),
@@ -320,39 +336,86 @@ function Iframe( {
 
 	useEffect( () => cleanup, [ cleanup ] );
 
-	const zoomOutAnimationClassnameRef = useRef( null );
-
+	const zoomOutAnimationTimeoutRef = useRef( null );
+	const isAnimatingZoomOut = useRef( null );
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
 	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
 	// number of dependencies.
 	useEffect( () => {
-		if ( ! iframeDocument || ! isZoomedOut ) {
+		// If we're animating, don't re-update things.
+		if ( ! iframeDocument || isAnimatingZoomOut.current ) {
 			return;
 		}
 
-		const handleZoomOutAnimationClassname = () => {
-			clearTimeout( zoomOutAnimationClassnameRef.current );
+		const handleZoomOutAnimation = () => {
+			clearTimeout( zoomOutAnimationTimeoutRef.current );
+			isAnimatingZoomOut.current = true;
+
+			const scrollTop = iframeDocument.documentElement.scrollTop;
+
+			// Convert previous values to the zoomed in scale.
+			// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+			const scrollTopOriginal = Math.round(
+				( scrollTop +
+					prevContainerHeightRef.current / 2 -
+					prevFrameSizeRef.current ) /
+					prevScaleRef.current -
+					prevContainerHeightRef.current / 2
+			);
+
+			// // Convert the zoomed in value to the new scale.
+			// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+			const scrollTopNext = Math.round(
+				( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
+					frameSizeValue -
+					containerHeight / 2
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top',
+				`${ scrollTop }px`
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+				`${ scrollTopNext }px`
+			);
 
 			iframeDocument.documentElement.classList.add(
 				'zoom-out-animation'
 			);
 
-			zoomOutAnimationClassnameRef.current = setTimeout( () => {
+			zoomOutAnimationTimeoutRef.current = setTimeout( () => {
 				iframeDocument.documentElement.classList.remove(
 					'zoom-out-animation'
 				);
+
+				prevContainerHeightRef.current = containerHeight;
+				prevFrameSizeRef.current = frameSizeValue;
+				prevScaleRef.current = scaleValue;
+				isAnimatingZoomOut.current = false;
+
+				iframeDocument.documentElement.scrollTop = scrollTopNext;
 			}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
 		};
 
-		handleZoomOutAnimationClassname();
-		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		handleZoomOutAnimation();
 
-		return () => {
-			handleZoomOutAnimationClassname();
+		if ( isZoomedOut ) {
+			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		} else {
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
-		};
-	}, [ iframeDocument, isZoomedOut ] );
+		}
+
+		return () => {};
+	}, [
+		iframeDocument,
+		isZoomedOut,
+		scaleValue,
+		frameSizeValue,
+		containerHeight,
+	] );
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
@@ -360,7 +423,6 @@ function Iframe( {
 			return;
 		}
 
-		const maxWidth = 750;
 		// Note: When we initialize the zoom out when the canvas is smaller (sidebars open),
 		// initialContainerWidthRef will be smaller than the full page, and reflow will happen
 		// when the canvas area becomes larger due to sidebars closing. This is a known but
@@ -371,11 +433,7 @@ function Iframe( {
 		// but calc( 100px / 2px ) is not.
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scale',
-			scale === 'auto-scaled'
-				? ( Math.min( containerWidth, maxWidth ) -
-						parseInt( frameSize ) * 2 ) /
-						scaleContainerWidth
-				: scale
+			scaleValue
 		);
 
 		// frameSize has to be a px value for the scaling and frame size to be computed correctly.
@@ -421,7 +479,7 @@ function Iframe( {
 			);
 		};
 	}, [
-		scale,
+		scaleValue,
 		frameSize,
 		iframeDocument,
 		iframeWindowInnerHeight,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -390,6 +390,14 @@ function Iframe( {
 
 		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
 
+		// TODO: See if there's a way to wait for CSS transition to finish.
+		// 400ms should match the animation speed used in components/iframe/content.scss
+		// Ignore the delay when reduce motion is enabled.
+		const reduceMotion = iframeDocument.defaultView.matchMedia(
+			'(prefers-reduced-motion: reduce)'
+		).matches;
+		const delay = reduceMotion ? 0 : 400;
+
 		zoomOutAnimationTimeoutRef.current = setTimeout( () => {
 			iframeDocument.documentElement.classList.remove(
 				'zoom-out-animation'
@@ -400,7 +408,7 @@ function Iframe( {
 			prevScaleRef.current = scaleValue;
 
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
-		}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
+		}, delay );
 	}, [
 		scaleValue,
 		frameSizeValue,

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -13,6 +13,7 @@ import {
 	useMemo,
 	useEffect,
 	useRef,
+	useCallback,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import {
@@ -20,6 +21,7 @@ import {
 	useMergeRefs,
 	useRefEffect,
 	useDisabled,
+	usePrevious,
 } from '@wordpress/compose';
 import { __experimentalStyleProvider as StyleProvider } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -258,6 +260,7 @@ function Iframe( {
 	}, [] );
 
 	const isZoomedOut = scale !== 1;
+	const prevIsZoomedOut = usePrevious( isZoomedOut );
 
 	useEffect( () => {
 		if ( ! isZoomedOut ) {
@@ -337,69 +340,66 @@ function Iframe( {
 	useEffect( () => cleanup, [ cleanup ] );
 
 	const zoomOutAnimationTimeoutRef = useRef( null );
-	const isAnimatingZoomOut = useRef( null );
+
+	const handleZoomOutAnimation = useCallback( () => {
+		clearTimeout( zoomOutAnimationTimeoutRef.current );
+
+		const scrollTop = iframeDocument.documentElement.scrollTop;
+
+		// Convert previous values to the zoomed in scale.
+		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+		const scrollTopOriginal = Math.round(
+			( scrollTop +
+				prevContainerHeightRef.current / 2 -
+				prevFrameSizeRef.current ) /
+				prevScaleRef.current -
+				prevContainerHeightRef.current / 2
+		);
+
+		// // Convert the zoomed in value to the new scale.
+		// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+		const scrollTopNext = Math.round(
+			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
+				frameSizeValue -
+				containerHeight / 2
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top',
+			`${ scrollTop }px`
+		);
+
+		iframeDocument.documentElement.style.setProperty(
+			'--wp-block-editor-iframe-zoom-out-scroll-top-next',
+			`${ scrollTopNext }px`
+		);
+
+		iframeDocument.documentElement.classList.add( 'zoom-out-animation' );
+
+		zoomOutAnimationTimeoutRef.current = setTimeout( () => {
+			iframeDocument.documentElement.classList.remove(
+				'zoom-out-animation'
+			);
+
+			prevContainerHeightRef.current = containerHeight;
+			prevFrameSizeRef.current = frameSizeValue;
+			prevScaleRef.current = scaleValue;
+
+			iframeDocument.documentElement.scrollTop = scrollTopNext;
+		}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
+	}, [ scaleValue, frameSizeValue, containerHeight, iframeDocument ] );
+
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're
 	// only toggling these when the zoom out mode changes, as that useEffect is also triggered by a large
 	// number of dependencies.
 	useEffect( () => {
 		// If we're animating, don't re-update things.
-		if ( ! iframeDocument || isAnimatingZoomOut.current ) {
+		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
 			return;
 		}
 
-		const handleZoomOutAnimation = () => {
-			clearTimeout( zoomOutAnimationTimeoutRef.current );
-			isAnimatingZoomOut.current = true;
-
-			const scrollTop = iframeDocument.documentElement.scrollTop;
-
-			// Convert previous values to the zoomed in scale.
-			// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
-			const scrollTopOriginal = Math.round(
-				( scrollTop +
-					prevContainerHeightRef.current / 2 -
-					prevFrameSizeRef.current ) /
-					prevScaleRef.current -
-					prevContainerHeightRef.current / 2
-			);
-
-			// // Convert the zoomed in value to the new scale.
-			// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
-			const scrollTopNext = Math.round(
-				( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
-					frameSizeValue -
-					containerHeight / 2
-			);
-
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top',
-				`${ scrollTop }px`
-			);
-
-			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scroll-top-next',
-				`${ scrollTopNext }px`
-			);
-
-			iframeDocument.documentElement.classList.add(
-				'zoom-out-animation'
-			);
-
-			zoomOutAnimationTimeoutRef.current = setTimeout( () => {
-				iframeDocument.documentElement.classList.remove(
-					'zoom-out-animation'
-				);
-
-				prevContainerHeightRef.current = containerHeight;
-				prevFrameSizeRef.current = frameSizeValue;
-				prevScaleRef.current = scaleValue;
-				isAnimatingZoomOut.current = false;
-
-				iframeDocument.documentElement.scrollTop = scrollTopNext;
-			}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
-		};
-
+		// If zoom out mode is toggled, handle the animation
 		handleZoomOutAnimation();
 
 		if ( isZoomedOut ) {
@@ -409,17 +409,11 @@ function Iframe( {
 		}
 
 		return () => {};
-	}, [
-		iframeDocument,
-		isZoomedOut,
-		scaleValue,
-		frameSizeValue,
-		containerHeight,
-	] );
+	}, [ iframeDocument, isZoomedOut, handleZoomOutAnimation ] );
 
 	// Calculate the scaling and CSS variables for the zoom out canvas
 	useEffect( () => {
-		if ( ! iframeDocument ) {
+		if ( ! iframeDocument || prevIsZoomedOut === isZoomedOut ) {
 			return;
 		}
 

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -356,13 +356,28 @@ function Iframe( {
 				prevContainerHeightRef.current / 2
 		);
 
-		// // Convert the zoomed in value to the new scale.
-		// // Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
-		const scrollTopNext = Math.round(
+		// Convert the zoomed in value to the new scale.
+		// Use Math.round to avoid subpixel scrolling which would effectively result in a Math.floor.
+		let scrollTopNext = Math.round(
 			( scrollTopOriginal + containerHeight / 2 ) * scaleValue +
 				frameSizeValue -
 				containerHeight / 2
 		);
+
+		const edgeThreshold = prevContainerHeightRef.current / 2;
+		const maxScrollPosition =
+			contentHeight - prevContainerHeightRef.current - frameSizeValue * 2;
+
+		const scaleToTop = scrollTopOriginal - edgeThreshold <= 0;
+		const scaleToBottom =
+			scrollTopOriginal - maxScrollPosition - edgeThreshold <= 0;
+
+		if ( scaleToTop ) {
+			scrollTopNext = 0;
+		} else if ( scaleToBottom ) {
+			// Not sure on this
+			scrollTopNext = maxScrollPosition * scaleValue;
+		}
 
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-scroll-top',
@@ -387,7 +402,13 @@ function Iframe( {
 
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}, 400 ); // 400ms should match the animation speed used in components/iframe/content.scss
-	}, [ scaleValue, frameSizeValue, containerHeight, iframeDocument ] );
+	}, [
+		scaleValue,
+		frameSizeValue,
+		containerHeight,
+		iframeDocument,
+		contentHeight,
+	] );
 
 	// Toggle zoom out CSS Classes only when zoom out mode changes. We could add these into the useEffect
 	// that controls settings the CSS variables, but then we would need to do more work to ensure we're

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -436,6 +436,9 @@ function Iframe( {
 			prevScaleRef.current = scaleValue;
 
 			// Set the final scroll position that was just animated to.
+			// Disable reason: Eslint isn't smart enough to know that this is a
+			// DOM element. https://github.com/facebook/react/issues/31483
+			// eslint-disable-next-line react-compiler/react-compiler
 			iframeDocument.documentElement.scrollTop = scrollTopNext;
 		}
 

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -109,6 +109,8 @@ test.describe( 'Zoom Out', () => {
 		page,
 		editor,
 	} ) => {
+		// Add some patterns into the page.
+		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT );
 		// Find the scroll container element
 		await page.evaluate( () => {
 			const { activeElement } =

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -3,6 +3,63 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
+const EDITOR_ZOOM_OUT_CONTENT = `
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-2-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>First Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>First Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>First Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>Second Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>Second Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Second Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-2-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>Third Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>Third Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Third Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>Fourth Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>Fourth Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>Fourth Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`;
+
 test.describe( 'Zoom Out', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyfour' );
@@ -46,5 +103,114 @@ test.describe( 'Zoom Out', () => {
 		} );
 		expect( htmlRect.y + paddingTop ).toBeGreaterThan( iframeRect.y );
 		expect( htmlRect.x ).toBeGreaterThan( iframeRect.x );
+	} );
+
+	test( 'Toggling zoom state should keep content centered', async ( {
+		page,
+		editor,
+	} ) => {
+		// Find the scroll container element
+		await page.evaluate( () => {
+			const { activeElement } =
+				document.activeElement?.contentDocument ?? document;
+			window.scrollContainer =
+				window.wp.dom.getScrollContainer( activeElement );
+			return window.scrollContainer;
+		} );
+
+		// Test: Test from top of page (scrollTop 0)
+		// Enter Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+
+		const scrollTopZoomed = await page.evaluate( () => {
+			return window.scrollContainer.scrollTop;
+		} );
+
+		expect( scrollTopZoomed ).toBe( 0 );
+
+		// Exit Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+
+		const scrollTopNoZoom = await page.evaluate( () => {
+			return window.scrollContainer.scrollTop;
+		} );
+
+		expect( scrollTopNoZoom ).toBe( 0 );
+
+		// Test: Should center the scroll position when zooming out/in
+		const firstSectionEnd = editor.canvas.locator(
+			'text=First Section End'
+		);
+		const secondSectionStart = editor.canvas.locator(
+			'text=Second Section Start'
+		);
+		const secondSectionCenter = editor.canvas.locator(
+			'text=Second Section Center'
+		);
+		const secondSectionEnd = editor.canvas.locator(
+			'text=Second Section End'
+		);
+		const thirdSectionStart = editor.canvas.locator(
+			'text=Third Section Start'
+		);
+		const thirdSectionCenter = editor.canvas.locator(
+			'text=Third Section Center'
+		);
+		const thirdSectionEnd = editor.canvas.locator(
+			'text=Third Section End'
+		);
+		const fourthSectionStart = editor.canvas.locator(
+			'text=Fourth Section Start'
+		);
+
+		// Test for second section
+		// Playwright scrolls it to the center of the viewport, so this is what we scroll to.
+		await secondSectionCenter.scrollIntoViewIfNeeded();
+
+		// Because the text is spread with a group height of 100vh, they should both be visible.
+		await expect( firstSectionEnd ).not.toBeInViewport();
+		await expect( secondSectionStart ).toBeInViewport();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).not.toBeInViewport();
+
+		// After zooming, if we zoomed out with the correct central point, they should both still be visible when toggling zoom out state
+		// Enter Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( firstSectionEnd ).toBeInViewport();
+		await expect( secondSectionStart ).toBeInViewport();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+
+		// Exit Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( firstSectionEnd ).not.toBeInViewport();
+		await expect( secondSectionStart ).toBeInViewport();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).not.toBeInViewport();
+
+		// Test for third section
+		// Playwright scrolls it to the center of the viewport, so this is what we scroll to.
+		await thirdSectionCenter.scrollIntoViewIfNeeded();
+
+		// Because the text is spread with a group height of 100vh, they should both be visible.
+		await expect( secondSectionEnd ).not.toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+		await expect( thirdSectionEnd ).toBeInViewport();
+		await expect( fourthSectionStart ).not.toBeInViewport();
+
+		// After zooming, if we zoomed out with the correct central point, they should both still be visible when toggling zoom out state
+		// Enter Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( secondSectionEnd ).toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+		await expect( thirdSectionEnd ).toBeInViewport();
+		await expect( fourthSectionStart ).toBeInViewport();
+
+		// Exit Zoom Out
+		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
+		await expect( secondSectionEnd ).not.toBeInViewport();
+		await expect( thirdSectionStart ).toBeInViewport();
+		await expect( thirdSectionEnd ).toBeInViewport();
+		await expect( fourthSectionStart ).not.toBeInViewport();
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

> [!IMPORTANT]
> This is a rebase of #66618 onto `trunk` without any additional refactoring.
>
> Refactoring to remove the hacks and address maintainability is being done in #66917.

Fixes https://github.com/WordPress/gutenberg/issues/65884

Also fixes a minor bug where setting the scroll position was still delayed even when there was no animation due to reduced motion settings.

## What?
<!-- In a few words, what is the PR actually doing? -->
Maintain the visible content of the editor canvas when zooming in/out.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It's disorienting to zoom in/out and lose your frame of reference.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
When changing scale (zoom in/out):
- get the current scroll height, position, and height of the canvas
- change the canvas to fixed position to remove the scrollbar so we can smoothly animate the scale change
- reapply the scroll position, calculated off of changes to scale and frame size

It will always attempt to scale to the center unless we are at the top of the canvas. In which case, it will scale to keep the top of the canvas visible.

### Known bugs
- **The scaling doesn't always go to the exact center**, but at least keeps your central content visible. This is due to there being changes from zoom in/out canvas sizes from appenders being added/removed, and possibly other unintended changes to content height when switching modes.
- **Sometimes flickering content when changing modes**: This is likely due to appenders being added/removed when the mode changes. 
- Images without fixed heights such as those coming from just a URL can also cause layout shift when switching modes leading to incorrect zoom positioning.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Zooming from Top
- Toggle zoom state with the scroll bar at the top position
- You should always go to the top position (0 scrollTop)
- From zoomed out with frame space above the canvas, toggle zoom state. This should also set to 0 scroll top. It should set to 0 scroll top unless you have scrolled down past the top edge of the canvas, at which point it will center your zoom.


https://github.com/user-attachments/assets/b42a9307-e134-4a9e-892a-acf75a1c88df


### Zooming from below Top
- Toggle zoom state at any point beneath the top edge of the canvas
- You should be zoomed to the central point (or nearby, as the known bugs contribute to discrepancies)

https://github.com/user-attachments/assets/683cb724-6a2c-4e3a-af29-2c2d86ac99f5


### Open/close sidebar scaling animations
- When zoomed out, toggle sidebars open and closed
- Animations should be the same as on wp/6.7 branch

### Try to break it :)

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**Before**

https://github.com/user-attachments/assets/8be0d1cb-c917-4bd9-adef-002b7b5c84fe 

**After**

https://github.com/user-attachments/assets/ca221060-f6c9-4c66-9c70-631c945dc4d2

