### PR TITLE
Fix: Styles section does not moves stylebook to typography.

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -89,6 +89,11 @@ const scrollToSection = ( anchorId, iframe ) => {
  */
 const getStyleBookNavigationFromPath = ( path ) => {
 	if ( path && typeof path === 'string' ) {
+		if ( path.startsWith( '/typography' ) ) {
+			return {
+				block: 'typography',
+			};
+		}
 		let block = path.includes( '/blocks/' )
 			? decodeURIComponent( path.split( '/blocks/' )[ 1 ] )
 			: null;


### PR DESCRIPTION
Fixes an issue where the styles section does not move the stylebook to the typography section as happens on the color and blocks section.
Follow up to https://github.com/WordPress/gutenberg/pull/65619

## Testing Instructions
Open the styles section in the styles section /wp-admin/site-editor.php?p=%2Fstyles
Select style book as the preview.
Navigate to the paragraph block styles.
Verify the style book moved to the paragraph automatically.
Navigate back and go to the typography styles.
Verify the style book moved to the typography section automatically. (on trunk it does not)
