### PR TITLE
Inserter: Remove reference to Pattern Directory when disabled

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/patterns-filter.js
@@ -101,6 +101,11 @@ export function PatternsFilter( {
 		}
 	}
 
+	// Run only when the directory is disabled.
+	const menuOptions = PATTERN_SOURCE_MENU_OPTIONS.filter(
+		( { value } ) => value !== 'directory'
+	);
+
 	return (
 		<>
 			<DropdownMenu
@@ -133,7 +138,7 @@ export function PatternsFilter( {
 						{ ! shouldHideSourcesFilter && (
 							<MenuGroup label={ __( 'Source' ) }>
 								<MenuItemsChoice
-									choices={ PATTERN_SOURCE_MENU_OPTIONS }
+									choices={ menuOptions }
 									onSelect={ ( value ) => {
 										handleSetSourceFilterChange( value );
 										scrollContainerRef.current?.scrollTo(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Starts the work to fix #66978. PR opened at WordCamp Wrocław together with @PawelDabrowa. So far it only identifies the place where the label needs to be removed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
