### PR TITLE
Remove inline-block display from image anchor in style.scss

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,9 +1,5 @@
 .wp-block-image {
 
-	a {
-		display: inline-block;
-	}
-
 	img {
 		height: auto;
 		max-width: 100%;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -1,5 +1,10 @@
 .wp-block-image {
 
+	> a,
+	> figure > a {
+		display: inline-block;
+	}
+
 	img {
 		height: auto;
 		max-width: 100%;


### PR DESCRIPTION
Fixes: #67366 

## What?
This PR removes the display: inline-block property from the image anchor that causes the caption anchors to not flow in continuation as described in the PR.

## How?
The CSS rule causing the side-effect was removed.

## Screenshots

**Before:**
![Screenshot 2024-11-28 at 12 37 31 PM](https://github.com/user-attachments/assets/6ee500df-1020-45a3-857c-50c2462d53c4)

**After:**
![Screenshot 2024-11-28 at 12 38 50 PM](https://github.com/user-attachments/assets/a41fe4a9-cdfc-4ee1-aefc-4241062ddfc8)


### Screencast:
https://github.com/user-attachments/assets/75f34e27-bebd-431f-8feb-23f6c62954fa


