### PR TITLE
Avoid zooming out when browsing styles if the preview mode is active

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-style-variations.js
+++ b/packages/edit-site/src/components/global-styles/screen-style-variations.js
@@ -1,10 +1,13 @@
 /**
  * WordPress dependencies
  */
+import {
+	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
+} from '@wordpress/block-editor';
 import { Card, CardBody } from '@wordpress/components';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { useDispatch } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect } from '@wordpress/element';
 
@@ -19,10 +22,13 @@ const { useZoomOut } = unlock( blockEditorPrivateApis );
 
 function ScreenStyleVariations() {
 	// Style Variations should only be previewed in with
-	// - a "zoomed out" editor
+	// - a "zoomed out" editor (but not when in preview mode)
 	// - "Desktop" device preview
+	const isPreviewMode = useSelect( ( select ) => {
+		return select( blockEditorStore ).getSettings().isPreviewMode;
+	}, [] );
 	const { setDeviceType } = useDispatch( editorStore );
-	useZoomOut();
+	useZoomOut( ! isPreviewMode );
 	useEffect( () => {
 		setDeviceType( 'desktop' );
 	}, [ setDeviceType ] );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #67166

Avoids zooming out when browsing styles if the preview mode is active.

## How?
Check if `isPreviewMode` is active, and if so, don't enter zoom out.

I expect it should never be possible to enter zoom out from the preview mode, so part of me wonders if this should be built-in to the `useZoomOut` hook. Or alternatively (and maybe better) into the `setZoomLevel` action. Would be good to get opinions on that.

## Testing Instructions
1. Open Edit Site from wp admin
2. Select 'Styles'
3. Select 'Browse Styles'
4. Observe you no longer zoom out
5. Now click into the actual editor frame to open the editor
6. Open the global styles sidebar (it might be open already)
7. Click 'Browse Styles' there
8. Observe this does still zoom out

## Screenshots or screencast <!-- if applicable -->
#### Before
<img width="600" alt="Screenshot 2024-11-21 at 4 20 56 pm" src="https://github.com/user-attachments/assets/4a0189aa-8efa-40b7-a89f-58a1f1b2847c">

#### After
<img width="600" alt="Screenshot 2024-11-21 at 4 20 37 pm" src="https://github.com/user-attachments/assets/16b68492-2430-4577-98d6-e61d31769eab">
