### PR TITLE
Social: Avoid conflict with Global Styles link font-size

### DIFF
--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -588,7 +588,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
-		'link'    => 'a:where(:not(.wp-element-button))', // The `where` is needed to lower the specificity.
+		'link'    => 'a:where(:not(.wp-element-button, .wp-block-social-link-anchor))', // The `where` is needed to lower the specificity.
 		'heading' => 'h1, h2, h3, h4, h5, h6',
 		'h1'      => 'h1',
 		'h2'      => 'h2',

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -588,7 +588,7 @@ class WP_Theme_JSON_Gutenberg {
 	 * @var string[]
 	 */
 	const ELEMENTS = array(
-		'link'    => 'a:where(:not(.wp-element-button, .wp-block-social-link-anchor))', // The `where` is needed to lower the specificity.
+		'link'    => 'a:where(:not(.wp-element-button, .wp-block-social-link-anchor))', // The `:where()` pseudo-class is used to lower specificity AND to exclude specific button and social link classes from global link styles.
 		'heading' => 'h1, h2, h3, h4, h5, h6',
 		'h1'      => 'h1',
 		'h2'      => 'h2',

--- a/phpunit/class-wp-theme-json-test.php
+++ b/phpunit/class-wp-theme-json-test.php
@@ -598,7 +598,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$variables = ':root{--wp--preset--color--grey: grey;--wp--preset--gradient--custom-gradient: linear-gradient(135deg,rgba(0,0,0) 0%,rgb(0,0,0) 100%);--wp--preset--font-size--small: 14px;--wp--preset--font-size--big: 41px;--wp--preset--font-family--arial: Arial, serif;}.wp-block-group{--wp--custom--base-font: 16;--wp--custom--line-height--small: 1.2;--wp--custom--line-height--medium: 1.4;--wp--custom--line-height--large: 1.8;}';
-		$styles    = static::$base_styles . 'body{color: var(--wp--preset--color--grey);}a:where(:not(.wp-element-button)){background-color: #333;color: #111;}:root :where(.wp-element-button, .wp-block-button__link){box-shadow: 10px 10px 5px 0px rgba(0,0,0,0.66);}:root :where(.wp-block-cover){min-height: unset;aspect-ratio: 16/9;}:root :where(.wp-block-group){background: var(--wp--preset--gradient--custom-gradient);border-radius: 10px;min-height: 50vh;padding: 24px;}:root :where(.wp-block-group a:where(:not(.wp-element-button))){color: #111;}:root :where(.wp-block-heading){color: #123456;}:root :where(.wp-block-heading a:where(:not(.wp-element-button))){background-color: #333;color: #111;font-size: 60px;}:root :where(.wp-block-media-text){text-align: center;}:root :where(.wp-block-post-date){color: #123456;}:root :where(.wp-block-post-date a:where(:not(.wp-element-button))){background-color: #777;color: #555;}:root :where(.wp-block-post-excerpt){column-count: 2;}:root :where(.wp-block-image){margin-bottom: 30px;}:root :where(.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder){border-top-left-radius: 10px;border-bottom-right-radius: 1em;}:root :where(.wp-block-image img, .wp-block-image .components-placeholder){filter: var(--wp--preset--duotone--custom-duotone);}';
+		$styles    = static::$base_styles . 'body{color: var(--wp--preset--color--grey);}a:where(:not(.wp-element-button, .wp-block-social-link-anchor)){background-color: #333;color: #111;}:root :where(.wp-element-button, .wp-block-button__link){box-shadow: 10px 10px 5px 0px rgba(0,0,0,0.66);}:root :where(.wp-block-cover){min-height: unset;aspect-ratio: 16/9;}:root :where(.wp-block-group){background: var(--wp--preset--gradient--custom-gradient);border-radius: 10px;min-height: 50vh;padding: 24px;}:root :where(.wp-block-group a:where(:not(.wp-element-button,.wp-block-group  .wp-block-social-link-anchor))){color: #111;}:root :where(.wp-block-heading){color: #123456;}:root :where(.wp-block-heading a:where(:not(.wp-element-button,.wp-block-heading  .wp-block-social-link-anchor))){background-color: #333;color: #111;font-size: 60px;}:root :where(.wp-block-media-text){text-align: center;}:root :where(.wp-block-post-date){color: #123456;}:root :where(.wp-block-post-date a:where(:not(.wp-element-button,.wp-block-post-date  .wp-block-social-link-anchor))){background-color: #777;color: #555;}:root :where(.wp-block-post-excerpt){column-count: 2;}:root :where(.wp-block-image){margin-bottom: 30px;}:root :where(.wp-block-image img, .wp-block-image .wp-block-image__crop-area, .wp-block-image .components-placeholder){border-top-left-radius: 10px;border-bottom-right-radius: 1em;}:root :where(.wp-block-image img, .wp-block-image .components-placeholder){filter: var(--wp--preset--duotone--custom-duotone);}';
 		$presets   = '.has-grey-color{color: var(--wp--preset--color--grey) !important;}.has-grey-background-color{background-color: var(--wp--preset--color--grey) !important;}.has-grey-border-color{border-color: var(--wp--preset--color--grey) !important;}.has-custom-gradient-gradient-background{background: var(--wp--preset--gradient--custom-gradient) !important;}.has-small-font-size{font-size: var(--wp--preset--font-size--small) !important;}.has-big-font-size{font-size: var(--wp--preset--font-size--big) !important;}.has-arial-font-family{font-family: var(--wp--preset--font-family--arial) !important;}';
 		$all       = $variables . $styles . $presets;
 
@@ -876,7 +876,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			'selector' => 'a:where(:not(.wp-element-button)):focus',
 		);
 
-		$link_style  = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}';
+		$link_style  = ':root :where(a:where(:not(.wp-element-button))){background-color: red;color: green;}';
 		$hover_style = ':root :where(a:where(:not(.wp-element-button)):hover){background-color: green;color: red;font-size: 10em;text-transform: uppercase;}';
 		$focus_style = ':root :where(a:where(:not(.wp-element-button)):focus){background-color: black;color: yellow;}';
 
