### PR TITLE
Terms: Respect order specified by register_taxonomy()

### DIFF
--- a/backport-changelog/6.8/7848.md
+++ b/backport-changelog/6.8/7848.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7848
+
+* https://github.com/WordPress/gutenberg/pull/67154

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -20,3 +20,17 @@ if ( ! function_exists( 'gutenberg_add_post_type_rendering_mode' ) ) {
 	}
 }
 add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
+
+function gutenberg_respect_taxonomy_default_args_in_rest_api( $args ) {
+	$t = get_taxonomy( $args['taxonomy'] );
+	if ( isset( $t->args ) && is_array( $t->args ) ) {
+		$args = array_merge( $args, $t->args );
+	}
+	return $args;
+}
+add_action(
+	'registered_taxonomy',
+	function ( $taxonomy ) {
+		add_filter( "rest_{$taxonomy}_query", 'gutenberg_respect_taxonomy_default_args_in_rest_api' );
+	}
+);

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -21,6 +21,8 @@ if ( ! function_exists( 'gutenberg_add_post_type_rendering_mode' ) ) {
 }
 add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
 
+// When querying terms for a given taxonomy in the REST API, respect the default
+// query arguments set for that taxonomy upon registration.
 function gutenberg_respect_taxonomy_default_args_in_rest_api( $args ) {
 	$t = get_taxonomy( $args['taxonomy'] );
 	if ( isset( $t->args ) && is_array( $t->args ) ) {

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -24,6 +24,13 @@ add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
 // When querying terms for a given taxonomy in the REST API, respect the default
 // query arguments set for that taxonomy upon registration.
 function gutenberg_respect_taxonomy_default_args_in_rest_api( $args ) {
+	// If a `post` argument is provided, the Terms controller will use
+	// `wp_get_object_terms`, which respects the default query arguments,
+	// so we don't need to do anything.
+	if ( ! empty( $args['post'] ) ) {
+		return $args;
+	}
+
 	$t = get_taxonomy( $args['taxonomy'] );
 	if ( isset( $t->args ) && is_array( $t->args ) ) {
 		$args = array_merge( $args, $t->args );

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -43,3 +43,9 @@ add_action(
 		add_filter( "rest_{$taxonomy}_query", 'gutenberg_respect_taxonomy_default_args_in_rest_api' );
 	}
 );
+add_action(
+	'unregistered_taxonomy',
+	function ( $taxonomy ) {
+		remove_filter( "rest_{$taxonomy}_query", 'gutenberg_respect_taxonomy_default_args_in_rest_api' );
+	}
+);


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/65052.
Supersedes #64471.

## What?
It is possible to supply a default set of `args` to [`register_taxonomy()`](https://developer.wordpress.org/reference/functions/register_taxonomy/) which will be used when querying a list of terms -- for example, `orderby` in order to specify how the resulting list of terms should be sorted. This PR makes it so that the list of terms returned by the Terms REST API controller respects that order.

## Why?
To reflect the order in which "flat terms" (such as tags) are supposed to be sorted. For example, see the `actors` taxonomy in the code sample (and screencasts) below: It uses `array( 'orderby' => 'term_order' )` to make sure that terms -- i.e. actor names -- are sorted in the order that they are stored (rather than in alphabetical order).

## How?
By adding a filter to the [`rest_{$this->taxonomy}_query` hook](https://developer.wordpress.org/reference/hooks/rest_this-taxonomy_query/) for all registered taxonomies, which then merges any `args` registered for a given taxonomy into the arguments given by the network request.

Note that this mimics behavior [already present](https://github.com/WordPress/wordpress-develop/blob/654475fa25c88a2fecf9290ffcd9512b553a8574/src/wp-includes/taxonomy.php#L2292-L2310) in `wp_get_object_terms()`. In the Terms Controller, the latter function is used for [requests that include a post ID](https://github.com/WordPress/wordpress-develop/blob/193f6eb26e65216576a10492dd4103044c3a079c/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php#L320-L327).  However, we cannot provide a post ID for reasons first explained [here](https://github.com/WordPress/gutenberg/pull/64471#issuecomment-2488161005):

> The problem is that when a new term is entered by the user, it is created (via a POST request), but not yet associated with the current post. This is by design: We only want that to happen once the user clicks the 'Save' button in order to persist their changes. (Otherwise, the new term would show up on that post, even if the user ends up never saving the post.)

Instead, our network requests go through a code branch in the controller that uses [`get_terms()`](https://developer.wordpress.org/reference/functions/get_terms/) (rather than `wp_get_object_terms()`) to query terms. To make that function respect the default args registered for a given taxonomy, we use the `rest_{$this->taxonomy}_query` hook.

## Testing Instructions
Add the following code (e.g. to your theme's `functions.php`) and use the "Actors" panel in the block inspector to assign a number of actor names to a given post. Note that their order is kept (unlike previously, when they were re-ordered in alphabetical order). Save the post, and verify that the term order is still kept. Reload the post, and verify that the order still persists.

Finally, verify that tags entered into the "Tags" panel are still sorted alphabetically across the same set of operations (tag creation, saving the post, reloading it). This demonstrates that the input field truly reflects the sort order that a taxonomy is registered with.

```php
function register_taxonomies() {
	/**
	 * Taxonomy: Actors.
	 */

	 $labels = array(
		'name'          => __( 'Actors' ),
		'singular_name' => __( 'Actor' ),
		'add_new_item'  => __( 'Add Actor' ),
		'new_item_name' => __( 'New Actor' ),
	);

	$args = array(
		'label'                 => __( 'Cast' ),
		'labels'                => $labels,
		'public'                => true,
		'publicly_queryable'    => true,
		'hierarchical'          => false,
		'show_ui'               => true,
		'show_in_menu'          => true,
		'show_in_nav_menus'     => true,
		'query_var'             => true,
		'show_admin_column'     => false,
		'show_in_rest'          => true,
		'show_tagcloud'         => false,
		'rest_base'             => 'actors',
		'rest_controller_class' => 'WP_REST_Terms_Controller',
		'rest_namespace'        => 'wp/v2',
		'show_in_quick_edit'    => false,
		'show_in_graphql'       => false,
		'sort'                  => true, // Note this.
		'args'                  => array( 'orderby' => 'term_order' ), // Note this!
	);

	register_taxonomy( 'actors', array( 'post' ), $args );
}

add_action( 'init', 'register_taxonomies', 0 );
```

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|-------|-------|
| ![flat-terms-before](https://github.com/user-attachments/assets/928605a7-6240-4fff-9e87-6f387f0c7c80)| ![flat-terms-after](https://github.com/user-attachments/assets/590f891c-2409-4ffd-994c-174a46cc037f) |