### PR TITLE
Preload: add testing for post editor and pages in site editor

### DIFF
--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -47,6 +47,10 @@ test.describe( 'Preload: should make no requests before the iframe is loaded', (
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
+	test.beforeEach( async ( { requestUtils } ) => {
+		await requestUtils.resetPreferences();
+	} );
+
 	test( 'Site Editor Root', async ( { page, admin } ) => {
 		const requests = recordRequests( page );
 		await admin.visitSiteEditor();
@@ -64,7 +68,10 @@ test.describe( 'Preload: should make no requests before the iframe is loaded', (
 		const requests = recordRequests( page );
 		const { id } = await requestUtils.createPost( post );
 		await admin.editPost( id );
-		expect( requests ).toEqual( [] );
+		expect( requests ).toEqual( [
+			// Seems to be coming from `enableComplementaryArea`.
+			[ 'POST', '/wp/v2/users/me' ],
+		] );
 	} );
 
 	test( 'Site Editor Page', async ( { page, admin, requestUtils } ) => {
@@ -79,6 +86,8 @@ test.describe( 'Preload: should make no requests before the iframe is loaded', (
 			[ 'GET', '/wp/v2/types/page' ],
 			[ 'OPTIONS', '/wp/v2/settings' ],
 			[ 'GET', '/wp/v2/taxonomies' ],
+			// Seems to be coming from `enableComplementaryArea`.
+			[ 'POST', '/wp/v2/users/me' ],
 		] );
 	} );
 } );

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -79,7 +79,6 @@ test.describe( 'Preload: should make no requests before the iframe is loaded', (
 			[ 'GET', '/wp/v2/types/page' ],
 			[ 'OPTIONS', '/wp/v2/settings' ],
 			[ 'GET', '/wp/v2/taxonomies' ],
-			[ 'POST', '/wp/v2/users/me' ],
 		] );
 	} );
 } );

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -3,7 +3,41 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Preload', () => {
+function recordRequests( page ) {
+	const requests = [];
+
+	function onRequest( request ) {
+		if (
+			request.resourceType() === 'document' &&
+			request.url().startsWith( 'blob:' )
+		) {
+			// Stop recording when the iframe is initialized.
+			page.off( 'request', onRequest );
+		} else if ( request.resourceType() === 'fetch' ) {
+			const url = request.url();
+			const urlObject = new URL( url );
+			const path =
+				urlObject.searchParams.get( 'rest_route' ) ??
+				urlObject.pathname;
+			const method = request.method();
+			requests.push( [ method, path ] );
+		}
+	}
+
+	page.on( 'request', onRequest );
+
+	return requests;
+}
+
+const post = {
+	status: 'publish',
+	title: 'A post',
+	content: `<!-- wp:paragraph -->
+<p>Post content</p>
+<!-- /wp:paragraph -->`,
+};
+
+test.describe( 'Preload: should make no requests before the iframe is loaded', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
 		await requestUtils.resetPreferences();
@@ -13,42 +47,39 @@ test.describe( 'Preload', () => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test( 'Should make no requests before the iframe is loaded', async ( {
-		page,
-		admin,
-	} ) => {
-		const requests = [];
-
-		function onRequest( request ) {
-			if (
-				request.resourceType() === 'document' &&
-				request.url().startsWith( 'blob:' )
-			) {
-				// Stop recording when the iframe is initialized.
-				page.off( 'request', onRequest );
-			} else if ( request.resourceType() === 'fetch' ) {
-				const url = request.url();
-				const urlObject = new URL( url );
-				const restRoute = urlObject.searchParams.get( 'rest_route' );
-				if ( restRoute ) {
-					requests.push( restRoute );
-				} else {
-					requests.push( url );
-				}
-			}
-		}
-
-		page.on( 'request', onRequest );
-
+	test( 'Site Editor Root', async ( { page, admin } ) => {
+		const requests = recordRequests( page );
 		await admin.visitSiteEditor();
-
 		// To do: these should all be removed or preloaded.
 		expect( requests ).toEqual( [
 			// There are two separate settings OPTIONS requests. We should fix
 			// so the one for canUser and getEntityRecord are reused.
-			'/wp/v2/settings',
+			[ 'OPTIONS', '/wp/v2/settings' ],
 			// Seems to be coming from `enableComplementaryArea`.
-			'/wp/v2/users/me',
+			[ 'POST', '/wp/v2/users/me' ],
+		] );
+	} );
+
+	test( 'Post Editor', async ( { page, admin, requestUtils } ) => {
+		const requests = recordRequests( page );
+		const { id } = await requestUtils.createPost( post );
+		await admin.editPost( id );
+		expect( requests ).toEqual( [] );
+	} );
+
+	test( 'Site Editor Page', async ( { page, admin, requestUtils } ) => {
+		const requests = recordRequests( page );
+		const { id } = await requestUtils.createPage( post );
+		await admin.visitSiteEditor( {
+			postType: 'page',
+			postId: id,
+			canvas: 'edit',
+		} );
+		expect( requests ).toEqual( [
+			[ 'GET', '/wp/v2/types/page' ],
+			[ 'OPTIONS', '/wp/v2/settings' ],
+			[ 'GET', '/wp/v2/taxonomies' ],
+			[ 'POST', '/wp/v2/users/me' ],
 		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds tests to prevent regressions in preloading (and thus load performance) for the post editor and page editor within the site editor.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To prevent regressions and make people more aware. These tests are meant to catch regressions early instead of after the fact in performance graphs. It's also much more scalable to test all kinds of different pages.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Use the recording added in #67475.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

n/a
