### PR TITLE
Enhance: Added Dialog Wrapper for `EntitiesSavedStatesExtensible` 

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -80,13 +80,11 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 	);
 };
 
-const _EntitiesSavedStates = ( { onClose, renderDialog = undefined } ) => {
+const _EntitiesSavedStates = ( { onClose } ) => {
 	if ( isPreviewingTheme() ) {
 		return <EntitiesSavedStatesForPreview onClose={ onClose } />;
 	}
-	return (
-		<EntitiesSavedStates close={ onClose } renderDialog={ renderDialog } />
-	);
+	return <EntitiesSavedStates close={ onClose } />;
 };
 
 export default function SavePanel() {
@@ -159,9 +157,7 @@ export default function SavePanel() {
 					{ __( 'Open save panel' ) }
 				</Button>
 			</div>
-			{ isSaveViewOpen && (
-				<_EntitiesSavedStates onClose={ onClose } renderDialog />
-			) }
+			{ isSaveViewOpen && <_EntitiesSavedStates onClose={ onClose } /> }
 		</NavigableRegion>
 	);
 }

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -11,6 +11,7 @@ import {
 	EntitiesSavedStates,
 	useEntitiesSavedStatesIsDirty,
 	privateApis,
+	EntitiesSavedStatesDialogWrapper,
 } from '@wordpress/editor';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -32,7 +33,10 @@ const { EntitiesSavedStatesExtensible, NavigableRegion } =
 const { useLocation } = unlock( routerPrivateApis );
 
 const EntitiesSavedStatesForPreview = ( { onClose } ) => {
+	const { params } = useLocation();
+	const { canvas = 'view' } = params;
 	const isDirtyProps = useEntitiesSavedStatesIsDirty();
+
 	let activateSaveLabel;
 	if ( isDirtyProps.isDirty ) {
 		activateSaveLabel = __( 'Activate & Save' );
@@ -66,17 +70,34 @@ const EntitiesSavedStatesForPreview = ( { onClose } ) => {
 		return values;
 	};
 
+	if ( canvas === 'view' ) {
+		return (
+			<EntitiesSavedStatesExtensible
+				{ ...{
+					...isDirtyProps,
+					additionalPrompt,
+					close: onClose,
+					onSave,
+					saveEnabled: true,
+					saveLabel: activateSaveLabel,
+				} }
+			/>
+		);
+	}
+
 	return (
-		<EntitiesSavedStatesExtensible
-			{ ...{
-				...isDirtyProps,
-				additionalPrompt,
-				close: onClose,
-				onSave,
-				saveEnabled: true,
-				saveLabel: activateSaveLabel,
-			} }
-		/>
+		<EntitiesSavedStatesDialogWrapper close={ onClose }>
+			<EntitiesSavedStatesExtensible
+				{ ...{
+					...isDirtyProps,
+					additionalPrompt,
+					close: onClose,
+					onSave,
+					saveEnabled: true,
+					saveLabel: activateSaveLabel,
+				} }
+			/>
+		</EntitiesSavedStatesDialogWrapper>
 	);
 };
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -401,7 +401,6 @@ _Parameters_
 
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
--   _props.renderDialog_ `Function`: The function to render the dialog.
 
 _Returns_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -406,6 +406,20 @@ _Returns_
 
 -   `JSX.Element`: The rendered component.
 
+### EntitiesSavedStatesDialogWrapper
+
+A wrapper component that renders a dialog for displaying entities.
+
+_Parameters_
+
+-   _props_ `Object`: The component's props.
+-   _props.children_ `React.ReactNode`: The content to be displayed inside the dialog.
+-   _props.close_ `Function`: A function to close the dialog.
+
+_Returns_
+
+-   `React.Element`: The rendered dialog element with children.
+
 ### ErrorBoundary
 
 ErrorBoundary is used to catch JavaScript errors anywhere in a child component tree, log those errors, and display a fallback UI.

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -9,6 +9,10 @@ import {
 	createInterpolateElement,
 } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
+import {
+	__experimentalUseDialog as useDialog,
+	useInstanceId,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -164,6 +168,40 @@ export function EntitiesSavedStatesExtensible( {
 					/>
 				);
 			} ) }
+		</div>
+	);
+}
+
+/**
+ * A wrapper component that renders a dialog for displaying entities.
+ *
+ * @param {Object}          props          The component's props.
+ * @param {React.ReactNode} props.children The content to be displayed inside the dialog.
+ * @param {Function}        props.close    A function to close the dialog.
+ *
+ * @return {React.Element} The rendered dialog element with children.
+ */
+export function EntitiesSavedStatesDialogWrapper( { children, close } ) {
+	const dismissPanel = useCallback( () => close(), [ close ] );
+	const [ saveDialogRef, saveDialogProps ] = useDialog( {
+		onClose: () => dismissPanel(),
+	} );
+
+	const dialogLabel = useInstanceId( EntitiesSavedStatesExtensible, 'label' );
+	const dialogDescription = useInstanceId(
+		EntitiesSavedStatesExtensible,
+		'description'
+	);
+
+	return (
+		<div
+			ref={ saveDialogRef }
+			{ ...saveDialogProps }
+			role="dialog"
+			aria-labelledby={ dialogLabel }
+			aria-describedby={ dialogDescription }
+		>
+			{ children }
 		</div>
 	);
 }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -8,10 +8,6 @@ import {
 	useRef,
 	createInterpolateElement,
 } from '@wordpress/element';
