### PR TITLE
Fix typo in use-block-sync tests

### DIFF
--- a/packages/block-editor/src/components/provider/test/use-block-sync.js
+++ b/packages/block-editor/src/components/provider/test/use-block-sync.js
@@ -22,7 +22,9 @@ jest.mock( '../../../store/actions', () => {
 		...actions,
 		resetBlocks: jest.fn( actions.resetBlocks ),
 		replaceInnerBlocks: jest.fn( actions.replaceInnerBlocks ),
-		setHasControlledInnerBlocks: jest.fn( actions.replaceInnerBlocks ),
+		setHasControlledInnerBlocks: jest.fn(
+			actions.setHasControlledInnerBlocks
+		),
 	};
 } );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes a typo/bug in the `useBlockSync` unit tests.

The typo causes `setHasControlledInnerBlocks` not to run for these tests, instead `replaceInnerBlocks` is dispatched  in place of  `setHasControlledInnerBlocks` with the args that `setHasControlledInnerBlocks` would usually receive. This can cause some weird results, like the `blocks` arg of `replaceInnerBlocks` being a boolean value. 😵 

Amazingly the tests still work(ed) 🤨 
