### PR TITLE
Add #7895 Core Backport PR to the changelog

### DIFF
--- a/backport-changelog/6.8/7895.md
+++ b/backport-changelog/6.8/7895.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7895
+
+* https://github.com/WordPress/gutenberg/pull/66459


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR adds https://github.com/WordPress/wordpress-develop/pull/7895 Core Backport PR to the changelog.
