### PR TITLE
Fix fatal error in in_array call in post_type_default_rendering_mode

### DIFF
--- a/lib/compat/wordpress-6.8/post.php
+++ b/lib/compat/wordpress-6.8/post.php
@@ -39,7 +39,7 @@ function gutenberg_post_type_default_rendering_mode( $args, $post_type ) {
 	if (
 		wp_is_block_theme() &&
 		( isset( $args['show_in_rest'] ) && $args['show_in_rest'] ) &&
-		( isset( $args['supports'] ) && in_array( 'editor', $args['supports'], true ) )
+		( ! empty( $args['supports'] ) && in_array( 'editor', $args['supports'], true ) )
 	) {
 		// Validate the supplied rendering mode.
 		if (


### PR DESCRIPTION
Fixes a fatal error in `in_array` call when a `supports` arg of `register_post_type` is a boolean `false`. The error was introduced in #62304. See also https://github.com/WordPress/gutenberg/pull/62304/files#r1853540430.

I'm fixing this by calling `empty( ... )` instead of `isset( ... )`. `empty` does the job of both checking that a variable is defined and also that it's not `false`. Used also at other places for similar checks, guarding a `in_array` call.

FYI @TylerB24890.
