### PR TITLE
useBlockNameForPatterns: Refactor as a single useSelect call

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -272,32 +272,31 @@ export const getTransformedBlocksFromPattern = (
  * @return {string} The block name to be used in the patterns suggestions.
  */
 export function useBlockNameForPatterns( clientId, attributes ) {
-	const activeVariationName = useSelect(
-		( select ) =>
-			select( blocksStore ).getActiveBlockVariation(
-				'core/query',
-				attributes
-			)?.name,
-		[ attributes ]
-	);
-	const blockName = `core/query/${ activeVariationName }`;
-	const hasActiveVariationPatterns = useSelect(
+	return useSelect(
 		( select ) => {
+			const activeVariationName = select(
+				blocksStore
+			).getActiveBlockVariation( 'core/query', attributes )?.name;
+
 			if ( ! activeVariationName ) {
-				return false;
+				return 'core/query';
 			}
+
 			const { getBlockRootClientId, getPatternsByBlockTypes } =
 				select( blockEditorStore );
+
 			const rootClientId = getBlockRootClientId( clientId );
 			const activePatterns = getPatternsByBlockTypes(
-				blockName,
+				`core/query/${ activeVariationName }`,
 				rootClientId
 			);
-			return activePatterns.length > 0;
+
+			return activePatterns.length > 0
+				? `core/query/${ activeVariationName }`
+				: 'core/query';
 		},
-		[ clientId, activeVariationName, blockName ]
+		[ clientId, attributes ]
 	);
-	return hasActiveVariationPatterns ? blockName : 'core/query';
 }
 
 /**


### PR DESCRIPTION
## What?

Refactors a hook used by the Query block, `useBlockNameForPatterns` so as to make a single `useSelect` call rather than two. This hook supports a feature introduced in #44197 that:

* by default, suggests available query-type patterns to substitute the current Query block instance;
* if the current block instance is a variation of the Query block, suggests available patterns specific to that variation, if any exist.

## Testing Instructions

Test the pattern selection modal in the Query block or the placeholder view, ensuring that there is **no change in behaviour**. When operating on a non-variation Query block instance, it should suggest regular query patterns, and when operating on a variation with registered patterns, it should suggest those. See #44197 for details.

I used the following patch to test, modified from the original PR to use `postType: 'post'`:

```diff
diff --git a/gutenberg.php b/gutenberg.php
index f79182f3ead..57ee31a78af 100644
--- a/gutenberg.php
+++ b/gutenberg.php
@@ -74,5 +74,113 @@ function gutenberg_pre_init() {
 		return;
 	}
 
+	add_action( 'init', function() {
+		wp_add_inline_script(
+			'wp-block-library',
+			'wp.blocks.registerBlockVariation(
+				"core/query",
+				{
+					name: "products-list",
+					title: "Products List",
+					description: "Display a list of your products.",
+					attributes: {
+						query: {
+							perPage: 4,
+							pages: 0,
+							offset: 0,
+							postType: "post",
+							order: "desc",
+							orderBy: "date",
+							author: "",
+							search: "",
+							sticky: "",
+							inherit: false,
+						},
+						namespace: "prefix/products-list",
+					},
+					allowedControls: [ "order", "taxQuery", "search" ],
+					isActive: [ "namespace" ],
+					scope: [ "inserter" ],
+				}
+			)',
+			'after',
+		);
+
+		register_block_pattern(
+			'demo/my-example-1',
+			array(
+				'title'         => __( 'Demo pattern 1', 'textdomain' ),
+				'description'   => _x( 'This is my first block pattern', 'Block pattern description', 'textdomain' ),
+				'content'       => '
+				<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"namespace":"prefix/products-list","backgroundColor":"black","textColor":"luminous-vivid-amber"} -->
+		<div class="wp-block-query has-luminous-vivid-amber-color has-black-background-color has-text-color has-background"><!-- wp:post-template -->
+		<!-- wp:post-title /-->
+
+		<!-- wp:post-date /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p></p>
+		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results --></div>
+		<!-- /wp:query -->',
+				'categories'    => array( 'text' ),
+				'viewportWidth' => 800,
+				'blockTypes'    => array( 'core/query/products-list' ),
+			)
+		);
+
+		register_block_pattern(
+			'demo/my-example-2',
+			array(
+				'title'         => __( 'Demo pattern 2', 'textdomain' ),
+				'description'   => _x( 'This is my first block pattern', 'Block pattern description', 'textdomain' ),
+				'content'       => '
+				<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"product","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"namespace":"prefix/products-list","backgroundColor":"black","textColor":"luminous-vivid-amber"} -->
+		<div class="wp-block-query has-luminous-vivid-amber-color has-black-background-color has-text-color has-background"><!-- wp:post-template -->
+		<!-- wp:post-title /-->
+
+		<!-- wp:post-date /-->
+		<!-- /wp:post-template -->
+
+		<!-- wp:query-pagination -->
+		<!-- wp:query-pagination-previous /-->
+
+		<!-- wp:query-pagination-numbers /-->
+
+		<!-- wp:query-pagination-next /-->
+		<!-- /wp:query-pagination -->
+
+		<!-- wp:query-no-results -->
+		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+		<p></p>
+		<!-- /wp:paragraph -->
+		<!-- /wp:query-no-results --></div>
+		<!-- /wp:query -->',
+				'categories'    => array( 'text' ),
+				'viewportWidth' => 800,
+				'blockTypes'    => array( 'core/query/products-list' ),
+			)
+		);
+
+	} );
+
 	require_once __DIR__ . '/lib/load.php';
 }
```