### PR TITLE
Fix EntitiesSavedStates panel dialog props.

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -31,7 +31,7 @@ const { EntitiesSavedStatesExtensible, NavigableRegion } =
 	unlock( privateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
-const EntitiesSavedStatesForPreview = ( { onClose } ) => {
+const EntitiesSavedStatesForPreview = ( { onClose, renderDialog = false } ) => {
 	const isDirtyProps = useEntitiesSavedStatesIsDirty();
 	let activateSaveLabel;
 	if ( isDirtyProps.isDirty ) {
@@ -75,14 +75,20 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 				onSave,
 				saveEnabled: true,
 				saveLabel: activateSaveLabel,
+				renderDialog,
 			} }
 		/>
 	);
 };
 
-const _EntitiesSavedStates = ( { onClose, renderDialog = undefined } ) => {
+const _EntitiesSavedStates = ( { onClose, renderDialog = false } ) => {
 	if ( isPreviewingTheme() ) {
-		return <EntitiesSavedStatesForPreview onClose={ onClose } />;
+		return (
+			<EntitiesSavedStatesForPreview
+				onClose={ onClose }
+				renderDialog={ renderDialog }
+			/>
+		);
 	}
 	return (
 		<EntitiesSavedStates close={ onClose } renderDialog={ renderDialog } />

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -31,7 +31,7 @@ const { EntitiesSavedStatesExtensible, NavigableRegion } =
 	unlock( privateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
-const EntitiesSavedStatesForPreview = ( { onClose, renderDialog = false } ) => {
+const EntitiesSavedStatesForPreview = ( { onClose, renderDialog } ) => {
 	const isDirtyProps = useEntitiesSavedStatesIsDirty();
 	let activateSaveLabel;
 	if ( isDirtyProps.isDirty ) {
@@ -81,7 +81,7 @@ const EntitiesSavedStatesForPreview = ( { onClose, renderDialog = false } ) => {
 	);
 };
 
-const _EntitiesSavedStates = ( { onClose, renderDialog = false } ) => {
+const _EntitiesSavedStates = ( { onClose, renderDialog } ) => {
 	if ( isPreviewingTheme() ) {
 		return (
 			<EntitiesSavedStatesForPreview

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -401,7 +401,7 @@ _Parameters_
 
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
--   _props.renderDialog_ `Function`: The function to render the dialog.
+-   _props.renderDialog_ `boolean`: Whether to render the component with modal dialog behavior.
 
 _Returns_
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -31,14 +31,11 @@ function identity( values ) {
  *
  * @param {Object}   props              The component props.
  * @param {Function} props.close        The function to close the dialog.
- * @param {Function} props.renderDialog The function to render the dialog.
+ * @param {boolean}  props.renderDialog Whether to render the component with modal dialog behavior.
  *
  * @return {React.ReactNode} The rendered component.
  */
-export default function EntitiesSavedStates( {
-	close,
-	renderDialog = undefined,
-} ) {
+export default function EntitiesSavedStates( { close, renderDialog = false } ) {
 	const isDirtyProps = useIsDirty();
 	return (
 		<EntitiesSavedStatesExtensible
@@ -58,7 +55,7 @@ export default function EntitiesSavedStates( {
  * @param {Function} props.onSave                Function to call when saving entities.
  * @param {boolean}  props.saveEnabled           Flag indicating if save is enabled.
  * @param {string}   props.saveLabel             Label for the save button.
- * @param {Function} props.renderDialog          Function to render a custom dialog.
+ * @param {boolean}  props.renderDialog          Whether to render the component with modal dialog behavior.
  * @param {Array}    props.dirtyEntityRecords    Array of dirty entity records.
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
@@ -72,7 +69,7 @@ export function EntitiesSavedStatesExtensible( {
 	onSave = identity,
 	saveEnabled: saveEnabledProp = undefined,
 	saveLabel = __( 'Save' ),
-	renderDialog = undefined,
+	renderDialog = false,
 	dirtyEntityRecords,
 	isDirty,
 	setUnselectedEntities,
@@ -120,8 +117,8 @@ export function EntitiesSavedStatesExtensible( {
 
 	return (
 		<div
-			ref={ saveDialogRef }
-			{ ...saveDialogProps }
+			ref={ renderDialog ? saveDialogRef : undefined }
+			{ ...( renderDialog && saveDialogProps ) }
 			className="entities-saved-states__panel"
 			role={ renderDialog ? 'dialog' : undefined }
 			aria-labelledby={ renderDialog ? dialogLabel : undefined }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -35,7 +35,7 @@ function identity( values ) {
  *
  * @return {React.ReactNode} The rendered component.
  */
-export default function EntitiesSavedStates( { close, renderDialog = false } ) {
+export default function EntitiesSavedStates( { close, renderDialog } ) {
 	const isDirtyProps = useIsDirty();
 	return (
 		<EntitiesSavedStatesExtensible
@@ -69,7 +69,7 @@ export function EntitiesSavedStatesExtensible( {
 	onSave = identity,
 	saveEnabled: saveEnabledProp = undefined,
 	saveLabel = __( 'Save' ),
-	renderDialog = false,
+	renderDialog,
 	dirtyEntityRecords,
 	isDirty,
 	setUnselectedEntities,

--- a/packages/editor/src/components/post-publish-button/index.js
+++ b/packages/editor/src/components/post-publish-button/index.js
@@ -151,6 +151,7 @@ export class PostPublishButton extends Component {
 			isBusy: ! isAutoSaving && isSaving,
 			variant: 'primary',
 			onClick: this.createOnClick( onClickButton ),
+			'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
 		};
 
 		const toggleProps = {
@@ -161,6 +162,7 @@ export class PostPublishButton extends Component {
 			variant: 'primary',
 			size: 'compact',
 			onClick: this.createOnClick( onClickToggle ),
+			'aria-haspopup': hasNonPostEntityChanges ? 'dialog' : undefined,
 		};
 		const componentProps = isToggle ? toggleProps : buttonProps;
 		return (

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -88,6 +88,7 @@ export default function SavePublishPanels( {
 					variant="secondary"
 					onClick={ openEntitiesSavedStates }
 					aria-expanded={ false }
+					aria-haspopup="dialog"
 					disabled={ ! isDirty }
 					accessibleWhenDisabled
 				>
@@ -102,7 +103,10 @@ export default function SavePublishPanels( {
 	return (
 		<>
 			{ isEntitiesSavedStatesOpen && (
-				<EntitiesSavedStates close={ closeEntitiesSavedStates } />
+				<EntitiesSavedStates
+					close={ closeEntitiesSavedStates }
+					renderDialog
+				/>
 			) }
 			<Slot bubblesVirtually />
 			{ ! isEntitiesSavedStatesOpen && unmountableContent }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/67313

Alternative to https://github.com/WordPress/gutenberg/pull/67327

## What?
<!-- In a few words, what is the PR actually doing? -->
When the entity saved states component is rendered inside a Modal component, clicking the padding area inside the modal dialog closes the modal unexpectedly.

Basically, this PR seeks to:
- Pass down the `renderDialog` prop as it is supposed to be used.
- Attach the `useDialog` props to the component only when it is expected to work with a modal behavior i.e. when `renderDialog` is true.
- Improve the `renderDialog` docs.

## TL;DR

https://github.com/WordPress/gutenberg/pull/59622 made the `EntitiesSavedStates` component behave like a modal dialog when the new `renderDialog` prop is true. However, the props from `useDialog` [are always passed unconditionally](https://github.com/WordPress/gutenberg/blob/443ce894391a0e07738661c5b3d4af4e34c47616/packages/editor/src/components/entities-saved-states/index.js#L123-L124) to the component. As such, the component gets some modal behaviors including the 'close when clicking outside'. This works when the component is rendered in the save panel on the right. I doesn't work well when it is rendered inside a Modal dialog because in this case it's a sort of 'modal behavior' within a 'modal behavior' e.g.: clicking outside the inner component with modal behavior but still inside the outer Modal component closes the modal unexpectedly.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Modal dialogs should not close unexpectedly.
The `useDialog` props should be passed conditionally, in the same way `role=dialog`, `aria-labelledby`, and `aria-describedby` are passed conditionally. This makes sure that when the component gets the ARIA attributes related to a modal dialog, it also behaves like a modal dialog. When `renderDialog` is false, none of the props related to the modal dialog should be set.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Passes the `useDialog` props conditionally based on `renderDialog`.
- Fixes the `renderDialog` props, please double check this as it seems to me the docs introduced in https://github.com/WordPress/gutenberg/pull/62377 aren't accurate.
- Makes sure that the buttons that open the entity saved state panel do have an `aria-haspopup="dialog"` attribute.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the testing instructions from https://github.com/WordPress/gutenberg/issues/67313
- Observe the modal dialog does not close unexpectedly any longer.
- Make styles changes in the Site editor or preview a block theme in the editor.
- Click the 'Save' or 'activate theme' button at the top right of the screen: the entity saved state component renders in the right sidebar.
- Inspect the source and observe the element with class `entities-saved-states__panel` does have a role=dialog and correct aria-labelledby and aria-describedby.
- Note: when there are changes, this component may still be rendered in the DOM even when it is closed and it's hidden via CSS.

These are the ARIA properties for the component in the Site editor:

![site editor](https://github.com/user-attachments/assets/038c3513-af10-4e6b-9f2b-8d7ca494a59f)

And these are the ones for the theme preview:

![theme preview](https://github.com/user-attachments/assets/3bf3612f-3d5a-4953-94ee-ef848d212f7d)

- Check that wherever the entity saved state component renders in the right sidebar:
  - It closes when clicking outside of it.
  - It has correct aria role, aria-labelledby and aria-describedby.
- For example, this should be checked also in the Post editor, after editing a template from the post editor and saving, the entity saved state component is used instead of the normal publish panel.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