-import {
-	__experimentalUseDialog as useDialog,
-	useInstanceId,
-} from '@wordpress/compose';
 import { useDispatch } from '@wordpress/data';
 
 /**
@@ -29,23 +25,15 @@ function identity( values ) {
 /**
  * Renders the component for managing saved states of entities.
  *
- * @param {Object}   props              The component props.
- * @param {Function} props.close        The function to close the dialog.
- * @param {Function} props.renderDialog The function to render the dialog.
+ * @param {Object}   props       The component props.
+ * @param {Function} props.close The function to close the dialog.
  *
  * @return {JSX.Element} The rendered component.
  */
-export default function EntitiesSavedStates( {
-	close,
-	renderDialog = undefined,
-} ) {
+export default function EntitiesSavedStates( { close } ) {
 	const isDirtyProps = useIsDirty();
 	return (
-		<EntitiesSavedStatesExtensible
-			close={ close }
-			renderDialog={ renderDialog }
-			{ ...isDirtyProps }
-		/>
+		<EntitiesSavedStatesExtensible close={ close } { ...isDirtyProps } />
 	);
 }
 
@@ -58,7 +46,6 @@ export default function EntitiesSavedStates( {
  * @param {Function} props.onSave                Function to call when saving entities.
  * @param {boolean}  props.saveEnabled           Flag indicating if save is enabled.
  * @param {string}   props.saveLabel             Label for the save button.
- * @param {Function} props.renderDialog          Function to render a custom dialog.
  * @param {Array}    props.dirtyEntityRecords    Array of dirty entity records.
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
@@ -72,7 +59,6 @@ export function EntitiesSavedStatesExtensible( {
 	onSave = identity,
 	saveEnabled: saveEnabledProp = undefined,
 	saveLabel = __( 'Save' ),
-	renderDialog = undefined,
 	dirtyEntityRecords,
 	isDirty,
 	setUnselectedEntities,
@@ -109,24 +95,8 @@ export function EntitiesSavedStatesExtensible( {
 	// its own will use the event object in place of the expected saved entities.
 	const dismissPanel = useCallback( () => close(), [ close ] );
 
-	const [ saveDialogRef, saveDialogProps ] = useDialog( {
-		onClose: () => dismissPanel(),
-	} );
-	const dialogLabel = useInstanceId( EntitiesSavedStatesExtensible, 'label' );
-	const dialogDescription = useInstanceId(
-		EntitiesSavedStatesExtensible,
-		'description'
-	);
-
 	return (
-		<div
-			ref={ saveDialogRef }
-			{ ...saveDialogProps }
-			className="entities-saved-states__panel"
-			role={ renderDialog ? 'dialog' : undefined }
-			aria-labelledby={ renderDialog ? dialogLabel : undefined }
-			aria-describedby={ renderDialog ? dialogDescription : undefined }
-		>
+		<div className="entities-saved-states__panel">
 			<Flex className="entities-saved-states__panel-header" gap={ 2 }>
 				<FlexItem
 					isBlock
@@ -160,16 +130,13 @@ export function EntitiesSavedStatesExtensible( {
 			</Flex>
 
 			<div className="entities-saved-states__text-prompt">
-				<div
-					className="entities-saved-states__text-prompt--header-wrapper"
-					id={ renderDialog ? dialogLabel : undefined }
-				>
+				<div className="entities-saved-states__text-prompt--header-wrapper">
 					<strong className="entities-saved-states__text-prompt--header">
 						{ __( 'Are you ready to save?' ) }
 					</strong>
 					{ additionalPrompt }
 				</div>
-				<p id={ renderDialog ? dialogDescription : undefined }>
+				<p>
 					{ isDirty
 						? createInterpolateElement(
 								sprintf(

--- a/packages/editor/src/components/index.js
+++ b/packages/editor/src/components/index.js
@@ -17,7 +17,10 @@ export { default as EditorHistoryRedo } from './editor-history/redo';
 export { default as EditorHistoryUndo } from './editor-history/undo';
 export { default as EditorNotices } from './editor-notices';
 export { default as EditorSnackbars } from './editor-snackbars';
-export { default as EntitiesSavedStates } from './entities-saved-states';
+export {
+	default as EntitiesSavedStates,
+	EntitiesSavedStatesDialogWrapper,
+} from './entities-saved-states';
 export { useIsDirty as useEntitiesSavedStatesIsDirty } from './entities-saved-states/hooks/use-is-dirty';
 export { default as ErrorBoundary } from './error-boundary';
 export { default as LocalAutosaveMonitor } from './local-autosave-monitor';

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -5,11 +5,17 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, createSlotFill } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
+import {
+	__experimentalUseDialog as useDialog,
+	useInstanceId,
+} from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
-import EntitiesSavedStates from '../entities-saved-states';
+import EntitiesSavedStates, {
+	EntitiesSavedStatesExtensible,
+} from '../entities-saved-states';
 import PostPublishPanel from '../post-publish-panel';
 import PluginPrePublishPanel from '../plugin-pre-publish-panel';
 import PluginPostPublishPanel from '../plugin-post-publish-panel';
@@ -102,10 +108,47 @@ export default function SavePublishPanels( {
 	return (
 		<>
 			{ isEntitiesSavedStatesOpen && (
-				<EntitiesSavedStates close={ closeEntitiesSavedStates } />
+				<EntitieDialogWrapper close={ closeEntitiesSavedStates }>
+					<EntitiesSavedStates close={ closeEntitiesSavedStates } />
+				</EntitieDialogWrapper>
 			) }
 			<Slot bubblesVirtually />
 			{ ! isEntitiesSavedStatesOpen && unmountableContent }
 		</>
+	);
+}
+
+/**
+ * A wrapper component that renders a dialog for displaying entities.
+ *
+ * @param {Object}          props          The component's props.
+ * @param {React.ReactNode} props.children The content to be displayed inside the dialog.
+ * @param {Function}        props.close    A function to close the dialog.
+ *
+ * @return {React.Element} The rendered dialog element with children.
+ */
+export function EntitieDialogWrapper( { children, close } ) {
+	const dismissPanel = useCallback( () => close(), [ close ] );
+	const [ saveDialogRef, saveDialogProps ] = useDialog( {
+		onClose: () => dismissPanel(),
+	} );
+
+	const dialogLabel = useInstanceId( EntitiesSavedStatesExtensible, 'label' );
+	const dialogDescription = useInstanceId(
+		EntitiesSavedStatesExtensible,
+		'description'
+	);
+
+	return (
+		<div
+			ref={ saveDialogRef }
+			{ ...saveDialogProps }
+			role="dialog"
+			aria-labelledby={ dialogLabel }
+			aria-describedby={ dialogDescription }
+		>
+			{ ' ' }
+			{ children }
+		</div>
 	);
 }

--- a/packages/editor/src/components/save-publish-panels/index.js
+++ b/packages/editor/src/components/save-publish-panels/index.js
@@ -5,16 +5,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, createSlotFill } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from '@wordpress/element';
-import {
-	__experimentalUseDialog as useDialog,
-	useInstanceId,
-} from '@wordpress/compose';
 
 /**
  * Internal dependencies
  */
 import EntitiesSavedStates, {
-	EntitiesSavedStatesExtensible,
+	EntitiesSavedStatesDialogWrapper,
 } from '../entities-saved-states';
 import PostPublishPanel from '../post-publish-panel';
 import PluginPrePublishPanel from '../plugin-pre-publish-panel';
@@ -108,47 +104,14 @@ export default function SavePublishPanels( {
 	return (
 		<>
 			{ isEntitiesSavedStatesOpen && (
-				<EntitieDialogWrapper close={ closeEntitiesSavedStates }>
+				<EntitiesSavedStatesDialogWrapper
+					close={ closeEntitiesSavedStates }
+				>
 					<EntitiesSavedStates close={ closeEntitiesSavedStates } />
-				</EntitieDialogWrapper>
+				</EntitiesSavedStatesDialogWrapper>
 			) }
 			<Slot bubblesVirtually />
 			{ ! isEntitiesSavedStatesOpen && unmountableContent }
 		</>
-	);
-}
-
-/**
- * A wrapper component that renders a dialog for displaying entities.
- *
- * @param {Object}          props          The component's props.
- * @param {React.ReactNode} props.children The content to be displayed inside the dialog.
- * @param {Function}        props.close    A function to close the dialog.
- *
- * @return {React.Element} The rendered dialog element with children.
- */
-export function EntitieDialogWrapper( { children, close } ) {
-	const dismissPanel = useCallback( () => close(), [ close ] );
-	const [ saveDialogRef, saveDialogProps ] = useDialog( {
-		onClose: () => dismissPanel(),
-	} );
-
-	const dialogLabel = useInstanceId( EntitiesSavedStatesExtensible, 'label' );
-	const dialogDescription = useInstanceId(
-		EntitiesSavedStatesExtensible,
-		'description'
-	);
-
-	return (
-		<div
-			ref={ saveDialogRef }
-			{ ...saveDialogProps }
-			role="dialog"
-			aria-labelledby={ dialogLabel }
-			aria-describedby={ dialogDescription }
-		>
-			{ ' ' }
-			{ children }
-		</div>
 	);
 }


### PR DESCRIPTION
Attempt to resolve #67313, Reference PR: https://github.com/WordPress/gutenberg/pull/67327

Alternate PR to consider: https://github.com/WordPress/gutenberg/pull/67351

## What?
This PR removes the renderDialog prop from EntitiesSavedStates and EntitiesSavedStatesExtensible, and moves the dialog functionality into a new wrapper function, EntitieDialogWrapper.

## Why?
The issue occurs when clicking on the 'padding area' of the Entity saved modal dialog, causing the dialog to close unexpectedly.

Animated GIF to illustrate:
![image](https://github.com/user-attachments/assets/7165a4bd-095b-4ebd-8f6d-dbdcb02f06d6)


## How?
This PR introduces a new wrapper function, `EntitieDialogWrapper`, to handle the dialog functionality inside the editor's "save-publish-panel". Additionally, the renderDialog prop has been removed from `EntitiesSavedStates` and `EntitiesSavedStatesExtensible`, as it is no longer necessary. This ensures that `EntitiesSavedStatesExtensible`  can be used with Modal in site-editor without any dialog logic.

## Testing Instructions

- Go to the Site editor.
- Make a simple change to a global style, e.g. change a color.
- Reopen the Navigation panel by clicking 'Open Navigation' at the top left of the screen.
- Click any item in the navigation other than 'Styles' e.g. click 'Pages' or 'Templates'.
- At this point, a blue button at the bottom of the Navigation panel appears, labeled 'Review 1 change...'

![image](https://github.com/user-attachments/assets/ec727ddc-876f-41b8-8b1f-3064a8b25898)

- Click the button: the modal dialog to save entities opens.
- Click the padding area of the modal dialog.
- Observe the modal dialog closes.
- Alternatively preview a block theme from the WP admin > Appearance > any block theme > Live Preview.
- Click the blue button labeled 'Activate {theme name}' at the bottom of hte Navigation panel: the modal dialog to save entities opens.
- Click the padding area of the modal dialog.
- Observe the modal dialog closes.

