### PR TITLE
Edit Post: Refactor 'MetaBoxVisibility' component

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/meta-box-visibility.js
+++ b/packages/edit-post/src/components/meta-boxes/meta-box-visibility.js
@@ -1,24 +1,21 @@
 /**
  * WordPress dependencies
  */
-import { Component } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 
-class MetaBoxVisibility extends Component {
-	componentDidMount() {
-		this.updateDOM();
-	}
+export default function MetaBoxVisibility( { id } ) {
+	const isVisible = useSelect(
+		( select ) => {
+			return select( editorStore ).isEditorPanelEnabled(
+				`meta-box-${ id }`
+			);
+		},
+		[ id ]
+	);
 
-	componentDidUpdate( prevProps ) {
-		if ( this.props.isVisible !== prevProps.isVisible ) {
-			this.updateDOM();
-		}
-	}
-
-	updateDOM() {
-		const { id, isVisible } = this.props;
-
+	useEffect( () => {
 		const element = document.getElementById( id );
 		if ( ! element ) {
 			return;
@@ -29,13 +26,7 @@ class MetaBoxVisibility extends Component {
 		} else {
 			element.classList.add( 'is-hidden' );
 		}
-	}
+	}, [ id, isVisible ] );
 
-	render() {
-		return null;
-	}
+	return null;
 }
-
-export default withSelect( ( select, { id } ) => ( {
-	isVisible: select( editorStore ).isEditorPanelEnabled( `meta-box-${ id }` ),
-} ) )( MetaBoxVisibility );


### PR DESCRIPTION
## What
PR refactors `MetaBoxVisibility` into a function component and replaces data HOC with hooks.

## Testing Instructions
1. Register a couple of meta boxes.
2. Open a post.
3. Toggle one of the meta boxes.
4. Confirm that it's hidden via CSS.

<details><summary>Test meta boxes</summary>
<p>

```php
add_action( 'add_meta_boxes', function() {
	add_meta_box(
		'mamaduka-test-meta-box-1',
		'Test Meta Box 1',
		function() {
			echo '<p>Test Meta Box 1</p>';
		},
	);

	add_meta_box(
		'mamaduka-test-meta-box-2',
		'Test Meta Box 2',
		function() {
			echo '<p>Test Meta Box 2</p>';
		},
	);
} );
```

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-25 at 12 45 55](https://github.com/user-attachments/assets/f606fab4-ded3-421c-9b11-9e1490c0ef6d)
