### PR TITLE
Router: Fix addition and removal of empty classnames

### DIFF
--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -129,13 +129,17 @@ export function useHistory() {
 
 			await new Promise< void >( ( resolve ) => {
 				const classname = options.transition ?? '';
-				document.documentElement.classList.add( classname );
+				if ( classname ) {
+					document.documentElement.classList.add( classname );
+				}
 				// @ts-expect-error
 				const transition = document.startViewTransition( () =>
 					performPush()
 				);
 				transition.finished.finally( () => {
-					document.documentElement.classList.remove( classname );
+					if ( classname ) {
+						document.documentElement.classList.remove( classname );
+					}
 					resolve();
 				} );
 			} );

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -125,21 +125,18 @@ export function useHistory() {
 				! options.transition
 			) {
 				performPush();
+				return;
 			}
 
 			await new Promise< void >( ( resolve ) => {
 				const classname = options.transition ?? '';
-				if ( classname ) {
-					document.documentElement.classList.add( classname );
-				}
+				document.documentElement.classList.add( classname );
 				// @ts-expect-error
 				const transition = document.startViewTransition( () =>
 					performPush()
 				);
 				transition.finished.finally( () => {
-					if ( classname ) {
-						document.documentElement.classList.remove( classname );
-					}
+					document.documentElement.classList.remove( classname );
 					resolve();
 				} );
 			} );


### PR DESCRIPTION
## What?
Fixes an error that occurs when navigating between different blocks in global styles in the site editor.

## Why?
Just fixing an error, seems like it was introduced in #67199.

Found while late testing #67199.

## How?
We're making sure that before adding or removing a classname during router navigation, there's actually one to be added or removed.

## Testing Instructions
* Open `/wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks`
* Navigate to a few blocks.
* Verify you no longer see the error.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-11-28 at 11 08 33](https://github.com/user-attachments/assets/1f78bec4-d431-4cc0-a85e-07a399d4e375)

