### PR TITLE
Preload: fix e2e test

### DIFF
--- a/backport-changelog/6.8/7687.md
+++ b/backport-changelog/6.8/7687.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7687
 
 * https://github.com/WordPress/gutenberg/pull/66488
+* https://github.com/WordPress/gutenberg/pull/67497

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -86,6 +86,9 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 		 */
 		$context = current_user_can( 'edit_theme_options' ) ? 'edit' : 'view';
 		$paths[] = "/wp/v2/global-styles/$global_styles_id?context=$context";
+
+		// Used by getBlockPatternCategories in useBlockEditorSettings.
+		$paths[] = '/wp/v2/block-patterns/categories';
 	}
 	return $paths;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

I added an e2e test in #67475, but it doesn't seem to work correctly since it's missing some requests.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It should catch all the requests.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

We start recording before page load, then turn off recording when the iframe src is requested.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Nothing, you can see that the remaining URLs are now properly recorded. I've also added one more to the preload list that was showing up.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

