### PR TITLE
Update the Site Title block to use block bindings

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -855,8 +855,8 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 
 -	**Name:** core/site-title
 -	**Category:** theme
--	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isLink, level, levelOptions, linkTarget, textAlign
+-	**Supports:** align (full, wide), blockBindings (content), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** content, isLink, level, levelOptions, linkTarget, textAlign
 
 ## Social Icon
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -855,7 +855,7 @@ Displays the name of this site. Update the block, and the changes apply everywhe
 
 -	**Name:** core/site-title
 -	**Category:** theme
--	**Supports:** align (full, wide), blockBindings (content), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** content, isLink, level, levelOptions, linkTarget, textAlign
 
 ## Social Icon

--- a/lib/compat/wordpress-6.8/block-bindings/site.php
+++ b/lib/compat/wordpress-6.8/block-bindings/site.php
@@ -18,7 +18,7 @@
  * @param WP_Block $block_instance The block instance.
  * @return mixed The value computed for the source.
  */
-function _block_bindings_post_meta_get_value( array $source_args, $block_instance ) {
+function _block_bindings_site_get_value( array $source_args, $block_instance ) {
 	if ( empty( $source_args['key'] ) ) {
 		return null;
 	}
@@ -36,7 +36,7 @@ function _block_bindings_post_meta_get_value( array $source_args, $block_instanc
  * @since 6.5.0
  * @access private
  */
-function _register_block_bindings_post_meta_source() {
+function _register_block_bindings_site_source() {
 	register_block_bindings_source(
 		'core/site',
 		array(
@@ -46,4 +46,4 @@ function _register_block_bindings_post_meta_source() {
 	);
 }
 
-add_action( 'init', '_register_block_bindings_post_meta_source' );
+add_action( 'init', '_register_block_bindings_site_source' );

--- a/lib/compat/wordpress-6.8/block-bindings/site.php
+++ b/lib/compat/wordpress-6.8/block-bindings/site.php
@@ -1,49 +1,55 @@
 <?php
 /**
- * Post Meta source for the block bindings.
+ * Suite source for the block bindings.
  *
- * @since 6.5.0
+ * @since 6.8.0
  * @package WordPress
  * @subpackage Block Bindings
  */
 
-/**
- * Gets value for Post Meta source.
- *
- * @since 6.5.0
- * @access private
- *
- * @param array    $source_args    Array containing source arguments used to look up the override value.
- *                                 Example: array( "key" => "foo" ).
- * @param WP_Block $block_instance The block instance.
- * @return mixed The value computed for the source.
- */
-function _block_bindings_site_get_value( array $source_args, $block_instance ) {
-	if ( empty( $source_args['key'] ) ) {
+
+if ( ! function_exists( '_block_bindings_site_get_value' ) ) {
+	/**
+	 * Gets value for Site source.
+	 *
+	 * @since 6.8.0
+	 * @access private
+	 *
+	 * @param array    $source_args    Array containing source arguments used to look up the override value.
+	 *                                 Example: array( "key" => "foo" ).
+	 * @param WP_Block $block_instance The block instance.
+	 * @return mixed The value computed for the source.
+	 */
+	function _block_bindings_site_get_value( array $source_args ) {
+		if ( empty( $source_args['key'] ) ) {
+			return null;
+		}
+
+		if ( 'title' === $source_args['key'] ) {
+			return esc_html( get_bloginfo( 'name' ) );
+		}
+
 		return null;
 	}
+}
 
-	if ( $source_args['key'] === 'title' ) {
-		return esc_html( get_bloginfo( 'name' ) );
+
+if ( ! function_exists( '_register_block_bindings_site_source' ) ) {
+	/**
+	 * Registers Site source in the block bindings registry.
+	 *
+	 * @since 6.8.0
+	 * @access private
+	 */
+	function _register_block_bindings_site_source() {
+		register_block_bindings_source(
+			'core/site',
+			array(
+				'label'              => _x( 'Site', 'block bindings source' ),
+				'get_value_callback' => '_block_bindings_site_get_value',
+			)
+		);
 	}
 
-	return null;
+	add_action( 'init', '_register_block_bindings_site_source' );
 }
-
-/**
- * Registers Post Meta source in the block bindings registry.
- *
- * @since 6.5.0
- * @access private
- */
-function _register_block_bindings_site_source() {
-	register_block_bindings_source(
-		'core/site',
-		array(
-			'label'              => _x( 'Site', 'block bindings source' ),
-			'get_value_callback' => '_block_bindings_site_get_value',
-		)
-	);
-}
-
-add_action( 'init', '_register_block_bindings_site_source' );

--- a/lib/compat/wordpress-6.8/block-bindings/site.php
+++ b/lib/compat/wordpress-6.8/block-bindings/site.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Post Meta source for the block bindings.
+ *
+ * @since 6.5.0
+ * @package WordPress
+ * @subpackage Block Bindings
+ */
+
+/**
+ * Gets value for Post Meta source.
+ *
+ * @since 6.5.0
+ * @access private
+ *
+ * @param array    $source_args    Array containing source arguments used to look up the override value.
+ *                                 Example: array( "key" => "foo" ).
+ * @param WP_Block $block_instance The block instance.
+ * @return mixed The value computed for the source.
+ */
+function _block_bindings_post_meta_get_value( array $source_args, $block_instance ) {
+	if ( empty( $source_args['key'] ) ) {
+		return null;
+	}
+
+	if ( $source_args['key'] === 'title' ) {
+		return esc_html( get_bloginfo( 'name' ) );
+	}
+
+	return null;
+}
+
+/**
+ * Registers Post Meta source in the block bindings registry.
+ *
+ * @since 6.5.0
+ * @access private
+ */
+function _register_block_bindings_post_meta_source() {
+	register_block_bindings_source(
+		'core/site',
+		array(
+			'label'              => _x( 'Site', 'block bindings source' ),
+			'get_value_callback' => '_block_bindings_site_get_value',
+		)
+	);
+}
+
+add_action( 'init', '_register_block_bindings_post_meta_source' );

--- a/lib/load.php
+++ b/lib/load.php
@@ -98,6 +98,7 @@ require __DIR__ . '/compat/wordpress-6.8/preload.php';
 require __DIR__ . '/compat/wordpress-6.8/blocks.php';
 require __DIR__ . '/compat/wordpress-6.8/functions.php';
 require __DIR__ . '/compat/wordpress-6.8/post.php';
+require __DIR__ . '/compat/wordpress-6.8/block-bindings/site.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -311,7 +311,6 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		</InspectorControls>
 	);
 };
-
 export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -311,6 +311,7 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 		</InspectorControls>
 	);
 };
+
 export default {
 	edit: BlockBindingsPanel,
 	attributeKeys: [ 'metadata' ],

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -7,6 +7,12 @@
 	"description": "Displays the name of this site. Update the block, and the changes apply everywhere it’s used. This will also appear in the browser title bar and in search results.",
 	"textdomain": "default",
 	"attributes": {
+		"content": {
+			"type": "rich-text",
+			"source": "rich-text",
+			"selector": "p,h1,h2,h3,h4,h5,h6",
+			"role": "content"
+		},
 		"level": {
 			"type": "number",
 			"default": 1
@@ -32,6 +38,14 @@
 	},
 	"supports": {
 		"align": [ "wide", "full" ],
+		"blockBindings": {
+			"content": {
+				"source": "core/site",
+				"args": {
+					"key": "title"
+				}
+			}
+		},
 		"html": false,
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -11,7 +11,13 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "p,h1,h2,h3,h4,h5,h6",
-			"role": "content"
+			"role": "content",
+			"binding": {
+				"source": "core/site",
+				"args": {
+					"key": "title"
+				}
+			}
 		},
 		"level": {
 			"type": "number",
@@ -38,14 +44,6 @@
 	},
 	"supports": {
 		"align": [ "wide", "full" ],
-		"blockBindings": {
-			"content": {
-				"source": "core/site",
-				"args": {
-					"key": "title"
-				}
-			}
-		},
 		"html": false,
 		"color": {
 			"gradients": true,

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import { __ } from '@wordpress/i18n';
 import {
@@ -26,37 +26,25 @@ export default function SiteTitleEdit( {
 	setAttributes,
 	insertBlocksAfter,
 } ) {
-	const { level, levelOptions, textAlign, isLink, linkTarget } = attributes;
-	const { canUserEdit, title } = useSelect( ( select ) => {
-		const { canUser, getEntityRecord, getEditedEntityRecord } =
-			select( coreStore );
-		const canEdit = canUser( 'update', {
-			kind: 'root',
-			name: 'site',
-		} );
-		const settings = canEdit ? getEditedEntityRecord( 'root', 'site' ) : {};
-		const readOnlySettings = getEntityRecord( 'root', '__unstableBase' );
-
-		return {
-			canUserEdit: canEdit,
-			title: canEdit ? settings?.title : readOnlySettings?.name,
-		};
-	}, [] );
-	const { editEntityRecord } = useDispatch( coreStore );
-
-	function setTitle( newTitle ) {
-		editEntityRecord( 'root', 'site', undefined, {
-			title: newTitle,
-		} );
-	}
+	const { content, level, levelOptions, textAlign, isLink, linkTarget } =
+		attributes;
+	const canUserEdit = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'update', {
+				kind: 'root',
+				name: 'site',
+			} ),
+		[]
+	);
 
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
-			'wp-block-site-title__placeholder': ! canUserEdit && ! title,
+			'wp-block-site-title__placeholder': ! canUserEdit && ! content,
 		} ),
 	} );
+
 	const siteTitleContent = canUserEdit ? (
 		<TagName { ...blockProps }>
 			<RichText
@@ -64,8 +52,8 @@ export default function SiteTitleEdit( {
 				href={ isLink ? '#site-title-pseudo-link' : undefined }
 				aria-label={ __( 'Site title text' ) }
 				placeholder={ __( 'Write site title…' ) }
-				value={ title }
-				onChange={ setTitle }
+				value={ content }
+				onChange={ ( value ) => setAttributes( { content: value } ) }
 				allowedFormats={ [] }
 				disableLineBreaks
 				__unstableOnSplitAtEnd={ () =>
@@ -80,12 +68,12 @@ export default function SiteTitleEdit( {
 					href="#site-title-pseudo-link"
 					onClick={ ( event ) => event.preventDefault() }
 				>
-					{ decodeEntities( title ) ||
+					{ decodeEntities( content ) ||
 						__( 'Site Title placeholder' ) }
 				</a>
 			) : (
 				<span>
-					{ decodeEntities( title ) ||
+					{ decodeEntities( content ) ||
 						__( 'Site Title placeholder' ) }
 				</span>
 			) }

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -15,13 +15,13 @@
  * @return string The render.
  */
 function render_block_core_site_title( $attributes ) {
-	if ( !  isset( $attributes['content'] ) ) {
+	if ( ! isset( $attributes['content'] ) ) {
 		return;
 	}
 
 	$site_title = $attributes['content'];
-	$tag_name = 'h1';
-	$classes  = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
+	$tag_name   = 'h1';
+	$classes    = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {
 		$classes .= ' has-link-color';
 	}

--- a/packages/block-library/src/site-title/index.php
+++ b/packages/block-library/src/site-title/index.php
@@ -15,11 +15,11 @@
  * @return string The render.
  */
 function render_block_core_site_title( $attributes ) {
-	$site_title = get_bloginfo( 'name' );
-	if ( ! $site_title ) {
+	if ( !  isset( $attributes['content'] ) ) {
 		return;
 	}
 
+	$site_title = $attributes['content'];
 	$tag_name = 'h1';
 	$classes  = empty( $attributes['textAlign'] ) ? '' : "has-text-align-{$attributes['textAlign']}";
 	if ( isset( $attributes['style']['elements']['link']['color']['text'] ) ) {

--- a/packages/editor/src/bindings/api.js
+++ b/packages/editor/src/bindings/api.js
@@ -8,6 +8,7 @@ import { registerBlockBindingsSource } from '@wordpress/blocks';
  */
 import patternOverrides from './pattern-overrides';
 import postMeta from './post-meta';
+import site from './site';
 
 /**
  * Function to register core block bindings sources provided by the editor.
@@ -22,4 +23,5 @@ import postMeta from './post-meta';
 export function registerCoreBlockBindingsSources() {
 	registerBlockBindingsSource( patternOverrides );
 	registerBlockBindingsSource( postMeta );
+	registerBlockBindingsSource( site );
 }

--- a/packages/editor/src/bindings/site.js
+++ b/packages/editor/src/bindings/site.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { store as coreDataStore } from '@wordpress/core-data';
+
+/**
+ * Gets a list of site fields with their values and labels
+ * to be consumed in the needed callbacks.
+ *
+ * @param {Object} select The select function from the data store.
+ * @return {Object} List of post meta fields with their value and label.
+ */
+const supportedFields = { title: { label: __( 'Title' ), type: 'string' } };
+function getSiteFields( select ) {
+	const { getEditedEntityRecord } = select( coreDataStore );
+
+	const entityValues = getEditedEntityRecord( 'root', 'site', undefined );
+	const siteFields = {};
+	Object.entries( supportedFields ).forEach( ( [ key, props ] ) => {
+		// Don't include footnotes or private fields.
+		siteFields[ key ] = {
+			label: props.title || key,
+			value: entityValues?.[ key ],
+			type: props.type,
+		};
+	} );
+	return siteFields;
+}
+
+export default {
+	name: 'core/site',
+	label: __( 'Site' ),
+	getValues( { select, bindings } ) {
+		const metaFields = getSiteFields( select );
+
+		const newValues = {};
+		for ( const [ attributeName, source ] of Object.entries( bindings ) ) {
+			// Use the value, the field label, or the field key.
+			const fieldKey = source.args.key;
+			const { value: fieldValue, label: fieldLabel } =
+				metaFields?.[ fieldKey ] || {};
+			newValues[ attributeName ] = fieldValue ?? fieldLabel ?? fieldKey;
+		}
+		return newValues;
+	},
+	setValues( { dispatch, bindings } ) {
+		const newValues = {};
+		Object.values( bindings ).forEach( ( { args, newValue } ) => {
+			newValues[ args.key ] = newValue;
+		} );
+
+		dispatch( coreDataStore ).editEntityRecord(
+			'root',
+			'site',
+			undefined,
+			newValues
+		);
+	},
+	canUserEditValue( { select, args } ) {
+		if ( ! supportedFields[ args.key ] ) {
+			return false;
+		}
+
+		// Check that the user has the capability to edit post meta.
+		return select( coreDataStore ).canUser( 'update', {
+			kind: 'root',
+			name: 'site',
+		} );
+	},
+	getFieldsList( { select, context } ) {
+		return getSiteFields( select, context );
+	},
+};

--- a/packages/editor/src/bindings/site.js
+++ b/packages/editor/src/bindings/site.js
@@ -67,7 +67,4 @@ export default {
 			name: 'site',
 		} );
 	},
-	getFieldsList( { select, context } ) {
-		return getSiteFields( select, context );
-	},
 };

--- a/packages/editor/src/bindings/site.js
+++ b/packages/editor/src/bindings/site.js
@@ -30,7 +30,6 @@ function getSiteFields( select ) {
 
 export default {
 	name: 'core/site',
-	label: __( 'Site' ),
 	getValues( { select, bindings } ) {
 		const metaFields = getSiteFields( select );
 

--- a/test/integration/fixtures/blocks/core__site-title.json
+++ b/test/integration/fixtures/blocks/core__site-title.json
@@ -3,6 +3,7 @@
 		"name": "core/site-title",
 		"isValid": true,
 		"attributes": {
+			"content": "",
 			"level": 1,
 			"levelOptions": [ 0, 1, 2, 3, 4, 5, 6 ],
 			"isLink": true,


### PR DESCRIPTION
## What?
Fixes part of #65778

Updates the Site Title block to use block bindings. This allows for a `content` attribute to be declared, and the block can be edited in `contentOnly` mode. If this approach works, it can also be used for other blocks (Site tagline, Post Title, Post Featured Image etc.).

## Why?
This provides some advantages:
- The block now has a clear `content` attribute, and can be edited in `contentOnly` mode.
- The block's `edit` function is simplified quite a bit.

## How?
- Adds a new `core/site` binding source.
- There was a choice of whether to deprecate the Site Title block and migrate existing instances to be a variation of the Heading block (with bindings). I'm not sure this is feasible due to the way Site Title supports paragraph tags. There would need to be variations of both paragraph and heading, or alternatively make the heading block support the paragraph tag (ugh). If anyone has a good idea for solving this in a way that allows the Site Title block to be gracefully deprecated, I'm open to exploring it. Post title also has this problem.
- Another challenge is to have the block's binding definition always present. Blocks with bindings usually have a `metadata.bindings` attribute value describing the bindings. The most feasible option seemed to be using a default block variation of the site title that declares the attribute value. The problem with allowing the binding to be declared as an attribute value is that it can be removed by the user, leaving the block in a confusing state. I instead opted to add a `bindings` property for the attribute in the block.json that the block bindings API reads. The advantage of this is that it's innate to the block, it can't be removed without modifying the block type definition. It's a technical decision that need some discussion.

## Still to solve
Block/attribute support for bindings is currently hard-coded. I've updated the support in JS. The PHP support is declared in WordPress core code. It's easy enough to solve, but two things will be needed to properly support the binding on the frontend:
- A core backport PR. I have some scrappy code locally I just need to finalize it.
- Some compatibility code added to the `lib/compat` folder for Gutenberg that adds support for this to the last to WP versions.

## Testing Instructions
1. Insert the site title block, it should work as in `trunk` (apart from the front-end)
2. Insert the following `contentOnly` template locked group using the code editor:
```html
<!-- wp:group {"templateLock":"contentOnly","className":"is-style-default","layout":{"type":"constrained"}} -->
<div class="wp-block-group is-style-default"><!-- wp:site-title {"level":0} /--></div>
<!-- /wp:group -->
```
3. Note that you can now edit the Site Title's content, while in `trunk` you can't.