### PR TITLE
Storybook: Add BorderRadiusControl story

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/README.md
+++ b/packages/block-editor/src/components/border-radius-control/README.md
@@ -1,0 +1,76 @@
+# BorderRadiusControl
+
+`BorderRadiusControl` is a React component that provides a user interface for managing border radius values. It allows users to control the border radius of each corner independently or link them together for uniform values.
+
+## Usage
+
+```jsx
+/**
+ * WordPress dependencies
+ */
+import { BorderRadiusControl } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+
+const MyBorderRadiusControl = () => {
+    const [values, setValues] = useState({
+        topLeft: '10px',
+        topRight: '10px',
+        bottomLeft: '10px',
+        bottomRight: '10px',
+    });
+
+    return (
+        <BorderRadiusControl
+            values={values}
+            onChange={setValues}
+        />
+    );
+};
+
+// ...
+
+<MyBorderRadiusControl />;
+```
+
+## Props
+
+The component accepts the following props:
+
+### values
+
+An object containing the border radius values for each corner.
+
+- Type: `Object`
+- Required: No
+
+The values object has the following schema:
+
+| Property    | Description                          | Type   |
+| ----------- | ------------------------------------ | ------ |
+| topLeft     | Border radius for top left corner    | string |
+| topRight    | Border radius for top right corner   | string |
+| bottomLeft  | Border radius for bottom left corner | string |
+| bottomRight | Border radius for bottom right corner| string |
+
+Each value should be a valid CSS border radius value (e.g., '10px', '1em').
+
+### onChange
+
+Callback function that is called when any border radius value changes.
+
+- Type: `Function`
+- Required: Yes
+
+The function receives the updated values object as its argument.
+
+## Limitations
+
+The component has the following built-in constraints:
+
+- Minimum border radius value: 0
+- Maximum values by unit:
+  - px: 100
+  - em: 20
+  - rem: 20
+
+Please refer to the component's stories for more examples of usage.

--- a/packages/block-editor/src/components/border-radius-control/README.md
+++ b/packages/block-editor/src/components/border-radius-control/README.md
@@ -8,7 +8,7 @@
 /**
  * WordPress dependencies
  */
-import { BorderRadiusControl } from '@wordpress/block-editor';
+import { __experimentalBorderRadiusControl as BorderRadiusControl } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 
 const MyBorderRadiusControl = () => {
@@ -26,15 +26,9 @@ const MyBorderRadiusControl = () => {
         />
     );
 };
