### PR TITLE
Block Editor: Animate `useScaleCanvas()` only when toggling zoomed out mode

### DIFF
--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { useEffect, useRef, useCallback } from '@wordpress/element';
-import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
+import {
+	usePrevious,
+	useReducedMotion,
+	useResizeObserver,
+} from '@wordpress/compose';
 
 /**
  * @typedef {Object} TransitionState
@@ -280,6 +284,7 @@ export function useScaleCanvas( {
 		transitionFromRef.current = transitionToRef.current;
 	}, [ iframeDocument ] );
 
+	const previousIsZoomedOut = usePrevious( isZoomedOut );
 	/**
 	 * Runs when zoom out mode is toggled, and sets the startAnimation flag
 	 * so the animation will start when the next useEffect runs. We _only_
@@ -287,7 +292,7 @@ export function useScaleCanvas( {
 	 * changes due to the container resizing.
 	 */
 	useEffect( () => {
-		if ( ! iframeDocument ) {
+		if ( ! iframeDocument || previousIsZoomedOut === isZoomedOut ) {
 			return;
 		}
 
@@ -300,7 +305,7 @@ export function useScaleCanvas( {
 		return () => {
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
-	}, [ iframeDocument, isZoomedOut ] );
+	}, [ iframeDocument, isZoomedOut, previousIsZoomedOut ] );
 
 	/**
 	 * This handles:


### PR DESCRIPTION
## What?
Fixes an error that occurs when navigating directly to block styles of a particular block in the site editor.

Alternative of #67375.

## Why?
Just fixing an error that seems to have been introduced in #66917.

Found while testing #67199.

## How?
We're only starting calculations for the zoomed out animation if the user actually toggled the zoomed out mode. 

Previously, the calculations were running when attempting to "directly" load the page with styles of a particular block.

## Testing Instructions
* Open `/wp-admin/site-editor.php?p=%2Fstyles&section=%2Fblocks%2Fcore%252Fheading` directly (not by navigating to it)
* Verify you don't see an error.
* Verify testing instructions of #66917 still work well.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-11-28 at 11 04 49](https://github.com/user-attachments/assets/43d52ad2-fc3e-4f8b-ace9-8b11c6225d3f)
