### PR TITLE
Add: Media field changing ui to Dataviews and content preview field to posts and pages

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -1,7 +1,8 @@
 /**
  * External dependencies
  */
-import type { ChangeEvent } from 'react';
+import type { ChangeEvent, ReactNode } from 'react';
+import clsx from 'clsx';
 
 /**
  * WordPress dependencies
@@ -26,7 +27,7 @@ import {
 	Icon,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
-import { memo, useContext, useMemo } from '@wordpress/element';
+import { memo, useContext, useMemo, useState } from '@wordpress/element';
 import {
 	chevronDown,
 	chevronUp,
@@ -34,6 +35,7 @@ import {
 	seen,
 	unseen,
 	lock,
+	moreVertical,
 } from '@wordpress/icons';
 import warning from '@wordpress/warning';
 import { useInstanceId } from '@wordpress/compose';
@@ -253,24 +255,34 @@ function ItemsPerPageControl() {
 	);
 }
 
-function FieldItem( {
-	field,
+function BaseFieldItem( {
+	fieldId,
+	label,
+	subLabel,
 	isVisible,
 	isFirst,
 	isLast,
 	canMove = true,
+	canHide = true,
+	isInteracting = false,
 	onToggleVisibility,
 	onMoveUp,
 	onMoveDown,
+	additionalActions,
 }: {
-	field: NormalizedField< any >;
+	fieldId: string;
+	label: string;
+	subLabel?: string;
 	isVisible: boolean;
 	isFirst?: boolean;
 	isLast?: boolean;
 	canMove?: boolean;
+	canHide?: boolean;
+	isInteracting?: boolean;
 	onToggleVisibility?: () => void;
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
+	additionalActions?: ReactNode;
 } ) {
 	const focusVisibilityField = () => {
 		// Focus the visibility button to avoid focus loss.
@@ -278,7 +290,7 @@ function FieldItem( {
 		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
 		setTimeout( () => {
 			const element = document.querySelector(
-				`.dataviews-field-control__field-${ field.id } .dataviews-field-control__field-visibility-button`
+				`.dataviews-field-control__field-${ fieldId } .dataviews-field-control__field-visibility-button`
 			);
 			if ( element instanceof HTMLElement ) {
 				element.focus();
@@ -290,16 +302,25 @@ function FieldItem( {
 		<Item>
 			<HStack
 				expanded
-				className={ `dataviews-field-control__field dataviews-field-control__field-${ field.id }` }
+				className={ clsx(
+					'dataviews-field-control__field',
+					`dataviews-field-control__field-${ fieldId }`,
+					{ 'is-interacting': isInteracting }
+				) }
 				justify="flex-start"
 			>
 				<span className="dataviews-field-control__icon">
-					{ ! canMove && ! field.enableHiding && (
-						<Icon icon={ lock } />
-					) }
+					{ ! canMove && ! canHide && <Icon icon={ lock } /> }
 				</span>
+				<span className="dataviews-field-control__label-sub-label-container">
 				<span className="dataviews-field-control__label">
-					{ field.label }
+						{ label }
+					</span>
+					{ subLabel && (
+						<span className="dataviews-field-control__sub-label">
+							{ subLabel }
+						</span>
+					) }
 				</span>
 				<HStack
 					justify="flex-end"
@@ -320,7 +341,7 @@ function FieldItem( {
 										: sprintf(
 												/* translators: %s: field label */
 												__( 'Move %s up' ),
-												field.label
+												label
 										  )
 								}
 							/>
