### PR TITLE
Fix: Duplicate template part refers to original name instead of duplicated name.

### DIFF
--- a/packages/editor/src/dataviews/actions/duplicate-template-part.tsx
+++ b/packages/editor/src/dataviews/actions/duplicate-template-part.tsx
@@ -15,7 +15,7 @@ import type { Action } from '@wordpress/dataviews';
 import { TEMPLATE_PART_POST_TYPE } from '../../store/constants';
 import { CreateTemplatePartModalContents } from '../../components/create-template-part-modal';
 import { getItemTitle } from './utils';
-import type { TemplatePart } from '../types';
+import type { Post, TemplatePart } from '../types';
 
 const duplicateTemplatePart: Action< TemplatePart > = {
 	id: 'duplicate-template-part',
@@ -38,12 +38,12 @@ const duplicateTemplatePart: Action< TemplatePart > = {
 			);
 		}, [ item.content, item.blocks ] );
 		const { createSuccessNotice } = useDispatch( noticesStore );
-		function onTemplatePartSuccess() {
+		function onTemplatePartSuccess( templatePart: Post ) {
 			createSuccessNotice(
 				sprintf(
 					// translators: %s: The new template part's title e.g. 'Call to action (copy)'.
 					_x( '"%s" duplicated.', 'template part' ),
-					getItemTitle( item )
+					getItemTitle( templatePart )
 				),
 				{ type: 'snackbar', id: 'edit-site-patterns-success' }
 			);


### PR DESCRIPTION
When duplicating a page or pattern the success messages refers to the "new title" (title of the created duplicated object), for template parts the success messages referred the "old title" (title of the original object that was duplicated.


This PR fixes the issue and makes the success message refer the new title as the other duplicate actions do. Making the actions consistent.

## Testing 

- Go to wp-admin/site-editor.php?categoryId=header&postType=wp_template_part.
- Duplicate a header.
- Verify the success message references the new title.
