### PR TITLE
DataViews list layout: scroll selected item to top on mount

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -150,6 +150,16 @@ function ListItem< Item >( {
 		setIsHovered( isHover );
 	};
 
+	// This effect is to scroll the item to the top of the list only on mount,
+	// so no dependencies declared.
+	useEffect( () => {
+		if ( isSelected ) {
+			itemRef.current?.scrollIntoView( true );
+		}
+		// eslint-disable-next-line react-compiler/react-compiler
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	useEffect( () => {
 		if ( isSelected ) {
 			itemRef.current?.scrollIntoView( {


### PR DESCRIPTION
## What?

This PR scrolls the selected item to the top on mounting the list layout.

## Why?

To give it more visibility.

## How?

Add a effect that only runs on mount.

## Testing Instructions

### 1. Select an item that is near the top:

- Before

https://github.com/user-attachments/assets/d3ec37d3-04b6-4e2c-942c-31c0ae03444f

- After

https://github.com/user-attachments/assets/eb3c151a-f810-4a94-90ba-24c5a5716e6a

### 2. Select an item that is near the bottom:

- Before

https://github.com/user-attachments/assets/d1926d61-482c-4a40-abb3-17b4916cbc13


- After

https://github.com/user-attachments/assets/f4e7696f-ab5f-44b7-8691-7c04455cb28a
