### PR TITLE
Global Styles: Don't call store actions during the render

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
 import { useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,7 +23,9 @@ function ScreenStyleVariations() {
 	// - "Desktop" device preview
 	const { setDeviceType } = useDispatch( editorStore );
 	useZoomOut();
-	setDeviceType( 'desktop' );
+	useEffect( () => {
+		setDeviceType( 'desktop' );
+	}, [ setDeviceType ] );
 
 	return (
 		<>


### PR DESCRIPTION
## What?
This is a follow-up to #66023.

Update the `ScreenStyleVariations` component to dispatch the `setDeviceType` action inside effect instead of render.

## Why?
React might re-render or call components for various reasons; there's no need to dispatch action every time it happens.

## Testing Instructions
1. Open the Site Editor.
2. Change canvas view to Mobile.
3. Open Styles > Browse Styles.
4. Confirm that the view has switched back to Desktop.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-20 at 12 16 58](https://github.com/user-attachments/assets/23eaf10a-432f-4eb4-b9f2-3b388d0a98ef)
