### PR TITLE
DataViews: allow register/unregister fields

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1602,6 +1602,18 @@ _Parameters_
 -   _name_ `string`: Entity name.
 -   _config_ `Action`: Action configuration.
 
+### registerEntityField
+
+Registers a new DataViews field.
+
+This is an experimental API and is subject to change. it's only available in the Gutenberg plugin for now.
+
+_Parameters_
+
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _config_ `Field`: Field configuration.
+
 ### RichText
 
 > **Deprecated** since 5.3, use `wp.blockEditor.RichText` instead.
@@ -1696,6 +1708,18 @@ _Parameters_
 -   _kind_ `string`: Entity kind.
 -   _name_ `string`: Entity name.
 -   _actionId_ `string`: Action ID.
+
+### unregisterEntityField
+
+Unregisters a DataViews field.
+
+This is an experimental API and is subject to change. it's only available in the Gutenberg plugin for now.
+
+_Parameters_
+
+-   _kind_ `string`: Entity kind.
+-   _name_ `string`: Entity name.
+-   _fieldId_ `string`: Field ID.
 
 ### UnsavedChangesWarning
 

--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -21,10 +21,10 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 		[ postType ]
 	);
 
-	const { registerPostTypeActions } = unlock( useDispatch( editorStore ) );
+	const { registerPostTypeSchema } = unlock( useDispatch( editorStore ) );
 	useEffect( () => {
-		registerPostTypeActions( postType );
-	}, [ registerPostTypeActions, postType ] );
+		registerPostTypeSchema( postType );
+	}, [ registerPostTypeSchema, postType ] );
 
 	return useMemo( () => {
 		// Filter actions based on provided context. If not provided

--- a/packages/editor/src/components/post-fields/index.ts
+++ b/packages/editor/src/components/post-fields/index.ts
@@ -1,21 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useEffect, useMemo } from '@wordpress/element';
 import { useEntityRecords } from '@wordpress/core-data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import type { Field } from '@wordpress/dataviews';
-import {
-	featuredImageField,
-	slugField,
-	parentField,
-	passwordField,
-	statusField,
-	commentStatusField,
-	titleField,
-	dateField,
-	authorField,
-} from '@wordpress/fields';
 import type { BasePostWithEmbeddedAuthor } from '@wordpress/fields';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+import { store as editorStore } from '../../store';
 
 interface UsePostFieldsReturn {
 	isLoading: boolean;
@@ -28,29 +24,44 @@ interface Author {
 }
 
 function usePostFields(): UsePostFieldsReturn {
+	const postType = 'page'; // TODO: this could be page or post (experimental).
+
+	const { registerPostTypeFields } = unlock( useDispatch( editorStore ) );
+	useEffect( () => {
+		registerPostTypeFields( postType );
+	}, [ registerPostTypeFields, postType ] );
+
+	const { defaultFields } = useSelect(
+		( select ) => {
+			const { getEntityFields } = unlock( select( editorStore ) );
+			return {
+				defaultFields: getEntityFields( 'postType', postType ),
+			};
+		},
+		[ postType ]
+	);
+
 	const { records: authors, isResolving: isLoadingAuthors } =
 		useEntityRecords< Author >( 'root', 'user', { per_page: -1 } );
 
 	const fields = useMemo(
 		() =>
-			[
-				featuredImageField,
-				titleField,
-				{
-					...authorField,
-					elements: authors?.map( ( { id, name } ) => ( {
-						value: id,
-						label: name,
-					} ) ),
-				},
-				statusField,
-				dateField,
-				slugField,
-				parentField,
-				commentStatusField,
-				passwordField,
-			] as Field< BasePostWithEmbeddedAuthor >[],
-		[ authors ]
+			defaultFields.map(
+				( field: Field< BasePostWithEmbeddedAuthor > ) => {
+					if ( field.id === 'author' ) {
+						return {
+							...field,
+							elements: authors?.map( ( { id, name } ) => ( {
+								value: id,
+								label: name,
+							} ) ),
+						};
+					}
+
+					return field;
+				}
+			) as Field< BasePostWithEmbeddedAuthor >[],
+		[ authors, defaultFields ]
 	);
 
 	return {

--- a/packages/editor/src/components/post-fields/index.ts
+++ b/packages/editor/src/components/post-fields/index.ts
@@ -26,10 +26,10 @@ interface Author {
 function usePostFields(): UsePostFieldsReturn {
 	const postType = 'page'; // TODO: this could be page or post (experimental).
 
-	const { registerPostTypeFields } = unlock( useDispatch( editorStore ) );
+	const { registerPostTypeSchema } = unlock( useDispatch( editorStore ) );
 	useEffect( () => {
-		registerPostTypeFields( postType );
-	}, [ registerPostTypeFields, postType ] );
+		registerPostTypeSchema( postType );
+	}, [ registerPostTypeSchema, postType ] );
 
 	const { defaultFields } = useSelect(
 		( select ) => {

--- a/packages/editor/src/dataviews/api.js
+++ b/packages/editor/src/dataviews/api.js
@@ -11,6 +11,7 @@ import { store as editorStore } from '../store';
 
 /**
  * @typedef {import('@wordpress/dataviews').Action} Action
+ * @typedef {import('@wordpress/dataviews').Field} Field
  */
 
 /**
@@ -51,5 +52,45 @@ export function unregisterEntityAction( kind, name, actionId ) {
 
 	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
 		_unregisterEntityAction( kind, name, actionId );
+	}
+}
+
+/**
+ * Registers a new DataViews field.
+ *
+ * This is an experimental API and is subject to change.
+ * it's only available in the Gutenberg plugin for now.
+ *
+ * @param {string} kind   Entity kind.
+ * @param {string} name   Entity name.
+ * @param {Field}  config Field configuration.
+ */
+export function registerEntityField( kind, name, config ) {
+	const { registerEntityField: _registerEntityField } = unlock(
+		dispatch( editorStore )
+	);
+
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		_registerEntityField( kind, name, config );
+	}
+}
+
+/**
+ * Unregisters a DataViews field.
+ *
+ * This is an experimental API and is subject to change.
+ * it's only available in the Gutenberg plugin for now.
+ *
+ * @param {string} kind    Entity kind.
+ * @param {string} name    Entity name.
+ * @param {string} fieldId Field ID.
+ */
+export function unregisterEntityField( kind, name, fieldId ) {
+	const { unregisterEntityField: _unregisterEntityField } = unlock(
+		dispatch( editorStore )
+	);
+
+	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
+		_unregisterEntityField( kind, name, fieldId );
 	}
 }

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { store as coreStore } from '@wordpress/core-data';
-import type { Action } from '@wordpress/dataviews';
+import type { Action, Field } from '@wordpress/dataviews';
 import { doAction } from '@wordpress/hooks';
 
 /**
@@ -24,6 +24,15 @@ import {
 	renamePost,
 	resetPost,
 	deletePost,
+	featuredImageField,
+	dateField,
+	parentField,
+	passwordField,
+	commentStatusField,
+	slugField,
+	statusField,
+	authorField,
+	titleField,
 } from '@wordpress/fields';
 import duplicateTemplatePart from '../actions/duplicate-template-part';
 
@@ -50,6 +59,32 @@ export function unregisterEntityAction(
 		kind,
 		name,
 		actionId,
+	};
+}
+
+export function registerEntityField< Item >(
+	kind: string,
+	name: string,
+	config: Field< Item >
+) {
+	return {
+		type: 'REGISTER_ENTITY_FIELD' as const,
+		kind,
+		name,
+		config,
+	};
+}
+
+export function unregisterEntityField(
+	kind: string,
+	name: string,
+	fieldId: string
+) {
+	return {
+		type: 'UNREGISTER_ENTITY_FIELD' as const,
+		kind,
+		name,
+		fieldId,
 	};
 }
 
@@ -138,4 +173,35 @@ export const registerPostTypeActions =
 		} );
 
 		doAction( 'core.registerPostTypeActions', postType );
+	};
+
+export const registerPostTypeFields =
+	( postType: string ) =>
+	async ( { registry }: { registry: any } ) => {
+		// TODO: do not register fields if there were already registered.
+		// Consider the existing isReady state.
+
+		const fields = [
+			featuredImageField,
+			titleField,
+			authorField,
+			statusField,
+			dateField,
+			slugField,
+			parentField,
+			commentStatusField,
+			passwordField,
+		];
+
+		registry.batch( () => {
+			fields.forEach( ( field ) => {
+				unlock( registry.dispatch( editorStore ) ).registerEntityField(
+					'postType',
+					postType,
+					field
+				);
+			} );
+		} );
+
+		doAction( 'core.registerPostTypeFields', postType );
 	};

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -88,11 +88,12 @@ export function unregisterEntityField(
 	};
 }
 
-export function setIsReady( kind: string, name: string ) {
+export function setIsReady( kind: string, name: string, part: string ) {
 	return {
 		type: 'SET_IS_READY' as const,
 		kind,
 		name,
+		part,
 	};
 }
 
@@ -101,7 +102,8 @@ export const registerPostTypeActions =
 	async ( { registry }: { registry: any } ) => {
 		const isReady = unlock( registry.select( editorStore ) ).isEntityReady(
 			'postType',
-			postType
+			postType,
+			'actions'
 		);
 		if ( isReady ) {
 			return;
@@ -109,7 +111,8 @@ export const registerPostTypeActions =
 
 		unlock( registry.dispatch( editorStore ) ).setIsReady(
 			'postType',
-			postType
+			postType,
+			'actions'
 		);
 
 		const postTypeConfig = ( await registry
@@ -178,8 +181,20 @@ export const registerPostTypeActions =
 export const registerPostTypeFields =
 	( postType: string ) =>
 	async ( { registry }: { registry: any } ) => {
-		// TODO: do not register fields if there were already registered.
-		// Consider the existing isReady state.
+		const isReady = unlock( registry.select( editorStore ) ).isEntityReady(
+			'postType',
+			postType,
+			'fields'
+		);
+		if ( isReady ) {
+			return;
+		}
+
+		unlock( registry.dispatch( editorStore ) ).setIsReady(
+			'postType',
+			postType,
+			'fields'
+		);
 
 		const fields = [
 			featuredImageField,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -88,22 +88,20 @@ export function unregisterEntityField(
 	};
 }
 
-export function setIsReady( kind: string, name: string, part: string ) {
+export function setIsReady( kind: string, name: string ) {
 	return {
 		type: 'SET_IS_READY' as const,
 		kind,
 		name,
-		part,
 	};
 }
 
-export const registerPostTypeActions =
+export const registerPostTypeSchema =
 	( postType: string ) =>
 	async ( { registry }: { registry: any } ) => {
 		const isReady = unlock( registry.select( editorStore ) ).isEntityReady(
 			'postType',
-			postType,
-			'actions'
+			postType
 		);
 		if ( isReady ) {
 			return;
@@ -111,8 +109,7 @@ export const registerPostTypeActions =
 
 		unlock( registry.dispatch( editorStore ) ).setIsReady(
 			'postType',
-			postType,
-			'actions'
+			postType
 		);
 
 		const postTypeConfig = ( await registry
@@ -162,40 +159,6 @@ export const registerPostTypeActions =
 			permanentlyDeletePost,
 		];
 
-		registry.batch( () => {
-			actions.forEach( ( action ) => {
-				if ( ! action ) {
-					return;
-				}
-				unlock( registry.dispatch( editorStore ) ).registerEntityAction(
-					'postType',
-					postType,
-					action
-				);
-			} );
-		} );
-
-		doAction( 'core.registerPostTypeActions', postType );
-	};
-
-export const registerPostTypeFields =
-	( postType: string ) =>
-	async ( { registry }: { registry: any } ) => {
-		const isReady = unlock( registry.select( editorStore ) ).isEntityReady(
-			'postType',
-			postType,
-			'fields'
-		);
-		if ( isReady ) {
-			return;
-		}
-
-		unlock( registry.dispatch( editorStore ) ).setIsReady(
-			'postType',
-			postType,
-			'fields'
-		);
-
 		const fields = [
 			featuredImageField,
 			titleField,
@@ -209,6 +172,16 @@ export const registerPostTypeFields =
 		];
 
 		registry.batch( () => {
+			actions.forEach( ( action ) => {
+				if ( ! action ) {
+					return;
+				}
+				unlock( registry.dispatch( editorStore ) ).registerEntityAction(
+					'postType',
+					postType,
+					action
+				);
+			} );
 			fields.forEach( ( field ) => {
 				unlock( registry.dispatch( editorStore ) ).registerEntityField(
 					'postType',
@@ -218,5 +191,5 @@ export const registerPostTypeFields =
 			} );
 		} );
 
-		doAction( 'core.registerPostTypeFields', postType );
+		doAction( 'core.registerPostTypeSchema', postType );
 	};

--- a/packages/editor/src/dataviews/store/private-selectors.ts
+++ b/packages/editor/src/dataviews/store/private-selectors.ts
@@ -9,6 +9,10 @@ export function getEntityActions( state: State, kind: string, name: string ) {
 	return state.actions[ kind ]?.[ name ] ?? EMPTY_ARRAY;
 }
 
+export function getEntityFields( state: State, kind: string, name: string ) {
+	return state.fields[ kind ]?.[ name ] ?? EMPTY_ARRAY;
+}
+
 export function isEntityReady( state: State, kind: string, name: string ) {
 	return state.isReady[ kind ]?.[ name ];
 }

--- a/packages/editor/src/dataviews/store/private-selectors.ts
+++ b/packages/editor/src/dataviews/store/private-selectors.ts
@@ -13,6 +13,11 @@ export function getEntityFields( state: State, kind: string, name: string ) {
 	return state.fields[ kind ]?.[ name ] ?? EMPTY_ARRAY;
 }
 
-export function isEntityReady( state: State, kind: string, name: string ) {
-	return state.isReady[ kind ]?.[ name ];
+export function isEntityReady(
+	state: State,
+	kind: string,
+	name: string,
+	part: string
+) {
+	return state.isReady[ kind ]?.[ name ]?.[ part ];
 }

--- a/packages/editor/src/dataviews/store/private-selectors.ts
+++ b/packages/editor/src/dataviews/store/private-selectors.ts
@@ -13,11 +13,6 @@ export function getEntityFields( state: State, kind: string, name: string ) {
 	return state.fields[ kind ]?.[ name ] ?? EMPTY_ARRAY;
 }
 
-export function isEntityReady(
-	state: State,
-	kind: string,
-	name: string,
-	part: string
-) {
-	return state.isReady[ kind ]?.[ name ]?.[ part ];
+export function isEntityReady( state: State, kind: string, name: string ) {
+	return state.isReady[ kind ]?.[ name ];
 }

--- a/packages/editor/src/dataviews/store/reducer.ts
+++ b/packages/editor/src/dataviews/store/reducer.ts
@@ -2,17 +2,21 @@
  * WordPress dependencies
  */
 import { combineReducers } from '@wordpress/data';
-import type { Action } from '@wordpress/dataviews';
+import type { Action, Field } from '@wordpress/dataviews';
 
 type ReduxAction =
 	| ReturnType< typeof import('./private-actions').registerEntityAction >
 	| ReturnType< typeof import('./private-actions').unregisterEntityAction >
+	| ReturnType< typeof import('./private-actions').registerEntityField >
+	| ReturnType< typeof import('./private-actions').unregisterEntityField >
 	| ReturnType< typeof import('./private-actions').setIsReady >;
 
 export type ActionState = Record< string, Record< string, Action< any >[] > >;
+export type FieldsState = Record< string, Record< string, Field< any >[] > >;
 export type ReadyState = Record< string, Record< string, boolean > >;
 export type State = {
 	actions: ActionState;
+	fields: FieldsState;
 	isReady: ReadyState;
 };
 
@@ -64,7 +68,40 @@ function actions( state: ActionState = {}, action: ReduxAction ) {
 	return state;
 }
 
+function fields( state: FieldsState = {}, action: ReduxAction ) {
+	switch ( action.type ) {
+		case 'REGISTER_ENTITY_FIELD':
+			return {
+				...state,
+				[ action.kind ]: {
+					...state[ action.kind ],
+					[ action.name ]: [
+						...(
+							state[ action.kind ]?.[ action.name ] ?? []
+						).filter(
+							( _field ) => _field.id !== action.config.id
+						),
+						action.config,
+					],
+				},
+			};
+		case 'UNREGISTER_ENTITY_FIELD':
+			return {
+				...state,
+				[ action.kind ]: {
+					...state[ action.kind ],
+					[ action.name ]: (
+						state[ action.kind ]?.[ action.name ] ?? []
+					).filter( ( _field ) => _field.id !== action.fieldId ),
+				},
+			};
+	}
+
+	return state;
+}
+
 export default combineReducers( {
 	actions,
+	fields,
 	isReady,
 } );

--- a/packages/editor/src/dataviews/store/reducer.ts
+++ b/packages/editor/src/dataviews/store/reducer.ts
@@ -13,7 +13,10 @@ type ReduxAction =
 
 export type ActionState = Record< string, Record< string, Action< any >[] > >;
 export type FieldsState = Record< string, Record< string, Field< any >[] > >;
-export type ReadyState = Record< string, Record< string, boolean > >;
+export type ReadyState = Record<
+	string,
+	Record< string, Record< string, boolean > >
+>;
 export type State = {
 	actions: ActionState;
 	fields: FieldsState;
@@ -27,7 +30,10 @@ function isReady( state: ReadyState = {}, action: ReduxAction ) {
 				...state,
 				[ action.kind ]: {
 					...state[ action.kind ],
-					[ action.name ]: true,
+					[ action.name ]: {
+						...( state[ action.kind ]?.[ action.name ] ?? {} ),
+						[ action.part ]: true,
+					},
 				},
 			};
 	}

--- a/packages/editor/src/dataviews/store/reducer.ts
+++ b/packages/editor/src/dataviews/store/reducer.ts
@@ -13,10 +13,7 @@ type ReduxAction =
 
 export type ActionState = Record< string, Record< string, Action< any >[] > >;
 export type FieldsState = Record< string, Record< string, Field< any >[] > >;
-export type ReadyState = Record<
-	string,
-	Record< string, Record< string, boolean > >
->;
+export type ReadyState = Record< string, Record< string, boolean > >;
 export type State = {
 	actions: ActionState;
 	fields: FieldsState;
@@ -30,10 +27,7 @@ function isReady( state: ReadyState = {}, action: ReduxAction ) {
 				...state,
 				[ action.kind ]: {
 					...state[ action.kind ],
-					[ action.name ]: {
-						...( state[ action.kind ]?.[ action.name ] ?? {} ),
-						[ action.part ]: true,
-					},
+					[ action.name ]: true,
 				},
 			};
 	}

--- a/packages/editor/src/store/private-selectors.js
+++ b/packages/editor/src/store/private-selectors.js
@@ -27,6 +27,7 @@ import {
 } from './selectors';
 import {
 	getEntityActions as _getEntityActions,
+	getEntityFields as _getEntityFields,
 	isEntityReady as _isEntityReady,
 } from '../dataviews/store/private-selectors';
 
@@ -169,6 +170,10 @@ export function getEntityActions( state, ...args ) {
 
 export function isEntityReady( state, ...args ) {
 	return _isEntityReady( state.dataviews, ...args );
+}
+
+export function getEntityFields( state, ...args ) {
+	return _getEntityFields( state.dataviews, ...args );
 }
 
 /**


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/61084

## What?

This PR updates the `usePostFields` hook to take the fields from a central registry. It also implement the low-level APIs to allow register/unregister a field for any post type.

**This new API is only available in the Gutenberg plugin and it's private for now.**

## Why?

This follows suit of what we've done for actions. It is part of how we envision making the entities (dataviews) extensible, see https://github.com/WordPress/gutenberg/issues/61084

## How?

- Implement low-level store: reducer, selectors, actions. 3012632c74da9c0cc79599fbe11d549021855246
- Implement API: `wp.editor.registerEntityField` and `wp.editor.unregisterEntityField`. 74436150810ae1d1adb73a41cd27780722d0aadc
- Update the `usePostFields` hook to take fields from the registry. 8649f93b3596c5efe49a5d41f375217d35e2ec28
- Update the `isReady` state to acomodate `actions` and `fields`. df078fd48f0290a66593d18ac2234b7ea320824a

After feedback:

- Consolidate into `registerEntitySchema` and have a single `isReady` for the post type: 3e6782ea6e469534767e8e5da641fd41698cae2e

## Testing Instructions

1. Go to the Pages page and verify that everything works as expected.

2. Test unregistering a field. After unregistering it, the field won't be available. In the Pages page, open the console and type:

```js
wp.editor.unregisterEntityField( 'postType', 'page', 'author' );
```

https://github.com/user-attachments/assets/ece59037-d693-449f-a65a-6f5b6bcca582


3. Test registering a field. In the Pages page, open the console and type:

```js
wp.editor.registerEntityField('postType', 'page', {
  id: 'permalink_template',
  type: 'text',
  label: 'Permalink',
})
```

https://github.com/user-attachments/assets/99ba9c9f-ddb2-4f7e-8839-c5f487e852b3

