### PR TITLE
BlockCanvas: Make contentRef property stable

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -139,6 +139,7 @@ _Parameters_
 -   _props_ `Object`: Component props.
 -   _props.height_ `string`: Canvas height, defaults to 300px.
 -   _props.styles_ `Array`: Content styles to inject into the iframe.
+-   _props.contentRef_ `Object`: Reference to the content element.
 -   _props.children_ `Element`: Content of the canvas, defaults to the BlockList component.
 
 _Returns_

--- a/packages/block-editor/src/components/block-canvas/index.js
+++ b/packages/block-editor/src/components/block-canvas/index.js
@@ -123,15 +123,20 @@ export function ExperimentalBlockCanvas( {
  * }
  * ```
  *
- * @param {Object}  props          Component props.
- * @param {string}  props.height   Canvas height, defaults to 300px.
- * @param {Array}   props.styles   Content styles to inject into the iframe.
- * @param {Element} props.children Content of the canvas, defaults to the BlockList component.
- * @return {Element}               Block Breadcrumb.
+ * @param {Object}  props            Component props.
+ * @param {string}  props.height     Canvas height, defaults to 300px.
+ * @param {Array}   props.styles     Content styles to inject into the iframe.
+ * @param {Object}  props.contentRef Reference to the content element.
+ * @param {Element} props.children   Content of the canvas, defaults to the BlockList component.
+ * @return {Element}                 Block Breadcrumb.
  */
-function BlockCanvas( { children, height, styles } ) {
+function BlockCanvas( { children, height, styles, contentRef } ) {
 	return (
-		<ExperimentalBlockCanvas height={ height } styles={ styles }>
+		<ExperimentalBlockCanvas
+			height={ height }
+			styles={ styles }
+			contentRef={ contentRef }
+		>
 			{ children }
 		</ExperimentalBlockCanvas>
 	);


### PR DESCRIPTION
## What?
This PR makes BlockCanvas's contentRef property stable.

## Why?
It is used by a couple of custom build block editors. Please see more details in https://github.com/WordPress/gutenberg/issues/67209

Fixes https://github.com/WordPress/gutenberg/issues/67209
