### PR TITLE
Fix ESLint Jest reporting entire body of the test function rather than the identifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
 				"eslint-import-resolver-node": "0.3.4",
 				"eslint-plugin-eslint-comments": "3.1.2",
 				"eslint-plugin-import": "2.25.2",
-				"eslint-plugin-jest": "27.2.3",
+				"eslint-plugin-jest": "27.4.3",
 				"eslint-plugin-jest-dom": "5.0.2",
 				"eslint-plugin-prettier": "5.0.0",
 				"eslint-plugin-react-compiler": "19.0.0-beta-0dec889-20241115",
@@ -25190,9 +25190,10 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "27.2.3",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.2.3.tgz",
-			"integrity": "sha512-sRLlSCpICzWuje66Gl9zvdF6mwD5X86I4u55hJyFBsxYOsBCmT5+kSUjf+fkFWVMMgpzNEupjW8WzUqi83hJAQ==",
+			"version": "27.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-27.4.3.tgz",
+			"integrity": "sha512-7S6SmmsHsgIm06BAGCAxL+ABd9/IB3MWkz2pudj6Qqor2y1qQpWPfuFU4SG9pWj4xDjF0e+D7Llh5useuSzAZw==",
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/utils": "^5.10.0"
 			},
@@ -54649,7 +54650,7 @@
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-plugin-import": "^2.25.2",
-				"eslint-plugin-jest": "^27.2.3",
+				"eslint-plugin-jest": "^27.4.3",
 				"eslint-plugin-jsdoc": "^46.4.6",
 				"eslint-plugin-jsx-a11y": "^6.5.1",
 				"eslint-plugin-playwright": "^0.15.3",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
 		"eslint-import-resolver-node": "0.3.4",
 		"eslint-plugin-eslint-comments": "3.1.2",
 		"eslint-plugin-import": "2.25.2",
-		"eslint-plugin-jest": "27.2.3",
+		"eslint-plugin-jest": "27.4.3",
 		"eslint-plugin-jest-dom": "5.0.2",
 		"eslint-plugin-prettier": "5.0.0",
 		"eslint-plugin-react-compiler": "19.0.0-beta-0dec889-20241115",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -39,7 +39,7 @@
 		"cosmiconfig": "^7.0.0",
 		"eslint-config-prettier": "^8.3.0",
 		"eslint-plugin-import": "^2.25.2",
-		"eslint-plugin-jest": "^27.2.3",
+		"eslint-plugin-jest": "^27.4.3",
 		"eslint-plugin-jsdoc": "^46.4.6",
 		"eslint-plugin-jsx-a11y": "^6.5.1",
 		"eslint-plugin-playwright": "^0.15.3",


### PR DESCRIPTION
Fixes #67185

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
In the previous versions, [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) reported the entire body as erroneous for `expect-expect` rule, which adds a lot of noise as mentioned in the linked issue.

## Why?
The latest version removes that noise.

## How?
This PR updates `eslint-plugin-jest` to the latest version

## Testing Instructions
- Open a test file in VS Code
- Remove the assertion call
- Confirm that the `expect-expect` warning is shown on the test function identifier (`test`, `it`), rather than the whole body.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


| Before | After |
|--------|--------|
| <img width="837" alt="Screenshot 2024-11-22 at 1 09 41 PM" src="https://github.com/user-attachments/assets/20e913b2-fd5a-4629-964d-144159eff505"> | <img width="861" alt="Screenshot 2024-11-22 at 1 08 51 PM" src="https://github.com/user-attachments/assets/ba5787de-d1b5-49f5-a0a0-c2aedccdfd77"> | 