### PR TITLE
Social Links: Fix font family and weight inconsistency in editor

### DIFF
--- a/packages/block-library/src/social-link/editor.scss
+++ b/packages/block-library/src/social-link/editor.scss
@@ -14,6 +14,8 @@
 	font-size: inherit;
 	color: currentColor;
 	height: auto;
+	font-weight: inherit;
+	font-family: inherit;
 
 	// This rule ensures social link buttons display correctly in template parts.
 	opacity: 1;


### PR DESCRIPTION
Fixes #46778

## What?
Added `font-weight: inherit;` and `font-family: inherit;` to the `.wp-block-social-link-anchor` class in the editor to ensure consistent font styling with the frontend.  

## Why?
The inconsistency was caused because:  
- **Frontend:** Social links use an `<a>` tag, inheriting `font-family` and `font-weight` from the body.  
- **Editor:** Social links use a `<button>` element, which applies default button styles (`font-family` and `font-weight`) instead of inheriting from the body.  

This change ensures uniform font styling for social links across both the editor and frontend.  

## How?
Updated the `.wp-block-social-link-anchor` class in the editor with the following CSS:  
```css  
font-weight: inherit;  
font-family: inherit;  
```

## Testing Instructions
1.	Open the editor and add a social links block.
2.	Add a few social links and check the font weight and font family.
3.	Save and view the post on the frontend.
4.	Compare the font styling (weight and family) between the editor and frontend to ensure consistency.

## Screenshots or screencast <!-- if applicable -->
### Before:
#### Chrome:

| Editor    | Frontend |
| -------- | ------- |
| <img width="439" alt="image" src="https://github.com/user-attachments/assets/4e82bbbb-2185-469f-9338-3dee51fa2900">  | <img width="394" alt="image" src="https://github.com/user-attachments/assets/e555633b-a7c6-4298-8752-acdc9c87ab67">    |

#### Firefox:
| Editor    | Frontend |
| -------- | ------- |
| <img width="752" alt="image" src="https://github.com/user-attachments/assets/b84a945a-28dd-4045-8020-2a9425c29fc8"> | <img width="721" alt="image" src="https://github.com/user-attachments/assets/da590fa0-cc72-4b08-91c2-f125af83bc20"> |


### After fix: 

#### Chrome:

| Editor    | Frontend |
| -------- | ------- |
| <img width="413" alt="image" src="https://github.com/user-attachments/assets/269e7f52-d47b-4197-8314-b0da397cfb4f"> | <img width="413" alt="image" src="https://github.com/user-attachments/assets/6576a00d-feb8-4fb4-b662-6af89b95a6b5"> |

#### Firefox:

| Editor    | Frontend |
| -------- | ------- |
|  <img width="606" alt="image" src="https://github.com/user-attachments/assets/64ebf9f4-e658-4cf3-bd5c-97454cc42d99">| <img width="656" alt="image" src="https://github.com/user-attachments/assets/2e90f54c-f5db-4cb0-9513-bd1aee5bfb4d">|
