### PR TITLE
Image Block: Fixes Aligned Images size in Lightbox

### DIFF
--- a/backport-changelog/6.8/8105.md
+++ b/backport-changelog/6.8/8105.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8105
+
+* https://github.com/WordPress/gutenberg/pull/67528

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1106,14 +1106,15 @@ function gutenberg_restore_image_outer_container( $block_content, $block ) {
 
 	$wrapper_classnames = array( 'wp-block-image' );
 
-	// If the block has a classNames attribute these classnames need to be added back
+	// If the block has a classNames attribute these classnames need to be removed from the content and added back
 	// to the new wrapper div also.
 	if ( ! empty( $block['attrs']['className'] ) ) {
 		$wrapper_classnames = array_merge( $wrapper_classnames, explode( ' ', $block['attrs']['className'] ) );
 	}
+	$content_classnames          = explode( ' ', $matches[2] );
+	$filtered_content_classnames = array_diff( $content_classnames, $wrapper_classnames );
 
-	// Wrap the existing content with the new wrapper div.
-	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $block_content . '</div>';
+	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $matches[1] . implode( ' ', $filtered_content_classnames ) . $matches[3] . '</div>';
 }
 
 if ( function_exists( 'wp_restore_image_outer_container' ) ) {

--- a/lib/block-supports/layout.php
+++ b/lib/block-supports/layout.php
@@ -1106,15 +1106,14 @@ function gutenberg_restore_image_outer_container( $block_content, $block ) {
 
 	$wrapper_classnames = array( 'wp-block-image' );
 
-	// If the block has a classNames attribute these classnames need to be removed from the content and added back
+	// If the block has a classNames attribute these classnames need to be added back
 	// to the new wrapper div also.
 	if ( ! empty( $block['attrs']['className'] ) ) {
 		$wrapper_classnames = array_merge( $wrapper_classnames, explode( ' ', $block['attrs']['className'] ) );
 	}
-	$content_classnames          = explode( ' ', $matches[2] );
-	$filtered_content_classnames = array_diff( $content_classnames, $wrapper_classnames );
 
-	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $matches[1] . implode( ' ', $filtered_content_classnames ) . $matches[3] . '</div>';
+	// Wrap the existing content with the new wrapper div.
+	return '<div class="' . implode( ' ', $wrapper_classnames ) . '">' . $block_content . '</div>';
 }
 
 if ( function_exists( 'wp_restore_image_outer_container' ) ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/66692

## Why?
This PR fixes the position and size of images in the Image blocks of themes without a json file.

## How?
Updated the `function gutenberg_restore_image_outer_container` so that the lightbox does not affect the position and image size.

## Testing Instructions

1. Log in to the WordPress Dashboard with administrator credentials.
2. Activate a classic theme without theme.json (e.g., Twenty Twenty-One or Twenty Nineteen).
3. Create a new page and add an Image block.
4. Select or upload an image in the Image block.
5. Enable the "Expand on click" option by clicking the link option.
6. Align the image to center, left or right using the align option.
7. Save or publish the page.
8. Open the page on the frontend.
9. Click the image to open the lightbox.
10. Verify that the lightbox displays the image in correct position and original image size correctly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

**After the fix**

https://github.com/user-attachments/assets/8fd09712-8d0b-4402-94bd-635a449017b4




