### PR TITLE
Storybook: Add PlainText Storybook stories

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -705,9 +705,49 @@ Undocumented declaration.
 
 ### PlainText
 
+Render an auto-growing textarea allow users to fill any textual content.
+
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/plain-text/README.md>
+
+_Usage_
+
+```jsx
+import { registerBlockType } from '@wordpress/blocks';
+import { PlainText } from '@wordpress/block-editor';
+
+registerBlockType( 'my-plugin/example-block', {
+	// ...
+
+	attributes: {
+		content: {
+			type: 'string',
+		},
+	},
+
+	edit( { className, attributes, setAttributes } ) {
+		return (
+			<PlainText
+				className={ className }
+				value={ attributes.content }
+				onChange={ ( content ) => setAttributes( { content } ) }
+			/>
+		);
+	},
+} );
+```
+
+_Parameters_
+
+-   _props_ `Object`: Component props.
+-   _props.value_ `string`: String value of the textarea
+-   _props.onChange_ `Function`: Called when the value changes
+-   _props.ref_ `[Object]`: The component forwards the `ref` property to the `TextareaAutosize` component.
+
+_Returns_
+
+-   `Element`: Plain text component
 
 ### privateApis
 

--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -741,8 +741,8 @@ registerBlockType( 'my-plugin/example-block', {
 _Parameters_
 
 -   _props_ `Object`: Component props.
--   _props.value_ `string`: String value of the textarea
--   _props.onChange_ `Function`: Called when the value changes
+-   _props.value_ `string`: String value of the textarea.
+-   _props.onChange_ `Function`: Function called when the text value changes.
 -   _props.ref_ `[Object]`: The component forwards the `ref` property to the `TextareaAutosize` component.
 
 _Returns_

--- a/packages/block-editor/src/components/plain-text/README.md
+++ b/packages/block-editor/src/components/plain-text/README.md
@@ -6,11 +6,11 @@ Render an auto-growing textarea allow users to fill any textual content.
 
 ### `value: string`
 
-_Required._ String value of the textarea
+_Required._ String value of the textarea.
 
 ### `onChange( value: string ): Function`
 
-_Required._ Called when the value changes.
+_Required._ Function called when the text value changes.
 
 You can also pass any extra prop to the textarea rendered by this component.
 

--- a/packages/block-editor/src/components/plain-text/index.js
+++ b/packages/block-editor/src/components/plain-text/index.js
@@ -46,8 +46,8 @@ import EditableText from '../editable-text';
  * ````
  *
  * @param {Object}   props          Component props.
- * @param {string}   props.value    String value of the textarea
- * @param {Function} props.onChange Called when the value changes
+ * @param {string}   props.value    String value of the textarea.
+ * @param {Function} props.onChange Function called when the text value changes.
  * @param {Object}   [props.ref]    The component forwards the `ref` property to the `TextareaAutosize` component.
  * @return {Element} Plain text component
  */

--- a/packages/block-editor/src/components/plain-text/index.js
+++ b/packages/block-editor/src/components/plain-text/index.js
@@ -15,7 +15,41 @@ import { forwardRef } from '@wordpress/element';
 import EditableText from '../editable-text';
 
 /**
+ * Render an auto-growing textarea allow users to fill any textual content.
+ *
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/plain-text/README.md
+ *
+ * @example
+ * ```jsx
+ * import { registerBlockType } from '@wordpress/blocks';
+ * import { PlainText } from '@wordpress/block-editor';
+ *
+ * registerBlockType( 'my-plugin/example-block', {
+ *   // ...
+ *
+ *   attributes: {
+ *     content: {
+ *       type: 'string',
+ *     },
+ *   },
+ *
+ *   edit( { className, attributes, setAttributes } ) {
+ *     return (
+ *       <PlainText
+ *         className={ className }
+ *         value={ attributes.content }
+ *         onChange={ ( content ) => setAttributes( { content } ) }
+ *       />
+ *     );
+ *   },
+ * } );
+ * ````
+ *
+ * @param {Object}   props          Component props.
+ * @param {string}   props.value    String value of the textarea
+ * @param {Function} props.onChange Called when the value changes
+ * @param {Object}   [props.ref]    The component forwards the `ref` property to the `TextareaAutosize` component.
+ * @return {Element} Plain text component
  */
 const PlainText = forwardRef( ( { __experimentalVersion, ...props }, ref ) => {
 	if ( __experimentalVersion === 2 ) {

--- a/packages/block-editor/src/components/plain-text/stories/index.story.js
+++ b/packages/block-editor/src/components/plain-text/stories/index.story.js
@@ -6,17 +6,33 @@ import PlainText from '..';
 /**
  * WordPress dependencies
  */
-import { useEffect, useState } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
- * Render an auto-growing textarea allow users to fill any textual content.
+ * Render an auto-growing textarea for user input.
  */
 const meta = {
 	title: 'BlockEditor/PlainText',
 	component: PlainText,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+		},
+		description: {
+			component:
+				'PlainText renders an auto-growing textarea that allows users to enter any textual content.',
+		},
+	},
 	argTypes: {
 		value: {
-			control: 'text',
+			control: {
+				type: null,
+			},
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
 			description: 'The current text value of the PlainText',
 		},
 		onChange: {
@@ -24,34 +40,33 @@ const meta = {
 			control: {
 				type: null,
 			},
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
 			description: 'Function called when the text value changes',
 		},
 		className: {
 			control: 'text',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
 			description: 'Additional class name for the PlainText',
 		},
 	},
-	render: function Render( args ) {
-		const [ value, setValue ] = useState( '' );
-
-		const { value: argValue, className, onChange } = args;
-
-		useEffect( () => {
-			setValue( argValue );
-		}, [ argValue ] );
-
-		const handleOnChange = ( newValue ) => {
-			setValue( newValue );
-			if ( onChange ) {
-				onChange( newValue );
-			}
-		};
-
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( args.value );
 		return (
 			<PlainText
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
 				value={ value }
-				onChange={ handleOnChange }
-				className={ className }
 			/>
 		);
 	},
@@ -62,25 +77,6 @@ export default meta;
 export const Default = {
 	args: {
 		className: 'bold',
-		value: 'Type some text here...',
-	},
-};
-
-/**
- * PlainText component with a long text value to test auto-grow.
- */
-export const LongText = {
-	args: {
-		value: 'Type a long piece of text to see auto-grow in action...',
-	},
-};
-
-/**
- * PlainText component with a custom class name.
- */
-export const WithClassName = {
-	args: {
-		className: 'my-custom-class',
 		value: 'Type some text here...',
 	},
 };

--- a/packages/block-editor/src/components/plain-text/stories/index.story.js
+++ b/packages/block-editor/src/components/plain-text/stories/index.story.js
@@ -8,19 +8,16 @@ import PlainText from '..';
  */
 import { useState } from '@wordpress/element';
 
-/**
- * Render an auto-growing textarea for user input.
- */
 const meta = {
 	title: 'BlockEditor/PlainText',
 	component: PlainText,
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },
-		},
-		description: {
-			component:
-				'PlainText renders an auto-growing textarea that allows users to enter any textual content.',
+			description: {
+				component:
+					'PlainText renders an auto-growing textarea that allows users to enter any textual content.',
+			},
 		},
 	},
 	argTypes: {
@@ -57,6 +54,11 @@ const meta = {
 			description: 'Additional class name for the PlainText',
 		},
 	},
+};
+
+export default meta;
+
+export const Default = {
 	render: function Template( { onChange, ...args } ) {
 		const [ value, setValue ] = useState( args.value );
 		return (
@@ -69,14 +71,5 @@ const meta = {
 				value={ value }
 			/>
 		);
-	},
-};
-
-export default meta;
-
-export const Default = {
-	args: {
-		className: 'bold',
-		value: 'Type some text here...',
 	},
 };

--- a/packages/block-editor/src/components/plain-text/stories/index.story.js
+++ b/packages/block-editor/src/components/plain-text/stories/index.story.js
@@ -1,0 +1,86 @@
+/**
+ * Internal dependencies
+ */
+import PlainText from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Render an auto-growing textarea allow users to fill any textual content.
+ */
+const meta = {
+	title: 'BlockEditor/PlainText',
+	component: PlainText,
+	argTypes: {
+		value: {
+			control: 'text',
+			description: 'The current text value of the PlainText',
+		},
+		onChange: {
+			action: 'onChange',
+			control: {
+				type: null,
+			},
+			description: 'Function called when the text value changes',
+		},
+		className: {
+			control: 'text',
+			description: 'Additional class name for the PlainText',
+		},
+	},
+	render: function Render( args ) {
+		const [ value, setValue ] = useState( '' );
+
+		const { value: argValue, className, onChange } = args;
+
+		useEffect( () => {
+			setValue( argValue );
+		}, [ argValue ] );
+
+		const handleOnChange = ( newValue ) => {
+			setValue( newValue );
+			if ( onChange ) {
+				onChange( newValue );
+			}
+		};
+
+		return (
+			<PlainText
+				value={ value }
+				onChange={ handleOnChange }
+				className={ className }
+			/>
+		);
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		className: 'bold',
+		value: 'Type some text here...',
+	},
+};
+
+/**
+ * PlainText component with a long text value to test auto-grow.
+ */
+export const LongText = {
+	args: {
+		value: 'Type a long piece of text to see auto-grow in action...',
+	},
+};
+
+/**
+ * PlainText component with a custom class name.
+ */
+export const WithClassName = {
+	args: {
+		className: 'my-custom-class',
+		value: 'Type some text here...',
+	},
+};

--- a/packages/block-editor/src/components/plain-text/stories/index.story.js
+++ b/packages/block-editor/src/components/plain-text/stories/index.story.js
@@ -30,7 +30,7 @@ const meta = {
 					summary: 'string',
 				},
 			},
-			description: 'The current text value of the PlainText.',
+			description: 'String value of the textarea.',
 		},
 		onChange: {
 			action: 'onChange',

--- a/packages/block-editor/src/components/plain-text/stories/index.story.js
+++ b/packages/block-editor/src/components/plain-text/stories/index.story.js
@@ -1,12 +1,12 @@
 /**
- * Internal dependencies
- */
-import PlainText from '..';
-
-/**
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PlainText from '..';
 
 const meta = {
 	title: 'BlockEditor/PlainText',
@@ -30,7 +30,7 @@ const meta = {
 					summary: 'string',
 				},
 			},
-			description: 'The current text value of the PlainText',
+			description: 'The current text value of the PlainText.',
 		},
 		onChange: {
 			action: 'onChange',
@@ -42,7 +42,7 @@ const meta = {
 					summary: 'function',
 				},
 			},
-			description: 'Function called when the text value changes',
+			description: 'Function called when the text value changes.',
 		},
 		className: {
 			control: 'text',
@@ -51,7 +51,7 @@ const meta = {
 					summary: 'string',
 				},
 			},
-			description: 'Additional class name for the PlainText',
+			description: 'Additional class name for the PlainText.',
 		},
 	},
 };
@@ -60,7 +60,7 @@ export default meta;
 
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
-		const [ value, setValue ] = useState( args.value );
+		const [ value, setValue ] = useState();
 		return (
 			<PlainText
 				{ ...args }


### PR DESCRIPTION
Part of #67165  

## What?
This PR adds Storybook stories for the PlainText component to improve component documentation and testability.

## Why?
- To provide clear visual documentation for the PlainText component.
- To enable interactive testing for various PlainText scenarios.
- To enhance the development experience for Block Editor components.

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open Storybook at http://localhost:50240/
3. Verify the following stories are present and functioning:
	- Default rendering of the PlainText component.
	- PlainText with a long text value to test auto-grow functionality.
	- PlainText with a custom class name applied.

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/6e363cf7-979a-46a7-942e-7061c82b3e1c

