### PR TITLE
Use rems for Nav overlay left padding

### DIFF
--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -510,7 +510,7 @@ button.wp-block-navigation-item__content {
 		padding-top: clamp(1rem, var(--wp--style--root--padding-top), 20rem);
 		padding-right: clamp(1rem, var(--wp--style--root--padding-right), 20rem);
 		padding-bottom: clamp(1rem, var(--wp--style--root--padding-bottom), 20rem);
-		padding-left: clamp(1rem, var(--wp--style--root--padding-left), 20em);
+		padding-left: clamp(1rem, var(--wp--style--root--padding-left), 20rem);
 
 		// Allow modal to scroll.
 		overflow: auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Updates overlay padding on nav block to use `rem` like all the other dimensions.

Closes https://github.com/WordPress/gutenberg/issues/55329

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Typing an `r` character in the correct position in the correct CSS file.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Check overlay layout is as per trunk on Editor and Front end.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<img width="3006" alt="Screen Shot 2024-11-20 at 15 04 45" src="https://github.com/user-attachments/assets/c9add95e-180b-48b6-a3dc-2cd416829324">

