### PR TITLE
Fix color of disabled buttons in dark toolbar

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -157,6 +157,11 @@
 			&:focus::before {
 				box-shadow: inset 0 0 0 1px $gray-900, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 			}
+
+			&:disabled,
+			&[aria-disabled="true"] {
+				color: $gray-700;
+			}
 		}
 
 		.block-editor-block-parent-selector .block-editor-block-parent-selector__button {


### PR DESCRIPTION
Follow up #66116

## What?

Provides visual differentiation between disabled buttons on dark toolbars.

## Why?

Regardless of whether the button is enabled or disabled, the color remains the same (`$gray-300`), making it visually impossible to tell whether the button is disabled or not.

## How?

I chose `$gray-700`, but the color we chose is up for debate.

If the color is too dark it will blend in with the background color, and if the color is too light it will be indistinguishable from a normal button. If none of the colors are suitable, we can also apply opacity instead of color.

| Color | Screenshot |
|--------|--------|
| `$gray-800` | ![image](https://github.com/user-attachments/assets/627b7b98-4dfb-4f23-bcd5-0d41d653936f) | 
| `$gray-700` | ![image](https://github.com/user-attachments/assets/a7f42c98-6152-4069-98d8-a77606ecbd0d) | 
| `$gray-600` | ![image](https://github.com/user-attachments/assets/2ec40de0-642e-4b6a-b4ce-634d7f28097a) |
| `$gray-400` | ![image](https://github.com/user-attachments/assets/005dd0a8-a001-46c2-b0dd-c11f470e6e87) |

## Testing Instructions

- Insert two list items.
- Select the second list item.
- Switch to Write mode.
- The color of the Move down and Outdent buttons should now be visually different from the other buttons.

## Screenshots or screencast <!-- if applicable -->

### Before

![image](https://github.com/user-attachments/assets/c87c677a-6c18-472e-a9ec-d8810a78f2d0)


### After

![image](https://github.com/user-attachments/assets/c2abedb5-6a61-44ee-82eb-e59a59d00ead)
