### PR TITLE
Always render metaboxes areas and use CSS to hide them when all panel are inactive

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -226,10 +226,6 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	};
 
-	if ( ! hasAnyVisible ) {
-		return;
-	}
-
 	const contents = (
 		<div
 			className={ clsx(
@@ -281,14 +277,22 @@ function MetaBoxesMain( { isLegacy } ) {
 	if ( isShort ) {
 		Pane = NavigableRegion;
 		paneProps = {
-			className: clsx( className, 'is-toggle-only' ),
+			className: clsx(
+				className,
+				'is-toggle-only',
+				! hasAnyVisible && 'is-hidden'
+			),
 		};
 	} else {
 		Pane = ResizableBox;
 		paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
 			as: NavigableRegion,
 			ref: metaBoxesMainRef,
-			className: clsx( className, 'is-resizable' ),
+			className: clsx(
+				className,
+				'is-resizable',
+				! hasAnyVisible && 'is-hidden'
+			),
 			defaultSize: { height: openHeight },
 			minHeight: min,
 			maxHeight: usedMax,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -272,10 +272,11 @@ function MetaBoxesMain( { isLegacy } ) {
 		}
 	};
 	const className = 'edit-post-meta-boxes-main';
-	const paneLabel = __( 'Meta Boxes' );
+	const paneLabel = hasAnyVisible ? __( 'Meta Boxes' ) : undefined;
 	let Pane, paneProps;
 	if ( isShort ) {
-		Pane = NavigableRegion;
+		// Only use a NavigableRegion when the Meta Boxes area is visible.
+		Pane = hasAnyVisible ? NavigableRegion : 'div';
 		paneProps = {
 			className: clsx(
 				className,
@@ -286,7 +287,8 @@ function MetaBoxesMain( { isLegacy } ) {
 	} else {
 		Pane = ResizableBox;
 		paneProps = /** @type {Parameters<typeof ResizableBox>[0]} */ ( {
-			as: NavigableRegion,
+			// Only use a NavigableRegion when the Meta Boxes area is visible.
+			as: hasAnyVisible ? NavigableRegion : 'div',
 			ref: metaBoxesMainRef,
 			className: clsx(
 				className,

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -10,6 +10,10 @@
 	&.is-resizable {
 		padding-block-start: $grid-unit-30;
 	}
+
+	&.is-hidden {
+		display: none;
+	}
 }
 
 .edit-post-meta-boxes-main__presenter {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/67207

## What?
<!-- In a few words, what is the PR actually doing? -->
WordPress 6.7 introduced a breaking change related to metaboxes where the 'normal' and 'advanced' metaboxes area don't render any HTML when all metaboxes panels are disabled in Preferences > General > Advanced.
Previously, the metaboxes HTML content was rendered and hidden with CSS.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Given the metaboxes content HTML is not rendered any longer, any form and hidden input fields used to save meta are not rendered as well. As such, Gutenberg will not fire a POST request to save those meta because the metaboxes areas are 'empty'.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR attempts to restore the previous behavior by rendering the HTML anyways and hiding the content with CSS when all metaboxes panels are disabled in Preferences > General > Advanced.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the testing instructions from the issue https://github.com/WordPress/gutenberg/issues/67207
- Observe a POST request is fired.
- Observe the focus keyphrase changed value is saved (refresh the page and see it has the new value).

Important:
Test the layout and expected behavior in various conditions for example with [a viewport height less than 550 pixels](https://github.com/WordPress/gutenberg/blob/4d2fb64425d7653315997d9c4003f1fa6a4f912a/packages/edit-post/src/components/layout/index.js#L169). Test with other plugins that add metaboxes in teh normal and advanced areas.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
