### PR TITLE
Fix hiding and showing of meta boxes

### DIFF
--- a/packages/edit-post/src/components/meta-boxes/index.js
+++ b/packages/edit-post/src/components/meta-boxes/index.js
@@ -13,9 +13,9 @@ import { store as editPostStore } from '../../store';
 export default function MetaBoxes( { location } ) {
 	const metaBoxes = useSelect(
 		( select ) =>
-			select( editPostStore ).getMetaBoxesPerLocation[ location ]
+			select( editPostStore ).getMetaBoxesPerLocation( location ),
+		[ location ]
 	);
-
 	return (
 		<>
 			{ ( metaBoxes ?? [] ).map( ( { id } ) => (


### PR DESCRIPTION
## What?
A fix for a bug introduced in #67254.

## Why?
Toggling visibility of meta boxes is broken. They are visible even if their switched off in Preferences (if at least one other is visible).

## How?
Fixes the `useSelect` usage to correct what was a blatant mistake.

## Testing Instructions
1. Activate a plugin that adds meta boxes
2. Go to a post in the Post editor
3. Open the "Preferences" modal
4. Toggle the option(s) for meta boxes on and off
5. Verify that the meta boxes hide/show as expected

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Demonstration of the broken behavior on trunk:

https://github.com/user-attachments/assets/0d7dc2f9-1783-41de-9fd0-99668891bcc8

