### PR TITLE
Update @ariakit/react to 0.4.15 and @ariakit/test to 0.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
 				"@actions/core": "1.9.1",
 				"@actions/github": "5.0.0",
 				"@apidevtools/json-schema-ref-parser": "11.6.4",
-				"@ariakit/test": "^0.4.5",
 				"@babel/core": "7.25.7",
 				"@babel/plugin-syntax-jsx": "7.25.7",
 				"@babel/runtime-corejs3": "7.25.7",
@@ -1431,40 +1430,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
-		},
-		"node_modules/@ariakit/test": {
-			"version": "0.4.5",
-			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.4.5.tgz",
-			"integrity": "sha512-dK9OtI8MeKfdtOiW1auDITnyaelq0O0aUTnolIqJj+RJd8LFai0gi7fQUgrun9CZHJ2wWsEad4vlviGfhfIIhQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@ariakit/core": "0.4.12",
-				"@testing-library/dom": "^8.0.0 || ^9.0.0 || ^10.0.0"
-			},
-			"peerDependencies": {
-				"@playwright/test": "^1.27.0",
-				"@testing-library/react": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			},
-			"peerDependenciesMeta": {
-				"@playwright/test": {
-					"optional": true
-				},
-				"@testing-library/react": {
-					"optional": true
-				},
-				"react": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@ariakit/test/node_modules/@ariakit/core": {
-			"version": "0.4.12",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.12.tgz",
-			"integrity": "sha512-+NNpy88tdP/w9mOBPuDrMTbtapPbo/8yVIzpQB7TAmN0sPh/Cq3nU1f2KCTCIujPmwRvAcMSW9UHOlFmbKEPOA==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/@aw-web-design/x-default-browser": {
 			"version": "1.4.126",
@@ -49342,15 +49307,6 @@
 				"react": "^17.0.0"
 			}
 		},
-		"node_modules/use-sync-external-store": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-			"integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
-			"license": "MIT",
-			"peerDependencies": {
-				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
-			}
-		},
 		"node_modules/userhome": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
@@ -53681,7 +53637,6 @@
 			"version": "28.13.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.13",
 				"@babel/runtime": "7.25.7",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -53734,44 +53689,6 @@
 			"peerDependencies": {
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
-			}
-		},
-		"packages/components/node_modules/@ariakit/core": {
-			"version": "0.4.12",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.12.tgz",
-			"integrity": "sha512-+NNpy88tdP/w9mOBPuDrMTbtapPbo/8yVIzpQB7TAmN0sPh/Cq3nU1f2KCTCIujPmwRvAcMSW9UHOlFmbKEPOA==",
-			"license": "MIT"
-		},
-		"packages/components/node_modules/@ariakit/react": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.13.tgz",
-			"integrity": "sha512-pTGYgoqCojfyt2xNJ5VQhejxXwwtcP7VDDqcnnVChv7TA2TWWyYerJ5m4oxViI1pgeNqnHZwKlQ79ZipF7W2kQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@ariakit/react-core": "0.4.13"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ariakit"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"packages/components/node_modules/@ariakit/react-core": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.13.tgz",
-			"integrity": "sha512-iIjQeupP9d0pOubOzX4a0UPXbhXbp0ZCduDpkv7+u/pYP/utk/YRECD0M/QpZr6YSeltmDiNxKjdyK8r9Yhv4Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@ariakit/core": "0.4.12",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"packages/components/node_modules/@floating-ui/react-dom": {
@@ -54051,7 +53968,6 @@
 			"version": "4.9.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@ariakit/react": "^0.4.13",
 				"@babel/runtime": "7.25.7",
 				"@wordpress/components": "*",
 				"@wordpress/compose": "*",
@@ -54071,44 +53987,6 @@
 			},
 			"peerDependencies": {
 				"react": "^18.0.0"
-			}
-		},
-		"packages/dataviews/node_modules/@ariakit/core": {
-			"version": "0.4.12",
-			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.12.tgz",
-			"integrity": "sha512-+NNpy88tdP/w9mOBPuDrMTbtapPbo/8yVIzpQB7TAmN0sPh/Cq3nU1f2KCTCIujPmwRvAcMSW9UHOlFmbKEPOA==",
-			"license": "MIT"
-		},
-		"packages/dataviews/node_modules/@ariakit/react": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.13.tgz",
-			"integrity": "sha512-pTGYgoqCojfyt2xNJ5VQhejxXwwtcP7VDDqcnnVChv7TA2TWWyYerJ5m4oxViI1pgeNqnHZwKlQ79ZipF7W2kQ==",
-			"license": "MIT",
-			"dependencies": {
-				"@ariakit/react-core": "0.4.13"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/ariakit"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"packages/dataviews/node_modules/@ariakit/react-core": {
-			"version": "0.4.13",
-			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.13.tgz",
-			"integrity": "sha512-iIjQeupP9d0pOubOzX4a0UPXbhXbp0ZCduDpkv7+u/pYP/utk/YRECD0M/QpZr6YSeltmDiNxKjdyK8r9Yhv4Q==",
-			"license": "MIT",
-			"dependencies": {
-				"@ariakit/core": "0.4.12",
-				"@floating-ui/dom": "^1.0.0",
-				"use-sync-external-store": "^1.2.0"
-			},
-			"peerDependencies": {
-				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
 			}
 		},
 		"packages/date": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
 				"@actions/core": "1.9.1",
 				"@actions/github": "5.0.0",
 				"@apidevtools/json-schema-ref-parser": "11.6.4",
