### PR TITLE
Block editor: try direct drag (outside text editable)

### DIFF
--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -18,3 +18,7 @@
 		content: none !important;
 	}
 }
+
+img:not([draggable]) {
+	pointer-events: none;
+}

--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -20,6 +20,7 @@
 
 // Images are draggable by default, so disable drag for them if not explicitly
 // set. This is done so that the block can capture the drag event instead.
-.wp-block img:not([draggable]) {
+.wp-block img:not([draggable]),
+.wp-block svg:not([draggable]) {
 	pointer-events: none;
 }

--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -18,6 +18,8 @@
 	}
 }
 
-img:not([draggable]) {
+// Images are draggable by default, so disable drag for them if not explicitly
+// set. This is done so that the block can capture the drag event instead.
+.wp-block img:not([draggable]) {
 	pointer-events: none;
 }

--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -5,10 +5,6 @@
 	opacity: 0.05 !important;
 	border-radius: $radius-small !important;
 
-	// Disabling pointer events during the drag event is necessary,
-	// lest the block might affect your drag operation.
-	pointer-events: none !important;
-
 	// Hide the multi selection indicator when dragging.
 	&::selection {
 		background: transparent !important;

--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -4,6 +4,10 @@
 	opacity: 0.1 !important;
 	border-radius: $radius-small !important;
 
+	iframe {
+		pointer-events: none;
+	}
+
 	// Hide the multi selection indicator when dragging.
 	&::selection {
 		background: transparent !important;

--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -1,8 +1,7 @@
 // This creates a "slot" where the block you're dragging appeared.
 // We use !important as one of the rules are meant to be overridden.
 .block-editor-block-list__layout .is-dragging {
-	background-color: currentColor !important;
-	opacity: 0.05 !important;
+	opacity: 0.1 !important;
 	border-radius: $radius-small !important;
 
 	// Hide the multi selection indicator when dragging.

--- a/packages/block-editor/src/components/block-list/block.js
+++ b/packages/block-editor/src/components/block-list/block.js
@@ -797,6 +797,7 @@ function BlockListBlockProvider( props ) {
 		mayDisplayParentControls,
 		originalBlockClientId,
 		themeSupportsLayout,
+		canMove,
 	};
 
 	// Here we separate between the props passed to BlockListBlock and any other

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -427,3 +427,9 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	// Additional -1px is required to avoid sub pixel rounding errors allowing background to show.
 	margin: 0 calc(-1 * var(--wp--style--root--padding-right) - 1px) 0 calc(-1 * var(--wp--style--root--padding-left) - 1px) !important;
 }
+
+// This only works in Firefox, Chrome and Safari don't accept a custom cursor
+// during drag.
+.is-dragging {
+	cursor: grabbing;
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -152,6 +152,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
+		draggable: true,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -100,6 +100,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		isTemporarilyEditingAsBlocks,
 		defaultClassName,
 		isSectionBlock,
+		canMove,
 	} = useContext( PrivateBlockContext );
 
 	// translators: %s: Type of block (i.e. Text, Image etc)
@@ -152,7 +153,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
-		draggable: hasChildSelected ? undefined : true,
+		draggable: ! hasChildSelected && canMove ? true : undefined,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -152,7 +152,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
-		draggable: true,
+		draggable: hasChildSelected ? undefined : true,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -30,6 +30,7 @@ import { useIntersectionObserver } from './use-intersection-observer';
 import { useScrollIntoView } from './use-scroll-into-view';
 import { useFlashEditableBlocks } from '../../use-flash-editable-blocks';
 import { canBindBlock } from '../../../hooks/use-bindings-attributes';
+import { useFirefoxDraggableCompatibility } from './use-firefox-draggable-compatibility';
 
 /**
  * This hook is used to lightly mark an element as a block element. The element
@@ -106,6 +107,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
+	const ffDragRef = useFirefoxDraggableCompatibility();
 	const mergedRefs = useMergeRefs( [
 		props.ref,
 		useFocusFirstElement( { clientId, initialPosition } ),
@@ -121,6 +123,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			isEnabled: isSectionBlock,
 		} ),
 		useScrollIntoView( { isSelected } ),
+		canMove ? ffDragRef : undefined,
 	] );
 
 	const blockEditContext = useBlockEditContext();
@@ -153,7 +156,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
-		draggable: ! hasChildSelected && canMove ? true : undefined,
+		draggable: canMove ? true : undefined,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,

--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -104,6 +104,8 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		canMove,
 	} = useContext( PrivateBlockContext );
 
+	const canDrag = canMove && ! hasChildSelected;
+
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
@@ -123,7 +125,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			isEnabled: isSectionBlock,
 		} ),
 		useScrollIntoView( { isSelected } ),
-		canMove ? ffDragRef : undefined,
+		canDrag ? ffDragRef : undefined,
 	] );
 
 	const blockEditContext = useBlockEditContext();
@@ -156,7 +158,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
-		draggable: canMove ? true : undefined,
+		draggable: canDrag ? true : undefined,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,

--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -1,0 +1,21 @@
+/**
+ * WordPress dependencies
+ */
+import { useRefEffect } from '@wordpress/compose';
+
+export function useFirefoxDraggableCompatibility() {
+	return useRefEffect( ( node ) => {
+		function onDown( event ) {
+			if ( event.target.isContentEditable ) {
+				node.draggable = false;
+			} else {
+				node.draggable = true;
+			}
+		}
+		const { ownerDocument } = node;
+		ownerDocument.addEventListener( 'pointerdown', onDown );
+		return () => {
+			ownerDocument.removeEventListener( 'pointerdown', onDown );
+		};
+	}, [] );
+}

--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -6,11 +6,7 @@ import { useRefEffect } from '@wordpress/compose';
 export function useFirefoxDraggableCompatibility() {
 	return useRefEffect( ( node ) => {
 		function onDown( event ) {
-			if ( event.target.isContentEditable ) {
-				node.draggable = false;
-			} else {
-				node.draggable = true;
-			}
+			node.draggable = ! event.target.isContentEditable;
 		}
 		const { ownerDocument } = node;
 		ownerDocument.addEventListener( 'pointerdown', onDown );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -3,6 +3,14 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 
+/**
+ * In Firefox, the `draggable` and `contenteditable` attributes don't play well
+ * together. When `contenteditable` is within a `draggable` element, selection
+ * doesn't get set in the right place. The only solution is to temporarily
+ * remove the `draggable` attribute clicking inside `contenteditable` elements.
+ *
+ * @return {Function} Cleanup function.
+ */
 export function useFirefoxDraggableCompatibility() {
 	return useRefEffect( ( node ) => {
 		function onDown( event ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -76,7 +76,25 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 * @param {DragEvent} event Drag event.
 			 */
 			function onDragStart( event ) {
-				event.preventDefault();
+				const { ownerDocument } = node;
+				const { defaultView } = ownerDocument;
+				const selection = defaultView.getSelection();
+				if (
+					node !== event.target ||
+					node.contains( selection.anchorNode ) ||
+					node.contains( selection.focusNode )
+				) {
+					event.preventDefault();
+					return;
+				}
+				const data = JSON.stringify( {
+					type: 'block',
+					srcClientIds: [ clientId ],
+					srcRootClientId: getBlockRootClientId( clientId ),
+				} );
+				event.dataTransfer.clearData();
+				event.dataTransfer.setData( 'wp-blocks', data );
+				selection.removeAllRanges();
 			}
 
 			node.addEventListener( 'keydown', onKeyDown );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -79,10 +79,19 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				const { ownerDocument } = node;
 				const { defaultView } = ownerDocument;
 				const selection = defaultView.getSelection();
+				let { anchorNode, focusNode } = selection;
+				if ( anchorNode !== anchorNode.ELEMENT_NODE ) {
+					anchorNode = anchorNode.parentElement;
+				}
+				if ( focusNode !== focusNode.ELEMENT_NODE ) {
+					focusNode = focusNode.parentElement;
+				}
 				if (
 					node !== event.target ||
-					node.contains( selection.anchorNode ) ||
-					node.contains( selection.focusNode )
+					( node.contains( anchorNode ) &&
+						anchorNode.isContentEditable ) ||
+					( node.contains( focusNode ) &&
+						focusNode.isContentEditable )
 				) {
 					event.preventDefault();
 					return;

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -27,9 +27,13 @@ export function useEventHandlers( { clientId, isSelected } ) {
 	const { getBlockType } = useSelect( blocksStore );
 	const { getBlockRootClientId, isZoomOut, hasMultiSelection, getBlockName } =
 		unlock( useSelect( blockEditorStore ) );
-	const { insertAfterBlock, removeBlock, resetZoomLevel } = unlock(
-		useDispatch( blockEditorStore )
-	);
+	const {
+		insertAfterBlock,
+		removeBlock,
+		resetZoomLevel,
+		startDraggingBlocks,
+		stopDraggingBlocks,
+	} = unlock( useDispatch( blockEditorStore ) );
 
 	return useRefEffect(
 		( node ) => {
@@ -147,11 +151,14 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					ownerDocument.removeEventListener( 'dragend', end );
 					domNode.remove();
 					img.remove();
+					stopDraggingBlocks();
 				}
 
 				ownerDocument.addEventListener( 'dragover', over );
 				ownerDocument.addEventListener( 'dragend', end );
 				ownerDocument.addEventListener( 'drop', end );
+
+				startDraggingBlocks( [ clientId ] );
 			}
 
 			node.addEventListener( 'keydown', onKeyDown );
@@ -171,6 +178,8 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			isZoomOut,
 			resetZoomLevel,
 			hasMultiSelection,
+			startDraggingBlocks,
+			stopDraggingBlocks,
 		]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -159,6 +159,9 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					document.body.classList.remove(
 						'is-dragging-components-draggable'
 					);
+					ownerDocument.documentElement.classList.remove(
+						'is-dragging'
+					);
 				}
 
 				ownerDocument.addEventListener( 'dragover', over );
@@ -170,6 +173,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				document.body.classList.add(
 					'is-dragging-components-draggable'
 				);
+				ownerDocument.documentElement.classList.add( 'is-dragging' );
 			}
 
 			node.addEventListener( 'keydown', onKeyDown );

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -126,6 +126,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				// ourselves.
 				const img = ownerDocument.createElement( 'canvas' );
 				ownerDocument.body.appendChild( img );
+				img.style.opacity = '0';
 				event.dataTransfer.setDragImage( img, 0, 0 );
 
 				let offset = { x: 0, y: 0 };

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -76,23 +76,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 * @param {DragEvent} event Drag event.
 			 */
 			function onDragStart( event ) {
-				const { ownerDocument } = node;
-				const { defaultView } = ownerDocument;
-				const selection = defaultView.getSelection();
-				let { anchorNode, focusNode } = selection;
-				if ( anchorNode !== anchorNode.ELEMENT_NODE ) {
-					anchorNode = anchorNode.parentElement;
-				}
-				if ( focusNode !== focusNode.ELEMENT_NODE ) {
-					focusNode = focusNode.parentElement;
-				}
-				if (
-					node !== event.target ||
-					( node.contains( anchorNode ) &&
-						anchorNode.isContentEditable ) ||
-					( node.contains( focusNode ) &&
-						focusNode.isContentEditable )
-				) {
+				if ( node !== event.target || node.isContentEditable ) {
 					event.preventDefault();
 					return;
 				}
@@ -103,6 +87,9 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				} );
 				event.dataTransfer.clearData();
 				event.dataTransfer.setData( 'wp-blocks', data );
+				const { ownerDocument } = node;
+				const { defaultView } = ownerDocument;
+				const selection = defaultView.getSelection();
 				selection.removeAllRanges();
 			}
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -86,6 +86,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				if (
 					node !== event.target ||
 					node.isContentEditable ||
+					node.ownerDocument.activeElement !== node ||
 					hasMultiSelection()
 				) {
 					event.preventDefault();

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -21,7 +21,7 @@ import { unlock } from '../../../lock-unlock';
  * @param {string} clientId Block client ID.
  */
 export function useEventHandlers( { clientId, isSelected } ) {
-	const { getBlockRootClientId, getBlockIndex, isZoomOut } = unlock(
+	const { getBlockRootClientId, isZoomOut, hasMultiSelection } = unlock(
 		useSelect( blockEditorStore )
 	);
 	const { insertAfterBlock, removeBlock, resetZoomLevel } = unlock(
@@ -76,7 +76,11 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			 * @param {DragEvent} event Drag event.
 			 */
 			function onDragStart( event ) {
-				if ( node !== event.target || node.isContentEditable ) {
+				if (
+					node !== event.target ||
+					node.isContentEditable ||
+					hasMultiSelection()
+				) {
 					event.preventDefault();
 					return;
 				}
@@ -105,11 +109,11 @@ export function useEventHandlers( { clientId, isSelected } ) {
 			clientId,
 			isSelected,
 			getBlockRootClientId,
-			getBlockIndex,
 			insertAfterBlock,
 			removeBlock,
 			isZoomOut,
 			resetZoomLevel,
+			hasMultiSelection,
 		]
 	);
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -124,10 +124,15 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				// Safari, it animates, in Firefox it's slightly transparent...
 				// So we set a fake drag image and have to reposition it
 				// ourselves.
-				const img = ownerDocument.createElement( 'canvas' );
-				ownerDocument.body.appendChild( img );
-				img.style.opacity = '0';
-				event.dataTransfer.setDragImage( img, 0, 0 );
+				const dragElement = ownerDocument.createElement( 'div' );
+				// Chrome will show a globe icon if the drag element does not
+				// have dimensions.
+				dragElement.style.width = '1px';
+				dragElement.style.height = '1px';
+				dragElement.style.position = 'fixed';
+				dragElement.style.visibility = 'hidden';
+				ownerDocument.body.appendChild( dragElement );
+				event.dataTransfer.setDragImage( dragElement, 0, 0 );
 
 				let offset = { x: 0, y: 0 };
 
@@ -154,7 +159,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					ownerDocument.removeEventListener( 'dragover', over );
 					ownerDocument.removeEventListener( 'dragend', end );
 					domNode.remove();
-					img.remove();
+					dragElement.remove();
 					stopDraggingBlocks();
 					document.body.classList.remove(
 						'is-dragging-components-draggable'

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -148,12 +148,17 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					}px, ${ e.clientY + offset.y }px )`;
 				}
 
+				over( event );
+
 				function end() {
 					ownerDocument.removeEventListener( 'dragover', over );
 					ownerDocument.removeEventListener( 'dragend', end );
 					domNode.remove();
 					img.remove();
 					stopDraggingBlocks();
+					document.body.classList.remove(
+						'is-dragging-components-draggable'
+					);
 				}
 
 				ownerDocument.addEventListener( 'dragover', over );
@@ -161,6 +166,10 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.addEventListener( 'drop', end );
 
 				startDraggingBlocks( [ clientId ] );
+				// Important because it hides the block toolbar.
+				document.body.classList.add(
+					'is-dragging-components-draggable'
+				);
 			}
 
 			node.addEventListener( 'keydown', onKeyDown );

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -25,7 +25,6 @@ export function useShowBlockTools() {
 			getSettings,
 			__unstableGetEditorMode,
 			isTyping,
-			isDraggingBlocks,
 		} = unlock( select( blockEditorStore ) );
 
 		const clientId =
@@ -49,7 +48,6 @@ export function useShowBlockTools() {
 			! getSettings().hasFixedToolbar &&
 			! _showEmptyBlockSideInserter &&
 			hasSelectedBlock &&
-			! isDraggingBlocks() &&
 			! isEmptyDefaultBlock;
 
 		return {

--- a/packages/block-editor/src/components/block-tools/use-show-block-tools.js
+++ b/packages/block-editor/src/components/block-tools/use-show-block-tools.js
@@ -25,6 +25,7 @@ export function useShowBlockTools() {
 			getSettings,
 			__unstableGetEditorMode,
 			isTyping,
+			isDraggingBlocks,
 		} = unlock( select( blockEditorStore ) );
 
 		const clientId =
@@ -48,6 +49,7 @@ export function useShowBlockTools() {
 			! getSettings().hasFixedToolbar &&
 			! _showEmptyBlockSideInserter &&
 			hasSelectedBlock &&
+			! isDraggingBlocks() &&
 			! isEmptyDefaultBlock;
 
 		return {

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -60,5 +60,9 @@
 				}
 			}
 		}
+
+		.wp-block[draggable] {
+			cursor: grab;
+		}
 	}
 }

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -431,6 +431,10 @@ export function RichTextWrapper(
 				aria-multiline={ ! disableLineBreaks }
 				aria-readonly={ shouldDisableEditing }
 				{ ...props }
+				// Unset draggable for contentEditable elements because it will
+				// interfere with multi block selection when the contentEditable
+				// and draggable elements are the same element.
+				draggable={ undefined }
 				aria-label={
 					bindingsLabel || props[ 'aria-label' ] || placeholder
 				}

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -431,9 +431,10 @@ export function RichTextWrapper(
 				aria-multiline={ ! disableLineBreaks }
 				aria-readonly={ shouldDisableEditing }
 				{ ...props }
-				// Unset draggable for contentEditable elements because it will
-				// interfere with multi block selection when the contentEditable
-				// and draggable elements are the same element.
+				// Unset draggable (coming from block props) for contentEditable
+				// elements because it will interfere with multi block selection
+				// when the contentEditable and draggable elements are the same
+				// element.
 				draggable={ undefined }
 				aria-label={
 					bindingsLabel || props[ 'aria-label' ] || placeholder

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -332,6 +332,7 @@ export default function useBlockDropZone( {
 		isGroupable,
 		isZoomOut,
 		getSectionRootClientId,
+		getBlockParents,
 	} = unlock( useSelect( blockEditorStore ) );
 	const {
 		showInsertionPoint,
@@ -358,13 +359,29 @@ export default function useBlockDropZone( {
 					// So, ensure that the drag state is set when the user drags over a drop zone.
 					startDragging();
 				}
+
+				const draggedBlockClientIds = getDraggedBlockClientIds();
+				const targetParents = [
+					targetRootClientId,
+					...getBlockParents( targetRootClientId, true ),
+				];
+
+				// Check if the target is within any of the dragged blocks.
+				const isTargetWithinDraggedBlocks = draggedBlockClientIds.some(
+					( clientId ) => targetParents.includes( clientId )
+				);
+
+				if ( isTargetWithinDraggedBlocks ) {
+					return;
+				}
+
 				const allowedBlocks = getAllowedBlocks( targetRootClientId );
 				const targetBlockName = getBlockNamesByClientId( [
 					targetRootClientId,
 				] )[ 0 ];
 
 				const draggedBlockNames = getBlockNamesByClientId(
-					getDraggedBlockClientIds()
+					draggedBlockClientIds
 				);
 				const isBlockDroppingAllowed = isDropTargetValid(
 					getBlockType,

--- a/packages/block-editor/src/components/writing-flow/use-drag-selection.js
+++ b/packages/block-editor/src/components/writing-flow/use-drag-selection.js
@@ -80,7 +80,17 @@ export default function useDragSelection() {
 				} );
 			}
 
+			let lastMouseDownTarget;
+
+			function onMouseDown( { target } ) {
+				lastMouseDownTarget = target;
+			}
+
 			function onMouseLeave( { buttons, target, relatedTarget } ) {
+				if ( ! target.contains( lastMouseDownTarget ) ) {
+					return;
+				}
+
 				// If we're moving into a child element, ignore. We're tracking
 				// the mouse leaving the element to a parent, no a child.
 				if ( target.contains( relatedTarget ) ) {
@@ -141,6 +151,7 @@ export default function useDragSelection() {
 			}
 
 			node.addEventListener( 'mouseout', onMouseLeave );
+			node.addEventListener( 'mousedown', onMouseDown );
 
 			return () => {
 				node.removeEventListener( 'mouseout', onMouseLeave );

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -16,6 +16,10 @@
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
 -   Upgraded `@ariakit/react` (v0.4.15) and `@ariakit/test` (v0.4.7) ([#67404](https://github.com/WordPress/gutenberg/pull/67404)).
 
+### Bug Fixes
+
+-   `ResizableBox`: Make drag handles focusable ([#67305](https://github.com/WordPress/gutenberg/pull/67305)).
+
 ## 28.13.0 (2024-11-27)
 
 ### Deprecations
@@ -39,7 +43,6 @@
 -   `FormFileUpload`: Prevent HEIC and HEIF files from being uploaded on Safari ([#67139](https://github.com/WordPress/gutenberg/pull/67139)).
 -   `Composite.Hover`: Restore functionality ([#67212](https://github.com/WordPress/gutenberg/pull/67212)).
 -   `Composite.Typeahead`: Restore functionality ([#67212](https://github.com/WordPress/gutenberg/pull/67212)).
--   `ResizableBox`: Make drag handles focusable ([#67305](https://github.com/WordPress/gutenberg/pull/67305)).
 -   `Dashicons`: Remove non-existent icons from type ([#67235](https://github.com/WordPress/gutenberg/pull/67235)).
 
 ### Enhancements

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -39,6 +39,7 @@
 -   `FormFileUpload`: Prevent HEIC and HEIF files from being uploaded on Safari ([#67139](https://github.com/WordPress/gutenberg/pull/67139)).
 -   `Composite.Hover`: Restore functionality ([#67212](https://github.com/WordPress/gutenberg/pull/67212)).
 -   `Composite.Typeahead`: Restore functionality ([#67212](https://github.com/WordPress/gutenberg/pull/67212)).
+-   `ResizableBox`: Make drag handles focusable ([#67305](https://github.com/WordPress/gutenberg/pull/67305)).
 -   `Dashicons`: Remove non-existent icons from type ([#67235](https://github.com/WordPress/gutenberg/pull/67235)).
 
 ### Enhancements

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -115,6 +115,11 @@ function UnforwardedResizableBox(
 			handleClasses={ HANDLE_CLASSES }
 			handleStyles={ HANDLE_STYLES }
 			ref={ ref }
+			// Resizable unfortunately does provide focusable drag handles
+			// (as it should), so capture focus here to prevent block drag
+			// from being triggered.
+			// @ts-expect-error
+			tabIndex={ -1 }
 			{ ...props }
 		>
 			{ children }

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -112,14 +112,15 @@ function UnforwardedResizableBox(
 				showHandle && 'has-show-handle',
 				className
 			) }
+			handleComponent={ Object.fromEntries(
+				Object.keys( HANDLE_CLASSES ).map( ( key ) => [
+					key,
+					<div key={ key } tabIndex={ -1 } />,
+				] )
+			) }
 			handleClasses={ HANDLE_CLASSES }
 			handleStyles={ HANDLE_STYLES }
 			ref={ ref }
-			// Resizable unfortunately does provide focusable drag handles
-			// (as it should), so capture focus here to prevent block drag
-			// from being triggered.
-			// @ts-expect-error
-			tabIndex={ -1 }
 			{ ...props }
 		>
 			{ children }

--- a/packages/components/src/resizable-box/index.tsx
+++ b/packages/components/src/resizable-box/index.tsx
@@ -112,6 +112,10 @@ function UnforwardedResizableBox(
 				showHandle && 'has-show-handle',
 				className
 			) }
+			// Add a focusable element within the drag handle. Unfortunately,
+			// `re-resizable` does not make them properly focusable by default,
+			// causing focus to move the the block wrapper which triggers block
+			// drag.
 			handleComponent={ Object.fromEntries(
 				Object.keys( HANDLE_CLASSES ).map( ( key ) => [
 					key,

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -21,6 +21,7 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 		width: 100%;
 		height: 100%;
 		z-index: z-index(".components-resizable-box__handle");
+		outline: none;
 	}
 }
 

--- a/packages/components/src/resizable-box/style.scss
+++ b/packages/components/src/resizable-box/style.scss
@@ -15,6 +15,13 @@ $resize-handler-container-size: $resize-handler-size + ($grid-unit-05 * 2); // M
 	.components-resizable-box__container.has-show-handle & {
 		display: block;
 	}
+
+	> div {
+		position: relative;
+		width: 100%;
+		height: 100%;
+		z-index: z-index(".components-resizable-box__handle");
+	}
 }
 
 // Make the image inside the resize to get the full width

--- a/test/e2e/specs/editor/blocks/spacer.spec.js
+++ b/test/e2e/specs/editor/blocks/spacer.spec.js
@@ -43,7 +43,9 @@ test.describe( 'Spacer', () => {
 		expect( await editor.getEditedPostContent() ).toMatchSnapshot();
 
 		await expect(
-			editor.canvas.locator( 'role=document[name="Block: Spacer"i]' )
+			editor.canvas.locator(
+				'role=document[name="Block: Spacer"i] >> css=.components-resizable-box__handle >> [tabindex]'
+			)
 		).toBeFocused();
 	} );
 } );

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -168,7 +168,10 @@ test.describe( 'Registered sources', () => {
 					name: 'Block: Image',
 				} )
 				.locator( 'img' );
-			await imageBlockImg.click();
+			// Playwright will complain that the pointer events are captured by
+			// the parent, but that's fine.
+			// eslint-disable-next-line playwright/no-force-option
+			await imageBlockImg.click( { force: true } );
 
 			// Image src is the custom field value.
 			await expect( imageBlockImg ).toHaveAttribute(
@@ -735,7 +738,10 @@ test.describe( 'Registered sources', () => {
 					name: 'Block: Image',
 				} )
 				.locator( 'img' );
-			await imageBlockImg.click();
+			// Playwright will complain that the pointer events are captured by
+			// the parent, but that's fine.
+			// eslint-disable-next-line playwright/no-force-option
+			await imageBlockImg.click( { force: true } );
 
 			// Edit the custom field value in the alt textarea.
 			const altInputArea = page

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -67,7 +67,6 @@ test.describe( 'Draggable block', () => {
 		const firstParagraph = editor.canvas.locator(
 			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
-		await dragTo( page, firstParagraph );
 		const firstParagraphBound = await firstParagraph.boundingBox();
 		await dragTo( page, firstParagraphBound.x, firstParagraphBound.y );
 

--- a/test/e2e/specs/editor/various/draggable-blocks.spec.js
+++ b/test/e2e/specs/editor/various/draggable-blocks.spec.js
@@ -18,6 +18,14 @@ test.use( {
 	},
 } );
 
+async function dragTo( page, x, y ) {
+	// Call the move function twice to make sure the `dragOver` event is sent.
+	// @see https://github.com/microsoft/playwright/issues/17153
+	for ( let i = 0; i < 2; i += 1 ) {
+		await page.mouse.move( x, y );
+	}
+}
+
 test.describe( 'Draggable block', () => {
 	test.beforeEach( async ( { admin } ) => {
 		await admin.createNewPost();
@@ -59,15 +67,9 @@ test.describe( 'Draggable block', () => {
 		const firstParagraph = editor.canvas.locator(
 			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
+		await dragTo( page, firstParagraph );
 		const firstParagraphBound = await firstParagraph.boundingBox();
-		// Call the move function twice to make sure the `dragOver` event is sent.
-		// @see https://github.com/microsoft/playwright/issues/17153
-		for ( let i = 0; i < 2; i += 1 ) {
-			await page.mouse.move(
-				firstParagraphBound.x,
-				firstParagraphBound.y
-			);
-		}
+		await dragTo( page, firstParagraphBound.x, firstParagraphBound.y );
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
@@ -132,15 +134,11 @@ test.describe( 'Draggable block', () => {
 			'role=document[name="Block: Paragraph"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();
-		// Call the move function twice to make sure the `dragOver` event is sent.
-		// @see https://github.com/microsoft/playwright/issues/17153
-		// Make sure mouse is > 30px within the block for bottom drop indicator to appear.
-		for ( let i = 0; i < 2; i += 1 ) {
-			await page.mouse.move(
-				secondParagraphBound.x + 32,
-				secondParagraphBound.y + secondParagraphBound.height * 0.75
-			);
-		}
+		await dragTo(
+			page,
+			secondParagraphBound.x + 32,
+			secondParagraphBound.y + secondParagraphBound.height * 0.75
+		);
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
@@ -216,14 +214,11 @@ test.describe( 'Draggable block', () => {
 			'role=document[name="Block: Paragraph"i] >> text=1'
 		);
 		const firstParagraphBound = await firstParagraph.boundingBox();
-		// Call the move function twice to make sure the `dragOver` event is sent.
-		// @see https://github.com/microsoft/playwright/issues/17153
-		for ( let i = 0; i < 2; i += 1 ) {
-			await page.mouse.move(
-				firstParagraphBound.x + firstParagraphBound.width * 0.25,
-				firstParagraphBound.y
-			);
-		}
+		await dragTo(
+			page,
+			firstParagraphBound.x + firstParagraphBound.width * 0.25,
+			firstParagraphBound.y
+		);
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
@@ -297,14 +292,11 @@ test.describe( 'Draggable block', () => {
 			'role=document[name="Block: Paragraph"i] >> text=2'
 		);
 		const secondParagraphBound = await secondParagraph.boundingBox();
-		// Call the move function twice to make sure the `dragOver` event is sent.
-		// @see https://github.com/microsoft/playwright/issues/17153
-		for ( let i = 0; i < 2; i += 1 ) {
-			await page.mouse.move(
-				secondParagraphBound.x + secondParagraphBound.width * 0.75,
-				secondParagraphBound.y
-			);
-		}
+		await dragTo(
+			page,
+			secondParagraphBound.x + secondParagraphBound.width * 0.75,
+			secondParagraphBound.y
+		);
 
 		await expect(
 			page.locator( 'data-testid=block-draggable-chip >> visible=true' )
@@ -464,5 +456,48 @@ test.describe( 'Draggable block', () => {
 				},
 			] );
 		}
+	} );
+
+	test( 'can directly drag an image', async ( { page, editor } ) => {
+		await editor.insertBlock( { name: 'core/image' } );
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: { layout: { type: 'constrained' } },
+			innerBlocks: [ { name: 'core/paragraph' } ],
+		} );
+
+		const imageBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Image',
+		} );
+
+		const groupBlock = editor.canvas.getByRole( 'document', {
+			name: 'Block: Group',
+		} );
+
+		await imageBlock.hover();
+		await page.mouse.down();
+		const groupBlockBox = await groupBlock.boundingBox();
+		await dragTo(
+			page,
+			groupBlockBox.x + groupBlockBox.width * 0.5,
+			groupBlockBox.y + groupBlockBox.height * 0.5
+		);
+		await page.mouse.up();
+
+		await expect.poll( editor.getBlocks ).toMatchObject( [
+			{
+				name: 'core/group',
+				attributes: {
+					tagName: 'div',
+					layout: { type: 'constrained' },
+				},
+				innerBlocks: [
+					{
+						name: 'core/image',
+						attributes: { alt: '', caption: '' },
+					},
+				],
+			},
+		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

![direct-drag](https://github.com/user-attachments/assets/88633805-1b8e-4baa-b6aa-6df77e737a64)


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it's more intuitive.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Enable built-in drag support and set the correct data.

We might want to use the current drag chip, instead of the default preview that the browser provides, not sure. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Drag an image by click and holding it directly instead of using the toolbar.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
