### PR TITLE
Fix misc type compilation errors in editor and block editor packages

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -20,6 +20,7 @@
 
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
 -   Upgraded `@ariakit/react` (v0.4.15) and `@ariakit/test` (v0.4.7) ([#67404](https://github.com/WordPress/gutenberg/pull/67404)).
+-   Exported the `WPCompleter` type as it was being used in block-editor/autocompleters ([#67410](https://github.com/WordPress/gutenberg/pull/67410)).
 
 ### Bug Fixes
 

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -108,6 +108,7 @@ export { Heading as __experimentalHeading } from './heading';
 export { HStack as __experimentalHStack } from './h-stack';
 export { default as Icon } from './icon';
 export type { IconType } from './icon';
+export type { WPCompleter } from './autocomplete/types.ts';
 export { default as IconButton } from './button/deprecated';
 export {
 	ItemGroup as __experimentalItemGroup,

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1462,11 +1462,11 @@ Wrapper component that renders its children only if the post can trashed.
 _Parameters_
 
 -   _props_ `Object`: - The component props.
--   _props.children_ `React.ReactEl`: - The child components to render.
+-   _props.children_ `React.ReactNode`: - The child components to render.
 
 _Returns_
 
--   `React.ReactElement`: The rendered child components or null if the post can not trashed.
+-   `React.ReactNode`: The rendered child components or null if the post can not trashed.
 
 ### PostTypeSupportCheck
 
@@ -1494,7 +1494,8 @@ _Usage_
 
 _Parameters_
 
--   _onClose_ `Function`: Callback function to be executed when the popover is closed.
+-   _props_ `{ onClose: () => void }`: The props for the component.
+-   _props.onClose_ `() => void`: Callback function to be executed when the popover is closed.
 
 _Returns_
 

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -13,10 +13,10 @@ import { GLOBAL_POST_TYPES } from '../../store/constants';
 /**
  * Wrapper component that renders its children only if the post can trashed.
  *
- * @param {Object}        props          - The component props.
- * @param {React.ReactEl} props.children - The child components to render.
+ * @param {Object}          props          - The component props.
+ * @param {React.ReactNode} props.children - The child components to render.
  *
- * @return {React.ReactElement} The rendered child components or null if the post can not trashed.
+ * @return {React.ReactNode} The rendered child components or null if the post can not trashed.
  */
 export default function PostTrashCheck( { children } ) {
 	const { canTrashPost } = useSelect( ( select ) => {

--- a/packages/editor/src/components/post-url/index.js
+++ b/packages/editor/src/components/post-url/index.js
@@ -32,7 +32,8 @@ import { store as editorStore } from '../../store';
  * <PostURL />
  * ```
  *
- * @param {Function} onClose Callback function to be executed when the popover is closed.
+ * @param {{ onClose: () => void }} props         The props for the component.
+ * @param {() => void}              props.onClose Callback function to be executed when the popover is closed.
  *
  * @return {React.ReactNode} The rendered PostURL component.
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? How?

I noticed while working on https://github.com/WordPress/gutenberg/pull/67406 there were some typing errors locally.

Some of the JS Docs type annotations weren't quite right. Updated.

Also, `WPCompleter` was used in the block editor package for autocompleters, but it wasn't exported. So I exported it YOLO style.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->


## Testing Instructions

Build should pass as expected