### PR TITLE
Fix: Remove parent block selector while in Write mode

### DIFF
--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -44,6 +44,8 @@ export default function BlockParentSelector() {
 			isVisible:
 				_parentClientId &&
 				getBlockEditingMode( _parentClientId ) !== 'disabled' &&
+				getBlockEditingMode( selectedBlockClientId ) !==
+					'contentOnly' &&
 				hasBlockSupport(
 					_parentBlockType,
 					'__experimentalParentSelector',

--- a/packages/block-editor/src/components/block-parent-selector/index.js
+++ b/packages/block-editor/src/components/block-parent-selector/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { getBlockType, store as blocksStore } from '@wordpress/blocks';
 import { ToolbarButton } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
@@ -24,33 +23,18 @@ import { unlock } from '../../lock-unlock';
  */
 export default function BlockParentSelector() {
 	const { selectBlock } = useDispatch( blockEditorStore );
-	const { parentClientId, isVisible } = useSelect( ( select ) => {
+	const { parentClientId } = useSelect( ( select ) => {
 		const {
-			getBlockName,
 			getBlockParents,
 			getSelectedBlockClientId,
-			getBlockEditingMode,
 			getParentSectionBlock,
 		} = unlock( select( blockEditorStore ) );
-		const { hasBlockSupport } = select( blocksStore );
 		const selectedBlockClientId = getSelectedBlockClientId();
 		const parentSection = getParentSectionBlock( selectedBlockClientId );
 		const parents = getBlockParents( selectedBlockClientId );
 		const _parentClientId = parentSection ?? parents[ parents.length - 1 ];
-		const parentBlockName = getBlockName( _parentClientId );
-		const _parentBlockType = getBlockType( parentBlockName );
 		return {
 			parentClientId: _parentClientId,
-			isVisible:
-				_parentClientId &&
-				getBlockEditingMode( _parentClientId ) !== 'disabled' &&
-				getBlockEditingMode( selectedBlockClientId ) !==
-					'contentOnly' &&
-				hasBlockSupport(
-					_parentBlockType,
-					'__experimentalParentSelector',
-					true
-				),
 		};
 	}, [] );
 	const blockInformation = useBlockDisplayInformation( parentClientId );
@@ -62,10 +46,6 @@ export default function BlockParentSelector() {
 		ref: nodeRef,
 		highlightParent: true,
 	} );
-
-	if ( ! isVisible ) {
-		return null;
-	}
 
 	return (
 		<div

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -136,9 +136,8 @@ export function PrivateBlockToolbar( {
 			showParentSelector:
 				! _isZoomOut &&
 				parentBlockType &&
+				editingMode !== 'contentOnly' &&
 				getBlockEditingMode( parentClientId ) !== 'disabled' &&
-				getBlockEditingMode( selectedBlockClientId ) !==
-					'contentOnly' &&
 				hasBlockSupport(
 					parentBlockType,
 					'__experimentalParentSelector',

--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -137,6 +137,8 @@ export function PrivateBlockToolbar( {
 				! _isZoomOut &&
 				parentBlockType &&
 				getBlockEditingMode( parentClientId ) !== 'disabled' &&
+				getBlockEditingMode( selectedBlockClientId ) !==
+					'contentOnly' &&
 				hasBlockSupport(
 					parentBlockType,
 					'__experimentalParentSelector',


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/66684
Fixes: https://github.com/WordPress/gutenberg/issues/65577

Removes the parent selector while in write mode.
cc: @richtabor 

## Testing Instructions
Enable the write mode under experiments.
Change the post to write mode.
Add a pattern e.g: a call to action.
Select a paragraph block and verify the parent selector is not available.