### PR TITLE
Fix List View not updating when switching editor modes

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { createSelector, createRegistrySelector } from '@wordpress/data';
-import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -118,7 +117,7 @@ export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,
-		select( preferencesStore ).get( 'core', 'editorTool' ),
+		select( STORE_NAME ).__unstableGetEditorMode( state ),
 	] )
 );
 

--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { createSelector, createRegistrySelector } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -109,16 +110,16 @@ function getEnabledClientIdsTreeUnmemoized( state, rootClientId ) {
  *
  * @return {Object[]} Tree of block objects with only clientID and innerBlocks set.
  */
-export const getEnabledClientIdsTree = createSelector(
-	getEnabledClientIdsTreeUnmemoized,
-	( state ) => [
+export const getEnabledClientIdsTree = createRegistrySelector( ( select ) =>
+	createSelector( getEnabledClientIdsTreeUnmemoized, ( state ) => [
 		state.blocks.order,
 		state.derivedBlockEditingModes,
 		state.derivedNavModeBlockEditingModes,
 		state.blockEditingModes,
 		state.settings.templateLock,
 		state.blockListSettings,
-	]
+		select( preferencesStore ).get( 'core', 'editorTool' ),
+	] )
 );
 
 /**

--- a/test/e2e/specs/editor/various/write-design-mode.spec.js
+++ b/test/e2e/specs/editor/various/write-design-mode.spec.js
@@ -121,4 +121,59 @@ test.describe( 'Write/Design mode', () => {
 			editorSettings.getByRole( 'button', { name: 'Content' } )
 		).toBeVisible();
 	} );
+
+	test( 'hides the blocks that cannot be interacted with in List View', async ( {
+		editor,
+		page,
+		pageUtils,
+	} ) => {
+		await editor.setContent( '' );
+
+		// Insert a section with a nested block and an editable block.
+		await editor.insertBlock( {
+			name: 'core/group',
+			attributes: {},
+			innerBlocks: [
+				{
+					name: 'core/group',
+					attributes: {
+						metadata: {
+							name: 'Non-content block',
+						},
+					},
+					innerBlocks: [
+						{
+							name: 'core/paragraph',
+							attributes: {
+								content: 'Something',
+							},
+						},
+					],
+				},
+			],
+		} );
+
+		// Select the inner paragraph block so that List View is expanded.
+		await editor.canvas
+			.getByRole( 'document', {
+				name: 'Block: Paragraph',
+			} )
+			.click();
+
+		// Open List View.
+		await pageUtils.pressKeys( 'access+o' );
+		const listView = page.getByRole( 'treegrid', {
+			name: 'Block navigation structure',
+		} );
+		const nonContentBlock = listView.getByRole( 'link', {
+			name: 'Non-content block',
+		} );
+
+		await expect( nonContentBlock ).toBeVisible();
+
+		// Switch to write mode.
+		await editor.switchEditorTool( 'Write' );
+
+		await expect( nonContentBlock ).toBeHidden();
+	} );
 } );


### PR DESCRIPTION
## What?
Fixes a small bug I reintroduced in #67026.

When switching block editor modes, the List View doesn't update to shown the blocks that can be interacted with.

## How?
#67026 removed some dependencies of the selector, but some changes were made that meant the `select( STORE_NAME ).__unstableGetEditorMode( state )` dependency needed to be added back.

This PR resolves the issue.

## Testing Instructions
As this bug has happened before, I've added an e2e test to prevent further regressions.

1. Enable the Write Mode gutenberg experiment (WP Admin sidebar > Gutenberg > Experiments)
2. Open the site editor and edit a template like Blog Homepage (TT4 is probably the best theme as it has multiple sections)
3. Open List View and mentally record what it looks like
4. Switch to Write Mode using the tool selector in the top bar
5. Compare your mental record from step 3 to how List View looks now

In trunk: It doesn't change which is a bug
In this PR: It updates to show which blocks can be interacted with

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/0047a2c0-9220-44c9-95ef-7c2714ae437f

