### PR TITLE
Allow template part editing in write mode

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -502,13 +502,23 @@ export const getParentSectionBlock = ( state, clientId ) => {
  * @return {boolean} Whether the block is a content locking parent.
  */
 export function isSectionBlock( state, clientId ) {
+	const blockName = getBlockName( state, clientId );
+	if (
+		blockName === 'core/block' ||
+		getTemplateLock( state, clientId ) === 'contentOnly'
+	) {
+		return true;
+	}
+
+	// Template parts become sections in navigation mode.
+	const _isNavigationMode = isNavigationMode( state );
+	if ( _isNavigationMode && blockName === 'core/template-part' ) {
+		return true;
+	}
+
 	const sectionRootClientId = getSectionRootClientId( state );
 	const sectionClientIds = getBlockOrder( state, sectionRootClientId );
-	return (
-		getBlockName( state, clientId ) === 'core/block' ||
-		getTemplateLock( state, clientId ) === 'contentOnly' ||
-		( isNavigationMode( state ) && sectionClientIds.includes( clientId ) )
-	);
+	return _isNavigationMode && sectionClientIds.includes( clientId );
 }
 
 /**

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2287,11 +2287,24 @@ function getDerivedBlockEditingModesForTree(
 
 			// If zoomed out, all blocks that aren't sections or the section root are
 			// disabled.
-			// If the tree root is not in a section, set its editing mode to disabled.
-			if (
-				isZoomedOut ||
-				! findParentInClientIdsList( state, clientId, sectionClientIds )
-			) {
+			if ( isZoomedOut ) {
+				derivedBlockEditingModes.set( clientId, 'disabled' );
+				return;
+			}
+
+			const isInSection = findParentInClientIdsList(
+				state,
+				clientId,
+				sectionClientIds
+			);
+			if ( ! isInSection ) {
+				// If the block is not in a section, it should only be contentOnly if it's a template part.
+				// All other blocks should be disabled.
+				if ( block.name === 'core/template-part' ) {
+					derivedBlockEditingModes.set( clientId, 'contentOnly' );
+					return;
+				}
+
 				derivedBlockEditingModes.set( clientId, 'disabled' );
 				return;
 			}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2411,7 +2411,7 @@ function getDerivedBlockEditingModesForTree(
 				}
 			}
 
-			if ( blockName && isContentBlock( blockName, clientId ) ) {
+			if ( blockName && isContentBlock( blockName ) ) {
 				derivedBlockEditingModes.set( clientId, 'contentOnly' );
 				return;
 			}

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2186,19 +2186,19 @@ function getBlockTreeBlock( state, clientId ) {
  *                            The callback receives the current block as its argument.
  */
 function traverseBlockTree( state, clientId, callback ) {
-	const parentTree = getBlockTreeBlock( state, clientId );
-	if ( ! parentTree ) {
+	const tree = getBlockTreeBlock( state, clientId );
+	if ( ! tree ) {
 		return;
 	}
 
-	callback( parentTree );
+	callback( tree );
 
-	if ( ! parentTree?.innerBlocks?.length ) {
+	if ( ! tree?.innerBlocks?.length ) {
 		return;
 	}
 
-	for ( const block of parentTree?.innerBlocks ) {
-		traverseBlockTree( state, block.clientId, callback );
+	for ( const innerBlock of tree?.innerBlocks ) {
+		traverseBlockTree( state, innerBlock.clientId, callback );
 	}
 }
 
@@ -2217,9 +2217,27 @@ function findParentInClientIdsList( state, clientId, clientIds ) {
 	}
 
 	let parent = state.blocks.parents.get( clientId );
-	while ( parent ) {
+	while ( parent !== undefined ) {
 		if ( clientIds.includes( parent ) ) {
 			return parent;
+		}
+		parent = state.blocks.parents.get( parent );
+	}
+}
+
+/**
+ * Retrieves the block editing mode of the ancestor block of a given block.
+ *
+ * @param {Object} state    The current state object.
+ * @param {string} clientId The client ID of the block to find the ancestor block for.
+ *
+ * @return {string|undefined} The block editing mode of the ancestor block, or undefined if not found.
+ */
+function getAncestorBlockEditingMode( state, clientId ) {
+	let parent = state.blocks.parents.get( clientId );
+	while ( parent !== undefined ) {
+		if ( state.blockEditingModes.has( parent ) ) {
+			return state.blockEditingModes.get( parent );
 		}
 		parent = state.blocks.parents.get( parent );
 	}
@@ -2262,6 +2280,9 @@ function getDerivedBlockEditingModesForTree(
 	// so the default block editing mode is set to disabled.
 	const sectionRootClientId = state.settings?.[ sectionRootClientIdKey ];
 	const sectionClientIds = state.blocks.order.get( sectionRootClientId );
+	const hasDisabledBlocks = state.blockEditingModes
+		.entries()
+		.some( ( [ , mode ] ) => mode === 'disabled' );
 	const templatePartClientIds = [];
 	const syncedPatternClientIds = [];
 
@@ -2279,6 +2300,27 @@ function getDerivedBlockEditingModesForTree(
 
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
+
+		// If the block already has an explicit block editing mode set,
+		// don't override it.
+		if ( state.blockEditingModes.has( clientId ) ) {
+			return;
+		}
+
+		// An explicitly disabled block editing mode cascades to all its children.
+		// Check ancestors of the current block to see if the nearest one with a block
+		// editing mode set is disabled.
+		if ( hasDisabledBlocks ) {
+			const ancestorBlockEditingMode = getAncestorBlockEditingMode(
+				state,
+				clientId
+			);
+			if ( ancestorBlockEditingMode === 'disabled' ) {
+				derivedBlockEditingModes.set( clientId, 'disabled' );
+				return;
+			}
+		}
+
 		if ( isZoomedOut || isNavMode ) {
 			// If the root block is the section root set its editing mode to contentOnly.
 			if ( clientId === sectionRootClientId ) {
@@ -2327,7 +2369,7 @@ function getDerivedBlockEditingModesForTree(
 					templatePartClientIds
 				);
 				// Allow contentOnly blocks in template parts outside of sections
-				// to be editable. Only disable blocks that aren't don't fit this criteria.
+				// to be editable. Only disable blocks that don't fit this criteria.
 				if ( ! isInTemplatePart && ! isContentBlock( blockName ) ) {
 					derivedBlockEditingModes.set( clientId, 'disabled' );
 					return;
@@ -2369,7 +2411,7 @@ function getDerivedBlockEditingModesForTree(
 				}
 			}
 
-			if ( blockName && isContentBlock( blockName ) ) {
+			if ( blockName && isContentBlock( blockName, clientId ) ) {
 				derivedBlockEditingModes.set( clientId, 'contentOnly' );
 				return;
 			}
@@ -2598,11 +2640,16 @@ export function withDerivedBlockEditingModes( reducer ) {
 				}
 				break;
 			}
+			case 'SET_BLOCK_EDITING_MODE':
+			case 'UNSET_BLOCK_EDITING_MODE':
 			case 'SET_HAS_CONTROLLED_INNER_BLOCKS': {
-				const updatedBlock = nextState.blocks.tree.get(
+				const updatedBlock = getBlockTreeBlock(
+					nextState,
 					action.clientId
 				);
-				// The block might have been removed.
+
+				// The block might have been removed in which case it'll be
+				// handled by the `REMOVE_BLOCKS` action.
 				if ( ! updatedBlock ) {
 					break;
 				}
@@ -2611,6 +2658,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
+						removedClientIds: [ action.clientId ],
 						addedBlocks: [ updatedBlock ],
 						isNavMode: false,
 					} );
@@ -2618,6 +2666,7 @@ export function withDerivedBlockEditingModes( reducer ) {
 					getDerivedBlockEditingModesUpdates( {
 						prevState: state,
 						nextState,
+						removedClientIds: [ action.clientId ],
 						addedBlocks: [ updatedBlock ],
 						isNavMode: true,
 					} );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2280,9 +2280,9 @@ function getDerivedBlockEditingModesForTree(
 	// so the default block editing mode is set to disabled.
 	const sectionRootClientId = state.settings?.[ sectionRootClientIdKey ];
 	const sectionClientIds = state.blocks.order.get( sectionRootClientId );
-	const hasDisabledBlocks = state.blockEditingModes
-		.entries()
-		.some( ( [ , mode ] ) => mode === 'disabled' );
+	const hasDisabledBlocks = Array.from( state.blockEditingModes ).some(
+		( [ , mode ] ) => mode === 'disabled'
+	);
 	const templatePartClientIds = [];
 	const syncedPatternClientIds = [];
 

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1964,8 +1964,14 @@ export function temporarilyEditingFocusModeRevert( state = '', action ) {
 export function blockEditingModes( state = new Map(), action ) {
 	switch ( action.type ) {
 		case 'SET_BLOCK_EDITING_MODE':
+			if ( state.get( action.clientId ) === action.mode ) {
+				return state;
+			}
 			return new Map( state ).set( action.clientId, action.mode );
 		case 'UNSET_BLOCK_EDITING_MODE': {
+			if ( ! state.has( action.clientId ) ) {
+				return state;
+			}
 			const newState = new Map( state );
 			newState.delete( action.clientId );
 			return newState;

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2226,24 +2226,6 @@ function findParentInClientIdsList( state, clientId, clientIds ) {
 }
 
 /**
- * Retrieves the block editing mode of the ancestor block of a given block.
- *
- * @param {Object} state    The current state object.
- * @param {string} clientId The client ID of the block to find the ancestor block for.
- *
- * @return {string|undefined} The block editing mode of the ancestor block, or undefined if not found.
- */
-function getAncestorBlockEditingMode( state, clientId ) {
-	let parent = state.blocks.parents.get( clientId );
-	while ( parent !== undefined ) {
-		if ( state.blockEditingModes.has( parent ) ) {
-			return state.blockEditingModes.get( parent );
-		}
-		parent = state.blocks.parents.get( parent );
-	}
-}
-
-/**
  * Checks if a block has any bindings in its metadata attributes.
  *
  * @param {Object} block The block object to check for bindings.
@@ -2307,14 +2289,32 @@ function getDerivedBlockEditingModesForTree(
 			return;
 		}
 
-		// An explicitly disabled block editing mode cascades to all its children.
-		// Check ancestors of the current block to see if the nearest one with a block
-		// editing mode set is disabled.
+		// Disabled explicit block editing modes are inherited by children.
+		// It's an expensive calculation, so only do it if there are disabled blocks.
 		if ( hasDisabledBlocks ) {
-			const ancestorBlockEditingMode = getAncestorBlockEditingMode(
-				state,
-				clientId
-			);
+			// Look through parents to find one with an explicit block editing mode.
+			let ancestorBlockEditingMode;
+			let parent = state.blocks.parents.get( clientId );
+			while ( parent !== undefined ) {
+				// There's a chance we only just calculated this for the parent,
+				// if so we can return that value for a faster lookup.
+				if ( derivedBlockEditingModes.has( parent ) ) {
+					ancestorBlockEditingMode =
+						derivedBlockEditingModes.get( parent );
+				} else if ( state.blockEditingModes.has( parent ) ) {
+					// Checking the explicit block editing mode will be slower,
+					// as the block editing mode is more likely to be set on a
+					// distant ancestor.
+					ancestorBlockEditingMode =
+						state.blockEditingModes.get( parent );
+				}
+				if ( ancestorBlockEditingMode ) {
+					break;
+				}
+				parent = state.blocks.parents.get( parent );
+			}
+
+			// If the ancestor block editing mode is disabled, it's inherited by the child.
 			if ( ancestorBlockEditingMode === 'disabled' ) {
 				derivedBlockEditingModes.set( clientId, 'disabled' );
 				return;

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3087,9 +3087,7 @@ export const getBlockEditingMode = createRegistrySelector(
 				const isContent = hasContentRoleAttribute( name );
 				return isContent ? 'contentOnly' : 'disabled';
 			}
-			// Otherwise, check if there's an ancestor that is contentOnly
-			const parentMode = getBlockEditingMode( state, rootClientId );
-			return parentMode === 'contentOnly' ? 'default' : parentMode;
+			return 'default';
 		}
 );
 

--- a/packages/block-editor/src/store/test/private-selectors.js
+++ b/packages/block-editor/src/store/test/private-selectors.js
@@ -122,6 +122,7 @@ describe( 'private selectors', () => {
 				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {},
 			},
 			blockEditingModes: new Map( [] ),
+			derivedBlockEditingModes: new Map( [] ),
 		};
 
 		const hasContentRoleAttribute = jest.fn( () => false );
@@ -142,6 +143,7 @@ describe( 'private selectors', () => {
 			const state = {
 				...baseState,
 				blockEditingModes: new Map( [] ),
+				derivedBlockEditingModes: new Map( [] ),
 			};
 			expect(
 				isBlockSubtreeDisabled(
@@ -157,6 +159,12 @@ describe( 'private selectors', () => {
 				blockEditingModes: new Map( [
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				] ),
 			};
 			expect(
 				isBlockSubtreeDisabled(
@@ -166,10 +174,18 @@ describe( 'private selectors', () => {
 			).toBe( true );
 		} );
 
-		it( 'should return true when top level block is disabled via inheritence and there are no editing modes within it', () => {
+		it( 'should return true when top level block is disabled via inheritance and there are no editing modes within it', () => {
 			const state = {
 				...baseState,
 				blockEditingModes: new Map( [ [ '', 'disabled' ] ] ),
+				derivedBlockEditingModes: new Map( [
+					[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				] ),
 			};
 			expect(
 				isBlockSubtreeDisabled(
@@ -185,6 +201,11 @@ describe( 'private selectors', () => {
 				blockEditingModes: new Map( [
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
 				] ),
 			};
 			expect(
@@ -202,6 +223,11 @@ describe( 'private selectors', () => {
 					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
 				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				] ),
 			};
 			expect(
 				isBlockSubtreeDisabled(
@@ -217,6 +243,13 @@ describe( 'private selectors', () => {
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],
 					[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'default' ],
+				] ),
+				derivedBlockEditingModes: new Map( [
+					[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
 				] ),
 			};
 			expect(
@@ -303,6 +336,7 @@ describe( 'private selectors', () => {
 			const state = {
 				...baseState,
 				blockEditingModes: new Map( [] ),
+				derivedBlockEditingModes: new Map( [] ),
 			};
 			expect( getEnabledClientIdsTree( state ) ).toEqual( [
 				{
@@ -340,6 +374,7 @@ describe( 'private selectors', () => {
 			const state = {
 				...baseState,
 				blockEditingModes: new Map( [] ),
+				derivedBlockEditingModes: new Map( [] ),
 			};
 			expect(
 				getEnabledClientIdsTree(
@@ -374,6 +409,10 @@ describe( 'private selectors', () => {
 					[ '', 'disabled' ],
 					[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'contentOnly' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'contentOnly' ],
+				] ),
+				derivedBlockEditingModes: new Map( [
+					[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 				] ),
 			};
 			expect( getEnabledClientIdsTree( state ) ).toEqual( [
@@ -412,6 +451,7 @@ describe( 'private selectors', () => {
 					] ),
 				},
 				blockEditingModes: new Map(),
+				derivedBlockEditingModes: new Map(),
 			};
 			expect(
 				getEnabledBlockParents(
@@ -433,7 +473,7 @@ describe( 'private selectors', () => {
 						],
 						[
 							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
-							'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
+							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
 						],
 						[
 							'4c2b7140-fffd-44b4-b2a7-820c670a6514',
@@ -442,6 +482,7 @@ describe( 'private selectors', () => {
 					] ),
 
 					order: new Map( [
+						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 						[
 							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
 							[
@@ -453,12 +494,15 @@ describe( 'private selectors', () => {
 							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
 							[ '4c2b7140-fffd-44b4-b2a7-820c670a6514' ],
 						],
-						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 					] ),
 				},
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],
-					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'default' ],
+					[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'default' ],
+				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 				] ),
 				blockListSettings: {},
 			};
@@ -467,10 +511,7 @@ describe( 'private selectors', () => {
 					state,
 					'4c2b7140-fffd-44b4-b2a7-820c670a6514'
 				)
-			).toEqual( [
-				'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f',
-				'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
-			] );
+			).toEqual( [ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c' ] );
 		} );
 
 		it( 'should order from bottom to top if ascending is true', () => {
@@ -493,6 +534,7 @@ describe( 'private selectors', () => {
 						],
 					] ),
 					order: new Map( [
+						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 						[
 							'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337',
 							[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f' ],
@@ -505,12 +547,14 @@ describe( 'private selectors', () => {
 							'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c',
 							[ '4c2b7140-fffd-44b4-b2a7-820c670a6514' ],
 						],
-						[ '', [ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337' ] ],
 					] ),
 				},
 				blockEditingModes: new Map( [
 					[ '', 'disabled' ],
 					[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'default' ],
+				] ),
+				derivedBlockEditingModes: new Map( [
+					[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 				] ),
 				blockListSettings: {},
 			};

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4029,6 +4029,47 @@ describe( 'state', () => {
 								},
 							],
 						},
+						{
+							type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+							clientId: 'header',
+							hasControlledInnerBlocks: true,
+						},
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'header',
+							blocks: [
+								{
+									name: 'core/group',
+									clientId: 'header-group',
+									attributes: {},
+									innerBlocks: [
+										{
+											name: 'core/paragraph',
+											clientId: 'header-paragraph',
+											attributes: {},
+											innerBlocks: [],
+										},
+									],
+								},
+							],
+						},
+						{
+							type: 'SET_HAS_CONTROLLED_INNER_BLOCKS',
+							clientId: 'footer',
+							hasControlledInnerBlocks: true,
+						},
+						{
+							type: 'REPLACE_INNER_BLOCKS',
+							rootClientId: 'footer',
+							blocks: [
+								{
+									name: 'core/paragraph',
+									clientId: 'footer-paragraph',
+									attributes: {},
+									innerBlocks: [],
+								},
+							],
+						},
 					],
 					testReducer
 				);
@@ -4044,7 +4085,10 @@ describe( 'state', () => {
 						Object.entries( {
 							'': 'disabled',
 							header: 'contentOnly', // Template part.
+							'header-group': 'disabled', // Content block in template part.
+							'header-paragraph': 'contentOnly', // Content block in template part.
 							footer: 'contentOnly', // Template part.
+							'footer-paragraph': 'contentOnly', // Content block in template part.
 							'section-root': 'contentOnly', // Section root.
 							'group-1': 'contentOnly', // Section block.
 							'paragraph-1': 'contentOnly', // Content block in section.
@@ -4071,8 +4115,11 @@ describe( 'state', () => {
 					new Map(
 						Object.entries( {
 							'': 'disabled',
-							header: 'contentOnly',
-							footer: 'contentOnly',
+							header: 'contentOnly', // Template part.
+							'header-group': 'disabled', // Content block in template part.
+							'header-paragraph': 'contentOnly', // Content block in template part.
+							footer: 'contentOnly', // Template part.
+							'footer-paragraph': 'contentOnly', // Content block in template part.
 							'section-root': 'contentOnly',
 							'group-1': 'contentOnly',
 							'paragraph-1': 'contentOnly',
@@ -4119,7 +4166,10 @@ describe( 'state', () => {
 						Object.entries( {
 							'': 'disabled', // Section root.
 							header: 'contentOnly', // Template part.
+							'header-group': 'disabled', // Content block in template part.
+							'header-paragraph': 'contentOnly', // Content block in template part.
 							footer: 'contentOnly', // Template part.
+							'footer-paragraph': 'contentOnly', // Content block in template part.
 							'section-root': 'contentOnly', // Section root.
 							'group-1': 'contentOnly', // Section block.
 							'paragraph-1': 'contentOnly', // Content block in section.
@@ -4151,7 +4201,10 @@ describe( 'state', () => {
 						Object.entries( {
 							'': 'disabled', // Section root.
 							header: 'contentOnly', // Template part.
+							'header-group': 'disabled', // Content block in template part.
+							'header-paragraph': 'contentOnly', // Content block in template part.
 							footer: 'contentOnly', // Template part.
+							'footer-paragraph': 'contentOnly', // Content block in template part.
 							'section-root': 'contentOnly', // Section root.
 							'group-1': 'contentOnly', // Section block.
 							'paragraph-1': 'contentOnly', // Content block in section.
@@ -4180,8 +4233,11 @@ describe( 'state', () => {
 					new Map(
 						Object.entries( {
 							'': 'disabled',
-							header: 'contentOnly',
-							footer: 'contentOnly',
+							header: 'contentOnly', // Template part.
+							'header-group': 'disabled', // Content block in template part.
+							'header-paragraph': 'contentOnly', // Content block in template part.
+							footer: 'contentOnly', // Template part.
+							'footer-paragraph': 'contentOnly', // Content block in template part.
 							'section-root': 'disabled',
 							'group-1': 'contentOnly', // New section root.
 							'paragraph-1': 'contentOnly', // Section and content block

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -3975,37 +3975,57 @@ describe( 'state', () => {
 						{
 							type: 'UPDATE_SETTINGS',
 							settings: {
-								[ sectionRootClientIdKey ]: '',
+								[ sectionRootClientIdKey ]: 'section-root',
 							},
 						},
 						{
 							type: 'RESET_BLOCKS',
 							blocks: [
 								{
+									name: 'core/template-part',
+									clientId: 'header',
+									attributes: {},
+									innerBlocks: [],
+								},
+								{
 									name: 'core/group',
-									clientId: 'group-1',
+									clientId: 'section-root',
 									attributes: {},
 									innerBlocks: [
 										{
-											name: 'core/paragraph',
-											clientId: 'paragraph-1',
-											attributes: {},
-											innerBlocks: [],
-										},
-										{
 											name: 'core/group',
-											clientId: 'group-2',
+											clientId: 'group-1',
 											attributes: {},
 											innerBlocks: [
 												{
 													name: 'core/paragraph',
-													clientId: 'paragraph-2',
+													clientId: 'paragraph-1',
 													attributes: {},
 													innerBlocks: [],
+												},
+												{
+													name: 'core/group',
+													clientId: 'group-2',
+													attributes: {},
+													innerBlocks: [
+														{
+															name: 'core/paragraph',
+															clientId:
+																'paragraph-2',
+															attributes: {},
+															innerBlocks: [],
+														},
+													],
 												},
 											],
 										},
 									],
+								},
+								{
+									name: 'core/template-part',
+									clientId: 'footer',
+									attributes: {},
+									innerBlocks: [],
 								},
 							],
 						},
@@ -4022,7 +4042,10 @@ describe( 'state', () => {
 				expect( initialState.derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
-							'': 'contentOnly', // Section root.
+							'': 'disabled',
+							header: 'contentOnly', // Template part.
+							footer: 'contentOnly', // Template part.
+							'section-root': 'contentOnly', // Section root.
 							'group-1': 'contentOnly', // Section block.
 							'paragraph-1': 'contentOnly', // Content block in section.
 							'group-2': 'disabled', // Non-content block in section.
@@ -4047,7 +4070,10 @@ describe( 'state', () => {
 				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
-							'': 'contentOnly',
+							'': 'disabled',
+							header: 'contentOnly',
+							footer: 'contentOnly',
+							'section-root': 'contentOnly',
 							'group-1': 'contentOnly',
 							'paragraph-1': 'contentOnly',
 						} )
@@ -4060,7 +4086,7 @@ describe( 'state', () => {
 					[
 						{
 							type: 'INSERT_BLOCKS',
-							rootClientId: '',
+							rootClientId: 'section-root',
 							blocks: [
 								{
 									name: 'core/group',
@@ -4091,7 +4117,10 @@ describe( 'state', () => {
 				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
-							'': 'contentOnly', // Section root.
+							'': 'disabled', // Section root.
+							header: 'contentOnly', // Template part.
+							footer: 'contentOnly', // Template part.
+							'section-root': 'contentOnly', // Section root.
 							'group-1': 'contentOnly', // Section block.
 							'paragraph-1': 'contentOnly', // Content block in section.
 							'group-2': 'disabled', // Non-content block in section.
@@ -4111,7 +4140,7 @@ describe( 'state', () => {
 							type: 'MOVE_BLOCKS_TO_POSITION',
 							clientIds: [ 'group-2' ],
 							fromRootClientId: 'group-1',
-							toRootClientId: '',
+							toRootClientId: 'section-root',
 						},
 					],
 					testReducer,
@@ -4120,7 +4149,10 @@ describe( 'state', () => {
 				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
-							'': 'contentOnly', // Section root.
+							'': 'disabled', // Section root.
+							header: 'contentOnly', // Template part.
+							footer: 'contentOnly', // Template part.
+							'section-root': 'contentOnly', // Section root.
 							'group-1': 'contentOnly', // Section block.
 							'paragraph-1': 'contentOnly', // Content block in section.
 							'group-2': 'contentOnly', // New section block.
@@ -4148,10 +4180,13 @@ describe( 'state', () => {
 					new Map(
 						Object.entries( {
 							'': 'disabled',
-							'group-1': 'contentOnly',
-							'paragraph-1': 'contentOnly',
-							'group-2': 'contentOnly',
-							'paragraph-2': 'contentOnly',
+							header: 'contentOnly',
+							footer: 'contentOnly',
+							'section-root': 'disabled',
+							'group-1': 'contentOnly', // New section root.
+							'paragraph-1': 'contentOnly', // Section and content block
+							'group-2': 'contentOnly', // Section.
+							'paragraph-2': 'contentOnly', // Content block.
 						} )
 					)
 				);

--- a/packages/block-editor/src/store/test/reducer.js
+++ b/packages/block-editor/src/store/test/reducer.js
@@ -4015,7 +4015,10 @@ describe( 'state', () => {
 			} );
 
 			it( 'allows content blocks to be disabled explicitly using the block editing mode', () => {
-				const { derivedNavModeBlockEditingModes } = dispatchActions(
+				const {
+					derivedNavModeBlockEditingModes,
+					blockEditingModes: _blockEditingModes,
+				} = dispatchActions(
 					[
 						{
 							type: 'SET_BLOCK_EDITING_MODE',
@@ -4027,6 +4030,15 @@ describe( 'state', () => {
 					initialState
 				);
 
+				// Paragraph 1 is explicitly disabled and omitted from the
+				// derived block editing modes.
+				expect( _blockEditingModes ).toEqual(
+					new Map(
+						Object.entries( {
+							'paragraph-1': 'disabled',
+						} )
+					)
+				);
 				expect( derivedNavModeBlockEditingModes ).toEqual(
 					new Map(
 						Object.entries( {
@@ -4038,7 +4050,6 @@ describe( 'state', () => {
 							'footer-paragraph': 'contentOnly',
 							'section-root': 'contentOnly',
 							'group-1': 'contentOnly',
-							'paragraph-1': 'disabled', // Block explicitly disabled.
 							'group-2': 'disabled',
 							'paragraph-2': 'contentOnly',
 						} )

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -4465,6 +4465,7 @@ describe( 'getBlockEditingMode', () => {
 			'9b9c5c3f-2e46-4f02-9e14-9fe9515b958f': {},
 		},
 		blockEditingModes: new Map( [] ),
+		derivedBlockEditingModes: new Map( [] ),
 	};
 
 	const hasContentRoleAttribute = jest.fn( () => false );
@@ -4519,6 +4520,13 @@ describe( 'getBlockEditingMode', () => {
 			blockEditingModes: new Map( [
 				[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
 			] ),
+			derivedBlockEditingModes: new Map( [
+				[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+				[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+				[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fed515b958s', 'disabled' ],
+			] ),
 		};
 		expect(
 			getBlockEditingMode( state, 'b3247f75-fd94-4fef-97f9-5bfd162cc416' )
@@ -4545,6 +4553,12 @@ describe( 'getBlockEditingMode', () => {
 				[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'default' ],
 				[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
 			] ),
+			derivedBlockEditingModes: new Map( [
+				[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
+				[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+				[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fed515b958s', 'disabled' ],
+			] ),
 		};
 		expect(
 			getBlockEditingMode( state, 'b3247f75-fd94-4fef-97f9-5bfd162cc416' )
@@ -4555,6 +4569,15 @@ describe( 'getBlockEditingMode', () => {
 		const state = {
 			...baseState,
 			blockEditingModes: new Map( [ [ '', 'disabled' ] ] ),
+			derivedBlockEditingModes: new Map( [
+				[ '6cf70164-9097-4460-bcbf-200560546988', 'disabled' ],
+				[ 'ef45d5fd-5234-4fd5-ac4f-c3736c7f9337', 'disabled' ],
+				[ 'b26fc763-417d-4f01-b81c-2ec61e14a972', 'disabled' ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fe9515b958f', 'disabled' ],
+				[ 'b3247f75-fd94-4fef-97f9-5bfd162cc416', 'disabled' ],
+				[ 'e178812d-ce5e-48c7-a945-8ae4ffcbbb7c', 'disabled' ],
+				[ '9b9c5c3f-2e46-4f02-9e14-9fed515b958s', 'disabled' ],
+			] ),
 		};
 		expect(
 			getBlockEditingMode( state, 'b3247f75-fd94-4fef-97f9-5bfd162cc416' )

--- a/packages/block-library/src/post-author-name/block.json
+++ b/packages/block-library/src/post-author-name/block.json
@@ -12,11 +12,13 @@
 		},
 		"isLink": {
 			"type": "boolean",
-			"default": false
+			"default": false,
+			"role": "content"
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_self"
+			"default": "_self",
+			"role": "content"
 		}
 	},
 	"usesContext": [ "postType", "postId" ],

--- a/packages/block-library/src/post-author/block.json
+++ b/packages/block-library/src/post-author/block.json
@@ -26,11 +26,13 @@
 		},
 		"isLink": {
 			"type": "boolean",
-			"default": false
+			"default": false,
+			"role": "content"
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_self"
+			"default": "_self",
+			"role": "content"
 		}
 	},
 	"usesContext": [ "postType", "postId", "queryId" ],

--- a/packages/block-library/src/post-date/block.json
+++ b/packages/block-library/src/post-date/block.json
@@ -15,7 +15,8 @@
 		},
 		"isLink": {
 			"type": "boolean",
-			"default": false
+			"default": false,
+			"role": "content"
 		},
 		"displayType": {
 			"type": "string",

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -9,7 +9,8 @@
 	"attributes": {
 		"isLink": {
 			"type": "boolean",
-			"default": false
+			"default": false,
+			"role": "content"
 		},
 		"aspectRatio": {
 			"type": "string"
@@ -30,11 +31,13 @@
 		"rel": {
 			"type": "string",
 			"attribute": "rel",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_self"
+			"default": "_self",
+			"role": "content"
 		},
 		"overlayColor": {
 			"type": "string"

--- a/packages/block-library/src/post-title/block.json
+++ b/packages/block-library/src/post-title/block.json
@@ -20,16 +20,19 @@
 		},
 		"isLink": {
 			"type": "boolean",
-			"default": false
+			"default": false,
+			"role": "content"
 		},
 		"rel": {
 			"type": "string",
 			"attribute": "rel",
-			"default": ""
+			"default": "",
+			"role": "content"
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_self"
+			"default": "_self",
+			"role": "content"
 		}
 	},
 	"example": {

--- a/packages/block-library/src/site-logo/block.json
+++ b/packages/block-library/src/site-logo/block.json
@@ -12,11 +12,13 @@
 		},
 		"isLink": {
 			"type": "boolean",
-			"default": true
+			"default": true,
+			"role": "content"
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_self"
+			"default": "_self",
+			"role": "content"
 		},
 		"shouldSyncIcon": {
 			"type": "boolean"

--- a/packages/block-library/src/site-title/block.json
+++ b/packages/block-library/src/site-title/block.json
@@ -20,11 +20,13 @@
 		},
 		"isLink": {
 			"type": "boolean",
-			"default": true
+			"default": true,
+			"role": "content"
 		},
 		"linkTarget": {
 			"type": "string",
-			"default": "_self"
+			"default": "_self",
+			"role": "content"
 		}
 	},
 	"example": {

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -370,8 +370,20 @@ export const __experimentalGetBlockAttributesNamesByRole = ( ...args ) => {
 	return getBlockAttributesNamesByRole( ...args );
 };
 
+/**
+ * Checks if a block is a content block by examining its attributes.
+ * A block is considered a content block if it has at least one attribute
+ * with a role of 'content'.
+ *
+ * @param {string} name The name of the block to check.
+ * @return {boolean}    Whether the block is a content block.
+ */
 export function isContentBlock( name ) {
 	const attributes = getBlockType( name )?.attributes;
+
+	if ( ! attributes ) {
+		return false;
+	}
 
 	return !! Object.keys( attributes )?.some( ( attributeKey ) => {
 		const attribute = attributes[ attributeKey ];

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -16,9 +16,13 @@ import usePostContentBlocks from './use-post-content-blocks';
  */
 export default function DisableNonPageContentBlocks() {
 	const contentOnlyIds = usePostContentBlocks();
-	const templateParts = useSelect( ( select ) => {
-		const { getBlocksByName } = select( blockEditorStore );
-		return getBlocksByName( 'core/template-part' );
+	const { templateParts, isNavigationMode } = useSelect( ( select ) => {
+		const { getBlocksByName, isNavigationMode: _isNavigationMode } =
+			select( blockEditorStore );
+		return {
+			templateParts: getBlocksByName( 'core/template-part' ),
+			isNavigationMode: _isNavigationMode(),
+		};
 	}, [] );
 	const disabledIds = useSelect(
 		( select ) => {
@@ -41,8 +45,10 @@ export default function DisableNonPageContentBlocks() {
 			for ( const clientId of contentOnlyIds ) {
 				setBlockEditingMode( clientId, 'contentOnly' );
 			}
-			for ( const clientId of templateParts ) {
-				setBlockEditingMode( clientId, 'contentOnly' );
+			if ( ! isNavigationMode ) {
+				for ( const clientId of templateParts ) {
+					setBlockEditingMode( clientId, 'contentOnly' );
+				}
 			}
 			for ( const clientId of disabledIds ) {
 				setBlockEditingMode( clientId, 'disabled' );
@@ -55,15 +61,23 @@ export default function DisableNonPageContentBlocks() {
 				for ( const clientId of contentOnlyIds ) {
 					unsetBlockEditingMode( clientId );
 				}
-				for ( const clientId of templateParts ) {
-					unsetBlockEditingMode( clientId );
+				if ( ! isNavigationMode ) {
+					for ( const clientId of templateParts ) {
+						unsetBlockEditingMode( clientId );
+					}
 				}
 				for ( const clientId of disabledIds ) {
 					unsetBlockEditingMode( clientId );
 				}
 			} );
 		};
-	}, [ templateParts, contentOnlyIds, disabledIds, registry ] );
+	}, [
+		templateParts,
+		contentOnlyIds,
+		disabledIds,
+		isNavigationMode,
+		registry,
+	] );
 
 	return null;
 }

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -84,9 +84,6 @@ export default function DisableNonPageContentBlocks() {
 					setBlockEditingMode( clientId, 'contentOnly' );
 				}
 			}
-			for ( const clientId of disabledIds ) {
-				setBlockEditingMode( clientId, 'disabled' );
-			}
 		} );
 
 		return () => {
@@ -98,7 +95,7 @@ export default function DisableNonPageContentBlocks() {
 				}
 			} );
 		};
-	}, [ templateParts, isNavigationMode, registry, disabledIds ] );
+	}, [ templateParts, isNavigationMode, registry ] );
 
 	useEffect( () => {
 		const { setBlockEditingMode, unsetBlockEditingMode } =

--- a/packages/editor/src/components/provider/disable-non-page-content-blocks.js
+++ b/packages/editor/src/components/provider/disable-non-page-content-blocks.js
@@ -36,15 +36,49 @@ export default function DisableNonPageContentBlocks() {
 
 	const registry = useRegistry();
 
+	// The code here is split into multiple `useEffects` calls.
+	// This is done to avoid setting/unsetting block editing modes multiple times unnecessarily.
+	//
+	// For example, the block editing mode of the root block (clientId: '') only
+	// needs to be set once, not when `contentOnlyIds` or `disabledIds` change.
+	//
+	// It's also unlikely that these different types of blocks are being inserted
+	// or removed at the same time, so using different effects reflects that.
+	useEffect( () => {
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+
+		setBlockEditingMode( '', 'disabled' );
+
+		return () => {
+			unsetBlockEditingMode( '' );
+		};
+	}, [ registry ] );
+
 	useEffect( () => {
 		const { setBlockEditingMode, unsetBlockEditingMode } =
 			registry.dispatch( blockEditorStore );
 
 		registry.batch( () => {
-			setBlockEditingMode( '', 'disabled' );
 			for ( const clientId of contentOnlyIds ) {
 				setBlockEditingMode( clientId, 'contentOnly' );
 			}
+		} );
+
+		return () => {
+			registry.batch( () => {
+				for ( const clientId of contentOnlyIds ) {
+					unsetBlockEditingMode( clientId );
+				}
+			} );
+		};
+	}, [ contentOnlyIds, registry ] );
+
+	useEffect( () => {
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+
+		registry.batch( () => {
 			if ( ! isNavigationMode ) {
 				for ( const clientId of templateParts ) {
 					setBlockEditingMode( clientId, 'contentOnly' );
@@ -57,27 +91,33 @@ export default function DisableNonPageContentBlocks() {
 
 		return () => {
 			registry.batch( () => {
-				unsetBlockEditingMode( '' );
-				for ( const clientId of contentOnlyIds ) {
-					unsetBlockEditingMode( clientId );
-				}
 				if ( ! isNavigationMode ) {
 					for ( const clientId of templateParts ) {
 						unsetBlockEditingMode( clientId );
 					}
 				}
+			} );
+		};
+	}, [ templateParts, isNavigationMode, registry, disabledIds ] );
+
+	useEffect( () => {
+		const { setBlockEditingMode, unsetBlockEditingMode } =
+			registry.dispatch( blockEditorStore );
+
+		registry.batch( () => {
+			for ( const clientId of disabledIds ) {
+				setBlockEditingMode( clientId, 'disabled' );
+			}
+		} );
+
+		return () => {
+			registry.batch( () => {
 				for ( const clientId of disabledIds ) {
 					unsetBlockEditingMode( clientId );
 				}
 			} );
 		};
-	}, [
-		templateParts,
-		contentOnlyIds,
-		disabledIds,
-		isNavigationMode,
-		registry,
-	] );
+	}, [ disabledIds, registry ] );
 
 	return null;
 }


### PR DESCRIPTION
## What?
Fixes #66463

Allows editing template parts in Write Mode. Also makes blocks like Site Title and Site Logo editable.

## Background
Before I describe changes in the PR, I'll describe how the whole things works in trunk.

The block editor has the concept of `blockEditingModes` (described more deeply in #67856). Blocks can be set into one of three editing modes:
- `default` - the block behaves normally, it can be selected and edited as it usually can with all block controls available (in the inspector and toolbar)
- `disabled` - the block can't be selected or edited. All child blocks are also disabled (unless they have one of the other two block editing modes set), and they can't be removed, inserted or reordered.
- `contentOnly` - makes the block only partially editable and selectable. The block's inspector controls and some other controls are hidden. The user should be able to update content of the block, but not the design. The block can still itself be moved, and any inner blocks are also free to be moved, deleted or new blocks inserted.

Features like Synced Patterns, Zoom Out, Write Mode, and the 'Show Template' option when editing a post are heavily dependent on this. When you use those features you may notice some blocks are disabled and some are contentOnly, others might just be normally editable.

Here's a brief description of each one:
- Synced Patterns - When an instance of a synced pattern is inserted, the design is locked and the user has to select the 'Edit original' button on the toolbar to edit the design. The locking of the instance is achieved by making all the `child` blocks `disabled`. When changing the design, particular blocks in the pattern can be enabled as pattern overrides or given bindings. If you insert a pattern instance that contains any of those kinds of blocks, the blocks are made `contentOnly` and allow content changes.
- Zoom Out - Uses a concept called 'sections'. A block that's an inner block of the 'section root' is considered a section. In Zoom Out, the section root is usually the group assigned the `<main>` tag. So any direct children of `<main>` are sections. The main element and the sections are in `contentOnly` mode, but all other blocks are `disabled` (including Synced Patterns).
- Write Mode (also known as `navigationMode` in the codebase) - Write mode has the same kind of section editing as Zoom Out. Additionally child blocks of sections that are considered 'content' blocks are in `contentOnly` mode so that their content can be updated. That's determined currently by whether the block has at least one attribute with `role: content`. Synced patterns have some special treatment to ensure users can't change the design of a pattern in write mode, they work very similarly regardless of whether write mode is active or not.

The coordination of the block editing modes for those three features is managed in the codebase within the `withDerivedBlockEditingModes` reducer in the block editor package (more specifically, `getDerivedBlockEditingModesForTree` contains the code that determines the mode for an individual `clientId`). It updates two properties in the block editor store  whenever particular actions are dispatched that require changes to the block editing modes (e.g. enabling zoom out, inserting a new section or synced pattern):
- `derivedBlockEditingModes` - The block editing modes for outside of write mode
- `derivedNavModeBlockEditingModes`- The block editing modes for write mode

There are two separate properties because the block editor store can't determine whether it's in write mode as that data isn't within the block editor store (it's a preference).

They're called 'derived' block editing modes because they haven't been explicitly set, they're calculated based on things like which block are sections, which blocks are synced patterns, and which have the `content` role, bindings, or pattern overrides.

There's one additional piece, which is that some block types are conferred 'section' status by the `isSectionBlock` selector. The main thing this does is show a 'Content' panel in the block's Inspector Controls.

The the 'Show Template' option was also mentioned. This is when a user is viewing a post and the 'Show Template' option is active. In this mode, the template is shown but the majority of blocks in the template are `disabled` and only page content is editable (title, featured image, any blocks within the Post Content). From the template, Post Title and Featured Image are `contentOnly` and the inner blocks of Post Content are set to `default`. Template Parts are also selectable, but can't be updated.

This 'Show Template' feature works a little differently. The block editor package doesn't know whether a page/post/pattern or something else entirely is being shown so it can't coordinate this. It's handled by [the Editor package in the `DisableNonPageContentBlocks` component](https://github.com/WordPress/gutenberg/blob/trunk/packages/editor/src/components/provider/disable-non-page-content-blocks.js). That component calls the `setBlockEditingMode`. 

When `setBlockEditingMode` is called it updates a different property within the block editor store called `blockEditingModes` (these are sometimes referred to as 'explicit' block editing modes because they've been explicitly set). This is kept separate to `derivedBlockEditingModes` so that if the user switches to zoom out and back, the `blockEditingModes` aren't removed.

The `derivedNavModeBlockEditingModes`, `derivedBlockEditingModes` and the `blockEditingModes` are returned by the same selector `getBlockEditingModes`. In `trunk` if the block has one of the derived modes it takes precedence over the explicit `blockEditingMode`.

## How?

- A range of blocks that typically appear in template parts have had `role: content` added to their attributes so that in Write Mode they'll be set to `contentOnly`.
- `isSectionBlock` has been updated to consider the template part block a section. It shows the 'Content' panel in the block inspector.
- `getDerivedBlockEditingModesForTree` has been updated to set the correct block editing modes for template parts in Write Mode.

The main challenge was the 'Show Template' option since it uses the explicit block editing modes, not the derived ones. The changes I described above alone made template parts editable when editing a page in Write Mode with 'Show Template' on. To solve this, I've made the explicit block editing modes take priority over the derived ones and added some code to `DisableNonPageContentBlocks` to not enable template parts when write mode is active.

There were also some performance issues caused by `DisableNonPageContentBlocks`, which I've partially solved by splitting it up into multiple `useEffect` calls.

## Problems to solve
I think the PR is almost there, but in my own testing:
- [x] The template parts don't display the "Content" panel in the sidebar and Inspector Controls for the inner blocks of template parts are displayed.
- [x] Drag and drop is a bit broken. Sections can be dragged into the Header / Footer TPs and it all goes a bit weird. I think somehow the Template Parts should now allow any block dropping (but still allow actions like dragging an image onto the Site Logo).
- [x] Template parts are now editable when editing a Page in Write Mode.
- [ ] Lots of the blocks that I changed have their link controls in the Inspector, which makes them unreachable in contentOnly mode. I imagine these should be moved to the toolbar. (seems like a follow-up issue)
- [ ] There might be a few blocks (like Site Tagline) that still need to be updated to work in contentOnly mode. This block is a tricky one because it doesn't have any suitable attributes for `"role":"content"`. (another follow-up issue)
- [ ] Consider removing 'Edit' / 'Edit original' from template part and synced pattern toolbars (or do so in a follow-up PR)

## Testing Instructions
(I find it's best to use Twenty Twenty Four for testing, as that theme has lots of sections out of the box)

#### Template editing
1. Open the site editor and edit a template like Blog Homepage
2. Switch to Write mode using the option in the topbar
3. Try editing the header and footer and blocks within the header and footer
4. Observe that most work, with the exception of Site Tagline (still needs a solution, but it'll need to be a follow-up)

#### Page editing
1. Still using the site editor open a page
2. Make sure the Show Template option is on in the document settings (it usually is by default in the site editor)
3. Switch to Write Mode (it might still be active)
4. Template parts now shouldn't be selectable or editable in this mode.
5. Unlike in trunk, blocks like Title and Featured Image are now editable in Write Mode, along with the Post Content as before.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/47b027c5-6f98-4ff7-a9c6-db3386c63b2a


