### PR TITLE
Enhance: Open "add new post" prompt in the sidebar for query block in new tab

### DIFF
--- a/packages/block-library/src/query/edit/inspector-controls/create-new-post-link.js
+++ b/packages/block-library/src/query/edit/inspector-controls/create-new-post-link.js
@@ -20,11 +20,10 @@ const CreateNewPostLink = ( { postType } ) => {
 	);
 	return (
 		<div className="wp-block-query__create-new-link">
-			{ createInterpolateElement(
-				'<a>' + addNewItemLabel + '</a>',
+			{ createInterpolateElement( '<a>' + addNewItemLabel + '</a>', {
 				// eslint-disable-next-line jsx-a11y/anchor-has-content
-				{ a: <a href={ newPostUrl } /> }
-			) }
+				a: <a href={ newPostUrl } target="_blank" rel="noreferrer" />,
+			} ) }
 		</div>
 	);
 };


### PR DESCRIPTION
Addresses #67177

## What?
This update changes the "Add New Post" button to open the post editor in a new tab. This makes it easier for users to switch between creating a post and their current work.

## Why?
In the Query Loop block, there’s a link to "Add New Post" in the block description. Clicking this link currently takes users to the post editor, which can disrupt their workflow. While the intent is to guide users to add posts, especially in an empty state, this flow can be confusing and counterproductive.

## How?
The change adds two properties to the link: target="_blank" and rel="noreferrer". This ensures the link opens in a new tab, improving the overall user experience.

## Testing Instructions

1. Open a post or page in the WordPress editor.
2. Add a Query Loop block to the page or post.
3. In the block description, locate the "Add New Post" link.
4. Click on the "Add New Post" link.
5. Verify that the post editor opens in a new tab instead of navigating away from the current page.
6. Ensure that the current page remains unchanged and no progress is lost.
7. Test the behavior on multiple browsers to confirm consistent functionality.
8. Check that the target="_blank" and rel="noreferrer" properties are applied to the link in the code.

## Screenshots

![image](https://github.com/user-attachments/assets/1b6de79c-4146-4eeb-9cce-ad1e7771ad6e)

