### PR TITLE
DataViews: make `field.type` required

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -545,10 +545,11 @@ export const themeData: Theme[] = [
 ];
 
 export const themeFields: Field< Theme >[] = [
-	{ id: 'slug', label: 'Slug' },
-	{ id: 'name', label: 'Name' },
+	{ id: 'slug', type: 'text', label: 'Slug' },
+	{ id: 'name', type: 'text', label: 'Name' },
 	{
 		id: 'description',
+		type: 'text',
 		label: 'Description',
 		render: ( { item } ) => (
 			<span className="theme-field-description">
@@ -556,11 +557,11 @@ export const themeFields: Field< Theme >[] = [
 			</span>
 		),
 	},
-	{ id: 'requires', label: 'Requires at least' },
-	{ id: 'tested', label: 'Tested up to' },
+	{ id: 'requires', type: 'text', label: 'Requires at least' },
+	{ id: 'tested', type: 'text', label: 'Tested up to' },
 	{
 		id: 'tags',
-		label: 'Tags',
+		type: 'text',
 		render: ( { item } ) => item.tags.join( ', ' ),
 	},
 ];
@@ -616,8 +617,9 @@ export const actions: Action< SpaceObject >[] = [
 
 export const fields: Field< SpaceObject >[] = [
 	{
-		label: 'Image',
 		id: 'image',
+		type: 'text', // TODO: add media/image type
+		label: 'Image',
 		header: (
 			<HStack spacing={ 1 } justify="start">
 				<Icon icon={ image } />
@@ -632,8 +634,9 @@ export const fields: Field< SpaceObject >[] = [
 		enableSorting: false,
 	},
 	{
-		label: 'Title',
 		id: 'title',
+		type: 'text',
+		label: 'Title',
 		enableHiding: false,
 		enableGlobalSearch: true,
 		render: ( { item } ) => {
@@ -642,12 +645,13 @@ export const fields: Field< SpaceObject >[] = [
 	},
 	{
 		id: 'date',
-		label: 'Date',
 		type: 'datetime',
+		label: 'Date',
 	},
 	{
-		label: 'Type',
 		id: 'type',
+		type: 'text',
+		label: 'Type',
 		enableHiding: false,
 		elements: [
 			{ value: 'Not a planet', label: 'Not a planet' },
@@ -657,20 +661,22 @@ export const fields: Field< SpaceObject >[] = [
 		],
 	},
 	{
-		label: 'Satellites',
 		id: 'satellites',
 		type: 'integer',
+		label: 'Satellites',
 		enableSorting: true,
 	},
 	{
-		label: 'Description',
 		id: 'description',
+		type: 'text',
+		label: 'Description',
 		enableSorting: false,
 		enableGlobalSearch: true,
 	},
 	{
-		label: 'Categories',
 		id: 'categories',
+		type: 'text',
+		label: 'Categories',
 		header: (
 			<HStack spacing={ 1 } justify="start">
 				<Icon icon={ category } />

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -75,7 +75,7 @@ export type Field< Item > = {
 	/**
 	 * Type of the fields.
 	 */
-	type?: FieldType;
+	type: FieldType;
 
 	/**
 	 * The unique identifier of the field.

--- a/packages/edit-site/src/components/page-patterns/fields.js
+++ b/packages/edit-site/src/components/page-patterns/fields.js
@@ -105,8 +105,9 @@ function PreviewField( { item } ) {
 }
 
 export const previewField = {
-	label: __( 'Preview' ),
 	id: 'preview',
+	type: 'text', // TODO: add media/image type
+	label: __( 'Preview' ),
 	render: PreviewField,
 	enableSorting: false,
 };
@@ -155,8 +156,9 @@ function TitleField( { item } ) {
 }
 
 export const titleField = {
-	label: __( 'Title' ),
 	id: 'title',
+	type: 'text',
+	label: __( 'Title' ),
 	getValue: ( { item } ) => item.title?.raw || item.title,
 	render: TitleField,
 	enableHiding: false,
@@ -178,8 +180,9 @@ const SYNC_FILTERS = [
 ];
 
 export const patternStatusField = {
-	label: __( 'Sync status' ),
 	id: 'sync-status',
+	type: 'text',
+	label: __( 'Sync status' ),
 	render: ( { item } ) => {
 		const syncStatus =
 			'wp_pattern_sync_status' in item
@@ -236,8 +239,9 @@ function AuthorField( { item } ) {
 }
 
 export const templatePartAuthorField = {
-	label: __( 'Author' ),
 	id: 'author',
+	type: 'text',
+	label: __( 'Author' ),
 	getValue: ( { item } ) => item.author_text,
 	render: AuthorField,
 	filterBy: {

--- a/packages/edit-site/src/components/page-templates/fields.js
+++ b/packages/edit-site/src/components/page-templates/fields.js
@@ -73,8 +73,9 @@ function PreviewField( { item } ) {
 }
 
 export const previewField = {
-	label: __( 'Preview' ),
 	id: 'preview',
+	type: 'text', // TODO: add media/image type
+	label: __( 'Preview' ),
 	render: PreviewField,
 	enableSorting: false,
 };
@@ -95,8 +96,9 @@ function TitleField( { item } ) {
 }
 
 export const titleField = {
-	label: __( 'Template' ),
 	id: 'title',
+	type: 'text',
+	label: __( 'Template' ),
 	getValue: ( { item } ) => item.title?.rendered,
 	render: TitleField,
 	enableHiding: false,
@@ -104,8 +106,9 @@ export const titleField = {
 };
 
 export const descriptionField = {
-	label: __( 'Description' ),
 	id: 'description',
+	type: 'text',
+	label: __( 'Description' ),
 	render: ( { item } ) => {
 		return (
 			item.description && (
@@ -149,8 +152,9 @@ function AuthorField( { item } ) {
 }
 
 export const authorField = {
-	label: __( 'Author' ),
 	id: 'author',
+	type: 'text',
+	label: __( 'Author' ),
 	getValue: ( { item } ) => item.author_text,
 	render: AuthorField,
 };


### PR DESCRIPTION
## What?

Makes the `field.type` required.

## Why?

To move towards a more declarative API for Fields.

## How?

Add `field.type` to any field that doesn't have one.

## Testing Instructions

- Smoke test the Pages, Patterns, and Templates pages in site editor.
- Smoke test the QuickEdit (table view in Pages page).
- Smoke test the storybook for DataViews & DataFom.
