### PR TITLE
Enhance block switcher dropdown with accessible group labels

### DIFF
--- a/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
+++ b/packages/block-editor/src/components/block-switcher/block-transformations-menu.js
@@ -137,7 +137,10 @@ const BlockTransformationsMenu = ( {
 				{ ! hasBothContentTransformations && restTransformItems }
 			</MenuGroup>
 			{ !! hasBothContentTransformations && (
-				<MenuGroup className={ className }>
+				<MenuGroup
+					label={ __( 'Advanced Transformations' ) }
+					className={ className }
+				>
 					{ restTransformItems }
 				</MenuGroup>
 			) }


### PR DESCRIPTION
Fixes: #62931

## What?
This PR updates the block switcher dropdown menu to include a label for the second group, titled "Advanced Transformations." The first group retains the "Transform To" label.

## Why?
The previous design lacked a label for the second group, causing potential confusion for users. Grouping items without clear labeling made the menu less intuitive and accessible. Adding meaningful labels enhances usability and ensures compliance with ARIA menu patterns.

## How?

1. Added "Advanced Transformations" as a label for the second group.
2. Retained the "Transform To" label for the first group to maintain existing functionality.

## Testing Instructions

1. Open the block switcher by selecting a block and clicking the block switcher option in the toolbar.
2. Verify the first group is labeled "Transform To."
3. Confirm the second group is labeled "Advanced Transformations."
4. Inspect the accessibility tree in browser dev tools and ensure both groups have appropriate ARIA labels and role attributes.
5. Check for any visual or functional regressions in the block switcher dropdown.

<!-- ## Screenshots or screencast  if applicable -->
