### PR TITLE
Improve Icon component stroybook

### DIFF
--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -3,11 +3,12 @@
  */
 import type { Meta, StoryFn } from '@storybook/react';
 
+
 /**
  * WordPress dependencies
  */
 import { SVG, Path } from '@wordpress/primitives';
-import { wordpress } from '@wordpress/icons';
+import * as icons from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -22,29 +23,50 @@ const meta: Meta< typeof Icon > = {
 		controls: { expanded: true },
 		docs: { canvas: { sourceState: 'shown' } },
 	},
+	args: {
+		additionalProps: {},
+		size: 24,
+	},
+	argTypes: {
+		size: {
+			control: {
+				type: 'range',
+				min: 1,
+				max: 200,
+			},
+		},
+		additionalProps: {
+			defaultValue: {},
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+	},
 };
 export default meta;
 
-const Template: StoryFn< typeof Icon > = ( args ) => <Icon { ...args } />;
+const Template: StoryFn< typeof Icon > = function (args) {
+	const { additionalProps, ...rest } = args;
+	const props = {
+		...rest,
+		...additionalProps,
+	};
+	return <Icon { ...props } />;
+};
+
 
 export const Default = Template.bind( {} );
 Default.args = {
-	icon: wordpress,
+	icon: icons.wordpress,
 };
 
-export const FillColor: StoryFn< typeof Icon > = ( args ) => {
-	return (
-		<div
-			style={ {
-				fill: 'blue',
-			} }
-		>
-			<Icon { ...args } />
-		</div>
-	);
-};
+export const FillColor = Template.bind( {} );
+
 FillColor.args = {
 	...Default.args,
+	additionalProps: {
+		fill: 'blue',
+	},
 };
 
 export const WithAFunction = Template.bind( {} );
@@ -98,4 +120,29 @@ export const WithADashicon: StoryFn< typeof Icon > = ( args ) => {
 WithADashicon.args = {
 	...Default.args,
 	icon: 'wordpress',
+};
+
+export const WithAnIconFromTheLibrary: StoryFn< typeof Icon > = ( args ) => {
+	const { additionalProps, ...rest } = args;
+
+	const props = {
+		...rest,
+		...additionalProps,
+		icon: icons[ args.icon as keyof typeof icons ],
+	};
+	
+	return <Icon { ...props } />;
+};
+
+WithAnIconFromTheLibrary.args = {
+	...Default.args,
+	icon: 'wordpress',
+	size: 24,
+};
+
+WithAnIconFromTheLibrary.argTypes = {
+	icon: {
+		options: Object.keys( icons ),
+		control: 'select',
+	},
 };

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -3,7 +3,6 @@
  */
 import type { Meta, StoryFn } from '@storybook/react';
 
-
 /**
  * WordPress dependencies
  */
@@ -13,10 +12,14 @@ import * as icons from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import Icon from '..';
+import Icon, { type Props, type IconType } from '..';
 import { VStack } from '../../v-stack';
 
-const meta: Meta< typeof Icon > = {
+type IconProps = Props & {
+	additionalProps: object;
+};
+
+const meta: Meta< IconProps > = {
 	title: 'Components/Icon',
 	component: Icon,
 	parameters: {
@@ -45,7 +48,7 @@ const meta: Meta< typeof Icon > = {
 };
 export default meta;
 
-const Template: StoryFn< typeof Icon > = function (args) {
+const Template: StoryFn< IconProps > = function ( args ) {
 	const { additionalProps, ...rest } = args;
 	const props = {
 		...rest,
@@ -53,7 +56,6 @@ const Template: StoryFn< typeof Icon > = function (args) {
 	};
 	return <Icon { ...props } />;
 };
-
 
 export const Default = Template.bind( {} );
 Default.args = {
@@ -106,7 +108,7 @@ WithAnSVG.args = {
  * as long as you are in a context where the Dashicons stylesheet is loaded. To simulate that here,
  * use the Global CSS Injector in the Storybook toolbar at the top and select the "WordPress" preset.
  */
-export const WithADashicon: StoryFn< typeof Icon > = ( args ) => {
+export const WithADashicon: StoryFn< IconProps > = ( args ) => {
 	return (
 		<VStack>
 			<Icon { ...args } />
@@ -122,15 +124,15 @@ WithADashicon.args = {
 	icon: 'wordpress',
 };
 
-export const WithAnIconFromTheLibrary: StoryFn< typeof Icon > = ( args ) => {
+export const WithAnIconFromTheLibrary: StoryFn< IconProps > = ( args ) => {
 	const { additionalProps, ...rest } = args;
 
 	const props = {
 		...rest,
 		...additionalProps,
-		icon: icons[ args.icon as keyof typeof icons ],
+		icon: icons[ args.icon as keyof typeof icons ] as IconType,
 	};
-	
+
 	return <Icon { ...props } />;
 };
 


### PR DESCRIPTION
## What?
Improve the Icon component storybook.

## Why?
This is to make it easier to test additional props on icons.
To make more accessible to test library icons.

## How?
With additions to the Icon storybook Icon component template.
By adding a new story to select a icons library  icon from a select.

## Testing Instructions
- Clone this PR.
- Compile storybook `npm run storybook:dev`
- Browse the storybook Icon component page (http://localhost:50240/?path=/story/components-icon--default) and use the component controls.
- Browse the new story page (http://localhost:50240/?path=/story/components-icon--with-an-icon-from-the-library&args=additionalProps.fill:red;size:86;icon:warning)



## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/538a2569-757f-4d77-94cd-2c572f14785d)



https://github.com/user-attachments/assets/6208a1fd-e8de-46ad-8627-3344aa5ee6e0

