### PR TITLE
Fix Site editor navigation menu items alignment visual regression.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -18,7 +18,7 @@
 .edit-site-sidebar-navigation-screen__content {
 	padding: 0 $grid-unit-20;
 
-	.edit-site-sidebar-navigation-screen-details-footer {
+	.components-item-group {
 		margin-left: -$grid-unit-20;
 		margin-right: -$grid-unit-20;
 	}
@@ -131,7 +131,7 @@
 	margin: $grid-unit-20 0 0;
 	border-top: 1px solid $gray-800;
 
-	.components-item-group {
+	.edit-site-sidebar-navigation-screen-details-footer {
 		margin-left: -$grid-unit-20;
 		margin-right: -$grid-unit-20;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Follow-up to https://github.com/WordPress/gutenberg/pull/66606

Cc @jameskoster @t-hamano 

## What?
<!-- In a few words, what is the PR actually doing? -->
Fizes a visual regression in the alignment of the Site editor Navigation menu items after https://github.com/WordPress/gutenberg/pull/66606 where a CSS selector change was applied in a wrong place.
See https://github.com/WordPress/gutenberg/pull/66606#issuecomment-2500996279


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Better alignment.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Restore previous selectors. Although using selectors related to components is not ideal, this restores the previous situation. Applies the code review suggestions from https://github.com/WordPress/gutenberg/pull/66606 in the right place.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site editor.
- Observe the menu items in the navigation are correctly aligned.
- For reference, see comparison screenshot at https://github.com/WordPress/gutenberg/pull/66606#issuecomment-2500996279

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
