### PR TITLE
Story Book: Add BlockRenameControl Story

### DIFF
--- a/packages/block-editor/src/components/block-rename/stories/index.story.js
+++ b/packages/block-editor/src/components/block-rename/stories/index.story.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
@@ -15,10 +16,10 @@ export default {
 
 export const Default = {
 	render: function Template( props ) {
-		const [ value, setValue ] = useState( 'New Name' );
+		const [ value, setValue ] = useState( __( 'New Name' ) );
 		return (
 			<BlockRenameControl
-				label="Rename"
+				label={ __( 'Rename' ) }
 				value={ value }
 				onChange={ setValue }
 				{ ...props }

--- a/packages/block-editor/src/components/block-rename/stories/index.story.js
+++ b/packages/block-editor/src/components/block-rename/stories/index.story.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockRenameControl from '../rename-control';
+
+export default {
+	component: BlockRenameControl,
+	title: 'BlockEditor/BlockRenameControl',
+};
+
+export const Default = {
+	render: function Template( props ) {
+		const [ value, setValue ] = useState( 'New Name' );
+		return (
+			<BlockRenameControl
+				label="Rename"
+				value={ value }
+				onChange={ setValue }
+				{ ...props }
+			/>
+		);
+	},
+	args: {
+		__nextHasNoMarginBottom: true,
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Part of https://github.com/WordPress/gutenberg/issues/67165
This PR will add stories for BlockRenameControl components in the Storybook


## Why?
BlockRenameControl don't have stories.

## How?
Adding story for BlockRenameControl

## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the BlockRenameControl stories.
