### PR TITLE
DatePicker: Fix day's labels for shifting by 1 in specific usr and website timezone combination

### DIFF
--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -168,7 +168,6 @@ export function DatePicker( {
 						if ( ! isSameMonth( day, viewing ) ) {
 							return null;
 						}
-						day.setHours( 15 );
 						return (
 							<Day
 								key={ day.toString() }
@@ -304,7 +303,8 @@ function Day( {
 		// isFocusAllowed is not a dep as there is no point calling focus() on
 		// an already focused element.
 	}, [ isFocusable ] );
-
+	const shiftedDay = new Date( day );
+	shiftedDay.setHours( 15 );
 	return (
 		<DayButton
 			ref={ ref }
@@ -319,7 +319,7 @@ function Day( {
 			onClick={ onClick }
 			onKeyDown={ onKeyDown }
 		>
-			{ dateI18n( 'j', day, -day.getTimezoneOffset() ) }
+			{ dateI18n( 'j', shiftedDay, -shiftedDay.getTimezoneOffset() ) }
 		</DayButton>
 	);
 }

--- a/packages/components/src/date-time/date/index.tsx
+++ b/packages/components/src/date-time/date/index.tsx
@@ -168,6 +168,7 @@ export function DatePicker( {
 						if ( ! isSameMonth( day, viewing ) ) {
 							return null;
 						}
+						day.setHours( 15 );
 						return (
 							<Day
 								key={ day.toString() }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes the days labels become wrong after the DST time when user is in UK and Website has US Timezone.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
https://github.com/WordPress/gutenberg/issues/67480

## How?
Add 15 hours to day before pathing it to `Day` component to avoid the DST impact described in a bug (in the similar maner as `date-fns` lib [do](https://github.com/date-fns/date-fns/blob/6c70ac6d073ebe869e42795f5e71dfecf5abbea0/src/eachWeekOfInterval/index.ts#L87))

## Testing Instructions

1. Set local UK timezone
2. Set website US timezone (America/New_York)
3. Go to post with Gutenberg enabled
4. Open the post date picker
5. find the October 2024 and November 2024
6. Check the day's labels

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/f71f36b7-aacb-4804-bccc-9028da222553)|![image](https://github.com/user-attachments/assets/958582d9-06a9-48c3-8989-ac2e91843285)|
