### PR TITLE
Block Hooks: Apply to Post Content (on frontend and in editor)

### DIFF
--- a/backport-changelog/6.8/7889.md
+++ b/backport-changelog/6.8/7889.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7889
+
+* https://github.com/WordPress/gutenberg/pull/67272

--- a/backport-changelog/6.8/7889.md
+++ b/backport-changelog/6.8/7889.md
@@ -1,3 +1,0 @@
-https://github.com/WordPress/wordpress-develop/pull/7889
-
-* https://github.com/WordPress/gutenberg/pull/67272

--- a/backport-changelog/6.8/7898.md
+++ b/backport-changelog/6.8/7898.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7898
+
+* https://github.com/WordPress/gutenberg/pull/67272

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -144,3 +144,12 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 }
 
 add_filter( 'register_block_type_args', 'gutenberg_stabilize_experimental_block_supports', PHP_INT_MAX, 1 );
+
+function gutenberg_apply_block_hooks_to_post_content( $content ) {
+	// The `the_content` filter does not provide the post that the content is coming from.
+	// However, we can infer it by calling `get_post()`, which will return the current post
+	// if no post ID is provided.
+	return apply_block_hooks_to_content( $content, get_post(), 'insert_hooked_blocks' );
+}
+// We need to apply this filter before `do_blocks` (which is hooked to `the_content` at priority 9).
+add_filter( 'the_content', 'gutenberg_apply_block_hooks_to_post_content', 8 );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -273,6 +273,7 @@ function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
 	$existing_post = get_post( $post->ID );
 	// Merge the existing post object with the updated post object to pass to the block hooks algorithm for context.
 	$context          = (object) array_merge( (array) $existing_post, (array) $post );
+	$context          = new WP_Post( $context ); // Convert to WP_Post object.
 	$serialized_block = apply_block_hooks_to_content( $markup, $context, 'set_ignored_hooked_blocks_metadata' );
 	$root_block       = parse_blocks( $serialized_block )[0];
 

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -153,3 +153,69 @@ function gutenberg_apply_block_hooks_to_post_content( $content ) {
 }
 // We need to apply this filter before `do_blocks` (which is hooked to `the_content` at priority 9).
 add_filter( 'the_content', 'gutenberg_apply_block_hooks_to_post_content', 8 );
