### PR TITLE
Buttons: Prevent empty HTML output for buttons blocks without inner blocks

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -62,6 +62,7 @@ Prompt visitors to take action with a group of button-style links. ([Source](htt
 -	**Category:** design
 -	**Allowed Blocks:** core/button
 -	**Supports:** align (full, wide), anchor, color (background, gradients, ~~text~~), interactivity (clientNavigation), layout (default, ~~allowInheriting~~, ~~allowSwitching~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** isInnerBlockEmpty
 
 ## Calendar
 

--- a/packages/block-library/src/buttons/block.json
+++ b/packages/block-library/src/buttons/block.json
@@ -8,6 +8,12 @@
 	"description": "Prompt visitors to take action with a group of button-style links.",
 	"keywords": [ "link" ],
 	"textdomain": "default",
+	"attributes": {
+		"isInnerBlockEmpty": {
+			"type": "boolean",
+			"default": false
+		}
+	},
 	"supports": {
 		"anchor": true,
 		"align": [ "wide", "full" ],

--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -6,9 +6,14 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import {
+	store as blockEditorStore,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 import { store as blocksStore } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 
 const DEFAULT_BLOCK = {
 	name: 'core/button',
@@ -25,8 +30,8 @@ const DEFAULT_BLOCK = {
 	],
 };
 
-function ButtonsEdit( { attributes, className } ) {
-	const { fontSize, layout, style } = attributes;
+function ButtonsEdit( { clientId, attributes, className, setAttributes } ) {
+	const { fontSize, layout, style, isInnerBlockEmpty } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,
@@ -41,6 +46,42 @@ function ButtonsEdit( { attributes, className } ) {
 			hasButtonVariations: buttonVariations.length > 0,
 		};
 	}, [] );
+
+	const isEmptyButtons = useSelect(
+		( select ) => {
+			const innerBlocks =
+				select( blockEditorStore ).getBlocks( clientId );
+			const buttonBlocks = innerBlocks.filter(
+				( block ) => block.name === 'core/button'
+			);
+
+			if ( buttonBlocks.length === 0 ) {
+				return true;
+			}
+
+			if ( buttonBlocks.length === 1 ) {
+				const text = buttonBlocks[ 0 ]?.attributes?.text;
+
+				const isEmptyOrInvalid =
+					text === null ||
+					text === undefined ||
+					( typeof text === 'string' && text.trim() === '' ) ||
+					( typeof text === 'object' &&
+						Object.keys( text ).length === 0 );
+
+				return isEmptyOrInvalid;
+			}
+
+			return false;
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		if ( isEmptyButtons !== isInnerBlockEmpty ) {
+			setAttributes( { isInnerBlockEmpty: isEmptyButtons } );
+		}
+	}, [ isEmptyButtons, isInnerBlockEmpty, setAttributes ] );
 
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		defaultBlock: DEFAULT_BLOCK,

--- a/packages/block-library/src/buttons/save.js
+++ b/packages/block-library/src/buttons/save.js
@@ -9,7 +9,12 @@ import clsx from 'clsx';
 import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';
 
 export default function save( { attributes, className } ) {
-	const { fontSize, style } = attributes;
+	const { fontSize, style, isInnerBlockEmpty } = attributes;
+
+	if ( isInnerBlockEmpty ) {
+		return null;
+	}
+
 	const blockProps = useBlockProps.save( {
 		className: clsx( className, {
 			'has-custom-font-size': fontSize || style?.typography?.fontSize,


### PR DESCRIPTION
Part of #63332

## What?
Prevents empty HTML markup generation for button blocks that have no inner blocks.

## Why?
Currently, parent button blocks without any inner/child blocks still output empty HTML wrapper tags on the frontend. This creates unnecessary DOM elements.

This change ensures that button block markup is only rendered when there are actual child blocks to display, resulting in cleaner HTML output.

## Testing Instructions
1. Create a new post.
2. Add a buttons block.
3. Add an empty button block, and save.
4. View the post on the front, and view the source.

## Screencast
### Before fix:

https://github.com/user-attachments/assets/e0ffde35-b806-4671-8599-1ac873deca08

### After fix:

https://github.com/user-attachments/assets/66701da7-5bcc-4b1b-89e8-19c96da0347f


