### PR TITLE
Fix: Caption with Link in Wide-Width and Full-Width Images Appears on two lines

### DIFF
--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -42,8 +42,8 @@
 		text-align: center;
 	}
 
-	&.alignfull a,
-	&.alignwide a {
+	&.alignfull > a,
+	&.alignwide > a {
 		width: 100%;
 	}
 


### PR DESCRIPTION
Currently, if there isa  caption with a link, each link takes a full line instead of keeping on the same line.

The issue was caused at https://github.com/WordPress/gutenberg/pull/62556.
We want the rule added in the PR above to apply to anchors directly descended of the figure image block container but not to anchors in the caption this PR fixes the issue by changing selectors "&.alignfull a" and "&.alignwide a" to  "&.alignfull > a" and "&.alignwide > a" respectively.


## Testing Instructions
Add an image block.
Select an image.
Make the block wide aligned.
Add a caption and include a link in the caption.
Verify the caption is still on a single line (on the trunk it is on two lines).
