### PR TITLE
Block Bindings: Remove fallback for `context.postType` in post meta

### DIFF
--- a/packages/editor/src/bindings/post-meta.js
+++ b/packages/editor/src/bindings/post-meta.js
@@ -108,11 +108,8 @@ export default {
 			return false;
 		}
 
-		const postType =
-			context?.postType || select( editorStore ).getCurrentPostType();
-
-		// Check that editing is happening in the post editor and not a template.
-		if ( postType === 'wp_template' ) {
+		// Lock editing when `postType` is not defined.
+		if ( ! context?.postType ) {
 			return false;
 		}
 


### PR DESCRIPTION
## What?
Remove an unnecessary fallback for `postType` in post meta block bindings source.

## Why?
It can just be assumed that if the `postType` is not defined, the custom fields are not available. If I am not mistaken, this was needed before [this other pull request](https://github.com/WordPress/gutenberg/pull/65062) but is not needed anymore.

## How?
Just removing the fallback.
 
## Testing Instructions
e2e tests should pass and everything should work as before.
1. Register a custom field with `show_in_rest` set to true.
2. Go to the `pages` template.
3. Connect a paragraph to a custom field.
4. Check it works as expected.
