### PR TITLE
Preload: fix settings fields order

### DIFF
--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -31,9 +31,9 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 				'site_icon_url',
 				'site_logo',
 				'timezone_string',
-				'url',
 				'default_template_part_areas',
 				'default_template_types',
+				'url',
 			)
 		);
 		$paths[] = '/wp/v2/templates/lookup?slug=front-page';


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

See https://github.com/WordPress/gutenberg/pull/66459#discussion_r1864879241. The fields were added to preload, but the order was not maintained.

We should somehow add e2e tests for this at some point. Perhaps check that there are no network requests before the iframe loads or something.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The order must match in order for the preload to be used.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Check the network tab for the site editor.

## Screenshots or screencast <!-- if applicable -->
