### PR TITLE
Style panel: use correct revisions count

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
@@ -23,6 +23,7 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 
 export default function SidebarNavigationScreenDetailsFooter( {
 	record,
+	recordCount = 0,
 	...otherProps
 } ) {
 	/*
@@ -35,9 +36,9 @@ export default function SidebarNavigationScreenDetailsFooter( {
 	const lastRevisionId =
 		record?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ?? null;
 	const revisionsCount =
-		record?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0;
-	// Enable the revisions link if there is a last revision and there are more than one revisions.
-	if ( lastRevisionId && revisionsCount > 1 ) {
+		recordCount || record?._links?.[ 'version-history' ]?.[ 0 ]?.count;
+	// Enable the revisions link if there is a last revision and there is more than one revision.
+	if ( lastRevisionId && revisionsCount ) {
 		hrefProps.href = addQueryArgs( 'revision.php', {
 			revision: record?._links[ 'predecessor-version' ][ 0 ].id,
 		} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
@@ -23,7 +23,7 @@ import SidebarNavigationItem from '../sidebar-navigation-item';
 
 export default function SidebarNavigationScreenDetailsFooter( {
 	record,
-	recordCount = 0,
+	revisionsCount,
 	...otherProps
 } ) {
 	/*
@@ -35,10 +35,21 @@ export default function SidebarNavigationScreenDetailsFooter( {
 	const hrefProps = {};
 	const lastRevisionId =
 		record?._links?.[ 'predecessor-version' ]?.[ 0 ]?.id ?? null;
-	const revisionsCount =
-		recordCount || record?._links?.[ 'version-history' ]?.[ 0 ]?.count;
-	// Enable the revisions link if there is a last revision and there is more than one revision.
-	if ( lastRevisionId && revisionsCount ) {
+
+	// Use incoming prop first, then the record's version history, if available.
+	revisionsCount =
+		revisionsCount ||
+		record?._links?.[ 'version-history' ]?.[ 0 ]?.count ||
+		0;
+
+	/*
+	 * Enable the revisions link if there is a last revision and there is more than one revision.
+	 * This link is used for theme assets, e.g., templates, which have no database record until they're edited.
+	 * For these files there's only a "revision" after they're edited twice,
+	 * which means the revision.php page won't display a proper diff.
+	 * See: https://github.com/WordPress/gutenberg/issues/49164.
+	 */
+	if ( lastRevisionId && revisionsCount > 1 ) {
 		hrefProps.href = addQueryArgs( 'revision.php', {
 			revision: record?._links[ 'predecessor-version' ][ 0 ].id,
 		} );

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -48,24 +48,15 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 export default function SidebarNavigationScreenGlobalStyles() {
 	const history = useHistory();
 	const { params } = useLocation();
-	const { revisions, isLoading: isLoadingRevisions } =
-		useGlobalStylesRevisions();
+	const {
+		revisions,
+		isLoading: isLoadingRevisions,
+		revisionsCount,
+	} = useGlobalStylesRevisions();
 	const { openGeneralSidebar } = useDispatch( editSiteStore );
 	const { setEditorCanvasContainerView } = unlock(
 		useDispatch( editSiteStore )
 	);
-	const { revisionsCount } = useSelect( ( select ) => {
-		const { getEntityRecord, __experimentalGetCurrentGlobalStylesId } =
-			select( coreStore );
-		const globalStylesId = __experimentalGetCurrentGlobalStylesId();
-		const globalStyles = globalStylesId
-			? getEntityRecord( 'root', 'globalStyles', globalStylesId )
-			: undefined;
-		return {
-			revisionsCount:
-				globalStyles?._links?.[ 'version-history' ]?.[ 0 ]?.count ?? 0,
-		};
-	}, [] );
 	const { set: setPreference } = useDispatch( preferencesStore );
 
 	const openGlobalStyles = useCallback( async () => {
@@ -95,10 +86,10 @@ export default function SidebarNavigationScreenGlobalStyles() {
 	}, [ openGlobalStyles, setEditorCanvasContainerView ] );
 
 	// If there are no revisions, do not render a footer.
-	const hasRevisions = revisionsCount > 0;
 	const modifiedDateTime = revisions?.[ 0 ]?.modified;
 	const shouldShowGlobalStylesFooter =
-		hasRevisions && ! isLoadingRevisions && modifiedDateTime;
+		revisionsCount && ! isLoadingRevisions && modifiedDateTime;
+
 	return (
 		<>
 			<SidebarNavigationScreen
@@ -114,6 +105,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 					shouldShowGlobalStylesFooter && (
 						<SidebarNavigationScreenDetailsFooter
 							record={ revisions?.[ 0 ] }
+							recordCount={ revisionsCount }
 							onClick={ openRevisions }
 						/>
 					)

--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -88,7 +88,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 	// If there are no revisions, do not render a footer.
 	const modifiedDateTime = revisions?.[ 0 ]?.modified;
 	const shouldShowGlobalStylesFooter =
-		revisionsCount && ! isLoadingRevisions && modifiedDateTime;
+		revisionsCount > 0 && ! isLoadingRevisions && modifiedDateTime;
 
 	return (
 		<>
@@ -105,7 +105,7 @@ export default function SidebarNavigationScreenGlobalStyles() {
 					shouldShowGlobalStylesFooter && (
 						<SidebarNavigationScreenDetailsFooter
 							record={ revisions?.[ 0 ] }
-							recordCount={ revisionsCount }
+							revisionsCount={ revisionsCount }
 							onClick={ openRevisions }
 						/>
 					)


### PR DESCRIPTION

This allows us to remove the globalstyle record selector.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

For the styles panel `<SidebarNavigationScreenGlobalStyles />` component, send the correct recordCount via optional prop to the footer component `<SidebarNavigationScreenDetailsFooter />`.

Props to @afercia for catching it over in https://github.com/WordPress/gutenberg/pull/66606#issuecomment-2488542836

## Why?

`<SidebarNavigationScreenGlobalStyles />` was passing a revision record to `<SidebarNavigationScreenDetailsFooter />`. Revision records do not contain a `_links` object, and therefore the record history count is not accessible.

## How?
Pass the correct revisionsCount to the component.

## Testing Instructions

The record count for global revisions is not actually used in the side panel, so the way to test is it to log out the revisionsCount in `<SidebarNavigationScreenDetailsFooter />`.


```diff
diff --git a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
index 4a5a617514..0702ace70c 100644
--- a/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-details-footer/index.js
@@ -44,6 +44,7 @@ export default function SidebarNavigationScreenDetailsFooter( {
 		} );
 		hrefProps.as = 'a';
 	}
+	console.log( { revisionsCount } );
 	return (
 		<ItemGroup className="edit-site-sidebar-navigation-screen-details-footer">
 			<SidebarNavigationItem

```

Create a few global styles revisions by editing a theme's global styles and saving.

The open up the left-hand style panel in the site editor.

<img width="284" alt="Screenshot 2024-11-21 at 10 30 03 am" src="https://github.com/user-attachments/assets/a16d8f51-b629-48b5-95dd-dfa65629d549">

Check the `revisionsCount` in the console.

Then click on the "Last modified link" to open revisions in the editor. The number in the revisions pane should match.

<img width="255" alt="Screenshot 2024-11-21 at 10 31 02 am" src="https://github.com/user-attachments/assets/dde2cab2-99f4-4dbd-ac04-bb3eb5dda407">


