### PR TITLE
Block Editor: Correctly mark Block Comment SlotFills private

### DIFF
--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -19,7 +19,7 @@ import { pipe, useCopyToClipboard } from '@wordpress/compose';
  * Internal dependencies
  */
 import BlockActions from '../block-actions';
-import CommentIconFill from '../../components/collab/block-comment-icon-slot';
+import CommentIconSlotFill from '../../components/collab/block-comment-icon-slot';
 import BlockHTMLConvertButton from './block-html-convert-button';
 import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
@@ -295,7 +295,7 @@ export function BlockSettingsDropdown( {
 											</MenuItem>
 										</>
 									) }
-									<CommentIconFill.Slot
+									<CommentIconSlotFill.Slot
 										fillProps={ { onClose } }
 									/>
 								</MenuGroup>

--- a/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
+++ b/packages/block-editor/src/components/block-settings-menu/block-settings-dropdown.js
@@ -19,7 +19,7 @@ import { pipe, useCopyToClipboard } from '@wordpress/compose';
  * Internal dependencies
  */
 import BlockActions from '../block-actions';
-import __unstableCommentIconFill from '../../components/collab/block-comment-icon-slot';
+import CommentIconFill from '../../components/collab/block-comment-icon-slot';
 import BlockHTMLConvertButton from './block-html-convert-button';
 import __unstableBlockSettingsMenuFirstItem from './block-settings-menu-first-item';
 import BlockSettingsMenuControls from '../block-settings-menu-controls';
@@ -295,7 +295,7 @@ export function BlockSettingsDropdown( {
 											</MenuItem>
 										</>
 									) }
-									<__unstableCommentIconFill.Slot
+									<CommentIconFill.Slot
 										fillProps={ { onClose } }
 									/>
 								</MenuGroup>

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -7,12 +7,12 @@ import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockSettingsDropdown from './block-settings-dropdown';
-import CommentIconToolbarFill from '../../components/collab/block-comment-icon-toolbar-slot';
+import CommentIconToolbarSlotFill from '../../components/collab/block-comment-icon-toolbar-slot';
 
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
 		<ToolbarGroup>
