### PR TITLE
Drag and drop: direct drag: move block instead of drag chip

### DIFF
--- a/packages/block-editor/src/components/block-draggable/content.scss
+++ b/packages/block-editor/src/components/block-draggable/content.scss
@@ -3,8 +3,7 @@
 // This creates a "slot" where the block you're dragging appeared.
 // We use !important as one of the rules are meant to be overridden.
 .block-editor-block-list__layout .is-dragging {
-	opacity: 0.1 !important;
-	border-radius: $radius-small !important;
+	opacity: 0.1;
 
 	iframe {
 		pointer-events: none;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -222,6 +222,7 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 		cursor: grab;
 	}
 
+	&[contenteditable],
 	[contenteditable] {
 		cursor: text;
 	}

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -228,17 +228,6 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 }
 
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {
-
-	&.is-selected,
-	&.is-hovered {
-		cursor: default;
-
-		&.rich-text,
-		.rich-text {
-			cursor: auto;
-		}
-	}
-
 	&.is-hovered:not(.is-selected),
 	&:not(.rich-text):not([contenteditable="true"]).is-selected {
 

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -211,6 +211,20 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	&[data-clear="true"] {
 		float: none;
 	}
+
+	&:not([draggable="true"]),
+	&:not([data-draggable="true"]) {
+		cursor: default;
+	}
+
+	&[draggable="true"],
+	&[data-draggable="true"] {
+		cursor: grab;
+	}
+
+	[contenteditable] {
+		cursor: text;
+	}
 }
 
 .is-outline-mode .block-editor-block-list__block:not(.remove-outline) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -5,15 +5,12 @@ import { isTextField } from '@wordpress/dom';
 import { ENTER, BACKSPACE, DELETE } from '@wordpress/keycodes';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useRefEffect } from '@wordpress/compose';
