### PR TITLE
fix: Prevent WordPress embed block share overlay cutoff

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -32,6 +32,7 @@
 	// Don't allow iframe to overflow it's container.
 	iframe {
 		max-width: 100%;
+		min-height: 200px;
 	}
 }
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/67148

## What?
This PR fixes an issue where the share overlay in WordPress embed blocks gets truncated in the editor when embedding posts with minimal content while displaying correctly on the published site.

## Why?
When embedding posts with minimal content using the WordPress embed block, the share overlay gets cut off in the editor interface, creating an inconsistent experience between the editor and the published site.

## How?
Added minimum height property to the embed block's iframe to ensure sufficient space for the share overlay to display completely, regardless of the embedded content's length.

## Testing Instructions
1. Create a new post with minimal content (just title and short paragraph)
2. Open a different post in the editor
3. Add a WordPress embed block
4. Paste the URL of the minimal content post into the embed block
5. Verify that the share overlay is fully visible in the editor
6. Save and preview the post
7. Verify that the overlay appearance matches between editor and published view

## Screenshots or screencast
### Before
![Screenshot 2024-11-20 at 1 33 46 PM](https://github.com/user-attachments/assets/9b5f49c8-7f7e-4744-87af-bd372c15ab21)
### After
![Screenshot 2024-11-20 at 2 28 25 PM](https://github.com/user-attachments/assets/465ecb8e-ff5d-42cc-a36c-821d3c3d99d0)


