### PR TITLE
Correctly apply current-menu-ancestor class in Nav block

### DIFF
--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -222,7 +222,7 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		if ( strpos( $inner_blocks_html, 'current-menu-item' ) ) {
 			$tag_processor = new WP_HTML_Tag_Processor( $html );
-			while ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-navigation-item__content' ) ) ) {
+			while ( $tag_processor->next_tag( array( 'class_name' => 'wp-block-navigation-item' ) ) ) {
 				$tag_processor->add_class( 'current-menu-ancestor' );
 			}
 			$html = $tag_processor->get_updated_html();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Applies the `current-menu-ancestor` class to the `<li>` not the `<a>`

Closes https://github.com/WordPress/gutenberg/issues/50069

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Consistency with `current-menu-item` which is applied to the `<li>`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->


Applies the `current-menu-ancestor` class to the `<li>` not the `<a>`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

You should be able to test this via Playground using the following link

https://playground.wordpress.net/?gutenberg-pr=67169

Note you can install any publicly available Theme for testing using the format:

```
https://playground.wordpress.net/?gutenberg-pr=67169&theme={theme-slug-here}
```

On your WordPress test site you can then...

- Create Navigation menu
- Add a Page
- Add a submenu under that page and add some links.
- Save
- View front of site
- Inspect HTML of top level link
- See class is on `li` not `a`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
