### PR TITLE
Drag and drop: fix scroll disorientation after drop

### DIFF
--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -52,6 +52,7 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 		isFirstMultiSelectedBlock,
 		isBlockMultiSelected,
 		isAncestorMultiSelected,
+		isDraggingBlocks,
 	} = useSelect( blockEditorStore );
 
 	// Whenever the trigger changes, we need to take a snapshot of the current
@@ -94,12 +95,10 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 		const disableAnimation =
 			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ||
 			isTyping() ||
+			isDraggingBlocks() ||
 			getGlobalBlockCount() > BLOCK_ANIMATION_THRESHOLD;
 
 		if ( disableAnimation ) {
-			// If the animation is disabled and the scroll needs to be adjusted,
-			// just move directly to the final scroll position.
-			preserveScrollPosition();
 			return;
 		}
 
@@ -153,6 +152,7 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 		isFirstMultiSelectedBlock,
 		isBlockMultiSelected,
 		isAncestorMultiSelected,
+		isDraggingBlocks,
 	] );
 
 	return ref;

--- a/packages/block-editor/src/components/use-moving-animation/index.js
+++ b/packages/block-editor/src/components/use-moving-animation/index.js
@@ -86,6 +86,11 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 			}
 		}
 
+		// Neither animate nor scroll.
+		if ( isDraggingBlocks() ) {
+			return;
+		}
+
 		// We disable the animation if the user has a preference for reduced
 		// motion, if the user is typing (insertion by Enter), or if the block
 		// count exceeds the threshold (insertion caused all the blocks that
@@ -95,10 +100,12 @@ function useMovingAnimation( { triggerAnimationOnChange, clientId } ) {
 		const disableAnimation =
 			window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches ||
 			isTyping() ||
-			isDraggingBlocks() ||
 			getGlobalBlockCount() > BLOCK_ANIMATION_THRESHOLD;
 
 		if ( disableAnimation ) {
+			// If the animation is disabled and the scroll needs to be adjusted,
+			// just move directly to the final scroll position.
+			preserveScrollPosition();
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes disorienting scrolling after dropping a dragged block. See #67303.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Disable the block moving scroll animation and scroll.

After:

![drag-scroll-fix](https://github.com/user-attachments/assets/7835c377-67ab-4a1e-9e15-78289e91f45f)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

* Drag blocks from one end of the demo page to the other.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