-
-// ...
-
-<MyBorderRadiusControl />;
 ```
 
 ## Props
-
-The component accepts the following props:
 
 ### values
 
@@ -42,7 +36,7 @@ An object containing the border radius values for each corner.
 
 - **Type:** `Object`
 - **Required:** No
-- **Default:** `{ topLeft: undefined, topRight: undefined, bottomLeft: undefined, bottomRight: undefined }`
+- **Default:** `undefined`
 
 The values object has the following schema:
 
@@ -64,15 +58,3 @@ Callback function that is called when any border radius value changes.
 - **Default:** `() => {}`
 
 The function receives the updated values object as its argument.
-
-## Limitations
-
-The component has the following built-in constraints:
-
-- Minimum border radius value: 0
-- Maximum values by unit:
-  - px: 100
-  - em: 20
-  - rem: 20
-
-Please refer to the component's stories for more examples of usage.

--- a/packages/block-editor/src/components/border-radius-control/README.md
+++ b/packages/block-editor/src/components/border-radius-control/README.md
@@ -55,6 +55,5 @@ Callback function that is called when any border radius value changes.
 
 - **Type:** `Function`
 - **Required:** Yes
-- **Default:** `() => {}`
 
 The function receives the updated values object as its argument.

--- a/packages/block-editor/src/components/border-radius-control/README.md
+++ b/packages/block-editor/src/components/border-radius-control/README.md
@@ -40,8 +40,9 @@ The component accepts the following props:
 
 An object containing the border radius values for each corner.
 
-- Type: `Object`
-- Required: No
+- **Type:** `Object`
+- **Required:** No
+- **Default:** `{ topLeft: undefined, topRight: undefined, bottomLeft: undefined, bottomRight: undefined }`
 
 The values object has the following schema:
 
@@ -58,8 +59,9 @@ Each value should be a valid CSS border radius value (e.g., '10px', '1em').
 
 Callback function that is called when any border radius value changes.
 
-- Type: `Function`
-- Required: Yes
+- **Type:** `Function`
+- **Required:** Yes
+- **Default:** `() => {}`
 
 The function receives the updated values object as its argument.
 

--- a/packages/block-editor/src/components/border-radius-control/stories/index.story.js
+++ b/packages/block-editor/src/components/border-radius-control/stories/index.story.js
@@ -11,7 +11,7 @@ import BorderRadiusControl from '../';
 /**
  * BorderRadiusControl component allows setting border radius values.
  */
-const meta = {
+export default {
 	title: 'BlockEditor/BorderRadiusControl',
 	component: BorderRadiusControl,
 	parameters: {
@@ -30,49 +30,27 @@ const meta = {
 		},
 	},
 };
-export default meta;
 
-const Template = ( initialValues ) => {
-	const [ values, setValues ] = useState( initialValues.values );
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ values, setValues ] = useState( args.values );
 
-	return (
-		<BorderRadiusControl
-			values={ values }
-			onChange={ ( newValues ) => {
-				setValues( newValues );
-				initialValues.onChange( newValues );
-			} }
-		/>
-	);
-};
-
-export const Default = Template.bind( {} );
-Default.args = {
-	values: {
-		topLeft: '10px',
-		topRight: '10px',
-		bottomLeft: '10px',
-		bottomRight: '10px',
+		return (
+			<BorderRadiusControl
+				values={ values }
+				onChange={ ( ...changeArgs ) => {
+					setValues( ...changeArgs );
+					onChange( ...changeArgs );
+				} }
+			/>
+		);
 	},
-};
-
-/**
- * This story demonstrates the control with no initial values.
- */
-export const NoInitialValues = Template.bind( {} );
-NoInitialValues.args = {
-	values: {},
-};
-
-/**
- * This story demonstrates the control with mixed values.
- */
-export const MixedUnits = Template.bind( {} );
-MixedUnits.args = {
-	values: {
-		topLeft: '10px',
-		topRight: '1em',
-		bottomLeft: '20%',
-		bottomRight: '5rem',
+	args: {
+		values: {
+			topLeft: '10px',
+			topRight: '10px',
+			bottomLeft: '10px',
+			bottomRight: '10px',
+		},
 	},
 };

--- a/packages/block-editor/src/components/border-radius-control/stories/index.story.js
+++ b/packages/block-editor/src/components/border-radius-control/stories/index.story.js
@@ -55,12 +55,4 @@ export const Default = {
 			/>
 		);
 	},
-	args: {
-		values: {
-			topLeft: '10px',
-			topRight: '10px',
-			bottomLeft: '10px',
-			bottomRight: '10px',
-		},
-	},
 };

--- a/packages/block-editor/src/components/border-radius-control/stories/index.story.js
+++ b/packages/block-editor/src/components/border-radius-control/stories/index.story.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BorderRadiusControl from '../';
+
+/**
+ * BorderRadiusControl component allows setting border radius values.
+ */
+const meta = {
+	title: 'BlockEditor/BorderRadiusControl',
+	component: BorderRadiusControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: 'Control to display border radius options.',
+			},
+		},
+	},
+	argTypes: {
+		values: { control: 'object', description: 'Border radius values.' },
+		onChange: {
+			action: 'onChange',
+			description: 'Callback to handle onChange.',
+		},
+	},
+};
+export default meta;
+
+const Template = ( initialValues ) => {
+	const [ values, setValues ] = useState( initialValues.values );
+
+	return (
+		<BorderRadiusControl
+			values={ values }
+			onChange={ ( newValues ) => {
+				setValues( newValues );
+				initialValues.onChange( newValues );
+			} }
+		/>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	values: {
+		topLeft: '10px',
+		topRight: '10px',
+		bottomLeft: '10px',
+		bottomRight: '10px',
+	},
+};
+
+/**
+ * This story demonstrates the control with no initial values.
+ */
+export const NoInitialValues = Template.bind( {} );
+NoInitialValues.args = {
+	values: {},
+};
+
+/**
+ * This story demonstrates the control with mixed values.
+ */
+export const MixedUnits = Template.bind( {} );
+MixedUnits.args = {
+	values: {
+		topLeft: '10px',
+		topRight: '1em',
+		bottomLeft: '20%',
+		bottomRight: '5rem',
+	},
+};

--- a/packages/block-editor/src/components/border-radius-control/stories/index.story.js
+++ b/packages/block-editor/src/components/border-radius-control/stories/index.story.js
@@ -8,10 +8,7 @@ import { useState } from '@wordpress/element';
  */
 import BorderRadiusControl from '../';
 
-/**
- * BorderRadiusControl component allows setting border radius values.
- */
-export default {
+const meta = {
 	title: 'BlockEditor/BorderRadiusControl',
 	component: BorderRadiusControl,
 	parameters: {
@@ -23,13 +20,25 @@ export default {
 		},
 	},
 	argTypes: {
-		values: { control: 'object', description: 'Border radius values.' },
+		values: {
+			control: 'object',
+			description: 'Border radius values.',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
 		onChange: {
 			action: 'onChange',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+			},
 			description: 'Callback to handle onChange.',
 		},
 	},
 };
+
+export default meta;
 
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
@@ -37,6 +46,7 @@ export const Default = {
 
 		return (
 			<BorderRadiusControl
+				{ ...args }
 				values={ values }
 				onChange={ ( ...changeArgs ) => {
 					setValues( ...changeArgs );


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for BorderRadiusControl component in the Storybook.

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the BorderRadiusControl stories.

## Screenshots or screencast

![Screenshot 2024-12-02 at 4 59 34 PM](https://github.com/user-attachments/assets/996d0ff0-1d34-4d47-8106-821cb05c8aa8)




