### PR TITLE
Site Editor Sidebar: Fixed focus/hover style for navigation item buttons

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -27,6 +27,14 @@
 			color: $white;
 		}
 	}
+
+	.block-editor-list-view-block__menu {
+		color: $gray-600;
+		&:hover,
+		&:focus {
+			color: $white;
+		}
+	}
 }
 
 .edit-site-sidebar-navigation-screen-navigation-menus__loading.components-spinner {


### PR DESCRIPTION
## What?

I noticed that on the navigation screen, the navigation button color and behavior were incorrect.

## Why?

The current navigation item buttons are barely visually visible - they are not visible unless you hover over where the navigation item button is located or focus on the button itself, and the button color is also incorrect.

## Testing Instructions

- In the site editor, go to the Navigation screen.
- Hover/focus on a navigation item or navigation button.
- This should have no effect on the default list view.

## Screenshots or screencast <!-- if applicable -->

| Action | Before | After |
|--------|--------|--------|
| Hover navigation item title | ![image](https://github.com/user-attachments/assets/07636231-1b02-42b9-82f8-4666ff7bc63c) | ![image](https://github.com/user-attachments/assets/a3f3a156-053f-4acf-935c-80e188685326) |
| Hover navigation item button | ![image](https://github.com/user-attachments/assets/42d3514f-1ac2-422c-98f6-470f72814d73) | ![image](https://github.com/user-attachments/assets/02bb92cd-495c-426d-a852-e0fab4637130) |
| Focus navigation item| ![image](https://github.com/user-attachments/assets/f54636a6-13a6-427c-8d55-e58d3573e2f1) | ![image](https://github.com/user-attachments/assets/78cb1e40-ba18-47bb-aaf9-78912d575f7d)
| Focus navigation item button | ![image](https://github.com/user-attachments/assets/e3a8bec2-893c-47a5-ac23-d83545b23c77) | ![image](https://github.com/user-attachments/assets/d32a4723-fcfc-415e-aaad-9f328d852e47)
