### PR TITLE
Fix: Fixed Position Toggle Button Not Taking Full Height

### DIFF
--- a/packages/block-editor/src/hooks/position.js
+++ b/packages/block-editor/src/hooks/position.js
@@ -287,6 +287,7 @@ export function PositionPanelPure( {
 								onChangeType( selectedItem.value );
 							} }
 							size="__unstable-large"
+							isLegacy={ false }
 						/>
 					</BaseControl>
 				</InspectorControls>

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -63,6 +63,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		value,
 		className: classNameProp,
 		showSelectedHint = false,
+		isLegacy = true,
 		...restProps
 	} = useDeprecatedProps( props );
 
@@ -189,7 +190,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 					'components-custom-select-control',
 					classNameProp
 				) }
-				isLegacy
+				isLegacy={ isLegacy }
 				{ ...restProps }
 			>
 				{ children }

--- a/packages/components/src/custom-select-control/types.ts
+++ b/packages/components/src/custom-select-control/types.ts
@@ -120,4 +120,13 @@ export type CustomSelectProps< T extends CustomSelectOption > = {
 	 * @default false
 	 */
 	__next40pxDefaultSize?: boolean;
+	/**
+	 * Enables legacy behavior for the custom select dropdown.
+	 *
+	 * When set to `true`, the dropdown will follow the legacy implementation, including
+	 * positioning and interaction styles. Set to `false` to use the updated behavior.
+	 *
+	 * @default true
+	 */
+	isLegacy?: boolean;
 };


### PR DESCRIPTION
resolves #67401

## What?
This PR adds a prop to `CustomSelectControl` to disable the legacy behavior and enable the new behavior of custom-select-v2. The new behavior, which includes flipping the dropdown, fixes the issue.

## Why?
In the WordPress block editor, the “Position” toggle button options in the Group block settings do not take up the full height of the settings panel. This causes a visual inconsistency, as users are required to scroll to see the full options.

## How?
This PR introduces a new prop to `CustomSelectControl` that enables the new dropdown flipping behavior when there isn’t enough space below. It also adds the isLegacy={false} prop in the position support of the inspector. The custom `isLegacy` prop in `CustomSelectControl` defaults to true to preserve the original behavior by default.

## Testing Instructions

1. Open the WordPress block editor.
2. Add a “Group” block to the page.
3. Select the “Group” block.
4. In the block settings panel on the right, locate the “Position” toggle button.
5. Observe that the “Position” toggle options do not extend to fill the full height of the settings panel.
6. Attempt to interact with the toggle options

## Screencast 

https://github.com/user-attachments/assets/c3db38e7-12c6-407d-af10-6a59009b046d

