### PR TITLE
Site Editor: Fix the patterns route on mobile

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/patterns.js
+++ b/packages/edit-site/src/components/site-editor-routes/patterns.js
@@ -10,6 +10,6 @@ export const patternsRoute = {
 	areas: {
 		sidebar: <SidebarNavigationScreenPatterns backPath="/" />,
 		content: <PagePatterns />,
-		mobile: <SidebarNavigationScreenPatterns backPath="/" />,
+		mobile: <PagePatterns />,
 	},
 };


### PR DESCRIPTION
closes #67460

## What?

Fix a small regression preventing patterns access on mobile.

## Testing Instructions

1- Open the site editor on mobile
2- Click "patterns"

You should see the grid of patterns.