-			<CommentIconToolbarFill.Slot />
+			<CommentIconToolbarSlotFill.Slot />
 
 			<ToolbarItem>
 				{ ( toggleProps ) => (

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -7,12 +7,12 @@ import { ToolbarGroup, ToolbarItem } from '@wordpress/components';
  * Internal dependencies
  */
 import BlockSettingsDropdown from './block-settings-dropdown';
-import __unstableCommentIconToolbarFill from '../../components/collab/block-comment-icon-toolbar-slot';
+import CommentIconToolbarFill from '../../components/collab/block-comment-icon-toolbar-slot';
 
 export function BlockSettingsMenu( { clientIds, ...props } ) {
 	return (
 		<ToolbarGroup>
-			<__unstableCommentIconToolbarFill.Slot />
+			<CommentIconToolbarFill.Slot />
 
 			<ToolbarItem>
 				{ ( toggleProps ) => (

--- a/packages/block-editor/src/components/collab/block-comment-icon-slot.js
+++ b/packages/block-editor/src/components/collab/block-comment-icon-slot.js
@@ -4,7 +4,7 @@
 import { createSlotFill } from '@wordpress/components';
 
 const { Fill: __unstableCommentIconFill, Slot } = createSlotFill(
-	'__unstableCommentIconFill'
+	Symbol( 'CommentIconFill' )
 );
 
 __unstableCommentIconFill.Slot = Slot;

--- a/packages/block-editor/src/components/collab/block-comment-icon-slot.js
+++ b/packages/block-editor/src/components/collab/block-comment-icon-slot.js
@@ -3,10 +3,6 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: CommentIconFill, Slot } = createSlotFill(
-	Symbol( 'CommentIconFill' )
-);
+const CommentIconSlotFill = createSlotFill( Symbol( 'CommentIconSlotFill' ) );
 
-CommentIconFill.Slot = Slot;
-
-export default CommentIconFill;
+export default CommentIconSlotFill;

--- a/packages/block-editor/src/components/collab/block-comment-icon-slot.js
+++ b/packages/block-editor/src/components/collab/block-comment-icon-slot.js
@@ -3,10 +3,10 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: __unstableCommentIconFill, Slot } = createSlotFill(
+const { Fill: CommentIconFill, Slot } = createSlotFill(
 	Symbol( 'CommentIconFill' )
 );
 
-__unstableCommentIconFill.Slot = Slot;
+CommentIconFill.Slot = Slot;
 
-export default __unstableCommentIconFill;
+export default CommentIconFill;

--- a/packages/block-editor/src/components/collab/block-comment-icon-toolbar-slot.js
+++ b/packages/block-editor/src/components/collab/block-comment-icon-toolbar-slot.js
@@ -3,10 +3,10 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: __unstableCommentIconToolbarFill, Slot } = createSlotFill(
+const { Fill: CommentIconToolbarFill, Slot } = createSlotFill(
 	Symbol( 'CommentIconToolbarFill' )
 );
 
-__unstableCommentIconToolbarFill.Slot = Slot;
+CommentIconToolbarFill.Slot = Slot;
 
-export default __unstableCommentIconToolbarFill;
+export default CommentIconToolbarFill;

--- a/packages/block-editor/src/components/collab/block-comment-icon-toolbar-slot.js
+++ b/packages/block-editor/src/components/collab/block-comment-icon-toolbar-slot.js
@@ -3,10 +3,8 @@
  */
 import { createSlotFill } from '@wordpress/components';
 
-const { Fill: CommentIconToolbarFill, Slot } = createSlotFill(
-	Symbol( 'CommentIconToolbarFill' )
+const CommentIconToolbarSlotFill = createSlotFill(
+	Symbol( 'CommentIconToolbarSlotFill' )
 );
 
-CommentIconToolbarFill.Slot = Slot;
-
-export default CommentIconToolbarFill;
+export default CommentIconToolbarSlotFill;

--- a/packages/block-editor/src/components/collab/block-comment-icon-toolbar-slot.js
+++ b/packages/block-editor/src/components/collab/block-comment-icon-toolbar-slot.js
@@ -4,7 +4,7 @@
 import { createSlotFill } from '@wordpress/components';
 
 const { Fill: __unstableCommentIconToolbarFill, Slot } = createSlotFill(
-	'__unstableCommentIconToolbarFill'
+	Symbol( 'CommentIconToolbarFill' )
 );
 
 __unstableCommentIconToolbarFill.Slot = Slot;

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -48,8 +48,8 @@ import { PrivatePublishDateTimePicker } from './components/publish-date-time-pic
 import useSpacingSizes from './components/spacing-sizes-control/hooks/use-spacing-sizes';
 import useBlockDisplayTitle from './components/block-title/use-block-display-title';
 import TabbedSidebar from './components/tabbed-sidebar';
-import __unstableCommentIconFill from './components/collab/block-comment-icon-slot';
-import __unstableCommentIconToolbarFill from './components/collab/block-comment-icon-toolbar-slot';
+import CommentIconFill from './components/collab/block-comment-icon-slot';
+import CommentIconToolbarFill from './components/collab/block-comment-icon-toolbar-slot';
 /**
  * Private @wordpress/block-editor APIs.
  */
@@ -95,6 +95,6 @@ lock( privateApis, {
 	__unstableBlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
 	sectionRootClientIdKey,
-	__unstableCommentIconFill,
-	__unstableCommentIconToolbarFill,
+	CommentIconFill,
+	CommentIconToolbarFill,
 } );

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -48,8 +48,8 @@ import { PrivatePublishDateTimePicker } from './components/publish-date-time-pic
 import useSpacingSizes from './components/spacing-sizes-control/hooks/use-spacing-sizes';
 import useBlockDisplayTitle from './components/block-title/use-block-display-title';
 import TabbedSidebar from './components/tabbed-sidebar';
-import CommentIconFill from './components/collab/block-comment-icon-slot';
-import CommentIconToolbarFill from './components/collab/block-comment-icon-toolbar-slot';
+import CommentIconSlotFill from './components/collab/block-comment-icon-slot';
+import CommentIconToolbarSlotFill from './components/collab/block-comment-icon-toolbar-slot';
 /**
  * Private @wordpress/block-editor APIs.
  */
@@ -95,6 +95,6 @@ lock( privateApis, {
 	__unstableBlockStyleVariationOverridesWithConfig,
 	setBackgroundStyleDefaults,
 	sectionRootClientIdKey,
-	CommentIconFill,
-	CommentIconToolbarFill,
+	CommentIconSlotFill,
+	CommentIconToolbarSlotFill,
 } );

--- a/packages/editor/src/components/collab-sidebar/comment-button-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-button-toolbar.js
@@ -11,18 +11,18 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const { CommentIconToolbarFill } = unlock( blockEditorPrivateApis );
+const { CommentIconToolbarSlotFill } = unlock( blockEditorPrivateApis );
 
 const AddCommentToolbarButton = ( { onClick } ) => {
 	return (
-		<CommentIconToolbarFill>
+		<CommentIconToolbarSlotFill.Fill>
 			<ToolbarButton
 				accessibleWhenDisabled
 				icon={ commentIcon }
 				label={ _x( 'Comment', 'View comment' ) }
 				onClick={ onClick }
 			/>
-		</CommentIconToolbarFill>
+		</CommentIconToolbarSlotFill.Fill>
 	);
 };
 

--- a/packages/editor/src/components/collab-sidebar/comment-button-toolbar.js
+++ b/packages/editor/src/components/collab-sidebar/comment-button-toolbar.js
@@ -11,18 +11,18 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const { __unstableCommentIconToolbarFill } = unlock( blockEditorPrivateApis );
+const { CommentIconToolbarFill } = unlock( blockEditorPrivateApis );
 
 const AddCommentToolbarButton = ( { onClick } ) => {
 	return (
-		<__unstableCommentIconToolbarFill>
+		<CommentIconToolbarFill>
 			<ToolbarButton
 				accessibleWhenDisabled
 				icon={ commentIcon }
 				label={ _x( 'Comment', 'View comment' ) }
 				onClick={ onClick }
 			/>
-		</__unstableCommentIconToolbarFill>
+		</CommentIconToolbarFill>
 	);
 };
 

--- a/packages/editor/src/components/collab-sidebar/comment-button.js
+++ b/packages/editor/src/components/collab-sidebar/comment-button.js
@@ -12,11 +12,11 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const { __unstableCommentIconFill } = unlock( blockEditorPrivateApis );
+const { CommentIconFill } = unlock( blockEditorPrivateApis );
 
 const AddCommentButton = ( { onClick } ) => {
 	return (
-		<__unstableCommentIconFill>
+		<CommentIconFill>
 			<MenuItem
 				icon={ commentIcon }
 				onClick={ onClick }
@@ -24,7 +24,7 @@ const AddCommentButton = ( { onClick } ) => {
 			>
 				{ _x( 'Comment', 'Add comment button' ) }
 			</MenuItem>
-		</__unstableCommentIconFill>
+		</CommentIconFill>
 	);
 };
 

--- a/packages/editor/src/components/collab-sidebar/comment-button.js
+++ b/packages/editor/src/components/collab-sidebar/comment-button.js
@@ -12,11 +12,11 @@ import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
  */
 import { unlock } from '../../lock-unlock';
 
-const { CommentIconFill } = unlock( blockEditorPrivateApis );
+const { CommentIconSlotFill } = unlock( blockEditorPrivateApis );
 
 const AddCommentButton = ( { onClick } ) => {
 	return (
-		<CommentIconFill>
+		<CommentIconSlotFill.Fill>
 			<MenuItem
 				icon={ commentIcon }
 				onClick={ onClick }
@@ -24,7 +24,7 @@ const AddCommentButton = ( { onClick } ) => {
 			>
 				{ _x( 'Comment', 'Add comment button' ) }
 			</MenuItem>
-		</CommentIconFill>
+		</CommentIconSlotFill.Fill>
 	);
 };
 


### PR DESCRIPTION
## What?
PR updates block comment SlotFills and correctly mark them as private, preventing "leaking" them to consumers using string names.

I've also removed the `__unstable` prefix; it's not needed for private APIs.

Remembered this case while reviewing #67238.

## Testing Instructions
1. Enable "Enable multi-user commenting on blocks" experiment.
2. Confirm you can add comments from the block options dropdown.
3. Opens the comment sidebar from the block toolbar.
4. Confirm that custom fills can't be injected into private slots. See the snippet below.

<details><summary>Test the "leak"</summary>
<p>

```javascript
const {createElement: el} = wp.element;
const registerPlugin = wp.plugins.registerPlugin;
const {Fill, ToolbarButton} = wp.components;

function TestSlotFillLeak() {
    return el(Fill, {
        name: '__unstableCommentIconToolbarFill',
    }, el(ToolbarButton, {
        icon: 'carrot',
        label: 'Test',
        onClick: () => console.log('test')
    }, ));
}

registerPlugin('test-slot-fill-leak', {
    render: TestSlotFillLeak,
});
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-25 at 15 26 19](https://github.com/user-attachments/assets/e9f45c47-d08c-430d-9976-7df96fce44a6)