+				"@ariakit/test": "^0.4.7",
 				"@babel/core": "7.25.7",
 				"@babel/plugin-syntax-jsx": "7.25.7",
 				"@babel/runtime-corejs3": "7.25.7",
@@ -1429,6 +1430,71 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@ariakit/core": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/@ariakit/core/-/core-0.4.14.tgz",
+			"integrity": "sha512-hpzZvyYzGhP09S9jW1XGsU/FD5K3BKsH1eG/QJ8rfgEeUdPS7BvHPt5lHbOeJ2cMrRzBEvsEzLi1ivfDifHsVA==",
+			"license": "MIT"
+		},
+		"node_modules/@ariakit/react": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/@ariakit/react/-/react-0.4.15.tgz",
+			"integrity": "sha512-0V2LkNPFrGRT+SEIiObx/LQjR6v3rR+mKEDUu/3tq7jfCZ+7+6Q6EMR1rFaK+XMkaRY1RWUcj/rRDWAUWnsDww==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/react-core": "0.4.15"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/ariakit"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/react-core": {
+			"version": "0.4.15",
+			"resolved": "https://registry.npmjs.org/@ariakit/react-core/-/react-core-0.4.15.tgz",
+			"integrity": "sha512-Up8+U97nAPJdyUh9E8BCEhJYTA+eVztWpHoo1R9zZfHd4cnBWAg5RHxEmMH+MamlvuRxBQA71hFKY/735fDg+A==",
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.14",
+				"@floating-ui/dom": "^1.0.0",
+				"use-sync-external-store": "^1.2.0"
+			},
+			"peerDependencies": {
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+				"react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			}
+		},
+		"node_modules/@ariakit/test": {
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/@ariakit/test/-/test-0.4.7.tgz",
+			"integrity": "sha512-Zb5bnulzYGjr6sDubxOeOhk5Es6BYQq5lbcIe8xNrWUlpRiHsje/FlXNFpHnI92/7ESxH6X4pHhbb+qFAho1lw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ariakit/core": "0.4.14",
+				"@testing-library/dom": "^8.0.0 || ^9.0.0 || ^10.0.0"
+			},
+			"peerDependencies": {
+				"@playwright/test": "^1.27.0",
+				"@testing-library/react": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+				"react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@playwright/test": {
+					"optional": true
+				},
+				"@testing-library/react": {
+					"optional": true
+				},
+				"react": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@aw-web-design/x-default-browser": {
@@ -49307,6 +49373,15 @@
 				"react": "^17.0.0"
 			}
 		},
+		"node_modules/use-sync-external-store": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+			"integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+			"license": "MIT",
+			"peerDependencies": {
+				"react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+			}
+		},
 		"node_modules/userhome": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/userhome/-/userhome-1.0.0.tgz",
@@ -53637,6 +53712,7 @@
 			"version": "28.13.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@ariakit/react": "^0.4.15",
 				"@babel/runtime": "7.25.7",
 				"@emotion/cache": "^11.7.1",
 				"@emotion/css": "^11.7.1",
@@ -53968,6 +54044,7 @@
 			"version": "4.9.0",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
+				"@ariakit/react": "^0.4.15",
 				"@babel/runtime": "7.25.7",
 				"@wordpress/components": "*",
 				"@wordpress/compose": "*",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
 		"@actions/core": "1.9.1",
 		"@actions/github": "5.0.0",
 		"@apidevtools/json-schema-ref-parser": "11.6.4",
-		"@ariakit/test": "^0.4.5",
 		"@babel/core": "7.25.7",
 		"@babel/plugin-syntax-jsx": "7.25.7",
 		"@babel/runtime-corejs3": "7.25.7",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@actions/core": "1.9.1",
 		"@actions/github": "5.0.0",
 		"@apidevtools/json-schema-ref-parser": "11.6.4",
