### PR TITLE
DataView: Pass `disabled` prop to a primary action

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -80,6 +80,8 @@ function ButtonTrigger< Item >( {
 			isDestructive={ action.isDestructive }
 			size="compact"
 			onClick={ onClick }
+			accessibleWhenDisabled
+			disabled={ action?.disabled }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR changes to pass the `disabled` prop to a primary action in the same way as item actions. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To align disabled handling for primary actions with item actions, ensuring consistency.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Passing `action.disabled` to `ButtonTrigger`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->


<!-- 
### Testing Instructions for Keyboard

How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
