### PR TITLE
DropdownMenu: Increase option height to 40px

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,9 @@
 ### Enhancements
 
 -   `BorderBoxControl`: Reduce gap value when unlinked ([#67049](https://github.com/WordPress/gutenberg/pull/67049)).
+-   `DropdownMenu`: Increase option height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).
+-   `MenuItem`: Increase height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).
+-   `MenuItemsChoice`: Increase option height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).
 
 ### Experimental
 

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -164,6 +164,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 						{ controlSets?.flatMap( ( controlSet, indexOfSet ) =>
 							controlSet.map( ( control, indexOfControl ) => (
 								<Button
+									__next40pxDefaultSize
 									key={ [
 										indexOfSet,
 										indexOfControl,

--- a/packages/components/src/dropdown-menu/style.scss
+++ b/packages/components/src/dropdown-menu/style.scss
@@ -53,7 +53,7 @@
 
 	.components-menu-item__button,
 	.components-menu-item__button.components-button {
-		min-height: $button-size;
+		min-height: $button-size-next-default-40px;
 		height: auto;
 		text-align: left;
 		padding-left: $grid-unit-10;

--- a/packages/components/src/menu-items-choice/style.scss
+++ b/packages/components/src/menu-items-choice/style.scss
@@ -1,5 +1,6 @@
 .components-menu-items-choice,
 .components-menu-items-choice.components-button {
+	min-height: $button-size-next-default-40px;
 	height: auto;
 
 	svg {


### PR DESCRIPTION
In preparation for #65751 

## What?

Increases the option heights in `DropdownMenu` (also `MenuItem` and `MenuItemsChoice`) so they match the new sizing scheme.

## Testing Instructions

- In the DropdownMenu, MenuGroup, and MenuItem stories in the Storybook, check that all items are at least 40px high.
- In the story for MenuItemsChoice, remove the `"info"` text from the `choices` so you can check the default height.
- Smoke test some instances in the Gutenberg app.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|-------|
|<img src="https://github.com/user-attachments/assets/7886eb65-5a15-4659-ac5b-0f346f1a2f8f" alt="DropdownMenu, before" width="266">|<img src="https://github.com/user-attachments/assets/44159b51-b901-47d2-bbf8-694951e1678a" alt="DropdownMenu, after" width="266">|
