### PR TITLE
Removed trailing space in "Color randomizer "

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -69,7 +69,7 @@ function gutenberg_initialize_experiments_settings() {
 
 	add_settings_field(
 		'gutenberg-color-randomizer',
-		__( 'Color randomizer ', 'gutenberg' ),
+		__( 'Color randomizer', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',


### PR DESCRIPTION
## What?

In continuation of issue #59821, this [comment](https://github.com/WordPress/gutenberg/issues/59821#issuecomment-2395363161) by @ramonjd requested opening a PR to remove the trailing space in the "Color randomizer" string in lib/experiments-page.php.

## Why?
The issue was re-opened to address it as it was not completely resolved; the string 'Color randomizer ' still contained a trailing space.

## How?
Based on the suggestion, I have removed the trailing space from the string and am now raising a PR to address this.
