### PR TITLE
DataViews: Add density option to `table` layout

### DIFF
--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -28,7 +28,6 @@ type DataViewsContextType< Item > = {
 	getItemId: ( item: Item ) => string;
 	onClickItem: ( item: Item ) => void;
 	isItemClickable: ( item: Item ) => boolean;
-	density: number;
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -47,7 +46,6 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	getItemId: ( item ) => item.id,
 	onClickItem: () => {},
 	isItemClickable: () => false,
-	density: 0,
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews-layout/index.tsx
+++ b/packages/dataviews/src/components/dataviews-layout/index.tsx
@@ -27,7 +27,6 @@ export default function DataViewsLayout() {
 		selection,
 		onChangeSelection,
 		setOpenedFilter,
-		density,
 		onClickItem,
 		isItemClickable,
 	} = useContext( DataViewsContext );
@@ -49,7 +48,6 @@ export default function DataViewsLayout() {
 			onClickItem={ onClickItem }
 			isItemClickable={ isItemClickable }
 			view={ view }
-			density={ density }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -35,7 +35,6 @@ import { useInstanceId } from '@wordpress/compose';
  */
 import {
 	SORTING_DIRECTIONS,
-	LAYOUT_GRID,
 	LAYOUT_TABLE,
 	sortIcons,
 	sortLabels,
@@ -49,7 +48,6 @@ import {
 import type { SupportedLayouts, View, Field } from '../../types';
 import DataViewsContext from '../dataviews-context';
 import { unlock } from '../../lock-unlock';
-import DensityPicker from '../../dataviews-layouts/grid/density-picker';
 
 const { Menu } = unlock( componentsPrivateApis );
 
@@ -512,19 +510,15 @@ function SettingsSection( {
 	);
 }
 
-function DataviewsViewConfigDropdown( {
-	density,
-	setDensity,
-}: {
-	density: number;
-	setDensity: React.Dispatch< React.SetStateAction< number > >;
-} ) {
+function DataviewsViewConfigDropdown() {
 	const { view } = useContext( DataViewsContext );
 	const popoverId = useInstanceId(
 		_DataViewsViewConfig,
 		'dataviews-view-config-dropdown'
 	);
-
+	const usedLayout = VIEW_LAYOUTS.find(
+		( layout ) => layout.type === view.type
+	);
 	return (
 		<Dropdown
 			popoverProps={ {
@@ -551,11 +545,8 @@ function DataviewsViewConfigDropdown( {
 								<SortFieldControl />
 								<SortDirectionControl />
 							</HStack>
-							{ view.type === LAYOUT_GRID && (
-								<DensityPicker
-									density={ density }
-									setDensity={ setDensity }
-								/>
+							{ !! usedLayout?.viewConfigOptions && (
+								<usedLayout.viewConfigOptions />
 							) }
 							<ItemsPerPageControl />
 						</SettingsSection>
@@ -570,21 +561,14 @@ function DataviewsViewConfigDropdown( {
 }
 
 function _DataViewsViewConfig( {
-	density,
-	setDensity,
 	defaultLayouts = { list: {}, grid: {}, table: {} },
 }: {
-	density: number;
-	setDensity: React.Dispatch< React.SetStateAction< number > >;
 	defaultLayouts?: SupportedLayouts;
 } ) {
 	return (
 		<>
 			<ViewTypeMenu defaultLayouts={ defaultLayouts } />
-			<DataviewsViewConfigDropdown
-				density={ density }
-				setDensity={ setDensity }
-			/>
+			<DataviewsViewConfigDropdown />
 		</>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -516,7 +516,7 @@ function DataviewsViewConfigDropdown() {
 		_DataViewsViewConfig,
 		'dataviews-view-config-dropdown'
 	);
-	const usedLayout = VIEW_LAYOUTS.find(
+	const activeLayout = VIEW_LAYOUTS.find(
 		( layout ) => layout.type === view.type
 	);
 	return (
@@ -545,8 +545,8 @@ function DataviewsViewConfigDropdown() {
 								<SortFieldControl />
 								<SortDirectionControl />
 							</HStack>
-							{ !! usedLayout?.viewConfigOptions && (
-								<usedLayout.viewConfigOptions />
+							{ !! activeLayout?.viewConfigOptions && (
+								<activeLayout.viewConfigOptions />
 							) }
 							<ItemsPerPageControl />
 						</SettingsSection>

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -75,7 +75,6 @@ export default function DataViews< Item >( {
 	header,
 }: DataViewsProps< Item > ) {
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
-	const [ density, setDensity ] = useState< number >( 0 );
 	const isUncontrolled =
 		selectionProperty === undefined || onChangeSelection === undefined;
 	const selection = isUncontrolled ? selectionState : selectionProperty;
@@ -119,7 +118,6 @@ export default function DataViews< Item >( {
 				getItemId,
 				isItemClickable,
 				onClickItem,
-				density,
 			} }
 		>
 			<div className="dataviews-wrapper">
@@ -151,8 +149,6 @@ export default function DataViews< Item >( {
 					>
 						<DataViewsViewConfig
 							defaultLayouts={ defaultLayouts }
-							density={ density }
-							setDensity={ setDensity }
 						/>
 						{ header }
 					</HStack>

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -25,6 +25,7 @@ import { useHasAPossibleBulkAction } from '../../components/dataviews-bulk-actio
 import type { Action, NormalizedField, ViewGridProps } from '../../types';
 import type { SetSelection } from '../../private-types';
 import getClickableItemProps from '../utils/get-clickable-item-props';
+import { useChangeGridColumnsOnViewportChange } from './preview-size-picker';
 
 interface GridItemProps< Item > {
 	selection: string[];
@@ -192,8 +193,8 @@ export default function ViewGrid< Item >( {
 	isItemClickable,
 	selection,
 	view,
-	density,
 }: ViewGridProps< Item > ) {
+	useChangeGridColumnsOnViewportChange();
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout?.mediaField
 	);
@@ -223,8 +224,10 @@ export default function ViewGrid< Item >( {
 		{ visibleFields: [], badgeFields: [] }
 	);
 	const hasData = !! data?.length;
-	const gridStyle = density
-		? { gridTemplateColumns: `repeat(${ density }, minmax(0, 1fr))` }
+	const gridStyle = view.layout?.gridColumns
+		? {
+				gridTemplateColumns: `repeat(${ view.layout.gridColumns }, minmax(0, 1fr))`,
+		  }
 		: {};
 	return (
 		<>

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -25,7 +25,7 @@ import { useHasAPossibleBulkAction } from '../../components/dataviews-bulk-actio
 import type { Action, NormalizedField, ViewGridProps } from '../../types';
 import type { SetSelection } from '../../private-types';
 import getClickableItemProps from '../utils/get-clickable-item-props';
-import { useChangePreviewSizeOnViewportChange } from './preview-size-picker';
+import { useUpdatedPreviewSizeOnViewportChange } from './preview-size-picker';
 
 interface GridItemProps< Item > {
 	selection: string[];
@@ -194,7 +194,6 @@ export default function ViewGrid< Item >( {
 	selection,
 	view,
 }: ViewGridProps< Item > ) {
-	useChangePreviewSizeOnViewportChange();
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout?.mediaField
 	);
@@ -224,9 +223,11 @@ export default function ViewGrid< Item >( {
 		{ visibleFields: [], badgeFields: [] }
 	);
 	const hasData = !! data?.length;
-	const gridStyle = view.layout?.previewSize
+	const updatedPreviewSize = useUpdatedPreviewSizeOnViewportChange();
+	const usedPreviewSize = updatedPreviewSize || view.layout?.previewSize;
+	const gridStyle = usedPreviewSize
 		? {
-				gridTemplateColumns: `repeat(${ view.layout.previewSize }, minmax(0, 1fr))`,
+				gridTemplateColumns: `repeat(${ usedPreviewSize }, minmax(0, 1fr))`,
 		  }
 		: {};
 	return (

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -25,7 +25,7 @@ import { useHasAPossibleBulkAction } from '../../components/dataviews-bulk-actio
 import type { Action, NormalizedField, ViewGridProps } from '../../types';
 import type { SetSelection } from '../../private-types';
 import getClickableItemProps from '../utils/get-clickable-item-props';
-import { useChangeGridColumnsOnViewportChange } from './preview-size-picker';
+import { useChangePreviewSizeOnViewportChange } from './preview-size-picker';
 
 interface GridItemProps< Item > {
 	selection: string[];
@@ -194,7 +194,7 @@ export default function ViewGrid< Item >( {
 	selection,
 	view,
 }: ViewGridProps< Item > ) {
-	useChangeGridColumnsOnViewportChange();
+	useChangePreviewSizeOnViewportChange();
 	const mediaField = fields.find(
 		( field ) => field.id === view.layout?.mediaField
 	);
@@ -224,9 +224,9 @@ export default function ViewGrid< Item >( {
 		{ visibleFields: [], badgeFields: [] }
 	);
 	const hasData = !! data?.length;
-	const gridStyle = view.layout?.gridColumns
+	const gridStyle = view.layout?.previewSize
 		? {
-				gridTemplateColumns: `repeat(${ view.layout.gridColumns }, minmax(0, 1fr))`,
+				gridTemplateColumns: `repeat(${ view.layout.previewSize }, minmax(0, 1fr))`,
 		  }
 		: {};
 	return (

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -4,7 +4,7 @@
 import { RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useViewportMatch } from '@wordpress/compose';
-import { useEffect, useMemo, useContext } from '@wordpress/element';
+import { useMemo, useContext } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -45,11 +45,10 @@ function useViewPortBreakpoint() {
 	return null;
 }
 
-export function useChangePreviewSizeOnViewportChange() {
+export function useUpdatedPreviewSizeOnViewportChange() {
 	const viewport = useViewPortBreakpoint();
-	const context = useContext( DataViewsContext );
-	const view = context.view as ViewGrid;
-	useEffect( () => {
+	const view = useContext( DataViewsContext ).view as ViewGrid;
+	return useMemo( () => {
 		const previewSize = view.layout?.previewSize;
 		let newPreviewSize;
 		if ( ! viewport || ! previewSize ) {
@@ -62,16 +61,8 @@ export function useChangePreviewSizeOnViewportChange() {
 		if ( previewSize > breakValues.max ) {
 			newPreviewSize = breakValues.max;
 		}
-		if ( newPreviewSize ) {
-			context.onChangeView( {
-				...view,
-				layout: {
-					...view.layout,
-					previewSize: newPreviewSize,
-				},
-			} );
-		}
-	}, [ viewport, view, context ] );
+		return newPreviewSize;
+	}, [ viewport, view ] );
 }
 
 export default function PreviewSizePicker() {

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -74,7 +74,7 @@ export function useChangeGridColumnsOnViewportChange() {
 	}, [ viewport, view, context ] );
 }
 
-export default function DensityPicker() {
+export default function PreviewSizePicker() {
 	const viewport = useViewPortBreakpoint();
 	const context = useContext( DataViewsContext );
 	const view = context.view as ViewGrid;

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -45,29 +45,29 @@ function useViewPortBreakpoint() {
 	return null;
 }
 
-export function useChangeGridColumnsOnViewportChange() {
+export function useChangePreviewSizeOnViewportChange() {
 	const viewport = useViewPortBreakpoint();
 	const context = useContext( DataViewsContext );
 	const view = context.view as ViewGrid;
 	useEffect( () => {
-		const gridColumns = view.layout?.gridColumns;
-		let newGridColumns;
-		if ( ! viewport || ! gridColumns ) {
+		const previewSize = view.layout?.previewSize;
+		let newPreviewSize;
+		if ( ! viewport || ! previewSize ) {
 			return;
 		}
 		const breakValues = viewportBreaks[ viewport ];
-		if ( gridColumns < breakValues.min ) {
-			newGridColumns = breakValues.min;
+		if ( previewSize < breakValues.min ) {
+			newPreviewSize = breakValues.min;
 		}
-		if ( gridColumns > breakValues.max ) {
-			newGridColumns = breakValues.max;
+		if ( previewSize > breakValues.max ) {
+			newPreviewSize = breakValues.max;
 		}
-		if ( newGridColumns ) {
+		if ( newPreviewSize ) {
 			context.onChangeView( {
 				...view,
 				layout: {
 					...view.layout,
-					gridColumns: newGridColumns,
+					previewSize: newPreviewSize,
 				},
 			} );
 		}
@@ -79,7 +79,7 @@ export default function PreviewSizePicker() {
 	const context = useContext( DataViewsContext );
 	const view = context.view as ViewGrid;
 	const breakValues = viewportBreaks[ viewport || 'mobile' ];
-	const densityToUse = view.layout?.gridColumns || breakValues.default;
+	const previewSizeToUse = view.layout?.previewSize || breakValues.default;
 
 	const marks = useMemo(
 		() =>
@@ -104,7 +104,7 @@ export default function PreviewSizePicker() {
 			__next40pxDefaultSize
 			showTooltip={ false }
 			label={ __( 'Preview size' ) }
-			value={ breakValues.max + breakValues.min - densityToUse }
+			value={ breakValues.max + breakValues.min - previewSizeToUse }
 			marks={ marks }
 			min={ breakValues.min }
 			max={ breakValues.max }
@@ -114,7 +114,7 @@ export default function PreviewSizePicker() {
 					...view,
 					layout: {
 						...view.layout,
-						gridColumns: breakValues.max + breakValues.min - value,
+						previewSize: breakValues.max + breakValues.min - value,
 					},
 				} );
 			} }

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -17,6 +17,8 @@ import ViewGrid from './grid';
 import ViewList from './list';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../constants';
 import type { View, Field } from '../types';
+import PreviewSizePicker from './grid/preview-size-picker';
+import DensityPicker from './table/density-picker';
 
 export const VIEW_LAYOUTS = [
 	{
@@ -24,12 +26,14 @@ export const VIEW_LAYOUTS = [
 		label: __( 'Table' ),
 		component: ViewTable,
 		icon: blockTable,
+		viewConfigOptions: DensityPicker,
 	},
 	{
 		type: LAYOUT_GRID,
 		label: __( 'Grid' ),
 		component: ViewGrid,
 		icon: category,
+		viewConfigOptions: PreviewSizePicker,
 	},
 	{
 		type: LAYOUT_LIST,

--- a/packages/dataviews/src/dataviews-layouts/table/density-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/density-picker.tsx
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalToggleGroupControl as ToggleGroupControl,
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+} from '@wordpress/components';
+import { __, _x } from '@wordpress/i18n';
+import { useContext } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DataViewsContext from '../../components/dataviews-context';
+import type { ViewTable, Density } from '../../types';
+
+export default function DensityPicker() {
+	const context = useContext( DataViewsContext );
+	const view = context.view as ViewTable;
+	return (
+		<ToggleGroupControl
+			__nextHasNoMarginBottom
+			size="__unstable-large"
+			label={ __( 'Density' ) }
+			value={ view.layout?.density || 'balanced' }
+			onChange={ ( value ) => {
+				context.onChangeView( {
+					...view,
+					layout: {
+						...view.layout,
+						density: value as Density,
+					},
+				} );
+			} }
+			isBlock
+		>
+			<ToggleGroupControlOption
+				key="comfortable"
+				value="comfortable"
+				label={ _x(
+					'Comfortable',
+					'Density option for DataView layout'
+				) }
+			/>
+			<ToggleGroupControlOption
+				key="balanced"
+				value="balanced"
+				label={ _x( 'Balanced', 'Density option for DataView layout' ) }
+			/>
+			<ToggleGroupControlOption
+				key="compact"
+				value="compact"
+				label={ _x( 'Compact', 'Density option for DataView layout' ) }
+			/>
+		</ToggleGroupControl>
+	);
+}

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -332,7 +332,13 @@ function ViewTable< Item >( {
 	return (
 		<>
 			<table
-				className="dataviews-view-table"
+				className={ clsx( 'dataviews-view-table', {
+					[ `has-${ view.layout?.density }-density` ]:
+						view.layout?.density &&
+						[ 'compact', 'comfortable' ].includes(
+							view.layout.density
+						),
+				} ) }
 				aria-busy={ isLoading }
 				aria-describedby={ tableNoticeId }
 			>

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -169,6 +169,21 @@
 			opacity: 1;
 		}
 	}
+
+	// Density style overrides.
+	&.has-compact-density {
+		td,
+		th {
+			padding: $grid-unit-05;
+		}
+	}
+
+	&.has-comfortable-density {
+		td,
+		th {
+			padding: $grid-unit-20;
+		}
+	}
 }
 
 /* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -172,16 +172,33 @@
 
 	// Density style overrides.
 	&.has-compact-density {
+		thead {
+			th {
+				&:has(.dataviews-view-table-header-button):not(:first-child) {
+					padding-left: 0;
+				}
+			}
+		}
 		td,
 		th {
-			padding: $grid-unit-05;
+			padding: $grid-unit-05 $grid-unit-10;
 		}
 	}
 
 	&.has-comfortable-density {
 		td,
 		th {
-			padding: $grid-unit-20;
+			padding: $grid-unit-20 $grid-unit-15;
+		}
+	}
+
+	&.has-compact-density,
+	&.has-comfortable-density {
+		td,
+		th {
+			&.dataviews-view-table__checkbox-column {
+				padding-right: 0;
+			}
 		}
 	}
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -329,6 +329,8 @@ export interface ColumnStyle {
 	minWidth?: string | number;
 }
 
+export type Density = 'compact' | 'balanced' | 'comfortable';
+
 export interface ViewTable extends ViewBase {
 	type: 'table';
 
@@ -347,6 +349,11 @@ export interface ViewTable extends ViewBase {
 		 * The styles for the columns.
 		 */
 		styles?: Record< string, ColumnStyle >;
+
+		/**
+		 * The density of the view.
+		 */
+		density?: Density;
 	};
 }
 
@@ -389,6 +396,11 @@ export interface ViewGrid extends ViewBase {
 		 * The fields to use as badge fields.
 		 */
 		badgeFields?: string[];
+
+		/**
+		 * The number of grid columns.
+		 */
+		gridColumns?: number;
 	};
 }
 
@@ -501,7 +513,6 @@ export interface ViewBaseProps< Item > {
 	onClickItem: ( item: Item ) => void;
 	isItemClickable: ( item: Item ) => boolean;
 	view: View;
-	density: number;
 }
 
 export interface ViewTableProps< Item > extends ViewBaseProps< Item > {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -398,9 +398,9 @@ export interface ViewGrid extends ViewBase {
 		badgeFields?: string[];
 
 		/**
-		 * The number of grid columns.
+		 * The preview size of the grid.
 		 */
-		gridColumns?: number;
+		previewSize?: number;
 	};
 }
 

--- a/packages/edit-site/src/components/page-templates/style.scss
+++ b/packages/edit-site/src/components/page-templates/style.scss
@@ -60,6 +60,7 @@
 
 	.dataviews-view-table & {
 		margin-bottom: $grid-unit-10;
+		display: block;
 	}
 }
 

--- a/packages/fields/src/fields/featured-image/style.scss
+++ b/packages/fields/src/fields/featured-image/style.scss
@@ -83,13 +83,10 @@ fieldset.fields-controls__featured-image {
 }
 
 .dataviews-view-table__cell-content-wrapper {
-	.fields-controls__featured-image-image {
-		width: 32px;
-		height: 32px;
-	}
-
+	.fields-controls__featured-image-image,
 	.fields-controls__featured-image-placeholder {
 		width: 32px;
 		height: 32px;
+		display: block;
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/66312

This PR adds a `density` option to `table` layout. I [first explored](https://github.com/WordPress/gutenberg/pull/66837) whether an abstraction for the `density` concept could be a good fit for layouts, but after discussions and better consideration it's better not to rush to such abstraction. The main reason is the `density` for `grid` for example might confuse users, because common expectations would be a clear setting for controlling the columns(preview size).

Having said that, this PR adds a [viewConfigOptions](https://github.com/WordPress/gutenberg/pull/67170/files#diff-d2a7d86b5c3e6cb139c1e0bafed051ee821e70d8b86ae1809f3d2c681db94cd0R29) to layouts, where layouts can optionally add some specific controls (React components) in a specific place in the `view options` dropdown.

By doing that, we decouple the previews grid's `preview size` control from the DataViews core components code and the layout is responsible for providing this control. Additionally these props have been moved inside `view.layout` object, since they are specific to each layout.


## Tasks 

- [x] Finalize design for `density` control and available options
- [x] Style `table` layout per `density` option

## Testing instructions
1. Visit  a list where we use DataViews (like site editor pages, templates, etc..) 
2. play around the `density` option in `table` layout
3. play around the `preview size` option in `grid layout (they should behave the same with trunk with an improvement to auto adjust when the viewport changes)

## Screenshots

https://github.com/user-attachments/assets/5efc90d3-91b8-46ec-a608-b30d7f27593f



