### PR TITLE
Autocomplete: Increase option height

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### Enhancements
 
 -   `ColorPicker`: Update sizes of color format select and copy button ([#67093](https://github.com/WordPress/gutenberg/pull/67093)).
+-   `Autocomplete`: Increase option height ([#67214](https://github.com/WordPress/gutenberg/pull/67214)).
 
 ### Experimental
 

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -57,6 +57,7 @@ function ListBox( {
 					key={ option.key }
 					id={ `components-autocomplete-item-${ instanceId }-${ option.key }` }
 					role="option"
+					__next40pxDefaultSize
 					aria-selected={ index === selectedIndex }
 					accessibleWhenDisabled
 					disabled={ option.isDisabled }


### PR DESCRIPTION
In preparation for #65751

## What?

Increases the option height of the Autocomplete to align with the current sizing scheme.

## Testing Instructions

In a Paragraph block in the Block Editor, type `@` to start trigger the user autocomplete popover.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/3ddad3df-089f-4cce-8cfe-deddc8c4a807" alt="Autocompleter item, before" width="259">|<img src="https://github.com/user-attachments/assets/f1f610cf-74d9-4c96-ba1a-5589d4a7083a" alt="Autocompleter item, after" width="259">|
