### PR TITLE
DataViews: fix action visibility logic

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -190,7 +190,7 @@ function hasOnlyOneActionAndIsPrimary< Item >(
 	primaryActions: Action< Item >[],
 	actions: Action< Item >[]
 ) {
-	return primaryActions.length === 1 && actions.length;
+	return primaryActions.length === 1 && actions.length === 1;
 }
 
 export default function ItemActions< Item >( {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/67020#discussion_r1851538821

## What?

This fixes a bug that hid the action menu, even when there was seconday actions.

## How?

Fix the visibility logic so that it hides the action menu only when there's a single action and is primary, as it was originally intended.

## Testing Instructions

```js
npm install && npm run storybook:dev
```

Go to the storybook and visit the default story for dataviews. It should display both the primary action (delete) and the action menu with two actions. In `trunk` it only displays the primary action.

<img width="1736" alt="Screenshot 2024-11-21 at 11 37 19" src="https://github.com/user-attachments/assets/4fa840f2-e8c0-448b-beb5-dbd159668217">

Then, go to [this line](https://github.com/WordPress/gutenberg/blob/62dd64710ecdcf10ce2594d34d96b6df978e2df2/packages/dataviews/src/components/dataviews/stories/fixtures.tsx#L609) and remove the secondary action so the actions array only contains the `id: delete` action. The expected behaviour is that the action menu is hidden in this case:

<img width="1736" alt="Screenshot 2024-11-21 at 11 39 36" src="https://github.com/user-attachments/assets/15faf63f-bda7-44aa-a11c-561298158a0c">


