### PR TITLE
Site editor: Allow access to quick edit

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -44,7 +44,7 @@ export const pagesRoute = {
 		mobile: <MobilePagesView />,
 		edit( { query } ) {
 			const hasQuickEdit =
-				( query.layout ?? 'list' ) === 'list' && !! query.quickEdit;
+				( query.layout ?? 'list' ) !== 'list' && !! query.quickEdit;
 			return hasQuickEdit ? (
 				<PostEdit postType="page" postId={ query.postId } />
 			) : undefined;
@@ -59,7 +59,7 @@ export const pagesRoute = {
 		},
 		edit( { query } ) {
 			const hasQuickEdit =
-				( query.layout ?? 'list' ) === 'list' && !! query.quickEdit;
+				( query.layout ?? 'list' ) !== 'list' && !! query.quickEdit;
 			return hasQuickEdit ? 380 : undefined;
 		},
 	},


### PR DESCRIPTION
Related #55101 

## What?

Fixes a recent regression where accessing the quick edit panel is not possible. It's just a typo during the refactoring PR.

## Testing Instructions

1- Enable quick edit experiment 
2- Go to the "tables" layout of the pages dataviews
3- Click the "quick edit" button in the top right
4- Quick edit panel appears.