### PR TITLE
Fix Meta boxes saving when they’re not present

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -447,7 +447,8 @@ function Layout( {
 			settings.supportsTemplateMode,
 		]
 	);
-	useMetaBoxInitialization( showMetaBoxes );
+	useMetaBoxInitialization( hasActiveMetaboxes );
+
 	const [ paddingAppenderRef, paddingStyle ] = usePaddingAppender(
 		enablePaddingAppender
 	);

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -74,7 +74,7 @@ import useEditPostCommands from '../../commands/use-commands';
 import { usePaddingAppender } from './use-padding-appender';
 import { useShouldIframe } from './use-should-iframe';
 import useNavigateToEntityRecord from '../../hooks/use-navigate-to-entity-record';
-import useMetaBoxInitialization from '../meta-boxes/use-meta-box-initialization';
+import { useMetaBoxInitialization } from '../meta-boxes/use-meta-box-initialization';
 
 const { getLayoutStyles } = unlock( blockEditorPrivateApis );
 const { useCommands } = unlock( coreCommandsPrivateApis );

--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -1,9 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useRegistry } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
-import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -13,37 +11,10 @@ import MetaBoxVisibility from './meta-box-visibility';
 import { store as editPostStore } from '../../store';
 
 export default function MetaBoxes( { location } ) {
-	const registry = useRegistry();
-	const { metaBoxes, areMetaBoxesInitialized, isEditorReady } = useSelect(
-		( select ) => {
-			const { __unstableIsEditorReady } = select( editorStore );
-			const {
-				getMetaBoxesPerLocation,
-				areMetaBoxesInitialized: _areMetaBoxesInitialized,
-			} = select( editPostStore );
-			return {
-				metaBoxes: getMetaBoxesPerLocation( location ),
-				areMetaBoxesInitialized: _areMetaBoxesInitialized(),
-				isEditorReady: __unstableIsEditorReady(),
-			};
-		},
-		[ location ]
+	const metaBoxes = useSelect(
+		( select ) =>
+			select( editPostStore ).getMetaBoxesPerLocation[ location ]
 	);
-
-	const hasMetaBoxes = !! metaBoxes?.length;
-
-	// When editor is ready, initialize postboxes (wp core script) and metabox
-	// saving. This initializes all meta box locations, not just this specific
-	// one.
-	useEffect( () => {
-		if ( isEditorReady && hasMetaBoxes && ! areMetaBoxesInitialized ) {
-			registry.dispatch( editPostStore ).initializeMetaBoxes();
-		}
-	}, [ isEditorReady, hasMetaBoxes, areMetaBoxesInitialized ] );
-
-	if ( ! areMetaBoxesInitialized ) {
-		return null;
-	}
 
 	return (
 		<>

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -1,0 +1,44 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor';
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { store as editPostStore } from '../../store';
+
+/**
+ * Initializes postboxes (wp core script) and meta box saving for all meta box locations.
+ *
+ * @param { boolean } enabled
+ */
+export default ( enabled ) => {
+	const { areInitialized, isEditorReady, hasAny } = useSelect(
+		( select ) => {
+			if ( ! enabled ) {
+				return {};
+			}
+			const { __unstableIsEditorReady } = select( editorStore );
+			const { areMetaBoxesInitialized, getMetaBoxesPerLocation } =
+				select( editPostStore );
+			return {
+				areInitialized: areMetaBoxesInitialized(),
+				isEditorReady: __unstableIsEditorReady(),
+				hasAny:
+					getMetaBoxesPerLocation( 'normal' ).length > 0 ||
+					getMetaBoxesPerLocation( 'advanced' ).length > 0 ||
+					getMetaBoxesPerLocation( 'side' ).length > 0,
+			};
+		},
+		[ enabled ]
+	);
+	const { initializeMetaBoxes } = useDispatch( editPostStore );
+	useEffect( () => {
+		if ( isEditorReady && hasAny && ! areInitialized ) {
+			initializeMetaBoxes();
+		}
+	}, [ isEditorReady, hasAny, areInitialized, initializeMetaBoxes ] );
+};

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -11,34 +11,22 @@ import { useEffect } from '@wordpress/element';
 import { store as editPostStore } from '../../store';
 
 /**
- * Initializes postboxes (wp core script) and meta box saving for all meta box locations.
+ * Initializes WordPress `postboxes` script and the logic for saving meta boxes.
  *
  * @param { boolean } enabled
  */
 export default ( enabled ) => {
-	const { areInitialized, isEditorReady, hasAny } = useSelect(
-		( select ) => {
-			if ( ! enabled ) {
-				return {};
-			}
-			const { __unstableIsEditorReady } = select( editorStore );
-			const { areMetaBoxesInitialized, getMetaBoxesPerLocation } =
-				select( editPostStore );
-			return {
-				areInitialized: areMetaBoxesInitialized(),
-				isEditorReady: __unstableIsEditorReady(),
-				hasAny:
-					getMetaBoxesPerLocation( 'normal' ).length > 0 ||
-					getMetaBoxesPerLocation( 'advanced' ).length > 0 ||
-					getMetaBoxesPerLocation( 'side' ).length > 0,
-			};
-		},
+	const isEnabledAndEditorReady = useSelect(
+		( select ) =>
+			enabled && select( editorStore ).__unstableIsEditorReady(),
 		[ enabled ]
 	);
 	const { initializeMetaBoxes } = useDispatch( editPostStore );
+	// The effect has to rerun when the editor is ready because initializeMetaBoxes
+	// will noop until then.
 	useEffect( () => {
-		if ( isEditorReady && hasAny && ! areInitialized ) {
+		if ( isEnabledAndEditorReady ) {
 			initializeMetaBoxes();
 		}
-	}, [ isEditorReady, hasAny, areInitialized, initializeMetaBoxes ] );
+	}, [ isEnabledAndEditorReady, initializeMetaBoxes ] );
 };

--- a/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
+++ b/packages/edit-post/src/components/meta-boxes/use-meta-box-initialization.js
@@ -15,7 +15,7 @@ import { store as editPostStore } from '../../store';
  *
  * @param { boolean } enabled
  */
-export default ( enabled ) => {
+export const useMetaBoxInitialization = ( enabled ) => {
 	const isEnabledAndEditorReady = useSelect(
 		( select ) =>
 			enabled && select( editorStore ).__unstableIsEditorReady(),


### PR DESCRIPTION
## What?
Ensures meta boxes are saved even if none of their areas are present in the Post editor’s UI.

Fixes #67207. Alternative to #67228 (or possibly a follow up to it).

## Why?
Besides fixing a bug, this makes the meta box initialization more explicit/visible. It’s also a small optimization by invoking an effect in fewer places and executing less code when meta boxes aren’t present.

It seems more sensible this way because the initialization of all meta boxes is not really a responsibility of a component that represents only a single area of meta boxes.

## How?
1. Removes the effect to initialize meta boxes from the `MetaBoxes` component
2. Encapsulates the effect and its dependencies in a custom hook
3. Uses the hook in the `Layout` component

## Testing Instructions
1. Install and activate only one plugin adding metaboxes, e.g. Yoast SEO
2. In the block editor, Preferences > General > Advanced, disable "Yoast SEO" and close
3. Important: reload the page or edit another post - the metabox needs to be hidden from the beginning
open the Yoast SEO sidebar and change a setting, e.g. the focus keyphrase
4. Save the post
5. Observe a request is fired to post.php
6. Reload the page and verify the changed value was persisted