@@ -917,7 +917,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(a:where(:not(.wp-element-button)):hover){background-color: green;color: red;font-size: 10em;text-transform: uppercase;}:root :where(a:where(:not(.wp-element-button)):focus){background-color: black;color: yellow;}';
+		$expected = ':root :where(a:where(:not(.wp-element-button:hover, .wp-block-social-link-anchor)):hover){background-color: green;color: red;font-size: 10em;text-transform: uppercase;}:root :where(a:where(:not(.wp-element-button:focus, .wp-block-social-link-anchor)):focus){background-color: black;color: yellow;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
@@ -983,7 +983,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = 'a:where(:not(.wp-element-button)){background-color: red;color: green;}:root :where(a:where(:not(.wp-element-button)):hover){background-color: green;color: red;}';
+		$expected = 'a:where(:not(.wp-element-button, .wp-block-social-link-anchor)){background-color: red;color: green;}:root :where(a:where(:not(.wp-element-button:hover, .wp-block-social-link-anchor)):hover){background-color: green;color: red;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 		$this->assertStringNotContainsString( 'a:levitate{', $theme_json->get_stylesheet( array( 'styles' ) ) );
 	}
@@ -1029,7 +1029,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$expected = ':root :where(.wp-block-group a:where(:not(.wp-element-button))){background-color: red;color: green;}:root :where(.wp-block-group a:where(:not(.wp-element-button)):hover){background-color: green;color: red;font-size: 10em;text-transform: uppercase;}:root :where(.wp-block-group a:where(:not(.wp-element-button)):focus){background-color: black;color: yellow;}';
+		$expected = ':root :where(.wp-block-group a:where(:not(.wp-element-button,.wp-block-group  .wp-block-social-link-anchor))){background-color: red;color: green;}:root :where(.wp-block-group a:where(:not(.wp-element-button:hover,.wp-block-group  .wp-block-social-link-anchor)):hover){background-color: green;color: red;font-size: 10em;text-transform: uppercase;}:root :where(.wp-block-group a:where(:not(.wp-element-button:focus,.wp-block-group  .wp-block-social-link-anchor)):focus){background-color: black;color: yellow;}';
 		$this->assertSameCSS( $expected, $theme_json->get_stylesheet( array( 'styles' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}
 
@@ -5144,7 +5144,7 @@ class WP_Theme_JSON_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		$variable_styles = ':root{--wp--preset--shadow--natural: 5px 5px 0 0 black;}';
-		$element_styles  = 'a:where(:not(.wp-element-button)){box-shadow: var(--wp--preset--shadow--natural);}:root :where(.wp-element-button, .wp-block-button__link){box-shadow: var(--wp--preset--shadow--natural);}:root :where(p){box-shadow: var(--wp--preset--shadow--natural);}';
+		$element_styles  = 'a:where(:not(.wp-element-button, .wp-block-social-link-anchor)){box-shadow: var(--wp--preset--shadow--natural);}:root :where(.wp-element-button, .wp-block-button__link){box-shadow: var(--wp--preset--shadow--natural);}:root :where(p){box-shadow: var(--wp--preset--shadow--natural);}';
 		$expected_styles = $variable_styles . $element_styles;
 		$this->assertSameCSS( $expected_styles, $theme_json->get_stylesheet( array( 'styles', 'presets', 'variables' ), null, array( 'skip_root_layout_styles' => true ) ) );
 	}


### PR DESCRIPTION
resolves #67133 

## What?
This PR addresses issue #67133 by adding the .wp-block-social-link-anchor class to the a:where(:not()) specifier in the CSS generated by the Gutenberg block editor.

## Why?
Currently, the global font size settings override custom font sizes defined within the Social Links block. This issue arises due to the order of CSS rules being applied. To resolve this, the native block class .wp-block-social-link-anchor must be included in the CSS selector to prevent the global styles from interfering with the Social Links block styles.

## How?
The PR updates the WP_Theme_JSON_Gutenberg file by modifying the link key value from:
```
'a:where(:not(.wp-element-button))'
```
to:
```
'a:where(:not(.wp-element-button, .wp-block-social-link-anchor))'
```

This change ensures that the global font size settings do not apply to Social Links, allowing the block-specific styles to take precedence.


## Testing Instructions  

1. **Set Up the Environment:**  
   - Add the following configuration to your theme’s `theme.json` file to define a global font size for links:  
     ```json
     {
         "styles": {
             "elements": {
                 "link": {
                     "typography": {
                         "fontSize": "var(--wp--preset--font-size--small)"
                     }
                 }
             }
         }
     }
     ```

2. **Open the Gutenberg Editor:**  
   - Go to the WordPress admin panel.  
   - Open any post or page in the Gutenberg editor.

3. **Insert a Social Links Block:**  
   - Use the block inserter to add a "Social Links" block to the page.

4. **Set a Custom Font Size for Social Links:**  
   - Select the Social Links block.  
   - In the block settings panel, customize the font size for the links within the Social Links block.

5. **Check the Font Size Behavior:**  
   - Observe whether the font size applied to the Social Links block respects the custom size set in the block settings or is overridden by the global font size defined in `theme.json`.

6. **Apply the PR Changes:**  
   - Implement the changes in the PR by modifying the `WP_Theme_JSON_Gutenberg` file as follows:  
     ```php
     'link' => 'a:where(:not(.wp-element-button, .wp-block-social-link-anchor))'
     ```  

7. **Retest the Behavior:**  
   - Reload the Gutenberg editor.  
   - Repeat steps 3-5.  
   - Confirm that the Social Links block now respects the custom font size set in the block settings, unaffected by the global font size.

8. **Verify No Regressions:**  
   - Test other blocks (e.g., Paragraph, Heading) to ensure global font size settings still apply correctly to their links without unexpected behavior.

