### PR TITLE
Edit Site: Fix block styles navigation error

### DIFF
--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -379,7 +379,9 @@ export function useScaleCanvas( {
 			 * If we already have an animation running, reverse it.
 			 */
 			if ( animationRef.current ) {
-				animationRef.current.reverse();
+				if ( animationRef.current.timeline.currentTime ) {
+					animationRef.current.reverse();
+				}
 				// Swap the transition to/from refs so that we set the correct values when
 				// finishZoomOutAnimation runs.
 				const tempTransitionFrom = transitionFromRef.current;


### PR DESCRIPTION
## What?
Fixes an error that occurs when navigating directly to block styles in the site editor.

## Why?
Just fixing an error that seems to have been introduced in #66917.

Found while testing #67199.

## How?
We're checking if the animation has a timeline before attempting to reverse it.

## Testing Instructions
* Open `/wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks%2Fcore%252Fheading`
* Verify you don't see an error.
* Verify testing instructions of #66917 still work well.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-11-28 at 11 04 49](https://github.com/user-attachments/assets/43d52ad2-fc3e-4f8b-ace9-8b11c6225d3f)
