### PR TITLE
Storybook: Add stories for BlockAlignmentMatrixControl Component

### DIFF
--- a/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/README.md
@@ -48,6 +48,7 @@ const controls = (
 
 | Name       | Type       | Default                   | Description                                                                                                                              |
 | ---------- | ---------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`    | `string`   | `Change matrix alignment` | concise description of tool's functionality.                                                                                             |
-| `onChange` | `function` | `noop`                    | the function to execute upon a user's change of the matrix state                                                                         |
-| `value`    | `string`   | `center`                  | describes the content alignment location and can be `top`, `right`, `bottom`, `left`, `topRight`, `bottomRight`, `bottomLeft`, `topLeft` |
+| `label`    | `string`   | `Change matrix alignment` | Label for the control.											                                                                                             |
+| `onChange` | `function` | `noop`                    | Function to execute upon a user's change of the matrix state.                                                                            |
+| `value`    | `string`   | `center`                  | Describes the content alignment location and can be `center center`, `center left`, `center right`, `top center`, `top left`, `top right`, `bottom center`, `bottom left`, `bottom right`. |
+| `isDisabled` | `boolean` | `false`                   | Disables the control.                                                                                                                    |

--- a/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/README.md
@@ -41,7 +41,7 @@ const controls = (
       />
     </BlockControls>
   </>
-}
+);
 ```
 
 ### Props

--- a/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
@@ -35,28 +35,22 @@ export default {
 	},
 };
 
-const Template = ( { onChange, ...args } ) => {
-	const [ value, setValue ] = useState( 'center center' );
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( 'center center' );
 
-	return (
-		<BlockAlignmentMatrixControl
-			{ ...args }
-			value={ value }
-			onChange={ ( ...changeArgs ) => {
-				onChange( ...changeArgs );
-				setValue( ...changeArgs );
-			} }
-		/>
-	);
-};
-
-export const Default = Template.bind( {} );
-Default.args = {
-	label: 'Change matrix alignment',
-};
-
-export const Disabled = Template.bind( {} );
-Disabled.args = {
-	label: 'Disabled Alignment Control',
-	isDisabled: true,
+		return (
+			<BlockAlignmentMatrixControl
+				{ ...args }
+				value={ value }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+			/>
+		);
+	},
+	args: {
+		label: 'Change matrix alignment',
+	},
 };

--- a/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockAlignmentMatrixControl from '../';
+
+export default {
+	title: 'BlockEditor/BlockAlignmentMatrixControl',
+	component: BlockAlignmentMatrixControl,
+	parameters: {
+		layout: 'centered',
+	},
+	argTypes: {
+		label: {
+			control: 'text',
+			defaultValue: 'Change matrix alignment',
+			description: 'Label for the control.',
+		},
+		onChange: {
+			action: 'onChange',
+			description: 'Function called when the value changes.',
+		},
+		isDisabled: {
+			control: 'boolean',
+			defaultValue: false,
+			description: 'Whether the control is disabled.',
+		},
+		value: {
+			description: 'The current alignment value.',
+		},
+	},
+};
+
+const Template = ( { onChange, ...args } ) => {
+	const [ value, setValue ] = useState( 'center center' );
+
+	return (
+		<BlockAlignmentMatrixControl
+			{ ...args }
+			value={ value }
+			onChange={ ( ...changeArgs ) => {
+				onChange( ...changeArgs );
+				setValue( ...changeArgs );
+			} }
+		/>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	label: 'Change matrix alignment',
+};
+
+export const Disabled = Template.bind( {} );
+Disabled.args = {
+	label: 'Disabled Alignment Control',
+	isDisabled: true,
+};

--- a/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
@@ -8,36 +8,61 @@ import { useState } from '@wordpress/element';
  */
 import BlockAlignmentMatrixControl from '../';
 
-export default {
+const meta = {
 	title: 'BlockEditor/BlockAlignmentMatrixControl',
 	component: BlockAlignmentMatrixControl,
 	parameters: {
-		layout: 'centered',
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders a control for selecting block alignment using a matrix of alignment options.',
+			},
+		},
 	},
 	argTypes: {
 		label: {
 			control: 'text',
-			defaultValue: 'Change matrix alignment',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'Change matrix alignment' },
+			},
 			description: 'Label for the control.',
 		},
 		onChange: {
 			action: 'onChange',
-			description: 'Function called when the value changes.',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: '() => {}' },
+			},
+			description:
+				"Function to execute upon a user's change of the matrix state.",
 		},
 		isDisabled: {
 			control: 'boolean',
-			defaultValue: false,
-			description: 'Whether the control is disabled.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+			description: 'Disables the control.',
 		},
 		value: {
-			description: 'The current alignment value.',
+			control: 'text',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'center center' },
+			},
+			description: 'Value of the control.',
 		},
 	},
 };
 
+export default meta;
+
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
-		const [ value, setValue ] = useState( 'center center' );
+		const [ value, setValue ] = useState();
 
 		return (
 			<BlockAlignmentMatrixControl
@@ -49,8 +74,5 @@ export const Default = {
 				} }
 			/>
 		);
-	},
-	args: {
-		label: 'Change matrix alignment',
 	},
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for BlockAlignmentMatrixControl component in the Storybook.

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the BlockAlignmentMatrixControl stories.

## Screenshots or screencast
![Screenshot 2024-12-02 at 5 35 09 PM](https://github.com/user-attachments/assets/019f3c54-e81c-4378-b32f-936cf795c347)




