### PR TITLE
DataViews: Avoid double click handler on primary fields

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
+++ b/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
@@ -13,13 +13,13 @@ export default function getClickableItemProps< Item >(
 		role: 'button',
 		tabIndex: 0,
 		onClick: ( event: React.MouseEvent ) => {
-			event.preventDefault();
+			// Prevents onChangeSelection from triggering.
 			event.stopPropagation();
 			onClickItem( item );
 		},
 		onKeyDown: ( event: React.KeyboardEvent ) => {
 			if ( event.key === 'Enter' || event.key === '' ) {
-				event.preventDefault();
+				// Prevents onChangeSelection from triggering.
 				event.stopPropagation();
 				onClickItem( item );
 			}

--- a/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
+++ b/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
@@ -12,9 +12,15 @@ export default function getClickableItemProps< Item >(
 		className: `${ className } ${ className }--clickable`,
 		role: 'button',
 		tabIndex: 0,
-		onClick: () => onClickItem( item ),
+		onClick: ( event: React.MouseEvent ) => {
+			event.preventDefault();
+			event.stopPropagation();
+			onClickItem( item );
+		},
 		onKeyDown: ( event: React.KeyboardEvent ) => {
 			if ( event.key === 'Enter' || event.key === '' ) {
+				event.preventDefault();
+				event.stopPropagation();
 				onClickItem( item );
 			}
 		},


### PR DESCRIPTION
Follow up to #67199

## What?

That PR highlighted a hidden bug in DataViews where clicking primary fields triggered both "onClick" handler and "onSelectionChange". This PR prevents that by stopping the propagation of the event.

## Testing Instructions

1- Open the "pages" page in the site editor.
2- Switch to table view.
3- Click on the "title" of a page.
4- You should navigate to the editor.
