### PR TITLE
BorderBoxControl: Suppress redundant warnings for deprecated 36px size

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -36,6 +36,7 @@
 -   `SlotFill`: fix dependencies of `Fill` registration effects ([#67071](https://github.com/WordPress/gutenberg/pull/67071)).
 -   `SlotFill`: rewrite the `Slot` component from class component to functional ([#67153](https://github.com/WordPress/gutenberg/pull/67153)).
 -   `Menu.ItemHelpText`: Fix text wrapping to prevent unintended word breaks ([#67011](https://github.com/WordPress/gutenberg/pull/67011)).
+-   `BorderBoxControl`: Suppress redundant warnings for deprecated 36px size ([#67213](https://github.com/WordPress/gutenberg/pull/67213)).
 
 ## 28.12.0 (2024-11-16)
 

--- a/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control-split-controls/component.tsx
@@ -67,6 +67,7 @@ const BorderBoxControlSplitControls = (
 		isCompact: true,
 		__experimentalIsRenderedInSidebar,
 		size,
+		__shouldNotWarnDeprecated36pxSize: true,
 	};
 
 	const mergedRef = useMergeRefs( [ setPopoverAnchor, forwardedRef ] );

--- a/packages/components/src/border-box-control/border-box-control/component.tsx
+++ b/packages/components/src/border-box-control/border-box-control/component.tsx
@@ -118,6 +118,7 @@ const UnconnectedBorderBoxControl = (
 						__experimentalIsRenderedInSidebar={
 							__experimentalIsRenderedInSidebar
 						}
+						__shouldNotWarnDeprecated36pxSize
 						size={ size }
 					/>
 				) : (

--- a/packages/components/src/border-control/border-control/hook.ts
+++ b/packages/components/src/border-control/border-control/hook.ts
@@ -38,6 +38,7 @@ export function useBorderControl(
 		width,
 		__experimentalIsRenderedInSidebar = false,
 		__next40pxDefaultSize,
+		__shouldNotWarnDeprecated36pxSize,
 		...otherProps
 	} = useContextSystem( props, 'BorderControl' );
 
@@ -45,6 +46,7 @@ export function useBorderControl(
 		componentName: 'BorderControl',
 		__next40pxDefaultSize,
 		size,
+		__shouldNotWarnDeprecated36pxSize,
 	} );
 
 	const computedSize =

--- a/packages/components/src/border-control/types.ts
+++ b/packages/components/src/border-control/types.ts
@@ -116,6 +116,13 @@ export type BorderControlProps = ColorProps &
 		 * @default false
 		 */
 		__next40pxDefaultSize?: boolean;
+		/**
+		 * Do not throw a warning for the deprecated 36px default size.
+		 * For internal components of other components that already throw the warning.
+		 *
+		 * @ignore
+		 */
+		__shouldNotWarnDeprecated36pxSize?: boolean;
 	};
 
 export type DropdownProps = ColorProps &


### PR DESCRIPTION
Follow-up to #65752

## What?

Suppresses a redundant console warning when BorderBoxControl is used in its deprecated 36px size.

## Why?

BorderBoxControl has a BorderControl under the hood, and when BorderBoxControl is used in the deprecated 36px size, the internal BorderControl also logs a warning. This is redundant and confusing to the consumer.

## How?

Use the `__shouldNotWarnDeprecated36pxSize` feature of the `maybeWarnDeprecated36pxSize` util.

## Testing Instructions

Go to the Storybook story for BorderBoxControl and disable the `__next40pxDefaultSize` prop. The console warning for the deprecated size should only be logged once by the BorderBoxControl itself, and not by its internal components.
