### PR TITLE
Query: Remove 'inherit' override from query block attributes

### DIFF
--- a/packages/block-library/src/query/utils.js
+++ b/packages/block-library/src/query/utils.js
@@ -231,7 +231,7 @@ export const getTransformedBlocksFromPattern = (
 	queryBlockAttributes
 ) => {
 	const {
-		query: { postType, inherit },
+		query: { postType },
 		namespace,
 	} = queryBlockAttributes;
 	const clonedBlocks = blocks.map( ( block ) => cloneBlock( block ) );
@@ -243,7 +243,6 @@ export const getTransformedBlocksFromPattern = (
 			block.attributes.query = {
 				...block.attributes.query,
 				postType,
-				inherit,
 			};
 			if ( namespace ) {
 				block.attributes.namespace = namespace;


### PR DESCRIPTION
Fixes: #67288 

## What?
This PR removes the logic that tends to override the inherit value with the block's inherit value ( which is set to True by default ) leading to a bug where, if in the Pattern, we've specified inherit as false, then that gets overwritten to True which can potentially also ignore the perPage being set for the query block in the pattern. Better explained here: https://github.com/WordPress/gutenberg/issues/67288#issuecomment-2502921007

## How?
By removing the override of inherit, the bug was resolved.

## Testing Instructions
1. Create a Query Loop Block.
2. Choose a Pattern titled List of posts, 1 column.
3. Make sure to set the inherit to false in the Pattern for testing purposes.
4. Notice the perPage is now whatever's mentioned in the perPage inside the pattern, instead of a default value from the reading settings. Earlier, even when inherit was explicitly set to false, the perPage from reading settings was used instead of using the perPage from the Block Code. ( Described in the above comment. )

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/022724ec-d3a2-47fd-a351-105c4920e79a

