### PR TITLE
Make sure Document Bar doesn’t go missing

### DIFF
--- a/packages/editor/src/components/header/index.js
+++ b/packages/editor/src/components/header/index.js
@@ -97,8 +97,10 @@ function Header( {
 		useState( true );
 
 	const hasCenter =
-		( ! hasBlockSelection || isBlockToolsCollapsed ) &&
-		! isTooNarrowForDocumentBar;
+		! isTooNarrowForDocumentBar &&
+		( ! hasFixedToolbar ||
+			( hasFixedToolbar &&
+				( ! hasBlockSelection || isBlockToolsCollapsed ) ) );
 	const hasBackButton = useHasBackButton();
 	/*
 	 * The edit-post-header classname is only kept for backward compatability


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
A bug fix to keep the Document Bar visible as expected. An alternative to #67076.

## Why?
In trunk, the Document Bar can go missing after turning off either of “Top toolbar” or “Distraction free” while having a block selected.

## How?
Includes the `fixedToolbar` preference in the condition that determines whether the Document Bar is rendered. This ensures the result is different when DF or top toolbar settings change.

## Testing Instructions
1. In either the Post or Site editor
2. Enable either “Top toolbar” or “Distraction free”
3. Select a block
4. Disable either “Top toolbar” or “Distraction free”
5. Verify that the Document Bar is visible