### PR TITLE
Drag and drop: fix drop zones on block drag

### DIFF
--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { Draggable } from '@wordpress/components';
-import {
-	createBlock,
-	serialize,
-	store as blocksStore,
-} from '@wordpress/blocks';
+import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
@@ -24,11 +20,6 @@ const InserterDraggableBlocks = ( {
 	children,
 	pattern,
 } ) => {
-	const transferData = {
-		type: 'inserter',
-		blocks,
-	};
-
 	const blockTypeIcon = useSelect(
 		( select ) => {
 			const { getBlockType } = select( blocksStore );
@@ -51,21 +42,18 @@ const InserterDraggableBlocks = ( {
 		} );
 	}
 
+	const parsedBlocks =
+		pattern?.type === INSERTER_PATTERN_TYPES.user &&
+		pattern?.syncStatus !== 'unsynced'
+			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
+			: blocks;
+
 	return (
 		<Draggable
 			__experimentalTransferDataType="wp-blocks"
-			transferData={ transferData }
-			onDragStart={ ( event ) => {
+			transferData={ { type: 'inserter', blocks: parsedBlocks } }
+			onDragStart={ () => {
 				startDragging();
-				const parsedBlocks =
-					pattern?.type === INSERTER_PATTERN_TYPES.user &&
-					pattern?.syncStatus !== 'unsynced'
-						? [ createBlock( 'core/block', { ref: pattern.id } ) ]
-						: blocks;
-				event.dataTransfer.setData(
-					'text/html',
-					serialize( parsedBlocks )
-				);
 			} }
 			onDragEnd={ () => {
 				stopDragging();

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -59,6 +59,10 @@ const InserterDraggableBlocks = ( {
 				startDragging();
 				for ( const block of draggableBlocks ) {
 					const type = `wp-block:${ block.name }`;
+					// This will fill in the dataTransfer.types array so that
+					// the drop zone can check if the draggable is eligible.
+					// Unfortuantely, on drag start, we don't have access to the
+					// actual data, only the data keys/types.
 					event.dataTransfer.items.add( '', type );
 				}
 			} }

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -29,15 +29,6 @@ const InserterDraggableBlocks = ( {
 		blocks,
 	};
 
-	const blocksContainMedia =
-		blocks.filter(
-			( block ) =>
-				( block.name === 'core/image' ||
-					block.name === 'core/audio' ||
-					block.name === 'core/video' ) &&
-				( block.attributes.url || block.attributes.src )
-		).length > 0;
-
 	const blockTypeIcon = useSelect(
 		( select ) => {
 			const { getBlockType } = select( blocksStore );
@@ -72,7 +63,7 @@ const InserterDraggableBlocks = ( {
 						? [ createBlock( 'core/block', { ref: pattern.id } ) ]
 						: blocks;
 				event.dataTransfer.setData(
-					blocksContainMedia ? 'default' : 'text/html',
+					'text/html',
 					serialize( parsedBlocks )
 				);
 			} }

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -50,10 +50,21 @@ const InserterDraggableBlocks = ( {
 
 	return (
 		<Draggable
+			// To do: remove in favour of `wp-block:*` items.
 			__experimentalTransferDataType="wp-blocks"
 			transferData={ { type: 'inserter', blocks: parsedBlocks } }
-			onDragStart={ () => {
+			onDragStart={ ( event ) => {
+				if ( ! event.dataTransfer ) {
+					return;
+				}
 				startDragging();
+
+				for ( const block of parsedBlocks ) {
+					event.dataTransfer.items.add(
+						JSON.stringify( block ),
+						`wp-block:${ block.name }`
+					);
+				}
 			} }
 			onDragEnd={ () => {
 				stopDragging();

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -4,6 +4,7 @@
 import { Draggable } from '@wordpress/components';
 import { createBlock, store as blocksStore } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -34,6 +35,13 @@ const InserterDraggableBlocks = ( {
 		useDispatch( blockEditorStore )
 	);
 
+	const patternBlock = useMemo( () => {
+		return pattern?.type === INSERTER_PATTERN_TYPES.user &&
+			pattern?.syncStatus !== 'unsynced'
+			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
+			: undefined;
+	}, [ pattern ] );
+
 	if ( ! isEnabled ) {
 		return children( {
 			draggable: false,
@@ -42,19 +50,14 @@ const InserterDraggableBlocks = ( {
 		} );
 	}
 
-	const parsedBlocks =
-		pattern?.type === INSERTER_PATTERN_TYPES.user &&
-		pattern?.syncStatus !== 'unsynced'
-			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
-			: blocks;
-
+	const draggableBlocks = patternBlock ?? blocks;
 	return (
 		<Draggable
 			__experimentalTransferDataType="wp-blocks"
-			transferData={ { type: 'inserter', blocks: parsedBlocks } }
+			transferData={ { type: 'inserter', blocks: draggableBlocks } }
 			onDragStart={ ( event ) => {
 				startDragging();
-				for ( const block of parsedBlocks ) {
+				for ( const block of draggableBlocks ) {
 					const type = `wp-block:${ block.name }`;
 					event.dataTransfer.items.add( '', type );
 				}

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -20,11 +20,6 @@ const InserterDraggableBlocks = ( {
 	children,
 	pattern,
 } ) => {
-	const transferData = {
-		type: 'inserter',
-		blocks,
-	};
-
 	const blockTypeIcon = useSelect(
 		( select ) => {
 			const { getBlockType } = select( blocksStore );
@@ -47,26 +42,21 @@ const InserterDraggableBlocks = ( {
 		} );
 	}
 
+	const parsedBlocks =
+		pattern?.type === INSERTER_PATTERN_TYPES.user &&
+		pattern?.syncStatus !== 'unsynced'
+			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
+			: blocks;
+
 	return (
 		<Draggable
 			__experimentalTransferDataType="wp-blocks"
-			transferData={ transferData }
+			transferData={ { type: 'inserter', blocks: parsedBlocks } }
 			onDragStart={ ( event ) => {
-				if ( ! event.dataTransfer ) {
-					return;
-				}
 				startDragging();
-				const parsedBlocks =
-					pattern?.type === INSERTER_PATTERN_TYPES.user &&
-					pattern?.syncStatus !== 'unsynced'
-						? [ createBlock( 'core/block', { ref: pattern.id } ) ]
-						: blocks;
-
 				for ( const block of parsedBlocks ) {
-					event.dataTransfer.items.add(
-						JSON.stringify( block ),
-						`wp-block:${ block.name }`
-					);
+					const type = `wp-block:${ block.name }`;
+					event.dataTransfer.items.add( '', type );
 				}
 			} }
 			onDragEnd={ () => {

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -20,6 +20,11 @@ const InserterDraggableBlocks = ( {
 	children,
 	pattern,
 } ) => {
+	const transferData = {
+		type: 'inserter',
+		blocks,
+	};
+
 	const blockTypeIcon = useSelect(
 		( select ) => {
 			const { getBlockType } = select( blocksStore );
@@ -42,22 +47,20 @@ const InserterDraggableBlocks = ( {
 		} );
 	}
 
-	const parsedBlocks =
-		pattern?.type === INSERTER_PATTERN_TYPES.user &&
-		pattern?.syncStatus !== 'unsynced'
-			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
-			: blocks;
-
 	return (
 		<Draggable
-			// To do: remove in favour of `wp-block:*` items.
 			__experimentalTransferDataType="wp-blocks"
-			transferData={ { type: 'inserter', blocks: parsedBlocks } }
+			transferData={ transferData }
 			onDragStart={ ( event ) => {
 				if ( ! event.dataTransfer ) {
 					return;
 				}
 				startDragging();
+				const parsedBlocks =
+					pattern?.type === INSERTER_PATTERN_TYPES.user &&
+					pattern?.syncStatus !== 'unsynced'
+						? [ createBlock( 'core/block', { ref: pattern.id } ) ]
+						: blocks;
 
 				for ( const block of parsedBlocks ) {
 					event.dataTransfer.items.add(

--- a/packages/block-editor/src/components/inserter-draggable-blocks/index.js
+++ b/packages/block-editor/src/components/inserter-draggable-blocks/index.js
@@ -40,7 +40,7 @@ const InserterDraggableBlocks = ( {
 			pattern?.syncStatus !== 'unsynced'
 			? [ createBlock( 'core/block', { ref: pattern.id } ) ]
 			: undefined;
-	}, [ pattern ] );
+	}, [ pattern?.type, pattern?.syncStatus, pattern?.id ] );
 
 	if ( ! isEnabled ) {
 		return children( {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -390,25 +390,18 @@ export function MediaPlaceholder( {
 				onFilesDrop={ onFilesUpload }
 				onDrop={ onDrop }
 				isEligible={ ( dataTransfer ) => {
-					const types = dataTransfer.types.filter( ( type ) =>
-						type.startsWith( 'wp-block:' )
-					);
-					const typeMap = {
-						image: 'wp-block:core/image',
-						audio: 'wp-block:core/audio',
-						video: 'wp-block:core/video',
-					};
-					const allowed = allowedTypes
-						.map( ( type ) => typeMap[ type ] )
-						.filter( Boolean );
-
-					if ( ! multiple ) {
-						return (
-							types.length === 1 && allowed.includes( types[ 0 ] )
-						);
+					const prefix = 'wp-block:core/';
+					const types = [];
+					for ( const type of dataTransfer.types ) {
+						if ( type.startsWith( prefix ) ) {
+							types.push( type.slice( prefix.length ) );
+						}
 					}
-
-					return types.every( ( type ) => allowed.includes( type ) );
+					return (
+						types.every( ( type ) =>
+							allowedTypes.includes( type )
+						) && ( multiple ? true : types.length === 1 )
+					);
 				} }
 			/>
 		);

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -292,10 +292,8 @@ export function MediaPlaceholder( {
 		}
 	}
 
-	async function onDrop( event ) {
-		const blocks = pasteHandler( {
-			HTML: event.dataTransfer?.getData( 'default' ),
-		} );
+	async function onHTMLDrop( HTML ) {
+		const blocks = pasteHandler( { HTML } );
 		return await handleBlocksDrop( blocks );
 	}
 
@@ -385,7 +383,9 @@ export function MediaPlaceholder( {
 			return null;
 		}
 
-		return <DropZone onFilesDrop={ onFilesUpload } onDrop={ onDrop } />;
+		return (
+			<DropZone onFilesDrop={ onFilesUpload } onHTMLDrop={ onHTMLDrop } />
+		);
 	};
 
 	const renderCancelLink = () => {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -385,7 +385,33 @@ export function MediaPlaceholder( {
 			return null;
 		}
 
-		return <DropZone onFilesDrop={ onFilesUpload } onDrop={ onDrop } />;
+		return (
+			<DropZone
+				onFilesDrop={ onFilesUpload }
+				onDrop={ onDrop }
+				isEligible={ ( dataTransfer ) => {
+					const types = dataTransfer.types.filter( ( type ) =>
+						type.startsWith( 'wp-block:' )
+					);
+					const typeMap = {
+						image: 'wp-block:core/image',
+						audio: 'wp-block:core/audio',
+						video: 'wp-block:core/video',
+					};
+					const allowed = allowedTypes
+						.map( ( type ) => typeMap[ type ] )
+						.filter( Boolean );
+
+					if ( ! multiple ) {
+						return (
+							types.length === 1 && allowed.includes( types[ 0 ] )
+						);
+					}
+
+					return types.every( ( type ) => allowed.includes( type ) );
+				} }
+			/>
+		);
 	};
 
 	const renderCancelLink = () => {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -19,7 +19,6 @@ import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { keyboardReturn } from '@wordpress/icons';
-import { pasteHandler } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
 /**
@@ -29,6 +28,7 @@ import MediaUpload from '../media-upload';
 import MediaUploadCheck from '../media-upload/check';
 import URLPopover from '../url-popover';
 import { store as blockEditorStore } from '../../store';
+import { parseDropEvent } from '../use-on-block-drop';
 
 const noop = () => {};
 
@@ -292,9 +292,11 @@ export function MediaPlaceholder( {
 		}
 	}
 
-	async function onHTMLDrop( HTML ) {
-		const blocks = pasteHandler( { HTML } );
-		return await handleBlocksDrop( blocks );
+	function onDrop( event ) {
+		const { blocks } = parseDropEvent( event );
+		if ( blocks ) {
+			handleBlocksDrop( blocks );
+		}
 	}
 
 	const onUpload = ( event ) => {
@@ -383,9 +385,7 @@ export function MediaPlaceholder( {
 			return null;
 		}
 
-		return (
-			<DropZone onFilesDrop={ onFilesUpload } onHTMLDrop={ onHTMLDrop } />
-		);
+		return <DropZone onFilesDrop={ onFilesUpload } onDrop={ onDrop } />;
 	};
 
 	const renderCancelLink = () => {

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -229,30 +229,15 @@ export function MediaPlaceholder( {
 		} );
 	};
 
-	async function handleBlocksDrop( blocks ) {
-		if ( ! blocks || ! Array.isArray( blocks ) ) {
-			return;
-		}
+	async function handleBlocksDrop( event ) {
+		const { blocks } = parseDropEvent( event );
 
-		function recursivelyFindMediaFromBlocks( _blocks ) {
-			return _blocks.flatMap( ( block ) =>
-				( block.name === 'core/image' ||
-					block.name === 'core/audio' ||
-					block.name === 'core/video' ) &&
-				( block.attributes.url || block.attributes.src )
-					? [ block ]
-					: recursivelyFindMediaFromBlocks( block.innerBlocks )
-			);
-		}
-
-		const mediaBlocks = recursivelyFindMediaFromBlocks( blocks );
-
-		if ( ! mediaBlocks.length ) {
+		if ( ! blocks || ! blocks.length ) {
 			return;
 		}
 
 		const uploadedMediaList = await Promise.all(
-			mediaBlocks.map( ( block ) => {
+			blocks.map( ( block ) => {
 				const blockType = block.name.split( '/' )[ 1 ];
 				if ( block.attributes.id ) {
 					block.attributes.type = blockType;
@@ -289,13 +274,6 @@ export function MediaPlaceholder( {
 			onSelect( uploadedMediaList );
 		} else {
 			onSelect( uploadedMediaList[ 0 ] );
-		}
-	}
-
-	function onDrop( event ) {
-		const { blocks } = parseDropEvent( event );
-		if ( blocks ) {
-			handleBlocksDrop( blocks );
 		}
 	}
 
@@ -388,7 +366,7 @@ export function MediaPlaceholder( {
 		return (
 			<DropZone
 				onFilesDrop={ onFilesUpload }
-				onDrop={ onDrop }
+				onDrop={ handleBlocksDrop }
 				isEligible={ ( dataTransfer ) => {
 					const prefix = 'wp-block:core/';
 					const types = [];

--- a/packages/block-editor/src/components/media-placeholder/index.js
+++ b/packages/block-editor/src/components/media-placeholder/index.js
@@ -232,7 +232,7 @@ export function MediaPlaceholder( {
 	async function handleBlocksDrop( event ) {
 		const { blocks } = parseDropEvent( event );
 
-		if ( ! blocks || ! blocks.length ) {
+		if ( ! blocks?.length ) {
 			return;
 		}
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `ColorPicker`: Update sizes of color format select and copy button ([#67093](https://github.com/WordPress/gutenberg/pull/67093)).
 -   `ComboboxControl`: Update reset button size ([#67215](https://github.com/WordPress/gutenberg/pull/67215)).
 -   `Autocomplete`: Increase option height ([#67214](https://github.com/WordPress/gutenberg/pull/67214)).
+-   `DropZone`: Add `isEligible` prop to allow customizing whether the drop zone should activate ([#67317](https://github.com/WordPress/gutenberg/pull/67317)).
 -   `CircularOptionPicker`: Update `Button` sizes to be ready for 40px default size ([#67285](https://github.com/WordPress/gutenberg/pull/67285)).
 
 ### Experimental

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -15,7 +15,7 @@ import { __experimentalUseDropZone as useDropZone } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
-import type { DropType, DropZoneProps } from './types';
+import type { DropZoneProps } from './types';
 import type { WordPressComponentProps } from '../context';
 
 /**
@@ -47,19 +47,22 @@ export function DropZoneComponent( {
 	onFilesDrop,
 	onHTMLDrop,
 	onDrop,
+	isEligible = () => true,
 	...restProps
 }: WordPressComponentProps< DropZoneProps, 'div', false > ) {
 	const [ isDraggingOverDocument, setIsDraggingOverDocument ] =
 		useState< boolean >();
 	const [ isDraggingOverElement, setIsDraggingOverElement ] =
 		useState< boolean >();
-	const [ type, setType ] = useState< DropType >();
+	const [ isActive, setIsActive ] = useState< boolean >();
 	const ref = useDropZone( {
 		onDrop( event ) {
-			const files = event.dataTransfer
-				? getFilesFromDataTransfer( event.dataTransfer )
-				: [];
-			const html = event.dataTransfer?.getData( 'text/html' );
+			if ( ! event.dataTransfer ) {
+				return;
+			}
+
+			const files = getFilesFromDataTransfer( event.dataTransfer );
+			const html = event.dataTransfer.getData( 'text/html' );
 
 			/**
 			 * From Windows Chrome 96, the `event.dataTransfer` returns both file object and HTML.
@@ -76,32 +79,30 @@ export function DropZoneComponent( {
 		onDragStart( event ) {
 			setIsDraggingOverDocument( true );
 
-			let _type: DropType = 'default';
+			if ( ! event.dataTransfer ) {
+				return;
+			}
 
 			/**
 			 * From Windows Chrome 96, the `event.dataTransfer` returns both file object and HTML.
 			 * The order of the checks is important to recognize the HTML drop.
 			 */
-			if ( event.dataTransfer?.types.includes( 'text/html' ) ) {
-				_type = 'html';
+			if ( event.dataTransfer.types.includes( 'text/html' ) ) {
+				setIsActive( !! onHTMLDrop );
 			} else if (
 				// Check for the types because sometimes the files themselves
 				// are only available on drop.
-				event.dataTransfer?.types.includes( 'Files' ) ||
-				( event.dataTransfer
-					? getFilesFromDataTransfer( event.dataTransfer )
-					: []
-				).length > 0
+				event.dataTransfer.types.includes( 'Files' ) ||
+				getFilesFromDataTransfer( event.dataTransfer ).length > 0
 			) {
-				_type = 'file';
+				setIsActive( !! onFilesDrop );
+			} else {
+				setIsActive( !! onDrop && isEligible( event.dataTransfer ) );
 			}
-
-			setType( _type );
 		},
 		onDragEnd() {
 			setIsDraggingOverElement( false );
 			setIsDraggingOverDocument( false );
-			setType( undefined );
 		},
 		onDragEnter() {
 			setIsDraggingOverElement( true );
@@ -112,14 +113,9 @@ export function DropZoneComponent( {
 	} );
 
 	const classes = clsx( 'components-drop-zone', className, {
-		'is-active':
-			( isDraggingOverDocument || isDraggingOverElement ) &&
-			( ( type === 'file' && onFilesDrop ) ||
-				( type === 'html' && onHTMLDrop ) ||
-				( type === 'default' && onDrop ) ),
+		'is-active': isActive,
 		'is-dragging-over-document': isDraggingOverDocument,
 		'is-dragging-over-element': isDraggingOverElement,
-		[ `is-dragging-${ type }` ]: !! type,
 	} );
 
 	return (

--- a/packages/components/src/drop-zone/index.tsx
+++ b/packages/components/src/drop-zone/index.tsx
@@ -103,6 +103,7 @@ export function DropZoneComponent( {
 		onDragEnd() {
 			setIsDraggingOverElement( false );
 			setIsDraggingOverDocument( false );
+			setIsActive( undefined );
 		},
 		onDragEnter() {
 			setIsDraggingOverElement( true );

--- a/packages/components/src/drop-zone/types.ts
+++ b/packages/components/src/drop-zone/types.ts
@@ -26,4 +26,9 @@ export type DropZoneProps = {
 	 * It receives the HTML being dropped as an argument.
 	 */
 	onHTMLDrop?: ( html: string ) => void;
+	/**
+	 * A function to determine if the drop zone is eligible to handle the drop
+	 * event.
+	 */
+	isEligible?: ( dataTransfer: DataTransfer ) => boolean;
 };

--- a/packages/components/src/drop-zone/types.ts
+++ b/packages/components/src/drop-zone/types.ts
@@ -28,7 +28,7 @@ export type DropZoneProps = {
 	onHTMLDrop?: ( html: string ) => void;
 	/**
 	 * A function to determine if the drop zone is eligible to handle the drop
-	 * event.
+	 * data transfer items.
 	 */
 	isEligible?: ( dataTransfer: DataTransfer ) => boolean;
 };

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -528,14 +528,13 @@ test.describe( 'Image', () => {
 			name: 'Block: Image',
 		} );
 
-		const html = `
-			<figure>
-				<img src="https://live.staticflickr.com/3894/14962688165_04759a8b03_b.jpg" alt="Cat">
-				<figcaption>"Cat" by tomhouslay is licensed under <a href="https://creativecommons.org/licenses/by-nc/2.0/?ref=openverse">CC BY-NC 2.0</a>.</figcaption>
-			</figure>
-		`;
-
-		await page.evaluate( ( _html ) => {
+		await page.evaluate( () => {
+			const { createBlock } = window.wp.blocks;
+			const block = createBlock( 'core/image', {
+				url: 'https://live.staticflickr.com/3894/14962688165_04759a8b03_b.jpg',
+				alt: 'Cat',
+				caption: `"Cat" by tomhouslay is licensed under <a href="https://creativecommons.org/licenses/by-nc/2.0/?ref=openverse">CC BY-NC 2.0</a>.`,
+			} );
 			const dummy = document.createElement( 'div' );
 			dummy.style.width = '10px';
 			dummy.style.height = '10px';
@@ -545,13 +544,17 @@ test.describe( 'Image', () => {
 			dummy.style.left = 0;
 			dummy.draggable = 'true';
 			dummy.addEventListener( 'dragstart', ( event ) => {
-				event.dataTransfer.setData( 'text/html', _html );
+				event.dataTransfer.setData(
+					'wp-blocks',
+					JSON.stringify( { blocks: [ block ] } )
+				);
+				event.dataTransfer.setData( 'wp-block:core/image', '' );
 				setTimeout( () => {
 					dummy.remove();
 				}, 0 );
 			} );
 			document.body.appendChild( dummy );
-		}, html );
+		} );
 
 		await page.mouse.move( 0, 0 );
 		await page.mouse.down();

--- a/test/e2e/specs/editor/blocks/image.spec.js
+++ b/test/e2e/specs/editor/blocks/image.spec.js
@@ -545,7 +545,7 @@ test.describe( 'Image', () => {
 			dummy.style.left = 0;
 			dummy.draggable = 'true';
 			dummy.addEventListener( 'dragstart', ( event ) => {
-				event.dataTransfer.setData( 'default', _html );
+				event.dataTransfer.setData( 'text/html', _html );
 				setTimeout( () => {
 					dummy.remove();
 				}, 0 );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Currently in trunk, when you drag an image in a gallery for example, it triggers the placeholder inside the other images.

![Screenshot 2024-11-26 at 15 11 50](https://github.com/user-attachments/assets/a1c22a97-0b4d-4ca4-aa92-bf87d17ccda1)

This seems to be a regression #66986.

I ended up reverting that PR in 48fd68f550ce52b760ab46106ca101089a0eb268.
Additionally I reverted the HTML drop on the media placeholder component introduced by #49673 in 732cca83f7d796a284d8df8360323a7e8c4977f5. I did this because we're basically duplicating the custom block data transfer we already have with additional HTML data transfer that needs to be serialised and re-parsed.
Then finally, to restore the ability to drag media items from the inserter, I added new data transfer items for each block so that we can check the block types on drag start. Note that the data itself is never available at drag start (there's some browser security reasons behind that), but the data _types_ are. So we just encode our block types into the data types so we can check them.

This solution allow the MediaPlaceholder to check for itself if the dragged blocks are accepted, rather than setting a different catch all key for the draggable item.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Drag an image within a gallery. It shouldn't trigger other images' drop zones.
* Drag a pattern from the pattern inserter over an image or cover block. It shouldn't trigger the drop zones.
* Drag an image from the media inserter over an image block. It _should_ trigger the drop zone and be droppable.
* Do that again, but now just try to insert it in between other block to make sure that works too.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