+		"@ariakit/test": "^0.4.7",
 		"@babel/core": "7.25.7",
 		"@babel/plugin-syntax-jsx": "7.25.7",
 		"@babel/runtime-corejs3": "7.25.7",

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Internal
 
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
+-   Upgraded `@ariakit/react` (v0.4.15) and `@ariakit/test` (v0.4.7) ([#67404](https://github.com/WordPress/gutenberg/pull/67404)).
 
 ## 28.13.0 (2024-11-27)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,6 +32,7 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
+		"@ariakit/react": "^0.4.15",
 		"@babel/runtime": "7.25.7",
 		"@emotion/cache": "^11.7.1",
 		"@emotion/css": "^11.7.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -32,7 +32,6 @@
 		"src/**/*.scss"
 	],
 	"dependencies": {
-		"@ariakit/react": "^0.4.13",
 		"@babel/runtime": "7.25.7",
 		"@emotion/cache": "^11.7.1",
 		"@emotion/css": "^11.7.1",

--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## Internal
+
+-   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
+-   Upgraded `@ariakit/react` (v0.4.15) and `@ariakit/test` (v0.4.7) ([#67404](https://github.com/WordPress/gutenberg/pull/67404)).
+
 ## 4.9.0 (2024-11-27)
 
 ### Bug Fixes

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -43,6 +43,7 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
+		"@ariakit/react": "^0.4.15",
 		"@babel/runtime": "7.25.7",
 		"@wordpress/components": "*",
 		"@wordpress/compose": "*",

--- a/packages/dataviews/package.json
+++ b/packages/dataviews/package.json
@@ -43,7 +43,6 @@
 	"types": "build-types",
 	"sideEffects": false,
 	"dependencies": {
-		"@ariakit/react": "^0.4.13",
 		"@babel/runtime": "7.25.7",
 		"@wordpress/components": "*",
 		"@wordpress/compose": "*",


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

- Update `@ariakit/react` from version `0.4.13` to `0.4.15`
- Update `@ariakit/test` from version `0.4.5` to `0.4.7`

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Using the latest available version of ariakit allows the project to enjoy the latest features and bug fixes;
- Doing so frequently allows us to have leaner updates and fewer changes to test

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Updated the various `package.json` files, remove all references to the target dependencies
- Ran `npm cache clean --force && npm run distclean && npm install` to update the `package-lock.json` file
- Updated the various `package.json` files, re-adding the target dependencies with the latest versions
- Ran `npm cache clean --force && npm run distclean && npm install` to update the `package-lock.json` file
- Removed any existing workarounds that are now fixed at the ariakit level

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Smoke test ariakit-powered components Storybook and the editor: `Composite`, `Tabs`, `TabPanel`, `DropdownMenuV2`, `CustomSelectControl`, `Toolbar`, `Disclosure`, `Divider`, `RadioGroup`, `ToggleGroupControl`, `Tooltip`
- Smoke test dataviews UI using ariakit 

Looking at the release notes, I couldn't find any entry in particular that could affect directly our components.

### Full changelog
<details>

<summary>`@ariakit/react` release notes</summary>

#### 0.4.15

- Fixed a regression on [Hovercard](https://ariakit.org/components/hovercard) that sometimes prevented it from closing when other popups were opened.
- Fixed typings for [`onSubmit`](https://ariakit.org/reference/use-form-store#onsubmit) and [`onValidate`](https://ariakit.org/reference/use-form-store#onvalidate).
- Improved JSDocs.
- Updated dependencies: `@ariakit/react-core@0.4.15`

#### 0.4.14

##### Improved performance on composite widgets

Composite item components such as [`ComboboxItem`](https://ariakit.org/reference/combobox-item) and [`SelectItem`](https://ariakit.org/reference/select-item) now render 20-30% faster compared to Ariakit v0.4.13.

This enhancement should decrease the time needed to render large collections of items in composite widgets and improve the Interaction to Next Paint (INP) metric. We're working on further optimizations to make composite widgets even faster in future releases.

##### Combobox auto-scroll

The [`Combobox`](https://ariakit.org/reference/combobox) component now scrolls the list to the top while typing when the [`autoSelect`](https://ariakit.org/reference/combobox#autoselect) prop is disabled.

The behavior is now consistent with the [`autoSelect`](https://ariakit.org/reference/combobox#autoselect) prop, except the first item won't be automatically focused.

##### Other updates

- Fixed the [`item`](https://ariakit.org/reference/use-collection-store#item) method to prevent it from returning items that have been removed from the collection store.
- Fixed the [`item`](https://ariakit.org/reference/use-menu-store#item) method when keeping different menu stores in sync.
- Added [`id`](https://ariakit.org/reference/use-composite-store#id) prop to composite stores.
- Fixed composite typeahead functionality when rendering virtualized lists.
- Fixed [`SelectValue`](https://ariakit.org/reference/select-value) to display the [`fallback`](https://ariakit.org/reference/select-value#fallback) when the value is an empty array or string.
- Fixed an issue where composite widgets might not navigate to the correct item when pressing <kbd>↑</kbd> while the composite base element was focused.
- Improved JSDocs.
- Updated dependencies: `@ariakit/react-core@0.4.14`

</details>

<details>

<summary>`@ariakit/test` release notes</summary>

#### 0.4.7

- Updated dependencies: `@ariakit/core@0.4.14`

#### 0.4.6

- Updated dependencies: `@ariakit/core@0.4.13`

</details>

