### PR TITLE
InspectorControlsSlot: remove unused framer motion context forwarding

### DIFF
--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -1,11 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	__experimentalUseSlotFills as useSlotFills,
-	__unstableMotionContext as MotionContext,
-} from '@wordpress/components';
-import { useContext, useMemo } from '@wordpress/element';
+import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
+import { useMemo } from '@wordpress/element';
 import warning from '@wordpress/warning';
 import deprecated from '@wordpress/deprecated';
 
@@ -37,17 +34,12 @@ export default function InspectorControlsSlot( {
 	const slotFill = groups[ group ];
 	const fills = useSlotFills( slotFill?.name );
 
-	const motionContextValue = useContext( MotionContext );
-
 	const computedFillProps = useMemo(
 		() => ( {
 			...fillProps,
-			forwardedContext: [
-				...( fillProps?.forwardedContext ?? [] ),
-				[ MotionContext.Provider, { value: motionContextValue } ],
-			],
+			forwardedContext: [ ...( fillProps?.forwardedContext ?? [] ) ],
 		} ),
-		[ motionContextValue, fillProps ]
+		[ fillProps ]
 	);
 
 	if ( ! slotFill ) {

--- a/packages/block-editor/src/components/inspector-controls/slot.js
+++ b/packages/block-editor/src/components/inspector-controls/slot.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __experimentalUseSlotFills as useSlotFills } from '@wordpress/components';
-import { useMemo } from '@wordpress/element';
 import warning from '@wordpress/warning';
 import deprecated from '@wordpress/deprecated';
 
@@ -34,14 +33,6 @@ export default function InspectorControlsSlot( {
 	const slotFill = groups[ group ];
 	const fills = useSlotFills( slotFill?.name );
 
-	const computedFillProps = useMemo(
-		() => ( {
-			...fillProps,
-			forwardedContext: [ ...( fillProps?.forwardedContext ?? [] ) ],
-		} ),
-		[ fillProps ]
-	);
-
 	if ( ! slotFill ) {
 		warning( `Unknown InspectorControls group "${ group }" provided.` );
 		return null;
@@ -58,14 +49,12 @@ export default function InspectorControlsSlot( {
 			<BlockSupportToolsPanel group={ group } label={ label }>
 				<BlockSupportSlotContainer
 					{ ...props }
-					fillProps={ computedFillProps }
+					fillProps={ fillProps }
 					Slot={ Slot }
 				/>
 			</BlockSupportToolsPanel>
 		);
 	}
 
-	return (
-		<Slot { ...props } fillProps={ computedFillProps } bubblesVirtually />
-	);
+	return <Slot { ...props } fillProps={ fillProps } bubblesVirtually />;
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Stop forwarding Framer Motion's context in the inspector controls SlotFill

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The forwarding was introduced in #50278, but shouldn't be necessary anymore after refactoring `ToggleGroupControl` and `Tabs` away from `framer-motion`.

Removing unnecessary lines of code and runtime computation is always a good idea.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Deleted the relevant lines of code.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Smoke tests a few different block controls in the inspector controls, make sure that they all work as expected, especially any framer-motion-based animation (if any).

