### PR TITLE
Enhance: Add icon for layout along side label in Dropdown

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -23,6 +23,7 @@ import {
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
 	BaseControl,
+	Icon,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
@@ -68,6 +69,7 @@ function ViewTypeMenu( {
 	const activeView = VIEW_LAYOUTS.find( ( v ) => view.type === v.type );
 	return (
 		<Menu
+			className="view-actions-available-menu"
 			trigger={
 				<Button
 					size="compact"
@@ -83,10 +85,18 @@ function ViewTypeMenu( {
 				}
 				return (
 					<Menu.RadioItem
+						suffix={
+							<Icon
+								size={ 24 }
+								icon={ config?.icon }
+								aria-label={ __( 'Layout' ) }
+							/>
+						}
 						key={ layout }
 						value={ layout }
 						name="view-actions-available-view"
 						checked={ layout === view.type }
+						className="view-actions-available-view-item"
 						hideOnClick
 						onChange={ ( e: ChangeEvent< HTMLInputElement > ) => {
 							switch ( e.target.value ) {

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -67,3 +67,8 @@
 		top: unset;
 	}
 }
+
+.view-actions-available-menu .view-actions-available-view-item {
+	cursor: pointer;
+}
+


### PR DESCRIPTION
attempt to resolve #67418,
This PR is just for exploring the issue. 

## What?
This PR adds icons alongside the layout dropdown to indicate the icon for opening the dropdown.

## Why?
Currently, users can change the DataView layout through an icon that updates whenever the layout changes. However, if users don’t notice the icon change (e.g., switching from Table View to ListView), they might struggle to find the layout entry point again since the icon is now different.

## How?
This PR implements Option 2 as described in the issue. It adds the icons for each layout type next to the dropdown labels, ensuring users are aware of the icons and their meaning.

## Testing Instructions

1. Navigate to the Site Editor.
2. Click the `Layout` button and change the view from the dropdown.
3. Observe that the Layout button icon updates accordingly after the view is changed.

## Screenshots

![image](https://github.com/user-attachments/assets/becfb4a3-9700-42f7-826f-ee4dcd517ed4)
![image](https://github.com/user-attachments/assets/ffe184b8-c7c8-4716-be4e-501e9e7a4c1b)
![image](https://github.com/user-attachments/assets/d33d068a-e2fa-49e0-a698-caeb998e7f91)



