### PR TITLE
REST API: Support search_columns argument in the user endpoint

### DIFF
--- a/backport-changelog/6.8/7909.md
+++ b/backport-changelog/6.8/7909.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7909
+
+* https://github.com/WordPress/gutenberg/pull/67330

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * Add search_columns parameter to users endpoint parameters
+ *
+ * @param array $query_params JSON Schema-formatted collection parameters.
+ * @return array Updated collection parameters
+ */
+function gutenberg_add_search_columns_param( $query_params ) {
+	$query_params['search_columns'] = array(
+		'default'     => array(),
+		'description' => __( 'Array of column names to be searched.' ),
+		'type'        => 'array',
+		'items'       => array(
+			'enum' => array( 'email', 'name', 'id', 'username', 'slug' ),
+			'type' => 'string',
+		),
+	);
+
+	return $query_params;
+}
+
+add_filter( 'rest_user_collection_params', 'gutenberg_add_search_columns_param', 10, 1 );
+
+/**
+ * Modify user query based on search_columns parameter
+ *
+ * @param array           $prepared_args Array of arguments for WP_User_Query.
+ * @param WP_REST_Request $request       The REST API request.
+ * @return array Modified arguments
+ */
+function gutenberg_modify_user_query_args( $prepared_args, $request ) {
+	if ( $request->get_param( 'search' ) && $request->get_param( 'search_columns' ) ) {
+		$search_columns = $request->get_param( 'search_columns' );
+
+		// Validate search columns
+		$valid_columns          = isset( $prepared_args['search_columns'] )
+			? $prepared_args['search_columns']
+			: array( 'ID', 'user_login', 'user_nicename', 'user_email', 'user_url', 'display_name' );
+		$search_columns_mapping = array(
+			'id'       => 'ID',
+			'username' => 'user_login',
+			'slug'     => 'user_nicename',
+			'email'    => 'user_email',
+			'name'     => 'display_name',
+		);
+		$search_columns         = array_map(
+			function ( $column ) use ( $search_columns_mapping ) {
+				return isset( $search_columns_mapping[ $column ] )
+					? $search_columns_mapping[ $column ]
+					: $column;
+			},
+			$search_columns
+		);
+		$search_columns         = array_intersect( $search_columns, $valid_columns );
+
+		if ( ! empty( $search_columns ) ) {
+			$prepared_args['search_columns'] = $search_columns;
+		}
+	}
+
+	return $prepared_args;
+}
+add_filter( 'rest_user_query', 'gutenberg_modify_user_query_args', 10, 2 );

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php
@@ -45,7 +45,7 @@ function gutenberg_modify_user_query_args( $prepared_args, $request ) {
 			'name'     => 'display_name',
 		);
 		$search_columns         = array_map(
-			function ( $column ) use ( $search_columns_mapping ) {
+			static function ( $column ) use ( $search_columns_mapping ) {
 				return $search_columns_mapping[ $column ];
 			},
 			$search_columns

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php
@@ -46,9 +46,7 @@ function gutenberg_modify_user_query_args( $prepared_args, $request ) {
 		);
 		$search_columns         = array_map(
 			function ( $column ) use ( $search_columns_mapping ) {
-				return isset( $search_columns_mapping[ $column ] )
-					? $search_columns_mapping[ $column ]
-					: $column;
+				return $search_columns_mapping[ $column ];
 			},
 			$search_columns
 		);

--- a/lib/load.php
+++ b/lib/load.php
@@ -99,6 +99,7 @@ require __DIR__ . '/compat/wordpress-6.8/blocks.php';
 require __DIR__ . '/compat/wordpress-6.8/functions.php';
 require __DIR__ . '/compat/wordpress-6.8/post.php';
 require __DIR__ . '/compat/wordpress-6.8/site-editor.php';
+require __DIR__ . '/compat/wordpress-6.8/class-gutenberg-rest-user-controller.php';
 
 // Experimental features.
 require __DIR__ . '/experimental/block-editor-settings-mobile.php';

--- a/packages/editor/src/components/post-author/constants.js
+++ b/packages/editor/src/components/post-author/constants.js
@@ -5,6 +5,6 @@ export const BASE_QUERY = {
 
 export const AUTHORS_QUERY = {
 	who: 'authors',
-	per_page: 50,
+	per_page: 100,
 	...BASE_QUERY,
 };

--- a/packages/editor/src/components/post-author/hook.js
+++ b/packages/editor/src/components/post-author/hook.js
@@ -23,6 +23,7 @@ export function useAuthorsQuery( search ) {
 
 			if ( search ) {
 				query.search = search;
+				query.search_columns = [ 'name' ];
 			}
 
 			return {


### PR DESCRIPTION
closes #67331

## What?

There's a weird bug in the "post author" selector in the editor. Say you have a site with thousands of users, and imagine these users all have emails that end with `@automattic.com` :).  This means that if you search for an author named "Matt" in the post author selector, you'll never be able to assign the post to that person. The reason is the following:

 - The REST API would return the 50 first results and the user endpoint by default search within emails, names slugs and usernames, all the users will be returned, so you'll be getting the first 50 users and none of them is actually named "Matt" :P 

What a funny 🐛 right :) 

This PR solves this by adding support for a `search_columns` argument to the user endpoint. A similar argument is already supported for the posts endpoints.

## Testing Instructions

Based on #38791, props to @claudiulodro!

1. Generate a couple of hundred users and give them all `example.com` email address.
2. Open Dashboard > Users page.
3. Navigate to the last page on the list table and edit the last user.
4. Change their display and nickname name to `User Example`.
5. Open a post or page and search for an `example` author.
6. Confirm that "User Example" shows up in the results. **This doesn't work on trunk**

A snippet for user generation via WP CLI

```bash
wp user generate --role=author --format=ids --count=300 | tr ' ' '\n' | xargs -I % wp user update % --user_email="blah-$(echo %)@example.com"
```

## Screenshot

<img width="874" alt="153926147-1bda6114-1610-4dd0-9e74-4c6b14862a97" src="https://github.com/user-attachments/assets/3e716802-cf18-4ad7-96fc-0c7b0ee6774c">
