### PR TITLE
Site Editor: Fix focus mode navigation

### DIFF
--- a/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
+++ b/packages/edit-site/src/components/block-editor/use-navigate-to-entity-record.js
@@ -17,7 +17,7 @@ export default function useNavigateToEntityRecord() {
 	const onNavigateToEntityRecord = useCallback(
 		( params ) => {
 			history.navigate(
-				`/${ params.postType }/${ params.id }?canvas=edit&focusMode=true`
+				`/${ params.postType }/${ params.postId }?canvas=edit&focusMode=true`
 			);
 		},
 		[ history ]

--- a/packages/router/src/router.tsx
+++ b/packages/router/src/router.tsx
@@ -146,6 +146,7 @@ export function useHistory() {
 	return useMemo(
 		() => ( {
 			navigate,
+			back: history.back,
 		} ),
 		[ navigate ]
 	);

--- a/test/e2e/specs/site-editor/template-part-focus-mode.spec.js
+++ b/test/e2e/specs/site-editor/template-part-focus-mode.spec.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Template Part Focus mode', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyfour' );
+	} );
+
+	test.afterEach( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'Should navigate to template part and back.', async ( {
+		admin,
+		page,
+		editor,
+	} ) => {
+		await admin.visitAdminPage( 'site-editor.php?canvas=edit' );
+		await editor.setPreferences( 'core/edit-site', {
+			welcomeGuide: false,
+		} );
+
+		// Check that we're editing the template
+		await expect( page.locator( 'h1' ) ).toContainText( 'Blog Home' );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Template' );
+
+		// Click Template Part
+		await editor.canvas
+			.getByRole( 'document', {
+				name: 'Header',
+			} )
+			.click();
+
+		// Navigate to Focus mode
+		await editor.clickBlockToolbarButton( 'Edit' );
+
+		// Check if focus mode is active
+		await expect( page.locator( 'h1' ) ).toContainText( 'Header' );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Template Part' );
+
+		// Go back
+		await page.getByRole( 'button', { name: 'Back' } ).click();
+
+		// Check that we're editing the template
+		await expect( page.locator( 'h1' ) ).toContainText( 'Blog Home' );
+		await expect( page.locator( 'h1' ) ).toContainText( 'Template' );
+	} );
+} );


### PR DESCRIPTION
Regression introduced in https://github.com/WordPress/gutenberg/pull/67199
Fixes #67443 

## What?

This Fixes an issue where it was not possible to navigate into focus mode of a given entity (template part for instance) and back after the refactoring done in #67199 

I'm actually a bit surprised that we don't have any e2e test for this, I'll be adding one.

## Testing Instructions

1- Open a template in the site editor
2- Select a template part
3- Click "edit"
4- you should be in focused mode
5- Click "back" in the header
6- You should be back in the template editor.