### PR TITLE
DataViews: Add apiVersion in view config

### DIFF
--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -25,6 +25,7 @@ import DataViewsViewConfig from '../dataviews-view-config';
 import { normalizeFields } from '../../normalize-fields';
 import type { Action, Field, View, SupportedLayouts } from '../../types';
 import type { SelectionOrUpdater } from '../../private-types';
+import { migrateViewConfig } from '../../migrations';
 
 type ItemWithId = { id: string };
 
@@ -89,6 +90,7 @@ export default function DataViews< Item >( {
 			onChangeSelection( newValue );
 		}
 	}
+	const _view = useMemo( () => migrateViewConfig( view ), [ view ] );
 	const _fields = useMemo( () => normalizeFields( fields ), [ fields ] );
 	const _selection = useMemo( () => {
 		return selection.filter( ( id ) =>
@@ -96,7 +98,7 @@ export default function DataViews< Item >( {
 		);
 	}, [ selection, data, getItemId ] );
 
-	const filters = useFilters( _fields, view );
+	const filters = useFilters( _fields, _view );
 	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
 		( filters || [] ).some( ( filter ) => filter.isPrimary )
 	);
@@ -104,7 +106,7 @@ export default function DataViews< Item >( {
 	return (
 		<DataViewsContext.Provider
 			value={ {
-				view,
+				view: _view,
 				onChangeView,
 				fields: _fields,
 				actions,
@@ -135,7 +137,7 @@ export default function DataViews< Item >( {
 						{ search && <DataViewsSearch label={ searchLabel } /> }
 						<FiltersToggle
 							filters={ filters }
-							view={ view }
+							view={ _view }
 							onChangeView={ onChangeView }
 							setOpenedFilter={ setOpenedFilter }
 							setIsShowingFilter={ setIsShowingFilter }

--- a/packages/dataviews/src/migrations.ts
+++ b/packages/dataviews/src/migrations.ts
@@ -1,0 +1,11 @@
+/**
+ * Internal dependencies
+ */
+import type { View } from './types';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const VIEW_CONFIG_API_VERSION = 1;
+
+export function migrateViewConfig( view: View ) {
+	return view;
+}

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -249,6 +249,11 @@ export interface NormalizedFilter {
 
 interface ViewBase {
 	/**
+	 * The version of the API.
+	 */
+	apiVersion?: number;
+
+	/**
 	 * The layout of the view.
 	 */
 	type: string;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/67274

This PR explores adding an `apiVersion` to DataViews view config for preparation for making the API stable.
Right now the migration function is just an identity one, as we don't have the need for any migration.

What concerns me though is the migration cannot be an one time thing by checking `VIEW_CONFIG_API_VERSION`. The reason for this is the `onChangeView` callback where consumers can update the view config externally and they could be adding/updating some previous version props. Probably the approach for this config should be a callback (like `isVersion1` or something) and not a check with a version number.

## Testing Instructions
1. Everything should work as before and no visible changes.
