### PR TITLE
Inline Commenting: Update collab sidebar style

### DIFF
--- a/packages/editor/src/components/collab-sidebar/style.scss
+++ b/packages/editor/src/components/collab-sidebar/style.scss
@@ -1,5 +1,15 @@
+.interface-interface-skeleton__sidebar:has(.editor-collab-sidebar-panel) {
+	box-shadow: none;
+
+	.interface-complementary-area-header {
+		display: none;
+	}
+}
+
 .editor-collab-sidebar-panel {
 	padding: $grid-unit-20;
+	background: var(--wp--preset--color--base);
+	height: 100vw;
 
 	&__thread {
 		position: relative;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of - https://github.com/WordPress/gutenberg/issues/66377

## What? & Why?
<!-- In a few words, what is the PR actually doing? -->
Originally mentioned in https://github.com/WordPress/gutenberg/issues/66377#issuecomment-2450010006, Styling the collaboration sidebar in such a way that comment boards appear to be in the editor canvas.
 
 ## Testing Instructions
- Enable experimental inline commenting option under `Gutenberg` -> `Experiments`
- Edit any post/page
- Add some blocks, and block comments
- Reload the post, notice the comment order in comments sidebar.

## Screenshots or screencast <!-- if applicable -->


<img width="1381" alt="image" src="https://github.com/user-attachments/assets/9d19fdc2-5b4b-4c7c-bb45-906d16c91297">
