### PR TITLE
Storybook: Support keyword search in Icon Library

### DIFF
--- a/packages/icons/src/icon/stories/index.story.js
+++ b/packages/icons/src/icon/stories/index.story.js
@@ -9,6 +9,7 @@ import { useState, Fragment } from '@wordpress/element';
 import Icon from '../';
 import check from '../../library/check';
 import * as icons from '../../';
+import keywords from './keywords';
 
 const { Icon: _Icon, ...availableIcons } = icons;
 
@@ -46,14 +47,23 @@ const LibraryExample = () => {
 	const [ filter, setFilter ] = useState( '' );
 	const filteredIcons = filter.length
 		? Object.fromEntries(
-				Object.entries( availableIcons ).filter( ( [ name ] ) =>
-					name.toLowerCase().includes( filter.toLowerCase() )
-				)
+				Object.entries( availableIcons ).filter( ( [ name ] ) => {
+					const normalizedName = name.toLowerCase();
+					const normalizedFilter = filter.toLowerCase();
+
+					return (
+						normalizedName.includes( normalizedFilter ) ||
+						// @ts-expect-error - Not worth the effort to cast `name`
+						keywords[ name ]?.some( ( keyword ) =>
+							keyword.toLowerCase().includes( normalizedFilter )
+						)
+					);
+				} )
 		  )
 		: availableIcons;
 	return (
 		<div style={ { padding: 20 } }>
-			<label htmlFor="filter-icon" style={ { paddingRight: 10 } }>
+			<label htmlFor="filter-icons" style={ { paddingRight: 10 } }>
 				Filter Icons
 			</label>
 			<input

--- a/packages/icons/src/icon/stories/keywords.ts
+++ b/packages/icons/src/icon/stories/keywords.ts
@@ -1,0 +1,13 @@
+const keywords: Partial< Record< keyof typeof import('../../'), string[] > > = {
+	cancelCircleFilled: [ 'close' ],
+	create: [ 'add' ],
+	file: [ 'folder' ],
+	seen: [ 'show' ],
+	thumbsDown: [ 'dislike' ],
+	thumbsUp: [ 'like' ],
+	trash: [ 'delete' ],
+	unseen: [ 'hide' ],
+	warning: [ 'alert', 'caution' ],
+};
+
+export default keywords;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Support keyword search for the Icon Library in Storybook.

## Why?

I was looking at some new icons being added in https://github.com/WordPress/gutenberg/issues/61106#issuecomment-2507782529 and thought we're at the point where keyword searching could be useful.

## How?

Not sure if we'll eventually want to use this metadata elsewhere, but for now I added a separate file with keywords for certain icons.

## Testing Instructions

See the Storybook story for [Icons ▸ Library](http://localhost:50240/?path=/story/icons-icon--library).

## Screenshots or screencast <!-- if applicable -->

<img width="285" alt="Searching for folder matches the file icon" src="https://github.com/user-attachments/assets/2bf22a61-5e82-4294-9bcc-41dad61a9bad">