### PR TITLE
Added `is-focus-mode` class on all viewports.

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -12,11 +12,7 @@ import {
 	useDispatch,
 	useRegistry,
 } from '@wordpress/data';
-import {
-	useViewportMatch,
-	useMergeRefs,
-	useDebounce,
-} from '@wordpress/compose';
+import { useMergeRefs, useDebounce } from '@wordpress/compose';
 import {
 	createContext,
 	useMemo,
@@ -46,7 +42,6 @@ export const IntersectionObserver = createContext();
 const pendingBlockVisibilityUpdatesPerRegistry = new WeakMap();
 
 function Root( { className, ...settings } ) {
-	const isLargeViewport = useViewportMatch( 'medium' );
 	const { isOutlineMode, isFocusMode, temporarilyEditingAsBlocks } =
 		useSelect( ( select ) => {
 			const { getSettings, getTemporarilyEditingAsBlocks, isTyping } =
@@ -105,7 +100,7 @@ function Root( { className, ...settings } ) {
 			] ),
 			className: clsx( 'is-root-container', className, {
 				'is-outline-mode': isOutlineMode,
-				'is-focus-mode': isFocusMode && isLargeViewport,
+				'is-focus-mode': isFocusMode,
 			} ),
 		},
 		settings


### PR DESCRIPTION
Fixes: #67376 

## What?
This pull request addresses and resolves the issue where Spotlight Mode does not function as intended on mobile viewports. The fix ensures that the feature behaves consistently across all devices, aligning the mobile experience with the expected functionality seen on desktop. By implementing this solution, users will now observe the proper highlighting of the active block with reduced opacity for surrounding elements.

## Why?

This fix is crucial as displaying the Spotlight Mode toggle on mobile viewports without any associated functionality can mislead users into believing the toggle is broken. To address this, two solutions were proposed in the issue description:

1. Remove the toggle entirely from mobile viewports.
2. Enable the functionality for mobile viewports.

This PR adopts and enables the functionality of Spotlight Mode on mobile devices.

## How?
https://github.com/WordPress/gutenberg/blob/b54d1fe5fe96b00d7f6455b4aaf40bb21ec43967/packages/block-editor/src/components/block-list/index.js#L108

The code above previously prevented the is-focus-mode class from being applied to viewports with smaller widths, resulting in the observed bug. The additional viewport restrictions were removed to resolve this issue, ensuring consistent functionality across all viewport sizes.

## Screencast


https://github.com/user-attachments/assets/ad76eb78-3d1e-4b91-8cc7-1eecb35debd6

