### PR TITLE
DataViews: Unify layout config

### DIFF
--- a/packages/dataviews/CHANGELOG.md
+++ b/packages/dataviews/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+## Breaking Changes
+
+-   Support showing or hiding title, media and description fields ([#67477](https://github.com/WordPress/gutenberg/pull/67477)).
+-   Unify the `title`, `media` and `description` fields for the different layouts. So instead of the previous `view.layout.mediaField`, `view.layout.primaryField` and `view.layout.columnFields`, all the layouts now support these three fields with the following config ([#67477](https://github.com/WordPress/gutenberg/pull/67477)): 
+
+```js
+const view = {
+    type: 'table',
+    titleField: 'title',
+    mediaField: 'media',
+    descriptionField: 'description',
+    fields: [ 'author', 'date' ],
+}
+```
+
 ## Internal
 
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).

--- a/packages/dataviews/README.md
+++ b/packages/dataviews/README.md
@@ -165,6 +165,7 @@ const view = {
 		field: 'date',
 		direction: 'desc',
 	},
+	titleField: 'title',
 	fields: [ 'author', 'status' ],
 	layout: {},
 };
@@ -184,49 +185,21 @@ Properties:
 
     -   `field`: the field used for sorting the dataset.
     -   `direction`: the direction to use for sorting, one of `asc` or `desc`.
-
--   `fields`: a list of field `id` that are visible in the UI and the specific order in which they are displayed.
+-   `titleField`: The id of the field reprensenting the title of the record.
+-   `mediaField`: The id of the field reprensenting the media of the record.
+-   `descriptionField`: The id of field the reprensenting the description of the record.
+-   `showTitle`: Whether the title should be shown in the UI. `true` by default.
+-   `showMedia`: Whether the media should be shown in the UI. `true` by default.
+-   `showDescription`: Whether the description should be shown in the UI. `true` by default.
+-   `fields`: a list of remaining field `id` that are visible in the UI and the specific order in which they are displayed.
 -   `layout`: config that is specific to a particular layout type.
 
 ##### Properties of `layout`
 
 | Properties of `layout`                                                                                          | Table | Grid | List |
 | --------------------------------------------------------------------------------------------------------------- | ----- | ---- | ---- |
-| `primaryField`: the field's `id` to be highlighted in each layout. It's not hidable.                            | ✓     | ✓    | ✓    |
-| `mediaField`: the field's `id` to be used for rendering each card's media. It's not hiddable.                   |       | ✓    | ✓    |
-| `columnFields`: a list of field's `id` to render vertically stacked instead of horizontally (the default).      |       | ✓    |      |
 | `badgeFields`: a list of field's `id` to render without label and styled as badges.                             |       | ✓    |      |
-| `combinedFields`: a list of "virtual" fields that are made by combining others. See "Combining fields" section. | ✓     |      |      |
 | `styles`: additional `width`, `maxWidth`, `minWidth` styles for each field column.                              | ✓     |      |      |
-
-##### Combining fields
-
-The `table` layout has the ability to create "virtual" fields that are made out by combining existing ones.
-
-Each "virtual field", has to provide an `id` and `label` (optionally a `header` instead), which have the same meaning as any other field.
-
-Additionally, they need to provide:
-
--   `children`: a list of field's `id` to combine
--   `direction`: how should they be stacked, `vertical` or `horizontal`
-
-For example, this is how you'd define a `site` field which is a combination of a `title` and `description` fields, which are not displayed:
-
-```js
-{
-	fields: [ 'site', 'status' ],
-	layout: {
-		combinedFields: [
-			{
-				id: 'site',
-				label: 'Site',
-				children: [ 'title', 'description' ],
-				direction: 'vertical',
-			}
-		]
-	}
-}
-```
 
 #### `onChangeView`: `function`
 
@@ -255,6 +228,7 @@ function MyCustomPageTable() {
 				value: [ 'publish', 'draft' ],
 			},
 		],
+		titleField: 'title',
 		fields: [ 'author', 'status' ],
 		layout: {},
 	} );
@@ -370,14 +344,15 @@ For example, this is how you'd enable only the table view type:
 ```js
 const defaultLayouts = {
 	table: {
-		layout: {
-			primaryField: 'my-key',
-		},
+		showMedia: false,
 	},
+	grid: {
+		showMedia: true,
+	}
 };
 ```
 
-The `defaultLayouts` property should be an object that includes properties named `table`, `grid`, or `list`. Each of these properties should contain a `layout` property, which holds the configuration for each specific layout type. Check "Properties of layout" for the full list of properties available for each layout's configuration
+The `defaultLayouts` property should be an object that includes properties named `table`, `grid`, or `list`. These properties are applied to the view object each time the user switches to the corresponding layout.
 
 #### `selection`: `string[]`
 

--- a/packages/dataviews/src/components/dataviews-selection-checkbox/index.tsx
+++ b/packages/dataviews/src/components/dataviews-selection-checkbox/index.tsx
@@ -15,7 +15,7 @@ interface DataViewsSelectionCheckboxProps< Item > {
 	onChangeSelection: SetSelection;
 	item: Item;
 	getItemId: ( item: Item ) => string;
-	primaryField?: Field< Item >;
+	titleField?: Field< Item >;
 	disabled: boolean;
 }
 
