### PR TITLE
BlockInspector: Conditionally render Inspector Control Tabs depending on Write Mode

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -215,7 +215,7 @@ const BlockInspectorSingleBlock = ( {
 	const availableTabs = useInspectorControlsTabs( blockName );
 	const showTabs = ! isSectionBlock && availableTabs?.length > 1;
 
-	const { hasBlockStyles, mode } = useSelect(
+	const { hasBlockStyles, isNavigationMode } = useSelect(
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );
 			const blockStyles = getBlockStyles( blockName );
@@ -223,7 +223,7 @@ const BlockInspectorSingleBlock = ( {
 
 			return {
 				hasBlockStyles: blockStyles && blockStyles.length > 0,
-				mode: editorMode,
+				isNavigationMode: editorMode,
 			};
 		},
 		[ blockName ]
@@ -259,7 +259,7 @@ const BlockInspectorSingleBlock = ( {
 			/>
 			<BlockVariationTransforms blockClientId={ clientId } />
 			<BlockInfo.Slot />
-			{ showTabs && ! mode && (
+			{ showTabs && ! isNavigationMode && (
 				<InspectorControlsTabs
 					hasBlockStyles={ hasBlockStyles }
 					clientId={ clientId }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -215,11 +215,17 @@ const BlockInspectorSingleBlock = ( {
 	const availableTabs = useInspectorControlsTabs( blockName );
 	const showTabs = ! isSectionBlock && availableTabs?.length > 1;
 
-	const hasBlockStyles = useSelect(
+	const { hasBlockStyles, mode } = useSelect(
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );
 			const blockStyles = getBlockStyles( blockName );
-			return blockStyles && blockStyles.length > 0;
+			const editorMode =
+				select( blockEditorStore ).__unstableGetEditorMode();
+
+			return {
+				hasBlockStyles: blockStyles && blockStyles.length > 0,
+				mode: editorMode,
+			};
 		},
 		[ blockName ]
 	);
@@ -254,7 +260,7 @@ const BlockInspectorSingleBlock = ( {
 			/>
 			<BlockVariationTransforms blockClientId={ clientId } />
 			<BlockInfo.Slot />
-			{ showTabs && (
+			{ showTabs && mode !== 'navigation' && (
 				<InspectorControlsTabs
 					hasBlockStyles={ hasBlockStyles }
 					clientId={ clientId }

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -219,8 +219,7 @@ const BlockInspectorSingleBlock = ( {
 		( select ) => {
 			const { getBlockStyles } = select( blocksStore );
 			const blockStyles = getBlockStyles( blockName );
-			const editorMode =
-				select( blockEditorStore ).__unstableGetEditorMode();
+			const editorMode = select( blockEditorStore ).isNavigationMode();
 
 			return {
 				hasBlockStyles: blockStyles && blockStyles.length > 0,
@@ -260,7 +259,7 @@ const BlockInspectorSingleBlock = ( {
 			/>
 			<BlockVariationTransforms blockClientId={ clientId } />
 			<BlockInfo.Slot />
-			{ showTabs && mode !== 'navigation' && (
+			{ showTabs && ! mode && (
 				<InspectorControlsTabs
 					hasBlockStyles={ hasBlockStyles }
 					clientId={ clientId }


### PR DESCRIPTION
Fixes: #67129 

## What?
This PR resolves a bug that causes block controls to be displayed when both "Show Template Mode" and "Write Mode" are enabled. In this scenario, the controls should not be visible, and the block should remain non-editable, as "Write Mode" is specifically intended for creating content.

## How?
The Inspector Controls were conditionally rendered to stay hidden when viewing with Show Template Mode and Write Mode enabled, thereby preventing the user from updating the Block.

## Testing Instructions
1. Create a post.
2. Inside the edit post screen, toggle the display type to the template and select the content block. Observe the absence of editing the block attribute options.

## Screencast


https://github.com/user-attachments/assets/d2877c00-0876-4e00-acf1-d7ca6e613a4c



