### PR TITLE
Editor: Update focus return handler for the Featured Image

### DIFF
--- a/packages/editor/src/components/post-featured-image/index.js
+++ b/packages/editor/src/components/post-featured-image/index.js
@@ -18,7 +18,7 @@ import {
 	Notice,
 } from '@wordpress/components';
 import { isBlobURL } from '@wordpress/blob';
-import { useState, useRef, useEffect } from '@wordpress/element';
+import { useState, useRef } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { useSelect, withDispatch, withSelect } from '@wordpress/data';
 import {
@@ -102,17 +102,10 @@ function PostFeaturedImage( {
 	noticeOperations,
 	isRequestingFeaturedImageMedia,
 } ) {
-	const toggleRef = useRef();
+	const returnsFocusRef = useRef( false );
 	const [ isLoading, setIsLoading ] = useState( false );
 	const { getSettings } = useSelect( blockEditorStore );
 	const { mediaSourceUrl } = getMediaDetails( media, currentPostId );
-	const toggleFocusTimerRef = useRef();
-
-	useEffect( () => {
-		return () => {
-			clearTimeout( toggleFocusTimerRef.current );
-		};
-	}, [] );
 
 	function onDropFiles( filesList ) {
 		getSettings().mediaUpload( {
@@ -164,6 +157,13 @@ function PostFeaturedImage( {
 		);
 	}
 
+	function returnFocus( node ) {
+		if ( returnsFocusRef.current && node ) {
+			node.focus();
+			returnsFocusRef.current = false;
+		}
+	}
+
 	const isMissingMedia =
 		! isRequestingFeaturedImageMedia && !! featuredImageId && ! media;
 
@@ -203,7 +203,7 @@ function PostFeaturedImage( {
 								) : (
 									<Button
 										__next40pxDefaultSize
-										ref={ toggleRef }
+										ref={ returnFocus }
 										className={
 											! featuredImageId
 												? 'editor-post-featured-image__toggle'
@@ -276,12 +276,10 @@ function PostFeaturedImage( {
 											className="editor-post-featured-image__action"
 											onClick={ () => {
 												onRemoveImage();
-												// The toggle button is rendered conditionally, we need
-												// to wait it is rendered before moving focus to it.
-												toggleFocusTimerRef.current =
-													setTimeout( () => {
-														toggleRef.current?.focus();
-													} );
+												// Signal that the toggle button should be focused,
+												// when it is rendered. Can't focus it directly here
+												// because it's rendered conditionally.
+												returnsFocusRef.current = true;
 											} }
 											variant={
 												isMissingMedia


### PR DESCRIPTION
## What?
This is a follow-up to #66936.

PR tries an alternative method to return focus to the Featured Image toggle button. Instead of an arbitrary timeout, it uses a ref callback and a flag to focus the button when it's rendered.

## Why?
While the timeout callback seems to work, it's not guaranteed what element will be rendered when the callback runs.

## Testing Instructions
1. Open a post.
2. Set a featured image and remove it.
3. Confirm that focus is returned to the "Set featured image" toggle.
4. Set missing image as featured for a post - `wp post meta update <post-id> _thumbnail_id 999999`.
5. Confirm that notice is displayed.
6. Remove the missing featured image.
7. Confirm that focus is returned to the "Set featured image" toggle.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-24 at 17 33 37](https://github.com/user-attachments/assets/d90494ac-62ba-444e-8dfa-d2d8b6a7b847)
