### PR TITLE
Handling Date format change in  PostScheduleLabel

### DIFF
--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -44,14 +44,15 @@ export function usePostScheduleLabel( { full = false } = {} ) {
 }
 
 export function getFullPostScheduleLabel( dateAttribute ) {
-	const date = getDate( dateAttribute );
-
 	const timezoneAbbreviation = getTimezoneAbbreviation();
-	const formattedDate = dateI18n(
-		// translators: Use a non-breaking space between 'g:i' and 'a' if appropriate.
-		_x( 'F j, Y g:i\xa0a', 'post schedule full date format' ),
-		date
-	);
+	// eslint-disable-next-line react-hooks/rules-of-hooks
+	const formattedDate = useSelect( () => {
+		const date = getDate( dateAttribute ); // Ensure `getDate` is imported or defined.
+		const dateFormat = getSettings().formats.date;
+		const timeFormat = getSettings().formats.time;
+		const fullDateFormat = `${ dateFormat } ${ timeFormat }`;
+		return date ? dateI18n( fullDateFormat, date ) : null;
+	}, [ dateAttribute ] );
 	return isRTL()
 		? `${ timezoneAbbreviation } ${ formattedDate }`
 		: `${ formattedDate } ${ timezoneAbbreviation }`;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/67486

## Why?
Date format from general settings isn't used in the PostScheduleLabel component.

## How?
Modified the code to apply the changes to post schedule label format based on the general settings time and date format.

## Testing Instructions

- Go to Settings > General
- Change your site's date format to j F Y
- Go to Posts > Add New
- Write a new post
- Hit "Publish"
- Check the date displayed, it will display the selected format.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![beforfix](https://github.com/user-attachments/assets/ee76fc6c-95fe-4aaf-9492-18acc24472e7)|![afterfix](https://github.com/user-attachments/assets/d4084e65-cc66-4196-a683-876b983f7351)|

