### PR TITLE
Editor: Fix deprecation version for template selectors

### DIFF
--- a/packages/editor/src/store/selectors.js
+++ b/packages/editor/src/store/selectors.js
@@ -1707,7 +1707,7 @@ export const __experimentalGetDefaultTemplateTypes = createRegistrySelector(
 		deprecated(
 			"select('core/editor').__experimentalGetDefaultTemplateTypes",
 			{
-				since: '6.7',
+				since: '6.8',
 				alternative:
 					"select('core/core-data').getEntityRecord( 'root', '__unstableBase' )?.default_template_types",
 			}
@@ -1730,7 +1730,7 @@ export const __experimentalGetDefaultTemplatePartAreas = createRegistrySelector(
 			deprecated(
 				"select('core/editor').__experimentalGetDefaultTemplatePartAreas",
 				{
-					since: '6.7',
+					since: '6.8',
 					alternative:
 						"select('core/core-data').getEntityRecord( 'root', '__unstableBase' )?.default_template_part_areas",
 				}
@@ -1760,7 +1760,7 @@ export const __experimentalGetDefaultTemplateType = createRegistrySelector(
 			deprecated(
 				"select('core/editor').__experimentalGetDefaultTemplateType",
 				{
-					since: '6.7',
+					since: '6.8',
 				}
 			);
 			const templateTypes = select( coreStore ).getEntityRecord(
@@ -1792,7 +1792,7 @@ export const __experimentalGetTemplateInfo = createRegistrySelector(
 	( select ) =>
 		createSelector( ( state, template ) => {
 			deprecated( "select('core/editor').__experimentalGetTemplateInfo", {
-				since: '6.7',
+				since: '6.8',
 			} );
 
 			if ( ! template ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes the WordPress version where `__experimentalGetDefaultTemplateTypes`, `__experimentalGetDefaultTemplatePartAreas`, `__experimentalGetTemplateInfo` and `__experimentalGetDefaultTemplateType` selectors are deprecated.

Thanks @oandregal for catching this! 🙇 (https://github.com/WordPress/gutenberg/pull/66459#discussion_r1858163481)
