### PR TITLE
FontFamilyControl: Restore margin bottom

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { CustomSelectControl } from '@wordpress/components';
@@ -18,6 +23,7 @@ export default function FontFamilyControl( {
 	value = '',
 	onChange,
 	fontFamilies,
+	className,
 	...props
 } ) {
 	const [ blockLevelFontFamilies ] = useSettings( 'typography.fontFamilies' );
@@ -59,6 +65,9 @@ export default function FontFamilyControl( {
 			value={ value }
 			onChange={ ( { selectedItem } ) => onChange( selectedItem.key ) }
 			options={ options }
+			className={ clsx( 'block-editor-font-family-control', className, {
+				'is-next-has-no-margin-bottom': __nextHasNoMarginBottom,
+			} ) }
 			{ ...props }
 		/>
 	);

--- a/packages/block-editor/src/components/font-family/style.scss
+++ b/packages/block-editor/src/components/font-family/style.scss
@@ -1,0 +1,5 @@
+.block-editor-font-family-control {
+	&:not(.is-next-has-no-margin-bottom) {
+		margin-bottom: $grid-unit-10;
+	}
+}

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -28,6 +28,7 @@
 @import "./components/date-format-picker/style.scss";
 @import "./components/duotone-control/style.scss";
 @import "./components/font-appearance-control/style.scss";
+@import "./components/font-family/style.scss";
 @import "./components/global-styles/style.scss";
 @import "./components/grid/style.scss";
 @import "./components/height-control/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Restores the default bottom margin in FontFamilyControl, which regressed in #67118.

## Why?

I failed to notice that the changes in #67118 removed the default bottom margin that is still in the deprecation grace period. Because `CustomSelectControl` is not built with `BaseControl` and thus won't receive an automatic margin when used normally in the Block Inspector (#65191), it is relatively likely to visibly break.

## Testing Instructions

See Storybook for the FontFamilyControl, and enable the margin checker in the toolbar. Toggle the `__nextHasNoMarginBottom` prop.

https://github.com/user-attachments/assets/284ecf5f-8aae-4bd8-9439-fff668f24500


