### PR TITLE
Drag and drop: fix firefox compat logic

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/index.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/index.js
@@ -104,8 +104,6 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 		canMove,
 	} = useContext( PrivateBlockContext );
 
-	const canDrag = canMove && ! hasChildSelected;
-
 	// translators: %s: Type of block (i.e. Text, Image etc)
 	const blockLabel = sprintf( __( 'Block: %s' ), blockTitle );
 	const htmlSuffix = mode === 'html' && ! __unstableIsHtml ? '-visual' : '';
@@ -125,7 +123,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 			isEnabled: isSectionBlock,
 		} ),
 		useScrollIntoView( { isSelected } ),
-		canDrag ? ffDragRef : undefined,
+		canMove ? ffDragRef : undefined,
 	] );
 
 	const blockEditContext = useBlockEditContext();
@@ -158,7 +156,7 @@ export function useBlockProps( props = {}, { __unstableIsHtml } = {} ) {
 
 	return {
 		tabIndex: blockEditingMode === 'disabled' ? -1 : 0,
-		draggable: canDrag ? true : undefined,
+		draggable: canMove && ! hasChildSelected ? true : undefined,
 		...wrapperProps,
 		...props,
 		ref: mergedRefs,

--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -3,6 +3,48 @@
  */
 import { useRefEffect } from '@wordpress/compose';
 
+class NodeSet extends Set {
+	constructor() {
+		super();
+		this.documents = new Set();
+	}
+	add( node ) {
+		const { ownerDocument } = node;
+		if ( ! this.documents.has( ownerDocument ) ) {
+			ownerDocument.addEventListener( 'pointerdown', down );
+			this.documents.add( ownerDocument );
+		}
+		return super.add( node );
+	}
+}
+
+const nodes = new NodeSet();
+
+function down( event ) {
+	if ( event.target.isContentEditable ) {
+		// Whenever an editable element is clicked, check which draggable
+		// blocks contain this element, and temporarily disable draggability.
+		for ( const node of nodes ) {
+			if (
+				node.getAttribute( 'draggable' ) === 'true' &&
+				node.contains( event.target )
+			) {
+				node.setAttribute( 'draggable', 'false' );
+				node.setAttribute( 'data-draggable', 'true' );
+			}
+		}
+	} else {
+		// Whenever a non-editable element is clicked, re-enable draggability
+		// for any blocks that were previously disabled.
+		for ( const node of nodes ) {
+			if ( node.getAttribute( 'data-draggable' ) === 'true' ) {
+				node.setAttribute( 'draggable', 'true' );
+				node.removeAttribute( 'data-draggable' );
+			}
+		}
+	}
+}
+
 /**
  * In Firefox, the `draggable` and `contenteditable` attributes don't play well
  * together. When `contenteditable` is within a `draggable` element, selection
@@ -13,24 +55,9 @@ import { useRefEffect } from '@wordpress/compose';
  */
 export function useFirefoxDraggableCompatibility() {
 	return useRefEffect( ( node ) => {
-		function onDown( event ) {
-			if ( node.draggable === true ) {
-				if ( event.target.isContentEditable ) {
-					node.draggable = false;
-					node.setAttribute( 'data-draggable', 'true' );
-				}
-			} else if (
-				! event.target.isContentEditable &&
-				node.getAttribute( 'data-draggable' ) === 'true'
-			) {
-				node.draggable = true;
-				node.removeAttribute( 'data-draggable' );
-			}
-		}
-		const { ownerDocument } = node;
-		ownerDocument.addEventListener( 'pointerdown', onDown );
+		nodes.add( node );
 		return () => {
-			ownerDocument.removeEventListener( 'pointerdown', onDown );
+			nodes.delete( node );
 		};
 	}, [] );
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -16,9 +16,25 @@ class NodeSet extends Set {
 		}
 		return super.add( node );
 	}
+	delete( node ) {
+		restore( node );
+		return super.delete( node );
+	}
 }
 
 const nodes = new NodeSet();
+
+function restore( node ) {
+	const prevDraggable = node.getAttribute( 'data-draggable' );
+	if ( prevDraggable ) {
+		node.removeAttribute( 'data-draggable' );
+		// Only restore if `draggable` is still removed. It could have been
+		// changed by React in the meantime.
+		if ( prevDraggable === 'true' && ! node.getAttribute( 'draggable' ) ) {
+			node.setAttribute( 'draggable', 'true' );
+		}
+	}
+}
 
 function down( event ) {
 	if ( event.target.isContentEditable ) {
@@ -29,7 +45,7 @@ function down( event ) {
 				node.getAttribute( 'draggable' ) === 'true' &&
 				node.contains( event.target )
 			) {
-				node.setAttribute( 'draggable', 'false' );
+				node.removeAttribute( 'draggable' );
 				node.setAttribute( 'data-draggable', 'true' );
 			}
 		}
@@ -37,10 +53,7 @@ function down( event ) {
 		// Whenever a non-editable element is clicked, re-enable draggability
 		// for any blocks that were previously disabled.
 		for ( const node of nodes ) {
-			if ( node.getAttribute( 'data-draggable' ) === 'true' ) {
-				node.setAttribute( 'draggable', 'true' );
-				node.removeAttribute( 'data-draggable' );
-			}
+			restore( node );
 		}
 	}
 }

--- a/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-firefox-draggable-compatibility.js
@@ -14,7 +14,18 @@ import { useRefEffect } from '@wordpress/compose';
 export function useFirefoxDraggableCompatibility() {
 	return useRefEffect( ( node ) => {
 		function onDown( event ) {
-			node.draggable = ! event.target.isContentEditable;
+			if ( node.draggable === true ) {
+				if ( event.target.isContentEditable ) {
+					node.draggable = false;
+					node.setAttribute( 'data-draggable', 'true' );
+				}
+			} else if (
+				! event.target.isContentEditable &&
+				node.getAttribute( 'data-draggable' ) === 'true'
+			) {
+				node.draggable = true;
+				node.removeAttribute( 'data-draggable' );
+			}
 		}
 		const { ownerDocument } = node;
 		ownerDocument.addEventListener( 'pointerdown', onDown );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What? Why? How?
<!-- In a few words, what is the PR actually doing? -->

While trying `cursor:grab` for draggable blocks, I noticed that `draggable` is currently being set to true for a lot of block by accident that shouldn't be draggable after you click on them. That's because of a mistake in the Firefox compatibility logic. It doesn't check if the block is draggable first. We'll also have to set a temporary attribute to store the previous state so we only restore it to `true` when it was previously draggable.

Also fixes an edge case where you can't drag the block you select an inner block.

Also improves the performance of this hook by only adding a single event handler.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Use Firefox. Make sure we the compatibility logic still works; it should still be possible to select within editable fields within a block such as the quote block.

Also click in a paragraph for example and out of it. The paragraph should not be left with a `draggable` attribute.

Now also click a paragraph in a quote and then try to drag the quote. In trunk this doesn't work. With this PR it does.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
