### PR TITLE
Draft: Use Combobox for post-meta and custom sources block bindings.Initial commit

### DIFF
--- a/packages/block-editor/src/hooks/block-bindings.js
+++ b/packages/block-editor/src/hooks/block-bindings.js
@@ -76,9 +76,10 @@ function BlockBindingsPanelDropdown( { fieldsList, attribute } ) {
 			__next40pxDefaultSize
 			__nextHasNoMarginBottom
 			allowReset
-			expandOnFocus={ false }
+			expandOnFocus
 			label={ __( 'Connect attributes' ) }
 			options={ filteredOptions }
+			className="block-editor-bindings__combobox"
 			__experimentalRenderItem={ ( element ) => {
 				const { label, source, value } = element.item;
 				return (

--- a/packages/block-editor/src/hooks/block-bindings.scss
+++ b/packages/block-editor/src/hooks/block-bindings.scss
@@ -4,3 +4,6 @@ div.block-editor-bindings__panel {
 		color: inherit;
 	}
 }
+.block-editor-bindings__combobox .components-form-token-field__suggestions-list {
+	max-height: 400px;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Similar to #67012. This time I'm experimenting with using the combobox for the custom source fields list selection. This allows to have a search box.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1) Add your custom post meta.
2) Tweak with the new block bindings UI.

## Demo: <!-- if applicable -->
![combobox](https://github.com/user-attachments/assets/fe95a2a1-c222-4018-864b-6686a744b8bd)

https://github.com/user-attachments/assets/77f0beca-f74b-4dbe-a3d9-595ce89ecb52




