### PR TITLE
Fix: Fixed site-editor crashing when added front-page template and clicking more option

### DIFF
--- a/packages/editor/src/components/post-actions/actions.js
+++ b/packages/editor/src/components/post-actions/actions.js
@@ -52,10 +52,11 @@ export function usePostActions( { postType, onActionPerformed, context } ) {
 	}, [ registerPostTypeSchema, postType ] );
 
 	return useMemo( () => {
-		let actions = [
-			...defaultActions,
-			shouldShowSetAsHomepageAction ? setAsHomepageAction : [],
-		];
+		let actions = [ ...defaultActions ];
+		if ( shouldShowSetAsHomepageAction ) {
+			actions.push( setAsHomepageAction );
+		}
+
 		// Filter actions based on provided context. If not provided
 		// all actions are returned. We'll have a single entry for getting the actions
 		// and the consumer should provide the context to filter the actions, if needed.


### PR DESCRIPTION
resolves #67498

## What?
This PR modifies how the array for actions is constructed by using default action destructuring and conditionally pushing values to the array.

## Why?
The previous implementation was adding an empty array at the end of the actions list when the condition for shouldShowSetAsHomepageAction was false. This caused issues, particularly in the "More Options" menu, where an empty action was being passed and leading to a crash. This PR resolves that by ensuring that only valid actions are added to the array.

## How?
To address this issue, I changed the following snippet:
`Old Code:`
```JS
let actions = [
    ...defaultActions,
    shouldShowSetAsHomepageAction ? setAsHomepageAction : [],
];
```
The previous code resulted in adding an empty array at the end when the condition shouldShowSetAsHomepageAction was false.

`New Code:`
```JS
let actions = [...defaultActions];
if (shouldShowSetAsHomepageAction) {
    actions.push(setAsHomepageAction);
}
```

This change ensures that if shouldShowSetAsHomepageAction is false, the setAsHomepageAction is not pushed into the array, avoiding the empty array scenario and preventing the crash.

## Testing Instructions

1. Go to Appearance > Editor (Site Editor) in the WordPress admin > Templates.
2. Add a new Front Page template through the Site Editor.
3. Save the changes to ensure the template is added.
4. Click on the three dots (More Options) for any template in the template list.
5. It should not crashe the page anymore
6. Now delete front page template and click, it should work as expected.

