### PR TITLE
`FormFileUpload`: Prevent HEIC and HEIF files from always being uploaded on Safari

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--  `FormFileUpload`: Prevent HEIC and HEIF files from being uploaded on Safari ([67139](https://github.com/WordPress/gutenberg/pull/67139)).
+-  `FormFileUpload`: Prevent HEIC and HEIF files from being uploaded on Safari ([#67139](https://github.com/WordPress/gutenberg/pull/67139)).
 
 ### Deprecations
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-  `FormFileUpload`: Revert "Ensure HEIC files selectable from “Upload” button" ([67139](https://github.com/WordPress/gutenberg/pull/67139)).
+
 ### Deprecations
 
 -   `Radio`: Deprecate 36px default size ([#66572](https://github.com/WordPress/gutenberg/pull/66572)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
--  `FormFileUpload`: Image Block: Fix transparent pngs not being uploaded correctly on Safari browser. ([67139](https://github.com/WordPress/gutenberg/pull/67139)).
+-  `FormFileUpload`: Prevent HEIC and HEIF files from being uploaded on Safari ([67139](https://github.com/WordPress/gutenberg/pull/67139)).
 
 ### Deprecations
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Unreleased
 
--  `FormFileUpload`: Revert "Ensure HEIC files selectable from “Upload” button" ([67139](https://github.com/WordPress/gutenberg/pull/67139)).
+### Bug Fixes
+
+-  `FormFileUpload`: Image Block: Fix transparent pngs not being uploaded correctly on Safari browser. ([67139](https://github.com/WordPress/gutenberg/pull/67139)).
 
 ### Deprecations
 

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef } from '@wordpress/element';
+import { useRef, useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,6 +26,7 @@ import type { FormFileUploadProps } from './types';
  * );
  * ```
  */
+
 export function FormFileUpload( {
 	accept,
 	children,
@@ -48,6 +49,20 @@ export function FormFileUpload( {
 		</Button>
 	);
 
+	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
+	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
+	// This can be removed once the Chromium fix is in the stable channel.
+	const [ isSafari, setIsSafari ] = useState( false );
+	useEffect( () => {
+		setIsSafari(
+			/^((?!chrome|android).)*safari/i.test( navigator.userAgent )
+		);
+	}, [] );
+	const compatAccept =
+		! isSafari && !! accept?.includes( 'image/*' )
+			? `${ accept }, image/heic, image/heif`
+			: accept;
+
 	return (
 		<div className="components-form-file-upload">
 			{ ui }
@@ -56,7 +71,7 @@ export function FormFileUpload( {
 				ref={ ref }
 				multiple={ multiple }
 				style={ { display: 'none' } }
-				accept={ accept }
+				accept={ compatAccept }
 				onChange={ onChange }
 				onClick={ onClick }
 				data-testid="form-file-upload-input"

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -47,12 +47,6 @@ export function FormFileUpload( {
 			{ children }
 		</Button>
 	);
-	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
-	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
-	// This can be removed once the Chromium fix is in the stable channel.
-	const compatAccept = !! accept?.includes( 'image/*' )
-		? `${ accept }, image/heic, image/heif`
-		: accept;
 
 	return (
 		<div className="components-form-file-upload">
@@ -62,7 +56,7 @@ export function FormFileUpload( {
 				ref={ ref }
 				multiple={ multiple }
 				style={ { display: 'none' } }
-				accept={ compatAccept }
+				accept={ accept }
 				onChange={ onChange }
 				onClick={ onClick }
 				data-testid="form-file-upload-input"

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useRef, useState, useEffect } from '@wordpress/element';
+import { useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -50,12 +50,11 @@ export function FormFileUpload( {
 	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
 	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
 	// This can be removed once the Chromium fix is in the stable channel.
-	const [ isSafari, setIsSafari ] = useState( false );
-	useEffect( () => {
-		setIsSafari(
-			/^((?!chrome|android).)*safari/i.test( navigator.userAgent )
-		);
-	}, [] );
+	// Prevent Safari from adding "image/heic" and "image/heif" to the accept attribute.
+	const isSafari =
+		globalThis.navigator?.userAgent.includes( 'Safari' ) &&
+		! globalThis.navigator?.userAgent.includes( 'Chrome' ) &&
+		! globalThis.navigator?.userAgent.includes( 'Chromium' );
 	const compatAccept =
 		! isSafari && !! accept?.includes( 'image/*' )
 			? `${ accept }, image/heic, image/heif`

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -52,9 +52,9 @@ export function FormFileUpload( {
 	// This can be removed once the Chromium fix is in the stable channel.
 	// Prevent Safari from adding "image/heic" and "image/heif" to the accept attribute.
 	const isSafari =
-		globalThis.navigator?.userAgent.includes( 'Safari' ) &&
-		! globalThis.navigator?.userAgent.includes( 'Chrome' ) &&
-		! globalThis.navigator?.userAgent.includes( 'Chromium' );
+		globalThis.window?.navigator.userAgent.includes( 'Safari' ) &&
+		! globalThis.window?.navigator.userAgent.includes( 'Chrome' ) &&
+		! globalThis.window?.navigator.userAgent.includes( 'Chromium' );
 	const compatAccept =
 		! isSafari && !! accept?.includes( 'image/*' )
 			? `${ accept }, image/heic, image/heif`

--- a/packages/components/src/form-file-upload/index.tsx
+++ b/packages/components/src/form-file-upload/index.tsx
@@ -26,7 +26,6 @@ import type { FormFileUploadProps } from './types';
  * );
  * ```
  */
-
 export function FormFileUpload( {
 	accept,
 	children,
@@ -48,7 +47,6 @@ export function FormFileUpload( {
 			{ children }
 		</Button>
 	);
-
 	// @todo: Temporary fix a bug that prevents Chromium browsers from selecting ".heic" files
 	// from the file upload. See https://core.trac.wordpress.org/ticket/62268#comment:4.
 	// This can be removed once the Chromium fix is in the stable channel.


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
One fix could be reverting this commit c5921d766c143ef6774c827c8c2f6322b2b26b6b.

Adding this compatibility is causing the bug reported in https://core.trac.wordpress.org/ticket/62447

The bug reports that uploading a transparent PNG by using the upload button on a Safari browser is renaming the filename and removing the transparent background.

We can make it conditional for non Safari browsers only.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Image: ![charmander](https://github.com/user-attachments/assets/32793656-2ef2-4336-bb41-4707ddaa4a23)

In Chrome or Firefox, create a group, set a background color, upload a block image and use the upload button to upload you're transparent PNG. Check on the frontend that the image uploaded is a transparent PNG.

Do the same in Safari. Check on the frontend that the image uploaded is a transparent PNG.

## Screenshots or screencast <!-- if applicable -->
<img width="478" alt="Screenshot 2024-11-19 at 21 53 50" src="https://github.com/user-attachments/assets/4f1eb90d-fbb0-4656-a149-b67c4223d4ca">
<img width="823" alt="Screenshot 2024-11-19 at 21 54 21" src="https://github.com/user-attachments/assets/df198372-6013-4aae-99d6-95d3b3b97b81">

