### PR TITLE
Cover Block: Image size option for featured image

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -120,7 +120,9 @@ function CoverEdit( {
 			select( coreStore ).getMedia( featuredImage, { context: 'view' } ),
 		[ featuredImage ]
 	);
-	const mediaUrl = media?.source_url;
+	const mediaUrl =
+		media?.media_details?.sizes?.[ sizeSlug ]?.source_url ??
+		media?.source_url;
 
 	// User can change the featured image outside of the block, but we still
 	// need to update the block when that happens. This effect should only
@@ -451,6 +453,7 @@ function CoverEdit( {
 			toggleUseFeaturedImage={ toggleUseFeaturedImage }
 			updateDimRatio={ onUpdateDimRatio }
 			onClearMedia={ onClearMedia }
+			featuredImage={ media }
 		/>
 	);
 

--- a/packages/block-library/src/cover/edit/inspector-controls.js
+++ b/packages/block-library/src/cover/edit/inspector-controls.js
@@ -96,6 +96,7 @@ export default function CoverInspectorControls( {
 	coverRef,
 	currentSettings,
 	updateDimRatio,
+	featuredImage,
 } ) {
 	const {
 		useFeaturedImage,
@@ -132,8 +133,12 @@ export default function CoverInspectorControls( {
 		[ id, isImageBackground ]
 	);
 
+	const currentBackgroundImage = useFeaturedImage ? featuredImage : image;
+
 	function updateImage( newSizeSlug ) {
-		const newUrl = image?.media_details?.sizes?.[ newSizeSlug ]?.source_url;
+		const newUrl =
+			currentBackgroundImage?.media_details?.sizes?.[ newSizeSlug ]
+				?.source_url;
 		if ( ! newUrl ) {
 			return null;
 		}
@@ -146,7 +151,9 @@ export default function CoverInspectorControls( {
 
 	const imageSizeOptions = imageSizes
 		?.filter(
-			( { slug } ) => image?.media_details?.sizes?.[ slug ]?.source_url
+			( { slug } ) =>
+				currentBackgroundImage?.media_details?.sizes?.[ slug ]
+					?.source_url
 		)
 		?.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
 
@@ -321,7 +328,7 @@ export default function CoverInspectorControls( {
 								/>
 							</ToolsPanelItem>
 						) }
-						{ ! useFeaturedImage && !! imageSizeOptions?.length && (
+						{ !! imageSizeOptions?.length && (
 							<ResolutionTool
 								value={ sizeSlug }
 								onChange={ updateImage }

--- a/packages/block-library/src/cover/index.php
+++ b/packages/block-library/src/cover/index.php
@@ -35,12 +35,12 @@ function render_block_core_cover( $attributes, $content ) {
 			$attr['style']                = 'object-position:' . $object_position . ';';
 		}
 
-		$image = get_the_post_thumbnail( null, 'post-thumbnail', $attr );
+		$image = get_the_post_thumbnail( null, $attributes['sizeSlug'] ?? 'post-thumbnail', $attr );
 	} else {
 		if ( in_the_loop() ) {
 			update_post_thumbnail_cache();
 		}
-		$current_featured_image = get_the_post_thumbnail_url();
+		$current_featured_image = get_the_post_thumbnail_url( null, $attributes['sizeSlug'] ?? null );
 		if ( ! $current_featured_image ) {
 			return $content;
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Implement resolution size support for the featured image in the cover block, as originally discussed in https://github.com/WordPress/gutenberg/pull/62926#issuecomment-2496828923

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
When the featured image is set as the background in the cover block, the `ResolutionTool` is not currently available. The same is true for other media blocks (such as the featured image block), but we will only focus on the cover block in this PR.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR implement `ResolutionTool` support for featured image.

## Testing Instructions
 1. Add cover block
 2. Select `Use Featured Image` option from toolbar of cover block
 3. Look for `Resolution` dropdown in cover block controls
 4. Select different size in Resolution dropdown, Notice the change of image size in editor and on front-end
 5. Update featured image from post setting sidebar, and make sure cover background get updated in editor and on front-end with same resolution that was previously selected.

## Screenshots or screencast <!-- if applicable -->

[Edit-Post-“Hello-world-”-‹-gutenberg-—-WordPress.webm](https://github.com/user-attachments/assets/d5a3bf96-c055-4eb8-9ce5-30a199375d06)
