### PR TITLE
Update extending-the-query-loop-block.md

### DIFF
--- a/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
+++ b/docs/how-to-guides/block-tutorial/extending-the-query-loop-block.md
@@ -186,6 +186,8 @@ As of Gutenberg version 14.2, the following controls are available:
 -   `taxQuery` - Shows available taxonomies filters for the currently selected post type.
 -   `author` - Shows an input field to filter the query by author.
 -   `search` - Shows an input field to filter the query by keywords.
+-   `format` - Shows an input field to filter the query by array/collection of [formats](https://developer.wordpress.org/advanced-administration/wordpress/post-formats/#supported-formats).
+-   `parents` - Shows an input field to filter the query using parent(s) entity.
 
 In our case, the property would look like this:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add allowedControls properties format and parents.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Properties [parents](https://github.com/WordPress/gutenberg/blob/43a92c5dbe729602df7cbf496b4ff7208ed7e2a1/packages/block-library/src/query/edit/inspector-controls/index.js#L146-L148) and [format](https://github.com/WordPress/gutenberg/blob/43a92c5dbe729602df7cbf496b4ff7208ed7e2a1/packages/block-library/src/query/edit/inspector-controls/index.js#L151-L172) can be enabled/disabled in query controls.
