### PR TITLE
Media Text Block: Added blockGap support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -444,7 +444,7 @@ Set media and words side-by-side for a richer layout. ([Source](https://github.c
 
 -	**Name:** core/media-text
 -	**Category:** media
--	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), anchor, color (background, gradients, heading, link, text), interactivity (clientNavigation), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** align, allowedBlocks, focalPoint, href, imageFill, isStackedOnMobile, linkClass, linkDestination, linkTarget, mediaAlt, mediaId, mediaLink, mediaPosition, mediaSizeSlug, mediaType, mediaUrl, mediaWidth, rel, useFeaturedImage, verticalAlignment
 
 ## Unsupported

--- a/packages/block-library/src/media-text/block.json
+++ b/packages/block-library/src/media-text/block.json
@@ -126,7 +126,14 @@
 		},
 		"spacing": {
 			"margin": true,
-			"padding": true
+			"padding": true,
+			"blockGap": {
+				"__experimentalDefault": "2em",
+				"sides": [ "horizontal", "vertical" ]
+			},
+			"__experimentalDefaultControls": {
+				"blockGap": true
+			}
 		},
 		"typography": {
 			"fontSize": true,

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -19,6 +19,7 @@ import {
 	store as blockEditorStore,
 	useBlockEditingMode,
 	privateApis as blockEditorPrivateApis,
+	__experimentalGetGapCSSValue as getGapCSSValue,
 } from '@wordpress/block-editor';
 import {
 	RangeControl,
@@ -245,6 +246,35 @@ function MediaTextEdit( {
 		[ `is-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,
 		'is-image-fill-element': imageFill,
 	} );
+
+	const blockGap = attributes?.style?.spacing.blockGap;
+
+	const fallbackValue = 'var(--wp--style--block-gap)';
+
+	let gapStyle = { gap: fallbackValue };
+
+	if ( !! blockGap ) {
+		const row =
+			typeof blockGap === 'string'
+				? getGapCSSValue( blockGap )
+				: getGapCSSValue( blockGap?.top ) || fallbackValue;
+		const col =
+			typeof blockGap === 'string'
+				? getGapCSSValue( blockGap )
+				: getGapCSSValue( blockGap?.left ) || fallbackValue;
+
+		if ( col === row ) {
+			gapStyle = {
+				gap: col,
+			};
+		} else {
+			gapStyle = {
+				columnGap: col,
+				rowGap: row,
+			};
+		}
+	}
+
 	const widthString = `${ temporaryMediaWidth || mediaWidth }%`;
 	const gridTemplateColumns =
 		'right' === mediaPosition
@@ -253,6 +283,7 @@ function MediaTextEdit( {
 	const style = {
 		gridTemplateColumns,
 		msGridColumns: gridTemplateColumns,
+		...gapStyle,
 	};
 	const onMediaAltChange = ( newMediaAlt ) => {
 		setAttributes( { mediaAlt: newMediaAlt } );

--- a/packages/block-library/src/media-text/save.js
+++ b/packages/block-library/src/media-text/save.js
@@ -6,7 +6,11 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
+import {
+	useInnerBlocksProps,
+	useBlockProps,
+	__experimentalGetGapCSSValue as getGapCSSValue,
+} from '@wordpress/block-editor';
 
 /**
  * Internal dependencies
@@ -86,8 +90,38 @@ export default function save( { attributes } ) {
 				? `auto ${ mediaWidth }%`
 				: `${ mediaWidth }% auto`;
 	}
+
+	const blockGap = attributes?.style?.spacing.blockGap;
+
+	const fallbackValue = 'var(--wp--style--block-gap)';
+
+	let gapStyle = { gap: fallbackValue };
+
+	if ( !! blockGap ) {
+		const row =
+			typeof blockGap === 'string'
+				? getGapCSSValue( blockGap )
+				: getGapCSSValue( blockGap?.top ) || fallbackValue;
+		const col =
+			typeof blockGap === 'string'
+				? getGapCSSValue( blockGap )
+				: getGapCSSValue( blockGap?.left ) || fallbackValue;
+
+		if ( col === row ) {
+			gapStyle = {
+				gap: col,
+			};
+		} else {
+			gapStyle = {
+				columnGap: col,
+				rowGap: row,
+			};
+		}
+	}
+
 	const style = {
 		gridTemplateColumns,
+		...gapStyle,
 	};
 
 	if ( 'right' === mediaPosition ) {


### PR DESCRIPTION
resolves #67208 

## What?
This update introduces block gap support to the Media & Text block, along with new UI controls and a default gap value.

## Why?
It addresses issue #67208 by allowing users to control the spacing between the image and text elements within the block.

## How?
The update adds block gap support to the blocks.json file and uses __experimentalGetGapCSSValue (renamed as getGapCSSValue) to parse style attributes in the required format. It incorporates inline styles in both edit.js and save.js, with a default fallback gap value of 'var(--wp--style--block-gap)'.

## Testing Instructions

1. Open a post or page in the WordPress editor.
2. Add a Media & Text block to the editor.
3. Check if the block gap control is available in the block settings panel.
4. Adjust the gap using the control and observe changes in the spacing between the image and text.
5. Save the post or page and verify that the changes persist on the frontend.
6. Test the block with no gap value set to ensure the default fallback (var(--wp--style--block-gap)) is applied.
7. Inspect the block in the editor and on the frontend to confirm the correct inline styles are applied.
8. Repeat the test with various themes to ensure compatibility with custom block-gap settings.

## Screenshots

![image](https://github.com/user-attachments/assets/ec9fdd6a-a107-43d0-a25c-6de892b2bc7b)
![image](https://github.com/user-attachments/assets/ed0771fc-69d5-48bb-99a0-24896456c13f)
![image](https://github.com/user-attachments/assets/29d7880e-c042-46f7-89c5-4cc405d10b6d)
![image](https://github.com/user-attachments/assets/12b8f056-bc17-4d07-9f84-73f973d67a36)

