### PR TITLE
Add up/down arrow key navigation to filter configuration listbox

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -99,6 +99,39 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 		( f ) => f.field === filter.field
 	);
 	const currentValue = getCurrentValue( filter, currentFilter );
+
+	const handleKeyDown = ( event: React.KeyboardEvent< HTMLDivElement > ) => {
+		const currentIndex = filter.elements.findIndex(
+			( element ) =>
+				activeCompositeId ===
+				generateFilterElementCompositeItemId( baseId, element.value )
+		);
+
+		if ( event.key === 'ArrowDown' ) {
+			const nextIndex = Math.min(
+				filter.elements.length - 1,
+				currentIndex + 1
+			);
+
+			setActiveCompositeId(
+				generateFilterElementCompositeItemId(
+					baseId,
+					filter.elements[ nextIndex ].value
+				)
+			);
+		}
+
+		if ( event.key === 'ArrowUp' ) {
+			const prevIndex = Math.max( 0, currentIndex - 1 );
+			setActiveCompositeId(
+				generateFilterElementCompositeItemId(
+					baseId,
+					filter.elements[ prevIndex ].value
+				)
+			);
+		}
+	};
+
 	return (
 		<Composite
 			virtualFocus
@@ -124,6 +157,7 @@ function ListBox( { view, filter, onChangeView }: SearchWidgetProps ) {
 					);
 				}
 			} }
+			onKeyDown={ handleKeyDown }
 			render={ <Composite.Typeahead /> }
 		>
 			{ filter.elements.map( ( element ) => (


### PR DESCRIPTION

## What?

Fixes: #67152
This PR adds proper up/down arrow key navigation to the filter configuration listbox in the DataViews component. It ensures that the up and down arrows now navigate through filter options as expected. 

## Why?

This PR addresses an issue where the up and down arrow keys did not work as expected for navigation in the filter configuration listbox of the DataViews component. The left and right arrow keys were functioning correctly, but up and down arrows did not navigate between options. This behavior is now fixed, resolving issue [ #67152 ]

## Testing Instructions
1. Open Editor 
2. Go to Pages 
3. Click on 'Add filter' 
4. Choose any filter which has multiple options in the menu (in my case i chose status) as it has many options in the dropdown
5. Press up arrow and down arrow key to navigate the menu . You should be able to navigate using this 2 keys.

### Testing Instructions for Keyboard
1. Press the Up or Down arrow key and confirm that the selection moves up and down between the available filter options.
2. Ensure that the Left and Right arrow keys still behave as expected.


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0dbefcad-1da7-4d61-942e-0be6d7972184


