### PR TITLE
Prefer exact matches in Link Search results sorting

### DIFF
--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -393,6 +393,43 @@ describe( 'sortResults', () => {
 			6,
 		] );
 	} );
+
+	it( 'orders results to prefer direct matches over sub matches', () => {
+		const results = [
+			{
+				id: 1,
+				title: 'News',
+				url: 'http://wordpress.local/news/',
+				type: 'page',
+				kind: 'post-type',
+			},
+			{
+				id: 2,
+				title: 'Newspaper',
+				url: 'http://wordpress.local/newspaper/',
+				type: 'page',
+				kind: 'post-type',
+			},
+			{
+				id: 3,
+				title: 'News Flash News',
+				url: 'http://wordpress.local/news-flash-news/',
+				type: 'page',
+				kind: 'post-type',
+			},
+			{
+				id: 4,
+				title: 'News',
+				url: 'http://wordpress.local/news-2/',
+				type: 'page',
+				kind: 'post-type',
+			},
+		];
+		const order = sortResults( results, 'News' ).map(
+			( result ) => result.id
+		);
+		expect( order ).toEqual( [ 1, 4, 3, 2 ] );
+	} );
 } );
 
 describe( 'tokenize', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes Link search results sorting to sort in favour of exact search term matches over sub matches

Closes https://github.com/WordPress/gutenberg/issues/38121

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When searching for a Post it's important that results are ordered to weight towards exact matches. If we don't do this then we end up in situations where a search for "News" will return:

- "News"
- "Newspaper"
- "News" (note this is a Post with a duplicate title)

...even though both "News" pages are logically more relevant to the search term. Histroically this has lead to strange results [as reported in the Issue.](https://github.com/WordPress/gutenberg/issues/38121#issuecomment-2469783587).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Updates the client-side search sorting/ordering algorithm to weight towards exact matches over sub matches. This means if a search term matches a title token exactly it [the result] will "score" more highly in the weighting. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Create Pages in the following order with the following titles:
    - `News`
    - `Newspaper`
    - `News Flash News`
    - `News`
- In the Site Editor find a Navigation block (or insert if one isn't in your Theme).
- Add a "Page" link to the Navigation block (note this is the _default_ option when inserting via the canvas).
- Search for "News"
- See the results in the following order:
    - News
    - News
    - News Flash News
    - Newspaper
- Try other variations of this and try and break it.

## Screenshots or screencast <!-- if applicable -->
<img width="1218" alt="Screen Shot 2024-11-28 at 06 18 33" src="https://github.com/user-attachments/assets/0883204f-25eb-4b9e-a31e-dd47cee6d674">
