### PR TITLE
Storybook : Add TextTransformControl stories

### DIFF
--- a/packages/block-editor/src/components/text-transform-control/README.md
+++ b/packages/block-editor/src/components/text-transform-control/README.md
@@ -1,7 +1,7 @@
 # TextTransformControl
 
 The `TextTransformControl` component is responsible for rendering a control element that allows users to select and apply text transformation options to blocks or elements in the Gutenberg editor. It provides an intuitive interface for changing the text appearance by applying different transformations such as `none`, `uppercase`, `lowercase`, `capitalize`.
- 
+
 ![TextTransformConrol Element in Inspector Control](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/text-transform-component.png?raw=true)
 
 ## Development guidelines
@@ -28,7 +28,6 @@ const MyTextTransformControlComponent = () => (
 ### `value`
 
 -   **Type:** `String`
--   **Default:** `none`
 -   **Options:** `none`, `uppercase`, `lowercase`, `capitalize`
 
 The current value of the Text Transform setting. You may only choose from the `Options` listed above.

--- a/packages/block-editor/src/components/text-transform-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-transform-control/stories/index.story.js
@@ -3,14 +3,6 @@
  */
 import TextTransformControl from '../';
 
-/**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
- * Meta configuration for Storybook
- */
 const meta = {
 	title: 'BlockEditor/TextTransformControl',
 	component: TextTransformControl,
@@ -29,7 +21,7 @@ const meta = {
 			control: {
 				type: null,
 			},
-			description: 'Callback function when text transform changes',
+			description: 'Handles change in text transform selection.',
 			table: {
 				type: {
 					summary: 'function',
@@ -38,37 +30,30 @@ const meta = {
 		},
 		className: {
 			control: { type: 'text' },
-			description: 'Additional CSS class name to apply',
+			description: 'Class name to add to the control.',
 			table: {
 				type: { summary: 'string' },
 			},
 		},
 		value: {
-			control: { type: null },
-			description: 'Currently selected writing mode.',
-			table: { type: { summary: 'string' } },
+			options: [ 'none', 'uppercase', 'lowercase', 'capitalize' ],
+			control: { type: 'radio' },
+			description: 'Currently selected text transform.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'none' },
+			},
 		},
 	},
 };
 
 export default meta;
 
-/**
- * Default Story Export
- */
 export const Default = {
-	render: function Template( { onChange, ...args } ) {
-		const [ value, setValue ] = useState();
-
-		return (
-			<TextTransformControl
-				{ ...args }
-				onChange={ ( ...changeArgs ) => {
-					onChange( ...changeArgs );
-					setValue( ...changeArgs );
-				} }
-				value={ value }
-			/>
-		);
+	args: {
+		value: 'none',
+	},
+	render: function Template( props ) {
+		return <TextTransformControl { ...props } />;
 	},
 };

--- a/packages/block-editor/src/components/text-transform-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-transform-control/stories/index.story.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import TextTransformControl from '../';
@@ -36,12 +41,10 @@ const meta = {
 			},
 		},
 		value: {
-			options: [ 'none', 'uppercase', 'lowercase', 'capitalize' ],
-			control: { type: 'radio' },
+			control: { type: null },
 			description: 'Currently selected text transform.',
 			table: {
 				type: { summary: 'string' },
-				defaultValue: { summary: 'none' },
 			},
 		},
 	},
@@ -50,10 +53,18 @@ const meta = {
 export default meta;
 
 export const Default = {
-	args: {
-		value: 'none',
-	},
-	render: function Template( props ) {
-		return <TextTransformControl { ...props } />;
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
+
+		return (
+			<TextTransformControl
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				value={ value }
+			/>
+		);
 	},
 };

--- a/packages/block-editor/src/components/text-transform-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-transform-control/stories/index.story.js
@@ -6,40 +6,24 @@ import TextTransformControl from '../';
 /**
  * WordPress dependencies
  */
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 
 /**
- * Text transform options
+ * Meta configuration for Storybook
  */
-const TRANSFORM_OPTIONS = [ 'none', 'uppercase', 'lowercase', 'capitalize' ];
-
-/**
- * Demo text component to show text transform effect
- */
-const DemoText = ( { transform } ) => (
-	<p style={ { textTransform: transform } }>
-		This is a sample text to demonstrate the text transformation.
-	</p>
-);
-
-/**
- * TextTransformControl Properties
- */
-export default {
+const meta = {
 	title: 'BlockEditor/TextTransformControl',
 	component: TextTransformControl,
-	argTypes: {
-		value: {
-			control: 'select',
-			options: TRANSFORM_OPTIONS,
-			description: 'Currently selected text transform value',
-			table: {
-				type: {
-					summary: 'string',
-				},
-				defaultValue: { summary: 'none' },
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Control to facilitate text transformation selections.',
 			},
 		},
+	},
+	argTypes: {
 		onChange: {
 			action: 'onChange',
 			control: {
@@ -53,84 +37,38 @@ export default {
 			},
 		},
 		className: {
-			control: 'text',
+			control: { type: 'text' },
 			description: 'Additional CSS class name to apply',
 			table: {
 				type: { summary: 'string' },
 			},
 		},
-	},
-	render: function Render( { onChange, value, className } ) {
-		const [ selectedTransform, setSelectedTransform ] = useState( value );
-
-		useEffect( () => {
-			setSelectedTransform( value );
-		}, [ value ] );
-
-		const handleTransformChange = ( newValue ) => {
-			const updatedValue =
-				newValue === selectedTransform ? undefined : newValue;
-			setSelectedTransform( updatedValue );
-			if ( onChange ) {
-				onChange( updatedValue );
-			}
-		};
-
-		return (
-			<div>
-				<TextTransformControl
-					value={ selectedTransform }
-					onChange={ handleTransformChange }
-					className={ className }
-				/>
-				<DemoText transform={ selectedTransform } />
-			</div>
-		);
+		value: {
+			control: { type: null },
+			description: 'Currently selected writing mode.',
+			table: { type: { summary: 'string' } },
+		},
 	},
 };
 
+export default meta;
+
 /**
- * Story demonstrating TextTransformControl with default settings
+ * Default Story Export
  */
 export const Default = {
-	args: {
-		value: 'none',
-	},
-};
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
 
-/**
- * TextTransformControl with uppercase transform selected
- */
-export const WithUppercase = {
-	args: {
-		value: 'uppercase',
-	},
-};
-
-/**
- * TextTransformControl with lowercase transform selected
- */
-export const WithLowercase = {
-	args: {
-		value: 'lowercase',
-	},
-};
-
-/**
- * TextTransformControl with capitalize transform selected
- */
-export const WithCapitalize = {
-	args: {
-		value: 'capitalize',
-	},
-};
-
-/**
- * TextTransformControl with custom className
- */
-export const WithCustomClass = {
-	args: {
-		value: 'none',
-		className: 'custom-text-transform-control',
+		return (
+			<TextTransformControl
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				value={ value }
+			/>
+		);
 	},
 };

--- a/packages/block-editor/src/components/text-transform-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-transform-control/stories/index.story.js
@@ -1,33 +1,136 @@
 /**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
-/**
  * Internal dependencies
  */
 import TextTransformControl from '../';
 
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Text transform options
+ */
+const TRANSFORM_OPTIONS = [ 'none', 'uppercase', 'lowercase', 'capitalize' ];
+
+/**
+ * Demo text component to show text transform effect
+ */
+const DemoText = ( { transform } ) => (
+	<p style={ { textTransform: transform } }>
+		This is a sample text to demonstrate the text transformation.
+	</p>
+);
+
+/**
+ * TextTransformControl Properties
+ */
 export default {
 	title: 'BlockEditor/TextTransformControl',
 	component: TextTransformControl,
 	argTypes: {
-		onChange: { action: 'onChange' },
+		value: {
+			control: 'select',
+			options: TRANSFORM_OPTIONS,
+			description: 'Currently selected text transform value',
+			table: {
+				type: {
+					summary: 'string',
+				},
+				defaultValue: { summary: 'none' },
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: {
+				type: null,
+			},
+			description: 'Callback function when text transform changes',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		className: {
+			control: 'text',
+			description: 'Additional CSS class name to apply',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+	},
+	render: function Render( { onChange, value, className } ) {
+		const [ selectedTransform, setSelectedTransform ] = useState( value );
+
+		useEffect( () => {
+			setSelectedTransform( value );
+		}, [ value ] );
+
+		const handleTransformChange = ( newValue ) => {
+			const updatedValue =
+				newValue === selectedTransform ? undefined : newValue;
+			setSelectedTransform( updatedValue );
+			if ( onChange ) {
+				onChange( updatedValue );
+			}
+		};
+
+		return (
+			<div>
+				<TextTransformControl
+					value={ selectedTransform }
+					onChange={ handleTransformChange }
+					className={ className }
+				/>
+				<DemoText transform={ selectedTransform } />
+			</div>
+		);
 	},
 };
 
-const Template = ( { onChange, ...args } ) => {
-	const [ value, setValue ] = useState();
-	return (
-		<TextTransformControl
-			{ ...args }
-			onChange={ ( ...changeArgs ) => {
-				onChange( ...changeArgs );
-				setValue( ...changeArgs );
-			} }
-			value={ value }
-		/>
-	);
+/**
+ * Story demonstrating TextTransformControl with default settings
+ */
+export const Default = {
+	args: {
+		value: 'none',
+	},
 };
 
-export const Default = Template.bind( {} );
+/**
+ * TextTransformControl with uppercase transform selected
+ */
+export const WithUppercase = {
+	args: {
+		value: 'uppercase',
+	},
+};
+
+/**
+ * TextTransformControl with lowercase transform selected
+ */
+export const WithLowercase = {
+	args: {
+		value: 'lowercase',
+	},
+};
+
+/**
+ * TextTransformControl with capitalize transform selected
+ */
+export const WithCapitalize = {
+	args: {
+		value: 'capitalize',
+	},
+};
+
+/**
+ * TextTransformControl with custom className
+ */
+export const WithCustomClass = {
+	args: {
+		value: 'none',
+		className: 'custom-text-transform-control',
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for TextTransformControl component in the Storybook.

## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the TextTransformControl stories.

## Screen shot

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/3451d2bf-c770-4e60-ac1d-28574e4d5327" />




