### PR TITLE
Add an "Open in new tab" option to the navigation block's sidebar settings.

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -15,6 +15,7 @@ import {
 	ToolbarButton,
 	Tooltip,
 	ToolbarGroup,
+	CheckboxControl,
 } from '@wordpress/components';
 import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
@@ -159,7 +160,7 @@ function getMissingText( type ) {
  * Consider reuseing this components for both blocks.
  */
 function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
-	const { label, url, description, title, rel } = attributes;
+	const { label, url, description, title, rel, opensInNewTab } = attributes;
 	return (
 		<PanelBody title={ __( 'Settings' ) }>
 			<TextControl
@@ -187,6 +188,14 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				} }
 				label={ __( 'Link' ) }
 				autoComplete="off"
+			/>
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={ __( 'Open in new tab' ) }
+				checked={ opensInNewTab }
+				onChange={ ( value ) =>
+					setAttributes( { opensInNewTab: value } )
+				}
 			/>
 			<TextareaControl
 				__nextHasNoMarginBottom


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/67246

## What?
Adds the "Open in new tab" Option to the Navigation Link block's settings just like we do using Toolbar

## Why?
The "Open in new tab" setting is currently limited to the link modal in the Toolbar, while other link options are located in the block settings sidebar. This inconsistency has led to confusion for editors trying to find this commonly used feature.

## How?
I have added the same option in the sidebar like we have in the Toolbar

## Screenshots or screencast
<img width="1433" alt="Screenshot 2024-11-26 at 11 18 25 AM" src="https://github.com/user-attachments/assets/841fd36f-7c39-4160-9ad4-dfae8c67f66c">

