### PR TITLE
Fix: write mode is enabled after disabling the experiment

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -3041,9 +3041,7 @@ export const getBlockEditingMode = createRegistrySelector(
 				clientId = '';
 			}
 
-			const isNavMode =
-				select( preferencesStore )?.get( 'core', 'editorTool' ) ===
-				'navigation';
+			const isNavMode = isNavigationMode( state );
 
 			// If the editor is currently not in navigation mode, check if the clientId
 			// has an editing mode set in the regular derived map.


### PR DESCRIPTION
## What?
There is an issue where the "Write" mode remains enabled even after deactivating the experiment. This PR aims to fix that.

## Why?
It is an unexpected behavior.

## How?
Use the `isNavigationMode` helper function instead of directly checking the preference. This helper checks if the experiment is enabled or not.

## Testing Instructions
1. Go to Gutenberg -> Experiments and enable Write mode.
2. Go to the index template -> Click on the "Tools" icon -> Select "Write".
3. Go to Gutenberg -> Experiments and disable Write mode.
4. Go to the template again and check "Write" mode is not enabled anymore. Previously, it was kept activated.
