### PR TITLE
Editor: Refactor 'PostPublishPanelPostpublish' to function component

### DIFF
--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -3,8 +3,8 @@
  */
 import { PanelBody, Button, TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
-import { Component, createRef } from '@wordpress/element';
-import { withSelect } from '@wordpress/data';
+import { useCallback, useEffect, useState, useRef } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
 import { addQueryArgs, safeDecodeURIComponent } from '@wordpress/url';
 import { decodeEntities } from '@wordpress/html-entities';
 import { useCopyToClipboard } from '@wordpress/compose';
@@ -41,142 +41,131 @@ const getFuturePostUrl = ( post ) => {
 	return post.permalink_template;
 };
 
-function CopyButton( { text, onCopy, children } ) {
-	const ref = useCopyToClipboard( text, onCopy );
-	return (
-		<Button __next40pxDefaultSize variant="secondary" ref={ ref }>
-			{ children }
-		</Button>
-	);
-}
+export default function PostPublishPanelPostpublish( {
+	focusOnMount,
+	children,
+} ) {
+	const { post, postType, isScheduled } = useSelect( ( select ) => {
+		const {
+			getEditedPostAttribute,
+			getCurrentPost,
+			isCurrentPostScheduled,
+		} = select( editorStore );
+		const { getPostType } = select( coreStore );
 
-class PostPublishPanelPostpublish extends Component {
-	constructor() {
-		super( ...arguments );
-		this.state = {
-			showCopyConfirmation: false,
+		return {
+			post: getCurrentPost(),
+			postType: getPostType( getEditedPostAttribute( 'type' ) ),
+			isScheduled: isCurrentPostScheduled(),
 		};
-		this.onCopy = this.onCopy.bind( this );
-		this.onSelectInput = this.onSelectInput.bind( this );
-		this.postLink = createRef();
-	}
+	}, [] );
+	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
+	const timeoutIdRef = useRef();
 
-	componentDidMount() {
-		if ( this.props.focusOnMount ) {
-			this.postLink.current.focus();
+	useEffect( () => {
+		return () => {
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
+	}, [] );
+
+	const postLabel = postType?.labels?.singular_name;
+	const viewPostLabel = postType?.labels?.view_item;
+	const addNewPostLabel = postType?.labels?.add_new_item;
+	const link =
+		post.status === 'future' ? getFuturePostUrl( post ) : post.link;
+	const addLink = addQueryArgs( 'post-new.php', {
+		post_type: post.type,
+	} );
+
+	const copyRef = useCopyToClipboard( link, () => {
+		setShowCopyConfirmation( true );
+		if ( timeoutIdRef.current ) {
+			clearTimeout( timeoutIdRef.current );
 		}
-	}
-
-	componentWillUnmount() {
-		clearTimeout( this.dismissCopyConfirmation );
-	}
-
-	onCopy() {
-		this.setState( {
-			showCopyConfirmation: true,
-		} );
-
-		clearTimeout( this.dismissCopyConfirmation );
-		this.dismissCopyConfirmation = setTimeout( () => {
-			this.setState( {
-				showCopyConfirmation: false,
-			} );
+		timeoutIdRef.current = setTimeout( () => {
+			setShowCopyConfirmation( false );
 		}, 4000 );
-	}
+	} );
+	const postLinkRef = useCallback(
+		( node ) => {
+			if ( focusOnMount && node ) {
+				node.focus();
+			}
+		},
+		[ focusOnMount ]
+	);
 
-	onSelectInput( event ) {
-		event.target.select();
-	}
+	const postPublishNonLinkHeader = isScheduled ? (
+		<>
+			{ __( 'is now scheduled. It will go live on' ) }{ ' ' }
+			<PostScheduleLabel />.
+		</>
+	) : (
+		__( 'is now live.' )
+	);
 
-	render() {
-		const { children, isScheduled, post, postType } = this.props;
-		const postLabel = postType?.labels?.singular_name;
-		const viewPostLabel = postType?.labels?.view_item;
-		const addNewPostLabel = postType?.labels?.add_new_item;
-		const link =
-			post.status === 'future' ? getFuturePostUrl( post ) : post.link;
-		const addLink = addQueryArgs( 'post-new.php', {
-			post_type: post.type,
-		} );
-
-		const postPublishNonLinkHeader = isScheduled ? (
-			<>
-				{ __( 'is now scheduled. It will go live on' ) }{ ' ' }
-				<PostScheduleLabel />.
-			</>
-		) : (
-			__( 'is now live.' )
-		);
-
-		return (
-			<div className="post-publish-panel__postpublish">
-				<PanelBody className="post-publish-panel__postpublish-header">
-					<a ref={ this.postLink } href={ link }>
-						{ decodeEntities( post.title ) || __( '(no title)' ) }
-					</a>{ ' ' }
-					{ postPublishNonLinkHeader }
-				</PanelBody>
-				<PanelBody>
-					<p className="post-publish-panel__postpublish-subheader">
-						<strong>{ __( 'What’s next?' ) }</strong>
-					</p>
-					<div className="post-publish-panel__postpublish-post-address-container">
-						<TextControl
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-							className="post-publish-panel__postpublish-post-address"
-							readOnly
-							label={ sprintf(
-								/* translators: %s: post type singular name */
-								__( '%s address' ),
-								postLabel
-							) }
-							value={ safeDecodeURIComponent( link ) }
-							onFocus={ this.onSelectInput }
-						/>
-
-						<div className="post-publish-panel__postpublish-post-address__copy-button-wrap">
-							<CopyButton text={ link } onCopy={ this.onCopy }>
-								{ this.state.showCopyConfirmation
-									? __( 'Copied!' )
-									: __( 'Copy' ) }
-							</CopyButton>
-						</div>
-					</div>
-
-					<div className="post-publish-panel__postpublish-buttons">
-						{ ! isScheduled && (
-							<Button
-								variant="primary"
-								href={ link }
-								__next40pxDefaultSize
-							>
-								{ viewPostLabel }
-							</Button>
+	return (
+		<div className="post-publish-panel__postpublish">
+			<PanelBody className="post-publish-panel__postpublish-header">
+				<a ref={ postLinkRef } href={ link }>
+					{ decodeEntities( post.title ) || __( '(no title)' ) }
+				</a>{ ' ' }
+				{ postPublishNonLinkHeader }
+			</PanelBody>
+			<PanelBody>
+				<p className="post-publish-panel__postpublish-subheader">
+					<strong>{ __( 'What’s next?' ) }</strong>
+				</p>
+				<div className="post-publish-panel__postpublish-post-address-container">
+					<TextControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						className="post-publish-panel__postpublish-post-address"
+						readOnly
+						label={ sprintf(
+							/* translators: %s: post type singular name */
+							__( '%s address' ),
+							postLabel
 						) }
+						value={ safeDecodeURIComponent( link ) }
+						onFocus={ ( event ) => event.target.select() }
+					/>
+
+					<div className="post-publish-panel__postpublish-post-address__copy-button-wrap">
 						<Button
-							variant={ isScheduled ? 'primary' : 'secondary' }
 							__next40pxDefaultSize
-							href={ addLink }
+							variant="secondary"
+							ref={ copyRef }
 						>
-							{ addNewPostLabel }
+							{ showCopyConfirmation
+								? __( 'Copied!' )
+								: __( 'Copy' ) }
 						</Button>
 					</div>
-				</PanelBody>
-				{ children }
-			</div>
-		);
-	}
+				</div>
+
+				<div className="post-publish-panel__postpublish-buttons">
+					{ ! isScheduled && (
+						<Button
+							variant="primary"
+							href={ link }
+							__next40pxDefaultSize
+						>
+							{ viewPostLabel }
+						</Button>
+					) }
+					<Button
+						variant={ isScheduled ? 'primary' : 'secondary' }
+						__next40pxDefaultSize
+						href={ addLink }
+					>
+						{ addNewPostLabel }
+					</Button>
+				</div>
+			</PanelBody>
+			{ children }
+		</div>
+	);
 }
-
-export default withSelect( ( select ) => {
-	const { getEditedPostAttribute, getCurrentPost, isCurrentPostScheduled } =
-		select( editorStore );
-	const { getPostType } = select( coreStore );
-
-	return {
-		post: getCurrentPost(),
-		postType: getPostType( getEditedPostAttribute( 'type' ) ),
-		isScheduled: isCurrentPostScheduled(),
-	};
-} )( PostPublishPanelPostpublish );

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -41,6 +41,34 @@ const getFuturePostUrl = ( post ) => {
 	return post.permalink_template;
 };
 
+function CopyButton( { text } ) {
+	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
+	const timeoutIdRef = useRef();
+	const ref = useCopyToClipboard( text, () => {
+		setShowCopyConfirmation( true );
+		if ( timeoutIdRef.current ) {
+			clearTimeout( timeoutIdRef.current );
+		}
+		timeoutIdRef.current = setTimeout( () => {
+			setShowCopyConfirmation( false );
+		}, 4000 );
+	} );
+
+	useEffect( () => {
+		return () => {
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
+	}, [] );
+
+	return (
+		<Button __next40pxDefaultSize variant="secondary" ref={ ref }>
+			{ showCopyConfirmation ? __( 'Copied!' ) : __( 'Copy' ) }
+		</Button>
+	);
+}
+
 export default function PostPublishPanelPostpublish( {
 	focusOnMount,
 	children,
@@ -59,16 +87,6 @@ export default function PostPublishPanelPostpublish( {
 			isScheduled: isCurrentPostScheduled(),
 		};
 	}, [] );
-	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
-	const timeoutIdRef = useRef();
-
-	useEffect( () => {
-		return () => {
-			if ( timeoutIdRef.current ) {
-				clearTimeout( timeoutIdRef.current );
-			}
-		};
-	}, [] );
 
 	const postLabel = postType?.labels?.singular_name;
 	const viewPostLabel = postType?.labels?.view_item;
@@ -79,15 +97,6 @@ export default function PostPublishPanelPostpublish( {
 		post_type: post.type,
 	} );
 
-	const copyRef = useCopyToClipboard( link, () => {
-		setShowCopyConfirmation( true );
-		if ( timeoutIdRef.current ) {
-			clearTimeout( timeoutIdRef.current );
-		}
-		timeoutIdRef.current = setTimeout( () => {
-			setShowCopyConfirmation( false );
-		}, 4000 );
-	} );
 	const postLinkRef = useCallback(
 		( node ) => {
 			if ( focusOnMount && node ) {
@@ -134,15 +143,7 @@ export default function PostPublishPanelPostpublish( {
 					/>
 
 					<div className="post-publish-panel__postpublish-post-address__copy-button-wrap">
-						<Button
-							__next40pxDefaultSize
-							variant="secondary"
-							ref={ copyRef }
-						>
-							{ showCopyConfirmation
-								? __( 'Copied!' )
-								: __( 'Copy' ) }
-						</Button>
+						<CopyButton text={ link } />
 					</div>
 				</div>
 


### PR DESCRIPTION
## What?
Part of #22890.

PR refactors the `PostPublishPanelPostpublish` class into a function component and replaces data HOC use with hooks.

## Why?
React now labels class Components as legacy API.

## Testing Instructions
1. Ensure you have "Enable pre-publish checks" enabled.
2. Publish a draft post.
3. Confirm that the post-publish panel is rendered correctly.
4. Confirm that the post title link receives focus.
5. Smoke test the URL copy button. Its label should switch between copy and copied states.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-11-28 at 19 27 09](https://github.com/user-attachments/assets/f593a3f4-5cb2-4cd1-9949-291e88340300)