+
+/**
+ * Hooks into the REST API response for the Posts endpoint and adds the first and last inner blocks.
+ *
+ * @since 6.6.0
+ * @since 6.8.0 Support non-`wp_navigation` post types.
+ *
+ * @param WP_REST_Response $response The response object.
+ * @param WP_Post          $post     Post object.
+ * @return WP_REST_Response The response object.
+ */
+function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
+	if ( empty( $response->data['content']['raw'] ) || empty( $response->data['content']['rendered'] ) ) {
+		return $response;
+	}
+
+	$attributes            = array();
+	$ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks  = json_decode( $ignored_hooked_blocks, true );
+		$attributes['metadata'] = array(
+			'ignoredHookedBlocks' => $ignored_hooked_blocks,
+		);
+	}
+
+	if ( 'wp_navigation' === $post->post_type ) {
+		$wrapper_block_type = 'core/navigation';
+	} else {
+		$wrapper_block_type = 'core/post-content';
+	}
+
+	$content = get_comment_delimited_block_content(
+		$wrapper_block_type,
+		$attributes,
+		$response->data['content']['raw']
+	);
+
+	$content = apply_block_hooks_to_content(
+		$content,
+		$post,
+		'insert_hooked_blocks_and_set_ignored_hooked_blocks_metadata'
+	);
+
+	// Remove mock block wrapper.
+	$content = remove_serialized_parent_block( $content );
+
+	$response->data['content']['raw'] = $content;
+
+	// No need to inject hooked blocks twice.
+	$priority = has_filter( 'the_content', 'apply_block_hooks_to_content' );
+	if ( false !== $priority ) {
+		remove_filter( 'the_content', 'apply_block_hooks_to_content', $priority );
+	}
+
+	/** This filter is documented in wp-includes/post-template.php */
+	$response->data['content']['rendered'] = apply_filters( 'the_content', $content );
+
+	// Add back the filter.
+	if ( false !== $priority ) {
+		add_filter( 'the_content', 'apply_block_hooks_to_content', $priority );
+	}
+
+	return $response;
+}
+add_filter( 'rest_prepare_page', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
+add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -219,3 +219,82 @@ function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
 }
 add_filter( 'rest_prepare_page', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
+
+/**
+ * Updates the wp_postmeta with the list of ignored hooked blocks
+ * where the inner blocks are stored as post content.
+ *
+ * @since 6.6.0
+ * @since 6.8.0 Support non-`wp_navigation` post types.
+ * @access private
+ *
+ * @param stdClass $post Post object.
+ * @return stdClass The updated post object.
+ */
+function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
+	/*
+	 * In this scenario the user has likely tried to create a new post object via the REST API.
+	 * In which case we won't have a post ID to work with and store meta against.
+	 */
+	if ( empty( $post->ID ) ) {
+		return $post;
+	}
+
+	/*
+	 * Skip meta generation when consumers intentionally update specific fields
+	 * and omit the content update.
+	 */
+	if ( ! isset( $post->post_content ) ) {
+		return $post;
+	}
+
+	$attributes = array();
+
+	$ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks  = json_decode( $ignored_hooked_blocks, true );
+		$attributes['metadata'] = array(
+			'ignoredHookedBlocks' => $ignored_hooked_blocks,
+		);
+	}
+
+	if ( 'wp_navigation' === $post->post_type ) {
+		$wrapper_block_type = 'core/navigation';
+	} else {
+		$wrapper_block_type = 'core/post-content';
+	}
+
+	$markup = get_comment_delimited_block_content(
+		$wrapper_block_type,
+		$attributes,
+		$post->post_content
+	);
+
+	$existing_post = get_post( $post->ID );
+	// Merge the existing post object with the updated post object to pass to the block hooks algorithm for context.
+	$context          = (object) array_merge( (array) $existing_post, (array) $post );
+	$serialized_block = apply_block_hooks_to_content( $markup, $context, 'set_ignored_hooked_blocks_metadata' );
+	$root_block       = parse_blocks( $serialized_block )[0];
+
+	$ignored_hooked_blocks = isset( $root_block['attrs']['metadata']['ignoredHookedBlocks'] )
+		? $root_block['attrs']['metadata']['ignoredHookedBlocks']
+		: array();
+
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$existing_ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );
+		if ( ! empty( $existing_ignored_hooked_blocks ) ) {
+			$existing_ignored_hooked_blocks = json_decode( $existing_ignored_hooked_blocks, true );
+			$ignored_hooked_blocks          = array_unique( array_merge( $ignored_hooked_blocks, $existing_ignored_hooked_blocks ) );
+		}
+
+		if ( ! isset( $post->meta_input ) ) {
+			$post->meta_input = array();
+		}
+		$post->meta_input['_wp_ignored_hooked_blocks'] = json_encode( $ignored_hooked_blocks );
+	}
+
+	$post->post_content = remove_serialized_parent_block( $serialized_block );
+	return $post;
+}
+add_filter( 'rest_pre_insert_page', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
+add_filter( 'rest_pre_insert_post', 'gutenberg_update_ignored_hooked_blocks_postmeta' );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -248,6 +248,13 @@ function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
 		return $post;
 	}
 
+	/*
+	 * Skip meta generation if post type is not set.
+	 */
+	if ( ! isset( $post->post_type ) ) {
+		return $post;
+	}
+
 	$attributes = array();
 
 	$ignored_hooked_blocks = get_post_meta( $post->ID, '_wp_ignored_hooked_blocks', true );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -225,7 +225,7 @@ add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_respo
  * where the inner blocks are stored as post content.
  *
  * @since 6.6.0
- * @since 6.8.0 Support non-`wp_navigation` post types.
+ * @since 6.8.0 Support other post types. (Previously, it was limited to `wp_navigation` only.)
  * @access private
  *
  * @param stdClass $post Post object.

--- a/packages/block-library/src/post-content/index.php
+++ b/packages/block-library/src/post-content/index.php
@@ -46,11 +46,19 @@ function render_block_core_post_content( $attributes, $content, $block ) {
 		$content .= wp_link_pages( array( 'echo' => 0 ) );
 	}
 
+	$ignored_hooked_blocks = get_post_meta( $post_id, '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks  = json_decode( $ignored_hooked_blocks, true );
+		$attributes['metadata'] = array(
+			'ignoredHookedBlocks' => $ignored_hooked_blocks,
+		);
+	}
+
 	// Wrap in Post Content block so the Block Hooks algorithm can insert blocks
 	// that are hooked as first or last child of `core/post-content`.
 	$content = get_comment_delimited_block_content(
 		'core/post-content',
-		$attributes, // TODO: Merge ignoredHookedBlocks from post meta.
+		$attributes,
 		$content
 	);
 


