### PR TITLE
Comment Content block: Update placeholder copy

### DIFF
--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -48,7 +48,7 @@ export default function Edit( {
 		'content',
 		commentId
 	);
-	const isFirstCommentContentBlockinTemplate = useSelect(
+	const isFirstCommentContentBlockInBlockTemplate = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlockParentsByBlockName(
 				clientId,
@@ -73,7 +73,7 @@ export default function Edit( {
 				{ blockControls }
 				<div { ...blockProps }>
 					<p>
-						{ isFirstCommentContentBlockinTemplate
+						{ isFirstCommentContentBlockInBlockTemplate
 							? __(
 									'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
 							  )

--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -10,9 +10,11 @@ import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 import {
 	AlignmentControl,
 	BlockControls,
+	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
 
@@ -25,6 +27,7 @@ import {
  * @param {string} props.attributes.textAlign The `textAlign` attribute.
  * @param {Object} props.context              Inherited context.
  * @param {string} props.context.commentId    The comment ID.
+ * @param {string} props.clientId             The block client ID.
  *
  * @return {JSX.Element} React element.
  */
@@ -32,6 +35,7 @@ export default function Edit( {
 	setAttributes,
 	attributes: { textAlign },
 	context: { commentId },
+	clientId,
 } ) {
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -43,6 +47,13 @@ export default function Edit( {
 		'comment',
 		'content',
 		commentId
+	);
+	const isFirstCommentContentBlockinTemplate = useSelect(
+		( select ) =>
+			select( blockEditorStore ).getBlockParentsByBlockName(
+				clientId,
+				'core/comment-template'
+			).length > 0
 	);
 
 	const blockControls = (
@@ -62,9 +73,11 @@ export default function Edit( {
 				{ blockControls }
 				<div { ...blockProps }>
 					<p>
-						{ __(
-							'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
-						) }
+						{ isFirstCommentContentBlockinTemplate
+							? __(
+									'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
+							  )
+							: __( 'This is another Comment Content block.' ) }
 					</p>
 				</div>
 			</>

--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -10,11 +10,9 @@ import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
 import {
 	AlignmentControl,
 	BlockControls,
-	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
 
@@ -27,7 +25,6 @@ import {
  * @param {string} props.attributes.textAlign The `textAlign` attribute.
  * @param {Object} props.context              Inherited context.
  * @param {string} props.context.commentId    The comment ID.
- * @param {string} props.clientId             The block client ID.
  *
  * @return {JSX.Element} React element.
  */
@@ -35,7 +32,6 @@ export default function Edit( {
 	setAttributes,
 	attributes: { textAlign },
 	context: { commentId },
-	clientId,
 } ) {
 	const blockProps = useBlockProps( {
 		className: clsx( {
@@ -47,13 +43,6 @@ export default function Edit( {
 		'comment',
 		'content',
 		commentId
-	);
-	const isFirstCommentContentBlockinTemplate = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getBlockParentsByBlockName(
-				clientId,
-				'core/comment-template'
-			).length > 0
 	);
 
 	const blockControls = (
@@ -73,11 +62,9 @@ export default function Edit( {
 				{ blockControls }
 				<div { ...blockProps }>
 					<p>
-						{ isFirstCommentContentBlockinTemplate
-							? __(
-									'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
-							  )
-							: __( 'This is another Comment Content block.' ) }
+						{ __(
+							'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
+						) }
 					</p>
 				</div>
 			</>

--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -48,7 +48,7 @@ export default function Edit( {
 		'content',
 		commentId
 	);
-	const isFirstCommentContentBlockInBlockTemplate = useSelect(
+	const isFirstCommentContentBlockinTemplate = useSelect(
 		( select ) =>
 			select( blockEditorStore ).getBlockParentsByBlockName(
 				clientId,
@@ -73,7 +73,7 @@ export default function Edit( {
 				{ blockControls }
 				<div { ...blockProps }>
 					<p>
-						{ isFirstCommentContentBlockInBlockTemplate
+						{ isFirstCommentContentBlockinTemplate
 							? __(
 									'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
 							  )

--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -6,7 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { RawHTML } from '@wordpress/element';
 import { Disabled } from '@wordpress/components';
 import { useEntityProp } from '@wordpress/core-data';
@@ -61,7 +61,7 @@ export default function Edit( {
 			<>
 				{ blockControls }
 				<div { ...blockProps }>
-					<p>{ _x( 'Comment Content', 'block title' ) }</p>
+					<p>{ __( 'This is the Comment Content block.' ) }</p>
 				</div>
 			</>
 		);

--- a/packages/block-library/src/comment-content/edit.js
+++ b/packages/block-library/src/comment-content/edit.js
@@ -61,7 +61,11 @@ export default function Edit( {
 			<>
 				{ blockControls }
 				<div { ...blockProps }>
-					<p>{ __( 'This is the Comment Content block.' ) }</p>
+					<p>
+						{ __(
+							'This is the Comment Content block. It displays the text of user comments submitted on your site, ranging from short remarks to longer, multi-paragraph responses.'
+						) }
+					</p>
 				</div>
 			</>
 		);


### PR DESCRIPTION
## What?
Update the placeholder copy of the Comment Content block in the editor to read "This is the Comment Content block." instead of just "Comment Content".

(I'm open to other suggestion 🙂)

## Why?
To make it less terse, and more consistent with the _Post_ Content block: https://github.com/WordPress/gutenberg/blob/22c43ff9e687eb5752b790316f2b1eeb99976dbb/packages/block-library/src/post-content/edit.js#L138-L152

## How?
By replacing a string.

## Testing Instructions
In the Site Editor, view any template that contains the Comments block (and thus, the Comment Content block). Or insert one.

## Screenshots or screencast <!-- if applicable -->

| Before | After |
|--------|------|
| ![image](https://github.com/user-attachments/assets/a60e618a-3c28-4019-9139-60b87942652f) | ![image](https://github.com/user-attachments/assets/fc06bddd-a83f-422a-9819-4885e6fabb3d) |