### PR TITLE
Query block: Update Enhanced Pagination help text

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
+++ b/packages/block-library/src/query/edit/inspector-controls/enhanced-pagination-control.js
@@ -18,14 +18,12 @@ export default function EnhancedPaginationControl( {
 	const fullPageClientSideNavigation =
 		window.__experimentalFullPageClientSideNavigation;
 
-	let help = __( 'Browsing between pages requires a full page reload.' );
+	let help = __(
+		'Reload the full page—instead of just the posts list—when visitors navigate between pages.'
+	);
 	if ( fullPageClientSideNavigation ) {
 		help = __(
 			'Experimental full-page client-side navigation setting enabled.'
-		);
-	} else if ( enhancedPagination ) {
-		help = __(
-			'Reload the full page—instead of just the posts list—when visitors navigate between pages.'
 		);
 	} else if ( hasUnsupportedBlocks ) {
 		help = __(


### PR DESCRIPTION
## What
Updated the help text message for Enhanced Pagination to say `"Reload the full page—instead of just the posts list—when visitors navigate between pages."` in both enabled and disabled states.

## Before
<img width="267" alt="Screenshot 2024-11-20 at 11 26 18" src="https://github.com/user-attachments/assets/3b92455e-6a9b-479b-9c44-9c2034c52a1e">
<img width="276" alt="Screenshot 2024-11-20 at 11 26 31" src="https://github.com/user-attachments/assets/1acda8be-247a-4115-9257-c50312d0a06f">



## After
<img width="266" alt="Screenshot 2024-11-20 at 11 23 26" src="https://github.com/user-attachments/assets/2cac3b78-a6be-4960-9308-25fee7ffaebb">
<img width="267" alt="Screenshot 2024-11-20 at 11 23 36" src="https://github.com/user-attachments/assets/04384b56-8592-4453-a52e-7e4bdd2881c6">

This way, the purpose of the setting is more straightforward.


## Testing
- [ ] Verify help text displays correctly in all states (default, full-page navigation, unsupported blocks)

