### PR TITLE
Simplify description and option names in the Lock modal dialog

### DIFF
--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -99,9 +99,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 			>
 				<fieldset className="block-editor-block-lock-modal__options">
 					<legend>
-						{ __(
-							'Choose "Lock all" to disable all actions, or select specific features to lock.'
-						) }
+						{ __( 'Select the features you want to lock' ) }
 					</legend>
 					{ /*
 					 * Disable reason: The `list` ARIA role is redundant but

--- a/packages/block-editor/src/components/block-lock/modal.js
+++ b/packages/block-editor/src/components/block-lock/modal.js
@@ -100,7 +100,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 				<fieldset className="block-editor-block-lock-modal__options">
 					<legend>
 						{ __(
-							'Choose specific attributes to restrict or lock all available options.'
+							'Choose "Lock all" to disable all actions, or select specific features to lock.'
 						) }
 					</legend>
 					{ /*
@@ -137,7 +137,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 									<li className="block-editor-block-lock-modal__checklist-item">
 										<CheckboxControl
 											__nextHasNoMarginBottom
-											label={ __( 'Restrict editing' ) }
+											label={ __( 'Lock editing' ) }
 											checked={ !! lock.edit }
 											onChange={ ( edit ) =>
 												setLock( ( prevLock ) => ( {
@@ -159,7 +159,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 								<li className="block-editor-block-lock-modal__checklist-item">
 									<CheckboxControl
 										__nextHasNoMarginBottom
-										label={ __( 'Disable movement' ) }
+										label={ __( 'Lock movement' ) }
 										checked={ lock.move }
 										onChange={ ( move ) =>
 											setLock( ( prevLock ) => ( {
@@ -178,7 +178,7 @@ export default function BlockLockModal( { clientId, onClose } ) {
 								<li className="block-editor-block-lock-modal__checklist-item">
 									<CheckboxControl
 										__nextHasNoMarginBottom
-										label={ __( 'Prevent removal' ) }
+										label={ __( 'Lock removal' ) }
 										checked={ lock.remove }
 										onChange={ ( remove ) =>
 											setLock( ( prevLock ) => ( {

--- a/test/e2e/specs/editor/blocks/columns.spec.js
+++ b/test/e2e/specs/editor/blocks/columns.spec.js
@@ -63,7 +63,7 @@ test.describe( 'Columns', () => {
 		);
 		await editor.clickBlockToolbarButton( 'Options' );
 		await page.click( 'role=menuitem[name="Lock"i]' );
-		await page.locator( 'role=checkbox[name="Prevent removal"i]' ).check();
+		await page.locator( 'role=checkbox[name="Lock removal"i]' ).check();
 		await page.click( 'role=button[name="Apply"i]' );
 
 		// Select columns block

--- a/test/e2e/specs/editor/various/block-locking.spec.js
+++ b/test/e2e/specs/editor/various/block-locking.spec.js
@@ -16,7 +16,7 @@ test.describe( 'Block Locking', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-		await page.click( 'role=checkbox[name="Prevent removal"]' );
+		await page.click( 'role=checkbox[name="Lock removal"]' );
 		await page.click( 'role=button[name="Apply"]' );
 
 		await expect(
@@ -35,7 +35,7 @@ test.describe( 'Block Locking', () => {
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
 
-		await page.click( 'role=checkbox[name="Disable movement"]' );
+		await page.click( 'role=checkbox[name="Lock movement"]' );
 		await page.click( 'role=button[name="Apply"]' );
 
 		// Hide options.

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -107,7 +107,7 @@ test.describe( 'Block Switcher', () => {
 		await expect( button ).toBeEnabled();
 
 		await editor.clickBlockOptionsMenuItem( 'Lock' );
-		await page.click( 'role=checkbox[name="Prevent removal"]' );
+		await page.click( 'role=checkbox[name="Lock removal"]' );
 		await page.click( 'role=button[name="Apply"]' );
 
 		// Verify the block switcher isn't enabled.


### PR DESCRIPTION
Fixes: #62843

## What?
This PR simplifies the description and renames the options in the Lock modal dialog to make the interface clearer and more intuitive for users.

## Why?
The original description was too long and confusing, with mismatched visuals and terminology that added cognitive load. Additionally, the varying verbs for options were inconsistent and unnecessary. Simplifying the language and standardizing the option names enhances user understanding.

## How?

1. The description was updated to focus on user intent: "Choose 'Lock all' to disable all actions, or select specific features to lock."
2. Option names were standardized to:
    - Lock all
    - Lock editing
    - Lock movement
    - Lock removal

## Testing Instructions

1. Add a Navigation block to a post.
2. Select the Navigation block and click Options > Lock.
3. Observe the updated description and option names. Ensure the visual order aligns with the description.
4. Verify the interface is now clearer and easier to understand.

## Screenshots or screencast <!-- if applicable -->
<img width="482" alt="Screenshot 2024-11-30 at 12 37 54 AM" src="https://github.com/user-attachments/assets/d697298a-441b-4ed8-81d0-355ddc4c76da">
