### PR TITLE
 Storybook: Add UnitControl story

### DIFF
--- a/packages/block-editor/src/components/unit-control/README.md
+++ b/packages/block-editor/src/components/unit-control/README.md
@@ -34,7 +34,7 @@ const Example = () => {
 
 ### Props
 
-#### disabledUnits
+#### disableUnits
 
 If true, the unit `<select>` is hidden.
 

--- a/packages/block-editor/src/components/unit-control/stories/index.story.js
+++ b/packages/block-editor/src/components/unit-control/stories/index.story.js
@@ -8,18 +8,18 @@ import { useState, useEffect } from '@wordpress/element';
  */
 import UnitControl from '../';
 
-const CUSTOM_UNITS = [
-	{ value: 'px', label: 'px', default: 0 },
-	{ value: 'em', label: 'em', default: 0 },
-	{ value: 'rem', label: 'rem', default: 0 },
-];
-
-/**
- * UnitControl Properties
- */
-export default {
+const meta = {
 	title: 'BlockEditor/UnitControl',
 	component: UnitControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'UnitControl allows the user to set a numeric quantity as well as a unit ',
+			},
+		},
+	},
 	argTypes: {
 		onChange: {
 			action: 'onChange',
@@ -36,7 +36,7 @@ export default {
 			},
 		},
 		labelPosition: {
-			control: 'select',
+			control: 'radio',
 			options: [ 'top', 'side', 'bottom' ],
 			description: 'The position of the label.',
 			table: {
@@ -59,12 +59,12 @@ export default {
 			},
 		},
 		size: {
-			control: 'select',
-			options: [ 'small', 'medium' ],
+			control: 'radio',
+			options: [ 'default', 'small' ],
 			description: 'The size of the control.',
 			table: {
 				type: { summary: 'string' },
-				defaultValue: { summary: 'medium' },
+				defaultValue: { summary: 'default' },
 			},
 		},
 		disabled: {
@@ -76,7 +76,12 @@ export default {
 			},
 		},
 	},
-	render: function Render( { onChange, onUnitChange, value, ...args } ) {
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, onUnitChange, value, ...args } ) {
 		const [ componentValue, setComponentValue ] = useState( value || '' );
 
 		useEffect( () => {
@@ -98,39 +103,5 @@ export default {
 				onUnitChange={ onUnitChange }
 			/>
 		);
-	},
-};
-
-/**
- * Story demonstrating UnitControl with default settings
- */
-export const Default = {
-	args: {
-		label: 'Default Unit Control',
-		value: '10',
-		size: 'medium',
-		labelPosition: 'top',
-	},
-};
-
-/**
- * Story demonstrating UnitControl with custom units
- */
-export const CustomUnits = {
-	args: {
-		...Default.args,
-		label: 'Custom Units',
-		units: CUSTOM_UNITS,
-	},
-};
-
-/**
- * Story demonstrating UnitControl in disabled state
- */
-export const Disabled = {
-	args: {
-		...Default.args,
-		label: 'Disabled Unit Control',
-		disabled: true,
 	},
 };

--- a/packages/block-editor/src/components/unit-control/stories/index.story.js
+++ b/packages/block-editor/src/components/unit-control/stories/index.story.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -16,7 +16,7 @@ const meta = {
 			canvas: { sourceState: 'shown' },
 			description: {
 				component:
-					'UnitControl allows the user to set a numeric quantity as well as a unit ',
+					'UnitControl allows the user to set a numeric quantity as well as a unit.',
 			},
 		},
 	},
@@ -37,11 +37,10 @@ const meta = {
 		},
 		labelPosition: {
 			control: 'radio',
-			options: [ 'top', 'side', 'bottom' ],
+			options: [ 'top', 'side', 'bottom', 'edge' ],
 			description: 'The position of the label.',
 			table: {
 				type: { summary: 'string' },
-				defaultValue: { summary: 'top' },
 			},
 		},
 		label: {
@@ -52,7 +51,7 @@ const meta = {
 			},
 		},
 		value: {
-			control: 'text',
+			control: { type: null },
 			description: 'The value of the control.',
 			table: {
 				type: { summary: 'string' },
@@ -75,33 +74,51 @@ const meta = {
 				defaultValue: { summary: false },
 			},
 		},
+		disabledUnits: {
+			control: 'boolean',
+			description: 'If true, the unit select is hidden.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
+		},
+		isPressEnterToChange: {
+			control: 'boolean',
+			description:
+				'If true, the ENTER key press is required to trigger onChange. Change is also triggered on blur.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
+		},
+		isUnitSelectTabbable: {
+			control: 'boolean',
+			description: 'Determines if the unit select is tabbable.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: true },
+			},
+		},
 	},
 };
 
 export default meta;
 
 export const Default = {
-	render: function Template( { onChange, onUnitChange, value, ...args } ) {
-		const [ componentValue, setComponentValue ] = useState( value || '' );
-
-		useEffect( () => {
-			setComponentValue( value );
-		}, [ value ] );
-
-		const handleValueChange = ( newValue ) => {
-			setComponentValue( newValue );
-			if ( onChange ) {
-				onChange( newValue );
-			}
-		};
-
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
 		return (
 			<UnitControl
 				{ ...args }
-				value={ componentValue }
-				onChange={ handleValueChange }
-				onUnitChange={ onUnitChange }
+				value={ value }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
 			/>
 		);
+	},
+	args: {
+		label: 'Label',
 	},
 };

