### PR TITLE
Refine `getServerState()` & `getServerContext()` docs

### DIFF
--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -830,7 +830,7 @@ store( 'myPlugin', {
 
 ### When to Use
 
-Whenever you have interactive blocks that rely on global state that may change due to navigation events, ensuring consistency across different parts of your application.
+Whenever you have interactive blocks that rely on global state or local context that may change due to navigation events, ensuring consistency across different parts of your application.
 
 ### Best Practices for using `getServerState()` and `getServerContext()`
 

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -746,15 +746,14 @@ When using region-based navigation, it's crucial to ensure that your interactive
 `getServerState()` allows you to subscribe to changes in the **global state** that occur during client-side navigation. This function is analogous to `getServerContext()`, but it works with the global state instead of the local context.
 
 The `getServerState()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
+
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
-<?php
-wp_interactivity_state( 'myPlugin', array(
+<div <?php echo wp_interactivity_state( 'myPlugin', array(
 	'question' => get_question_for_page( get_the_ID() ),
 	'timeLeft' => 5 * 60, // Time to answer all the questions.
-) );
-?>
+) ); ?>>
 ```
 
 ```javascript
@@ -795,11 +794,9 @@ The `getServerContext()` function returns a read-only reactive object. This mean
 Consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
-<?php
-wp_interactivity_context( 'myPlugin', array(
+<div <?php echo wp_interactivity_data_wp_context( 'myPlugin', array(
 	'currentQuestion' => get_question_for_page( get_the_ID() ),
-) );
-?>
+) ); ?>>
 ```
 
 ```javascript

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -745,6 +745,7 @@ When using region-based navigation, it's crucial to ensure that your interactive
 
 `getServerState()` allows you to subscribe to changes in the **global state** that occur during client-side navigation. This function is analogous to `getServerContext()`, but it works with the global state instead of the local context.
 
+The `getServerState()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
@@ -788,6 +789,8 @@ store( 'myPlugin', {
 ### `getServerContext()`
 
 `getServerContext()` allows you to subscribe to changes in the **local context** that occur during client-side navigation. This function is analogous to `getServerState()`, but it works with the local context instead of the global state.
+
+The `getServerContext()` function returns a read-only reactive object. This means that any [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) you have defined that watch the returned object will only trigger when the value returned by the function changes. If the value remains the same, the callback will not re-trigger.
 
 Consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
@@ -835,7 +838,7 @@ Whenever you have interactive blocks that rely on global state that may change d
 ### Best Practices for using `getServerState()` and `getServerContext()`
 
 -   **Read-Only References:** Both `getServerState()` and `getServerContext()` return read-only objects. You can use those objects to update the global state or local context.
--   **Callback Integration:** Incorporate these functions within your store [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) to react to state and context changes.
+-   **Callback Integration:** Incorporate these functions within your store [callbacks](/docs/reference-guides/interactivity-api/api-reference.md#accessing-data-in-callbacks) to react to state and context changes. Both `getServerState()` and `getServerContext()` return reactive objects. This means that their watch callbacks will only trigger when the value of a property changes. If the value remains the same, the callback will not re-trigger.
 
 ## Conclusion
 

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -750,10 +750,10 @@ The `getServerState()` function returns a read-only reactive object. This means 
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
-<div <?php echo wp_interactivity_data_wp_context( array(
+<div <?php echo wp_interactivity_state( 'myPlugin', array(
 	'question' => get_question_for_page( get_the_ID() ),
 	'timeLeft' => 5 * 60, // Time to answer all the questions.
-), 'myPlugin' ); ?>>
+) ); ?>>
 ```
 
 ```javascript
@@ -796,7 +796,7 @@ Consider a quiz that has multiple questions. Each question is a separate page. W
 ```php
 <div <?php echo wp_interactivity_data_wp_context( array(
 	'currentQuestion' => get_question_for_page( get_the_ID() ),
-), 'myPlugin' ); ?>>
+), ); ?>>
 ```
 
 ```javascript

--- a/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
+++ b/docs/reference-guides/interactivity-api/core-concepts/undestanding-global-state-local-context-and-derived-state.md
@@ -750,10 +750,10 @@ The `getServerState()` function returns a read-only reactive object. This means 
 Let's consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
-<div <?php echo wp_interactivity_state( 'myPlugin', array(
+<div <?php echo wp_interactivity_data_wp_context( array(
 	'question' => get_question_for_page( get_the_ID() ),
 	'timeLeft' => 5 * 60, // Time to answer all the questions.
-) ); ?>>
+), 'myPlugin' ); ?>>
 ```
 
 ```javascript
@@ -794,9 +794,9 @@ The `getServerContext()` function returns a read-only reactive object. This mean
 Consider a quiz that has multiple questions. Each question is a separate page. When the user navigates to a new question, the server provides the new question and the time left to answer all the questions.
 
 ```php
-<div <?php echo wp_interactivity_data_wp_context( 'myPlugin', array(
+<div <?php echo wp_interactivity_data_wp_context( array(
 	'currentQuestion' => get_question_for_page( get_the_ID() ),
-) ); ?>>
+), 'myPlugin' ); ?>>
 ```
 
 ```javascript


### PR DESCRIPTION
Implements comments from https://github.com/WordPress/gutenberg/pull/66104

1. Clarify that since `getServerState()` and `getServerContext()` are reactive, if the value of a property doesn’t change, the watch callback will not re-trigger.
2. Fix the code snippets to correctly include the HTML tags ([comment](https://github.com/WordPress/gutenberg/pull/66104#discussion_r1843713801))
3. Add note about local context ([comment](https://github.com/WordPress/gutenberg/pull/66104#discussion_r1843714427))