### PR TITLE
Storybook: Add stories for BlockCard component

### DIFF
--- a/packages/block-editor/src/components/block-card/stories/index.story.js
+++ b/packages/block-editor/src/components/block-card/stories/index.story.js
@@ -8,17 +8,14 @@ import { box, button, cog, paragraph } from '@wordpress/icons';
  */
 import BlockCard from '../';
 
-/**
- * BlockCard component displays information about a block including its icon, title, and description.
- */
-const meta = {
+export default {
 	title: 'BlockEditor/BlockCard',
 	component: BlockCard,
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The BlockCard component allows to display a card which contains the title of a block, its icon and its description.',
+					'The `BlockCard` component allows to display a card which contains the title of a block, its icon and its description.',
 			},
 			canvas: { sourceState: 'shown' },
 		},
@@ -65,8 +62,6 @@ const meta = {
 		},
 	},
 };
-
-export default meta;
 
 /**
  * Default story shows the basic BlockCard with title, icon, name and description.

--- a/packages/block-editor/src/components/block-card/stories/index.story.js
+++ b/packages/block-editor/src/components/block-card/stories/index.story.js
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import { box, button, cog, paragraph } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import BlockCard from '../';
+
+/**
+ * BlockCard component displays information about a block including its icon, title, and description.
+ */
+const meta = {
+	title: 'BlockEditor/BlockCard',
+	component: BlockCard,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'BlockCard component displays block information, including icon, title, and description.',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+	decorators: [ ( Story ) => <Story /> ],
+	argTypes: {
+		title: {
+			control: 'text',
+			description: 'The title of the block',
+		},
+		description: {
+			control: 'text',
+			description: 'A description of the block functionality',
+		},
+		icon: {
+			control: 'select',
+			options: [ 'paragraph', 'cog', 'box', 'button' ],
+			mapping: {
+				paragraph,
+				cog,
+				box,
+				button,
+			},
+			description: 'The icon to display for the block',
+		},
+		name: {
+			control: 'text',
+			description: 'Optional custom name for the block',
+		},
+		className: {
+			control: 'text',
+			description: 'Additional CSS class names',
+		},
+	},
+};
+
+export default meta;
+
+/**
+ * Default story shows the basic BlockCard with title, icon and description.
+ */
+export const Default = {
+	args: {
+		title: 'Paragraph',
+		icon: paragraph,
+		description: 'Start with the building block of all narrative.',
+	},
+};
+
+/**
+ * This story demonstrates the BlockCard with a name.
+ */
+export const Name = {
+	args: {
+		...Default.args,
+		name: 'Custom Name',
+	},
+};
+
+/**
+ * This story demonstrates the BlockCard with a description.
+ */
+export const Description = {
+	args: {
+		...Default.args,
+		description:
+			'Start with the building block of all narrative. Paragraph is a good block for text-heavy content.',
+	},
+};
+
+/**
+ * This story demonstrates the BlockCard with a icon
+ */
+export const Icon = {
+	args: {
+		...Default.args,
+		icon: box,
+		title: 'Box Icon',
+	},
+};
+
+export const Title = {
+	args: {
+		...Default.args,
+		title: 'A Custom Title',
+	},
+};

--- a/packages/block-editor/src/components/block-card/stories/index.story.js
+++ b/packages/block-editor/src/components/block-card/stories/index.story.js
@@ -44,7 +44,11 @@ const meta = {
 				box,
 				button,
 			},
