### PR TITLE
Update pre-publish panel wording to accurately describe the review process

### DIFF
--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -75,7 +75,7 @@ function PostPublishPanelPrepublish( { children } ) {
 	if ( ! hasPublishAction ) {
 		prePublishTitle = __( 'Are you ready to submit for review?' );
 		prePublishBodyText = __(
-			'your work will be reviewed and then approved.'
+			'Your work will be reviewed and then approved.'
 		);
 	} else if ( isBeingScheduled ) {
 		prePublishTitle = __( 'Are you ready to schedule?' );

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -75,7 +75,7 @@ function PostPublishPanelPrepublish( { children } ) {
 	if ( ! hasPublishAction ) {
 		prePublishTitle = __( 'Are you ready to submit for review?' );
 		prePublishBodyText = __(
-			'Since you are a Contributor, your work will be submitted for review, and a user with publishing permissions will be able to review and approve it for you.'
+			'A user with publishing permissions can review and approve it.'
 		);
 	} else if ( isBeingScheduled ) {
 		prePublishTitle = __( 'Are you ready to schedule?' );

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -75,7 +75,7 @@ function PostPublishPanelPrepublish( { children } ) {
 	if ( ! hasPublishAction ) {
 		prePublishTitle = __( 'Are you ready to submit for review?' );
 		prePublishBodyText = __(
-			'When you’re ready, submit your work for review, and an Editor will be able to approve it for you.'
+			'Since you are a Contributor, your work will be submitted for review, and a user with publishing permissions will be able to review and approve it for you.'
 		);
 	} else if ( isBeingScheduled ) {
 		prePublishTitle = __( 'Are you ready to schedule?' );

--- a/packages/editor/src/components/post-publish-panel/prepublish.js
+++ b/packages/editor/src/components/post-publish-panel/prepublish.js
@@ -75,7 +75,7 @@ function PostPublishPanelPrepublish( { children } ) {
 	if ( ! hasPublishAction ) {
 		prePublishTitle = __( 'Are you ready to submit for review?' );
 		prePublishBodyText = __(
-			'A user with publishing permissions can review and approve it.'
+			'your work will be reviewed and then approved.'
 		);
 	} else if ( isBeingScheduled ) {
 		prePublishTitle = __( 'Are you ready to schedule?' );

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -619,7 +619,7 @@ exports[`PostPublishPanel should render the pre-publish panel if the post is not
           </strong>
         </div>
         <p>
-          When you’re ready, submit your work for review, and an Editor will be able to approve it for you.
+          Your work will be reviewed and then approved.
         </p>
         <div
           class="components-site-card"

--- a/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
+++ b/packages/editor/src/components/post-publish-panel/test/__snapshots__/index.js.snap
@@ -466,7 +466,7 @@ exports[`PostPublishPanel should render the pre-publish panel if post status is 
           </strong>
         </div>
         <p>
-          When you’re ready, submit your work for review, and an Editor will be able to approve it for you.
+          Your work will be reviewed and then approved.
         </p>
         <div
           class="components-site-card"


### PR DESCRIPTION
fixes: #65368

## What?
This PR updates the pre-publish panel description shown to contributors when submitting a post for review. The updated text removes assumptions about the role of the reviewer and eliminates unnecessary wording for better clarity.

## Why?
The previous wording inaccurately implied that only users with the Editor role could review and publish the post. In reality, any user with the `publish` capability can do so. Additionally, "When you’re ready" was redundant since users are already prompted to click "Submit for Review."

## How?
Replaced "an Editor will be able to approve it for you" with "a user with publishing permissions can review it for you."
Removed "When you’re ready" to streamline the message.

## Testing Instructions

1. Log in as a Contributor
2. Create a new post.
3. Click "Submit for Review."
4. Verify Updated Message
5. Check the pre-publish panel description for clarity and accuracy.
6. Ensure the text no longer references "Editor" or includes redundant phrasing.

## Screenshots or screencast <!-- if applicable -->
| Before | After |
|-|-|
| <img width="1470" alt="Screenshot 2024-12-04 at 6 50 05 PM" src="https://github.com/user-attachments/assets/a0537f03-7a59-4679-85d2-f3f43901e81f"> | <img width="1470" alt="Screenshot 2024-12-04 at 6 50 27 PM" src="https://github.com/user-attachments/assets/ca9206aa-6b1f-453f-91e8-2541c8ab2eb4"> |