### PR TITLE
Details block: use summary content as default label

### DIFF
--- a/packages/block-library/src/details/index.js
+++ b/packages/block-library/src/details/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { details as icon } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -33,6 +33,28 @@ export const settings = {
 				},
 			},
 		],
+	},
+	__experimentalLabel( attributes, { context } ) {
+		const { summary } = attributes;
+
+		const customName = attributes?.metadata?.name;
+		const hasSummary = summary?.trim().length > 0;
+
+		// In the list view, use the block's summary as the label.
+		// If the summary is empty, fall back to the default label.
+		if ( context === 'list-view' && ( customName || hasSummary ) ) {
+			return customName || summary;
+		}
+
+		if ( context === 'accessibility' ) {
+			return ! hasSummary
+				? __( 'Details. Empty.' )
+				: sprintf(
+						/* translators: accessibility text; summary title. */
+						__( 'Details. %s' ),
+						summary
+				  );
+		}
 	},
 	save,
 	edit,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Allows the Details block to use it's summary attribute as the block label by default, similar to the Heading block.

## Why?
The Details block has a viable attribute to use as the default label, and in use cases where there are dozens on a page, it makes the List View more usable.

## How?
Defines custom __experimentalLabel handler to the Details block. Unsure if the accessibility label should be prefixed with "Details. " or not, tried to match the approach of the Heading block.

## Testing Instructions
1. Open the editor
2. Add a Details block, give it a summary value
3. Open List View, confirm summary is being used as the label
