### PR TITLE
Inserter: Fix unresponsive Browse All Button on Quick Inserter for Mobile Screens.

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -173,7 +173,7 @@ class Inserter extends Component {
 					isAppender={ isAppender }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
-					closeQuickInserter={ onClose }
+					onClose={ onClose }
 				/>
 			);
 		}

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -173,6 +173,7 @@ class Inserter extends Component {
 					isAppender={ isAppender }
 					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
+					closeQuickInserter={ onClose }
 				/>
 			);
 		}

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -33,7 +33,7 @@ export default function QuickInserter( {
 	isAppender,
 	prioritizePatterns,
 	selectBlockOnInsert,
-	closeQuickInserter,
+	onClose,
 	hasSearch = true,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
@@ -90,12 +90,8 @@ export default function QuickInserter( {
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
-		if (
-			isMobileDevice &&
-			closeQuickInserter &&
-			typeof closeQuickInserter === 'function'
-		) {
-			closeQuickInserter();
+		if ( isMobileDevice ) {
+			onClose?.();
 		}
 
 		setInserterIsOpened( {

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -19,6 +19,7 @@ import useInsertionPoint from './hooks/use-insertion-point';
 import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
 import { store as blockEditorStore } from '../../store';
+import { useViewportMatch } from '@wordpress/compose';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
@@ -32,6 +33,7 @@ export default function QuickInserter( {
 	isAppender,
 	prioritizePatterns,
 	selectBlockOnInsert,
+	closeQuickInserter,
 	hasSearch = true,
 } ) {
 	const [ filterValue, setFilterValue ] = useState( '' );
@@ -53,6 +55,8 @@ export default function QuickInserter( {
 		undefined,
 		true
 	);
+
+	const isMobileDevice = useViewportMatch( 'small', '<' );
 
 	const { setInserterIsOpened, insertionIndex } = useSelect(
 		( select ) => {
@@ -86,6 +90,14 @@ export default function QuickInserter( {
 	// When clicking Browse All select the appropriate block so as
 	// the insertion point can work as expected.
 	const onBrowseAll = () => {
+		if (
+			isMobileDevice &&
+			closeQuickInserter &&
+			typeof closeQuickInserter === 'function'
+		) {
+			closeQuickInserter();
+		}
+
 		setInserterIsOpened( {
 			filterValue,
 			onSelect,


### PR DESCRIPTION
Fixes: #67338 

## What?
This PR resolves a bug that causes the `Browse All` button in the `Quick Inserter` to become unresponsive when clicked on mobile devices. The issue occurs because the `Quick Inserter` opens in a full-screen dialog on mobile, obscuring the `sidebar Inserter`. With this fix, clicking `Browse All` on mobile will close the `Quick Inserter` and seamlessly open the `sidebar Inserter`.

## How?
A new prop has now been added to the `<QuickInserter />` component called `closeQuickInserter` which is used to close the `Dialog/Dropdown` exclusively on mobile devices when clicked. It precedes the old logic to open the `Inserter` via click event on `Browse All`.

## Testing Instructions
1. On a mobile screen, navigate to editing a post.
2. Try pressing the Plus (+) button inline with the block. It should open a full-screen dialog with a Browse All button at the bottom.
3. Try pressing the Browse All Button, and observe that the Quick Inserter Dialog is closed and the Sidebar Inserter opens up.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/3db3a80b-f5cf-48d6-8f25-204d96d1c09a


