### PR TITLE
Enhance: Added close on outside click flag & updated save post panel

### DIFF
--- a/packages/compose/src/hooks/use-dialog/index.ts
+++ b/packages/compose/src/hooks/use-dialog/index.ts
@@ -41,6 +41,12 @@ type DialogOptions = {
 	constrainTabbing?: boolean;
 	onClose?: () => void;
 	/**
+	 * Whether to close on click outside.
+	 *
+	 * @default true
+	 */
+	closeOnOutsideClick?: boolean;
+	/**
 	 * Use the `onClose` prop instead.
 	 *
 	 * @deprecated
@@ -67,7 +73,10 @@ type useDialogReturn = [
  */
 function useDialog( options: DialogOptions ): useDialogReturn {
 	const currentOptions = useRef< DialogOptions | undefined >();
-	const { constrainTabbing = options.focusOnMount !== false } = options;
+	const {
+		constrainTabbing = options.focusOnMount !== false,
+		closeOnOutsideClick = true,
+	} = options;
 	useEffect( () => {
 		currentOptions.current = options;
 	}, Object.values( options ) );
@@ -79,7 +88,7 @@ function useDialog( options: DialogOptions ): useDialogReturn {
 		// for the Popover component otherwise, the onClose should be enough.
 		if ( currentOptions.current?.__unstableOnClose ) {
 			currentOptions.current.__unstableOnClose( 'focus-outside', event );
-		} else if ( currentOptions.current?.onClose ) {
+		} else if ( currentOptions.current?.onClose && closeOnOutsideClick ) {
 			currentOptions.current.onClose();
 		}
 	} );

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -80,12 +80,20 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 	);
 };
 
-const _EntitiesSavedStates = ( { onClose, renderDialog = undefined } ) => {
+const _EntitiesSavedStates = ( {
+	onClose,
+	renderDialog = undefined,
+	closeOnOutsideClick = true,
+} ) => {
 	if ( isPreviewingTheme() ) {
 		return <EntitiesSavedStatesForPreview onClose={ onClose } />;
 	}
 	return (
-		<EntitiesSavedStates close={ onClose } renderDialog={ renderDialog } />
+		<EntitiesSavedStates
+			close={ onClose }
+			renderDialog={ renderDialog }
+			closeOnOutsideClick={ closeOnOutsideClick }
+		/>
 	);
 };
 
@@ -129,7 +137,10 @@ export default function SavePanel() {
 					'Save site, content, and template changes'
 				) }
 			>
-				<_EntitiesSavedStates onClose={ onClose } />
+				<_EntitiesSavedStates
+					onClose={ onClose }
+					closeOnOutsideClick={ false }
+				/>
 			</Modal>
 		) : null;
 	}

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -402,6 +402,7 @@ _Parameters_
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
 -   _props.renderDialog_ `Function`: The function to render the dialog.
+-   _props.closeOnOutsideClick_ `boolean`: Whether to close if outside click is detected.
 
 _Returns_
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -29,21 +29,24 @@ function identity( values ) {
 /**
  * Renders the component for managing saved states of entities.
  *
- * @param {Object}   props              The component props.
- * @param {Function} props.close        The function to close the dialog.
- * @param {Function} props.renderDialog The function to render the dialog.
+ * @param {Object}   props                     The component props.
+ * @param {Function} props.close               The function to close the dialog.
+ * @param {Function} props.renderDialog        The function to render the dialog.
+ * @param {boolean}  props.closeOnOutsideClick Whether to close if outside click is detected.
  *
  * @return {JSX.Element} The rendered component.
  */
 export default function EntitiesSavedStates( {
 	close,
 	renderDialog = undefined,
+	closeOnOutsideClick = true,
 } ) {
 	const isDirtyProps = useIsDirty();
 	return (
 		<EntitiesSavedStatesExtensible
 			close={ close }
 			renderDialog={ renderDialog }
+			closeOnOutsideClick={ closeOnOutsideClick }
 			{ ...isDirtyProps }
 		/>
 	);
@@ -63,6 +66,7 @@ export default function EntitiesSavedStates( {
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
  * @param {Array}    props.unselectedEntities    Array of unselected entities.
+ * @param {boolean}  props.closeOnOutsideClick   Whether to close if outside click is detected.
  *
  * @return {JSX.Element} The rendered component.
  */
@@ -77,6 +81,7 @@ export function EntitiesSavedStatesExtensible( {
 	isDirty,
 	setUnselectedEntities,
 	unselectedEntities,
+	closeOnOutsideClick = true,
 } ) {
 	const saveButtonRef = useRef();
 	const { saveDirtyEntities } = unlock( useDispatch( editorStore ) );
@@ -111,6 +116,7 @@ export function EntitiesSavedStatesExtensible( {
 
 	const [ saveDialogRef, saveDialogProps ] = useDialog( {
 		onClose: () => dismissPanel(),
+		closeOnOutsideClick,
 	} );
 	const dialogLabel = useInstanceId( EntitiesSavedStatesExtensible, 'label' );
 	const dialogDescription = useInstanceId(


### PR DESCRIPTION
Attempt to resolve #67313

## What?
This PR adds a flag to the useDialog component to disable the behavior of closing the dialog when clicking outside of it. It also updates the relevant save_post code to prevent closing the dialog when clicked in specific areas.

## Why?
The issue occurs when clicking on the 'padding area' of the Entity saved modal dialog, causing the dialog to close unexpectedly.

Animated GIF to illustrate:
![image](https://github.com/user-attachments/assets/7165a4bd-095b-4ebd-8f6d-dbdcb02f06d6)


## How?
A closeOnOutsideClick flag was added to the useDialog component. By default, this behavior is set to true, meaning the dialog will close when clicking outside. The save_post file has been updated to disable this behavior for the issue mentioned above.

## Testing Instructions

- Go to the Site editor.
- Make a simple change to a global style, e.g. change a color.
- Reopen the Navigation panel by clicking 'Open Navigation' at the top left of the screen.
- Click any item in the navigation other than 'Styles' e.g. click 'Pages' or 'Templates'.
- At this point, a blue button at the bottom of the Navigation panel appears, labeled 'Review 1 change...'

![image](https://github.com/user-attachments/assets/ec727ddc-876f-41b8-8b1f-3064a8b25898)

- Click the button: the modal dialog to save entities opens.
- Click the padding area of the modal dialog.
- Observe the modal dialog closes.
- Alternatively preview a block theme from the WP admin > Appearance > any block theme > Live Preview.
- Click the blue button labeled 'Activate {theme name}' at the bottom of hte Navigation panel: the modal dialog to save entities opens.
- Click the padding area of the modal dialog.
- Observe the modal dialog closes.

