### PR TITLE
DataViews: Update `usePostFields` to accept postType

### DIFF
--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -49,8 +49,7 @@ function PostEditForm( { postType, postId } ) {
 	);
 	const [ multiEdits, setMultiEdits ] = useState( {} );
 	const { editEntityRecord } = useDispatch( coreDataStore );
-	// TODO: This needs to be dynamic and will be handled in a follow up with the `format` field for posts.
-	const { fields: _fields } = usePostFields( { postType: 'page' } );
+	const { fields: _fields } = usePostFields( { postType } );
 	const fields = useMemo(
 		() =>
 			_fields?.map( ( field ) => {

--- a/packages/edit-site/src/components/post-edit/index.js
+++ b/packages/edit-site/src/components/post-edit/index.js
@@ -49,7 +49,8 @@ function PostEditForm( { postType, postId } ) {
 	);
 	const [ multiEdits, setMultiEdits ] = useState( {} );
 	const { editEntityRecord } = useDispatch( coreDataStore );
-	const { fields: _fields } = usePostFields();
+	// TODO: This needs to be dynamic and will be handled in a follow up with the `format` field for posts.
+	const { fields: _fields } = usePostFields( { postType: 'page' } );
 	const fields = useMemo(
 		() =>
 			_fields?.map( ( field ) => {

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -215,7 +215,9 @@ export default function PostList( { postType } ) {
 		return found?.filters ?? [];
 	};
 
-	const { isLoading: isLoadingFields, fields: _fields } = usePostFields();
+	const { isLoading: isLoadingFields, fields: _fields } = usePostFields( {
+		postType,
+	} );
 	const fields = useMemo( () => {
 		const activeViewFilters = getActiveViewFilters(
 			defaultViews,

--- a/packages/editor/src/components/post-fields/index.ts
+++ b/packages/editor/src/components/post-fields/index.ts
@@ -23,9 +23,11 @@ interface Author {
 	name: string;
 }
 
-function usePostFields(): UsePostFieldsReturn {
-	const postType = 'page'; // TODO: this could be page or post (experimental).
-
+function usePostFields( {
+	postType,
+}: {
+	postType: string;
+} ): UsePostFieldsReturn {
 	const { registerPostTypeSchema } = unlock( useDispatch( editorStore ) );
 	useEffect( () => {
 		registerPostTypeSchema( postType );

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -164,7 +164,7 @@ export const registerPostTypeSchema =
 				currentTheme?.[ 'theme-supports' ]?.[ 'post-thumbnails' ] &&
 				featuredImageField,
 			titleField,
-			authorField,
+			postTypeConfig.supports?.author && authorField,
 			statusField,
 			dateField,
 			slugField,

--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -128,7 +128,7 @@ export const registerPostTypeSchema =
 
 		const actions = [
 			postTypeConfig.viewable ? viewPost : undefined,
-			!! postTypeConfig?.supports?.revisions
+			!! postTypeConfig.supports?.revisions
 				? viewPostRevisions
 				: undefined,
 			// @ts-ignore
@@ -148,7 +148,7 @@ export const registerPostTypeSchema =
 				? duplicatePattern
 				: undefined,
 			postTypeConfig.supports?.title ? renamePost : undefined,
-			postTypeConfig?.supports?.[ 'page-attributes' ]
+			postTypeConfig.supports?.[ 'page-attributes' ]
 				? reorderPage
 				: undefined,
 			postTypeConfig.slug === 'wp_block' ? exportPattern : undefined,
@@ -157,25 +157,24 @@ export const registerPostTypeSchema =
 			deletePost,
 			trashPost,
 			permanentlyDeletePost,
-		];
+		].filter( Boolean );
 
 		const fields = [
-			featuredImageField,
+			postTypeConfig.supports?.thumbnail &&
+				currentTheme?.[ 'theme-supports' ]?.[ 'post-thumbnails' ] &&
+				featuredImageField,
 			titleField,
 			authorField,
 			statusField,
 			dateField,
 			slugField,
-			parentField,
-			commentStatusField,
+			postTypeConfig.supports?.[ 'page-attributes' ] && parentField,
+			postTypeConfig.supports?.comments && commentStatusField,
 			passwordField,
-		];
+		].filter( Boolean );
 
 		registry.batch( () => {
 			actions.forEach( ( action ) => {
-				if ( ! action ) {
-					return;
-				}
 				unlock( registry.dispatch( editorStore ) ).registerEntityAction(
 					'postType',
 					postType,

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -78,6 +78,8 @@ export interface PostType {
 		'page-attributes'?: boolean;
 		title?: boolean;
 		revisions?: boolean;
+		thumbnail?: boolean;
+		comments?: boolean;
 	};
 }
 

--- a/packages/editor/src/dataviews/types.ts
+++ b/packages/editor/src/dataviews/types.ts
@@ -80,6 +80,7 @@ export interface PostType {
 		revisions?: boolean;
 		thumbnail?: boolean;
 		comments?: boolean;
+		author?: boolean;
 	};
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of: https://github.com/WordPress/gutenberg/issues/61084

This PR updates `usePostFields` to accept postType and add some support checks to conditionally add some fields, like featured image.

This surfaces some issues we need to solve regarding layouts using some fields that might not exist. For example to handle when we don't support `featured image` but `view.layout.mediaField` is declared to show that. These should be handled in follow ups to iterate faster.



## Testing Instructions
1. Everything should work as before in trunk
2. Test `wp.editor.unregisterEntityField( 'postType', 'page', 'author' );` or `wp.editor.unregisterEntityField( 'postType', 'post', 'author' );` in the respective DataViews lists
