### PR TITLE
Exclude Set instance methods from polyfills

### DIFF
--- a/packages/babel-preset-default/polyfill-exclusions.js
+++ b/packages/babel-preset-default/polyfill-exclusions.js
@@ -7,4 +7,36 @@ module.exports = [
 	// This is an IE-only feature which we don't use, and don't want to polyfill.
 	// @see https://github.com/WordPress/gutenberg/pull/49234
 	'web.immediate',
+	// Remove Set feature polyfills.
+	//
+	// The Babel/core-js integration has a severe limitation, in that any Set
+	// objects (e.g. `new Set()`) are assumed to need all instance methods, and
+	// get them all polyfilled. There is no validation as to whether those
+	// methods are actually in use.
+	//
+	// This limitation causes a number of packages to unnecessarily get a
+	// dependency on `wp-polyfill`, which in most cases gets loaded as part of
+	// the critical path and can thus have an impact on performance.
+	//
+	// There is no good solution to this, and the one we've opted for here is
+	// to disable polyfilling these features entirely. Developers will need to
+	// take care not to use them in scenarios where the code may be running in
+	// older browsers without native support for them.
+	//
+	// These need to be specified as both `es.` and `esnext.` due to the way
+	// internal dependencies are set up in Babel / core-js.
+	'es.set.difference.v2',
+	'es.set.is-disjoint-from.v2',
+	'es.set.is-subset-of.v2',
+	'es.set.is-superset-of.v2',
+	'es.set.symmetric-difference.v2',
+	'es.set.union.v2',
+	'es.set.intersection.v2',
+	'esnext.set.difference.v2',
+	'esnext.set.is-disjoint-from.v2',
+	'esnext.set.is-subset-of.v2',
+	'esnext.set.is-superset-of.v2',
+	'esnext.set.symmetric-difference.v2',
+	'esnext.set.union.v2',
+	'esnext.set.intersection.v2',
 ];

--- a/packages/babel-preset-default/polyfill-exclusions.js
+++ b/packages/babel-preset-default/polyfill-exclusions.js
@@ -25,18 +25,7 @@ module.exports = [
 	//
 	// These need to be specified as both `es.` and `esnext.` due to the way
 	// internal dependencies are set up in Babel / core-js.
-	'es.set.difference.v2',
-	'es.set.is-disjoint-from.v2',
-	'es.set.is-subset-of.v2',
-	'es.set.is-superset-of.v2',
-	'es.set.symmetric-difference.v2',
-	'es.set.union.v2',
-	'es.set.intersection.v2',
-	'esnext.set.difference.v2',
-	'esnext.set.is-disjoint-from.v2',
-	'esnext.set.is-subset-of.v2',
-	'esnext.set.is-superset-of.v2',
-	'esnext.set.symmetric-difference.v2',
-	'esnext.set.union.v2',
-	'esnext.set.intersection.v2',
+	//
+	// @see https://github.com/WordPress/gutenberg/pull/67230
+	/^es(next)?\.set\./,
 ];


### PR DESCRIPTION
## What?
This PR adds a number of `Set` instance methods to the polyfill exclusions list.

## Why?
When dependencies were updated in #65926, new `Set` methods started getting polyfilled.

The Babel/core-js integration has a severe limitation, in that any Set objects (e.g. `new Set()`) are assumed to need all instance methods, and get them all polyfilled. There is no validation as to whether those methods are actually in use.

<details>
<summary>The list of problematic instance methods</summary>
<pre>
es.set.difference.v2
es.set.intersection.v2
es.set.is-disjoint-from.v2
es.set.is-subset-of.v2
es.set.is-superset-of.v2
es.set.symmetric-difference.v2
es.set.union.v2
</pre>
</details>

This limitation caused a regression, in that a number of packages unnecessarily got a new dependency on `wp-polyfill`, which in most cases gets loaded as part of the critical path and can thus have an impact on performance.

This PR fixes #66552.

## How?
There is no good solution to the issue, but the one this PR opts for is to disable polyfilling the aforementioned `Set` instance methods entirely. Developers will need to take care not to use these methods in scenarios where the code may be running in older browsers without native support for them.

## Testing Instructions
- Build trunk
- Notice that simple packages like `i8n` end up with a dependency on `wp-polyfill`
- Build this branch
- Confirm that the dependency on `wp-polyfill` is no longer present in simple packages like `i8n`
- Smoke-test the packages and ensure they continue working properly

### Testing Instructions for Keyboard
N/A

CC @anomiex @swissspidy 