### PR TITLE
Navigation Block: Fix issue with double-clicking "Create a new menu" causing duplicate menus.

### DIFF
--- a/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
+++ b/packages/block-library/src/navigation/edit/deleted-navigation-warning.js
@@ -4,9 +4,16 @@
 import { Warning } from '@wordpress/block-editor';
 import { Button, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { createInterpolateElement } from '@wordpress/element';
+import { useState, createInterpolateElement } from '@wordpress/element';
 
 function DeletedNavigationWarning( { onCreateNew, isNotice = false } ) {
+	const [ isButtonDisabled, setIsButtonDisabled ] = useState( false );
+
+	const handleButtonClick = () => {
+		setIsButtonDisabled( true );
+		onCreateNew();
+	};
+
 	const message = createInterpolateElement(
 		__(
 			'Navigation Menu has been deleted or is unavailable. <button>Create a new Menu?</button>'
@@ -15,8 +22,10 @@ function DeletedNavigationWarning( { onCreateNew, isNotice = false } ) {
 			button: (
 				<Button
 					__next40pxDefaultSize
-					onClick={ onCreateNew }
+					onClick={ handleButtonClick }
 					variant="link"
+					disabled={ isButtonDisabled }
+					accessibleWhenDisabled
 				/>
 			),
 		}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Fixes #56248

## What?

This PR addresses an issue where users could accidentally create two navigation menus by double-clicking the "Create a new menu" button in an empty block.

## Why?

[#56248](https://github.com/WordPress/gutenberg/issues/56248)

## How?

The DeletedNavigationWarning component has been updated:
- Added a useState hook to manage the disabled state of the button.
- Updated the button to disable immediately after the first click.
- Included the accessibleWhenDisabled prop to ensure the button remains accessible when disabled.

## Testing Instructions

1. Open the **Editor** (Post/Page editor or Site Editor) in WordPress.
2. Insert a **Navigation Block** into your content.
3. Delete the Navigation **Custom Post Type (CPT)** that the block is using.  
   - This can typically be done by navigating to the **Appearance > Navigation** section and deleting the menu associated with the block.
4. Return to the editor, and observe that the **"Create a new menu"** prompt appears within the Navigation block.
5. Quickly double-click the **"Create a new menu"** button.
6. Verify that:
   - The button becomes disabled after the first click.
   - Only one navigation menu is created in the **Appearance > Navigation** section.
   - No duplicate menus are created, even with rapid double-clicking.

### Testing Instructions for Keyboard

1. Follow the steps above using only the keyboard:
   - Navigate to the **"Create a new menu"** button using the **Tab** key.
   - Press **Enter** or **Space** to activate the button.
2. Confirm that the button disables after the first activation.
3. Verify that no duplicate menus are created when the button is activated repeatedly using the keyboard.

### Interacted Accounts

The following accounts have interacted with this PR and/or linked issues:
- @creador-dev
