### PR TITLE
Disable Zoom Out if no section root to allow for Theme opt in

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -58,6 +58,11 @@ function InserterMenu(
 		( select ) => unlock( select( blockEditorStore ) ).isZoomOut(),
 		[]
 	);
+	const hasSectionRootClientId = useSelect( ( select ) => {
+		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
+		const theRoot = getSectionRootClientId();
+		return !! theRoot?.length > 0;
+	}, [] );
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );
@@ -81,7 +86,9 @@ function InserterMenu(
 	const [ selectedTab, setSelectedTab ] = useState( getInitialTab() );
 
 	const shouldUseZoomOut =
-		selectedTab === 'patterns' || selectedTab === 'media';
+		hasSectionRootClientId &&
+		( selectedTab === 'patterns' || selectedTab === 'media' );
+
 	useZoomOut( shouldUseZoomOut && isLargeViewport );
 
 	const [ destinationRootClientId, onInsertBlocks, onToggleInsertionPoint ] =

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -61,7 +61,7 @@ function InserterMenu(
 	const hasSectionRootClientId = useSelect( ( select ) => {
 		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
 		const theRoot = getSectionRootClientId();
-		return !! theRoot?.length > 0;
+		return theRoot?.length > 0;
 	}, [] );
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );

--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -58,11 +58,11 @@ function InserterMenu(
 		( select ) => unlock( select( blockEditorStore ) ).isZoomOut(),
 		[]
 	);
-	const hasSectionRootClientId = useSelect( ( select ) => {
-		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
-		const theRoot = getSectionRootClientId();
-		return theRoot?.length > 0;
-	}, [] );
+	const hasSectionRootClientId = useSelect(
+		( select ) =>
+			!! unlock( select( blockEditorStore ) ).getSectionRootClientId(),
+		[]
+	);
 	const [ filterValue, setFilterValue, delayedFilterValue ] =
 		useDebouncedInput( __experimentalFilterValue );
 	const [ hoveredItem, setHoveredItem ] = useState( null );

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -107,7 +107,7 @@ function Header( {
 	const hasSectionRootClientId = useSelect( ( select ) => {
 		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
 		const theRoot = getSectionRootClientId();
-		return !! theRoot?.length > 0;
+		return theRoot?.length > 0;
 	}, [] );
 
 	/*

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -30,6 +30,7 @@ import {
 	PATTERN_POST_TYPE,
 	NAVIGATION_POST_TYPE,
 } from '../../store/constants';
+import { unlock } from '../../lock-unlock';
 
 const toolbarVariations = {
 	distractionFreeDisabled: { y: '-50px' },
@@ -102,6 +103,13 @@ function Header( {
 			( hasFixedToolbar &&
 				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
+
+	const hasSectionRootClientId = useSelect( ( select ) => {
+		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
+		const theRoot = getSectionRootClientId();
+		return !! theRoot?.length > 0;
+	}, [] );
+
 	/*
 	 * The edit-post-header classname is only kept for backward compatability
 	 * as some plugins might be relying on its presence.
@@ -169,9 +177,11 @@ function Header( {
 					forceIsAutosaveable={ forceIsDirty }
 				/>
 
-				{ canBeZoomedOut && isWideViewport && (
-					<ZoomOutToggle disabled={ forceDisableBlockTools } />
-				) }
+				{ canBeZoomedOut &&
+					isWideViewport &&
+					hasSectionRootClientId && (
+						<ZoomOutToggle disabled={ forceDisableBlockTools } />
+					) }
 
 				{ ( isWideViewport || ! showIconLabels ) && (
 					<PinnedItems.Slot scope="core" />

--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -104,11 +104,11 @@ function Header( {
 				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
 
-	const hasSectionRootClientId = useSelect( ( select ) => {
-		const { getSectionRootClientId } = unlock( select( blockEditorStore ) );
-		const theRoot = getSectionRootClientId();
-		return theRoot?.length > 0;
-	}, [] );
+	const hasSectionRootClientId = useSelect(
+		( select ) =>
+			!! unlock( select( blockEditorStore ) ).getSectionRootClientId(),
+		[]
+	);
 
 	/*
 	 * The edit-post-header classname is only kept for backward compatability

--- a/test/e2e/specs/editor/various/parsing-patterns.spec.js
+++ b/test/e2e/specs/editor/various/parsing-patterns.spec.js
@@ -37,9 +37,8 @@ test.describe( 'Parsing patterns', () => {
 			} );
 		} );
 
-		// Exit zoom out mode and select the inner buttons block to ensure
+		// Select the inner buttons block to ensure
 		// the correct insertion point is selected.
-		await page.getByRole( 'button', { name: 'Zoom Out' } ).click();
 		await editor.selectBlocks(
 			editor.canvas.locator( 'role=document[name="Block: Button"i]' )
 		);

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -269,9 +269,16 @@ test.describe( 'Pattern Overrides', () => {
 
 			await editor.setContent( '' );
 
+			// Insert the core/group block with a tagName of 'main'
 			await editor.insertBlock( {
-				name: 'core/block',
-				attributes: { ref: id },
+				name: 'core/group',
+				attributes: { tagName: 'main' },
+				innerBlocks: [
+					{
+						name: 'core/block',
+						attributes: { ref: id },
+					},
+				],
 			} );
 
 			const patternBlock = editor.canvas.getByRole( 'document', {

--- a/test/e2e/specs/editor/various/pattern-overrides.spec.js
+++ b/test/e2e/specs/editor/various/pattern-overrides.spec.js
@@ -268,8 +268,11 @@ test.describe( 'Pattern Overrides', () => {
 			} );
 
 			await editor.setContent( '' );
+			await editor.switchEditorTool( 'Design' );
 
-			// Insert the core/group block with a tagName of 'main'
+			// Insert a `<main>` group block.
+			// In zoomed out and write mode it acts as the section root.
+			// Inside is a pattern that acts as a section.
 			await editor.insertBlock( {
 				name: 'core/group',
 				attributes: { tagName: 'main' },
@@ -281,6 +284,9 @@ test.describe( 'Pattern Overrides', () => {
 				],
 			} );
 
+			const groupBlock = editor.canvas.getByRole( 'document', {
+				name: 'Block: Group',
+			} );
 			const patternBlock = editor.canvas.getByRole( 'document', {
 				name: 'Block: Pattern',
 			} );
@@ -297,14 +303,35 @@ test.describe( 'Pattern Overrides', () => {
 				hasText: 'No Overrides or Binding',
 			} );
 
-			await test.step( 'Zoomed in / Design mode', async () => {
-				await editor.switchEditorTool( 'Design' );
-				// In zoomed in and design mode the pattern block and child blocks
-				// with bindings are editable.
+			await test.step( 'Click-through behavior', async () => {
+				// With the group block selected, all the inner blocks of the pattern
+				// are inert due to the 'click-through' behavior, that requires the
+				// pattern block be selected first before its inner blocks are selectable.
+				await editor.selectBlocks( groupBlock );
 				await expect( patternBlock ).not.toHaveAttribute(
 					'inert',
 					'true'
 				);
+				await expect( blockWithOverrides ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+				await expect( blockWithoutOverridesOrBindings ).toHaveAttribute(
+					'inert',
+					'true'
+				);
+			} );
+
+			await test.step( 'Zoomed in / Design mode', async () => {
+				await editor.selectBlocks( patternBlock );
+
+				// Once selected and in zoomed in/design mode the child blocks
+				// of the pattern with bindings are editable, but unbound
+				// blocks are inert.
 				await expect( blockWithOverrides ).not.toHaveAttribute(
 					'inert',
 					'true'
@@ -321,11 +348,16 @@ test.describe( 'Pattern Overrides', () => {
 
 			await test.step( 'Zoomed in / Write mode - pattern as a section', async () => {
 				await editor.switchEditorTool( 'Write' );
+
 				// The pattern block is still editable as a section.
 				await expect( patternBlock ).not.toHaveAttribute(
 					'inert',
 					'true'
 				);
+
+				// Ensure the pattern block is selected.
+				await editor.selectBlocks( patternBlock );
+
 				// Child blocks of the pattern with bindings are editable.
 				await expect( blockWithOverrides ).not.toHaveAttribute(
 					'inert',
@@ -343,11 +375,18 @@ test.describe( 'Pattern Overrides', () => {
 
 			await test.step( 'Zoomed out / Write mode - pattern as a section', async () => {
 				await page.getByLabel( 'Zoom Out' ).click();
-				// In zoomed out only the pattern block is editable, as in this scenario it's a section.
+				// In zoomed out only the pattern block is editable,
+				// as in this scenario it's a section.
 				await expect( patternBlock ).not.toHaveAttribute(
 					'inert',
 					'true'
 				);
+
+				// Ensure the pattern block is selected before checking the child blocks
+				// to ensure the click-through behavior isn't interfering.
+				await editor.selectBlocks( patternBlock );
+
+				// None of the child blocks are editable in zoomed out mode.
 				await expect( blockWithOverrides ).toHaveAttribute(
 					'inert',
 					'true'
@@ -364,11 +403,17 @@ test.describe( 'Pattern Overrides', () => {
 
 			await test.step( 'Zoomed out / Design mode - pattern as a section', async () => {
 				await editor.switchEditorTool( 'Design' );
-				// In zoomed out only the pattern block is editable, as in this scenario it's a section.
+				// In zoomed out only the pattern block is editable,
+				// as in this scenario it's a section.
 				await expect( patternBlock ).not.toHaveAttribute(
 					'inert',
 					'true'
 				);
+
+				// Ensure the pattern block is selected before checking the child blocks
+				// to ensure the click-through behavior isn't interfering.
+				await editor.selectBlocks( patternBlock );
+
 				await expect( blockWithOverrides ).toHaveAttribute(
 					'inert',
 					'true'
@@ -383,7 +428,7 @@ test.describe( 'Pattern Overrides', () => {
 				);
 			} );
 
-			// Zoom out and group the pattern.
+			// Zoom out and group the pattern so that it's no longer a section.
 			await page.getByLabel( 'Zoom Out' ).click();
 			await editor.selectBlocks( patternBlock );
 			await editor.clickBlockOptionsMenuItem( 'Group' );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -83,6 +83,8 @@ test.describe( 'Zoom Out', () => {
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
+		await requestUtils.deleteAllTemplates( 'wp_template' );
+		await requestUtils.deleteAllTemplates( 'wp_template_part' );
 	} );
 
 	test.beforeEach( async ( { admin } ) => {

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -238,9 +238,22 @@ test.describe( 'Zoom Out', () => {
 	} ) => {
 		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT_NO_SECTION_ROOT );
 
-		// Check that the zoom out button is not visible.
+		// Check that the Zoom Out toggle button is not visible.
 		await expect(
 			page.getByRole( 'button', { name: 'Zoom Out' } )
 		).toBeHidden();
+
+		// Check that activating the Patterns tab in the Inserter does not activate
+		// Zoom Out.
+		await page
+			.getByRole( 'button', {
+				name: 'Block Inserter',
+				exact: true,
+			} )
+			.click();
+
+		await page.getByRole( 'tab', { name: 'Patterns' } ).click();
+
+		await expect( page.locator( '.is-zoomed-out' ) ).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -62,6 +62,20 @@ const EDITOR_ZOOM_OUT_CONTENT = `
 <!-- /wp:group --></main>
 <!-- /wp:group -->`;
 
+const EDITOR_ZOOM_OUT_CONTENT_NO_SECTION_ROOT = `<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<div class="wp-block-group has-base-2-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
+<p>First Section Start</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph {"style":{"layout":{"selfStretch":"fit","flexSize":null}}} -->
+<p>First Section Center</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:paragraph -->
+<p>First Section End</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group -->`;
+
 test.describe( 'Zoom Out', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyfour' );
@@ -216,5 +230,17 @@ test.describe( 'Zoom Out', () => {
 		await expect( thirdSectionStart ).toBeInViewport();
 		await expect( thirdSectionEnd ).toBeInViewport();
 		await expect( fourthSectionStart ).not.toBeInViewport();
+	} );
+
+	test( 'Zoom Out cannot be activated when the section root is missing', async ( {
+		page,
+		editor,
+	} ) => {
+		await editor.setContent( EDITOR_ZOOM_OUT_CONTENT_NO_SECTION_ROOT );
+
+		// Check that the zoom out button is not visible.
+		await expect(
+			page.getByRole( 'button', { name: 'Zoom Out' } )
+		).toBeHidden();
 	} );
 } );

--- a/test/e2e/specs/site-editor/zoom-out.spec.js
+++ b/test/e2e/specs/site-editor/zoom-out.spec.js
@@ -4,7 +4,8 @@
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 const EDITOR_ZOOM_OUT_CONTENT = `
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
+<!-- wp:group {"tagName":"main","layout":{"type":"constrained"}} -->
+<main class="wp-block-group"><!-- wp:group {"style":{"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"}},"dimensions":{"minHeight":"100vh"}},"backgroundColor":"base-2","layout":{"type":"flex","orientation":"vertical","verticalAlignment":"space-between"}} -->
 <div class="wp-block-group has-base-2-background-color has-background" style="min-height:100vh;padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:paragraph -->
 <p>First Section Start</p>
 <!-- /wp:paragraph -->
@@ -58,6 +59,7 @@ const EDITOR_ZOOM_OUT_CONTENT = `
 <!-- wp:paragraph -->
 <p>Fourth Section End</p>
 <!-- /wp:paragraph --></div>
+<!-- /wp:group --></main>
 <!-- /wp:group -->`;
 
 test.describe( 'Zoom Out', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Disable Zoom Out if no section root to allow for Theme opt in by defining a `<main>`

Closes https://github.com/WordPress/gutenberg/issues/65400

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because reports have been coming in that the block layout of some Themes isn't compatible with a good experience in Zoom Out.




## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

With this change if a `<main>` tag is not defined (or we're not editing a entity with a `core/post-content` block) then Zoom Out will be disabled.

This allows Themes to opt in to Zoom Out  based on where they place a `<main>` tag. If no `<main>` is defined then Zoom Out will not work.



## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Test in Site Editor 
- Remove `<main>` from template
- See Zoom Out is no longer possible to activate
- Test that you can still access Zoom Out from a Page (using _Post_ Editor **and** _Site_ Editor).
- 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
