### PR TITLE
useEditorTitle: fix wrong request without ID

### DIFF
--- a/packages/edit-site/src/components/editor/use-editor-title.js
+++ b/packages/edit-site/src/components/editor/use-editor-title.js
@@ -22,6 +22,10 @@ function useEditorTitle( postType, postId ) {
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
 
+			if ( ! postId ) {
+				return { isLoaded: false };
+			}
+
 			const _record = getEditedEntityRecord(
 				'postType',
 				postType,

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Preload', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'emptytheme' );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test( 'Should make no requests before the iframe is loaded', async ( {
+		page,
+		admin,
+	} ) => {
+		// Do not use `visitSiteEditor` because it waits for the iframe to load.
+		await admin.visitAdminPage( 'site-editor.php' );
+
+		const requests = [];
+		let isLoaded = false;
+
+		page.on( 'request', ( request ) => {
+			if ( request.resourceType() === 'document' ) {
+				// The iframe also "requests" a blob document. This is the most
+				// reliable way to wait for the iframe to start loading.
+				// `waitForSelector` is always a bit delayed, and we don't want
+				// to detect requests after the iframe mounts.
+				isLoaded = true;
+			} else if ( ! isLoaded && request.resourceType() === 'fetch' ) {
+				requests.push( request.url() );
+			}
+		} );
+
+		await page.waitForFunction( ( _isLoaded ) => _isLoaded, [ isLoaded ] );
+
+		expect( requests ).toEqual( [] );
+	} );
+} );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I think this has been introduced in #66955. `postId` may be undefined (try the root page in the Site Editor), which is causing a request to `/templates` (without the ID, so a useless request). This is delaying editor load (though we are not currently measuring it for template editing).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Return early.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open the Site Editor root, and check the first few `fetch` requests. Notice the loader before this PR, after this PR it's only 100ms, so it doesn't really show up.

I've added a test so we don't make these regressions again.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

