### PR TITLE
Fix block mover clickable area

### DIFF
--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -71,6 +71,9 @@
 
 // Specificity is necessary to override block toolbar button styles.
 .components-button.block-editor-block-mover-button {
+	// Prevent the SVGs inside the button from overflowing the button.
+	overflow: hidden;
+
 	// Focus and toggle pseudo elements.
 	&::before {
 		content: "";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes #67239

## How?
Applies `overflow: hidden` to the mover `<button>` so that the inner `<svg>` element can't overlap other parts of the UI.

We may also want to consider a fix fore this in the components package (cc @WordPress/gutenberg-components). It's a bit of a gray area since the mover buttons modify the general `Button` component quite a bit making the `<button>` smaller than normal and moving the position of the `<svg>`. I decided to try and get this one liner merged first, since it's a bad bug.

(also, I wonder if the mover buttons should be using `ToolbarButton` instead of plain old `Button`)

## Testing Instructions
1. Add a few paragraphs
2. Try clicking the bottom part of the Up mover button

In trunk: The block moves down
In this PR: The block moves up as it should

## Screenshots or screencast <!-- if applicable -->
### Before

https://github.com/user-attachments/assets/40837d54-3ae3-49ba-95e9-c80d06a9a9ec

### After

https://github.com/user-attachments/assets/bb8158b2-bfd6-44a4-9f47-158dfd019117


