### PR TITLE
Storybook: Add stories for HeadingLevelDropdown component

### DIFF
--- a/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
@@ -8,12 +8,12 @@ import { useState } from '@wordpress/element';
  */
 import HeadingLevelDropdown from '../';
 
-export default {
+const meta = {
 	title: 'BlockEditor/HeadingLevelDropdown',
 	component: HeadingLevelDropdown,
 	argTypes: {
 		value: {
-			control: { type: 'number', min: 0, max: 6, step: 1 },
+			control: { type: null },
 			description: 'The currently selected heading level.',
 		},
 		options: {
@@ -23,6 +23,7 @@ export default {
 		},
 		onChange: {
 			action: 'onChange',
+			control: { type: null },
 			description:
 				'Callback triggered when a new heading level is selected.',
 		},
@@ -36,9 +37,12 @@ export default {
 	],
 };
 
+export default meta;
+
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
 		const [ value, setValue ] = useState( args.value );
+
 		return (
 			<HeadingLevelDropdown
 				{ ...args }

--- a/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
@@ -36,59 +36,22 @@ export default {
 	],
 };
 
-const Template = ( args ) => {
-	const [ value, setValue ] = useState( args.value );
-
-	return (
-		<HeadingLevelDropdown
-			{ ...args }
-			value={ value }
-			onChange={ ( newLevel ) => {
-				setValue( newLevel );
-				args.onChange( newLevel );
-			} }
-		/>
-	);
-};
-
-export const Default = Template.bind( {} );
-Default.args = {
-	value: 2,
-	options: [ 1, 2, 3, 4, 5, 6 ],
-};
-
-export const WithParagraphOption = Template.bind( {} );
-WithParagraphOption.args = {
-	value: 0,
-	options: [ 0, 1, 2, 3, 4 ],
-};
-
-export const LimitedOptions = Template.bind( {} );
-LimitedOptions.args = {
-	value: 3,
-	options: [ 2, 3, 4 ],
-};
-
-export const StartingAsParagraph = Template.bind( {} );
-StartingAsParagraph.args = {
-	value: 0,
-	options: [ 0, 1, 2, 3 ],
-};
-
-export const InteractiveDropdown = () => {
-	const [ selectedLevel, setSelectedLevel ] = useState( 2 );
-
-	return (
-		<div>
-			<p>
-				Selected Level:{ ' ' }
-				{ selectedLevel === 0 ? 'Paragraph' : `H${ selectedLevel }` }
-			</p>
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( args.value );
+		return (
 			<HeadingLevelDropdown
-				value={ selectedLevel }
-				options={ [ 0, 1, 2, 3, 4, 5, 6 ] }
-				onChange={ ( newLevel ) => setSelectedLevel( newLevel ) }
+				{ ...args }
+				value={ value }
+				onChange={ ( ...changeArgs ) => {
+					setValue( ...changeArgs );
+					onChange( ...changeArgs );
+				} }
 			/>
-		</div>
-	);
+		);
+	},
+	args: {
+		value: 2,
+		options: [ 1, 2, 3, 4, 5, 6 ],
+	},
 };

--- a/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
@@ -1,0 +1,94 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import HeadingLevelDropdown from '../';
+
+export default {
+	title: 'BlockEditor/HeadingLevelDropdown',
+	component: HeadingLevelDropdown,
+	argTypes: {
+		value: {
+			control: { type: 'number', min: 0, max: 6, step: 1 },
+			description: 'The currently selected heading level.',
+		},
+		options: {
+			control: 'array',
+			description:
+				'An array of supported heading levels, e.g., [1, 2, 3, 4, 5, 6].',
+		},
+		onChange: {
+			action: 'onChange',
+			description:
+				'Callback triggered when a new heading level is selected.',
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<div style={ { padding: '20px', maxWidth: '300px' } }>
+				<Story />
+			</div>
+		),
+	],
+};
+
+const Template = ( args ) => {
+	const [ value, setValue ] = useState( args.value );
+
+	return (
+		<HeadingLevelDropdown
+			{ ...args }
+			value={ value }
+			onChange={ ( newLevel ) => {
+				setValue( newLevel );
+				args.onChange( newLevel );
+			} }
+		/>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	value: 2,
+	options: [ 1, 2, 3, 4, 5, 6 ],
+};
+
+export const WithParagraphOption = Template.bind( {} );
+WithParagraphOption.args = {
+	value: 0,
+	options: [ 0, 1, 2, 3, 4 ],
+};
+
+export const LimitedOptions = Template.bind( {} );
+LimitedOptions.args = {
+	value: 3,
+	options: [ 2, 3, 4 ],
+};
+
+export const StartingAsParagraph = Template.bind( {} );
+StartingAsParagraph.args = {
+	value: 0,
+	options: [ 0, 1, 2, 3 ],
+};
+
+export const InteractiveDropdown = () => {
+	const [ selectedLevel, setSelectedLevel ] = useState( 2 );
+
+	return (
+		<div>
+			<p>
+				Selected Level:{ ' ' }
+				{ selectedLevel === 0 ? 'Paragraph' : `H${ selectedLevel }` }
+			</p>
+			<HeadingLevelDropdown
+				value={ selectedLevel }
+				options={ [ 0, 1, 2, 3, 4, 5, 6 ] }
+				onChange={ ( newLevel ) => setSelectedLevel( newLevel ) }
+			/>
+		</div>
+	);
+};

--- a/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
+++ b/packages/block-editor/src/components/block-heading-level-dropdown/stories/index.story.js
@@ -11,30 +11,31 @@ import HeadingLevelDropdown from '../';
 const meta = {
 	title: 'BlockEditor/HeadingLevelDropdown',
 	component: HeadingLevelDropdown,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Dropdown for selecting a heading level (1 through 6) or paragraph (0).',
+			},
+		},
+	},
 	argTypes: {
 		value: {
 			control: { type: null },
-			description: 'The currently selected heading level.',
+			description: 'The chosen heading level.',
 		},
 		options: {
-			control: 'array',
-			description:
-				'An array of supported heading levels, e.g., [1, 2, 3, 4, 5, 6].',
+			control: 'check',
+			options: [ 1, 2, 3, 4, 5, 6 ],
+			description: 'An array of supported heading levels.',
 		},
 		onChange: {
 			action: 'onChange',
 			control: { type: null },
-			description:
-				'Callback triggered when a new heading level is selected.',
+			description: 'Function called with the selected value changes.',
 		},
 	},
-	decorators: [
-		( Story ) => (
-			<div style={ { padding: '20px', maxWidth: '300px' } }>
-				<Story />
-			</div>
-		),
-	],
 };
 
 export default meta;
@@ -56,6 +57,5 @@ export const Default = {
 	},
 	args: {
 		value: 2,
-		options: [ 1, 2, 3, 4, 5, 6 ],
 	},
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for HeadingLevelDropdown component in the Storybook

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open the storybook on http://localhost:50240/
3. Check the `HeadingLevelDropdown` stories.

## Screenshots or screencast 
![Screenshot 2024-12-02 at 5 29 42 PM](https://github.com/user-attachments/assets/30c0a23c-24db-45f8-bb3d-b3b3074484e1)



