### PR TITLE
useScaleCanvas performance improvements

### DIFF
--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -2,11 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect, useRef, useCallback } from '@wordpress/element';
-import {
-	usePrevious,
-	useReducedMotion,
-	useResizeObserver,
-} from '@wordpress/compose';
+import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 
 /**
  * @typedef {Object} TransitionState
@@ -284,7 +280,8 @@ export function useScaleCanvas( {
 		transitionFromRef.current = transitionToRef.current;
 	}, [ iframeDocument ] );
 
-	const previousIsZoomedOut = usePrevious( isZoomedOut );
+	const previousIsZoomedOut = useRef( false );
+
 	/**
 	 * Runs when zoom out mode is toggled, and sets the startAnimation flag
 	 * so the animation will start when the next useEffect runs. We _only_
@@ -292,20 +289,26 @@ export function useScaleCanvas( {
 	 * changes due to the container resizing.
 	 */
 	useEffect( () => {
-		if ( ! iframeDocument || previousIsZoomedOut === isZoomedOut ) {
-			return;
-		}
+		const trigger =
+			iframeDocument && previousIsZoomedOut.current !== isZoomedOut;
 
-		if ( isZoomedOut ) {
-			iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
+		previousIsZoomedOut.current = isZoomedOut;
+
+		if ( ! trigger ) {
+			return;
 		}
 
 		startAnimationRef.current = true;
 
+		if ( ! isZoomedOut ) {
+			return;
+		}
+
+		iframeDocument.documentElement.classList.add( 'is-zoomed-out' );
 		return () => {
 			iframeDocument.documentElement.classList.remove( 'is-zoomed-out' );
 		};
-	}, [ iframeDocument, isZoomedOut, previousIsZoomedOut ] );
+	}, [ iframeDocument, isZoomedOut ] );
 
 	/**
 	 * This handles:

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -6,11 +6,11 @@ import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 
 /**
  * @typedef {Object} TransitionState
- * @property {number} scaleValue   Scale of the canvas.
- * @property {number} frameSize    Size of the frame/offset around the canvas.
- * @property {number} clientHeight ClientHeight of the iframe.
- * @property {number} scrollTop    ScrollTop of the iframe.
- * @property {number} scrollHeight ScrollHeight of the iframe.
+ * @property {number} scaleValue      Scale of the canvas.
+ * @property {number} frameSize       Size of the frame/offset around the canvas.
+ * @property {number} containerHeight containerHeight of the iframe.
+ * @property {number} scrollTop       ScrollTop of the iframe.
+ * @property {number} scrollHeight    ScrollHeight of the iframe.
  */
 
 /**
@@ -44,27 +44,28 @@ function calculateScale( {
  */
 function computeScrollTopNext( transitionFrom, transitionTo ) {
 	const {
-		clientHeight: prevClientHeight,
+		containerHeight: prevContainerHeight,
 		frameSize: prevFrameSize,
 		scaleValue: prevScale,
 		scrollTop,
 		scrollHeight,
 	} = transitionFrom;
-	const { clientHeight, frameSize, scaleValue } = transitionTo;
+	const { containerHeight, frameSize, scaleValue } = transitionTo;
 	// Step 0: Start with the current scrollTop.
 	let scrollTopNext = scrollTop;
 	// Step 1: Undo the effects of the previous scale and frame around the
 	// midpoint of the visible area.
 	scrollTopNext =
-		( scrollTopNext + prevClientHeight / 2 - prevFrameSize ) / prevScale -
-		prevClientHeight / 2;
+		( scrollTopNext + prevContainerHeight / 2 - prevFrameSize ) /
+			prevScale -
+		prevContainerHeight / 2;
 
 	// Step 2: Apply the new scale and frame around the midpoint of the
 	// visible area.
 	scrollTopNext =
-		( scrollTopNext + clientHeight / 2 ) * scaleValue +
+		( scrollTopNext + containerHeight / 2 ) * scaleValue +
 		frameSize -
-		clientHeight / 2;
+		containerHeight / 2;
 
 	// Step 3: Handle an edge case so that you scroll to the top of the
 	// iframe if the top of the iframe content is visible in the container.
@@ -78,7 +79,7 @@ function computeScrollTopNext( transitionFrom, transitionTo ) {
 	const maxScrollTop =
 		scrollHeight * ( scaleValue / prevScale ) +
 		frameSize * 2 -
-		clientHeight;
+		containerHeight;
 
 	// Step 4: Clamp the scrollTopNext between the minimum and maximum
 	// possible scrollTop positions. Round the value to avoid subpixel
@@ -146,8 +147,10 @@ export function useScaleCanvas( {
 } ) {
 	const [ contentResizeListener, { height: contentHeight } ] =
 		useResizeObserver();
-	const [ containerResizeListener, { width: containerWidth } ] =
-		useResizeObserver();
+	const [
+		containerResizeListener,
+		{ width: containerWidth, height: containerHeight },
+	] = useResizeObserver();
 
 	const initialContainerWidthRef = useRef( 0 );
 	const isZoomedOut = scale !== 1;
@@ -186,7 +189,7 @@ export function useScaleCanvas( {
 	const transitionFromRef = useRef( {
 		scaleValue,
 		frameSize,
-		clientHeight: 0,
+		containerHeight: 0,
 		scrollTop: 0,
 		scrollHeight: 0,
 	} );
@@ -198,7 +201,7 @@ export function useScaleCanvas( {
 	const transitionToRef = useRef( {
 		scaleValue,
 		frameSize,
-		clientHeight: 0,
+		containerHeight: 0,
 		scrollTop: 0,
 		scrollHeight: 0,
 	} );
@@ -353,10 +356,9 @@ export function useScaleCanvas( {
 			`${ contentHeight }px`
 		);
 
-		const clientHeight = iframeDocument.documentElement.clientHeight;
 		iframeDocument.documentElement.style.setProperty(
 			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ clientHeight }px`
+			`${ containerHeight }px`
 		);
 
 		iframeDocument.documentElement.style.setProperty(
@@ -404,9 +406,11 @@ export function useScaleCanvas( {
 				// appenders may appear or disappear, so we need to get the height from
 				// the iframe at this point when we're about to animate the zoom out.
 				// The iframe scrollTop, scrollHeight, and clientHeight will all be
-				// the most accurate.
-				transitionFromRef.current.clientHeight =
-					transitionFromRef.current.clientHeight ?? clientHeight;
+				// the most accurate. clientHeight has a performance hit though, so we
+				// rely on containerHeight from the resize listener.
+				transitionFromRef.current.containerHeight =
+					transitionFromRef.current.containerHeight ??
+					containerHeight;
 				transitionFromRef.current.scrollTop =
 					iframeDocument.documentElement.scrollTop;
 				transitionFromRef.current.scrollHeight =
@@ -415,7 +419,7 @@ export function useScaleCanvas( {
 				transitionToRef.current = {
 					scaleValue,
 					frameSize,
-					clientHeight,
+					containerHeight,
 				};
 				transitionToRef.current.scrollTop = computeScrollTopNext(
 					transitionFromRef.current,
@@ -432,27 +436,6 @@ export function useScaleCanvas( {
 				}
 			}
 		}
-
-		return () => {
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-content-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-inner-height'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-container-width'
-			);
-			iframeDocument.documentElement.style.removeProperty(
-				'--wp-block-editor-iframe-zoom-out-scale-container-width'
-			);
-		};
 	}, [
 		startZoomOutAnimation,
 		finishZoomOutAnimation,
@@ -463,6 +446,7 @@ export function useScaleCanvas( {
 		iframeDocument,
 		contentHeight,
 		containerWidth,
+		containerHeight,
 		maxContainerWidth,
 		scaleContainerWidth,
 	] );

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -406,11 +406,10 @@ export function useScaleCanvas( {
 				// appenders may appear or disappear, so we need to get the height from
 				// the iframe at this point when we're about to animate the zoom out.
 				// The iframe scrollTop, scrollHeight, and clientHeight will all be
-				// the most accurate. clientHeight has a performance hit though, so we
-				// rely on containerHeight from the resize listener.
+				// the most accurate.
 				transitionFromRef.current.containerHeight =
 					transitionFromRef.current.containerHeight ??
-					containerHeight;
+					containerHeight; // Use containerHeight, as it's the previous container height value if none was set.
 				transitionFromRef.current.scrollTop =
 					iframeDocument.documentElement.scrollTop;
 				transitionFromRef.current.scrollHeight =
@@ -419,7 +418,8 @@ export function useScaleCanvas( {
 				transitionToRef.current = {
 					scaleValue,
 					frameSize,
-					containerHeight,
+					containerHeight:
+						iframeDocument.documentElement.clientHeight, // use clientHeight to get the actual height of the new container, as it will be the most up-to-date.
 				};
 				transitionToRef.current.scrollTop = computeScrollTopNext(
 					transitionFromRef.current,

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -336,39 +336,41 @@ export function useScaleCanvas( {
 			} );
 		}
 
-		// If we are not going to animate the transition, set the scale and frame size directly.
-		// If we are animating, these values will be set when the animation is finished.
-		// Example: Opening sidebars that reduce the scale of the canvas, but we don't want to
-		// animate the transition.
-		if ( ! startAnimationRef.current ) {
+		if ( scaleValue < 1 ) {
+			// If we are not going to animate the transition, set the scale and frame size directly.
+			// If we are animating, these values will be set when the animation is finished.
+			// Example: Opening sidebars that reduce the scale of the canvas, but we don't want to
+			// animate the transition.
+			if ( ! startAnimationRef.current ) {
+				iframeDocument.documentElement.style.setProperty(
+					'--wp-block-editor-iframe-zoom-out-scale',
+					scaleValue
+				);
+				iframeDocument.documentElement.style.setProperty(
+					'--wp-block-editor-iframe-zoom-out-frame-size',
+					`${ frameSize }px`
+				);
+			}
+
 			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-scale',
-				scaleValue
+				'--wp-block-editor-iframe-zoom-out-content-height',
+				`${ contentHeight }px`
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-inner-height',
+				`${ containerHeight }px`
+			);
+
+			iframeDocument.documentElement.style.setProperty(
+				'--wp-block-editor-iframe-zoom-out-container-width',
+				`${ containerWidth }px`
 			);
 			iframeDocument.documentElement.style.setProperty(
-				'--wp-block-editor-iframe-zoom-out-frame-size',
-				`${ frameSize }px`
+				'--wp-block-editor-iframe-zoom-out-scale-container-width',
+				`${ scaleContainerWidth }px`
 			);
 		}
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-content-height',
-			`${ contentHeight }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-inner-height',
-			`${ containerHeight }px`
-		);
-
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-container-width',
-			`${ containerWidth }px`
-		);
-		iframeDocument.documentElement.style.setProperty(
-			'--wp-block-editor-iframe-zoom-out-scale-container-width',
-			`${ scaleContainerWidth }px`
-		);
 
 		/**
 		 * Handle the zoom out animation:


### PR DESCRIPTION
Rely on `containerHeight` resize listener instead of iframe.documentElement.clientHeight

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Rely on containerHeight resize listener instead of `iframe.documentElement.clientHeight` when setting the CSS variables to fix the first block metric impact caused by https://github.com/WordPress/gutenberg/pull/66917.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
There was a performance hit when using `iframe.documentElement.clientHeight`.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Get the `containerHeight` from the existing resize listener.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

I ran `npm run test:performance test/performance/specs/post-editor.spec.js` locally to see the [first block metric](https://www.codevitals.run/project/gutenberg/firstBlock), since it was the one that was most impacted.

**Baseline: Without useScaleCanvas(): This is what we hope to return to**
│ firstBlock           │ '1825.45 ms +2.1% -2.47%' │
│ firstBlock           │ '1864.6 ms +1.53% -1.81%' │

**Original Perf issue: [With useScaleCanvas()](https://github.com/WordPress/gutenberg/pull/66917)**
│ firstBlock           │ '2221.9 ms +2.6% -4.08%' │
│ firstBlock           │ '2185.8 ms +2.48% -3.89%' │

**Fix 1 (https://github.com/WordPress/gutenberg/pull/67481, https://github.com/WordPress/gutenberg/pull/67495): Mounting hook for `prevIsZoomedOut` so it doesn't run on mount**
│ firstBlock           │ '2020.55 ms +2.43% -2.56%' │
│ firstBlock           │ '2091.9 ms +0.59% -2.96%'  │

**[Fix 2](https://github.com/WordPress/gutenberg/pull/67496/files#diff-0f9eb43596976bd4d0bd02528b0b8397f4dfd45b0900bc2c4f15beea290e8612R361-R362): Use containerHeight instead of iframeDocument.documentElement.clientHeight**
│ firstBlock           │ '1934.45 ms +2.1% -1.05%'  │
│ firstBlock           │ '1875.4 ms +0.83% -0.47%'  │

**[Fix 3](https://github.com/WordPress/gutenberg/pull/67496/files#diff-0f9eb43596976bd4d0bd02528b0b8397f4dfd45b0900bc2c4f15beea290e8612L432-L452): Remove useEffect unmounting the CSS variables**
│ firstBlock           │ '1900.75 ms +2.26% -0.8%' │
│ firstBlock           │ '1908.8 ms +0.67% -4.78%' │

**[Fix 4](https://github.com/WordPress/gutenberg/pull/67496/files#diff-0f9eb43596976bd4d0bd02528b0b8397f4dfd45b0900bc2c4f15beea290e8612R339): Only set CSS variables on scaleValue < 1: Yay! Baseline as been achieved.**
│ firstBlock           │ '1795.5 ms +0.47% -0.3%'  │
│ firstBlock           │ '1817.4 ms +1.38% -1.02%' │


**To be sure, check only set CSS variables on scaleValue < 1, but preserve unmounting all CSS variables in useEffect unmount (remove Fix 3)**
│ firstBlock           │ '1872.3 ms +2.85% -4.1%' │
│ firstBlock           │ '1831 ms +2.21% -1.59%'  │

|<!-- Before screenshot here -->|<!-- After screenshot here -->|
