### PR TITLE
Drag and drop: fix misplaced drop indicator

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -131,22 +131,21 @@ function BlockPopoverInbetween( {
 						? previousRect.height
 						: nextRect.height;
 
+					if ( previousRect && nextRect ) {
+						width = nextRect.left - previousRect.right;
+						// Avoid a negative width when the next rect is on
+						// the next line.
+						width = Math.max( width, 0 );
+					}
+
 					if ( isRTL() ) {
 						// non vertical, rtl
 						left = nextRect ? nextRect.right : previousRect.left;
-						width =
-							previousRect && nextRect
-								? previousRect.left - nextRect.right
-								: 0;
 					} else {
 						// non vertical, ltr
 						left = previousRect
 							? previousRect.right
 							: nextRect.left;
-						width =
-							previousRect && nextRect
-								? nextRect.left - previousRect.right
-								: 0;
 					}
 				}
 

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -131,22 +131,27 @@ function BlockPopoverInbetween( {
 						? previousRect.height
 						: nextRect.height;
 
-					if ( previousRect && nextRect ) {
-						width = nextRect.left - previousRect.right;
-						// Avoid a negative width when the next rect is on
-						// the next line.
-						width = Math.max( width, 0 );
-					}
-
 					if ( isRTL() ) {
 						// non vertical, rtl
 						left = nextRect ? nextRect.right : previousRect.left;
+						width =
+							previousRect && nextRect
+								? previousRect.left - nextRect.right
+								: 0;
 					} else {
 						// non vertical, ltr
 						left = previousRect
 							? previousRect.right
 							: nextRect.left;
+						width =
+							previousRect && nextRect
+								? nextRect.left - previousRect.right
+								: 0;
 					}
+
+					// Avoid a negative width which happens when the next rect
+					// is on the next line.
+					width = Math.max( width, 0 );
 				}
 
 				return new window.DOMRect( left, top, width, height );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

|Before|After|
|-|-|
|<img width="1352" alt="image" src="https://github.com/user-attachments/assets/25d2957d-599f-4e83-b5dd-8617770934b3">|<img width="1352" alt="image" src="https://github.com/user-attachments/assets/25b09b6f-f971-4c35-9e0d-32ffac38a8b3">|

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a bug.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We should ensure the width of the popover anchor does not become negative when the next and previous item are on a different line. 

Perhaps we should explore showing the inserter in between the line as a follow-up.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Create a block with inner block showing horizontally and make the items wrap. Drag an item to the end of the first line.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