--- a/packages/block-editor/src/components/unit-control/stories/index.story.js
+++ b/packages/block-editor/src/components/unit-control/stories/index.story.js
@@ -1,0 +1,136 @@
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import UnitControl from '../';
+
+const CUSTOM_UNITS = [
+	{ value: 'px', label: 'px', default: 0 },
+	{ value: 'em', label: 'em', default: 0 },
+	{ value: 'rem', label: 'rem', default: 0 },
+];
+
+/**
+ * UnitControl Properties
+ */
+export default {
+	title: 'BlockEditor/UnitControl',
+	component: UnitControl,
+	argTypes: {
+		onChange: {
+			action: 'onChange',
+			description: 'Callback function when the value changes.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		onUnitChange: {
+			action: 'onUnitChange',
+			description: 'Callback function when the unit changes.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		labelPosition: {
+			control: 'select',
+			options: [ 'top', 'side', 'bottom' ],
+			description: 'The position of the label.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'top' },
+			},
+		},
+		label: {
+			control: 'text',
+			description: 'The label for the control.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		value: {
+			control: 'text',
+			description: 'The value of the control.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		size: {
+			control: 'select',
+			options: [ 'small', 'medium' ],
+			description: 'The size of the control.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'medium' },
+			},
+		},
+		disabled: {
+			control: 'boolean',
+			description: 'Whether the control is disabled.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
+		},
+	},
+	render: function Render( { onChange, onUnitChange, value, ...args } ) {
+		const [ componentValue, setComponentValue ] = useState( value || '' );
+
+		useEffect( () => {
+			setComponentValue( value );
+		}, [ value ] );
+
+		const handleValueChange = ( newValue ) => {
+			setComponentValue( newValue );
+			if ( onChange ) {
+				onChange( newValue );
+			}
+		};
+
+		return (
+			<UnitControl
+				{ ...args }
+				value={ componentValue }
+				onChange={ handleValueChange }
+				onUnitChange={ onUnitChange }
+			/>
+		);
+	},
+};
+
+/**
+ * Story demonstrating UnitControl with default settings
+ */
+export const Default = {
+	args: {
+		label: 'Default Unit Control',
+		value: '10',
+		size: 'medium',
+		labelPosition: 'top',
+	},
+};
+
+/**
+ * Story demonstrating UnitControl with custom units
+ */
+export const CustomUnits = {
+	args: {
+		...Default.args,
+		label: 'Custom Units',
+		units: CUSTOM_UNITS,
+	},
+};
+
+/**
+ * Story demonstrating UnitControl in disabled state
+ */
+export const Disabled = {
+	args: {
+		...Default.args,
+		label: 'Disabled Unit Control',
+		disabled: true,
+	},
+};

--- a/packages/block-editor/src/components/unit-control/stories/index.story.js
+++ b/packages/block-editor/src/components/unit-control/stories/index.story.js
@@ -74,7 +74,7 @@ const meta = {
 				defaultValue: { summary: false },
 			},
 		},
-		disabledUnits: {
+		disableUnits: {
 			control: 'boolean',
 			description: 'If true, the unit select is hidden.',
 			table: {


### PR DESCRIPTION
Part of #67165 

## What?
This PR will add stories for UnitControl component in the Storybook.


## Why?
As part of the ongoing effort to improve component documentation and testing (tracked in https://github.com/WordPress/gutenberg/issues/22891), we need comprehensive stories for all Block Editor components.

## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the UnitControl stories.

## Screenshots or screencast 

https://github.com/user-attachments/assets/9f20752a-80d7-47e0-a052-1de761e1b32a


