### PR TITLE
Fix: Don't show `aria-label` when its value is empty

### DIFF
--- a/packages/block-library/src/navigation/index.php
+++ b/packages/block-library/src/navigation/index.php
@@ -567,13 +567,14 @@ class WP_Navigation_Block_Renderer {
 		$is_responsive_menu = static::is_responsive( $attributes );
 		$style              = static::get_styles( $attributes );
 		$class              = static::get_classes( $attributes );
-		$wrapper_attributes = get_block_wrapper_attributes(
-			array(
-				'class'      => $class,
-				'style'      => $style,
-				'aria-label' => $nav_menu_name,
-			)
+		$extra_attributes   = array(
+			'class' => $class,
+			'style' => $style,
 		);
+		if ( ! empty( $nav_menu_name ) ) {
+			$extra_attributes['aria-label'] = $nav_menu_name;
+		}
+		$wrapper_attributes = get_block_wrapper_attributes( $extra_attributes );
 
 		if ( $is_responsive_menu ) {
 			$nav_element_directives = static::get_nav_element_directives( $is_interactive );


### PR DESCRIPTION
## What?
Fixes an accessibility issue reported [here](https://github.com/WordPress/gutenberg/issues/54560#issuecomment-2505536216).

## Why?
`aria-label` shouldn't be present when its value is empty.

## How?
Checking if it is empty before passing it as an extra attribute.

## Testing Instructions
1. Go to a site with the default navigation block.
2. Inspect the `nav` element.
3. Check that `aria-label` is not there. Previously, it was without any value.
