### PR TITLE
Adding color filled icon

### DIFF
--- a/packages/icons/src/index.js
+++ b/packages/icons/src/index.js
@@ -56,6 +56,7 @@ export { default as cloud } from './library/cloud';
 export { default as code } from './library/code';
 export { default as cog } from './library/cog';
 export { default as color } from './library/color';
+export { default as colorFilled } from './library/color-filled';
 export { default as column } from './library/column';
 export { default as columns } from './library/columns';
 export { default as copy } from './library/copy';

--- a/packages/icons/src/library/color-filled.js
+++ b/packages/icons/src/library/color-filled.js
@@ -1,0 +1,12 @@
+/**
+ * WordPress dependencies
+ */
+import { Path, SVG } from '@wordpress/primitives';
+
+const color = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M17.2 10.9c-.5-1-1.2-2.1-2.1-3.2-.6-.9-1.3-1.7-2.1-2.6L12 4l-1 1.1c-.6.9-1.3 1.7-2 2.6-.8 1.2-1.5 2.3-2 3.2-.6 1.2-1 2.2-1 3 0 3.4 2.7 6.1 6.1 6.1s6.1-2.7 6.1-6.1c0-.8-.3-1.8-1-3z" />
+	</SVG>
+);
+
+export default color;

--- a/packages/icons/src/library/color-filled.js
+++ b/packages/icons/src/library/color-filled.js
@@ -3,10 +3,10 @@
  */
 import { Path, SVG } from '@wordpress/primitives';
 
-const color = (
+const colorFilled = (
 	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M17.2 10.9c-.5-1-1.2-2.1-2.1-3.2-.6-.9-1.3-1.7-2.1-2.6L12 4l-1 1.1c-.6.9-1.3 1.7-2 2.6-.8 1.2-1.5 2.3-2 3.2-.6 1.2-1 2.2-1 3 0 3.4 2.7 6.1 6.1 6.1s6.1-2.7 6.1-6.1c0-.8-.3-1.8-1-3z" />
 	</SVG>
 );
 
-export default color;
+export default colorFilled;


### PR DESCRIPTION
## What?
Adds a filled version of the 'color' icon, 'colorFilled'.

## Why?
To be able to implement the UI proposed in https://github.com/WordPress/gutenberg/issues/66465#issuecomment-2439960078 for https://github.com/WordPress/gutenberg/issues/66465 

## How?
Adds a new icon to the icons library.
This is a slightly modified version of the SVG code proposed by @aaronrobertshaw in https://github.com/WordPress/gutenberg/pull/67140#pullrequestreview-2447221592 props to him.
I removed some unwanted or hardcore properties to make the SVG code looks like the rest of the filled icons in the package.

## Testing Instructions
Import the 'colorFilled' from the `@wordpress/icons` package and observe how it looks.
Try to set a fill color and a stroke color too.


## Screenshots or screencast <!-- if applicable -->

**Default:**
![Screenshot from 2024-11-21 11-53-42](https://github.com/user-attachments/assets/cd54acaa-53a8-4c31-a450-3027e5abd67f)

**With custom fill color set:**
![Screenshot from 2024-11-21 11-52-43](https://github.com/user-attachments/assets/2409b347-92df-47af-ba90-93ba5e0887c3)

**With custom fill and stroke color set:**
![Screenshot from 2024-11-21 11-53-25](https://github.com/user-attachments/assets/89e30092-20c9-4d10-9fdc-5264dae16b4a)
