### PR TITLE
Remove one occurrence of incorrect usage of ItemGroup.

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -300,13 +300,11 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						/>
 					) }
 				</ItemGroup>
-				<ItemGroup>
-					<Text variant="muted">
-						{ __(
-							'Attributes connected to custom fields or other dynamic data.'
-						) }
-					</Text>
-				</ItemGroup>
+				<Text as="p" variant="muted">
+					{ __(
+						'Attributes connected to custom fields or other dynamic data.'
+					) }
+				</Text>
 			</ToolsPanel>
 		</InspectorControls>
 	);

--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -300,10 +300,16 @@ export const BlockBindingsPanel = ( { name: blockName, metadata } ) => {
 						/>
 					) }
 				</ItemGroup>
-				<Text as="p" variant="muted">
-					{ __(
-						'Attributes connected to custom fields or other dynamic data.'
-					) }
+				{ /*
+					Use a div element to make the ToolsPanelHiddenInnerWrapper
+					toggle the visibility of this help text automatically.
+				*/ }
+				<Text as="div" variant="muted">
+					<p>
+						{ __(
+							'Attributes connected to custom fields or other dynamic data.'
+						) }
+					</p>
 				</Text>
 			</ToolsPanel>
 		</InspectorControls>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/issues/67425

## What?
<!-- In a few words, what is the PR actually doing? -->
The `<ItemGroup>` component should only contain `<Item>` sub-components as it's intended to render a `list` with `listitems`. This quick PR removes one incorrect usage.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
`<ItemGroup>` should be used correctly, according to the documentation, only to render a list with listitems, i.e. a semantically and logically grouped set of items.
It must not be used only for visual purposes.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Use a paraagraph instead of an `<ItemGroup>`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Register a post meta to be usd for the Bindings API. For example, add this snippet fo your theme's functions.php

```
add_action( 'init', 'test_block_bindings' );

function test_block_bindings() {
	register_meta(
		'post',
		'text_short',
		array(
			'label'             => __( 'Genre' ),
			'show_in_rest'      => true,
			'single'            => true,
			'type'              => 'string',
			'sanitize_callback' => 'wp_strip_all_tags',
			'default'           => 'Some text for a Paragraph',
		)
	);
}
```

- Edit a post and select a Paragraph block.
- In the Settings panel, click the 'Attributes options' plus icon button at the right of 'Attributes'
- Add the `content` attribute.
- Observe the text `Attributes connected to custom fields or other dynamic data.` is now rendered within a paragraph element and it's not wrapped within a div with `role=list` any longer.
- Observe there are no relevant visual changes compared with trunk.



### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-11-29 at 15 40 42](https://github.com/user-attachments/assets/88b2ed6c-87d5-4ecf-bf48-e6da7193c0c2)
