### PR TITLE
resolve avatar block alignment issue.

### DIFF
--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -2,8 +2,16 @@
 	width: 100%;
 }
 
-.wp-block-avatar.aligncenter {
+.wp-block-avatar.aligncenter,
+.wp-block[data-align="center"] .wp-block-avatar__link > .wp-block-avatar,
+.wp-block[data-align="center"] > .wp-block-avatar {
 	.components-resizable-box__container {
 		margin: 0 auto;
+	}
+}
+
+.wp-block-avatar.alignright {
+	.components-resizable-box__container {
+		float: right;
 	}
 }


### PR DESCRIPTION
## What?
Resolve the mentioned issue of :- #56706
This pull request resolves an issue where the Avatar block is not properly center-aligned in the editor when the "Link to user profile" option is enabled. The alignment issue primarily affects themes like Twenty Seventeen, Twenty Nineteen, Twenty Sixteen, and Twenty Twenty-One. However, the alignment works as expected in Twenty Twenty-Two and Twenty Twenty-Three.

## why
The problem occurs because the necessary CSS styles to center the Avatar block are missing in the editor. This leads to inconsistent alignment behavior across themes when the block is center-aligned. Since this is an editor-side issue, the fix must first be implemented in the Gutenberg plugin to ensure proper alignment before checking for any related issues in the core.

## Testing Instructions
**Setup:**
Use one of the affected themes: Twenty Seventeen, Twenty Nineteen, Twenty Sixteen, or Twenty Twenty-One.
Ensure the Gutenberg plugin is activated.

**Steps to Reproduce:**
Add an Avatar Block to a post or page in the editor.
Enable the "Link to user profile" option in the block settings.
Center-align the Avatar block using the alignment controls in the block toolbar.

**Expected Behavior:**
The Avatar block should appear centered in both the editor and the frontend.
The alignment issue should no longer persist across affected themes.

**Additional Verification:**
Repeat the same steps with themes like Twenty Twenty-Two and Twenty Twenty-Three to confirm that the fix does not introduce any regressions in themes where the alignment already works correctly.