### PR TITLE
Interface: don't persist default complementary area on load

### DIFF
--- a/packages/interface/src/components/complementary-area/index.js
+++ b/packages/interface/src/components/complementary-area/index.js
@@ -243,10 +243,13 @@ function ComplementaryArea( {
 	useEffect( () => {
 		// Set initial visibility: For large screens, enable if it's active by
 		// default. For small screens, always initially disable.
-		if ( isActiveByDefault && activeArea === undefined && ! isSmall ) {
-			enableComplementaryArea( scope, identifier );
-		} else if ( activeArea === undefined && isSmall ) {
-			disableComplementaryArea( scope, identifier );
+		if ( activeArea === undefined ) {
+			const args = [ scope, identifier, { persist: false } ];
+			if ( isActiveByDefault && ! isSmall ) {
+				enableComplementaryArea( ...args );
+			} else if ( isSmall ) {
+				disableComplementaryArea( ...args );
+			}
 		}
 		setIsReady( true );
 	}, [

--- a/packages/interface/src/store/actions.js
+++ b/packages/interface/src/store/actions.js
@@ -33,11 +33,13 @@ export const setDefaultComplementaryArea = ( scope, area ) => {
 /**
  * Enable the complementary area.
  *
- * @param {string} scope Complementary area scope.
- * @param {string} area  Area identifier.
+ * @param {string}  scope           Complementary area scope.
+ * @param {string}  area            Area identifier.
+ * @param {Object}  options         Options.
+ * @param {boolean} options.persist Whether to persist.
  */
 export const enableComplementaryArea =
-	( scope, area ) =>
+	( scope, area, { persist = true } = {} ) =>
 	( { registry, dispatch } ) => {
 		// Return early if there's no area.
 		if ( ! area ) {
@@ -46,14 +48,16 @@ export const enableComplementaryArea =
 		scope = normalizeComplementaryAreaScope( scope );
 		area = normalizeComplementaryAreaName( scope, area );
 
-		const isComplementaryAreaVisible = registry
-			.select( preferencesStore )
-			.get( scope, 'isComplementaryAreaVisible' );
+		if ( persist ) {
+			const isComplementaryAreaVisible = registry
+				.select( preferencesStore )
+				.get( scope, 'isComplementaryAreaVisible' );
 
-		if ( ! isComplementaryAreaVisible ) {
-			registry
-				.dispatch( preferencesStore )
-				.set( scope, 'isComplementaryAreaVisible', true );
+			if ( ! isComplementaryAreaVisible ) {
+				registry
+					.dispatch( preferencesStore )
+					.set( scope, 'isComplementaryAreaVisible', true );
+			}
 		}
 
 		dispatch( {

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -46,8 +46,6 @@ test.describe( 'Preload', () => {
 			// There are two separate settings OPTIONS requests. We should fix
 			// so the one for canUser and getEntityRecord are reused.
 			'/wp/v2/settings',
-			// Seems to be coming from `enableComplementaryArea`.
-			'/wp/v2/users/me',
 		] );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related: #40923

The interface package currently seems to persist enabling/disabling the default complementary area on load. This shouldn't happen unless there was a user action. Simply being the default is not a user action.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

There should be no such requests on editor load.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add an option to not persist.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

It is best tested using the e2e test. When opening the editor page without any preferences set, there should be no POST request to `/wp/v2/users/me`

