### PR TITLE
Enhance: Add a link to the Beginner User Learning Pathway in the block editor Welcome Guide

### DIFF
--- a/packages/edit-post/src/components/welcome-guide/default.js
+++ b/packages/edit-post/src/components/welcome-guide/default.js
@@ -119,6 +119,22 @@ export default function WelcomeGuideDefault() {
 										),
 									}
 								) }
+								<br />
+								<br />
+								{ createInterpolateElement(
+									__(
+										'You can explore these <a>free courses offered by the official WordPress Training Team.</a>'
+									),
+									{
+										a: (
+											<ExternalLink
+												href={ __(
+													'https://learn.wordpress.org/learning-pathway/user/'
+												) }
+											/>
+										),
+									}
+								) }
 							</p>
 						</>
 					),


### PR DESCRIPTION
resolve #67219 

## What?
This PR proposes updating the final card of the Block Editor's Welcome Guide to include a link directing users to free courses provided by the official WordPress Training Team on [Learn WordPress](https://learn.wordpress.org/).

## Why?
This update aims to bring more attention to Learn WordPress by adding a link to its free courses in the Block Editor's Welcome Guide. Currently, the guide only links to a resource about using the block editor, missing a chance to showcase other learning materials. By including this link, we can help new users access more educational content and improve their WordPress experience.

## How?
Updated the final card in the Block Editor's Welcome Guide to include a link to free courses on Learn WordPress, alongside the existing link to the block editor guide. Ensure the new text fits well and keeps the guide's design clear and user-friendly.

## Testing Instructions
1. Open the Block Editor Welcome Guide:

    - Log in to WordPress and open a new post or page.
    - Ensure the Welcome Guide appears (if it doesn't, reset user preferences).
    Check the Final Card:

2. Go to the last card in the Welcome Guide.

    - Verify that the new text and link to Learn WordPress are added.

3. Test the Links:

    - Click the "Here's a detailed guide" link to confirm it opens the block editor guide.
    - Click the "f free courses offered by the official WordPress Training Team.↗" link to ensure it leads to Learn WordPress.

4. Review Layout:

    - Check that the new text and links are properly formatted and visually aligned.

5. Test Across Devices:

    - Open the Welcome Guide on desktop, tablet, and mobile to confirm it looks good on all screens.

6. Confirm Accessibility:

    - Use a screen reader or accessibility tool to ensure the new content is accessible to all users.


## Screenshots
![image](https://github.com/user-attachments/assets/e86e10fe-c569-4945-9891-a8dac75f1e29)

