### PR TITLE
Edit Post: Remove unused 'hasHistory' flag

### DIFF
--- a/packages/edit-post/src/components/browser-url/index.js
+++ b/packages/edit-post/src/components/browser-url/index.js
@@ -27,14 +27,13 @@ export class BrowserURL extends Component {
 	}
 
 	componentDidUpdate( prevProps ) {
-		const { postId, postStatus, hasHistory } = this.props;
+		const { postId, postStatus } = this.props;
 		const { historyId } = this.state;
 
 		if (
 			( postId !== prevProps.postId || postId !== historyId ) &&
 			postStatus !== 'auto-draft' &&
-			postId &&
-			! hasHistory
+			postId
 		) {
 			this.setBrowserURL( postId );
 		}

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -392,7 +392,6 @@ function Layout( {
 		showIconLabels,
 		isDistractionFree,
 		showMetaBoxes,
-		hasHistory,
 		isWelcomeGuideVisible,
 		templateId,
 		enablePaddingAppender,
@@ -595,7 +594,7 @@ function Layout( {
 						<PostLockedModal />
 						<EditorInitialization />
 						<FullscreenMode isActive={ isFullscreenActive } />
-						<BrowserURL hasHistory={ hasHistory } />
+						<BrowserURL />
 						<UnsavedChangesWarning />
 						<AutosaveMonitor />
 						<LocalAutosaveMonitor />


### PR DESCRIPTION
## What?
PR removes the unused  `hasHistory` flag for the `BrowserURL` component. It was introduced via #57036, but the store has returned no value since #62339.

## Testing Instructions
None. CI checks should be green.