### PR DESCRIPTION
## What?
Apply Block Hooks to post content -- i.e., insert hooked blocks into post content.

## Why?
We've seen some demand for this. A typical example would be a plugin that provides blocks that can be used in posts and that would like to provide extensibility for those blocks.

## How?

It works the same way as in templates:
- If a post is loaded on the frontend, Block Hooks will be applied to the post content, thus inserting hooked blocks.
- If it is loaded in the editor, the Posts endpoint will inject both the hooked blocks, and the `ignoredHookedBlocks` metadata (into anchor blocks).
- This means that if the post is modified in the editor -- including moving or deleting of hooked blocks -- it will have that `ignoredHookedBlocks` metadata on individual anchor blocks persisted when saving.
- Thus, when loading the post again on the frontend, no hooked blocks will be inserted next to anchor blocks that list them in their `ignoredHookedBlocks`. OTOH, any hooked blocks that were present when saving the post have now simply become part of the markup.

## Testing Instructions, Part One

Start by installing the following plugin, but **do not activate it yet**:

<details>
<summary>Plugin code</summary>

```php
<?php
/**
 * Plugin Name:       Insert Separator blocks Before Headings.
 * Description:       Block Hooks demo plugin that inserts Separator blocks before Heading blocks.
 * Version:           0.1.0
 * Requires at least: 6.7
 */

defined( 'ABSPATH' ) || exit;

function insert_separators_before_headings( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( ! $context instanceof WP_Post ) {
		return $hooked_blocks;
	}

	if (
		( $anchor_block === 'core/heading' && $position === 'before' ) ||
		( $anchor_block === 'core/post-content' && $position === 'last_child' )
	) {
		$hooked_blocks[] = 'core/separator';
	}

	return $hooked_blocks;
}
add_filter( 'hooked_block_types', 'insert_separators_before_headings', 10, 4 );

function set_separator_block_inner_html( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) {
	if (
		( $anchor_block['blockName'] === 'core/heading' && 'before' === $relative_position ) ||
		( $anchor_block['blockName'] === 'core/post-content' && 'last_child' === $relative_position )
	) {
        $hooked_block['innerContent'] = array( '<hr class="wp-block-separator has-alpha-channel-opacity"/>' );
	}

	return $hooked_block;
}
add_filter( 'hooked_block_core/separator', 'set_separator_block_inner_html', 10, 4 );
```
</details>

- Create a new post that contains a number of headings and paragraphs.
- Save that post, and view it on the frontend. Keep it open in a tab.
- Activate the plugin.
- Go back to the tab with the post (on the frontend). Reload.
- Verify that before each heading, a separator (i.e. a horizontal line) has been inserted.
- Also verify that another separator has been inserted as the post content block's last child block (i.e. after the last paragraph block). _Note that this isn't reflected in the below screencast, as the relevant code was added to the example plugin after the screencast was made._
- Open the post in the editor, and verify that the separators are also present there.
- Modify the separators -- e.g. move one of them around and delete another. Save the post again.
- Reload it on the frontend again. Verify that the changes you made in the editor are respected.

## Screenshots or screencast

![block-hooks-post-content](https://github.com/user-attachments/assets/d52fd019-00d1-4c39-a3fb-176521ac4f17)

## Testing Instructions, Part Two

_Edit: The behavior covered by the following testing instructions changed after I wrote them, as @gziolo noticed [here](https://github.com/WordPress/gutenberg/pull/67272#issuecomment-2536039160). We ended up deciding that the new behavior -- where hooked blocks would _not_ be inserted if the anchor block was added after the post was added [might be preferable](https://github.com/WordPress/gutenberg/pull/67272#issuecomment-2539029074)._

- ~Now edit the post, and insert another heading at the bottom. _Note that no separator is inserted at the client side "right away"_ -- the reason is that Block Hooks are almost exclusively handled on the server side. This is one minor UX inconsistency -- the same inconsistency is present in templates.~
- ~Save the post, and reload it on the frontend. Note that a separator has now been inserted before the newly added heading!~ ✨
- ~Finally, reload the post in the editor. Note that the separator is now also present there.~

## Screenshots or screencast, Part Two

![block-hooks-post-content-additonal-block](https://github.com/user-attachments/assets/45700aa9-7b62-41ea-becd-6f13675e4ccf)
