### PR TITLE
CommentsPagination: Set font-size to inherit for pagination items

### DIFF
--- a/packages/block-library/src/comments-pagination/editor.scss
+++ b/packages/block-library/src/comments-pagination/editor.scss
@@ -27,7 +27,6 @@ $pagination-margin: 0.5em;
 		margin-bottom: $pagination-margin;
 
 		font-size: inherit;
-
 		&:last-child {
 			/*rtl:ignore*/
 			margin-right: 0;

--- a/packages/block-library/src/comments-pagination/editor.scss
+++ b/packages/block-library/src/comments-pagination/editor.scss
@@ -26,6 +26,8 @@ $pagination-margin: 0.5em;
 		margin-right: $pagination-margin;
 		margin-bottom: $pagination-margin;
 
+		font-size: inherit;
+
 		&:last-child {
 			/*rtl:ignore*/
 			margin-right: 0;

--- a/packages/block-library/src/comments-pagination/style.scss
+++ b/packages/block-library/src/comments-pagination/style.scss
@@ -8,6 +8,8 @@ $pagination-margin: 0.5em;
 		margin-right: $pagination-margin;
 		margin-bottom: $pagination-margin;
 
+		font-size: inherit;
+
 		&:last-child {
 			/*rtl:ignore*/
 			margin-right: 0;

--- a/packages/block-library/src/comments-pagination/style.scss
+++ b/packages/block-library/src/comments-pagination/style.scss
@@ -9,7 +9,6 @@ $pagination-margin: 0.5em;
 		margin-bottom: $pagination-margin;
 
 		font-size: inherit;
-
 		&:last-child {
 			/*rtl:ignore*/
 			margin-right: 0;


### PR DESCRIPTION
Fixes: #67295 

## What?
Inside the Comments Pagination block, updating the font sizes from the Typography Controls do not get reflected in the Editor as well as the Front End. This PR aims to resolve that issue.

## Why?
This PR addresses a bug that does not let the font sizes of the items contained in the Comments Pagination block change upon changing the font size from the Typography Controls.

More info about the bug is reported in the issue.

## How?
Using `font-size: inherit` appears to resolve the issue.

## Testing Instructions
1. Create a Comments Block.
2. Inside Comments Block, choose the Comment Pagination block and try changing the font sizes to Large or Extra Large. Observe the size change getting reflected both on the Editor as well as the front-end.
3. The font size will be reflected on the next comment text, previous comment text and comment pagination numbers unless overwritten by changing font-sizes of each of those components separately, in that case, the separate styles will be prioritized.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/926db408-799f-4246-bb20-558e0df73c1a


