### PR TITLE
Improve the labeling of EntitiesSavedStates

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -401,7 +401,7 @@ _Parameters_
 
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
--   _props.renderDialog_ `Function`: The function to render the dialog.
+-   _props.renderDialog_ `boolean`: Whether to render the component with modal dialog behavior.
 
 _Returns_
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -31,14 +31,11 @@ function identity( values ) {
  *
  * @param {Object}   props              The component props.
  * @param {Function} props.close        The function to close the dialog.
- * @param {Function} props.renderDialog The function to render the dialog.
+ * @param {boolean}  props.renderDialog Whether to render the component with modal dialog behavior.
  *
  * @return {React.ReactNode} The rendered component.
  */
-export default function EntitiesSavedStates( {
-	close,
-	renderDialog = undefined,
-} ) {
+export default function EntitiesSavedStates( { close, renderDialog = false } ) {
 	const isDirtyProps = useIsDirty();
 	return (
 		<EntitiesSavedStatesExtensible
@@ -58,7 +55,7 @@ export default function EntitiesSavedStates( {
  * @param {Function} props.onSave                Function to call when saving entities.
  * @param {boolean}  props.saveEnabled           Flag indicating if save is enabled.
  * @param {string}   props.saveLabel             Label for the save button.
- * @param {Function} props.renderDialog          Function to render a custom dialog.
+ * @param {boolean}  props.renderDialog          Whether to render the component with modal dialog behavior.
  * @param {Array}    props.dirtyEntityRecords    Array of dirty entity records.
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
@@ -72,7 +69,7 @@ export function EntitiesSavedStatesExtensible( {
 	onSave = identity,
 	saveEnabled: saveEnabledProp = undefined,
 	saveLabel = __( 'Save' ),
-	renderDialog = undefined,
+	renderDialog = false,
 	dirtyEntityRecords,
 	isDirty,
 	setUnselectedEntities,
@@ -120,8 +117,8 @@ export function EntitiesSavedStatesExtensible( {
 
 	return (
 		<div
-			ref={ saveDialogRef }
-			{ ...saveDialogProps }
+			ref={ renderDialog ? saveDialogRef : undefined }
+			{ ...( renderDialog && saveDialogProps ) }
 			className="entities-saved-states__panel"
 			role={ renderDialog ? 'dialog' : undefined }
 			aria-labelledby={ renderDialog ? dialogLabel : undefined }
@@ -167,24 +164,26 @@ export function EntitiesSavedStatesExtensible( {
 					<strong className="entities-saved-states__text-prompt--header">
 						{ __( 'Are you ready to save?' ) }
 					</strong>
-					{ additionalPrompt }
 				</div>
-				<p id={ renderDialog ? dialogDescription : undefined }>
-					{ isDirty
-						? createInterpolateElement(
-								sprintf(
-									/* translators: %d: number of site changes waiting to be saved. */
-									_n(
-										'There is <strong>%d site change</strong> waiting to be saved.',
-										'There are <strong>%d site changes</strong> waiting to be saved.',
+				<div id={ renderDialog ? dialogDescription : undefined }>
+					{ additionalPrompt }
+					<p>
+						{ isDirty
+							? createInterpolateElement(
+									sprintf(
+										/* translators: %d: number of site changes waiting to be saved. */
+										_n(
+											'There is <strong>%d site change</strong> waiting to be saved.',
+											'There are <strong>%d site changes</strong> waiting to be saved.',
+											dirtyEntityRecords.length
+										),
 										dirtyEntityRecords.length
 									),
-									dirtyEntityRecords.length
-								),
-								{ strong: <strong /> }
-						  )
-						: __( 'Select the items you want to save.' ) }
-				</p>
+									{ strong: <strong /> }
+							  )
+							: __( 'Select the items you want to save.' ) }
+					</p>
+				</div>
 			</div>
 
 			{ sortedPartitionedSavables.map( ( list ) => {


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/67354

## What?
This PR updates the behavior of the EntitiesSavedStates component when used in a modal dialog (role="dialog") to ensure the dialog labeling is appropriate. Specifically:

The aria-labelledby attribute now references only the primary label text (Are you ready to save?).
The additionalPrompt text is moved to the aria-describedby attribute, ensuring it acts as a supplementary description instead of being included in the dialog label.

## Why?
When additionalPrompt is passed, it becomes part of the dialog label, which can make the labeling overly long and misleading. For example, in the Theme preview of the Site Editor, the dialog label currently reads:

"Are you ready to save? Saving your changes will change your active theme from Twenty Twenty-Five to Twenty Twenty-Four."

This excessively long label makes it harder for users, especially those using assistive technologies, to quickly understand the purpose of the dialog. By separating the primary label and the additional descriptive text, we enhance usability and accessibility.

## How?
Updated Markup for Descriptions:

- The additionalPrompt text is now wrapped in a div with an id dynamically assigned when the dialog is rendered (renderDialog). 
- This id is referenced by the aria-describedby attribute of the dialog.
- The additionalPrompt acts as a supplementary description and is displayed before the main description.

## Testing Instructions

1. Apply the changes from PR #67351 if it hasn't been merged yet.
2. Go to WP Admin > Appearance > any non-active block theme > Live preview.
3. Open the editor to preview the theme.
4. Click the editor canvas to switch to edit mode.
5. Click the "Activate {theme name}" button at the top right.
6. Inspect the DOM and select the element with role="dialog" and class entities-saved-states__panel.
7. Verify that:
   The aria-labelledby attribute references only the primary label.
   The aria-describedby attribute includes the additionalPrompt text.

## Screenshots or screencast 
![Screenshot from 2024-12-02 18-11-26](https://github.com/user-attachments/assets/cb318d2e-86d8-4ea6-aeec-f5039ba49ec0)

