### PR TITLE
Storybook: Add stories for DateFormatPicker Component

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/stories/index.story.js
+++ b/packages/block-editor/src/components/date-format-picker/stories/index.story.js
@@ -8,9 +8,6 @@ import DateFormatPicker from '../';
  */
 import { useState } from '@wordpress/element';
 
-/**
- * Storybook configuration for DateFormatPicker component
- */
 export default {
 	title: 'BlockEditor/DateFormatPicker',
 	component: DateFormatPicker,

--- a/packages/block-editor/src/components/date-format-picker/stories/index.story.js
+++ b/packages/block-editor/src/components/date-format-picker/stories/index.story.js
@@ -1,0 +1,101 @@
+/**
+ * Internal dependencies
+ */
+import DateFormatPicker from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Date format options
+ */
+const FORMAT_OPTIONS = [
+	null,
+	'Y-m-d',
+	'n/j/Y',
+	'n/j/Y g:i A',
+	'M j, Y',
+	'M j, Y g:i A',
+	'F j, Y',
+	'M j',
+];
+
+/**
+ * Storybook configuration for DateFormatPicker component
+ */
+export default {
+	title: 'BlockEditor/DateFormatPicker',
+	component: DateFormatPicker,
+	argTypes: {
+		defaultFormat: {
+			control: 'text',
+			description: 'Default date format to display',
+		},
+		format: {
+			control: 'select',
+			options: FORMAT_OPTIONS,
+			description: 'Selected date format',
+		},
+		onChange: {
+			action: 'onChange',
+			control: {
+				type: null,
+			},
+			description: 'Callback function when date format changes',
+		},
+	},
+	render: function Render( { onChange, format, defaultFormat } ) {
+		const [ selectedFormat, setSelectedFormat ] = useState( format );
+
+		useEffect( () => {
+			setSelectedFormat( format );
+		}, [ format ] );
+
+		const handleFormatChange = ( newValue ) => {
+			setSelectedFormat( newValue );
+			if ( onChange ) {
+				onChange( newValue );
+			}
+		};
+
+		return (
+			<DateFormatPicker
+				defaultFormat={ defaultFormat }
+				format={ selectedFormat }
+				onChange={ handleFormatChange }
+			/>
+		);
+	},
+};
+
+/**
+ * Story demonstrating DateFormatPicker with default settings
+ */
+export const Default = {
+	args: {
+		defaultFormat: 'M j, Y',
+		format: 'Y-m-d',
+	},
+};
+
+/**
+ * DateFormatPicker with format set to null and defaultFormat set to 'M j, Y'
+ */
+export const WithFormatNull = {
+	args: {
+		defaultFormat: 'M j, Y',
+		format: null,
+	},
+};
+
+/**
+ * DateFormatPicker with defaultFormat set to empty string and format set to 'Y-m-d'
+ */
+export const WithDefaultFormatEmpty = {
+	args: {
+		defaultFormat: '',
+		format: 'Y-m-d',
+	},
+};

--- a/packages/block-editor/src/components/date-format-picker/stories/index.story.js
+++ b/packages/block-editor/src/components/date-format-picker/stories/index.story.js
@@ -1,12 +1,12 @@
 /**
- * Internal dependencies
- */
-import DateFormatPicker from '../';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DateFormatPicker from '../';
 
 export default {
 	title: 'BlockEditor/DateFormatPicker',
@@ -34,7 +34,7 @@ export default {
 			description:
 				'The selected date format. If `null`, _Default_ is selected.',
 			table: {
-				type: { summary: 'string' },
+				type: { summary: 'string | null' },
 			},
 		},
 		onChange: {

--- a/packages/block-editor/src/components/date-format-picker/stories/index.story.js
+++ b/packages/block-editor/src/components/date-format-picker/stories/index.story.js
@@ -1,26 +1,12 @@
 /**
  * Internal dependencies
  */
-import DateFormatPicker from '..';
+import DateFormatPicker from '../';
 
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
-
-/**
- * Date format options
- */
-const FORMAT_OPTIONS = [
-	null,
-	'Y-m-d',
-	'n/j/Y',
-	'n/j/Y g:i A',
-	'M j, Y',
-	'M j, Y g:i A',
-	'F j, Y',
-	'M j',
-];
+import { useState } from '@wordpress/element';
 
 /**
  * Storybook configuration for DateFormatPicker component
@@ -28,74 +14,59 @@ const FORMAT_OPTIONS = [
 export default {
 	title: 'BlockEditor/DateFormatPicker',
 	component: DateFormatPicker,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The `DateFormatPicker` component enables users to configure their preferred *date format*. This determines how dates are displayed.',
+			},
+		},
+	},
 	argTypes: {
 		defaultFormat: {
 			control: 'text',
-			description: 'Default date format to display',
+			description:
+				'The date format that will be used if the user selects "Default".',
+			table: {
+				type: { summary: 'string' },
+			},
 		},
 		format: {
-			control: 'select',
-			options: FORMAT_OPTIONS,
-			description: 'Selected date format',
+			control: { type: null },
+			description:
+				'The selected date format. If `null`, _Default_ is selected.',
+			table: {
+				type: { summary: 'string' },
+			},
 		},
 		onChange: {
 			action: 'onChange',
-			control: {
-				type: null,
+			control: { type: null },
+			description:
+				'Called when a selection is made. If `null`, _Default_ is selected.',
+			table: {
+				type: { summary: 'function' },
 			},
-			description: 'Callback function when date format changes',
 		},
-	},
-	render: function Render( { onChange, format, defaultFormat } ) {
-		const [ selectedFormat, setSelectedFormat ] = useState( format );
-
-		useEffect( () => {
-			setSelectedFormat( format );
-		}, [ format ] );
-
-		const handleFormatChange = ( newValue ) => {
-			setSelectedFormat( newValue );
-			if ( onChange ) {
-				onChange( newValue );
-			}
-		};
-
-		return (
-			<DateFormatPicker
-				defaultFormat={ defaultFormat }
-				format={ selectedFormat }
-				onChange={ handleFormatChange }
-			/>
-		);
 	},
 };
 
-/**
- * Story demonstrating DateFormatPicker with default settings
- */
 export const Default = {
 	args: {
 		defaultFormat: 'M j, Y',
-		format: 'Y-m-d',
 	},
-};
-
-/**
- * DateFormatPicker with format set to null and defaultFormat set to 'M j, Y'
- */
-export const WithFormatNull = {
-	args: {
-		defaultFormat: 'M j, Y',
-		format: null,
-	},
-};
-
-/**
- * DateFormatPicker with defaultFormat set to empty string and format set to 'Y-m-d'
- */
-export const WithDefaultFormatEmpty = {
-	args: {
-		defaultFormat: '',
-		format: 'Y-m-d',
+	render: function Template( { onChange, ...args } ) {
+		const [ format, setFormat ] = useState();
+		return (
+			<DateFormatPicker
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setFormat( ...changeArgs );
+				} }
+				format={ format }
+			/>
+		);
 	},
 };


### PR DESCRIPTION
Part of #67165  

## What?
This PR adds Storybook stories for the `DateFormatPicker` component to improve component documentation and testability.

## Why?
- To provide clear visual documentation for the DateFormatPicker component.
- To enable interactive testing for various DateFormatPicker scenarios.
- To enhance the development experience for Block Editor components.

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open Storybook at http://localhost:50240/
3. Verify the following stories are present and functioning:
   - Default rendering of the DateFormatPicker.
   - DateFormatPicker with the format set to null.
   - DateFormatPicker with defaultFormat set to empty string.
   
## Screencast 

https://github.com/user-attachments/assets/4b6126d4-136c-40ea-856f-0c7d3f09d23f


