### PR TITLE
Icon: Improve `icon` prop usage docs in Storybook

### DIFF
--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -47,26 +47,70 @@ FillColor.args = {
 	...Default.args,
 };
 
+/**
+ * When `icon` is a function, it will be passed the `size` prop and any other additional props.
+ */
 export const WithAFunction = Template.bind( {} );
 WithAFunction.args = {
 	...Default.args,
-	icon: () => (
-		<SVG>
-			<Path d="M5 4v3h5.5v12h3V7H19V4z" />
-		</SVG>
+	icon: ( { size }: { size?: number } ) => (
+		<img
+			width={ size }
+			height={ size }
+			src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png"
+			alt="WordPress"
+		/>
 	),
 };
+WithAFunction.parameters = {
+	docs: {
+		source: {
+			code: `
+<Icon
+  icon={ ( { size } ) => (
+    <img
+      width={ size }
+      height={ size }
+      src="https://s.w.org/style/images/about/WordPress-logotype-wmark.png"
+      alt="WordPress"
+    />
+  ) }
+/>;
+		`,
+		},
+	},
+};
 
-const MyIconComponent = () => (
-	<SVG>
+const MyIconComponent = ( { size }: { size?: number } ) => (
+	<SVG width={ size } height={ size }>
 		<Path d="M5 4v3h5.5v12h3V7H19V4z" />
 	</SVG>
 );
 
+/**
+ * When `icon` is a component, it will be passed the `size` prop and any other additional props.
+ */
 export const WithAComponent = Template.bind( {} );
 WithAComponent.args = {
 	...Default.args,
-	icon: MyIconComponent,
+	icon: <MyIconComponent />,
+};
+WithAComponent.parameters = {
+	docs: {
+		source: {
+			code: `
+const MyIconComponent = ( { size } ) => (
+  <SVG width={ size } height={ size }>
+    <Path d="M5 4v3h5.5v12h3V7H19V4z" />
+  </SVG>
+);
+
+<Icon
+  icon={ <MyIconComponent /> }
+/>;
+		`,
+		},
+	},
 };
 
 export const WithAnSVG = Template.bind( {} );
@@ -80,7 +124,7 @@ WithAnSVG.args = {
 };
 
 /**
- * Although it's preferred to use icons from the `@wordpress/icons` package, Dashicons are still supported,
+ * Although it's preferred to use icons from the `@wordpress/icons` package, [Dashicons](https://developer.wordpress.org/resource/dashicons/) are still supported,
  * as long as you are in a context where the Dashicons stylesheet is loaded. To simulate that here,
  * use the Global CSS Injector in the Storybook toolbar at the top and select the "WordPress" preset.
  */

--- a/packages/components/src/icon/stories/index.story.tsx
+++ b/packages/components/src/icon/stories/index.story.tsx
@@ -75,7 +75,7 @@ WithAFunction.parameters = {
       alt="WordPress"
     />
   ) }
-/>;
+/>
 		`,
 		},
 	},
@@ -105,9 +105,7 @@ const MyIconComponent = ( { size } ) => (
   </SVG>
 );
 
-<Icon
-  icon={ <MyIconComponent /> }
-/>;
+<Icon icon={ <MyIconComponent /> } />
 		`,
 		},
 	},


### PR DESCRIPTION
In preparation for #67242

## What?

Improve the `icon` prop usage examples in the Storybook for `Icon`.

(The overall type docs and readme are improved in #67282.)

## Why?

The "With a Function" and "With a Component" examples didn't really make sense, and didn't demonstrate how the `size` prop is passed.

## Testing Instructions

See the Storybook docs for the `Icon` component in `@wordpress/components`.

## Screenshots or screencast <!-- if applicable -->

<img width="828" alt="Improved descriptions and code snippets for the function and component usages" src="https://github.com/user-attachments/assets/cbcd92d0-3f58-4125-ab08-e968c1f6d0a1">
