### PR TITLE
Replace deprecated useResizeObserver for useScaleCanvas

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -217,8 +217,8 @@ function Iframe( {
 	}, [] );
 
 	const {
-		contentRefCallback,
-		containerRefCallback,
+		contentRef: scaleContentRef,
+		containerRef,
 		isZoomedOut,
 		scaleContainerWidth,
 	} = useScaleCanvas( {
@@ -234,7 +234,7 @@ function Iframe( {
 		clearerRef,
 		writingFlowRef,
 		disabledRef,
-		contentRefCallback,
+		scaleContentRef,
 	] );
 
 	// Correct doctype is required to enable rendering in standards
@@ -354,10 +354,7 @@ function Iframe( {
 	);
 
 	return (
-		<div
-			className="block-editor-iframe__container"
-			ref={ containerRefCallback }
-		>
+		<div className="block-editor-iframe__container" ref={ containerRef }>
 			<div
 				className={ clsx(
 					'block-editor-iframe__scale-container',

--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -217,8 +217,8 @@ function Iframe( {
 	}, [] );
 
 	const {
-		contentResizeListener,
-		containerResizeListener,
+		contentRefCallback,
+		containerRefCallback,
 		isZoomedOut,
 		scaleContainerWidth,
 	} = useScaleCanvas( {
@@ -234,6 +234,7 @@ function Iframe( {
 		clearerRef,
 		writingFlowRef,
 		disabledRef,
+		contentRefCallback,
 	] );
 
 	// Correct doctype is required to enable rendering in standards
@@ -341,7 +342,6 @@ function Iframe( {
 								...bodyClasses
 							) }
 						>
-							{ contentResizeListener }
 							<StyleProvider document={ iframeDocument }>
 								{ children }
 							</StyleProvider>
@@ -354,8 +354,10 @@ function Iframe( {
 	);
 
 	return (
-		<div className="block-editor-iframe__container">
-			{ containerResizeListener }
+		<div
+			className="block-editor-iframe__container"
+			ref={ containerRefCallback }
+		>
 			<div
 				className={ clsx(
 					'block-editor-iframe__scale-container',

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -156,10 +156,10 @@ function extractSize( entries ) {
 
 /**
  * @typedef {Object} ScaleCanvasResult
- * @property {boolean} isZoomedOut             A boolean indicating if the canvas is zoomed out.
- * @property {number}  scaleContainerWidth     The width of the container used to calculate the scale.
- * @property {Object}  contentResizeListener   A resize observer for the content.
- * @property {Object}  containerResizeListener A resize observer for the container.
+ * @property {boolean}                      isZoomedOut         A boolean indicating if the canvas is zoomed out.
+ * @property {number}                       scaleContainerWidth The width of the container used to calculate the scale.
+ * @property {import('react').Ref<Element>} contentRef          A callback ref to the content element.
+ * @property {import('react').Ref<Element>} containerRef        A callback ref to the container element.
  */
 
 /**
@@ -180,14 +180,14 @@ export function useScaleCanvas( {
 	scale,
 } ) {
 	const [ { height: contentHeight }, setContentRect ] = useState( NULL_SIZE );
-	const contentRefCallback = useResizeObserver( ( entries ) => {
+	const contentRef = useResizeObserver( ( entries ) => {
 		setContentRect( extractSize( entries ) );
 	} );
 	const [
 		{ width: containerWidth, height: containerHeight },
 		setContainerRect,
 	] = useState( NULL_SIZE );
-	const containerRefCallback = useResizeObserver( ( entries ) => {
+	const containerRef = useResizeObserver( ( entries ) => {
 		setContainerRect( extractSize( entries ) );
 	} );
 
@@ -511,7 +511,7 @@ export function useScaleCanvas( {
 	return {
 		isZoomedOut,
 		scaleContainerWidth,
-		contentRefCallback,
-		containerRefCallback,
+		contentRef,
+		containerRef,
 	};
 }

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useEffect, useRef, useCallback } from '@wordpress/element';
+import { useEffect, useRef, useCallback, useState } from '@wordpress/element';
 import { useReducedMotion, useResizeObserver } from '@wordpress/compose';
 
 /**
@@ -132,6 +132,8 @@ function getAnimationKeyframes( transitionFrom, transitionTo ) {
 	];
 }
 
+const NULL_SIZE = { width: null, height: null };
+
 function extractSize( entries ) {
 	const contentBlockSize = entries.at( -1 ).contentBoxSize[ 0 ];
 	return {
@@ -165,13 +167,16 @@ export function useScaleCanvas( {
 	maxContainerWidth = 750,
 	scale,
 } ) {
-	const contentRectRef = useRef( { width: null, height: null } );
+	const [ { height: contentHeight }, setContentRect ] = useState( NULL_SIZE );
 	const contentRefCallback = useResizeObserver( ( entries ) => {
-		contentRectRef.current = extractSize( entries );
+		setContentRect( extractSize( entries ) );
 	} );
-	const containerRectRef = useRef( { width: null, height: null } );
+	const [
+		{ width: containerWidth, height: containerHeight },
+		setContainerRect,
+	] = useState( NULL_SIZE );
 	const containerRefCallback = useResizeObserver( ( entries ) => {
-		containerRectRef.current = extractSize( entries );
+		setContainerRect( extractSize( entries ) );
 	} );
 
 	const initialContainerWidthRef = useRef( 0 );
@@ -186,19 +191,19 @@ export function useScaleCanvas( {
 
 	useEffect( () => {
 		if ( ! isZoomedOut ) {
-			initialContainerWidthRef.current = containerRectRef.current.width;
+			initialContainerWidthRef.current = containerWidth;
 		}
-	}, [ isZoomedOut ] );
+	}, [ containerWidth, isZoomedOut ] );
 
 	const scaleContainerWidth = Math.max(
 		initialContainerWidthRef.current,
-		containerRectRef.current.width
+		containerWidth
 	);
 
 	const scaleValue = isAutoScaled
 		? calculateScale( {
 				frameSize,
-				containerWidth: containerRectRef.current.width,
+				containerWidth,
 				maxContainerWidth,
 				scaleContainerWidth,
 		  } )
@@ -364,9 +369,9 @@ export function useScaleCanvas( {
 			// exiting.
 			transitionFromRef.current.scaleValue = calculateScale( {
 				frameSize: transitionFromRef.current.frameSize,
-				containerWidth: containerRectRef.current.width,
+				containerWidth,
 				maxContainerWidth,
-				scaleContainerWidth: containerRectRef.current.width,
+				scaleContainerWidth: containerWidth,
 			} );
 		}
 
@@ -388,17 +393,17 @@ export function useScaleCanvas( {
 
 			iframeDocument.documentElement.style.setProperty(
 				'--wp-block-editor-iframe-zoom-out-content-height',
-				`${ contentRectRef.current.height }px`
+				`${ contentHeight }px`
 			);
 
 			iframeDocument.documentElement.style.setProperty(
 				'--wp-block-editor-iframe-zoom-out-inner-height',
-				`${ containerRectRef.current.height }px`
+				`${ containerHeight }px`
 			);
 
 			iframeDocument.documentElement.style.setProperty(
 				'--wp-block-editor-iframe-zoom-out-container-width',
-				`${ containerRectRef.current.width }px`
+				`${ containerWidth }px`
 			);
 			iframeDocument.documentElement.style.setProperty(
 				'--wp-block-editor-iframe-zoom-out-scale-container-width',
@@ -448,8 +453,7 @@ export function useScaleCanvas( {
 				transitionFromRef.current.scrollHeight =
 					iframeDocument.documentElement.scrollHeight;
 				// Use containerHeight, as it's the previous container height before the zoom out animation starts.
-				transitionFromRef.current.containerHeight =
-					containerRectRef.current.height;
+				transitionFromRef.current.containerHeight = containerHeight;
 
 				transitionToRef.current = {
 					scaleValue,
@@ -485,6 +489,9 @@ export function useScaleCanvas( {
 		scaleValue,
 		frameSize,
 		iframeDocument,
+		contentHeight,
+		containerWidth,
+		containerHeight,
 		maxContainerWidth,
 		scaleContainerWidth,
 	] );

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -147,10 +147,10 @@ const NULL_SIZE = { width: null, height: null };
  * @return {ObservedSize} Latest width and height of the observed element.
  */
 function extractSize( entries ) {
-	const contentBlockSize = entries.at( -1 ).contentBoxSize[ 0 ];
+	const contentBoxSize = entries.at( -1 ).contentBoxSize[ 0 ];
 	return {
-		width: contentBlockSize.inlineSize,
-		height: contentBlockSize.blockSize,
+		width: contentBoxSize.inlineSize,
+		height: contentBoxSize.blockSize,
 	};
 }
 

--- a/packages/block-editor/src/components/iframe/use-scale-canvas.js
+++ b/packages/block-editor/src/components/iframe/use-scale-canvas.js
@@ -132,8 +132,20 @@ function getAnimationKeyframes( transitionFrom, transitionTo ) {
 	];
 }
 
+/**
+ * @typedef {Object} ObservedSize
+ * @property {number|null} width  The width of the observed element.
+ * @property {number|null} height The height of the observed element.
+ */
+/** @type {ObservedSize} */
 const NULL_SIZE = { width: null, height: null };
 
+/**
+ * Get the size of the observed element.
+ *
+ * @param {ResizeObserverEntry[]} entries Array of the new dimensions of the element after each change.
+ * @return {ObservedSize} Latest width and height of the observed element.
+ */
 function extractSize( entries ) {
 	const contentBlockSize = entries.at( -1 ).contentBoxSize[ 0 ];
 	return {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Replaces `useResizeObserver` with the new callback-based implementation in `useScaleCanvas`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The old usage was deprecated.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

[`contentBlockSize`](https://caniuse.com/mdn-api_resizeobserverentry_contentboxsize) is available in all our supported browsers, so I only implemented that branch of the legacy `useResizeObserver` and I didn't bother with rounding as the algorithm does rounding elsewhere.
 https://github.com/WordPress/gutenberg/blob/1693537872a1357a40ecf25faafd77bff875a36f/packages/compose/src/hooks/use-resize-observer/legacy/index.tsx#L45-L67

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
