### PR TITLE
Align Submenu block and Nav Link block by including description and wrapping span 

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -474,6 +474,11 @@ export default function NavigationSubmenuEdit( {
 							}
 						} }
 					/>
+					{ description && (
+						<span className="wp-block-navigation-item__description">
+							{ description }
+						</span>
+					) }
 					{ ! openSubmenusOnClick && isLinkOpen && (
 						<LinkUI
 							clientId={ clientId }

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -160,10 +160,15 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		// End appending HTML attributes to anchor tag.
 
 		$html .= '<span class="wp-block-navigation-item__label">';
-
 		$html .= $label;
-
 		$html .= '</span>';
+
+		// Add description if available.
+		if ( ! empty( $attributes['description'] ) ) {
+			$html .= '<span class="wp-block-navigation-item__description">';
+			$html .= wp_kses_post( $attributes['description'] );
+			$html .= '</span>';
+		}
 
 		$html .= '</a>';
 		// End anchor tag content.
@@ -183,6 +188,13 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$html .= $label;
 
 		$html .= '</span>';
+
+		// Add description if available.
+		if ( ! empty( $attributes['description'] ) ) {
+			$html .= '<span class="wp-block-navigation-item__description">';
+			$html .= wp_kses_post( $attributes['description'] );
+			$html .= '</span>';
+		}
 
 		$html .= '</button>';
 

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -159,7 +159,11 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$html .= '>';
 		// End appending HTML attributes to anchor tag.
 
+		$html .= '<span class="wp-block-navigation-item__label">';
+
 		$html .= $label;
+
+		$html .= '</span>';
 
 		$html .= '</a>';
 		// End anchor tag content.

--- a/packages/block-library/src/navigation/README.md
+++ b/packages/block-library/src/navigation/README.md
@@ -10,4 +10,5 @@ The structural CSS for the navigation block targets generic classnames across me
 -   `.wp-block-navigation-item` is applied to every menu item.
 -   `.wp-block-navigation-item__content` is applied to the link inside a menu item.
 -   `.wp-block-navigation-item__label` is applied to the innermost container around the menu item text label.
+-   `.wp-block-navigation-item__description` is applied to the innermost container around the menu item description.
 -   `.wp-block-navigation__submenu-icon` is applied to the submenu indicator (chevron).


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Addresses part of #57099

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR fixes the missing `<span class="wp-block-navigation-item__label">` element for navigation items with submenus. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The absence of the `<span class="wp-block-navigation-item__label">` element in navigation items with submenus results in inconsistent markup, potentially impacting accessibility and styling.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The PR adjusts the rendering logic for navigation items with submenus to include the `<span class="wp-block-navigation-item__label">`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a navigation block
2. Add a navigation item to this block
3. Add a second navigation item to this block
4. Add a submenu item to the second navigation block
5. Check the source code

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![wp-block-navigation-item__label](https://github.com/user-attachments/assets/67293771-4291-4fa5-b478-86cb06f15898)


