### PR TITLE
[mini] Preload: add post type

### DIFF
--- a/backport-changelog/6.8/7695.md
+++ b/backport-changelog/6.8/7695.md
@@ -4,3 +4,4 @@ https://github.com/WordPress/wordpress-develop/pull/7695
 * https://github.com/WordPress/gutenberg/pull/67465
 * https://github.com/WordPress/gutenberg/pull/66579
 * https://github.com/WordPress/gutenberg/pull/66654
+* https://github.com/WordPress/gutenberg/pull/67518

--- a/lib/compat/wordpress-6.8/preload.php
+++ b/lib/compat/wordpress-6.8/preload.php
@@ -22,6 +22,7 @@ function gutenberg_block_editor_preload_paths_6_8( $paths, $context ) {
 			$route_for_post = rest_get_route_for_post( $post );
 			if ( $route_for_post ) {
 				$paths[] = add_query_arg( 'context', 'edit', $route_for_post );
+				$paths[] = add_query_arg( 'context', 'edit', '/wp/v2/types/' . $post->post_type );
 				if ( 'page' === $post->post_type ) {
 					$paths[] = add_query_arg(
 						'slug',


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Preloads the post type.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Fetching the post type is a bottleneck for loading the editor.

#67511 systematically adds tests for the editor pages, and there it can be seen that this is a request before the editor load.

|Before|After|
|-|-|
|<img width="1464" alt="Screenshot 2024-12-03 at 11 27 02" src="https://github.com/user-attachments/assets/efe4a6c1-1197-4fd3-9cda-4c4bcca627a2">|<img width="1464" alt="Screenshot 2024-12-03 at 11 26 37" src="https://github.com/user-attachments/assets/cef799ad-ca3b-48a7-9c9e-46ce9f709ac5">|

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add the path.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Open `/wp-admin/site-editor.php?p=%2Fpage&postId=<ID>` directly. There should be no post type request.
