### PR TITLE
Global Styles: Remove styles from blocks' previews

### DIFF
--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -18,16 +18,16 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 			return null;
 		}
 
-		let example = blockExample;
-		if ( variation ) {
-			example = {
-				...example,
-				attributes: {
-					...example.attributes,
-					className: getVariationClassName( variation ),
-				},
-			};
-		}
+		const example = {
+			...blockExample,
+			attributes: {
+				...blockExample.attributes,
+				style: undefined,
+				className: variation
+					? getVariationClassName( variation )
+					: blockExample.attributes.className,
+			},
+		};
 
 		return getBlockFromExample( name, example );
 	}, [ name, blockExample, variation ] );

--- a/packages/edit-site/src/components/global-styles/block-preview-panel.js
+++ b/packages/edit-site/src/components/global-styles/block-preview-panel.js
@@ -25,7 +25,7 @@ const BlockPreviewPanel = ( { name, variation = '' } ) => {
 				style: undefined,
 				className: variation
 					? getVariationClassName( variation )
-					: blockExample.attributes.className,
+					: blockExample.attributes?.className,
 			},
 		};
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follow up of: https://github.com/WordPress/gutenberg/pull/67098

This PR also removes the styles from block example previews (sidebar) when updating global styles, because they prevent global styles from being tested/previewed.

## Testing Instructions
1. In global styles sidebar (either from `Styles` in main site editor menu or in the editor) select the `Cover` block
2. Change text color
3. Observe that the preview reflects the changes
4. Also verify that the style variation className is still added properly. You can check this with `Image` block and select the `Rounded` style variation.


