### PR TITLE
Preload: parse post ID from p (path)

### DIFF
--- a/backport-changelog/6.8/7695.md
+++ b/backport-changelog/6.8/7695.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7695
 
 * https://github.com/WordPress/gutenberg/pull/66631
+* https://github.com/WordPress/gutenberg/pull/67465

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -10,8 +10,16 @@
  */
 function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 	if ( 'core/edit-site' === $context->name ) {
-		if ( ! empty( $_GET['postId'] ) ) {
-			$route_for_post = rest_get_route_for_post( $_GET['postId'] );
+		$post_id = null;
+		if ( isset( $_GET['postId'] ) && is_numeric( $_GET['postId'] ) ) {
+			$post_id = (int) $_GET['postId'];
+		}
+		if ( isset( $_GET['p'] ) && preg_match( '/^\/page\/(\d+)$/', $_GET['p'], $matches ) ) {
+			$post_id = (int) $matches[1];
+		}
+
+		if ( $post_id ) {
+			$route_for_post = rest_get_route_for_post( $post_id );
 			if ( $route_for_post ) {
 				$paths[] = add_query_arg( 'context', 'edit', $route_for_post );
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Since #67199, post preload no longer works for this path:

```
/wp-admin/site-editor.php?canvas=edit&p=%2Fpage%2F<ID>
```


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Preloading improves load performance when accessing site editor URLs directly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Parse the ID from the new path.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Load a page with the above URL and check the (first few) network requests. 

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
