### PR TITLE
API Fetch: Prevent infinite retries when auth session is invalid

### DIFF
--- a/packages/api-fetch/src/index.js
+++ b/packages/api-fetch/src/index.js
@@ -170,6 +170,14 @@ function apiFetch( options ) {
 			return Promise.reject( error );
 		}
 
+		// Check if user is still logged in by checking for wordpress_logged_in cookie
+		const hasAuthCookie = document.cookie
+			.split( '; ' )
+			.some( ( cookie ) => cookie.startsWith( 'wordpress_logged_in_' ) );
+		if ( ! hasAuthCookie ) {
+			return Promise.reject( error );
+		}
+
 		// If the nonce is invalid, refresh it and try again.
 		return (
 			window


### PR DESCRIPTION
## What?
Prevent infinite API request loop when the user's authentication session becomes invalid during block editor usage.


## Why?
Currently, when a user's authentication cookie (`wordpress_logged_in`) is removed while using the block editor, the API-fetch utility enters an infinite loop trying to refresh the nonce token. This causes:
- Continuous failed API requests
- High CPU usage
- Potential browser unresponsiveness
- Poor user experience


## Testing Instructions
1. Open the block editor for any post/page
2. Open browser dev tools
3. Go to the Application tab
4. Find and delete the `wordpress_logged_in` cookie
5. Make any changes and save draft
6. Observe in Network tab:
  - **Before fix**: Continuous failing API requests
  - **After fix**: Single failed request, no retries
  


