### PR TITLE
Fix: Fixed align right issue on avatar component

### DIFF
--- a/packages/block-library/src/avatar/edit.js
+++ b/packages/block-library/src/avatar/edit.js
@@ -130,6 +130,19 @@ const AvatarInspectorControls = ( {
 	);
 };
 
+const AvatarLinkWrapper = ( { children, isLink } ) =>
+	isLink ? (
+		<a
+			href="#avatar-pseudo-link"
+			className="wp-block-avatar__link"
+			onClick={ ( event ) => event.preventDefault() }
+		>
+			{ children }
+		</a>
+	) : (
+		children
+	);
+
 const ResizableAvatar = ( {
 	setAttributes,
 	attributes,
@@ -146,43 +159,46 @@ const ResizableAvatar = ( {
 	);
 	return (
 		<div { ...blockProps }>
-			<ResizableBox
-				size={ {
-					width: attributes.size,
-					height: attributes.size,
-				} }
-				showHandle={ isSelected }
-				onResizeStop={ ( event, direction, elt, delta ) => {
-					setAttributes( {
-						size: parseInt(
-							attributes.size + ( delta.height || delta.width ),
-							10
-						),
-					} );
-				} }
-				lockAspectRatio
-				enable={ {
-					top: false,
-					right: ! isRTL(),
-					bottom: true,
-					left: isRTL(),
-				} }
-				minWidth={ avatar.minSize }
-				maxWidth={ avatar.maxSize }
-			>
-				<img
-					src={ doubledSizedSrc }
-					alt={ avatar.alt }
-					className={ clsx(
-						'avatar',
-						'avatar-' + attributes.size,
-						'photo',
-						'wp-block-avatar__image',
-						borderProps.className
-					) }
-					style={ borderProps.style }
-				/>
-			</ResizableBox>
+			<AvatarLinkWrapper isLink={ attributes.isLink }>
+				<ResizableBox
+					size={ {
+						width: attributes.size,
+						height: attributes.size,
+					} }
+					showHandle={ isSelected }
+					onResizeStop={ ( event, direction, elt, delta ) => {
+						setAttributes( {
+							size: parseInt(
+								attributes.size +
+									( delta.height || delta.width ),
+								10
+							),
+						} );
+					} }
+					lockAspectRatio
+					enable={ {
+						top: false,
+						right: ! isRTL(),
+						bottom: true,
+						left: isRTL(),
+					} }
+					minWidth={ avatar.minSize }
+					maxWidth={ avatar.maxSize }
+				>
+					<img
+						src={ doubledSizedSrc }
+						alt={ avatar.alt }
+						className={ clsx(
+							'avatar',
+							'avatar-' + attributes.size,
+							'photo',
+							'wp-block-avatar__image',
+							borderProps.className
+						) }
+						style={ borderProps.style }
+					/>
+				</ResizableBox>
+			</AvatarLinkWrapper>
 		</div>
 	);
 };
@@ -198,29 +214,13 @@ const CommentEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				attributes={ attributes }
 				selectUser={ false }
 			/>
-			{ attributes.isLink ? (
-				<a
-					href="#avatar-pseudo-link"
-					className="wp-block-avatar__link"
-					onClick={ ( event ) => event.preventDefault() }
-				>
-					<ResizableAvatar
-						attributes={ attributes }
-						avatar={ avatar }
-						blockProps={ blockProps }
-						isSelected={ isSelected }
-						setAttributes={ setAttributes }
-					/>
-				</a>
-			) : (
-				<ResizableAvatar
-					attributes={ attributes }
-					avatar={ avatar }
-					blockProps={ blockProps }
-					isSelected={ isSelected }
-					setAttributes={ setAttributes }
-				/>
-			) }
+			<ResizableAvatar
+				attributes={ attributes }
+				avatar={ avatar }
+				blockProps={ blockProps }
+				isSelected={ isSelected }
+				setAttributes={ setAttributes }
+			/>
 		</>
 	);
 };
@@ -241,29 +241,14 @@ const UserEdit = ( { attributes, context, setAttributes, isSelected } ) => {
 				avatar={ avatar }
 				setAttributes={ setAttributes }
 			/>
-			{ attributes.isLink ? (
-				<a
-					href="#avatar-pseudo-link"
-					className="wp-block-avatar__link"
-					onClick={ ( event ) => event.preventDefault() }
-				>
-					<ResizableAvatar
-						attributes={ attributes }
-						avatar={ avatar }
-						blockProps={ blockProps }
-						isSelected={ isSelected }
-						setAttributes={ setAttributes }
-					/>
-				</a>
-			) : (
-				<ResizableAvatar
-					attributes={ attributes }
-					avatar={ avatar }
-					blockProps={ blockProps }
-					isSelected={ isSelected }
-					setAttributes={ setAttributes }
-				/>
-			) }
+
+			<ResizableAvatar
+				attributes={ attributes }
+				avatar={ avatar }
+				blockProps={ blockProps }
+				isSelected={ isSelected }
+				setAttributes={ setAttributes }
+			/>
 		</>
 	);
 };

--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -7,9 +7,3 @@
 		margin: 0 auto;
 	}
 }
-
-.wp-block-avatar.alignright {
-	.components-resizable-box__container {
-		float: right;
-	}
-}

--- a/packages/block-library/src/avatar/editor.scss
+++ b/packages/block-library/src/avatar/editor.scss
@@ -7,3 +7,9 @@
 		margin: 0 auto;
 	}
 }
+
+.wp-block-avatar.alignright {
+	.components-resizable-box__container {
+		float: right;
+	}
+}


### PR DESCRIPTION
resolves #67493

## What?
Added styles for Align Right in editor.scss for block themes to resolve the issue where the Avatar component alignment was not working when the "Link to Profile" option was enabled.

## Why?
The Align Right feature for the Avatar component was not functioning as expected in block-based themes (e.g., Twenty Twenty-Four, Twenty Twenty-Five) when the "Link to Profile" option was selected. This PR addresses that issue by ensuring that the alignment works correctly across block themes, ensuring consistency with classic themes like Twenty Twenty-One, where it worked fine.

## How?
This PR modifies the editor.scss file to explicitly add and enforce styles for the Align Right option in the block editor for Avatar components.

It adds following style snippet.

```css
.wp-block-avatar.alignright {
	.components-resizable-box__container {
		float: right;
	}
}
```

## Testing Instructions

1. Activate a block-based theme, e.g., Twenty Twenty-Four or Twenty Twenty-Five.
2. Add the Avatar component to a post or page using the block editor.
3. Enable the "Link to Profile" option in the Avatar component settings.
4. Set the alignment option to "Align Right".
5. Save and preview the post/page.
6. Repeat for classic theme.

## Screencast

### Before
https://github.com/user-attachments/assets/bab1c8e3-f2f8-43d2-a484-4481569e6cea

### After

https://github.com/user-attachments/assets/c2f35d91-25ae-4f15-b653-1380831a77bd