-			description: 'The icon to display for the block.',
+			description:
+				'The icon of the block. This can be any of [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.',
+			table: {
+				type: { summary: 'string | object' },
+			},
 		},
 		name: {
 			control: 'text',

--- a/packages/block-editor/src/components/block-card/stories/index.story.js
+++ b/packages/block-editor/src/components/block-card/stories/index.story.js
@@ -8,14 +8,14 @@ import { box, button, cog, paragraph } from '@wordpress/icons';
  */
 import BlockCard from '../';
 
-export default {
+const meta = {
 	title: 'BlockEditor/BlockCard',
 	component: BlockCard,
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The `BlockCard` component allows to display a card which contains the title of a block, its icon and its description.',
+					'The `BlockCard` component allows to display a "card" which contains the title of a block, its icon and its description.',
 			},
 			canvas: { sourceState: 'shown' },
 		},
@@ -23,14 +23,14 @@ export default {
 	argTypes: {
 		title: {
 			control: 'text',
-			description: 'The title of the block',
+			description: 'The title of the block.',
 			table: {
 				type: { summary: 'string' },
 			},
 		},
 		description: {
 			control: 'text',
-			description: 'A description of the block functionality',
+			description: 'A description of the block functionality.',
 			table: {
 				type: { summary: 'string' },
 			},
@@ -44,18 +44,18 @@ export default {
 				box,
 				button,
 			},
-			description: 'The icon to display for the block',
+			description: 'The icon to display for the block.',
 		},
 		name: {
 			control: 'text',
-			description: 'Optional custom name for the block',
+			description: 'Optional custom name for the block.',
 			table: {
 				type: { summary: 'string' },
 			},
 		},
 		className: {
 			control: 'text',
-			description: 'Additional CSS class names',
+			description: 'Additional CSS class names.',
 			table: {
 				type: { summary: 'string' },
 			},
@@ -63,9 +63,8 @@ export default {
 	},
 };
 
-/**
- * Default story shows the basic BlockCard with title, icon, name and description.
- */
+export default meta;
+
 export const Default = {
 	args: {
 		title: 'Paragraph',

--- a/packages/block-editor/src/components/block-card/stories/index.story.js
+++ b/packages/block-editor/src/components/block-card/stories/index.story.js
@@ -18,20 +18,25 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'BlockCard component displays block information, including icon, title, and description.',
+					'The BlockCard component allows to display a card which contains the title of a block, its icon and its description.',
 			},
 			canvas: { sourceState: 'shown' },
 		},
 	},
-	decorators: [ ( Story ) => <Story /> ],
 	argTypes: {
 		title: {
 			control: 'text',
 			description: 'The title of the block',
+			table: {
+				type: { summary: 'string' },
+			},
 		},
 		description: {
 			control: 'text',
 			description: 'A description of the block functionality',
+			table: {
+				type: { summary: 'string' },
+			},
 		},
 		icon: {
 			control: 'select',
@@ -47,10 +52,16 @@ const meta = {
 		name: {
 			control: 'text',
 			description: 'Optional custom name for the block',
+			table: {
+				type: { summary: 'string' },
+			},
 		},
 		className: {
 			control: 'text',
 			description: 'Additional CSS class names',
+			table: {
+				type: { summary: 'string' },
+			},
 		},
 	},
 };
@@ -58,51 +69,13 @@ const meta = {
 export default meta;
 
 /**
- * Default story shows the basic BlockCard with title, icon and description.
+ * Default story shows the basic BlockCard with title, icon, name and description.
  */
 export const Default = {
 	args: {
 		title: 'Paragraph',
 		icon: paragraph,
-		description: 'Start with the building block of all narrative.',
-	},
-};
-
-/**
- * This story demonstrates the BlockCard with a name.
- */
-export const Name = {
-	args: {
-		...Default.args,
-		name: 'Custom Name',
-	},
-};
-
-/**
- * This story demonstrates the BlockCard with a description.
- */
-export const Description = {
-	args: {
-		...Default.args,
-		description:
-			'Start with the building block of all narrative. Paragraph is a good block for text-heavy content.',
-	},
-};
-
-/**
- * This story demonstrates the BlockCard with a icon
- */
-export const Icon = {
-	args: {
-		...Default.args,
-		icon: box,
-		title: 'Box Icon',
-	},
-};
-
-export const Title = {
-	args: {
-		...Default.args,
-		title: 'A Custom Title',
+		description: 'This is a paragraph block description.',
+		name: 'Paragraph Block',
 	},
 };


### PR DESCRIPTION
Part of: #67165

## What?
This PR will add stories for the BlockCard component in the Storybook

## Screencast:

https://github.com/user-attachments/assets/01f4511c-5bee-4766-b0cf-e529aaab5cd7

