### PR TITLE
Block Editor: Add notice action to revert image to original after cropping

### DIFF
--- a/packages/block-editor/src/components/image-editor/use-save-image.js
+++ b/packages/block-editor/src/components/image-editor/use-save-image.js
@@ -83,6 +83,17 @@ export default function useSaveImage( {
 				} );
 				createSuccessNotice( messages[ modifierType ], {
 					type: 'snackbar',
+					actions: [
+						{
+							label: __( 'Undo' ),
+							onClick: () => {
+								onSaveImage( {
+									id,
+									url,
+								} );
+							},
+						},
+					],
 				} );
 			} )
 			.catch( ( error ) => {


### PR DESCRIPTION
## What?
Part of #43882.

PR adds an "Undo" action to the image editing notices to easily revert it to its original state.

## Why?
See #43882.

## Testing Instructions
1. Open a post or page.
2. Insert the Image block and select an image.
3. Crop or rotate the image.
4. Confirm you can easily undo changes using the snackbar action.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b876eebb-64d9-4588-afc9-1c0ebe67c64f

