### PR TITLE
Comments Pagination Numbers: Add spacing controls for margin and padding

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -268,7 +268,7 @@ Displays a list of page numbers for comments pagination. ([Source](https://githu
 -	**Name:** core/comments-pagination-numbers
 -	**Category:** theme
 -	**Parent:** core/comments-pagination
--	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** color (background, gradients, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments Previous Page
 

--- a/packages/block-library/src/comments-pagination-numbers/block.json
+++ b/packages/block-library/src/comments-pagination-numbers/block.json
@@ -33,6 +33,13 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"padding": true
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes: #67266 

## What?
Adds Spacing Controls ( Margin and Padding ) to the Comments Pagination Controls block.

## How?
block.json is modified to include the spacing options to enable support.

## Testing Instructions
1. Create a post and navigate to its edit screen.
2. Add a comments block.
3. From the Tree view, choose the comments page number block. Notice the presence of spacing options.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/171ad887-965d-4f67-a9e0-9f9ea68f3adf

