### PR TITLE
Storybook: Add WritingModeControl story

### DIFF
--- a/packages/block-editor/src/components/writing-mode-control/stories/index.story.js
+++ b/packages/block-editor/src/components/writing-mode-control/stories/index.story.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { isRTL } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -24,14 +25,7 @@ const meta = {
 	},
 	argTypes: {
 		value: {
-			control: { type: 'select' },
-			options: ( () => {
-				const modes = [
-					'horizontal-tb',
-					isRTL() ? 'vertical-lr' : 'vertical-rl',
-				];
-				return modes;
-			} )(),
+			control: { type: null },
 			description: 'Currently selected writing mode.',
 		},
 		className: {
@@ -40,6 +34,7 @@ const meta = {
 		},
 		onChange: {
 			action: 'onChange',
+			control: { type: null },
 			description: 'Handles change in the writing mode selection.',
 		},
 	},
@@ -48,16 +43,20 @@ const meta = {
 export default meta;
 
 export const Default = {
-	args: {
-		value: 'horizontal-tb',
-	},
-};
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState(
+			isRTL() ? 'vertical-lr' : 'vertical-rl'
+		);
 
-/**
- * This story demonstrates the WritingModeControl component with the vertical writing mode.
- */
-export const Vertical = {
-	args: {
-		value: isRTL() ? 'vertical-lr' : 'vertical-rl',
+		return (
+			<WritingModeControl
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				value={ value }
+			/>
+		);
 	},
 };

--- a/packages/block-editor/src/components/writing-mode-control/stories/index.story.js
+++ b/packages/block-editor/src/components/writing-mode-control/stories/index.story.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { isRTL } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
@@ -9,9 +8,6 @@ import { useState } from '@wordpress/element';
  */
 import WritingModeControl from '../';
 
-/**
- * WritingModeControl component allows selecting writing mode.
- */
 const meta = {
 	title: 'BlockEditor/WritingModeControl',
 	component: WritingModeControl,
@@ -44,9 +40,7 @@ export default meta;
 
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
-		const [ value, setValue ] = useState(
-			isRTL() ? 'vertical-lr' : 'vertical-rl'
-		);
+		const [ value, setValue ] = useState();
 
 		return (
 			<WritingModeControl

--- a/packages/block-editor/src/components/writing-mode-control/stories/index.story.js
+++ b/packages/block-editor/src/components/writing-mode-control/stories/index.story.js
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { isRTL } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import WritingModeControl from '../';
+
+/**
+ * WritingModeControl component allows selecting writing mode.
+ */
+const meta = {
+	title: 'BlockEditor/WritingModeControl',
+	component: WritingModeControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: 'Control to facilitate writing mode selections.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: { type: 'select' },
+			options: ( () => {
+				const modes = [
+					'horizontal-tb',
+					isRTL() ? 'vertical-lr' : 'vertical-rl',
+				];
+				return modes;
+			} )(),
+			description: 'Currently selected writing mode.',
+		},
+		className: {
+			control: 'text',
+			description: 'Class name to add to the control.',
+		},
+		onChange: {
+			action: 'onChange',
+			description: 'Handles change in the writing mode selection.',
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		value: 'horizontal-tb',
+	},
+};
+
+/**
+ * This story demonstrates the WritingModeControl component with the vertical writing mode.
+ */
+export const Vertical = {
+	args: {
+		value: isRTL() ? 'vertical-lr' : 'vertical-rl',
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for WritingModeControl component in the Storybook.

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the WritingModeControl stories.

## Screenshots or screencast


https://github.com/user-attachments/assets/eabbdd34-221a-467c-a5cc-c5a5838b0957

