### PR TITLE
Add documentation about required Core changes when updating minimum WordPress version

### DIFF
--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -84,6 +84,12 @@ The new reference commit hash that is chosen needs to meet the following require
  - Be compatible with the new WP version used in the "Tested up to" flag.
  - Is already tracked on "codevitals.run" for all existing metrics.
 
+Before releasing a version of the plugin with changes to the WordPress minimum requirements, the end-to-end test GitHub Action workflow in Core SVN will need to be updated for any branch losing support. Otherwise the next run of that workflow on that branch will fail.
+
+The version of the plugin can be pinned by adding the `gutenberg-version` input to the test matrix. [Core-59221](https://core.trac.wordpress.org/changeset/59221) is an example of this change for the 6.4 branch.
+
+**Note:** Always use the final release including bug fixes (ie. `x.y.2` or `x.y.3`).
+
 **A simple way to choose commit is to pick a very recent commit on trunk with a passing performance job.**
 
 ## Going further

--- a/docs/explanations/architecture/performance.md
+++ b/docs/explanations/architecture/performance.md
@@ -84,11 +84,11 @@ The new reference commit hash that is chosen needs to meet the following require
  - Be compatible with the new WP version used in the "Tested up to" flag.
  - Is already tracked on "codevitals.run" for all existing metrics.
 
-Before releasing a version of the plugin with changes to the WordPress minimum requirements, the end-to-end test GitHub Action workflow in Core SVN will need to be updated for any branch losing support. Otherwise the next run of that workflow on that branch will fail.
+When releasing a plugin update with changes to the minimum WordPress version requirements, the end-to-end test GitHub Action workflow in Core SVN will need to be updated for any branch losing support. Otherwise the first run of that workflow on that branch following the release will fail.
 
-The version of the plugin can be pinned by adding the `gutenberg-version` input to the test matrix. [Core-59221](https://core.trac.wordpress.org/changeset/59221) is an example of this change for the 6.4 branch.
+The version of the plugin used in the workflow can be pinned by adding the `gutenberg-version` input to the test matrix. [Core-59221](https://core.trac.wordpress.org/changeset/59221) is an example of this change for the 6.4 branch.
 
-**Note:** Always use the final release including bug fixes (ie. `x.y.2` or `x.y.3`).
+**Note:** Always use the final release including bug fixes (ie. `x.y.2` or `x.y.3`). If the final release is not yet known, create a [Trac ticket](https://core.trac.wordpress.org/ticket/62488) so it's not forgotten.
 
 **A simple way to choose commit is to pick a very recent commit on trunk with a passing performance job.**
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
When the minimum version of WordPress required for the plugin is raised, there is a change required in Core SVN to ensure the E2E test workflow does not break in any branch losing support with the version bump.

This adds a call out about this in the related section of the documentation.

## Notes
This doesn't feel like the best place to add this, but wasn't sure about where to add a new page for "Raising minimum required version of WordPress". Most of this "Update the reference commit" section could be pulled out into that more general page, I think.

See [Core Changeset 59221](https://core.trac.wordpress.org/changeset/59221).

I've also gone and created [Core-62488](https://core.trac.wordpress.org/ticket/62488) to account for the bump in #67117.