### PR TITLE
Remove use of `contentOnly` block editing mode for synced patterns

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2355,7 +2355,7 @@ function getDerivedBlockEditingModesForTree(
 					return;
 				}
 
-				derivedBlockEditingModes.set( clientId, 'contentOnly' );
+				// Else do nothing, use the default block editing mode.
 				return;
 			}
 

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3828,7 +3828,6 @@ describe( 'state', () => {
 				expect( initialState.derivedBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
-							'root-pattern': 'contentOnly',
 							'pattern-paragraph': 'disabled',
 							'pattern-group': 'disabled',
 							'pattern-paragraph-with-overrides': 'contentOnly',
@@ -3883,7 +3882,6 @@ describe( 'state', () => {
 				expect( derivedBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
-							'root-pattern': 'contentOnly', // Pattern and section.
 							'pattern-paragraph': 'disabled',
 							'pattern-group': 'disabled',
 							'pattern-paragraph-with-overrides': 'contentOnly', // Pattern child with bindings.
@@ -3903,7 +3901,7 @@ describe( 'state', () => {
 							'paragraph-1': 'contentOnly', // Content block in section.
 							'group-2': 'disabled',
 							'paragraph-2': 'contentOnly', // Content block in section.
-							'root-pattern': 'contentOnly', // Pattern and section.
+							'root-pattern': 'contentOnly', // Section.
 							'pattern-paragraph': 'disabled',
 							'pattern-group': 'disabled',
 							'pattern-paragraph-with-overrides': 'contentOnly', // Pattern child with bindings.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the broken e2e tests in `trunk`.

Removes the use of `contentOnly` mode for the synced pattern block. 

## Why?
`contentOnly` mode removes some of the options from the block:
<img width="403" alt="Screenshot 2024-11-28 at 1 03 38 pm" src="https://github.com/user-attachments/assets/9212e32c-b72c-45b5-a428-b03596c06d4a">

It results in the block no longer being groupable, which caused an e2e test failure.

## How?
The block now uses the default mode.

## Testing Instructions
1. Add a synced pattern
2. Check you have the full range of options in the block settings menu.

Also worth testing when the block is used as a section in Write Mode - the settings menu should have a reduced set of sections like any other section.

## Screenshots or screencast <!-- if applicable -->
### Before
<img width="403" alt="Screenshot 2024-11-28 at 1 03 38 pm" src="https://github.com/user-attachments/assets/f8fee3df-0f57-4d20-8da3-654c9cc7bafa">

### After
<img width="492" alt="Screenshot 2024-11-28 at 1 22 39 pm" src="https://github.com/user-attachments/assets/2586e891-0a5a-4912-85c0-8d3410def234">
