### PR TITLE
hacky list view search filter

### DIFF
--- a/packages/block-editor/src/components/list-view/focus-wrapper.js
+++ b/packages/block-editor/src/components/list-view/focus-wrapper.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useRef, useState, useCallback } from '@wordpress/element';
+
+const FocusWrapper = ( {
+	children,
+	onFocusWithin,
+	onBlurWithin,
+	onKeyDown,
+} ) => {
+	const [ isFocused, setIsFocused ] = useState( false );
+	const wrapperRef = useRef( null );
+	const handleFocusIn = useCallback(
+		( event ) => {
+			if (
+				wrapperRef.current &&
+				wrapperRef.current.contains( event.target )
+			) {
+				setIsFocused( true );
+				if ( onFocusWithin ) {
+					onFocusWithin();
+				}
+			}
+		},
+		[ onFocusWithin ]
+	);
+
+	// @TODO this should only fire if the focus is leaving the wrapper
+	// and there's no search activity going on (search control causes focus loss).
+	const handleFocusOut = useCallback(
+		( event ) => {
+			if (
+				wrapperRef.current &&
+				! wrapperRef.current.contains( event.relatedTarget )
+			) {
+				setIsFocused( false );
+				if ( onBlurWithin ) {
+					onBlurWithin();
+				}
+			}
+		},
+		[ onBlurWithin ]
+	);
+
+	const handleKeyDown = useCallback(
+		( event ) => {
+			if ( isFocused && onKeyDown ) {
+				onKeyDown( event );
+			}
+		},
+		[ isFocused, onKeyDown ]
+	);
+
+	useEffect( () => {
+		document.addEventListener( 'focusin', handleFocusIn );
+		document.addEventListener( 'focusout', handleFocusOut );
+		document.addEventListener( 'keydown', handleKeyDown );
+
+		return () => {
+			document.removeEventListener( 'focusin', handleFocusIn );
+			document.removeEventListener( 'focusout', handleFocusOut );
+			document.removeEventListener( 'keydown', handleKeyDown );
+		};
+	}, [ handleFocusIn, handleFocusOut, handleKeyDown ] );
+
+	return (
+		<div
+			ref={ wrapperRef }
+			className={ clsx( 'block-editor-list-view-tree__focus-wrapper', {
+				'is-focused': isFocused,
+			} ) }
+		>
+			{ children }
+		</div>
+	);
+};
+
+export default FocusWrapper;

--- a/packages/block-editor/src/components/list-view/index.js
+++ b/packages/block-editor/src/components/list-view/index.js
@@ -401,11 +401,13 @@ function ListViewComponent(
 			console.log( `Character pressed: ${ event.key }` );
 			setSearchInput( event.key );
 			setShowSearch( true );
+			setTimeout( () => { searchRef.current.focus(); }, 0 );
 		} else {
 			console.log( 'Non-character key pressed' );
 			// Your logic for handling non-character keys goes here
 		}
 	};
+	console.log( { showSearch, searchInput } );
 	return (
 		<AsyncModeProvider value>
 			<ListViewDropIndicatorPreview
@@ -426,11 +428,12 @@ function ListViewComponent(
 					onChange={ ( value ) => {
 						// If the search input is empty, hide the search input.
 						// @TODO does the search control need a callback when the X clear button is clicked?
-						console.log( { value } );
 						if ( value ) {
 							setSearchInput( value );
 						}
-						if ( ! searchInput && ! value ) {
+						if ( ! value ) {
+							console.log( 'should hide' );
+							setSearchInput( '' );
 							setShowSearch( false );
 						}
 					} }
@@ -440,8 +443,9 @@ function ListViewComponent(
 			<FocusWrapper
 				onKeyDown={ handleKeyDown }
 				onBlurWithin={ () => {
-					setSearchInput( '' );
-					setShowSearch( false );
+					console.log( 'onBlurWithin' );
+					// setSearchInput( '' );
+					// setShowSearch( false );
 				} }
 			>
 				<TreeGrid

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { createSelector, createRegistrySelector } from '@wordpress/data';
-
+import { getBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
@@ -84,14 +84,22 @@ export const isBlockSubtreeDisabled = ( state, clientId ) => {
 function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
 	const blockOrder = getBlockOrder( state, rootClientId );
 	const result = [];
-
 	for ( const clientId of blockOrder ) {
+		// @TODO create a custom selector for this to limit potential damage?
+		const blockName = getBlockName( state, clientId );
+		// @TODO how to handle template and pattern titles?
+		const blockType = getBlockType( blockName );
 		const innerBlocks = getEnabledClientIdsTreeUnmemoized(
 			state,
 			clientId
 		);
 		if ( getBlockEditingMode( state, clientId ) !== 'disabled' ) {
-			result.push( { clientId, innerBlocks } );
+			result.push( {
+				clientId,
+				blockTitle: blockType?.title,
+				blockName,
+				innerBlocks,
+			} );
 		} else {
 			result.push( ...innerBlocks );
 		}


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Just a hacky PR to test the usefulness of filtering the list view

Collating feedback:

Audience:

1. Power users
2. non-technical users who get turned around in the editor.
3. non-admin editors/content creators working on long form content.


UX ideas and questions

1. could the search box appear and become focused only if you press ⌘F?
2. Is there a space for an ellipsis menu near the top of this list? Would we want other actions in such an ellipsis? Should there be a search tab?
3. Does it [search control] need to be visible all the time? Main concern with something that doesn’t appear due to you invoking it is: you might think it searches things other than just the list view. .... Best practices would probably show a UI after you start typing, but in terms of striking the balance between power user prominence and simple first validating steps, would it be possible to just allow you to type the first letters of a block name, to select it? Or do we actually have to dim the ones not found? Do we actually have to show the search field?
4. will it be helpful for the user to see a list of 20 Heading blocks? We’ll likely need a custom UI to show the context (e.g. block structure breadcrumbs, anchor, etc). In such a case, we could keep the browser’s native search and either add search only inside the List View panel, or come up with an alternative keyboard shortcut that doesn’t hijack the default one, e.g. Shift + F.

## Why?

Coz, cuz

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9df14a9d-189c-4697-b40e-fc865b4f3b3f