-import { createRoot } from '@wordpress/element';
-import { store as blocksStore } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
  */
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
-import BlockDraggableChip from '../../../components/block-draggable/draggable-chip';
 
 /**
  * Adds block behaviour:
@@ -24,9 +21,9 @@ import BlockDraggableChip from '../../../components/block-draggable/draggable-ch
  * @param {string} clientId Block client ID.
  */
 export function useEventHandlers( { clientId, isSelected } ) {
-	const { getBlockType } = useSelect( blocksStore );
-	const { getBlockRootClientId, isZoomOut, hasMultiSelection, getBlockName } =
-		unlock( useSelect( blockEditorStore ) );
+	const { getBlockRootClientId, isZoomOut, hasMultiSelection } = unlock(
+		useSelect( blockEditorStore )
+	);
 	const {
 		insertAfterBlock,
 		removeBlock,
@@ -105,20 +102,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				const selection = defaultView.getSelection();
 				selection.removeAllRanges();
 
-				const domNode = document.createElement( 'div' );
-				const root = createRoot( domNode );
-				root.render(
-					<BlockDraggableChip
-						icon={ getBlockType( getBlockName( clientId ) ).icon }
-					/>
-				);
-				document.body.appendChild( domNode );
-				domNode.style.position = 'absolute';
-				domNode.style.top = '0';
-				domNode.style.left = '0';
-				domNode.style.zIndex = '1000';
-				domNode.style.pointerEvents = 'none';
-
 				// Setting the drag chip as the drag image actually works, but
 				// the behaviour is slightly different in every browser. In
 				// Safari, it animates, in Firefox it's slightly transparent...
@@ -134,31 +117,98 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.body.appendChild( dragElement );
 				event.dataTransfer.setDragImage( dragElement, 0, 0 );
 
-				let offset = { x: 0, y: 0 };
+				const rect = node.getBoundingClientRect();
 
-				if ( document !== ownerDocument ) {
-					const frame = defaultView.frameElement;
-					if ( frame ) {
-						const rect = frame.getBoundingClientRect();
-						offset = { x: rect.left, y: rect.top };
+				const clone = node.cloneNode( true );
+				clone.style.visibility = 'hidden';
+
+				// Remove the id and leave it on the clone so that drop target
+				// calculations are correct.
+				const id = node.id;
+				node.id = null;
+
+				let _scale = 1;
+
+				let parentElement = node;
+
+				while ( ( parentElement = parentElement.parentElement ) ) {
+					const { scale } =
+						defaultView.getComputedStyle( parentElement );
+					if ( scale && scale !== 'none' ) {
+						_scale = parseFloat( scale );
+						break;
 					}
 				}
 
-				// chip handle offset
-				offset.x -= 58;
+				let bgColor = 'transparent';
 
-				function over( e ) {
-					domNode.style.transform = `translate( ${
-						e.clientX + offset.x
-					}px, ${ e.clientY + offset.y }px )`;
+				parentElement = node;
+
+				while ( ( parentElement = parentElement.parentElement ) ) {
+					const { backgroundColor } =
+						defaultView.getComputedStyle( parentElement );
+					if (
+						backgroundColor &&
+						backgroundColor !== 'transparent' &&
+						backgroundColor !== 'rgba(0, 0, 0, 0)'
+					) {
+						bgColor = backgroundColor;
+						break;
+					}
 				}
 
-				over( event );
+				const inverted = 1 / _scale;
+
+				node.after( clone );
+
+				node.style.position = 'fixed';
+				node.style.top = `${ rect.top }px`;
+				node.style.left = `${ rect.left }px`;
+				node.style.width = `${ rect.width * inverted }px`;
+
+				const originX = event.clientX - rect.left;
+				const originY = event.clientY - rect.top;
+
+				// Scale everything to 200px.
+				const dragScale = rect.height > 200 ? 200 / rect.height : 1;
+
+				node.style.zIndex = '1000';
+				node.style.transformOrigin = '0 0';
+				node.style.transformOrigin = `${ originX }px ${ originY }px`;
+				node.style.transition = 'transform 0.2s ease-out';
+				node.style.transform = `scale(${ dragScale })`;
+				node.style.margin = '0';
+				node.style.opacity = '0.9';
+				node.style.backgroundColor = bgColor;
+
+				let hasStarted = false;
+
+				function over( e ) {
+					if ( ! hasStarted ) {
+						hasStarted = true;
+						node.style.pointerEvents = 'none';
+					}
+					node.style.top = `${ e.clientY * inverted - originY }px`;
+					node.style.left = `${ e.clientX * inverted - originX }px`;
+				}
 
 				function end() {
 					ownerDocument.removeEventListener( 'dragover', over );
 					ownerDocument.removeEventListener( 'dragend', end );
-					domNode.remove();
+					node.style.transform = '';
+					node.style.transformOrigin = '';
+					node.style.transition = '';
+					node.style.zIndex = '';
+					node.style.position = '';
+					node.style.top = '';
+					node.style.left = '';
+					node.style.width = '';
+					node.style.pointerEvents = '';
+					node.style.margin = '';
+					node.style.opacity = '';
+					node.style.backgroundColor = '';
+					clone.remove();
+					node.id = id;
 					dragElement.remove();
 					stopDraggingBlocks();
 					document.body.classList.remove(

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -12,6 +12,10 @@ import { useRefEffect } from '@wordpress/compose';
 import { store as blockEditorStore } from '../../../store';
 import { unlock } from '../../../lock-unlock';
 
+function isColorTransparent( color ) {
+	return ! color || color === 'transparent' || color === 'rgba(0, 0, 0, 0)';
+}
+
 /**
  * Adds block behaviour:
  *   - Removes the block on BACKSPACE.
@@ -131,31 +135,15 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 				let _scale = 1;
 
-				let parentElement = node;
-
-				while ( ( parentElement = parentElement.parentElement ) ) {
-					const { scale } =
-						defaultView.getComputedStyle( parentElement );
-					if ( scale && scale !== 'none' ) {
-						_scale = parseFloat( scale );
-						break;
-					}
-				}
-
-				let bgColor = 'transparent';
-
-				parentElement = node;
-
-				while ( ( parentElement = parentElement.parentElement ) ) {
-					const { backgroundColor } =
-						defaultView.getComputedStyle( parentElement );
-					if (
-						backgroundColor &&
-						backgroundColor !== 'transparent' &&
-						backgroundColor !== 'rgba(0, 0, 0, 0)'
-					) {
-						bgColor = backgroundColor;
-						break;
+				{
+					let parentElement = node;
+					while ( ( parentElement = parentElement.parentElement ) ) {
+						const { scale } =
+							defaultView.getComputedStyle( parentElement );
+						if ( scale && scale !== 'none' ) {
+							_scale = parseFloat( scale );
+							break;
+						}
 					}
 				}
 
@@ -209,7 +197,27 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				node.style.transition = 'transform 0.2s ease-out';
 				node.style.transform = `scale(${ dragScale })`;
 				node.style.opacity = '0.9';
-				node.style.backgroundColor = bgColor;
+
+				// If the block has no background color, use the parent's
+				// background color.
+				if (
+					isColorTransparent(
+						defaultView.getComputedStyle( node ).backgroundColor
+					)
+				) {
+					let bgColor = 'transparent';
+					let parentElement = node;
+					while ( ( parentElement = parentElement.parentElement ) ) {
+						const { backgroundColor } =
+							defaultView.getComputedStyle( parentElement );
+						if ( ! isColorTransparent( backgroundColor ) ) {
+							bgColor = backgroundColor;
+							break;
+						}
+					}
+
+					node.style.backgroundColor = bgColor;
+				}
 
 				let hasStarted = false;
 

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -186,8 +186,8 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				const originClientY = event.clientY;
 
 				// We can't use position fixed because it will behave different
-				// if the html element is is scaled or transformed (position
-				// will no longer be relative to the viewport). The downside of
+				// if the html element is scaled or transformed (position will
+				// no longer be relative to the viewport). The downside of
 				// relative is that we have to listen to scroll events. On the
 				// upside we don't have to clone to keep a space. Absolute
 				// positioning might be weird because it will be based on the
@@ -203,7 +203,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				const dragScale = rect.height > 200 ? 200 / rect.height : 1;
 
 				node.style.zIndex = '1000';
-				node.style.transformOrigin = '0 0';
 				node.style.transformOrigin = `${ originX * inverted }px ${
 					originY * inverted
 				}px`;
@@ -240,6 +239,8 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				function end() {
 					ownerDocument.removeEventListener( 'dragover', over );
 					ownerDocument.removeEventListener( 'dragend', end );
+					ownerDocument.removeEventListener( 'drop', end );
+					ownerDocument.removeEventListener( 'scroll', over );
 					for ( const [ property, value ] of Object.entries(
 						originalNodeProperties
 					) ) {

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -121,6 +121,8 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 				const clone = node.cloneNode( true );
 				clone.style.visibility = 'hidden';
+				// Maybe remove the clone now that it's relative?
+				clone.style.display = 'none';
 
 				// Remove the id and leave it on the clone so that drop target
 				// calculations are correct.
@@ -161,10 +163,23 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 				node.after( clone );
 
-				node.style.position = 'fixed';
-				node.style.top = `${ rect.top }px`;
-				node.style.left = `${ rect.left }px`;
-				node.style.width = `${ rect.width * inverted }px`;
+				// Get scroll position.
+				const originScrollTop = defaultView.scrollY;
+				const originScrollLeft = defaultView.scrollX;
+				const originClientX = event.clientX;
+				const originClientY = event.clientY;
+
+				// We can't use position fixed because it will behave different
+				// if the html element is is scaled or transformed (position
+				// will no longer be relative to the viewport). The downside of
+				// relative is that we have to listen to scroll events. On the
+				// upside we don't have to clone to keep a space. Absolute
+				// positioning might be weird because it will be based on the
+				// positioned parent, but it might be worth a try.
+				node.style.position = 'relative';
+				node.style.top = `${ 0 }px`;
+				node.style.left = `${ 0 }px`;
+				// node.style.width = `${ rect.width * inverted }px`;
 
 				const originX = event.clientX - rect.left;
 				const originY = event.clientY - rect.top;
@@ -174,10 +189,12 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 				node.style.zIndex = '1000';
 				node.style.transformOrigin = '0 0';
-				node.style.transformOrigin = `${ originX }px ${ originY }px`;
+				node.style.transformOrigin = `${ originX * inverted }px ${
+					originY * inverted
+				}px`;
 				node.style.transition = 'transform 0.2s ease-out';
 				node.style.transform = `scale(${ dragScale })`;
-				node.style.margin = '0';
+				// node.style.margin = '0';
 				node.style.opacity = '0.9';
 				node.style.backgroundColor = bgColor;
 
@@ -188,8 +205,22 @@ export function useEventHandlers( { clientId, isSelected } ) {
 						hasStarted = true;
 						node.style.pointerEvents = 'none';
 					}
-					node.style.top = `${ e.clientY * inverted - originY }px`;
-					node.style.left = `${ e.clientX * inverted - originX }px`;
+					const scrollTop = defaultView.scrollY;
+					const scrollLeft = defaultView.scrollX;
+					node.style.top = `${
+						( e.clientY -
+							originClientY +
+							scrollTop -
+							originScrollTop ) *
+						inverted
+					}px`;
+					node.style.left = `${
+						( e.clientX -
+							originClientX +
+							scrollLeft -
+							originScrollLeft ) *
+						inverted
+					}px`;
 				}
 
 				function end() {
@@ -202,9 +233,9 @@ export function useEventHandlers( { clientId, isSelected } ) {
 					node.style.position = '';
 					node.style.top = '';
 					node.style.left = '';
-					node.style.width = '';
+					// node.style.width = '';
 					node.style.pointerEvents = '';
-					node.style.margin = '';
+					// node.style.margin = '';
 					node.style.opacity = '';
 					node.style.backgroundColor = '';
 					clone.remove();
@@ -222,6 +253,7 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				ownerDocument.addEventListener( 'dragover', over );
 				ownerDocument.addEventListener( 'dragend', end );
 				ownerDocument.addEventListener( 'drop', end );
+				ownerDocument.addEventListener( 'scroll', over );
 
 				startDraggingBlocks( [ clientId ] );
 				// Important because it hides the block toolbar.

--- a/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-selected-block-event-handlers.js
@@ -163,6 +163,22 @@ export function useEventHandlers( { clientId, isSelected } ) {
 
 				node.after( clone );
 
+				const originalNodeProperties = {};
+				for ( const property of [
+					'transform',
+					'transformOrigin',
+					'transition',
+					'zIndex',
+					'position',
+					'top',
+					'left',
+					'pointerEvents',
+					'opacity',
+					'backgroundColor',
+				] ) {
+					originalNodeProperties[ property ] = node.style[ property ];
+				}
+
 				// Get scroll position.
 				const originScrollTop = defaultView.scrollY;
 				const originScrollLeft = defaultView.scrollX;
@@ -179,7 +195,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				node.style.position = 'relative';
 				node.style.top = `${ 0 }px`;
 				node.style.left = `${ 0 }px`;
-				// node.style.width = `${ rect.width * inverted }px`;
 
 				const originX = event.clientX - rect.left;
 				const originY = event.clientY - rect.top;
@@ -194,7 +209,6 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				}px`;
 				node.style.transition = 'transform 0.2s ease-out';
 				node.style.transform = `scale(${ dragScale })`;
-				// node.style.margin = '0';
 				node.style.opacity = '0.9';
 				node.style.backgroundColor = bgColor;
 
@@ -226,18 +240,11 @@ export function useEventHandlers( { clientId, isSelected } ) {
 				function end() {
 					ownerDocument.removeEventListener( 'dragover', over );
 					ownerDocument.removeEventListener( 'dragend', end );
-					node.style.transform = '';
-					node.style.transformOrigin = '';
-					node.style.transition = '';
-					node.style.zIndex = '';
-					node.style.position = '';
-					node.style.top = '';
-					node.style.left = '';
-					// node.style.width = '';
-					node.style.pointerEvents = '';
-					// node.style.margin = '';
-					node.style.opacity = '';
-					node.style.backgroundColor = '';
+					for ( const [ property, value ] of Object.entries(
+						originalNodeProperties
+					) ) {
+						node.style[ property ] = value;
+					}
 					clone.remove();
 					node.id = id;
 					dragElement.remove();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

It's a much nicer effect. This is actually what the native browser behaviour would be, but we couldn't make use of it because (1) it was actually a clone (which doesn't work for any iframes nested within blocks) and (2) it couldn't be scaled down so it was way too large for most blocks.

In this PR, we're moving the actual block around, which allows us to scale it down AND animate it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The drag and drop effects should feel as nice and natural as possible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


https://github.com/user-attachments/assets/04b8ecf9-84d4-47f7-a93f-e46d374158f4


