### PR TITLE
Block Editor: Add success notices for image editing

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -10,6 +10,12 @@ import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
+const messages = {
+	crop: __( 'Image cropped.' ),
+	rotate: __( 'Image rotated.' ),
+	cropAndRotate: __( 'Image cropped and rotated.' ),
+};
+
 export default function useSaveImage( {
 	crop,
 	rotation,
@@ -18,7 +24,8 @@ export default function useSaveImage( {
 	onSaveImage,
 	onFinishEditing,
 } ) {
-	const { createErrorNotice } = useDispatch( noticesStore );
+	const { createErrorNotice, createSuccessNotice } =
+		useDispatch( noticesStore );
 	const [ isInProgress, setIsInProgress ] = useState( false );
 
 	const cancel = useCallback( () => {
@@ -61,6 +68,9 @@ export default function useSaveImage( {
 			return;
 		}
 
+		const modifierType =
+			modifiers.length === 1 ? modifiers[ 0 ].type : 'cropAndRotate';
+
 		apiFetch( {
 			path: `/wp/v2/media/${ id }/edit`,
 			method: 'POST',
@@ -70,6 +80,9 @@ export default function useSaveImage( {
 				onSaveImage( {
 					id: response.id,
 					url: response.source_url,
+				} );
+				createSuccessNotice( messages[ modifierType ], {
+					type: 'snackbar',
 				} );
 			} )
 			.catch( ( error ) => {
@@ -96,6 +109,7 @@ export default function useSaveImage( {
 		url,
 		onSaveImage,
 		createErrorNotice,
+		createSuccessNotice,
 		onFinishEditing,
 	] );
 

--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -88,7 +88,7 @@ export default function useSaveImage( {
 			.catch( ( error ) => {
 				createErrorNotice(
 					sprintf(
-						/* translators: 1. Error message */
+						/* translators: %s: Error message. */
 						__( 'Could not edit image. %s' ),
 						stripHTML( error.message )
 					),


### PR DESCRIPTION
## What?
Closes #22573.

PR updates the image editor to display success notices after modification is completed.

## Why?
See #22573.

## Testing Instructions
1. Open a post or page.
2. Insert the Image block and select an image.
3. Try different editing tools - zoom, crop, rotate.
4. A correct message should be displayed after processing the media.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-26 at 16 44 01](https://github.com/user-attachments/assets/3ad77475-a2d7-46cb-9110-d1446727c54b)
