### PR TITLE
Components: Fix the 'ClipboardButton' effect cleanup

### DIFF
--- a/packages/components/src/clipboard-button/index.tsx
+++ b/packages/components/src/clipboard-button/index.tsx
@@ -45,9 +45,11 @@ export default function ClipboardButton( {
 	} );
 
 	useEffect( () => {
-		if ( timeoutIdRef.current ) {
-			clearTimeout( timeoutIdRef.current );
-		}
+		return () => {
+			if ( timeoutIdRef.current ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
 	}, [] );
 
 	const classes = clsx( 'components-clipboard-button', className );


### PR DESCRIPTION
## What?
PR fixes the effect in the `ClipboardButton` component to cancel the timeout when it is unmounted instead of when it is mounted.

## Testing Instructions
None. It's a straightforward fix.
