### PR TITLE
FontSizePickerSelect: Fix font size label mismatch in Global Styles

### DIFF
--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -145,11 +145,11 @@ function CustomSelectControl< T extends CustomSelectOption >(
 	const renderSelectedValueHint = () => {
 		const selectedOptionHint = options
 			?.map( applyOptionDeprecations )
-			?.find( ( { name } ) => currentValue === name )?.hint;
+			?.find( ( { name } ) => value?.name === name )?.hint;
 
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
-				{ currentValue }
+				{ value?.name }
 				{ selectedOptionHint && (
 					<Styled.SelectedExperimentalHintItem
 						// Keeping the classname for legacy reasons


### PR DESCRIPTION
Issue: #67283

## What?
Fix a font size selection label issue in the Global Styles UI when multiple custom font sizes are defined in theme.json.

## Why?
When a theme declares several custom font sizes (more than the standard S, M, L, XL, XXL pattern), the font size selection label becomes inconsistent and does not accurately reflect the currently selected font size. This creates a confusing user experience when configuring typography settings for headings.

## How?
Modified the `CustomSelectControl` component to correctly display the selected value's label by updating the `renderSelectedValueHint` function to use `value?.name` instead of `currentValue`. This ensures that the label always matches the currently selected font size, especially when multiple custom font sizes are defined.

## Testing Instructions
- Create a theme.json file with more than 5 custom font sizes
- Open the WordPress Site Editor
- Navigate to Global Styles > Typography > Headings
- Cycle through H1-H6 heading selectors
- Verify that the font size dropdown label correctly reflects the selected font size for each heading level


## Screenshots or screencast <!-- if applicable -->

### Before:
https://github.com/user-attachments/assets/64aefe19-a5fd-4149-a91d-6d258d86ecbd

### After:
https://github.com/user-attachments/assets/5c49a582-1114-4173-87e9-349bb11ad81f


