### PR TITLE
Columns: Remove empty html render for columns block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -108,7 +108,7 @@ Display content in multiple columns, with blocks added to each column. ([Source]
 -	**Category:** design
 -	**Allowed Blocks:** core/column
 -	**Supports:** align (full, wide), anchor, color (background, button, gradients, heading, link, text), interactivity (clientNavigation), layout (default, ~~allowEditing~~, ~~allowInheriting~~, ~~allowSwitching~~), shadow, spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** isStackedOnMobile, templateLock, verticalAlignment
+-	**Attributes:** isEmptyColumn, isStackedOnMobile, templateLock, verticalAlignment
 
 ## Comment Author Avatar (deprecated)
 

--- a/packages/block-library/src/columns/block.json
+++ b/packages/block-library/src/columns/block.json
@@ -8,6 +8,10 @@
 	"description": "Display content in multiple columns, with blocks added to each column.",
 	"textdomain": "default",
 	"attributes": {
+		"isEmptyColumn": {
+			"type": "boolean",
+			"default": false
+		},
 		"verticalAlignment": {
 			"type": "string"
 		},

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -33,6 +33,7 @@ import {
 /**
  * Internal dependencies
  */
+import { useEffect } from '@wordpress/element';
 import {
 	hasExplicitPercentColumnWidths,
 	getMappedColumnWidths,
@@ -296,12 +297,37 @@ function Placeholder( { clientId, name, setAttributes } ) {
 }
 
 const ColumnsEdit = ( props ) => {
-	const { clientId } = props;
+	const { clientId, setAttributes } = props;
 	const hasInnerBlocks = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlocks( clientId ).length > 0,
 		[ clientId ]
 	);
+
+	const isEmpty = useSelect(
+		( select ) => {
+			const blocks = select( blockEditorStore ).getBlocks( clientId );
+			const length = blocks?.length ?? 0;
+
+			for ( let i = 0; i < length; i++ ) {
+				const eachInnerBlock = select( blockEditorStore ).getBlocks(
+					blocks[ i ].clientId
+				);
+
+				if ( eachInnerBlock.length > 0 ) {
+					return false;
+				}
+			}
+
+			return true;
+		},
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		setAttributes( { isEmptyColumn: isEmpty } );
+	}, [ isEmpty, setAttributes ] );
+
 	const Component = hasInnerBlocks ? ColumnsEditContainer : Placeholder;
 
 	return <Component { ...props } />;

--- a/packages/block-library/src/columns/save.js
+++ b/packages/block-library/src/columns/save.js
@@ -9,7 +9,11 @@ import clsx from 'clsx';
 import { useInnerBlocksProps, useBlockProps } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
-	const { isStackedOnMobile, verticalAlignment } = attributes;
+	const { isStackedOnMobile, verticalAlignment, isEmptyColumn } = attributes;
+
+	if ( isEmptyColumn ) {
+		return null;
+	}
 
 	const className = clsx( {
 		[ `are-vertically-aligned-${ verticalAlignment }` ]: verticalAlignment,


### PR DESCRIPTION
Part of : #63332

## What?
Prevents empty HTML markup generation for columns blocks that have no inner blocks.

## Why?
This PR addresses an edge case where columns block wrappers continue to render empty HTML markup on the website even after there is no inner block content.

## Testing Instructions
1. Create a new post.
2. Add a columns block.
3. Add an empty column block, and save.

View the post on the front, and view the source.


## Screencast

### Before patch

https://github.com/user-attachments/assets/b16f00fa-dbf5-4da8-87d2-c06b43fb05b9

### After patch

https://github.com/user-attachments/assets/eb54ecc9-394f-4ac0-946a-adf4e6a0f17a
