### PR TITLE
Edit Site: Fix sidebar template author navigation

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -6,6 +6,7 @@ import { useMemo } from '@wordpress/element';
 import { __experimentalItemGroup as ItemGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Internal dependencies
@@ -25,7 +26,7 @@ function TemplateDataviewItem( { template, isActive } ) {
 
 	return (
 		<SidebarNavigationItem
-			to={ `/template?activeView=${ text }` }
+			to={ addQueryArgs( '/template', { activeView: text } ) }
 			icon={ icon }
 			aria-current={ isActive }
 		>


### PR DESCRIPTION
## What?
Fixes the template author sidebar navigation which regressed in #67199.

## Why?
We slightly broke it in #67199 - clicking on a template author to filter templates is not working right now.

## How?
We're using `addQueryArgs()` to properly deal with the existing query while adding the filter args.

## Testing Instructions
* Open the site editor
* Click "Templates"
* Click on one of the sub items (the theme one should be available)
* Verify navigation works correctly. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-11-28 at 12 03 29](https://github.com/user-attachments/assets/a5be1201-9bb1-44a2-8b1a-b20cc0c1e5ab)