@@ -336,7 +357,7 @@ function FieldItem( {
 										: sprintf(
 												/* translators: %s: field label */
 												__( 'Move %s down' ),
-												field.label
+												label
 										  )
 								}
 							/>
@@ -345,7 +366,7 @@ function FieldItem( {
 					{ onToggleVisibility && (
 						<Button
 							className="dataviews-field-control__field-visibility-button"
-							disabled={ ! field.enableHiding }
+							disabled={ ! canHide }
 							accessibleWhenDisabled
 							size="compact"
 							onClick={ () => {
@@ -358,19 +379,55 @@ function FieldItem( {
 									? sprintf(
 											/* translators: %s: field label */
 											_x( 'Hide %s', 'field' ),
-											field.label
+											label
 									  )
 									: sprintf(
 											/* translators: %s: field label */
 											_x( 'Show %s', 'field' ),
-											field.label
+											label
 									  )
 							}
 						/>
 					) }
+					{ additionalActions }
 				</HStack>
 			</HStack>
 		</Item>
+	);
+}
+
+function FieldItem( {
+	field,
+	isVisible,
+	isFirst,
+	isLast,
+	canMove = true,
+	onToggleVisibility,
+	onMoveUp,
+	onMoveDown,
+}: {
+	field: NormalizedField< any >;
+	isVisible: boolean;
+	isFirst?: boolean;
+	isLast?: boolean;
+	canMove?: boolean;
+	onToggleVisibility?: () => void;
+	onMoveUp?: () => void;
+	onMoveDown?: () => void;
+} ) {
+	return (
+		<BaseFieldItem
+			fieldId={ field.id }
+			label={ field.label }
+			isVisible={ isVisible }
+			isFirst={ isFirst }
+			isLast={ isLast }
+			canMove={ canMove }
+			canHide={ field.enableHiding }
+			onToggleVisibility={ onToggleVisibility }
+			onMoveUp={ onMoveUp }
+			onMoveDown={ onMoveDown }
+		/>
 	);
 }
 
@@ -445,6 +502,77 @@ function RegularFieldItem( {
 	);
 }
 
+function MediaFieldItem( {
+	view,
+	onChangeView,
+	isVisible = true,
+	mediaFields,
+	activeField,
+}: {
+	view: View;
+	onChangeView: ( view: View ) => void;
+	isVisible?: boolean;
+	mediaFields: NormalizedField< any >[];
+	activeField: NormalizedField< any > | undefined;
+} ) {
+	const [ isChangingPreview, setIsChangingPreview ] =
+		useState< boolean >( false );
+	if ( ! activeField ) {
+		return null;
+	}
+	return (
+		<BaseFieldItem
+			fieldId="preview"
+			label={ __( 'Preview' ) }
+			subLabel={ activeField.label }
+			isVisible={ isVisible }
+			onToggleVisibility={ () => {
+				onChangeView( {
+					...view,
+					showMedia: ! isVisible,
+				} );
+			} }
+			canMove={ false }
+			canHide
+			isInteracting={ isChangingPreview }
+			additionalActions={
+				isVisible && (
+					<Menu
+						trigger={
+							<Button
+								size="compact"
+								icon={ moreVertical }
+								label={ __( 'Preview' ) }
+							/>
+						}
+						onOpenChange={ setIsChangingPreview }
+					>
+						{ mediaFields.map( ( field ) => {
+							return (
+								<Menu.RadioItem
+									key={ field.id }
+									value={ field.id }
+									checked={ field.id === view.mediaField }
+									onChange={ () => {
+										onChangeView( {
+											...view,
+											mediaField: field.id,
+										} );
+									} }
+								>
+									<Menu.ItemLabel>
+										{ field.label }
+									</Menu.ItemLabel>
+								</Menu.RadioItem>
+							);
+						} ) }
+					</Menu>
+				)
+			}
+		/>
+	);
+}
+
 function isDefined< T >( item: T | undefined ): item is T {
 	return !! item;
 }
@@ -461,7 +589,8 @@ function FieldControl() {
 	const hiddenFields = fields.filter(
 		( f ) =>
 			! visibleFieldIds.includes( f.id ) &&
-			! togglableFields.includes( f.id )
+			! togglableFields.includes( f.id ) &&
+			! f.isMediaField
 	);
 	const visibleFields = visibleFieldIds
 		.map( ( fieldId ) => fields.find( ( f ) => f.id === fieldId ) )
@@ -475,6 +604,23 @@ function FieldControl() {
 	const descriptionField = fields.find(
 		( f ) => f.id === view.descriptionField
 	);
+
+	const mediaFields = fields.filter( ( f ) => f.isMediaField );
+
+	let mediaFieldUI;
+	if ( mediaFields.length > 1 ) {
+		const isMediaFieldVisible =
+			isDefined( mediaField ) && ( view.showMedia ?? true );
+		mediaFieldUI = (
+			<MediaFieldItem
+				view={ view }
+				onChangeView={ onChangeView }
+				isVisible={ isMediaFieldVisible }
+				mediaFields={ mediaFields }
+				activeField={ mediaField }
+			/>
+		);
+	}
 	const lockedFields = [
 		{
 			field: titleField,
@@ -483,6 +629,7 @@ function FieldControl() {
 		{
 			field: mediaField,
 			isVisibleFlag: 'showMedia',
+			ui: mediaFieldUI,
 		},
 		{
 			field: descriptionField,
@@ -493,12 +640,20 @@ function FieldControl() {
 		( { field, isVisibleFlag } ) =>
 			// @ts-expect-error
 			isDefined( field ) && ( view[ isVisibleFlag ] ?? true )
-	) as Array< { field: NormalizedField< any >; isVisibleFlag: string } >;
+	) as Array< {
+		field: NormalizedField< any >;
+		isVisibleFlag: string;
+		ui?: ReactNode;
+	} >;
 	const hiddenLockedFields = lockedFields.filter(
 		( { field, isVisibleFlag } ) =>
 			// @ts-expect-error
 			isDefined( field ) && ! ( view[ isVisibleFlag ] ?? true )
-	) as Array< { field: NormalizedField< any >; isVisibleFlag: string } >;
+	) as Array< {
+		field: NormalizedField< any >;
+		isVisibleFlag: string;
+		ui?: ReactNode;
+	} >;
 
 	return (
 		<VStack className="dataviews-field-control" spacing={ 6 }>
@@ -507,8 +662,9 @@ function FieldControl() {
 					!! visibleFields?.length ) && (
 					<ItemGroup isBordered isSeparated>
 						{ visibleLockedFields.map(
-							( { field, isVisibleFlag } ) => {
+							( { field, isVisibleFlag, ui } ) => {
 								return (
+									ui ?? (
 									<FieldItem
 										key={ field.id }
 										field={ field }
@@ -521,6 +677,7 @@ function FieldControl() {
 										} }
 										canMove={ false }
 									/>
+									)
 								);
 							}
 						) }
@@ -550,8 +707,9 @@ function FieldControl() {
 						<ItemGroup isBordered isSeparated>
 							{ hiddenLockedFields.length > 0 &&
 								hiddenLockedFields.map(
-									( { field, isVisibleFlag } ) => {
+									( { field, isVisibleFlag, ui } ) => {
 										return (
+											ui ?? (
 											<FieldItem
 												key={ field.id }
 												field={ field }
@@ -559,11 +717,13 @@ function FieldControl() {
 												onToggleVisibility={ () => {
 													onChangeView( {
 														...view,
-														[ isVisibleFlag ]: true,
+															[ isVisibleFlag ]:
+																true,
 													} );
 												} }
 												canMove={ false }
 											/>
+											)
 										);
 									}
 								) }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -256,9 +256,9 @@ function ItemsPerPageControl() {
 }
 
 function BaseFieldItem( {
-	fieldId,
+	identifier,
 	label,
-	subLabel,
+	description,
 	isVisible,
 	isFirst,
 	isLast,
@@ -270,9 +270,9 @@ function BaseFieldItem( {
 	onMoveDown,
 	additionalActions,
 }: {
-	fieldId: string;
+	identifier: string;
 	label: string;
-	subLabel?: string;
+	description?: string;
 	isVisible: boolean;
 	isFirst?: boolean;
 	isLast?: boolean;
@@ -290,7 +290,7 @@ function BaseFieldItem( {
 		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
 		setTimeout( () => {
 			const element = document.querySelector(
-				`.dataviews-field-control__field-${ fieldId } .dataviews-field-control__field-visibility-button`
+				`.dataviews-field-control__field-${ identifier } .dataviews-field-control__field-visibility-button`
 			);
 			if ( element instanceof HTMLElement ) {
 				element.focus();
@@ -316,9 +316,9 @@ function BaseFieldItem( {
 				<span className="dataviews-field-control__label">
 						{ label }
 					</span>
-					{ subLabel && (
+					{ description && (
 						<span className="dataviews-field-control__sub-label">
-							{ subLabel }
+							{ description }
 						</span>
 					) }
 				</span>
@@ -417,7 +417,7 @@ function FieldItem( {
 } ) {
 	return (
 		<BaseFieldItem
-			fieldId={ field.id }
+			identifier={ field.id }
 			label={ field.label }
 			isVisible={ isVisible }
 			isFirst={ isFirst }
@@ -502,17 +502,17 @@ function RegularFieldItem( {
 	);
 }
 
-function MediaFieldItem( {
+function PreviewFieldItem( {
 	view,
 	onChangeView,
 	isVisible = true,
-	mediaFields,
+	previewFields,
 	activeField,
 }: {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	isVisible?: boolean;
-	mediaFields: NormalizedField< any >[];
+	previewFields: NormalizedField< any >[];
 	activeField: NormalizedField< any > | undefined;
 } ) {
 	const [ isChangingPreview, setIsChangingPreview ] =
@@ -522,9 +522,9 @@ function MediaFieldItem( {
 	}
 	return (
 		<BaseFieldItem
-			fieldId="preview"
+			identifier="preview"
 			label={ __( 'Preview' ) }
-			subLabel={ activeField.label }
+			description={ activeField.label }
 			isVisible={ isVisible }
 			onToggleVisibility={ () => {
 				onChangeView( {
@@ -548,7 +548,7 @@ function MediaFieldItem( {
 						}
 						/>
 						<Menu.Popover>
-						{ mediaFields.map( ( field ) => {
+							{ previewFields.map( ( field ) => {
 							return (
 								<Menu.RadioItem
 									key={ field.id }
@@ -592,7 +592,7 @@ function FieldControl() {
 		( f ) =>
 			! visibleFieldIds.includes( f.id ) &&
 			! togglableFields.includes( f.id ) &&
-			! f.isMediaField
+			! f.isPreviewField
 	);
 	const visibleFields = visibleFieldIds
 		.map( ( fieldId ) => fields.find( ( f ) => f.id === fieldId ) )
@@ -602,24 +602,24 @@ function FieldControl() {
 		return null;
 	}
 	const titleField = fields.find( ( f ) => f.id === view.titleField );
-	const mediaField = fields.find( ( f ) => f.id === view.mediaField );
+	const previewField = fields.find( ( f ) => f.id === view.mediaField );
 	const descriptionField = fields.find(
 		( f ) => f.id === view.descriptionField
 	);
 
-	const mediaFields = fields.filter( ( f ) => f.isMediaField );
+	const previewFields = fields.filter( ( f ) => f.isPreviewField );
 
-	let mediaFieldUI;
-	if ( mediaFields.length > 1 ) {
-		const isMediaFieldVisible =
-			isDefined( mediaField ) && ( view.showMedia ?? true );
-		mediaFieldUI = (
-			<MediaFieldItem
+	let previewFieldUI;
+	if ( previewFields.length > 1 ) {
+		const isPreviewFieldVisible =
+			isDefined( previewField ) && ( view.showMedia ?? true );
+		previewFieldUI = (
+			<PreviewFieldItem
 				view={ view }
 				onChangeView={ onChangeView }
-				isVisible={ isMediaFieldVisible }
-				mediaFields={ mediaFields }
-				activeField={ mediaField }
+				isVisible={ isPreviewFieldVisible }
+				previewFields={ previewFields }
+				activeField={ previewField }
 			/>
 		);
 	}
@@ -629,9 +629,9 @@ function FieldControl() {
 			isVisibleFlag: 'showTitle',
 		},
 		{
-			field: mediaField,
+			field: previewField,
 			isVisibleFlag: 'showMedia',
-			ui: mediaFieldUI,
+			ui: previewFieldUI,
 		},
 		{
 			field: descriptionField,

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -268,7 +268,7 @@ function BaseFieldItem( {
 	onToggleVisibility,
 	onMoveUp,
 	onMoveDown,
-	additionalActions,
+	children,
 }: {
 	identifier: string;
 	label: string;
@@ -282,7 +282,7 @@ function BaseFieldItem( {
 	onToggleVisibility?: () => void;
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
-	additionalActions?: ReactNode;
+	children?: ReactNode;
 } ) {
 	const focusVisibilityField = () => {
 		// Focus the visibility button to avoid focus loss.
@@ -395,7 +395,7 @@ function BaseFieldItem( {
 							}
 						/>
 					) }
-					{ additionalActions }
+					{ children }
 				</HStack>
 			</HStack>
 		</Item>
@@ -541,8 +541,8 @@ function PreviewFieldItem( {
 			canMove={ false }
 			canHide
 			isInteracting={ isChangingPreview }
-			additionalActions={
-				isVisible && (
+		>
+			{ isVisible && (
 					<Menu onOpenChange={ setIsChangingPreview }>
 						<Menu.TriggerButton
 							render={
@@ -575,9 +575,8 @@ function PreviewFieldItem( {
 						} ) }
 						</Menu.Popover>
 					</Menu>
-				)
-			}
-		/>
+			) }
+		</BaseFieldItem>
 	);
 }
 

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -255,42 +255,84 @@ function ItemsPerPageControl() {
 	);
 }
 
-function BaseFieldItem( {
-	identifier,
+function PreviewOptions( {
+	previewOptions,
+	onChangePreviewOption,
+	onMenuOpenChange,
+	activeOption,
+}: {
+	previewOptions?: Array< { label: string; id: string } >;
+	onChangePreviewOption?: ( newPreviewOption: string ) => void;
+	onMenuOpenChange: ( isOpen: boolean ) => void;
+	activeOption?: string;
+} ) {
+	return (
+		<Menu onOpenChange={ onMenuOpenChange }>
+			<Menu.TriggerButton
+				render={
+					<Button
+						size="compact"
+						icon={ moreVertical }
+						label={ __( 'Preview' ) }
+					/>
+				}
+			/>
+			<Menu.Popover>
+				{ previewOptions?.map( ( { id, label } ) => {
+					return (
+						<Menu.RadioItem
+							key={ id }
+							value={ id }
+							checked={ id === activeOption }
+							onChange={ () => {
+								onChangePreviewOption?.( id );
+							} }
+						>
+							<Menu.ItemLabel>{ label }</Menu.ItemLabel>
+						</Menu.RadioItem>
+					);
+				} ) }
+			</Menu.Popover>
+		</Menu>
+	);
+}
+function FieldItem( {
+	field,
 	label,
 	description,
 	isVisible,
 	isFirst,
 	isLast,
 	canMove = true,
-	canHide = true,
-	isInteracting = false,
 	onToggleVisibility,
 	onMoveUp,
 	onMoveDown,
-	children,
+	previewOptions,
+	onChangePreviewOption,
 }: {
-	identifier: string;
-	label: string;
+	field: NormalizedField< any >;
+	label?: string;
 	description?: string;
 	isVisible: boolean;
 	isFirst?: boolean;
 	isLast?: boolean;
 	canMove?: boolean;
-	canHide?: boolean;
-	isInteracting?: boolean;
 	onToggleVisibility?: () => void;
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
-	children?: ReactNode;
+	previewOptions?: Array< { label: string; id: string } >;
+	onChangePreviewOption?: ( newPreviewOption: string ) => void;
 } ) {
+	const [ isChangingPreviewOption, setIsChangingPreviewOption ] =
+		useState< boolean >( false );
+
 	const focusVisibilityField = () => {
 		// Focus the visibility button to avoid focus loss.
 		// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.
 		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
 		setTimeout( () => {
 			const element = document.querySelector(
-				`.dataviews-field-control__field-${ identifier } .dataviews-field-control__field-visibility-button`
+				`.dataviews-field-control__field-${ field.id } .dataviews-field-control__field-visibility-button`
 			);
 			if ( element instanceof HTMLElement ) {
 				element.focus();
@@ -304,23 +346,25 @@ function BaseFieldItem( {
 				expanded
 				className={ clsx(
 					'dataviews-field-control__field',
-					`dataviews-field-control__field-${ identifier }`,
+					`dataviews-field-control__field-${ field.id }`,
 					// The actions are hidden when the mouse is not hovering the item, or focus
 					// is outside the item.
 					// For actions that require a popover, a menu etc, that would mean that when the interactive element
 					// opens and the focus goes there the actions would be hidden.
 					// To avoid that we add a class to the item, that makes sure actions are visible while there is some
 					// interaction with the item.
-					{ 'is-interacting': isInteracting }
+					{ 'is-interacting': isChangingPreviewOption }
 				) }
 				justify="flex-start"
 			>
 				<span className="dataviews-field-control__icon">
-					{ ! canMove && ! canHide && <Icon icon={ lock } /> }
+					{ ! canMove && ! field.enableHiding && (
+						<Icon icon={ lock } />
+					) }
 				</span>
 				<span className="dataviews-field-control__label-sub-label-container">
 					<span className="dataviews-field-control__label">
-						{ label }
+						{ label || field.label }
 					</span>
 					{ description && (
 						<span className="dataviews-field-control__sub-label">
@@ -347,7 +391,7 @@ function BaseFieldItem( {
 										: sprintf(
 												/* translators: %s: field label */
 												__( 'Move %s up' ),
-												label
+												field.label
 										  )
 								}
 							/>
@@ -363,7 +407,7 @@ function BaseFieldItem( {
 										: sprintf(
 												/* translators: %s: field label */
 												__( 'Move %s down' ),
-												label
+												field.label
 										  )
 								}
 							/>
@@ -372,7 +416,7 @@ function BaseFieldItem( {
 					{ onToggleVisibility && (
 						<Button
 							className="dataviews-field-control__field-visibility-button"
-							disabled={ ! canHide }
+							disabled={ ! field.enableHiding }
 							accessibleWhenDisabled
 							size="compact"
 							onClick={ () => {
@@ -385,55 +429,27 @@ function BaseFieldItem( {
 									? sprintf(
 											/* translators: %s: field label */
 											_x( 'Hide %s', 'field' ),
-											label
+											field.label
 									  )
 									: sprintf(
 											/* translators: %s: field label */
 											_x( 'Show %s', 'field' ),
-											label
+											field.label
 									  )
 							}
 						/>
 					) }
-					{ children }
+					{ previewOptions && (
+						<PreviewOptions
+							previewOptions={ previewOptions }
+							onChangePreviewOption={ onChangePreviewOption }
+							onMenuOpenChange={ setIsChangingPreviewOption }
+							activeOption={ field.id }
+						/>
+					) }
 				</HStack>
 			</HStack>
 		</Item>
-	);
-}
-
-function FieldItem( {
-	field,
-	isVisible,
-	isFirst,
-	isLast,
-	canMove = true,
-	onToggleVisibility,
-	onMoveUp,
-	onMoveDown,
-}: {
-	field: NormalizedField< any >;
-	isVisible: boolean;
-	isFirst?: boolean;
-	isLast?: boolean;
-	canMove?: boolean;
-	onToggleVisibility?: () => void;
-	onMoveUp?: () => void;
-	onMoveDown?: () => void;
-} ) {
-	return (
-		<BaseFieldItem
-			identifier={ field.id }
-			label={ field.label }
-			isVisible={ isVisible }
-			isFirst={ isFirst }
-			isLast={ isLast }
-			canMove={ canMove }
-			canHide={ field.enableHiding }
-			onToggleVisibility={ onToggleVisibility }
-			onMoveUp={ onMoveUp }
-			onMoveDown={ onMoveDown }
-		/>
 	);
 }
 
@@ -508,78 +524,6 @@ function RegularFieldItem( {
 	);
 }
 
-function PreviewFieldItem( {
-	view,
-	onChangeView,
-	isVisible = true,
-	previewFields,
-	activeField,
-}: {
-	view: View;
-	onChangeView: ( view: View ) => void;
-	isVisible?: boolean;
-	previewFields: NormalizedField< any >[];
-	activeField: NormalizedField< any > | undefined;
-} ) {
-	const [ isChangingPreview, setIsChangingPreview ] =
-		useState< boolean >( false );
-	if ( ! activeField ) {
-		return null;
-	}
-	return (
-		<BaseFieldItem
-			identifier="preview"
-			label={ __( 'Preview' ) }
-			description={ activeField.label }
-			isVisible={ isVisible }
-			onToggleVisibility={ () => {
-				onChangeView( {
-					...view,
-					showMedia: ! isVisible,
-				} );
-			} }
-			canMove={ false }
-			canHide
-			isInteracting={ isChangingPreview }
-		>
-			{ isVisible && (
-				<Menu onOpenChange={ setIsChangingPreview }>
-					<Menu.TriggerButton
-						render={
-							<Button
-								size="compact"
-								icon={ moreVertical }
-								label={ __( 'Preview' ) }
-							/>
-						}
-					/>
-					<Menu.Popover>
-						{ previewFields.map( ( field ) => {
-							return (
-								<Menu.RadioItem
-									key={ field.id }
-									value={ field.id }
-									checked={ field.id === view.mediaField }
-									onChange={ () => {
-										onChangeView( {
-											...view,
-											mediaField: field.id,
-										} );
-									} }
-								>
-									<Menu.ItemLabel>
-										{ field.label }
-									</Menu.ItemLabel>
-								</Menu.RadioItem>
-							);
-						} ) }
-					</Menu.Popover>
-				</Menu>
-			) }
-		</BaseFieldItem>
-	);
-}
-
 function isDefined< T >( item: T | undefined ): item is T {
 	return !! item;
 }
@@ -618,13 +562,27 @@ function FieldControl() {
 	if ( previewFields.length > 1 ) {
 		const isPreviewFieldVisible =
 			isDefined( previewField ) && ( view.showMedia ?? true );
-		previewFieldUI = (
-			<PreviewFieldItem
-				view={ view }
-				onChangeView={ onChangeView }
+		previewFieldUI = isDefined( previewField ) && (
+			<FieldItem
+				key={ previewField.id }
+				field={ previewField }
+				label={ __( 'Preview' ) }
+				description={ previewField.label }
 				isVisible={ isPreviewFieldVisible }
-				previewFields={ previewFields }
-				activeField={ previewField }
+				onToggleVisibility={ () => {
+					onChangeView( {
+						...view,
+						showMedia: ! isPreviewFieldVisible,
+					} );
+				} }
+				canMove={ false }
+				previewOptions={ previewFields.map( ( field ) => ( {
+					label: field.label,
+					id: field.id,
+				} ) ) }
+				onChangePreviewOption={ ( newPreviewId ) =>
+					onChangeView( { ...view, mediaField: newPreviewId } )
+				}
 			/>
 		);
 	}

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -304,7 +304,13 @@ function BaseFieldItem( {
 				expanded
 				className={ clsx(
 					'dataviews-field-control__field',
-					`dataviews-field-control__field-${ fieldId }`,
+					`dataviews-field-control__field-${ identifier }`,
+					// The actions are hidden when the mouse is not hovering the item, or focus
+					// is outside the item.
+					// For actions that require a popover, a menu etc, that would mean that when the interactive element
+					// opens and the focus goes there the actions would be hidden.
+					// To avoid that we add a class to the item, that makes sure actions are visible while there is some
+					// interaction with the item.
 					{ 'is-interacting': isInteracting }
 				) }
 				justify="flex-start"

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -266,11 +266,25 @@ function PreviewOptions( {
 	onMenuOpenChange: ( isOpen: boolean ) => void;
 	activeOption?: string;
 } ) {
+	const focusPreviewOptionsField = ( id: string ) => {
+		// Focus the visibility button to avoid focus loss.
+		// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.
+		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
+		setTimeout( () => {
+			const element = document.querySelector(
+				`.dataviews-field-control__field-${ id } .dataviews-field-control__field-preview-options-button`
+			);
+			if ( element instanceof HTMLElement ) {
+				element.focus();
+			}
+		}, 50 );
+	};
 	return (
 		<Menu onOpenChange={ onMenuOpenChange }>
 			<Menu.TriggerButton
 				render={
 					<Button
+						className="dataviews-field-control__field-preview-options-button"
 						size="compact"
 						icon={ moreVertical }
 						label={ __( 'Preview' ) }
@@ -286,6 +300,7 @@ function PreviewOptions( {
 							checked={ id === activeOption }
 							onChange={ () => {
 								onChangePreviewOption?.( id );
+								focusPreviewOptionsField( id );
 							} }
 						>
 							<Menu.ItemLabel>{ label }</Menu.ItemLabel>

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -319,7 +319,7 @@ function BaseFieldItem( {
 					{ ! canMove && ! canHide && <Icon icon={ lock } /> }
 				</span>
 				<span className="dataviews-field-control__label-sub-label-container">
-				<span className="dataviews-field-control__label">
+					<span className="dataviews-field-control__label">
 						{ label }
 					</span>
 					{ description && (
@@ -543,18 +543,18 @@ function PreviewFieldItem( {
 			isInteracting={ isChangingPreview }
 		>
 			{ isVisible && (
-					<Menu onOpenChange={ setIsChangingPreview }>
-						<Menu.TriggerButton
-							render={
+				<Menu onOpenChange={ setIsChangingPreview }>
+					<Menu.TriggerButton
+						render={
 							<Button
 								size="compact"
 								icon={ moreVertical }
 								label={ __( 'Preview' ) }
 							/>
 						}
-						/>
-						<Menu.Popover>
-							{ previewFields.map( ( field ) => {
+					/>
+					<Menu.Popover>
+						{ previewFields.map( ( field ) => {
 							return (
 								<Menu.RadioItem
 									key={ field.id }
@@ -573,8 +573,8 @@ function PreviewFieldItem( {
 								</Menu.RadioItem>
 							);
 						} ) }
-						</Menu.Popover>
-					</Menu>
+					</Menu.Popover>
+				</Menu>
 			) }
 		</BaseFieldItem>
 	);
@@ -597,7 +597,7 @@ function FieldControl() {
 		( f ) =>
 			! visibleFieldIds.includes( f.id ) &&
 			! togglableFields.includes( f.id ) &&
-			! f.isPreviewField
+			f.type !== 'media'
 	);
 	const visibleFields = visibleFieldIds
 		.map( ( fieldId ) => fields.find( ( f ) => f.id === fieldId ) )
@@ -612,7 +612,7 @@ function FieldControl() {
 		( f ) => f.id === view.descriptionField
 	);
 
-	const previewFields = fields.filter( ( f ) => f.isPreviewField );
+	const previewFields = fields.filter( ( f ) => f.type === 'media' );
 
 	let previewFieldUI;
 	if ( previewFields.length > 1 ) {
@@ -672,18 +672,18 @@ function FieldControl() {
 							( { field, isVisibleFlag, ui } ) => {
 								return (
 									ui ?? (
-									<FieldItem
-										key={ field.id }
-										field={ field }
-										isVisible
-										onToggleVisibility={ () => {
-											onChangeView( {
-												...view,
-												[ isVisibleFlag ]: false,
-											} );
-										} }
-										canMove={ false }
-									/>
+										<FieldItem
+											key={ field.id }
+											field={ field }
+											isVisible
+											onToggleVisibility={ () => {
+												onChangeView( {
+													...view,
+													[ isVisibleFlag ]: false,
+												} );
+											} }
+											canMove={ false }
+										/>
 									)
 								);
 							}
@@ -717,19 +717,19 @@ function FieldControl() {
 									( { field, isVisibleFlag, ui } ) => {
 										return (
 											ui ?? (
-											<FieldItem
-												key={ field.id }
-												field={ field }
-												isVisible={ false }
-												onToggleVisibility={ () => {
-													onChangeView( {
-														...view,
+												<FieldItem
+													key={ field.id }
+													field={ field }
+													isVisible={ false }
+													onToggleVisibility={ () => {
+														onChangeView( {
+															...view,
 															[ isVisibleFlag ]:
 																true,
-													} );
-												} }
-												canMove={ false }
-											/>
+														} );
+													} }
+													canMove={ false }
+												/>
 											)
 										);
 									}

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -537,16 +537,17 @@ function MediaFieldItem( {
 			isInteracting={ isChangingPreview }
 			additionalActions={
 				isVisible && (
-					<Menu
-						trigger={
+					<Menu onOpenChange={ setIsChangingPreview }>
+						<Menu.TriggerButton
+							render={
 							<Button
 								size="compact"
 								icon={ moreVertical }
 								label={ __( 'Preview' ) }
 							/>
 						}
-						onOpenChange={ setIsChangingPreview }
-					>
+						/>
+						<Menu.Popover>
 						{ mediaFields.map( ( field ) => {
 							return (
 								<Menu.RadioItem
@@ -566,6 +567,7 @@ function MediaFieldItem( {
 								</Menu.RadioItem>
 							);
 						} ) }
+						</Menu.Popover>
 					</Menu>
 				)
 			}

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -68,7 +68,8 @@
 }
 
 .dataviews-field-control__field:hover,
-.dataviews-field-control__field:focus-within {
+.dataviews-field-control__field:focus-within,
+.dataviews-field-control__field.is-interacting {
 	.dataviews-field-control__actions {
 		position: unset;
 		top: unset;
@@ -80,6 +81,18 @@
 	width: $icon-size;
 }
 
-.dataviews-field-control__label {
+.dataviews-field-control__label-sub-label-container {
 	flex-grow: 1;
+}
+
+.dataviews-field-control__label {
+	display: block;
+}
+
+.dataviews-field-control__sub-label {
+	margin-top: $grid-unit-10;
+	margin-bottom: 0;
+	font-size: 11px;
+	font-style: normal;
+	color: $gray-700;
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -158,6 +158,11 @@ export type Field< Item > = {
 	 * Defaults to `item[ field.id ]`.
 	 */
 	getValue?: ( args: { item: Item } ) => any;
+
+	/**
+	 * True if the field is supposed to be used as a media field.
+	 */
+	isMediaField?: boolean;
 };
 
 export type NormalizedField< Item > = Field< Item > & {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -162,7 +162,7 @@ export type Field< Item > = {
 	/**
 	 * True if the field is supposed to be used as a media field.
 	 */
-	isMediaField?: boolean;
+	isPreviewField?: boolean;
 };
 
 export type NormalizedField< Item > = Field< Item > & {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -42,7 +42,7 @@ export type Operator =
 	| 'isAll'
 	| 'isNotAll';
 
-export type FieldType = 'text' | 'integer' | 'datetime';
+export type FieldType = 'text' | 'integer' | 'datetime' | 'media';
 
 export type ValidationContext = {
 	elements?: Option[];
@@ -158,11 +158,6 @@ export type Field< Item > = {
 	 * Defaults to `item[ field.id ]`.
 	 */
 	getValue?: ( args: { item: Item } ) => any;
-
-	/**
-	 * True if the field is supposed to be used as a media field.
-	 */
-	isPreviewField?: boolean;
 };
 
 export type NormalizedField< Item > = Field< Item > & {

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -379,7 +379,7 @@ _Parameters_
 -   _props.post_ `[Object]`: The post object to edit. This is required.
 -   _props.\_\_unstableTemplate_ `[Object]`: The template object wrapper the edited post. This is optional and can only be used when the post type supports templates (like posts and pages).
 -   _props.settings_ `[Object]`: The settings object to use for the editor. This is optional and can be used to override the default settings.
--   _props.children_ `[Element]`: Children elements for which the BlockEditorProvider context should apply. This is optional.
+-   _props.children_ `[React.ReactNode]`: Children elements for which the BlockEditorProvider context should apply. This is optional.
 
 _Returns_
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -397,7 +397,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
  *                                             This is optional and can only be used when the post type supports templates (like posts and pages).
  * @param {Object}  [props.settings]           The settings object to use for the editor.
  *                                             This is optional and can be used to override the default settings.
- * @param {Element} [props.children]           Children elements for which the BlockEditorProvider context should apply.
+ * @param {React.ReactNode} [props.children]           Children elements for which the BlockEditorProvider context should apply.
  *                                             This is optional.
  *
  * @example

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -391,14 +391,14 @@ export const ExperimentalEditorProvider = withRegistryProvider(
  *
  * All modification and changes are performed to the `@wordpress/core-data` store.
  *
- * @param {Object}  props                      The component props.
- * @param {Object}  [props.post]               The post object to edit. This is required.
- * @param {Object}  [props.__unstableTemplate] The template object wrapper the edited post.
- *                                             This is optional and can only be used when the post type supports templates (like posts and pages).
- * @param {Object}  [props.settings]           The settings object to use for the editor.
- *                                             This is optional and can be used to override the default settings.
+ * @param {Object}          props                      The component props.
+ * @param {Object}          [props.post]               The post object to edit. This is required.
+ * @param {Object}          [props.__unstableTemplate] The template object wrapper the edited post.
+ *                                                     This is optional and can only be used when the post type supports templates (like posts and pages).
+ * @param {Object}          [props.settings]           The settings object to use for the editor.
+ *                                                     This is optional and can be used to override the default settings.
  * @param {React.ReactNode} [props.children]           Children elements for which the BlockEditorProvider context should apply.
- *                                             This is optional.
+ *                                                     This is optional.
  *
  * @example
  * ```jsx

--- a/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
@@ -1,0 +1,108 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import {
+	BlockPreview,
+	privateApis as blockEditorPrivateApis,
+	// @ts-ignore
+} from '@wordpress/block-editor';
+import type { BasePost } from '@wordpress/fields';
+import { useSelect } from '@wordpress/data';
+import { useEntityBlockEditor, store as coreStore } from '@wordpress/core-data';
+
+/**
+ * Internal dependencies
+ */
+import { EditorProvider } from '../../../components/provider';
+import { unlock } from '../../../lock-unlock';
+// @ts-ignore
+import { store as editorStore } from '../../../store';
+
+const { useGlobalStyle } = unlock( blockEditorPrivateApis );
+
+function ContentPreviewContainer( {
+	template,
+	post,
+}: {
+	template: any;
+	post: any;
+} ) {
+	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
+	const [ postBlocks ] = useEntityBlockEditor( 'postType', post.type, {
+		id: post.id,
+	} );
+	const [ templateBlocks ] = useEntityBlockEditor(
+		'postType',
+		template?.type,
+		{
+			id: template?.id,
+		}
+	);
+	const blocks = template && templateBlocks ? templateBlocks : postBlocks;
+	const isEmpty = ! blocks?.length;
+	return (
+		<div
+			className="editor-fields-content-preview"
+			style={ {
+				backgroundColor,
+			} }
+		>
+			{ isEmpty && (
+				<span className="editor-fields-content-preview__empty">
+					{ __( 'Empty content' ) }
+				</span>
+			) }
+			{ ! isEmpty && (
+				<BlockPreview.Async>
+					<BlockPreview blocks={ blocks } />
+				</BlockPreview.Async>
+			) }
+		</div>
+	);
+}
+
+export default function ContentPreviewView( { item }: { item: BasePost } ) {
+	const { settings, template } = useSelect(
+		( select ) => {
+			const { canUser, getPostType, getTemplateId, getEntityRecord } =
+				unlock( select( coreStore ) );
+			const canViewTemplate = canUser( 'read', {
+				kind: 'postType',
+				name: 'wp_template',
+			} );
+			const _settings = select( editorStore ).getEditorSettings();
+			// @ts-ignore
+			const supportsTemplateMode = _settings.supportsTemplateMode;
+			const isViewable = getPostType( item.type )?.viewable ?? false;
+
+			const templateId =
+				supportsTemplateMode && isViewable && canViewTemplate
+					? getTemplateId( item.type, item.id )
+					: null;
+			return {
+				settings: _settings,
+				template: templateId
+					? getEntityRecord( 'postType', 'wp_template', templateId )
+					: undefined,
+			};
+		},
+		[ item.type, item.id ]
+	);
+	// Wrap everything in a block editor provider to ensure 'styles' that are needed
+	// for the previews are synced between the site editor store and the block editor store.
+	// Additionally we need to have the `__experimentalBlockPatterns` setting in order to
+	// render patterns inside the previews.
+	// TODO: Same approach is used in the patterns list and it becomes obvious that some of
+	// the block editor settings are needed in context where we don't have the block editor.
+	// Explore how we can solve this in a better way.
+	return (
+		<EditorProvider
+			post={ item }
+			settings={ settings }
+			__unstableTemplate={ template }
+		>
+			<ContentPreviewContainer template={ template } post={ item } />
+		</EditorProvider>
+	);
+}

--- a/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/content-preview-view.tsx
@@ -21,7 +21,7 @@ import { store as editorStore } from '../../../store';
 
 const { useGlobalStyle } = unlock( blockEditorPrivateApis );
 
-function ContentPreviewContainer( {
+function PostPreviewContainer( {
 	template,
 	post,
 }: {
@@ -62,7 +62,7 @@ function ContentPreviewContainer( {
 	);
 }
 
-export default function ContentPreviewView( { item }: { item: BasePost } ) {
+export default function PostPreviewView( { item }: { item: BasePost } ) {
 	const { settings, template } = useSelect(
 		( select ) => {
 			const { canUser, getPostType, getTemplateId, getEntityRecord } =
@@ -102,7 +102,7 @@ export default function ContentPreviewView( { item }: { item: BasePost } ) {
 			settings={ settings }
 			__unstableTemplate={ template }
 		>
-			<ContentPreviewContainer template={ template } post={ item } />
+			<PostPreviewContainer template={ template } post={ item } />
 		</EditorProvider>
 	);
 }

--- a/packages/editor/src/dataviews/fields/content-preview/index.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/index.tsx
@@ -1,0 +1,22 @@
+/**
+ * WordPress dependencies
+ */
+import type { Field } from '@wordpress/dataviews';
+import type { BasePost } from '@wordpress/fields';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import ContentPreviewView from './content-preview-view';
+
+const contentPreviewField: Field< BasePost > = {
+	type: 'text',
+	id: 'content-preview',
+	label: __( 'Content preview' ),
+	render: ContentPreviewView,
+	enableSorting: false,
+	isMediaField: true,
+};
+
+export default contentPreviewField;

--- a/packages/editor/src/dataviews/fields/content-preview/index.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/index.tsx
@@ -16,7 +16,7 @@ const contentPreviewField: Field< BasePost > = {
 	label: __( 'Content preview' ),
 	render: ContentPreviewView,
 	enableSorting: false,
-	isMediaField: true,
+	isPreviewField: true,
 };
 
 export default contentPreviewField;

--- a/packages/editor/src/dataviews/fields/content-preview/index.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/index.tsx
@@ -8,15 +8,15 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ContentPreviewView from './content-preview-view';
+import PostPreviewView from './content-preview-view';
 
-const contentPreviewField: Field< BasePost > = {
+const postPreviewField: Field< BasePost > = {
 	type: 'text',
 	id: 'content-preview',
 	label: __( 'Content preview' ),
-	render: ContentPreviewView,
+	render: PostPreviewView,
 	enableSorting: false,
 	isPreviewField: true,
 };
 
-export default contentPreviewField;
+export default postPreviewField;

--- a/packages/editor/src/dataviews/fields/content-preview/index.tsx
+++ b/packages/editor/src/dataviews/fields/content-preview/index.tsx
@@ -11,12 +11,11 @@ import { __ } from '@wordpress/i18n';
 import PostPreviewView from './content-preview-view';
 
 const postPreviewField: Field< BasePost > = {
-	type: 'text',
+	type: 'media',
 	id: 'content-preview',
 	label: __( 'Content preview' ),
 	render: PostPreviewView,
 	enableSorting: false,
-	isPreviewField: true,
 };
 
 export default postPreviewField;

--- a/packages/editor/src/dataviews/fields/content-preview/style.scss
+++ b/packages/editor/src/dataviews/fields/content-preview/style.scss
@@ -1,0 +1,21 @@
+.editor-fields-content-preview {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	border-radius: $radius-medium;
+
+	.dataviews-view-table & {
+		width: 96px;
+		flex-grow: 0;
+	}
+
+	.block-editor-block-preview__container,
+	.editor-fields-content-preview__empty {
+		margin-top: auto;
+		margin-bottom: auto;
+	}
+}
+
+.editor-fields-content-preview__empty {
+	text-align: center;
+}

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -38,7 +38,7 @@ import {
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
-import contentPreviewField from '../fields/content-preview';
+import postPreviewField from '../fields/content-preview';
 import { unlock } from '../../lock-unlock';
 
 export function registerEntityAction< Item >(
@@ -176,7 +176,9 @@ export const registerPostTypeSchema =
 			postTypeConfig.supports?.comments && commentStatusField,
 			templateField,
 			passwordField,
-			contentPreviewField,
+			postTypeConfig.supports?.editor &&
+				postTypeConfig.viewable &&
+				postPreviewField,
 		].filter( Boolean );
 		if ( postTypeConfig.supports?.title ) {
 			let _titleField;

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -38,6 +38,7 @@ import {
  * Internal dependencies
  */
 import { store as editorStore } from '../../store';
+import contentPreviewField from '../fields/content-preview';
 import { unlock } from '../../lock-unlock';
 
 export function registerEntityAction< Item >(
@@ -175,6 +176,7 @@ export const registerPostTypeSchema =
 			postTypeConfig.supports?.comments && commentStatusField,
 			templateField,
 			passwordField,
+			contentPreviewField,
 		].filter( Boolean );
 		if ( postTypeConfig.supports?.title ) {
 			let _titleField;

--- a/packages/editor/src/style.scss
+++ b/packages/editor/src/style.scss
@@ -54,3 +54,4 @@
 @import "./components/table-of-contents/style.scss";
 @import "./components/text-editor/style.scss";
 @import "./components/visual-editor/style.scss";
+@import "./dataviews/fields/content-preview/style.scss";

--- a/packages/fields/README.md
+++ b/packages/fields/README.md
@@ -18,6 +18,10 @@ npm install @wordpress/fields --save
 
 Author field for BasePost.
 
+### BasePost
+
+Undocumented declaration.
+
 ### BasePostWithEmbeddedAuthor
 
 Undocumented declaration.

--- a/packages/fields/src/fields/featured-image/index.ts
+++ b/packages/fields/src/fields/featured-image/index.ts
@@ -13,12 +13,11 @@ import { FeaturedImageView } from './featured-image-view';
 
 const featuredImageField: Field< BasePost > = {
 	id: 'featured_media',
-	type: 'text',
+	type: 'media',
 	label: __( 'Featured Image' ),
 	Edit: FeaturedImageEdit,
 	render: FeaturedImageView,
 	enableSorting: false,
-	isPreviewField: true,
 };
 
 /**

--- a/packages/fields/src/fields/featured-image/index.ts
+++ b/packages/fields/src/fields/featured-image/index.ts
@@ -18,6 +18,7 @@ const featuredImageField: Field< BasePost > = {
 	Edit: FeaturedImageEdit,
 	render: FeaturedImageView,
 	enableSorting: false,
+	isMediaField: true,
 };
 
 /**

--- a/packages/fields/src/fields/featured-image/index.ts
+++ b/packages/fields/src/fields/featured-image/index.ts
@@ -18,7 +18,7 @@ const featuredImageField: Field< BasePost > = {
 	Edit: FeaturedImageEdit,
 	render: FeaturedImageView,
 	enableSorting: false,
-	isMediaField: true,
+	isPreviewField: true,
 };
 
 /**

--- a/packages/fields/src/index.ts
+++ b/packages/fields/src/index.ts
@@ -1,4 +1,4 @@
 export * from './fields';
 export * from './actions';
 export { default as CreateTemplatePartModal } from './components/create-template-part-modal';
-export type { BasePostWithEmbeddedAuthor, PostType } from './types';
+export type { BasePostWithEmbeddedAuthor, BasePost, PostType } from './types';

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -100,6 +100,7 @@ export interface PostType {
 		author?: string;
 		thumbnail?: string;
 		comments?: string;
+		editor?: boolean;
 	};
 }
 

--- a/packages/fields/src/types.ts
+++ b/packages/fields/src/types.ts
@@ -32,6 +32,9 @@ interface EmbeddedAuthor {
 	author: Author[];
 }
 
+/**
+ * BasePost interface used for all post types.
+ */
 export interface BasePost extends CommonPost {
 	comment_status?: 'open' | 'closed';
 	excerpt?: string | { raw: string; rendered: string };


### PR DESCRIPTION
Supersedes: https://github.com/WordPress/gutenberg/pull/65331
Fixes https://github.com/WordPress/gutenberg/issues/63719.
cc: @jameskoster, @jasmussen 

This PR implements the following changes:


- A preview field for posts and pages displaying content similar to patterns and templates.
- Adds the ability to have multiple media fields in the APIs. A field can indicate it is a media field by setting isMediaField to true.
- The user can switch the media field by pressing a new menu available under the preview field.

For some users, most pages don't have a featured image so this PR fixes the issue of having a gray square as a page media as the UI shown most of the time. This users can now switch to show the content preview.

## Testing Instructions
- Go to pages, and select the grid layout.
- Go to the view options, and verify there is "Preview" field shown.
- Verify the preview field has a UI to allow changing its source.
- Change the preview to content and verify it works as expected.

## Screenshot
<img width="1572" alt="Screenshot 2024-11-25 at 17 53 16" src="https://github.com/user-attachments/assets/8a22e9cf-2eb8-40bb-bd68-d49e1c0efa58">
<img width="441" alt="Screenshot 2024-11-25 at 17 52 57" src="https://github.com/user-attachments/assets/f0f6c3e0-3395-45fb-862f-5f599a7d69cc">
