### PR TITLE
Storybook: Add stories for BlockTitle Component

### DIFF
--- a/packages/block-editor/src/components/block-title/stories/index.story.js
+++ b/packages/block-editor/src/components/block-title/stories/index.story.js
@@ -39,7 +39,7 @@ const meta = {
 			canvas: { sourceState: 'shown' },
 			description: {
 				component:
-					"The Block Title component renders a block's configured title as a string.",
+					"Renders the block's configured title as a string, or empty if the title cannot be determined.",
 			},
 		},
 	},
@@ -65,7 +65,7 @@ const meta = {
 				blocks[ 1 ].clientId,
 				blocks[ 2 ].clientId,
 			],
-			description: 'The client ID of the block to render',
+			description: 'Client ID of block.',
 			table: {
 				type: {
 					summary: 'string',
@@ -79,7 +79,8 @@ const meta = {
 				max: 50,
 				step: 1,
 			},
-			description: 'Maximum length before title truncation',
+			description:
+				'The maximum length that the block title string may be before truncated.',
 			table: {
 				type: {
 					summary: 'number',
@@ -88,7 +89,7 @@ const meta = {
 		},
 		context: {
 			control: { type: 'text' },
-			description: 'Optional context to pass to getBlockLabel',
+			description: 'The context to pass to `getBlockLabel`.',
 			table: {
 				type: {
 					summary: 'string',
@@ -106,12 +107,5 @@ export default meta;
 export const Default = {
 	args: {
 		clientId: blocks[ 0 ].clientId,
-	},
-	parameters: {
-		docs: {
-			description: {
-				story: 'Default rendering of BlockTitle for a paragraph block',
-			},
-		},
 	},
 };

--- a/packages/block-editor/src/components/block-title/stories/index.story.js
+++ b/packages/block-editor/src/components/block-title/stories/index.story.js
@@ -3,30 +3,18 @@
  */
 import { registerCoreBlocks } from '@wordpress/block-library';
 import { createBlock } from '@wordpress/blocks';
-import { BlockEditorProvider } from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
  */
+import { ExperimentalBlockEditorProvider } from '../../provider';
 import BlockTitle from '../';
 
 // Register core blocks for the story environment
 registerCoreBlocks();
 
 // Sample blocks for testing
-const blocks = [
-	createBlock( 'core/paragraph', {
-		content: 'This is a sample paragraph block.',
-		className: 'sample-paragraph',
-	} ),
-	createBlock( 'core/heading', {
-		level: 2,
-		content: 'Sample Heading Block',
-	} ),
-	createBlock( 'core/group', {
-		layout: { type: 'flex', justifyContent: 'center' },
-	} ),
-];
+const blocks = [ createBlock( 'core/paragraph' ) ];
 
 const meta = {
 	title: 'BlockEditor/BlockTitle',
@@ -42,26 +30,13 @@ const meta = {
 	},
 	decorators: [
 		( Story ) => (
-			<BlockEditorProvider value={ blocks }>
+			<ExperimentalBlockEditorProvider value={ blocks }>
 				<Story />
-			</BlockEditorProvider>
+			</ExperimentalBlockEditorProvider>
 		),
 	],
 	argTypes: {
 		clientId: {
-			control: {
-				type: 'select',
-				labels: {
-					[ blocks[ 0 ].clientId ]: "Paragraph's Client ID",
-					[ blocks[ 1 ].clientId ]: "Heading's Client ID",
-					[ blocks[ 2 ].clientId ]: "Group's Client ID",
-				},
-			},
-			options: [
-				blocks[ 0 ].clientId,
-				blocks[ 1 ].clientId,
-				blocks[ 2 ].clientId,
-			],
 			description: 'Client ID of block.',
 			table: {
 				type: {
@@ -72,9 +47,6 @@ const meta = {
 		maximumLength: {
 			control: {
 				type: 'number',
-				min: 5,
-				max: 50,
-				step: 1,
 			},
 			description:
 				'The maximum length that the block title string may be before truncated.',
@@ -98,9 +70,6 @@ const meta = {
 
 export default meta;
 
-/**
- * Story variations demonstrating BlockTitle component capabilities
- */
 export const Default = {
 	args: {
 		clientId: blocks[ 0 ].clientId,

--- a/packages/block-editor/src/components/block-title/stories/index.story.js
+++ b/packages/block-editor/src/components/block-title/stories/index.story.js
@@ -37,6 +37,7 @@ const meta = {
 	],
 	argTypes: {
 		clientId: {
+			control: { type: null },
 			description: 'Client ID of block.',
 			table: {
 				type: {
@@ -45,9 +46,7 @@ const meta = {
 			},
 		},
 		maximumLength: {
-			control: {
-				type: 'number',
-			},
+			control: { type: 'number' },
 			description:
 				'The maximum length that the block title string may be before truncated.',
 			table: {

--- a/packages/block-editor/src/components/block-title/stories/index.story.js
+++ b/packages/block-editor/src/components/block-title/stories/index.story.js
@@ -1,0 +1,152 @@
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock } from '@wordpress/blocks';
+import { BlockEditorProvider } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import BlockTitle from '../';
+
+// Register core blocks for the story environment
+registerCoreBlocks();
+
+// Create more comprehensive sample blocks for testing
+const blocks = [
+	createBlock( 'core/paragraph', {
+		content: 'This is a sample paragraph block.',
+		className: 'sample-paragraph',
+	} ),
+	createBlock( 'core/heading', {
+		level: 2,
+		content: 'Sample Heading Block',
+	} ),
+	createBlock(
+		'core/group',
+		{
+			layout: { type: 'flex', justifyContent: 'center' },
+		},
+		[
+			createBlock( 'core/paragraph', {
+				content: 'Nested paragraph within a group block',
+			} ),
+		]
+	),
+];
+
+/**
+ * Storybook configuration for BlockTitle component
+ */
+const meta = {
+	title: 'BlockEditor/BlockTitle',
+	component: BlockTitle,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					"The Block Title component renders a block's configured title as a string.",
+			},
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<BlockEditorProvider value={ blocks }>
+				<div style={ { padding: '20px', backgroundColor: '#f0f0f0' } }>
+					<Story />
+				</div>
+			</BlockEditorProvider>
+		),
+	],
+	argTypes: {
+		clientId: {
+			control: {
+				type: 'select',
+				labels: {
+					[ blocks[ 0 ].clientId ]: "Paragraph's Client ID",
+					[ blocks[ 1 ].clientId ]: "Heading's Client ID",
+					[ blocks[ 2 ].clientId ]: "Group's Client ID",
+					[ blocks[ 2 ].innerBlocks[ 0 ].clientId ]:
+						"Nested Paragraph's Client ID",
+				},
+			},
+			options: [
+				blocks[ 0 ].clientId,
+				blocks[ 1 ].clientId,
+				blocks[ 2 ].clientId,
+				blocks[ 2 ].innerBlocks[ 0 ].clientId,
+			],
+			description: 'The client ID of the block to render',
+		},
+		maximumLength: {
+			control: {
+				type: 'number',
+				min: 5,
+				max: 50,
+				step: 1,
+			},
+			description: 'Maximum length before title truncation',
+		},
+		context: {
+			control: { type: 'text' },
+			description: 'Optional context to pass to getBlockLabel',
+		},
+	},
+};
+
+export default meta;
+
+/**
+ * Story variations demonstrating BlockTitle component capabilities
+ */
+export const Default = {
+	args: {
+		clientId: blocks[ 0 ].clientId,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story: 'Default rendering of BlockTitle for a paragraph block',
+			},
+		},
+	},
+};
+
+/**
+ * Story variations demonstrating BlockTitle component with maximum length
+ */
+export const WithMaxLength = {
+	args: {
+		clientId: blocks[ 0 ].clientId,
+		maximumLength: 5,
+	},
+};
+
+/**
+ * Story variations demonstrating BlockTitle component with client ID of a heading block
+ */
+export const HeadingBlock = {
+	args: {
+		clientId: blocks[ 1 ].clientId,
+	},
+};
+
+/**
+ * Story variations demonstrating BlockTitle component with client ID of a paragraph block
+ */
+export const ParagraphBlock = {
+	args: {
+		clientId: blocks[ 0 ].clientId,
+	},
+};
+
+/**
+ * Story variations demonstrating BlockTitle component with client ID of a nested block within a group
+ */
+export const NestedBlock = {
+	args: {
+		clientId: blocks[ 2 ].innerBlocks[ 0 ].clientId,
+	},
+};

--- a/packages/block-editor/src/components/block-title/stories/index.story.js
+++ b/packages/block-editor/src/components/block-title/stories/index.story.js
@@ -13,7 +13,7 @@ import BlockTitle from '../';
 // Register core blocks for the story environment
 registerCoreBlocks();
 
-// Create sample blocks for testing
+// Sample blocks for testing
 const blocks = [
 	createBlock( 'core/paragraph', {
 		content: 'This is a sample paragraph block.',
@@ -28,9 +28,6 @@ const blocks = [
 	} ),
 ];
 
-/**
- * Storybook configuration for BlockTitle component
- */
 const meta = {
 	title: 'BlockEditor/BlockTitle',
 	component: BlockTitle,

--- a/packages/block-editor/src/components/block-title/stories/index.story.js
+++ b/packages/block-editor/src/components/block-title/stories/index.story.js
@@ -13,7 +13,7 @@ import BlockTitle from '../';
 // Register core blocks for the story environment
 registerCoreBlocks();
 
-// Create more comprehensive sample blocks for testing
+// Create sample blocks for testing
 const blocks = [
 	createBlock( 'core/paragraph', {
 		content: 'This is a sample paragraph block.',
@@ -23,17 +23,9 @@ const blocks = [
 		level: 2,
 		content: 'Sample Heading Block',
 	} ),
-	createBlock(
-		'core/group',
-		{
-			layout: { type: 'flex', justifyContent: 'center' },
-		},
-		[
-			createBlock( 'core/paragraph', {
-				content: 'Nested paragraph within a group block',
-			} ),
-		]
-	),
+	createBlock( 'core/group', {
+		layout: { type: 'flex', justifyContent: 'center' },
+	} ),
 ];
 
 /**
@@ -54,9 +46,7 @@ const meta = {
 	decorators: [
 		( Story ) => (
 			<BlockEditorProvider value={ blocks }>
-				<div style={ { padding: '20px', backgroundColor: '#f0f0f0' } }>
-					<Story />
-				</div>
+				<Story />
 			</BlockEditorProvider>
 		),
 	],
@@ -68,17 +58,19 @@ const meta = {
 					[ blocks[ 0 ].clientId ]: "Paragraph's Client ID",
 					[ blocks[ 1 ].clientId ]: "Heading's Client ID",
 					[ blocks[ 2 ].clientId ]: "Group's Client ID",
-					[ blocks[ 2 ].innerBlocks[ 0 ].clientId ]:
-						"Nested Paragraph's Client ID",
 				},
 			},
 			options: [
 				blocks[ 0 ].clientId,
 				blocks[ 1 ].clientId,
 				blocks[ 2 ].clientId,
-				blocks[ 2 ].innerBlocks[ 0 ].clientId,
 			],
 			description: 'The client ID of the block to render',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
 		},
 		maximumLength: {
 			control: {
@@ -88,10 +80,20 @@ const meta = {
 				step: 1,
 			},
 			description: 'Maximum length before title truncation',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
 		},
 		context: {
 			control: { type: 'text' },
 			description: 'Optional context to pass to getBlockLabel',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
 		},
 	},
 };
@@ -111,42 +113,5 @@ export const Default = {
 				story: 'Default rendering of BlockTitle for a paragraph block',
 			},
 		},
-	},
-};
-
-/**
- * Story variations demonstrating BlockTitle component with maximum length
- */
-export const WithMaxLength = {
-	args: {
-		clientId: blocks[ 0 ].clientId,
-		maximumLength: 5,
-	},
-};
-
-/**
- * Story variations demonstrating BlockTitle component with client ID of a heading block
- */
-export const HeadingBlock = {
-	args: {
-		clientId: blocks[ 1 ].clientId,
-	},
-};
-
-/**
- * Story variations demonstrating BlockTitle component with client ID of a paragraph block
- */
-export const ParagraphBlock = {
-	args: {
-		clientId: blocks[ 0 ].clientId,
-	},
-};
-
-/**
- * Story variations demonstrating BlockTitle component with client ID of a nested block within a group
- */
-export const NestedBlock = {
-	args: {
-		clientId: blocks[ 2 ].innerBlocks[ 0 ].clientId,
 	},
 };


### PR DESCRIPTION
Part of #67165  

## What?
This PR adds Storybook stories for the `BlockTitle` component to improve component documentation and testability.

## Why?
- Provide visual documentation for the BlockTitle component
- Enable interactive testing of different block title scenarios
- Improve development experience for Block Editor components

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open Storybook at http://localhost:50240/
3. Verify the following stories are present and functioning:
   - Default block title rendering
   - Block title with maximum length truncation
   - Different block type titles (paragraph, heading, nested blocks)
   
## Screencast 
https://github.com/user-attachments/assets/11bb306e-4bed-4443-8e5f-9ef359352ff3


