### PR TITLE
DataViews: fix spacing when combining combined fields

### DIFF
--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -558,6 +558,7 @@ export const themeFields: Field< Theme >[] = [
 	},
 	{ id: 'requires', label: 'Requires at least' },
 	{ id: 'tested', label: 'Tested up to' },
+	{ id: 'icon', label: 'Icon', render: () => <Icon icon={ image } /> },
 	{
 		id: 'tags',
 		label: 'Tags',

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -142,10 +142,16 @@ export const CombinedFields = () => {
 				primaryField: 'name',
 				combinedFields: [
 					{
+						id: 'name_tested',
+						label: 'Theme', // This is not used, but is required for TS.
+						children: [ 'name', 'tested' ],
+						direction: 'vertical',
+					},
+					{
 						id: 'theme',
 						label: 'Theme',
-						children: [ 'name', 'description' ],
-						direction: 'vertical',
+						children: [ 'icon', 'name_tested' ],
+						direction: 'horizontal',
 					},
 				] as CombinedField[],
 				styles: {

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -137,20 +137,26 @@ export const FieldsNoSortableNoHidable = () => {
 export const CombinedFields = () => {
 	const defaultLayoutsThemes = {
 		table: {
-			fields: [ 'theme', 'requires', 'tested' ],
+			fields: [ 'theme_with_combined', 'theme_with_simple' ],
 			layout: {
 				primaryField: 'name',
 				combinedFields: [
 					{
 						id: 'name_tested',
-						label: 'Theme', // This is not used, but is required for TS.
+						label: 'Theme',
 						children: [ 'name', 'tested' ],
 						direction: 'vertical',
 					},
 					{
-						id: 'theme',
-						label: 'Theme',
+						id: 'theme_with_combined',
+						label: 'Combine combined fields',
 						children: [ 'icon', 'name_tested' ],
+						direction: 'horizontal',
+					},
+					{
+						id: 'theme_with_simple',
+						label: 'Combine simple fields',
+						children: [ 'icon', 'name' ],
 						direction: 'horizontal',
 					},
 				] as CombinedField[],

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -147,7 +147,11 @@ function TableColumnCombined< Item >( {
 	) );
 
 	if ( field.direction === 'horizontal' ) {
-		return <HStack spacing={ 3 }>{ children }</HStack>;
+		return (
+			<HStack spacing={ 3 } justify="flex-start">
+				{ children }
+			</HStack>
+		);
 	}
 	return <VStack spacing={ 0 }>{ children }</VStack>;
 }


### PR DESCRIPTION
## What?

This PR fixes combining fields horizontally for nested stacks:

```js
{
  combinedFields: [
    {
      id: "name_tested",
      label: "Theme",
      children: ["name", "tested"], // Defined in "fields"
      direction: "vertical",
    },
    {
      id: "theme_with_combined",
      label: "Combine combined fields",
      children: ["icon", "name_tested"], // Icon is defined in "fields", "name_tested" is combined
      direction: "horizontal",
    },
    {
      id: "theme_with_simple",
      label: "Combine simple fields",
      children: ["icon", "name"], // Defined in "fields"
      direction: "horizontal",
    },
  ];
}
```

| Before | After |
| --- | --- |
| <img width="910" alt="Screenshot 2024-11-22 at 10 50 40" src="https://github.com/user-attachments/assets/8c1abb3a-a392-4a4c-98e0-ae8fe8c3436e"> | <img width="910" alt="Screenshot 2024-11-22 at 10 51 06" src="https://github.com/user-attachments/assets/865fd7e3-d90d-4324-b0c9-521ee118e787"> | 

## How?

- Add `justify: flex-start` to the HStack.

## Testing Instructions

Test the storybook:

- `npm install && npm run storybook:dev`
- Visit the "Combined fields" story and verify the columns look as expected.

Smoke test the site editor pages: Pages, Templates, Patterns.
