### PR TITLE
Home Link: Remove label attribute synchronization

### DIFF
--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -6,15 +6,10 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import {
-	RichText,
-	useBlockProps,
-	store as blockEditorStore,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
-import { useEffect } from '@wordpress/element';
 
 const preventDefault = ( event ) => event.preventDefault();
 
@@ -24,8 +19,6 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 		return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
 			?.home;
 	}, [] );
-	const { __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
 
 	const { textColor, backgroundColor, style } = context;
 	const blockProps = useBlockProps( {
@@ -41,15 +34,6 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 		},
 	} );
 
-	const { label } = attributes;
-
-	useEffect( () => {
-		if ( label === undefined ) {
-			__unstableMarkNextChangeAsNotPersistent();
-			setAttributes( { label: __( 'Home' ) } );
-		}
-	}, [ label ] );
-
 	return (
 		<>
 			<div { ...blockProps }>
@@ -61,7 +45,7 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 					<RichText
 						identifier="label"
 						className="wp-block-home-link__label"
-						value={ label }
+						value={ attributes.label ?? __( 'Home' ) }
 						onChange={ ( labelValue ) => {
 							setAttributes( { label: labelValue } );
 						} }

--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -35,32 +35,30 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 	} );
 
 	return (
-		<>
-			<div { ...blockProps }>
-				<a
-					className="wp-block-home-link__content wp-block-navigation-item__content"
-					href={ homeUrl }
-					onClick={ preventDefault }
-				>
-					<RichText
-						identifier="label"
-						className="wp-block-home-link__label"
-						value={ attributes.label ?? __( 'Home' ) }
-						onChange={ ( labelValue ) => {
-							setAttributes( { label: labelValue } );
-						} }
-						aria-label={ __( 'Home link text' ) }
-						placeholder={ __( 'Add home link' ) }
-						withoutInteractiveFormatting
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
-					/>
-				</a>
-			</div>
-		</>
+		<div { ...blockProps }>
+			<a
+				className="wp-block-home-link__content wp-block-navigation-item__content"
+				href={ homeUrl }
+				onClick={ preventDefault }
+			>
+				<RichText
+					identifier="label"
+					className="wp-block-home-link__label"
+					value={ attributes.label ?? __( 'Home' ) }
+					onChange={ ( labelValue ) => {
+						setAttributes( { label: labelValue } );
+					} }
+					aria-label={ __( 'Home link text' ) }
+					placeholder={ __( 'Add home link' ) }
+					withoutInteractiveFormatting
+					allowedFormats={ [
+						'core/bold',
+						'core/italic',
+						'core/image',
+						'core/strikethrough',
+					] }
+				/>
+			</a>
+		</div>
 	);
 }

--- a/packages/block-library/src/home-link/index.php
+++ b/packages/block-library/src/home-link/index.php
@@ -137,9 +137,6 @@ function block_core_home_link_build_li_wrapper_attributes( $context ) {
  */
 function render_block_core_home_link( $attributes, $content, $block ) {
 	if ( empty( $attributes['label'] ) ) {
-		// Using a fallback for the label attribute allows rendering the block even if no attributes have been set,
-		// e.g. when using the block as a hooked block.
-		// Note that the fallback value needs to be kept in sync with the one set in `edit.js` (upon first loading the block in the editor).
 		$attributes['label'] = __( 'Home' );
 	}
 	$aria_current = '';


### PR DESCRIPTION
## What?
This is a follow-up to #58387.

PR removes client-side `label` attribute synchronization for the Home Link block in favor of render time default.

## Why?
The PHP side defaults shouldn't be preferred over the client-side synchronization for translatable strings when possible.

## Testing Instructions
1. Open a post or page.
2. Insert a Navigation block.
3. Add the home link and save.
4. Confirm that the default label is correctly displayed on the front end.
5. Change the home link label and save.
6. Confirm that the updated label is displayed instead of the default fallback.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-20 at 12 53 37](https://github.com/user-attachments/assets/1d20d6ce-7c27-4792-9479-2f08341eb766)
