### PR TITLE
Separator block: Allow divs to be used as separators

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -820,7 +820,7 @@ Create a break between ideas or sections with a horizontal separator. ([Source](
 -	**Name:** core/separator
 -	**Category:** design
 -	**Supports:** align (center, full, wide), anchor, color (background, gradients, ~~enableContrastChecker~~, ~~text~~), interactivity (clientNavigation), spacing (margin)
--	**Attributes:** opacity
+-	**Attributes:** opacity, tagName
 
 ## Shortcode
 

--- a/packages/block-library/src/separator/block.json
+++ b/packages/block-library/src/separator/block.json
@@ -11,6 +11,11 @@
 		"opacity": {
 			"type": "string",
 			"default": "alpha-channel"
+		},
+		"tagName": {
+			"type": "string",
+			"enum": [ "hr", "div" ],
+			"default": "hr"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/separator/deprecated.js
+++ b/packages/block-library/src/separator/deprecated.js
@@ -49,6 +49,7 @@ const v1 = {
 			style: customColor
 				? { color: { background: customColor } }
 				: undefined,
+			tagName: 'hr',
 		};
 	},
 };

--- a/packages/block-library/src/separator/edit.js
+++ b/packages/block-library/src/separator/edit.js
@@ -6,20 +6,28 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
-import { HorizontalRule } from '@wordpress/components';
+import { HorizontalRule, SelectControl } from '@wordpress/components';
 import {
 	useBlockProps,
 	getColorClassName,
 	__experimentalUseColorProps as useColorProps,
+	InspectorControls,
 } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import useDeprecatedOpacity from './use-deprecated-opacity';
 
+const htmlElementMessages = {
+	div: __(
+		'The <div> element should only be used if the separator is a design element that should not be announced.'
+	),
+};
+
 export default function SeparatorEdit( { attributes, setAttributes } ) {
-	const { backgroundColor, opacity, style } = attributes;
+	const { backgroundColor, opacity, style, tagName } = attributes;
 	const colorProps = useColorProps( attributes );
 	const currentColor = colorProps?.style?.backgroundColor;
 	const hasCustomColor = !! style?.color?.background;
@@ -44,10 +52,27 @@ export default function SeparatorEdit( { attributes, setAttributes } ) {
 		color: currentColor,
 		backgroundColor: currentColor,
 	};
+	const Wrapper = tagName === 'hr' ? HorizontalRule : tagName;
 
 	return (
 		<>
-			<HorizontalRule
+			<InspectorControls group="advanced">
+				<SelectControl
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+					label={ __( 'HTML element' ) }
+					options={ [
+						{ label: __( 'Default (<hr>)' ), value: 'hr' },
+						{ label: '<div>', value: 'div' },
+					] }
+					value={ tagName }
+					onChange={ ( value ) =>
+						setAttributes( { tagName: value } )
+					}
+					help={ htmlElementMessages[ tagName ] }
+				/>
+			</InspectorControls>
+			<Wrapper
 				{ ...useBlockProps( {
 					className,
 					style: hasCustomColor ? styles : undefined,

--- a/packages/block-library/src/separator/save.js
+++ b/packages/block-library/src/separator/save.js
@@ -13,7 +13,7 @@ import {
 } from '@wordpress/block-editor';
 
 export default function separatorSave( { attributes } ) {
-	const { backgroundColor, style, opacity } = attributes;
+	const { backgroundColor, style, opacity, tagName: Tag } = attributes;
 	const customColor = style?.color?.background;
 	const colorProps = getColorClassesAndStyles( attributes );
 	// The hr support changing color using border-color, since border-color
@@ -37,5 +37,5 @@ export default function separatorSave( { attributes } ) {
 		backgroundColor: colorProps?.style?.backgroundColor,
 		color: colorClass ? undefined : customColor,
 	};
-	return <hr { ...useBlockProps.save( { className, style: styles } ) } />;
+	return <Tag { ...useBlockProps.save( { className, style: styles } ) } />;
 }

--- a/packages/block-library/src/separator/test/edit.js
+++ b/packages/block-library/src/separator/test/edit.js
@@ -23,6 +23,7 @@ const defaultAttributes = {
 	opacity: 'alpha-channel',
 	style: {},
 	className: '',
+	tagName: 'hr',
 };
 const defaultProps = {
 	attributes: defaultAttributes,

--- a/test/integration/fixtures/blocks/core__separator-color.json
+++ b/test/integration/fixtures/blocks/core__separator-color.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"opacity": "alpha-channel",
-			"backgroundColor": "accent"
+			"backgroundColor": "accent",
+			"tagName": "hr"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator-custom-color.json
+++ b/test/integration/fixtures/blocks/core__separator-custom-color.json
@@ -8,7 +8,8 @@
 				"color": {
 					"background": "#5da54c"
 				}
-			}
+			},
+			"tagName": "hr"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator.json
+++ b/test/integration/fixtures/blocks/core__separator.json
@@ -3,7 +3,8 @@
 		"name": "core/separator",
 		"isValid": true,
 		"attributes": {
-			"opacity": "alpha-channel"
+			"opacity": "alpha-channel",
+			"tagName": "hr"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator__deprecated-color-v1.json
+++ b/test/integration/fixtures/blocks/core__separator__deprecated-color-v1.json
@@ -4,7 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"backgroundColor": "accent",
-			"opacity": "css"
+			"opacity": "css",
+			"tagName": "hr"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator__deprecated-custom-color-v1.json
+++ b/test/integration/fixtures/blocks/core__separator__deprecated-custom-color-v1.json
@@ -8,7 +8,8 @@
 				"color": {
 					"background": "#cc1d1d"
 				}
-			}
+			},
+			"tagName": "hr"
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
closes #54976 

## What?

In some situations, you might want the separator blocks to not be announced by screen readers. You want them to be just design tokens. This PRs allows that by adding a "tagName" attribute to the separator block. Also adds a help text to explain when you should be using "divs". 

## Testing Instructions

1- Insert the separator block.
2- Under "Advanced" in the inspector panel, you can switch to "div".
3- Check that the separator still looks and behaves properly (we might want to check different themes, including classic ones)