@@ -24,19 +24,19 @@ export default function DataViewsSelectionCheckbox< Item >( {
 	onChangeSelection,
 	item,
 	getItemId,
-	primaryField,
+	titleField,
 	disabled,
 }: DataViewsSelectionCheckboxProps< Item > ) {
 	const id = getItemId( item );
 	const checked = ! disabled && selection.includes( id );
 	let selectionLabel;
-	if ( primaryField?.getValue && item ) {
+	if ( titleField?.getValue && item ) {
 		// eslint-disable-next-line @wordpress/valid-sprintf
 		selectionLabel = sprintf(
 			checked
 				? /* translators: %s: item title. */ __( 'Deselect item: %s' )
 				: /* translators: %s: item title. */ __( 'Select item: %s' ),
-			primaryField.getValue( { item } )
+			titleField.getValue( { item } )
 		);
 	} else {
 		selectionLabel = checked

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -22,6 +22,7 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
+	BaseControl,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
@@ -428,74 +429,79 @@ function FieldControl() {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 
 	return (
-		<VStack
-			spacing={ 0 }
-			className="dataviews-field-control dataviews-view-config__properties"
-		>
-			{ togglableFields.length > 0 && (
-				<ItemGroup isBordered isSeparated>
-					{ titleField && (
-						<FieldItem
-							field={ titleField }
-							isVisible={ showTitle }
-							onToggleVisibility={ () => {
-								onChangeView( {
-									...view,
-									showTitle: ! showTitle,
-								} );
-							} }
-						/>
-					) }
-					{ mediaField && (
-						<FieldItem
-							field={ mediaField }
-							isVisible={ showMedia }
-							onToggleVisibility={ () => {
-								onChangeView( {
-									...view,
-									showMedia: ! showMedia,
-								} );
-							} }
-						/>
-					) }
-					{ descriptionField && (
-						<FieldItem
-							field={ descriptionField }
-							isVisible={ showDescription }
-							onToggleVisibility={ () => {
-								onChangeView( {
-									...view,
-									showDescription: ! showDescription,
-								} );
-							} }
-						/>
-					) }
-				</ItemGroup>
-			) }
-			{ !! visibleFields?.length && (
-				<ItemGroup isBordered isSeparated>
-					{ visibleFields.map( ( field, index ) => (
-						<RegularFieldItem
-							key={ field.id }
-							field={ field }
-							view={ view }
-							onChangeView={ onChangeView }
-							index={ index }
-						/>
-					) ) }
-				</ItemGroup>
-			) }
+		<VStack className="dataviews-field-control" spacing={ 6 }>
+			<VStack className="dataviews-view-config__properties" spacing={ 0 }>
+				{ togglableFields.length > 0 && (
+					<ItemGroup isBordered isSeparated>
+						{ titleField && (
+							<FieldItem
+								field={ titleField }
+								isVisible={ showTitle }
+								onToggleVisibility={ () => {
+									onChangeView( {
+										...view,
+										showTitle: ! showTitle,
+									} );
+								} }
+							/>
+						) }
+						{ mediaField && (
+							<FieldItem
+								field={ mediaField }
+								isVisible={ showMedia }
+								onToggleVisibility={ () => {
+									onChangeView( {
+										...view,
+										showMedia: ! showMedia,
+									} );
+								} }
+							/>
+						) }
+						{ descriptionField && (
+							<FieldItem
+								field={ descriptionField }
+								isVisible={ showDescription }
+								onToggleVisibility={ () => {
+									onChangeView( {
+										...view,
+										showDescription: ! showDescription,
+									} );
+								} }
+							/>
+						) }
+					</ItemGroup>
+				) }
+				{ !! visibleFields?.length && (
+					<ItemGroup isBordered isSeparated>
+						{ visibleFields.map( ( field, index ) => (
+							<RegularFieldItem
+								key={ field.id }
+								field={ field }
+								view={ view }
+								onChangeView={ onChangeView }
+								index={ index }
+							/>
+						) ) }
+					</ItemGroup>
+				) }
+			</VStack>
+
 			{ !! hiddenFields?.length && (
-				<ItemGroup isBordered isSeparated>
-					{ hiddenFields.map( ( field ) => (
-						<RegularFieldItem
-							key={ field.id }
-							field={ field }
-							view={ view }
-							onChangeView={ onChangeView }
-						/>
-					) ) }
-				</ItemGroup>
+				<VStack spacing={ 4 }>
+					<BaseControl.VisualLabel style={ { margin: 0 } }>
+						{ __( 'Hidden' ) }
+					</BaseControl.VisualLabel>
+					<ItemGroup isBordered isSeparated>
+						{ hiddenFields.map( ( field ) => (
+							<RegularFieldItem
+								key={ field.id }
+								field={ field }
+								view={ view }
+								onChangeView={ onChangeView }
+							/>
+						) ) }
+					</ItemGroup>
+				</VStack>
 			) }
 		</VStack>
 	);

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -245,6 +245,20 @@ function FieldItem( {
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
 } ) {
+	const focusVisibilityField = () => {
+		// Focus the visibility button to avoid focus loss.
+		// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.
+		// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
+		setTimeout( () => {
+			const element = document.querySelector(
+				`.dataviews-field-control__field-${ field.id } .dataviews-field-control__field-visibility-button`
+			);
+			if ( element instanceof HTMLElement ) {
+				element.focus();
+			}
+		}, 50 );
+	};
+
 	return (
 		<Item>
 			<HStack
@@ -291,7 +305,10 @@ function FieldItem( {
 							disabled={ ! field.enableHiding }
 							accessibleWhenDisabled
 							size="compact"
-							onClick={ onToggleVisibility }
+							onClick={ () => {
+								onToggleVisibility();
+								focusVisibilityField();
+							} }
 							icon={ isVisible ? unseen : seen }
 							label={
 								isVisible
@@ -346,17 +363,6 @@ function RegularFieldItem( {
 						  )
 						: [ ...visibleFieldIds, field.id ],
 				} );
-				// Focus the visibility button to avoid focus loss.
-				// Our code is safe against the component being unmounted, so we don't need to worry about cleaning the timeout.
-				// eslint-disable-next-line @wordpress/react-no-unsafe-timeout
-				setTimeout( () => {
-					const element = document.querySelector(
-						`.dataviews-field-control__field-${ field.id } .dataviews-field-control__field-visibility-button`
-					);
-					if ( element instanceof HTMLElement ) {
-						element.focus();
-					}
-				}, 50 );
 			} }
 			onMoveUp={
 				index !== undefined

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -23,10 +23,18 @@ import {
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
 	BaseControl,
+	Icon,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
-import { chevronDown, chevronUp, cog, seen, unseen } from '@wordpress/icons';
+import {
+	chevronDown,
+	chevronUp,
+	cog,
+	seen,
+	unseen,
+	lock,
+} from '@wordpress/icons';
 import warning from '@wordpress/warning';
 import { useInstanceId } from '@wordpress/compose';
 
@@ -237,6 +245,7 @@ function FieldItem( {
 	isVisible,
 	isFirst,
 	isLast,
+	canMove = true,
 	onToggleVisibility,
 	onMoveUp,
 	onMoveDown,
@@ -245,6 +254,7 @@ function FieldItem( {
 	isVisible: boolean;
 	isFirst?: boolean;
 	isLast?: boolean;
+	canMove?: boolean;
 	onToggleVisibility?: () => void;
 	onMoveUp?: () => void;
 	onMoveDown?: () => void;
@@ -268,38 +278,54 @@ function FieldItem( {
 			<HStack
 				expanded
 				className={ `dataviews-field-control__field dataviews-field-control__field-${ field.id }` }
+				justify="flex-start"
 			>
-				<span>{ field.label }</span>
+				<span className="dataviews-field-control__icon">
+					{ ! canMove && ! field.enableHiding && (
+						<Icon icon={ lock } />
+					) }
+				</span>
+				<span className="dataviews-field-control__label">
+					{ field.label }
+				</span>
 				<HStack
 					justify="flex-end"
 					expanded={ false }
 					className="dataviews-field-control__actions"
 				>
-					{ onMoveUp && onMoveDown && isVisible && (
+					{ isVisible && (
 						<>
 							<Button
-								disabled={ isFirst }
+								disabled={ isFirst || ! canMove }
 								accessibleWhenDisabled
 								size="compact"
 								onClick={ onMoveUp }
 								icon={ chevronUp }
-								label={ sprintf(
-									/* translators: %s: field label */
-									__( 'Move %s up' ),
-									field.label
-								) }
+								label={
+									isFirst || ! canMove
+										? __( "This field can't be moved up" )
+										: sprintf(
+												/* translators: %s: field label */
+												__( 'Move %s up' ),
+												field.label
+										  )
+								}
 							/>
 							<Button
-								disabled={ isLast }
+								disabled={ isLast || ! canMove }
 								accessibleWhenDisabled
 								size="compact"
 								onClick={ onMoveDown }
 								icon={ chevronDown }
-								label={ sprintf(
-									/* translators: %s: field label */
-									__( 'Move %s down' ),
-									field.label
-								) }
+								label={
+									isLast || ! canMove
+										? __( "This field can't be moved down" )
+										: sprintf(
+												/* translators: %s: field label */
+												__( 'Move %s down' ),
+												field.label
+										  )
+								}
 							/>
 						</>
 					) }
@@ -464,7 +490,8 @@ function FieldControl() {
 	return (
 		<VStack className="dataviews-field-control" spacing={ 6 }>
 			<VStack className="dataviews-view-config__properties" spacing={ 0 }>
-				{ visibleLockedFields.length > 0 && (
+				{ ( visibleLockedFields.length > 0 ||
+					!! visibleFields?.length ) && (
 					<ItemGroup isBordered isSeparated>
 						{ visibleLockedFields.map(
 							( { field, isVisibleFlag } ) => {
@@ -479,14 +506,12 @@ function FieldControl() {
 												[ isVisibleFlag ]: false,
 											} );
 										} }
+										canMove={ false }
 									/>
 								);
 							}
 						) }
-					</ItemGroup>
-				) }
-				{ !! visibleFields?.length && (
-					<ItemGroup isBordered isSeparated>
+
 						{ visibleFields.map( ( field, index ) => (
 							<RegularFieldItem
 								key={ field.id }
@@ -509,9 +534,9 @@ function FieldControl() {
 						className="dataviews-view-config__properties"
 						spacing={ 0 }
 					>
-						{ hiddenLockedFields.length > 0 && (
-							<ItemGroup isBordered isSeparated>
-								{ hiddenLockedFields.map(
+						<ItemGroup isBordered isSeparated>
+							{ hiddenLockedFields.length > 0 &&
+								hiddenLockedFields.map(
 									( { field, isVisibleFlag } ) => {
 										return (
 											<FieldItem
@@ -524,13 +549,11 @@ function FieldControl() {
 														[ isVisibleFlag ]: true,
 													} );
 												} }
+												canMove={ false }
 											/>
 										);
 									}
 								) }
-							</ItemGroup>
-						) }
-						<ItemGroup isBordered isSeparated>
 							{ hiddenFields.map( ( field ) => (
 								<RegularFieldItem
 									key={ field.id }

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -83,9 +83,13 @@ function ViewTypeMenu( {
 								case 'list':
 								case 'grid':
 								case 'table':
+									const viewWithoutLayout = { ...view };
+									if ( 'layout' in viewWithoutLayout ) {
+										delete viewWithoutLayout.layout;
+									}
 									// @ts-expect-error
 									return onChangeView( {
-										...view,
+										...viewWithoutLayout,
 										type: e.target.value,
 										...defaultLayouts[ e.target.value ],
 									} );

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -333,8 +333,10 @@ function RegularFieldItem( {
 		<FieldItem
 			field={ field }
 			isVisible={ isVisible }
-			isFirst={ !! index && index < 1 }
-			isLast={ !! index && index === visibleFieldIds.length - 1 }
+			isFirst={ index !== undefined && index < 1 }
+			isLast={
+				index !== undefined && index === visibleFieldIds.length - 1
+			}
 			onToggleVisibility={ () => {
 				onChangeView( {
 					...view,
@@ -357,7 +359,7 @@ function RegularFieldItem( {
 				}, 50 );
 			} }
 			onMoveUp={
-				index
+				index !== undefined
 					? () => {
 							onChangeView( {
 								...view,
@@ -375,7 +377,7 @@ function RegularFieldItem( {
 					: undefined
 			}
 			onMoveDown={
-				index
+				index !== undefined
 					? () => {
 							onChangeView( {
 								...view,

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -426,48 +426,52 @@ function FieldControl() {
 	const descriptionField = fields.find(
 		( f ) => f.id === view.descriptionField
 	);
-	const { showTitle = true, showMedia = true, showDescription = true } = view;
+	const lockedFields = [
+		{
+			field: titleField,
+			isVisibleFlag: 'showTitle',
+		},
+		{
+			field: mediaField,
+			isVisibleFlag: 'showMedia',
+		},
+		{
+			field: descriptionField,
+			isVisibleFlag: 'showDescription',
+		},
+	].filter( ( { field } ) => isDefined( field ) );
+	const visibleLockedFields = lockedFields.filter(
+		( { field, isVisibleFlag } ) =>
+			// @ts-expect-error
+			isDefined( field ) && ( view[ isVisibleFlag ] ?? true )
+	) as Array< { field: NormalizedField< any >; isVisibleFlag: string } >;
+	const hiddenLockedFields = lockedFields.filter(
+		( { field, isVisibleFlag } ) =>
+			// @ts-expect-error
+			isDefined( field ) && ! ( view[ isVisibleFlag ] ?? true )
+	) as Array< { field: NormalizedField< any >; isVisibleFlag: string } >;
 
 	return (
 		<VStack className="dataviews-field-control" spacing={ 6 }>
 			<VStack className="dataviews-view-config__properties" spacing={ 0 }>
-				{ togglableFields.length > 0 && (
+				{ visibleLockedFields.length > 0 && (
 					<ItemGroup isBordered isSeparated>
-						{ titleField && (
-							<FieldItem
-								field={ titleField }
-								isVisible={ showTitle }
-								onToggleVisibility={ () => {
-									onChangeView( {
-										...view,
-										showTitle: ! showTitle,
-									} );
-								} }
-							/>
-						) }
-						{ mediaField && (
-							<FieldItem
-								field={ mediaField }
-								isVisible={ showMedia }
-								onToggleVisibility={ () => {
-									onChangeView( {
-										...view,
-										showMedia: ! showMedia,
-									} );
-								} }
-							/>
-						) }
-						{ descriptionField && (
-							<FieldItem
-								field={ descriptionField }
-								isVisible={ showDescription }
-								onToggleVisibility={ () => {
-									onChangeView( {
-										...view,
-										showDescription: ! showDescription,
-									} );
-								} }
-							/>
+						{ visibleLockedFields.map(
+							( { field, isVisibleFlag } ) => {
+								return (
+									<FieldItem
+										key={ field.id }
+										field={ field }
+										isVisible
+										onToggleVisibility={ () => {
+											onChangeView( {
+												...view,
+												[ isVisibleFlag ]: false,
+											} );
+										} }
+									/>
+								);
+							}
 						) }
 					</ItemGroup>
 				) }
@@ -486,21 +490,47 @@ function FieldControl() {
 				) }
 			</VStack>
 
-			{ !! hiddenFields?.length && (
+			{ ( !! hiddenFields?.length || !! hiddenLockedFields.length ) && (
 				<VStack spacing={ 4 }>
 					<BaseControl.VisualLabel style={ { margin: 0 } }>
 						{ __( 'Hidden' ) }
 					</BaseControl.VisualLabel>
-					<ItemGroup isBordered isSeparated>
-						{ hiddenFields.map( ( field ) => (
-							<RegularFieldItem
-								key={ field.id }
-								field={ field }
-								view={ view }
-								onChangeView={ onChangeView }
-							/>
-						) ) }
-					</ItemGroup>
+					<VStack
+						className="dataviews-view-config__properties"
+						spacing={ 0 }
+					>
+						{ hiddenLockedFields.length > 0 && (
+							<ItemGroup isBordered isSeparated>
+								{ hiddenLockedFields.map(
+									( { field, isVisibleFlag } ) => {
+										return (
+											<FieldItem
+												key={ field.id }
+												field={ field }
+												isVisible={ false }
+												onToggleVisibility={ () => {
+													onChangeView( {
+														...view,
+														[ isVisibleFlag ]: true,
+													} );
+												} }
+											/>
+										);
+									}
+								) }
+							</ItemGroup>
+						) }
+						<ItemGroup isBordered isSeparated>
+							{ hiddenFields.map( ( field ) => (
+								<RegularFieldItem
+									key={ field.id }
+									field={ field }
+									view={ view }
+									onChangeView={ onChangeView }
+								/>
+							) ) }
+						</ItemGroup>
+					</VStack>
 				</VStack>
 			) }
 		</VStack>

--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -22,7 +22,6 @@ import {
 	__experimentalHeading as Heading,
 	__experimentalText as Text,
 	privateApis as componentsPrivateApis,
-	BaseControl,
 } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { memo, useContext, useMemo } from '@wordpress/element';
@@ -429,7 +428,10 @@ function FieldControl() {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 
 	return (
-		<VStack spacing={ 6 } className="dataviews-field-control">
+		<VStack
+			spacing={ 0 }
+			className="dataviews-field-control dataviews-view-config__properties"
+		>
 			{ togglableFields.length > 0 && (
 				<ItemGroup isBordered isSeparated>
 					{ titleField && (
@@ -484,23 +486,16 @@ function FieldControl() {
 				</ItemGroup>
 			) }
 			{ !! hiddenFields?.length && (
-				<>
-					<VStack spacing={ 4 }>
-						<BaseControl.VisualLabel style={ { margin: 0 } }>
-							{ __( 'Hidden' ) }
-						</BaseControl.VisualLabel>
-						<ItemGroup isBordered isSeparated>
-							{ hiddenFields.map( ( field ) => (
-								<RegularFieldItem
-									key={ field.id }
-									field={ field }
-									view={ view }
-									onChangeView={ onChangeView }
-								/>
-							) ) }
-						</ItemGroup>
-					</VStack>
-				</>
+				<ItemGroup isBordered isSeparated>
+					{ hiddenFields.map( ( field ) => (
+						<RegularFieldItem
+							key={ field.id }
+							field={ field }
+							view={ view }
+							onChangeView={ onChangeView }
+						/>
+					) ) }
+				</ItemGroup>
 			) }
 		</VStack>
 	);

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -68,13 +68,10 @@
 	}
 }
 
-.dataviews-view-config__properties > div {
-	&:not(:last-child) {
-		border-bottom-left-radius: 0;
-		border-bottom-right-radius: 0;
-	}
-	&:not(:first-child) {
-		border-top-left-radius: 0;
-		border-top-right-radius: 0;
-	}
+.dataviews-field-control__icon {
+	width: 24px;
+}
+
+.dataviews-field-control__label {
+	flex-grow: 1;
 }

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -69,5 +69,12 @@
 }
 
 .dataviews-view-config__properties > div {
-	border-radius: 0;
+	&:not(:last-child) {
+		border-bottom-left-radius: 0;
+		border-bottom-right-radius: 0;
+	}
+	&:not(:first-child) {
+		border-top-left-radius: 0;
+		border-top-right-radius: 0;
+	}
 }

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -69,7 +69,7 @@
 }
 
 .dataviews-field-control__icon {
-	width: 24px;
+	width: $icon-size;
 }
 
 .dataviews-field-control__label {

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -67,3 +67,7 @@
 		top: unset;
 	}
 }
+
+.dataviews-view-config__properties > div {
+	border-radius: 0;
+}

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -69,6 +69,7 @@
 }
 
 .dataviews-field-control__icon {
+	display: flex;
 	width: $icon-size;
 }
 

--- a/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/fixtures.tsx
@@ -637,9 +637,6 @@ export const fields: Field< SpaceObject >[] = [
 		id: 'title',
 		enableHiding: false,
 		enableGlobalSearch: true,
-		render: ( { item } ) => {
-			return <a href="#nothing">{ item.title }</a>;
-		},
 	},
 	{
 		id: 'date',

--- a/packages/dataviews/src/components/dataviews/stories/index.story.tsx
+++ b/packages/dataviews/src/components/dataviews/stories/index.story.tsx
@@ -7,17 +7,10 @@ import { useState, useMemo } from '@wordpress/element';
  * Internal dependencies
  */
 import DataViews from '../index';
-import {
-	DEFAULT_VIEW,
-	actions,
-	data,
-	fields,
-	themeData,
-	themeFields,
-} from './fixtures';
+import { DEFAULT_VIEW, actions, data, fields } from './fixtures';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../../../constants';
 import { filterSortAndPaginate } from '../../../filter-and-sort-data-view';
-import type { CombinedField, View } from '../../../types';
+import type { View } from '../../../types';
 
 import './style.css';
 
@@ -28,44 +21,18 @@ const meta = {
 export default meta;
 
 const defaultLayouts = {
-	[ LAYOUT_TABLE ]: {
-		layout: {
-			primaryField: 'title',
-			styles: {
-				image: {
-					width: 50,
-				},
-				title: {
-					maxWidth: 400,
-				},
-				type: {
-					maxWidth: 400,
-				},
-				description: {
-					maxWidth: 200,
-				},
-			},
-		},
-	},
-	[ LAYOUT_GRID ]: {
-		layout: {
-			mediaField: 'image',
-			primaryField: 'title',
-		},
-	},
-	[ LAYOUT_LIST ]: {
-		layout: {
-			mediaField: 'image',
-			primaryField: 'title',
-		},
-	},
+	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_GRID ]: {},
+	[ LAYOUT_LIST ]: {},
 };
 
 export const Default = () => {
 	const [ view, setView ] = useState< View >( {
 		...DEFAULT_VIEW,
-		fields: [ 'title', 'description', 'categories' ],
-		layout: defaultLayouts[ DEFAULT_VIEW.type ].layout,
+		fields: [ 'categories' ],
+		titleField: 'title',
+		descriptionField: 'description',
+		mediaField: 'image',
 	} );
 	const { data: shownData, paginationInfo } = useMemo( () => {
 		return filterSortAndPaginate( data, view, fields );
@@ -79,6 +46,11 @@ export const Default = () => {
 			fields={ fields }
 			onChangeView={ setView }
 			actions={ actions }
+			onClickItem={ ( item ) => {
+				// eslint-disable-next-line no-alert
+				alert( 'Clicked: ' + item.title );
+			} }
+			isItemClickable={ () => true }
 			defaultLayouts={ defaultLayouts }
 		/>
 	);
@@ -130,70 +102,6 @@ export const FieldsNoSortableNoHidable = () => {
 			defaultLayouts={ {
 				table: {},
 			} }
-		/>
-	);
-};
-
-export const CombinedFields = () => {
-	const defaultLayoutsThemes = {
-		table: {
-			fields: [ 'theme_with_combined', 'theme_with_simple' ],
-			layout: {
-				primaryField: 'name',
-				combinedFields: [
-					{
-						id: 'name_tested',
-						label: 'Theme',
-						children: [ 'name', 'tested' ],
-						direction: 'vertical',
-					},
-					{
-						id: 'theme_with_combined',
-						label: 'Combine combined fields',
-						children: [ 'icon', 'name_tested' ],
-						direction: 'horizontal',
-					},
-					{
-						id: 'theme_with_simple',
-						label: 'Combine simple fields',
-						children: [ 'icon', 'name' ],
-						direction: 'horizontal',
-					},
-				] as CombinedField[],
-				styles: {
-					theme: {
-						maxWidth: 300,
-					},
-				},
-			},
-		},
-		grid: {
-			fields: [ 'description', 'requires', 'tested' ],
-			layout: { primaryField: 'name', columnFields: [ 'description' ] },
-		},
-		list: {
-			fields: [ 'requires', 'tested' ],
-			layout: { primaryField: 'name' },
-		},
-	};
-	const [ view, setView ] = useState< View >( {
-		...DEFAULT_VIEW,
-		fields: defaultLayoutsThemes.table.fields,
-		layout: defaultLayoutsThemes.table.layout,
-	} );
-	const { data: shownData, paginationInfo } = useMemo( () => {
-		return filterSortAndPaginate( themeData, view, themeFields );
-	}, [ view ] );
-
-	return (
-		<DataViews
-			getItemId={ ( item ) => item.name }
-			paginationInfo={ paginationInfo }
-			data={ shownData }
-			view={ view }
-			fields={ themeFields }
-			onChangeView={ setView }
-			defaultLayouts={ defaultLayoutsThemes }
 		/>
 	);
 };

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -22,9 +22,32 @@
 	@include reduce-motion( "transition" );
 }
 
-.dataviews-view-list__primary-field,
-.dataviews-view-grid__primary-field,
-.dataviews-view-table__primary-field {
+.dataviews-no-results,
+.dataviews-loading {
+	padding: 0 $grid-unit-60;
+	flex-grow: 1;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	transition: padding ease-out 0.1s;
+	@include reduce-motion( "transition" );
+}
+
+/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
+@container (max-width: 430px) {
+	.dataviews__view-actions,
+	.dataviews-filters__container {
+		padding: $grid-unit-15 $grid-unit-30;
+	}
+
+	.dataviews-no-results,
+	.dataviews-loading {
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
+	}
+}
+
+.dataviews-primary-field {
 	font-size: $default-font-size;
 	font-weight: 500;
 	color: $gray-700;
@@ -72,34 +95,6 @@
 	}
 }
 
-.dataviews-view-list__primary-field--clickable,
-.dataviews-view-grid__primary-field--clickable,
-.dataviews-view-grid__media--clickable,
-.dataviews-view-table__primary-field > .dataviews-view-table__cell-content--clickable {
+.dataviews-primary-field--clickable {
 	cursor: pointer;
-}
-
-.dataviews-no-results,
-.dataviews-loading {
-	padding: 0 $grid-unit-60;
-	flex-grow: 1;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	transition: padding ease-out 0.1s;
-	@include reduce-motion( "transition" );
-}
-
-/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
-@container (max-width: 430px) {
-	.dataviews__view-actions,
-	.dataviews-filters__container {
-		padding: $grid-unit-15 $grid-unit-30;
-	}
-
-	.dataviews-no-results,
-	.dataviews-loading {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 }

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -50,7 +50,7 @@
 .dataviews-primary-field {
 	font-size: $default-font-size;
 	font-weight: 500;
-	color: $gray-700;
+	color: $gray-800;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 	width: 100%;
@@ -62,7 +62,7 @@
 		overflow: hidden;
 		display: block;
 		flex-grow: 0;
-		color: $gray-900;
+		color: $gray-800;
 
 		&:hover {
 			color: var(--wp-admin-theme-color);

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -83,18 +83,13 @@
 			color: var(--wp-admin-theme-color);
 		}
 	}
-
-	&.dataviews-view-grid__primary-field--clickable span,
-	> .dataviews-view-table__cell-content--clickable span {
-		color: $gray-900;
-
-		&:hover {
-			color: var(--wp-admin-theme-color);
-		}
-		@include link-reset();
-	}
 }
 
 .dataviews-primary-field--clickable {
 	cursor: pointer;
+	color: $gray-800;
+	&:hover {
+		color: var(--wp-admin-theme-color);
+	}
+	@include link-reset();
 }

--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -47,7 +47,7 @@
 	}
 }
 
-.dataviews-primary-field {
+.dataviews-title-field {
 	font-size: $default-font-size;
 	font-weight: 500;
 	color: $gray-800;
@@ -85,7 +85,7 @@
 	}
 }
 
-.dataviews-primary-field--clickable {
+.dataviews-title-field--clickable {
 	cursor: pointer;
 	color: $gray-800;
 	&:hover {

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ItemActions from '../../components/dataviews-item-actions';
-import SingleSelectionCheckbox from '../../components/dataviews-selection-checkbox';
+import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
 import { useHasAPossibleBulkAction } from '../../components/dataviews-bulk-actions';
 import type { Action, NormalizedField, ViewGridProps } from '../../types';
 import type { SetSelection } from '../../private-types';
@@ -103,12 +103,12 @@ function GridItem< Item >( {
 			} }
 		>
 			<div { ...clickableMediaItemProps }>{ renderedMediaField }</div>
-			<SingleSelectionCheckbox
+			<DataViewsSelectionCheckbox
 				item={ item }
 				selection={ selection }
 				onChangeSelection={ onChangeSelection }
 				getItemId={ getItemId }
-				primaryField={ titleField }
+				titleField={ titleField }
 				disabled={ ! hasBulkAction }
 			/>
 			<HStack

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -22,12 +22,18 @@ import { __ } from '@wordpress/i18n';
 import ItemActions from '../../components/dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
 import { useHasAPossibleBulkAction } from '../../components/dataviews-bulk-actions';
-import type { Action, NormalizedField, ViewGridProps } from '../../types';
+import type {
+	Action,
+	NormalizedField,
+	ViewGrid as ViewGridType,
+	ViewGridProps,
+} from '../../types';
 import type { SetSelection } from '../../private-types';
 import getClickableItemProps from '../utils/get-clickable-item-props';
 import { useUpdatedPreviewSizeOnViewportChange } from './preview-size-picker';
 
 interface GridItemProps< Item > {
+	view: ViewGridType;
 	selection: string[];
 	onChangeSelection: SetSelection;
 	getItemId: ( item: Item ) => string;
@@ -43,6 +49,7 @@ interface GridItemProps< Item > {
 }
 
 function GridItem< Item >( {
+	view,
 	selection,
 	onChangeSelection,
 	onClickItem,
@@ -56,15 +63,17 @@ function GridItem< Item >( {
 	regularFields,
 	badgeFields,
 }: GridItemProps< Item > ) {
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
 		<mediaField.render item={ item } />
 	) : null;
-	const renderedTitleField = titleField?.render ? (
-		<titleField.render item={ item } />
-	) : null;
+	const renderedTitleField =
+		showTitle && titleField?.render ? (
+			<titleField.render item={ item } />
+		) : null;
 
 	const clickableMediaItemProps = getClickableItemProps( {
 		item,
@@ -102,15 +111,19 @@ function GridItem< Item >( {
 				}
 			} }
 		>
-			<div { ...clickableMediaItemProps }>{ renderedMediaField }</div>
-			<DataViewsSelectionCheckbox
-				item={ item }
-				selection={ selection }
-				onChangeSelection={ onChangeSelection }
-				getItemId={ getItemId }
-				titleField={ titleField }
-				disabled={ ! hasBulkAction }
-			/>
+			{ showMedia && (
+				<div { ...clickableMediaItemProps }>{ renderedMediaField }</div>
+			) }
+			{ showMedia && (
+				<DataViewsSelectionCheckbox
+					item={ item }
+					selection={ selection }
+					onChangeSelection={ onChangeSelection }
+					getItemId={ getItemId }
+					titleField={ titleField }
+					disabled={ ! hasBulkAction }
+				/>
+			) }
 			<HStack
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
@@ -121,7 +134,7 @@ function GridItem< Item >( {
 				<ItemActions item={ item } actions={ actions } isCompact />
 			</HStack>
 			<VStack spacing={ 1 }>
-				{ descriptionField?.render && (
+				{ showDescription && descriptionField?.render && (
 					<descriptionField.render item={ item } />
 				) }
 				{ !! badgeFields?.length && (
@@ -248,6 +261,7 @@ export default function ViewGrid< Item >( {
 						return (
 							<GridItem
 								key={ getItemId( item ) }
+								view={ view }
 								selection={ selection }
 								onChangeSelection={ onChangeSelection }
 								onClickItem={ onClickItem }

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -111,10 +111,10 @@ function GridItem< Item >( {
 				}
 			} }
 		>
-			{ showMedia && (
+			{ showMedia && renderedMediaField && (
 				<div { ...clickableMediaItemProps }>{ renderedMediaField }</div>
 			) }
-			{ showMedia && (
+			{ showMedia && renderedMediaField && (
 				<DataViewsSelectionCheckbox
 					item={ item }
 					selection={ selection }

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -86,7 +86,7 @@ function GridItem< Item >( {
 		item,
 		isItemClickable,
 		onClickItem,
-		className: 'dataviews-view-grid__primary-field dataviews-primary-field',
+		className: 'dataviews-view-grid__primary-field dataviews-title-field',
 	} );
 
 	return (

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -81,36 +81,23 @@
 		}
 
 		.dataviews-view-grid__field {
-			align-items: flex-start;
 			min-height: $grid-unit-30;
+			align-items: center;
+
+			.dataviews-view-grid__field-name {
+				width: 35%;
+				color: $gray-700;
+			}
+
+			.dataviews-view-grid__field-value {
+				width: 65%;
+				overflow: hidden;
+				text-overflow: ellipsis;
+				white-space: nowrap;
+			}
 
 			&:not(:has(.dataviews-view-grid__field-value:not(:empty))) {
 				display: none;
-			}
-
-			&:not(.is-column) {
-				align-items: center;
-
-				.dataviews-view-grid__field-name {
-					width: 35%;
-				}
-
-				.dataviews-view-grid__field-value {
-					width: 65%;
-					overflow: hidden;
-					text-overflow: ellipsis;
-					white-space: nowrap;
-				}
-			}
-
-			&.is-column {
-				& + .is-row {
-					margin-top: $grid-unit-05;
-				}
-			}
-
-			.dataviews-view-grid__field-name {
-				color: $gray-700;
 			}
 		}
 	}

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -165,3 +165,7 @@
 		padding-right: $grid-unit-30;
 	}
 }
+
+.dataviews-view-grid__media--clickable {
+	cursor: pointer;
+}

--- a/packages/dataviews/src/dataviews-layouts/index.ts
+++ b/packages/dataviews/src/dataviews-layouts/index.ts
@@ -16,7 +16,6 @@ import ViewTable from './table';
 import ViewGrid from './grid';
 import ViewList from './list';
 import { LAYOUT_GRID, LAYOUT_LIST, LAYOUT_TABLE } from '../constants';
-import type { View, Field } from '../types';
 import PreviewSizePicker from './grid/preview-size-picker';
 import DensityPicker from './table/density-picker';
 
@@ -42,90 +41,3 @@ export const VIEW_LAYOUTS = [
 		icon: isRTL() ? formatListBulletsRTL : formatListBullets,
 	},
 ];
-
-export function getNotHidableFieldIds( view: View ): string[] {
-	if ( view.type === 'table' ) {
-		return [ view.layout?.primaryField ]
-			.concat(
-				view.layout?.combinedFields?.flatMap(
-					( field ) => field.children
-				) ?? []
-			)
-			.filter( ( item ): item is string => !! item );
-	}
-
-	if ( view.type === 'grid' ) {
-		return [ view.layout?.primaryField, view.layout?.mediaField ].filter(
-			( item ): item is string => !! item
-		);
-	}
-
-	if ( view.type === 'list' ) {
-		return [ view.layout?.primaryField, view.layout?.mediaField ].filter(
-			( item ): item is string => !! item
-		);
-	}
-
-	return [];
-}
-
-function getCombinedFieldIds( view: View ): string[] {
-	const combinedFields: string[] = [];
-	if ( view.type === LAYOUT_TABLE && view.layout?.combinedFields ) {
-		view.layout.combinedFields.forEach( ( combination ) => {
-			combinedFields.push( ...combination.children );
-		} );
-	}
-	return combinedFields;
-}
-
-export function getVisibleFieldIds(
-	view: View,
-	fields: Field< any >[]
-): string[] {
-	const fieldsToExclude = getCombinedFieldIds( view );
-
-	if ( view.fields ) {
-		return view.fields.filter( ( id ) => ! fieldsToExclude.includes( id ) );
-	}
-
-	const visibleFields = [];
-	if ( view.type === LAYOUT_TABLE && view.layout?.combinedFields ) {
-		visibleFields.push(
-			...view.layout.combinedFields.map( ( { id } ) => id )
-		);
-	}
-	visibleFields.push(
-		...fields
-			.filter( ( { id } ) => ! fieldsToExclude.includes( id ) )
-			.map( ( { id } ) => id )
-	);
-
-	return visibleFields;
-}
-
-export function getHiddenFieldIds(
-	view: View,
-	fields: Field< any >[]
-): string[] {
-	const fieldsToExclude = [
-		...getCombinedFieldIds( view ),
-		...getVisibleFieldIds( view, fields ),
-	];
-
-	// The media field does not need to be in the view.fields to be displayed.
-	if ( view.type === LAYOUT_GRID && view.layout?.mediaField ) {
-		fieldsToExclude.push( view.layout?.mediaField );
-	}
-
-	if ( view.type === LAYOUT_LIST && view.layout?.mediaField ) {
-		fieldsToExclude.push( view.layout?.mediaField );
-	}
-
-	return fields
-		.filter(
-			( { id, enableHiding } ) =>
-				! fieldsToExclude.includes( id ) && enableHiding
-		)
-		.map( ( { id } ) => id );
-}

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -35,9 +35,15 @@ import {
 	ActionsMenuGroup,
 	ActionModal,
 } from '../../components/dataviews-item-actions';
-import type { Action, NormalizedField, ViewListProps } from '../../types';
+import type {
+	Action,
+	NormalizedField,
+	ViewList as ViewListType,
+	ViewListProps,
+} from '../../types';
 
 interface ListViewItemProps< Item > {
+	view: ViewListType;
 	actions: Action< Item >[];
 	idPrefix: string;
 	isSelected: boolean;
@@ -131,6 +137,7 @@ function PrimaryActionGridCell< Item >( {
 }
 
 function ListItem< Item >( {
+	view,
 	actions,
 	idPrefix,
 	isSelected,
@@ -142,6 +149,7 @@ function ListItem< Item >( {
 	otherFields,
 	onDropdownTriggerKeyDown,
 }: ListViewItemProps< Item > ) {
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const itemRef = useRef< HTMLDivElement >( null );
 	const labelId = `${ idPrefix }-label`;
 	const descriptionId = `${ idPrefix }-description`;
@@ -179,15 +187,17 @@ function ListItem< Item >( {
 
 	const hasOnlyOnePrimaryAction = primaryAction && actions.length === 1;
 
-	const renderedMediaField = mediaField?.render ? (
-		<div className="dataviews-view-list__media-wrapper">
-			<mediaField.render item={ item } />
-		</div>
-	) : null;
+	const renderedMediaField =
+		showMedia && mediaField?.render ? (
+			<div className="dataviews-view-list__media-wrapper">
+				<mediaField.render item={ item } />
+			</div>
+		) : null;
 
-	const renderedTitleField = titleField?.render ? (
-		<titleField.render item={ item } />
-	) : null;
+	const renderedTitleField =
+		showTitle && titleField?.render ? (
+			<titleField.render item={ item } />
+		) : null;
 
 	const usedActions = eligibleActions?.length > 0 && (
 		<HStack spacing={ 3 } className="dataviews-view-list__item-actions">
@@ -268,7 +278,7 @@ function ListItem< Item >( {
 							</div>
 							{ usedActions }
 						</HStack>
-						{ descriptionField?.render && (
+						{ showDescription && descriptionField?.render && (
 							<div className="dataviews-view-list__field">
 								<descriptionField.render item={ item } />
 							</div>
@@ -471,6 +481,7 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 				return (
 					<ListItem
 						key={ id }
+						view={ view }
 						idPrefix={ id }
 						actions={ actions }
 						item={ item }

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -42,10 +42,11 @@ interface ListViewItemProps< Item > {
 	idPrefix: string;
 	isSelected: boolean;
 	item: Item;
+	titleField?: NormalizedField< Item >;
 	mediaField?: NormalizedField< Item >;
+	descriptionField?: NormalizedField< Item >;
 	onSelect: ( item: Item ) => void;
-	primaryField?: NormalizedField< Item >;
-	visibleFields: NormalizedField< Item >[];
+	otherFields: NormalizedField< Item >[];
 	onDropdownTriggerKeyDown: React.KeyboardEventHandler< HTMLButtonElement >;
 }
 
@@ -134,10 +135,11 @@ function ListItem< Item >( {
 	idPrefix,
 	isSelected,
 	item,
+	titleField,
 	mediaField,
+	descriptionField,
 	onSelect,
-	primaryField,
-	visibleFields,
+	otherFields,
 	onDropdownTriggerKeyDown,
 }: ListViewItemProps< Item > ) {
 	const itemRef = useRef< HTMLDivElement >( null );
@@ -183,8 +185,8 @@ function ListItem< Item >( {
 		</div>
 	) : null;
 
-	const renderedPrimaryField = primaryField?.render ? (
-		<primaryField.render item={ item } />
+	const renderedTitleField = titleField?.render ? (
+		<titleField.render item={ item } />
 	) : null;
 
 	const usedActions = eligibleActions?.length > 0 && (
@@ -259,18 +261,23 @@ function ListItem< Item >( {
 					>
 						<HStack spacing={ 0 }>
 							<div
-								className="dataviews-view-list__primary-field"
+								className="dataviews-primary-field"
 								id={ labelId }
 							>
-								{ renderedPrimaryField }
+								{ renderedTitleField }
 							</div>
 							{ usedActions }
 						</HStack>
+						{ descriptionField?.render && (
+							<div className="dataviews-view-list__field">
+								<descriptionField.render item={ item } />
+							</div>
+						) }
 						<div
 							className="dataviews-view-list__fields"
 							id={ descriptionId }
 						>
-							{ visibleFields.map( ( field ) => (
+							{ otherFields.map( ( field ) => (
 								<div
 									key={ field.id }
 									className="dataviews-view-list__field"
@@ -310,20 +317,19 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 	const selectedItem = data?.findLast( ( item ) =>
 		selection.includes( getItemId( item ) )
 	);
-
-	const mediaField = fields.find(
-		( field ) => field.id === view.layout?.mediaField
+	const titleField = fields.find( ( field ) => field.id === view.titleField );
+	const mediaField = fields.find( ( field ) => field.id === view.mediaField );
+	const descriptionField = fields.find(
+		( field ) => field.id === view.descriptionField
 	);
-	const primaryField = fields.find(
-		( field ) => field.id === view.layout?.primaryField
-	);
-	const viewFields = view.fields || fields.map( ( field ) => field.id );
-	const visibleFields = fields.filter(
+	const otherFields = fields.filter(
 		( field ) =>
-			viewFields.includes( field.id ) &&
-			! [ view.layout?.primaryField, view.layout?.mediaField ].includes(
-				field.id
-			)
+			( view.fields ?? [] ).includes( field.id ) &&
+			! [
+				view.titleField,
+				view.mediaField,
+				view.descriptionField,
+			].includes( field.id )
 	);
 
 	const onSelect = ( item: Item ) =>
@@ -471,8 +477,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 						isSelected={ item === selectedItem }
 						onSelect={ onSelect }
 						mediaField={ mediaField }
-						primaryField={ primaryField }
-						visibleFields={ visibleFields }
+						titleField={ titleField }
+						descriptionField={ descriptionField }
+						otherFields={ otherFields }
 						onDropdownTriggerKeyDown={ onDropdownTriggerKeyDown }
 					/>
 				);

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -271,7 +271,7 @@ function ListItem< Item >( {
 					>
 						<HStack spacing={ 0 }>
 							<div
-								className="dataviews-primary-field"
+								className="dataviews-title-field"
 								id={ labelId }
 							>
 								{ renderedTitleField }

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -27,7 +27,6 @@ import type {
 	ViewTable as ViewTableType,
 	Operator,
 } from '../../types';
-import { getVisibleFieldIds } from '../index';
 
 const { Menu } = unlock( componentsPrivateApis );
 
@@ -62,43 +61,34 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	}: HeaderMenuProps< Item >,
 	ref: Ref< HTMLButtonElement >
 ) {
-	const visibleFieldIds = getVisibleFieldIds( view, fields );
+	const visibleFieldIds = view.fields ?? [];
 	const index = visibleFieldIds?.indexOf( fieldId ) as number;
 	const isSorted = view.sort?.field === fieldId;
 	let isHidable = false;
 	let isSortable = false;
 	let canAddFilter = false;
-	let header;
 	let operators: Operator[] = [];
-
-	const combinedField = view.layout?.combinedFields?.find(
-		( f ) => f.id === fieldId
-	);
 	const field = fields.find( ( f ) => f.id === fieldId );
 
-	if ( ! combinedField ) {
-		if ( ! field ) {
-			// No combined or regular field found.
-			return null;
-		}
-
-		isHidable = field.enableHiding !== false;
-		isSortable = field.enableSorting !== false;
-		header = field.header;
-
-		operators = sanitizeOperators( field );
-		// Filter can be added:
-		// 1. If the field is not already part of a view's filters.
-		// 2. If the field meets the type and operator requirements.
-		// 3. If it's not primary. If it is, it should be already visible.
-		canAddFilter =
-			! view.filters?.some( ( _filter ) => fieldId === _filter.field ) &&
-			!! field.elements?.length &&
-			!! operators.length &&
-			! field.filterBy?.isPrimary;
-	} else {
-		header = combinedField.header || combinedField.label;
+	if ( ! field ) {
+		// No combined or regular field found.
+		return null;
 	}
+
+	isHidable = field.enableHiding !== false;
+	isSortable = field.enableSorting !== false;
+	const header = field.header;
+
+	operators = sanitizeOperators( field );
+	// Filter can be added:
+	// 1. If the field is not already part of a view's filters.
+	// 2. If the field meets the type and operator requirements.
+	// 3. If it's not primary. If it is, it should be already visible.
+	canAddFilter =
+		! view.filters?.some( ( _filter ) => fieldId === _filter.field ) &&
+		!! field.elements?.length &&
+		!! operators.length &&
+		! field.filterBy?.isPrimary;
 
 	return (
 		<Menu

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -37,6 +37,7 @@ interface HeaderMenuProps< Item > {
 	onChangeView: ( view: ViewTableType ) => void;
 	onHide: ( field: NormalizedField< Item > ) => void;
 	setOpenedFilter: ( fieldId: string ) => void;
+	canMove?: boolean;
 }
 
 function WithMenuSeparators( { children }: { children: ReactNode } ) {
@@ -58,6 +59,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 		onChangeView,
 		onHide,
 		setOpenedFilter,
+		canMove = true,
 	}: HeaderMenuProps< Item >,
 	ref: Ref< HTMLButtonElement >
 ) {
@@ -178,64 +180,80 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 						</Menu.Item>
 					</Menu.Group>
 				) }
-				<Menu.Group>
-					<Menu.Item
-						prefix={ <Icon icon={ arrowLeft } /> }
-						disabled={ index < 1 }
-						onClick={ () => {
-							onChangeView( {
-								...view,
-								fields: [
-									...( visibleFieldIds.slice(
-										0,
-										index - 1
-									) ?? [] ),
-									fieldId,
-									visibleFieldIds[ index - 1 ],
-									...visibleFieldIds.slice( index + 1 ),
-								],
-							} );
-						} }
-					>
-						<Menu.ItemLabel>{ __( 'Move left' ) }</Menu.ItemLabel>
-					</Menu.Item>
-					<Menu.Item
-						prefix={ <Icon icon={ arrowRight } /> }
-						disabled={ index >= visibleFieldIds.length - 1 }
-						onClick={ () => {
-							onChangeView( {
-								...view,
-								fields: [
-									...( visibleFieldIds.slice( 0, index ) ??
-										[] ),
-									visibleFieldIds[ index + 1 ],
-									fieldId,
-									...visibleFieldIds.slice( index + 2 ),
-								],
-							} );
-						} }
-					>
-						<Menu.ItemLabel>{ __( 'Move right' ) }</Menu.ItemLabel>
-					</Menu.Item>
-					{ isHidable && field && (
-						<Menu.Item
-							prefix={ <Icon icon={ unseen } /> }
-							onClick={ () => {
-								onHide( field );
-								onChangeView( {
-									...view,
-									fields: visibleFieldIds.filter(
-										( id ) => id !== fieldId
-									),
-								} );
-							} }
-						>
-							<Menu.ItemLabel>
-								{ __( 'Hide column' ) }
-							</Menu.ItemLabel>
-						</Menu.Item>
-					) }
-				</Menu.Group>
+				{ ( canMove || isHidable ) && field && (
+					<Menu.Group>
+						{ canMove && (
+							<Menu.Item
+								prefix={ <Icon icon={ arrowLeft } /> }
+								disabled={ index < 1 }
+								onClick={ () => {
+									onChangeView( {
+										...view,
+										fields: [
+											...( visibleFieldIds.slice(
+												0,
+												index - 1
+											) ?? [] ),
+											fieldId,
+											visibleFieldIds[ index - 1 ],
+											...visibleFieldIds.slice(
+												index + 1
+											),
+										],
+									} );
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Move left' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+						{ canMove && (
+							<Menu.Item
+								prefix={ <Icon icon={ arrowRight } /> }
+								disabled={ index >= visibleFieldIds.length - 1 }
+								onClick={ () => {
+									onChangeView( {
+										...view,
+										fields: [
+											...( visibleFieldIds.slice(
+												0,
+												index
+											) ?? [] ),
+											visibleFieldIds[ index + 1 ],
+											fieldId,
+											...visibleFieldIds.slice(
+												index + 2
+											),
+										],
+									} );
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Move right' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+						{ isHidable && field && (
+							<Menu.Item
+								prefix={ <Icon icon={ unseen } /> }
+								onClick={ () => {
+									onHide( field );
+									onChangeView( {
+										...view,
+										fields: visibleFieldIds.filter(
+											( id ) => id !== fieldId
+										),
+									} );
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Hide column' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+					</Menu.Group>
+				) }
 			</WithMenuSeparators>
 		</Menu>
 	);

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -1,0 +1,58 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+} from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import type { NormalizedField } from '../../types';
+import getClickableItemProps from '../utils/get-clickable-item-props';
+
+function ColumnPrimary< Item >( {
+	item,
+	titleField,
+	mediaField,
+	descriptionField,
+	onClickItem,
+	isItemClickable,
+}: {
+	item: Item;
+	titleField?: NormalizedField< Item >;
+	mediaField?: NormalizedField< Item >;
+	descriptionField?: NormalizedField< Item >;
+	onClickItem?: ( item: Item ) => void;
+	isItemClickable: ( item: Item ) => boolean;
+} ) {
+	const clickableProps = getClickableItemProps( {
+		item,
+		isItemClickable,
+		onClickItem,
+		className:
+			'dataviews-view-table__cell-content-wrapper dataviews-primary-field',
+	} );
+	return (
+		<HStack spacing={ 3 } justify="flex-start">
+			{ mediaField && (
+				<div className="dataviews-view-table__cell-content-wrapper dataviews-column-primary__media">
+					<mediaField.render item={ item } />
+				</div>
+			) }
+			<VStack spacing={ 0 }>
+				{ titleField && (
+					<div { ...clickableProps }>
+						<titleField.render item={ item } />
+					</div>
+				) }
+				{ descriptionField && (
+					<descriptionField.render item={ item } />
+				) }
+			</VStack>
+		</HStack>
+	);
+}
+
+export default ColumnPrimary;

--- a/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-primary.tsx
@@ -32,7 +32,7 @@ function ColumnPrimary< Item >( {
 		isItemClickable,
 		onClickItem,
 		className:
-			'dataviews-view-table__cell-content-wrapper dataviews-primary-field',
+			'dataviews-view-table__cell-content-wrapper dataviews-title-field',
 	} );
 	return (
 		<HStack spacing={ 3 } justify="flex-start">

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -13,7 +13,7 @@ import { useEffect, useId, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import SingleSelectionCheckbox from '../../components/dataviews-selection-checkbox';
+import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
 import ItemActions from '../../components/dataviews-item-actions';
 import { sortValues } from '../../constants';
 import {
@@ -142,12 +142,12 @@ function TableRow< Item >( {
 					} }
 				>
 					<div className="dataviews-view-table__cell-content-wrapper">
-						<SingleSelectionCheckbox
+						<DataViewsSelectionCheckbox
 							item={ item }
 							selection={ selection }
 							onChangeSelection={ onChangeSelection }
 							getItemId={ getItemId }
-							primaryField={ titleField }
+							titleField={ titleField }
 							disabled={ ! hasPossibleBulkAction }
 						/>
 					</div>

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -91,7 +91,7 @@ function TableRow< Item >( {
 	const hasPossibleBulkAction = useHasAPossibleBulkAction( actions, item );
 	const isSelected = hasPossibleBulkAction && selection.includes( id );
 	const [ isHovered, setIsHovered ] = useState( false );
-
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const handleMouseEnter = () => {
 		setIsHovered( true );
 	};
@@ -104,7 +104,10 @@ function TableRow< Item >( {
 	// behaviours.
 	const isTouchDeviceRef = useRef( false );
 	const columns = view.fields ?? [];
-	const hasPrimaryColumn = titleField || mediaField || descriptionField;
+	const hasPrimaryColumn =
+		( titleField && showTitle ) ||
+		( mediaField && showMedia ) ||
+		( descriptionField && showDescription );
 
 	return (
 		<tr
@@ -157,9 +160,11 @@ function TableRow< Item >( {
 				<td>
 					<ColumnPrimary
 						item={ item }
-						titleField={ titleField }
-						mediaField={ mediaField }
-						descriptionField={ descriptionField }
+						titleField={ showTitle ? titleField : undefined }
+						mediaField={ showMedia ? mediaField : undefined }
+						descriptionField={
+							showDescription ? descriptionField : undefined
+						}
 						isItemClickable={ isItemClickable }
 						onClickItem={ onClickItem }
 					/>
@@ -256,7 +261,11 @@ function ViewTable< Item >( {
 	const descriptionField = fields.find(
 		( field ) => field.id === view.descriptionField
 	);
-	const hasPrimaryColumn = titleField || mediaField || descriptionField;
+	const { showTitle = true, showMedia = true, showDescription = true } = view;
+	const hasPrimaryColumn =
+		( titleField && showTitle ) ||
+		( mediaField && showMedia ) ||
+		( descriptionField && showDescription );
 	const columns = view.fields ?? [];
 
 	return (

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -267,6 +267,17 @@ function ViewTable< Item >( {
 		( mediaField && showMedia ) ||
 		( descriptionField && showDescription );
 	const columns = view.fields ?? [];
+	const headerMenuRef =
+		( column: string, index: number ) => ( node: HTMLButtonElement ) => {
+			if ( node ) {
+				headerMenuRefs.current.set( column, {
+					node,
+					fallback: columns[ index > 0 ? index - 1 : 1 ],
+				} );
+			} else {
+				headerMenuRefs.current.delete( column );
+			}
+		};
 
 	return (
 		<>
@@ -303,7 +314,21 @@ function ViewTable< Item >( {
 						{ hasPrimaryColumn && (
 							<th scope="col">
 								<span className="dataviews-view-table-header">
-									{ __( 'Primary' ) }
+									{ titleField && (
+										<ColumnHeaderMenu
+											ref={ headerMenuRef(
+												titleField.id,
+												0
+											) }
+											fieldId={ titleField.id }
+											view={ view }
+											fields={ fields }
+											onChangeView={ onChangeView }
+											onHide={ onHide }
+											setOpenedFilter={ setOpenedFilter }
+											canMove={ false }
+										/>
+									) }
 								</span>
 							</th>
 						) }
@@ -324,26 +349,7 @@ function ViewTable< Item >( {
 									scope="col"
 								>
 									<ColumnHeaderMenu
-										ref={ ( node ) => {
-											if ( node ) {
-												headerMenuRefs.current.set(
-													column,
-													{
-														node,
-														fallback:
-															columns[
-																index > 0
-																	? index - 1
-																	: 1
-															],
-													}
-												);
-											} else {
-												headerMenuRefs.current.delete(
-													column
-												);
-											}
-										} }
+										ref={ headerMenuRef( column, index ) }
 										fieldId={ column }
 										view={ view }
 										fields={ fields }

--- a/packages/dataviews/src/dataviews-layouts/table/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/table/style.scss
@@ -222,3 +222,7 @@
 		--checkbox-input-size: 16px;
 	}
 }
+
+.dataviews-column-primary__media {
+	max-width: 60px;
+}

--- a/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
+++ b/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
@@ -7,14 +7,16 @@ export default function getClickableItemProps< Item >( {
 	item: Item;
 	isItemClickable: ( item: Item ) => boolean;
 	onClickItem?: ( item: Item ) => void;
-	className: string;
+	className?: string;
 } ) {
 	if ( ! isItemClickable( item ) || ! onClickItem ) {
 		return { className };
 	}
 
 	return {
-		className: `${ className } ${ className }--clickable`,
+		className: className
+			? `${ className } ${ className }--clickable`
+			: undefined,
 		role: 'button',
 		tabIndex: 0,
 		onClick: ( event: React.MouseEvent ) => {

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -3,7 +3,6 @@
 @import "./components/dataviews-filters/style.scss";
 @import "./components/dataviews-footer/style.scss";
 @import "./components/dataviews-pagination/style.scss";
-@import "./components/dataviews-primary-field/style.scss";
 @import "./components/dataviews-item-actions/style.scss";
 @import "./components/dataviews-selection-checkbox/style.scss";
 @import "./components/dataviews-view-config/style.scss";

--- a/packages/dataviews/src/style.scss
+++ b/packages/dataviews/src/style.scss
@@ -3,6 +3,7 @@
 @import "./components/dataviews-filters/style.scss";
 @import "./components/dataviews-footer/style.scss";
 @import "./components/dataviews-pagination/style.scss";
+@import "./components/dataviews-primary-field/style.scss";
 @import "./components/dataviews-item-actions/style.scss";
 @import "./components/dataviews-selection-checkbox/style.scss";
 @import "./components/dataviews-view-config/style.scss";

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -307,6 +307,21 @@ interface ViewBase {
 	 * Description field
 	 */
 	descriptionField?: string;
+
+	/**
+	 * Whether to show the title
+	 */
+	showTitle?: boolean;
+
+	/**
+	 * Whether to show the media
+	 */
+	showMedia?: boolean;
+
+	/**
+	 * Whether to show the description
+	 */
+	showDescription?: boolean;
 }
 
 export interface ColumnStyle {

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -292,24 +292,21 @@ interface ViewBase {
 	 * The fields to render
 	 */
 	fields?: string[];
-}
-
-export interface CombinedField {
-	id: string;
-
-	label: string;
-
-	header?: string | ReactElement;
 
 	/**
-	 * The fields to use as columns.
+	 * Title field
 	 */
-	children: string[];
+	titleField?: string;
 
 	/**
-	 * The direction of the stack.
+	 * Media field
 	 */
-	direction: 'horizontal' | 'vertical';
+	mediaField?: string;
+
+	/**
+	 * Description field
+	 */
+	descriptionField?: string;
 }
 
 export interface ColumnStyle {
@@ -336,16 +333,6 @@ export interface ViewTable extends ViewBase {
 
 	layout?: {
 		/**
-		 * The field to use as the primary field.
-		 */
-		primaryField?: string;
-
-		/**
-		 * The fields to use as columns.
-		 */
-		combinedFields?: CombinedField[];
-
-		/**
 		 * The styles for the columns.
 		 */
 		styles?: Record< string, ColumnStyle >;
@@ -359,39 +346,12 @@ export interface ViewTable extends ViewBase {
 
 export interface ViewList extends ViewBase {
 	type: 'list';
-
-	layout?: {
-		/**
-		 * The field to use as the primary field.
-		 */
-		primaryField?: string;
-
-		/**
-		 * The field to use as the media field.
-		 */
-		mediaField?: string;
-	};
 }
 
 export interface ViewGrid extends ViewBase {
 	type: 'grid';
 
 	layout?: {
-		/**
-		 * The field to use as the primary field.
-		 */
-		primaryField?: string;
-
-		/**
-		 * The field to use as the media field.
-		 */
-		mediaField?: string;
-
-		/**
-		 * The fields to use as columns.
-		 */
-		columnFields?: string[];
-
 		/**
 		 * The fields to use as badge fields.
 		 */

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -41,11 +41,7 @@ const EMPTY_ARRAY = [];
 const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
 		layout: {
-			primaryField: 'title',
 			styles: {
-				preview: {
-					width: '1%',
-				},
 				author: {
 					width: '1%',
 				},
@@ -54,8 +50,6 @@ const defaultLayouts = {
 	},
 	[ LAYOUT_GRID ]: {
 		layout: {
-			mediaField: 'preview',
-			primaryField: 'title',
 			badgeFields: [ 'sync-status' ],
 		},
 	},
@@ -65,8 +59,10 @@ const DEFAULT_VIEW = {
 	search: '',
 	page: 1,
 	perPage: 20,
+	titleField: 'title',
+	mediaField: 'preview',
 	layout: defaultLayouts[ LAYOUT_GRID ].layout,
-	fields: [ 'title', 'sync-status' ],
+	fields: [ 'sync-status' ],
 	filters: [],
 };
 

--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -61,9 +61,9 @@ const DEFAULT_VIEW = {
 	perPage: 20,
 	titleField: 'title',
 	mediaField: 'preview',
-	layout: defaultLayouts[ LAYOUT_GRID ].layout,
 	fields: [ 'sync-status' ],
 	filters: [],
+	...defaultLayouts[ LAYOUT_GRID ],
 };
 
 export default function DataviewsPatterns() {

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -34,24 +34,12 @@ const EMPTY_ARRAY = [];
 
 const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
-		fields: [ 'template', 'author' ],
+		mediaField: 'preview',
 		layout: {
-			primaryField: 'title',
-			combinedFields: [
-				{
-					id: 'template',
-					label: __( 'Template' ),
-					children: [ 'title', 'description' ],
-					direction: 'vertical',
-				},
-			],
 			styles: {
-				template: {
+				__primary: {
 					maxWidth: 400,
 					minWidth: 320,
-				},
-				preview: {
-					width: '1%',
 				},
 				author: {
 					width: '1%',
@@ -60,18 +48,12 @@ const defaultLayouts = {
 		},
 	},
 	[ LAYOUT_GRID ]: {
-		fields: [ 'title', 'description', 'author' ],
-		layout: {
-			mediaField: 'preview',
-			primaryField: 'title',
-			columnFields: [ 'description' ],
-		},
+		mediaField: 'preview',
+		layout: {},
 	},
 	[ LAYOUT_LIST ]: {
-		fields: [ 'title', 'description', 'author' ],
-		layout: {
-			primaryField: 'title',
-		},
+		mediaField: undefined,
+		layout: {},
 	},
 };
 
@@ -84,9 +66,11 @@ const DEFAULT_VIEW = {
 		field: 'title',
 		direction: 'asc',
 	},
-	fields: defaultLayouts[ LAYOUT_GRID ].fields,
-	layout: defaultLayouts[ LAYOUT_GRID ].layout,
+	titleField: 'title',
+	descriptionField: 'description',
+	fields: [ 'author' ],
 	filters: [],
+	...defaultLayouts[ LAYOUT_GRID ],
 };
 
 export default function PageTemplates() {
@@ -99,8 +83,6 @@ export default function PageTemplates() {
 		return {
 			...DEFAULT_VIEW,
 			type: usedType,
-			layout: defaultLayouts[ usedType ].layout,
-			fields: defaultLayouts[ usedType ].fields,
 			filters:
 				activeView !== 'all'
 					? [
@@ -111,6 +93,7 @@ export default function PageTemplates() {
 							},
 					  ]
 					: [],
+			...defaultLayouts[ usedType ],
 		};
 	}, [ layout, activeView ] );
 	const [ view, setView ] = useState( defaultView );

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -37,10 +37,6 @@ const defaultLayouts = {
 		showMedia: false,
 		layout: {
 			styles: {
-				__primary: {
-					maxWidth: 400,
-					minWidth: 320,
-				},
 				author: {
 					width: '1%',
 				},
@@ -49,11 +45,9 @@ const defaultLayouts = {
 	},
 	[ LAYOUT_GRID ]: {
 		showMedia: true,
-		layout: {},
 	},
 	[ LAYOUT_LIST ]: {
 		showMedia: false,
-		layout: {},
 	},
 };
 

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -34,7 +34,7 @@ const EMPTY_ARRAY = [];
 
 const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
-		mediaField: 'preview',
+		showMedia: false,
 		layout: {
 			styles: {
 				__primary: {
@@ -48,11 +48,11 @@ const defaultLayouts = {
 		},
 	},
 	[ LAYOUT_GRID ]: {
-		mediaField: 'preview',
+		showMedia: true,
 		layout: {},
 	},
 	[ LAYOUT_LIST ]: {
-		mediaField: undefined,
+		showMedia: false,
 		layout: {},
 	},
 };
@@ -68,6 +68,7 @@ const DEFAULT_VIEW = {
 	},
 	titleField: 'title',
 	descriptionField: 'description',
+	mediaField: 'preview',
 	fields: [ 'author' ],
 	filters: [],
 	...defaultLayouts[ LAYOUT_GRID ],

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -55,7 +55,7 @@ const getCustomView = ( editedEntityRecord ) => {
 
 	return {
 		...content,
-		layout: defaultLayouts[ content.type ]?.layout,
+		...defaultLayouts[ content.type ],
 	};
 };
 

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -29,25 +29,18 @@ import {
 export const defaultLayouts = {
 	[ LAYOUT_TABLE ]: {
 		layout: {
-			primaryField: 'title',
 			styles: {
-				title: {
+				__primary: {
 					maxWidth: 300,
 				},
 			},
 		},
 	},
 	[ LAYOUT_GRID ]: {
-		layout: {
-			mediaField: 'featured_media',
-			primaryField: 'title',
-		},
+		layout: {},
 	},
 	[ LAYOUT_LIST ]: {
-		layout: {
-			primaryField: 'title',
-			mediaField: 'featured_media',
-		},
+		layout: {},
 	},
 };
 
@@ -61,8 +54,10 @@ const DEFAULT_POST_BASE = {
 		field: 'date',
 		direction: 'desc',
 	},
-	fields: [ 'title', 'author', 'status' ],
-	layout: defaultLayouts[ LAYOUT_LIST ].layout,
+	titleField: 'title',
+	mediaField: 'featured_media',
+	fields: [ 'author', 'status' ],
+	...defaultLayouts[ LAYOUT_LIST ],
 };
 
 export function useDefaultViews( { postType } ) {

--- a/packages/edit-site/src/components/sidebar-dataviews/default-views.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/default-views.js
@@ -27,21 +27,9 @@ import {
 } from '../../utils/constants';
 
 export const defaultLayouts = {
-	[ LAYOUT_TABLE ]: {
-		layout: {
-			styles: {
-				__primary: {
-					maxWidth: 300,
-				},
-			},
-		},
-	},
-	[ LAYOUT_GRID ]: {
-		layout: {},
-	},
-	[ LAYOUT_LIST ]: {
-		layout: {},
-	},
+	[ LAYOUT_TABLE ]: {},
+	[ LAYOUT_GRID ]: {},
+	[ LAYOUT_LIST ]: {},
 };
 
 const DEFAULT_POST_BASE = {


### PR DESCRIPTION
Fixes #67391 

## What?

As explained in the main issue, the purpose of this PR is to unify the layout config and behavior for title, media and description fields. For the full reasoning, check the issue.

This is still not finished, but here's a todo list to track the progress. It's already possible to review I think. 

**Todo**

 - [x] Update the behavior of the different layouts.
 - [x] Check and update the styles properly.
 - [x] Update the stories.
 - [x] Update the documentation.
 - [x] Allow toggling the visibility of the title, media and description from the view config menu.
 - [x] Add a decent "table header" menu for the primary column in the table layout.

## Testing Instructions

1- Open the different dataviews (templates, patterns and pages)
2- Check the design of the different layouts.
3- Check how the "properties" menu work in the different layout.