### PR TITLE
Search and Query blocks: Add support for Default queries via `pre_get_posts` filter

### DIFF
--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -151,6 +151,12 @@ function gutenberg_block_core_query_add_url_filtering( $query, $block ) {
 }
 add_filter( 'query_loop_block_query_vars', 'gutenberg_block_core_query_add_url_filtering', 10, 2 );
 
+/**
+ * Adds the search query to Query blocks for the inherited queries if the instant search experiment is enabled.
+ *
+ * @param WP_Query $query The query object.
+ * @return void
+ */
 function gutenberg_block_core_query_add_search_query_filtering( $query ) {
 
 	// if the query is not the main query, return

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -154,7 +154,7 @@ add_filter( 'query_loop_block_query_vars', 'gutenberg_block_core_query_add_url_f
 function gutenberg_block_core_query_add_search_query_filtering( $query ) {
 
 	// if the query is not the main query, return
-	if ( ! $query->is_main_query() ) {
+	if ( $query->is_admin() || ! $query->is_main_query() ) {
 		return;
 	}
 

--- a/lib/experimental/blocks.php
+++ b/lib/experimental/blocks.php
@@ -151,6 +151,35 @@ function gutenberg_block_core_query_add_url_filtering( $query, $block ) {
 }
 add_filter( 'query_loop_block_query_vars', 'gutenberg_block_core_query_add_url_filtering', 10, 2 );
 
+function gutenberg_block_core_query_add_search_query_filtering( $query ) {
+
+	// if the query is not the main query, return
+	if ( ! $query->is_main_query() ) {
+		return;
+	}
+
+	// Check if the instant search gutenberg experiment is enabled
+	$gutenberg_experiments  = get_option( 'gutenberg-experiments' );
+	$instant_search_enabled = $gutenberg_experiments && array_key_exists( 'gutenberg-search-query-block', $gutenberg_experiments );
+	if ( ! $instant_search_enabled ) {
+		return;
+	}
+
+	// Get the search key from the URL
+	$search_key = 'instant-search';
+	if ( ! isset( $_GET[ $search_key ] ) ) {
+		return;
+	}
+
+	// Add the search parameter to the query
+	$query->set( 's', sanitize_text_field( $_GET[ $search_key ] ) );
+}
+
+add_action(
+	'pre_get_posts',
+	'gutenberg_block_core_query_add_search_query_filtering'
+);
+
 /**
  * Additional data to expose to the view script module in the Form block.
  */

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -214,6 +214,8 @@ function render_block_core_search( $attributes, $content, $block ) {
 
 	if ( $enhanced_pagination && $instant_search_enabled && isset( $block->context['queryId'] ) ) {
 
+		$form_directives .= ' data-wp-on--submit="actions.handleSearchSubmit"';
+
 		// Get the canonical URL without pagination
 		$canonical_url_no_pagination = get_pagenum_link(1);
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -213,6 +213,9 @@ function render_block_core_search( $attributes, $content, $block ) {
 	}
 
 	if ( $enhanced_pagination && $instant_search_enabled && isset( $block->context['queryId'] ) ) {
+
+		wp_interactivity_config( 'core/search', array( 'canonicalURL' => get_permalink() ) );
+
 		$is_inherited = isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] && ! empty( $block->context['queryId'] );
 		$search       = '';
 

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -112,7 +112,7 @@ function render_block_core_search( $attributes, $content, $block ) {
 			wp_enqueue_script_module( '@wordpress/block-library/search/view' );
 
 			if ( $instant_search_enabled ) {
-				$input->set_attribute( 'data-wp-bind--value', 'context.search' );
+				$input->set_attribute( 'data-wp-bind--value', 'state.searchGetter' );
 				$input->set_attribute( 'data-wp-on-async--input', 'actions.updateSearch' );
 			}
 		}
@@ -240,6 +240,10 @@ function render_block_core_search( $attributes, $content, $block ) {
 
 		// If the query is defined in the URL, it overrides the block context value.
 		$search = empty( $_GET[ $search_key ] ) ? $search : sanitize_text_field( $_GET[ $search_key ] );
+
+		if ( $is_inherited ) {
+			wp_interactivity_state( 'core/search', array( 'search' => $search ) );
+		}
 
 		$form_context = array_merge(
 			$form_context,

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -213,8 +213,8 @@ function render_block_core_search( $attributes, $content, $block ) {
 	}
 
 	if ( $enhanced_pagination && $instant_search_enabled && isset( $block->context['queryId'] ) ) {
-
-		$search = '';
+		$is_inherited = isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] && ! empty( $block->context['queryId'] );
+		$search       = '';
 
 		// If the query is defined in the block context, use it
 		if ( isset( $block->context['query']['search'] ) && '' !== $block->context['query']['search'] ) {
@@ -222,13 +222,18 @@ function render_block_core_search( $attributes, $content, $block ) {
 		}
 
 		// If the query is defined in the URL, it overrides the block context value if defined
-		$search = empty( $_GET[ 'instant-search-' . $block->context['queryId'] ] ) ? $search : sanitize_text_field( $_GET[ 'instant-search-' . $block->context['queryId'] ] );
+		if ( $is_inherited ) {
+			$search = empty( $_GET['instant-search'] ) ? '' : sanitize_text_field( $_GET['instant-search'] );
+		} else {
+			$search = empty( $_GET[ 'instant-search-' . $block->context['queryId'] ] ) ? '' : sanitize_text_field( $_GET[ 'instant-search-' . $block->context['queryId'] ] );
+		}
 
 		$form_context = array_merge(
 			$form_context,
 			array(
-				'search'  => $search,
-				'queryId' => $block->context['queryId'],
+				'search'      => $search,
+				'queryId'     => $block->context['queryId'],
+				'isInherited' => $is_inherited,
 			)
 		);
 	}

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -214,7 +214,15 @@ function render_block_core_search( $attributes, $content, $block ) {
 
 	if ( $enhanced_pagination && $instant_search_enabled && isset( $block->context['queryId'] ) ) {
 
-		wp_interactivity_config( 'core/search', array( 'canonicalURL' => get_permalink() ) );
+		// Get the canonical URL without pagination
+		$canonical_url_no_pagination = get_pagenum_link(1);
+
+		// If we're on a singular post/page, use its permalink instead
+		if (is_singular()) {
+			$canonical_url_no_pagination = get_permalink();
+		}
+
+		wp_interactivity_config( 'core/search', array( 'canonicalURL' => $canonical_url_no_pagination ) );
 
 		$is_inherited = isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] && ! empty( $block->context['queryId'] );
 		$search       = '';
@@ -224,11 +232,11 @@ function render_block_core_search( $attributes, $content, $block ) {
 			$search = $block->context['query']['search'];
 		}
 
-		// If the query is defined in the URL, it overrides the block context value if defined
+		// If the query is defined in the URL, it overrides the block context value.
 		if ( $is_inherited ) {
-			$search = empty( $_GET['instant-search'] ) ? '' : sanitize_text_field( $_GET['instant-search'] );
+			$search = empty( $_GET['instant-search'] ) ? $search : sanitize_text_field( $_GET['instant-search'] );
 		} else {
-			$search = empty( $_GET[ 'instant-search-' . $block->context['queryId'] ] ) ? '' : sanitize_text_field( $_GET[ 'instant-search-' . $block->context['queryId'] ] );
+			$search = empty( $_GET[ 'instant-search-' . $block->context['queryId'] ] ) ? $search : sanitize_text_field( $_GET[ 'instant-search-' . $block->context['queryId'] ] );
 		}
 
 		$form_context = array_merge(

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -224,7 +224,7 @@ function render_block_core_search( $attributes, $content, $block ) {
 
 		wp_interactivity_config( 'core/search', array( 'canonicalURL' => $canonical_url_no_pagination ) );
 
-		$is_inherited = isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] && ! empty( $block->context['queryId'] );
+		$query_id = $block->context['queryId'];
 		$search       = '';
 
 		// If the query is defined in the block context, use it
@@ -232,18 +232,20 @@ function render_block_core_search( $attributes, $content, $block ) {
 			$search = $block->context['query']['search'];
 		}
 
+		$is_inherited = isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] && ! empty( $query_id );
+
+		// Inherited query: `instant-search=`
+		//    Custom query: `instant-search-<query_id>=`
+		$search_key = $is_inherited ? 'instant-search' : 'instant-search-' . $query_id;
+
 		// If the query is defined in the URL, it overrides the block context value.
-		if ( $is_inherited ) {
-			$search = empty( $_GET['instant-search'] ) ? $search : sanitize_text_field( $_GET['instant-search'] );
-		} else {
-			$search = empty( $_GET[ 'instant-search-' . $block->context['queryId'] ] ) ? $search : sanitize_text_field( $_GET[ 'instant-search-' . $block->context['queryId'] ] );
-		}
+		$search = empty( $_GET[ $search_key ] ) ? $search : sanitize_text_field( $_GET[ $search_key ] );
 
 		$form_context = array_merge(
 			$form_context,
 			array(
 				'search'      => $search,
-				'queryId'     => $block->context['queryId'],
+				'queryId'     => $query_id,
 				'isInherited' => $is_inherited,
 			)
 		);

--- a/packages/block-library/src/search/index.php
+++ b/packages/block-library/src/search/index.php
@@ -217,17 +217,17 @@ function render_block_core_search( $attributes, $content, $block ) {
 		$form_directives .= ' data-wp-on--submit="actions.handleSearchSubmit"';
 
 		// Get the canonical URL without pagination
-		$canonical_url_no_pagination = get_pagenum_link(1);
+		$canonical_url_no_pagination = get_pagenum_link( 1 );
 
 		// If we're on a singular post/page, use its permalink instead
-		if (is_singular()) {
+		if ( is_singular() ) {
 			$canonical_url_no_pagination = get_permalink();
 		}
 
 		wp_interactivity_config( 'core/search', array( 'canonicalURL' => $canonical_url_no_pagination ) );
 
 		$query_id = $block->context['queryId'];
-		$search       = '';
+		$search   = '';
 
 		// If the query is defined in the block context, use it
 		if ( isset( $block->context['query']['search'] ) && '' !== $block->context['query']['search'] ) {

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -48,6 +48,10 @@ const { state, actions } = store(
 				}
 				return ctx.isSearchInputVisible;
 			},
+			get searchGetter() {
+				const { isInherited, search } = getContext();
+				return isInherited ? state.search : search;
+			},
 		},
 		actions: {
 			openSearchInput( event ) {
@@ -88,14 +92,18 @@ const { state, actions } = store(
 			*updateSearch( e ) {
 				const { value } = e.target;
 
-				const ctx = getContext();
-
 				// Don't navigate if the search didn't really change.
-				if ( value === ctx.search ) {
+				if ( value === state.searchGetter ) {
 					return;
 				}
 
-				ctx.search = value;
+				const ctx = getContext();
+
+				if ( ctx.isInherited ) {
+					state.search = value;
+				} else {
+					ctx.search = value;
+				}
 
 				// Debounce the search by 300ms to prevent multiple navigations.
 				supersedePreviousSearch?.();

--- a/packages/block-library/src/search/view.js
+++ b/packages/block-library/src/search/view.js
@@ -89,6 +89,9 @@ const { state, actions } = store(
 					actions.closeSearchInput();
 				}
 			},
+			handleSearchSubmit( e ) {
+				e.preventDefault();
+			},
 			*updateSearch( e ) {
 				const { value } = e.target;
 

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -19,7 +19,7 @@ import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
 import {
 	deleteAllTemplates,
 	createTemplate,
-	updateTemplate,
+	updateOrCreateTemplate,
 } from './templates';
 import {
 	activateTheme,
@@ -179,8 +179,9 @@ class RequestUtils {
 		deleteAllTemplates.bind( this );
 	/** @borrows createTemplate as this.createTemplate */
 	createTemplate: typeof createTemplate = createTemplate.bind( this );
-	/** @borrows updateTemplate as this.updateTemplate */
-	updateTemplate: typeof updateTemplate = updateTemplate.bind( this );
+	/** @borrows updateOrCreateTemplate as this.updateOrCreateTemplate */
+	updateOrCreateTemplate: typeof updateOrCreateTemplate =
+		updateOrCreateTemplate.bind( this );
 	/** @borrows resetPreferences as this.resetPreferences */
 	resetPreferences: typeof resetPreferences = resetPreferences.bind( this );
 	/** @borrows listMedia as this.listMedia */

--- a/packages/e2e-test-utils-playwright/src/request-utils/index.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/index.ts
@@ -16,7 +16,11 @@ import { listMedia, uploadMedia, deleteMedia, deleteAllMedia } from './media';
 import { createUser, deleteAllUsers } from './users';
 import { setupRest, rest, getMaxBatchSize, batchRest } from './rest';
 import { getPluginsMap, activatePlugin, deactivatePlugin } from './plugins';
-import { deleteAllTemplates, createTemplate } from './templates';
+import {
+	deleteAllTemplates,
+	createTemplate,
+	updateTemplate,
+} from './templates';
 import {
 	activateTheme,
 	getCurrentThemeGlobalStylesPostId,
@@ -175,6 +179,8 @@ class RequestUtils {
 		deleteAllTemplates.bind( this );
 	/** @borrows createTemplate as this.createTemplate */
 	createTemplate: typeof createTemplate = createTemplate.bind( this );
+	/** @borrows updateTemplate as this.updateTemplate */
+	updateTemplate: typeof updateTemplate = updateTemplate.bind( this );
 	/** @borrows resetPreferences as this.resetPreferences */
 	resetPreferences: typeof resetPreferences = resetPreferences.bind( this );
 	/** @borrows listMedia as this.listMedia */

--- a/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
+++ b/packages/e2e-test-utils-playwright/src/request-utils/templates.ts
@@ -89,7 +89,7 @@ async function createTemplate(
  * @param type    Template type.
  * @param payload Template attributes.
  */
-async function updateTemplate(
+async function updateOrCreateTemplate(
 	this: RequestUtils,
 	type: TemplateType,
 	payload: CreateTemplatePayload
@@ -104,8 +104,9 @@ async function updateTemplate(
 
 	const template = templates.find( ( t ) => t.slug === payload.slug );
 
+	// If the template is not found, create it.
 	if ( ! template ) {
-		throw new Error( `Template with slug "${ payload.slug }" not found.` );
+		return createTemplate.bind( this )( type, payload );
 	}
 
 	const updatedTemplate = await this.rest< Template >( {
@@ -117,4 +118,4 @@ async function updateTemplate(
 	return updatedTemplate;
 }
 
-export { deleteAllTemplates, createTemplate, updateTemplate };
+export { deleteAllTemplates, createTemplate, updateOrCreateTemplate };

--- a/test/e2e/specs/interactivity/instant-search.spec.ts
+++ b/test/e2e/specs/interactivity/instant-search.spec.ts
@@ -722,62 +722,58 @@ test.describe( 'Instant Search', () => {
 		} );
 	} );
 
-	test.describe( 'Multiple Inherited (Default) Queries', () => {
-		test.beforeEach( async ( { page } ) => {
-			// Navigate to the home page
-			await page.goto( '/' );
-		} );
-
-		test.beforeAll( async ( { requestUtils } ) => {
+	test.describe( 'Multiple Inherited and Custom Queries', () => {
+		test( 'should keep the search state in sync across multiple inherited queries', async ( {
+			page,
+			requestUtils,
+		} ) => {
 			await requestUtils.updateTemplate( 'wp_template', {
 				slug: 'home',
 				content: `
-<!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
-	<div class="wp-block-query" data-testid="default-query-1">
-		<!-- wp:search {"label":"1st-instant-search","buttonText":"Search"} /-->
-			<!-- wp:post-template -->
-				<!-- wp:post-title {"level":3} /-->
-				<!-- wp:post-excerpt /-->
-			<!-- /wp:post-template -->
-			<!-- wp:query-pagination -->
-				<!-- wp:query-pagination-previous /-->
-				<!-- wp:query-pagination-numbers /-->
-				<!-- wp:query-pagination-next /-->
-			<!-- /wp:query-pagination -->
-			<!-- wp:query-no-results -->
-				<!-- wp:paragraph -->
-				<p>No results found.</p>
-				<!-- /wp:paragraph -->
-			<!-- /wp:query-no-results -->
-		</div>
-<!-- /wp:query -->
-
-
-<!-- wp:query {"enhancedPagination":true,"queryId":2222,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
-	<div class="wp-block-query" data-testid="default-query-2">
-		<!-- wp:search {"label":"2nd-instant-search","buttonText":"Search"} /-->
-			<!-- wp:post-template -->
-				<!-- wp:post-title {"level":3} /-->
-				<!-- wp:post-excerpt /-->
-			<!-- /wp:post-template -->
-			<!-- wp:query-pagination -->
-				<!-- wp:query-pagination-previous /-->
-				<!-- wp:query-pagination-numbers /-->
-				<!-- wp:query-pagination-next /-->
-			<!-- /wp:query-pagination -->
-			<!-- wp:query-no-results -->
-				<!-- wp:paragraph -->
-				<p>No results found.</p>
-				<!-- /wp:paragraph -->
-			<!-- /wp:query-no-results -->
-		</div>
-<!-- /wp:query -->`,
+	<!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
+		<div class="wp-block-query" data-testid="default-query-1">
+			<!-- wp:search {"label":"1st-instant-search","buttonText":"Search"} /-->
+				<!-- wp:post-template -->
+					<!-- wp:post-title {"level":3} /-->
+					<!-- wp:post-excerpt /-->
+				<!-- /wp:post-template -->
+				<!-- wp:query-pagination -->
+					<!-- wp:query-pagination-previous /-->
+					<!-- wp:query-pagination-numbers /-->
+					<!-- wp:query-pagination-next /-->
+				<!-- /wp:query-pagination -->
+				<!-- wp:query-no-results -->
+					<!-- wp:paragraph -->
+					<p>No results found.</p>
+					<!-- /wp:paragraph -->
+				<!-- /wp:query-no-results -->
+			</div>
+	<!-- /wp:query -->
+	
+	
+	<!-- wp:query {"enhancedPagination":true,"queryId":2222,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
+		<div class="wp-block-query" data-testid="default-query-2">
+			<!-- wp:search {"label":"2nd-instant-search","buttonText":"Search"} /-->
+				<!-- wp:post-template -->
+					<!-- wp:post-title {"level":3} /-->
+					<!-- wp:post-excerpt /-->
+				<!-- /wp:post-template -->
+				<!-- wp:query-pagination -->
+					<!-- wp:query-pagination-previous /-->
+					<!-- wp:query-pagination-numbers /-->
+					<!-- wp:query-pagination-next /-->
+				<!-- /wp:query-pagination -->
+				<!-- wp:query-no-results -->
+					<!-- wp:paragraph -->
+					<p>No results found.</p>
+					<!-- /wp:paragraph -->
+				<!-- /wp:query-no-results -->
+			</div>
+	<!-- /wp:query -->`,
 			} );
-		} );
 
-		test( 'should keep the search state in sync across multiple inherited queries', async ( {
-			page,
-		} ) => {
+			await page.goto( '/' );
+
 			// Get search inputs
 			const firstQuerySearch = page.getByLabel( '1st-instant-search' );
 			const secondQuerySearch = page.getByLabel( '2nd-instant-search' );
@@ -804,6 +800,121 @@ test.describe( 'Instant Search', () => {
 				.getByRole( 'heading', { level: 3 } );
 			await expect( secondQueryPosts ).toHaveCount( 1 );
 			await expect( secondQueryPosts ).toContainText( 'Unique Post' );
+		} );
+
+		test( 'should handle searches independently when a Default and a Custom query are placed in a home template', async ( {
+			page,
+			requestUtils,
+		} ) => {
+			// Set up: Add one inherited and one custom query to the home template
+			await requestUtils.updateTemplate( 'wp_template', {
+				slug: 'home',
+				content: `
+	<!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
+		<div class="wp-block-query" data-testid="default-query">
+			<!-- wp:search {"label":"Default Query Search","buttonText":"Search"} /-->
+				<!-- wp:post-template -->
+					<!-- wp:post-title {"level":3} /-->
+					<!-- wp:post-excerpt /-->
+				<!-- /wp:post-template -->
+				<!-- wp:query-pagination -->
+					<!-- wp:query-pagination-previous /-->
+					<!-- wp:query-pagination-numbers /-->
+					<!-- wp:query-pagination-next /-->
+				<!-- /wp:query-pagination -->
+				<!-- wp:query-no-results -->
+					<!-- wp:paragraph -->
+					<p>No results found.</p>
+					<!-- /wp:paragraph -->
+				<!-- /wp:query-no-results -->
+			</div>
+	<!-- /wp:query -->
+	
+	
+	<!-- wp:query {"enhancedPagination":true,"queryId":2222,"query":{"inherit":false,"perPage":2,"order":"desc","orderBy":"date"}} -->
+		<div class="wp-block-query" data-testid="custom-query">
+			<!-- wp:search {"label":"Custom Query Search","buttonText":"Search"} /-->
+				<!-- wp:post-template -->
+					<!-- wp:post-title {"level":3} /-->
+					<!-- wp:post-excerpt /-->
+				<!-- /wp:post-template -->
+				<!-- wp:query-pagination -->
+					<!-- wp:query-pagination-previous /-->
+					<!-- wp:query-pagination-numbers /-->
+					<!-- wp:query-pagination-next /-->
+				<!-- /wp:query-pagination -->
+				<!-- wp:query-no-results -->
+					<!-- wp:paragraph -->
+					<p>No results found.</p>
+					<!-- /wp:paragraph -->
+				<!-- /wp:query-no-results -->
+			</div>
+	<!-- /wp:query -->`,
+			} );
+
+			await page.goto( '/' );
+
+			// Get search inputs
+			const defaultQuerySearch = page.getByLabel(
+				'Default Query Search'
+			);
+			const customQuerySearch = page.getByLabel( 'Custom Query Search' );
+
+			// Search for "Unique" in the default query
+			await defaultQuerySearch.fill( 'Unique' );
+
+			// Verify that the URL has been updated with the search parameter
+			await expect( page ).toHaveURL( /instant-search=Unique/ );
+
+			// Verify that the custom query search input has no value
+			await expect( customQuerySearch ).toHaveValue( '' );
+
+			// Verify that the default query has only one post which is the "Unique" post
+			const defaultQueryPosts = page
+				.getByTestId( 'default-query' )
+				.getByRole( 'heading', { level: 3 } );
+			await expect( defaultQueryPosts ).toHaveCount( 1 );
+			await expect( defaultQueryPosts ).toContainText( 'Unique Post' );
+
+			// Verify that the custom query shows exactly 2 posts: First Test Post and Second Test Post
+			const customQuery = page.getByTestId( 'custom-query' );
+			const posts = customQuery.getByRole( 'heading', { level: 3 } );
+			await expect( posts ).toHaveCount( 2 );
+			await expect( posts ).toContainText( [
+				'First Test Post',
+				'Second Test Post',
+			] );
+
+			// Search for "Third" in the custom query
+			await customQuerySearch.fill( 'Third' );
+
+			// Verify that the URL has been updated with the search parameter
+			await expect( page ).toHaveURL(
+				/instant-search=Unique&instant-search-2222=Third/
+			);
+
+			// Verify that the default query search input still has "Unique"
+			await expect( defaultQuerySearch ).toHaveValue( 'Unique' );
+
+			// Verify that the default query has only one post which is the "Unique" post
+			await expect( defaultQueryPosts ).toHaveCount( 1 );
+			await expect( defaultQueryPosts ).toContainText( 'Unique Post' );
+
+			// Verify that the custom query has only one post which is the "Third Test Post"
+			const customQueryPosts = page
+				.getByTestId( 'custom-query' )
+				.getByRole( 'heading', { level: 3 } );
+			await expect( customQueryPosts ).toHaveCount( 1 );
+			await expect( customQueryPosts ).toContainText( 'Third Test Post' );
+
+			// Clear default query search
+			await defaultQuerySearch.fill( '' );
+			await expect( page ).not.toHaveURL( /instant-search=Unique/ );
+			await expect( page ).toHaveURL( /instant-search-2222=Third/ );
+
+			// Clear custom query search
+			await customQuerySearch.fill( '' );
+			await expect( page ).not.toHaveURL( /instant-search-2222=Third/ );
 		} );
 	} );
 

--- a/test/e2e/specs/interactivity/instant-search.spec.ts
+++ b/test/e2e/specs/interactivity/instant-search.spec.ts
@@ -982,13 +982,15 @@ test.describe( 'Instant Search', () => {
 				name: 'Editor settings',
 			} );
 
+			const blockCard = editorSettings.locator(
+				'.block-editor-block-card'
+			);
+
 			// Check that the Search block is renamed to "Instant Search" in the Inspector Controls title
 			await editor.canvas
 				.getByRole( 'document', { name: 'Block: Search' } )
 				.click();
-			await expect( editorSettings ).toContainText(
-				'Instant Search (Search)'
-			);
+			await expect( blockCard ).toContainText( 'Instant Search' );
 
 			// Select the Query Loop block and open the Advanced View and disable enhanced pagination
 			await editor.selectBlocks(
@@ -1008,10 +1010,8 @@ test.describe( 'Instant Search', () => {
 			await editor.canvas
 				.getByRole( 'document', { name: 'Block: Search' } )
 				.click();
-			await expect( editorSettings ).toContainText( 'Search' );
-			await expect( editorSettings ).not.toContainText(
-				'Instant Search (Search)'
-			);
+			await expect( blockCard ).toContainText( 'Search' );
+			await expect( blockCard ).not.toContainText( 'Instant Search' );
 
 			// Check that the Search block is renamed back to "Search" in the List View
 			await expect( listView.getByText( 'Search' ) ).toBeVisible();

--- a/test/e2e/specs/interactivity/instant-search.spec.ts
+++ b/test/e2e/specs/interactivity/instant-search.spec.ts
@@ -548,6 +548,180 @@ test.describe( 'Instant Search', () => {
 		} );
 	} );
 
+	test.describe( 'Inherited (Default) Query', () => {
+		test.beforeEach( async ( { page } ) => {
+			// Navigate to the home page
+			await page.goto( '/' );
+		} );
+
+		test.beforeAll( async ( { requestUtils } ) => {
+			// Edit the Home template instead of creating a new page
+			await requestUtils.updateTemplate( 'wp_template', {
+				slug: 'home',
+				content: `
+<!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
+	<div class="wp-block-query" data-testid="default-query">
+		<!-- wp:search {"label":"","buttonText":"Search"} /-->
+			<!-- wp:post-template -->
+				<!-- wp:post-title {"level":3} /-->
+				<!-- wp:post-excerpt /-->
+			<!-- /wp:post-template -->
+			<!-- wp:query-pagination -->
+				<!-- wp:query-pagination-previous /-->
+				<!-- wp:query-pagination-numbers /-->
+				<!-- wp:query-pagination-next /-->
+			<!-- /wp:query-pagination -->
+			<!-- wp:query-no-results -->
+				<!-- wp:paragraph -->
+				<p>No results found.</p>
+				<!-- /wp:paragraph -->
+			<!-- /wp:query-no-results -->
+		</div>
+<!-- /wp:query -->`,
+			} );
+		} );
+
+		test( 'should update search results without page reload', async ( {
+			page,
+		} ) => {
+			// Check that the first post is shown initially
+			await expect(
+				page.getByText( 'First Test Post', { exact: true } )
+			).toBeVisible();
+
+			// Type in search input and verify results update
+			await page.locator( 'input[type="search"]' ).fill( 'Unique' );
+			await page.waitForResponse( ( response ) =>
+				response.url().includes( 'instant-search=Unique' )
+			);
+
+			// Verify the unique post is shown
+			await expect(
+				page.getByText( 'Unique Post', { exact: true } )
+			).toBeVisible();
+
+			// Check that there is only one post
+			const posts = page
+				.getByTestId( 'default-query' )
+				.getByRole( 'heading', { level: 3 } );
+			await expect( posts ).toHaveCount( 1 );
+
+			// Verify that the other posts are hidden
+			await expect(
+				page.getByText( 'First Test Post', { exact: true } )
+			).toBeHidden();
+		} );
+
+		test( 'should update URL with search parameter', async ( { page } ) => {
+			// Test global query search parameter
+			await page.locator( 'input[type="search"]' ).fill( 'Test' );
+			await expect( page ).toHaveURL( /instant-search=Test/ );
+
+			// Clear search and verify parameter is removed
+			await page.locator( 'input[type="search"]' ).fill( '' );
+			await expect( page ).not.toHaveURL( /instant-search=/ );
+		} );
+
+		test( 'should handle search debouncing', async ( { page } ) => {
+			let responseCount = 0;
+
+			// Monitor the number of requests
+			page.on( 'response', ( response ) => {
+				if ( response.url().includes( 'instant-search=' ) ) {
+					responseCount++;
+				}
+			} );
+
+			// Type quickly and wait for the response
+			let responsePromise = page.waitForResponse( ( response ) => {
+				return (
+					response.url().includes( 'instant-search=Test' ) &&
+					response.status() === 200
+				);
+			} );
+			await page
+				.locator( 'input[type="search"]' )
+				.pressSequentially( 'Test', { delay: 100 } );
+			await responsePromise;
+
+			// Check that only one request was made
+			expect( responseCount ).toBe( 1 );
+
+			// Verify URL is updated after debounce
+			await expect( page ).toHaveURL( /instant-search=Test/ );
+
+			responsePromise = page.waitForResponse( ( response ) => {
+				return response.url().includes( 'instant-search=Test1234' );
+			} );
+			// Type again with a large delay and verify that a request is made
+			// for each character
+			await page
+				.locator( 'input[type="search"]' )
+				.pressSequentially( '1234', { delay: 500 } );
+			await responsePromise;
+
+			// Check that five requests were made (Test, Test1, Test12, Test123, Test1234)
+			expect( responseCount ).toBe( 5 );
+		} );
+
+		test( 'should reset pagination when searching', async ( { page } ) => {
+			// Navigate to second page
+			await page.click( 'a.wp-block-query-pagination-next' );
+
+			// Check that the url contains either `?paged=2` or `/page/2/`. If the
+			// site has the `pretty` permalink structure, the url will contain
+			// `/page/2/` instead of `?paged=2`.
+			await expect( page ).toHaveURL( /(?:paged=2|\/page\/2\/)/ );
+
+			// Search and verify we're back to first page
+			await page.locator( 'input[type="search"]' ).fill( 'Test' );
+			await expect( page ).not.toHaveURL( /paged=2/ );
+
+			// Now we're back on the first page, so the URL should just contain the search parameter
+			await expect( page ).toHaveURL( /\?instant-search=Test/ );
+		} );
+
+		test( 'should show no-results block when search has no matches', async ( {
+			page,
+		} ) => {
+			await page
+				.locator( 'input[type="search"]' )
+				.fill( 'NonexistentContent' );
+			await page.waitForResponse( ( response ) =>
+				response.url().includes( 'instant-search=NonexistentContent' )
+			);
+
+			// Verify no-results block is shown
+			await expect( page.getByText( 'No results found.' ) ).toBeVisible();
+		} );
+
+		test( 'should update pagination numbers based on search results', async ( {
+			page,
+		} ) => {
+			// Initially should show pagination numbers for 3 pages
+			await expect(
+				page.locator( '.wp-block-query-pagination-numbers' )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', { name: '2' } )
+			).toBeVisible();
+			await expect(
+				page.getByRole( 'link', { name: '3' } )
+			).toBeVisible();
+
+			// Search for unique post
+			await page.locator( 'input[type="search"]' ).fill( 'Unique' );
+			await page.waitForResponse( ( response ) =>
+				response.url().includes( 'instant-search=Unique' )
+			);
+
+			// Pagination numbers should not be visible with single result
+			await expect(
+				page.locator( '.wp-block-query-pagination-numbers' )
+			).toBeHidden();
+		} );
+	} );
+
 	test.describe( 'Editor', () => {
 		test.beforeEach( async ( { admin } ) => {
 			await admin.createNewPost( {

--- a/test/e2e/specs/interactivity/instant-search.spec.ts
+++ b/test/e2e/specs/interactivity/instant-search.spec.ts
@@ -556,7 +556,7 @@ test.describe( 'Instant Search', () => {
 
 		test.beforeAll( async ( { requestUtils } ) => {
 			// Edit the Home template instead of creating a new page
-			await requestUtils.updateTemplate( 'wp_template', {
+			await requestUtils.updateOrCreateTemplate( 'wp_template', {
 				slug: 'home',
 				content: `
 <!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
@@ -727,7 +727,7 @@ test.describe( 'Instant Search', () => {
 			page,
 			requestUtils,
 		} ) => {
-			await requestUtils.updateTemplate( 'wp_template', {
+			await requestUtils.updateOrCreateTemplate( 'wp_template', {
 				slug: 'home',
 				content: `
 	<!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->
@@ -807,7 +807,7 @@ test.describe( 'Instant Search', () => {
 			requestUtils,
 		} ) => {
 			// Set up: Add one inherited and one custom query to the home template
-			await requestUtils.updateTemplate( 'wp_template', {
+			await requestUtils.updateOrCreateTemplate( 'wp_template', {
 				slug: 'home',
 				content: `
 	<!-- wp:query {"enhancedPagination":true,"queryId":1111,"query":{"inherit":true,"perPage":2,"order":"desc","orderBy":"date"}} -->


### PR DESCRIPTION
## What?
This adds support for Default queries via `pre_get_posts` filter. 

## Why?
The PR implementing the Instant Search ([#67181](https://github.com/WordPress/gutenberg/pull/67181)) does not handle the Default (inherited) queries.

## How?

The Default queries use the `?instant-search=<search-term>` URL search param.

