### PR TITLE
Add Storybook story for BlockFullHeightAlignmentControl

### DIFF
--- a/packages/block-editor/src/components/block-full-height-alignment-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-full-height-alignment-control/stories/index.story.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import BlockFullHeightAlignmentControl from '../';
+
+registerCoreBlocks();
+
+const meta = {
+	title: 'BlockEditor/BlockFullHeightAlignmentControl',
+	component: BlockFullHeightAlignmentControl,
+	parameters: {
+		docs: { canvas: { sourceState: 'shown' } },
+	},
+	argTypes: {
+		isActive: {
+			control: 'boolean',
+			description: 'Whether the full height alignment is active.',
+		},
+		label: {
+			control: 'text',
+			description: 'Label for the button in the toolbar.',
+		},
+		onToggle: {
+			action: 'onToggle',
+			description:
+				'Callback function to toggle the active state of the button.',
+		},
+		isDisabled: {
+			control: 'boolean',
+			description: 'Whether the button is disabled.',
+		},
+	},
+};
+export default meta;
+
+export const Default = {
+	args: {
+		isActive: true,
+	},
+};


### PR DESCRIPTION
Part of: #67165 

## What?
This PR will add stories for the BlockFullHeightAlignmentControl component in the Storybook

## Screencast

https://github.com/user-attachments/assets/ff8c8647-35b2-4fc6-a2e8-cf1503b73835


