### PR TITLE
Fix: Fixed styling tab not opening on themes without style variations on mobile & desktop

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -41,7 +41,13 @@ export function SidebarNavigationItemGlobalStyles( props ) {
 			/>
 		);
 	}
-	return <SidebarNavigationItem { ...props } />;
+	return (
+		<SidebarNavigationItem
+			{ ...props }
+			to="/styles"
+			aria-current={ name === 'styles' }
+		/>
+	);
 }
 
 export default function SidebarNavigationScreenGlobalStyles() {


### PR DESCRIPTION
resolves #67532

## What?
This PR adds to="/styles" and aria-current={ name === 'styles' } to SidebarNavigationItem to ensure the Styles tab works correctly on mobile devices.

## Why?
When a block theme lacks global style variations, the top-level Styles panel in the Site Editor does not open on mobile when using Gutenberg 19.7 or the nightly build. This PR resolves the issue to ensure consistent behavior across all themes.

## How?
The conditional rendering for SidebarNavigationItem was updated. The onClick logic was removed with the introduction of the Styles panel in `2a18aae3768da80f94e437c16e8d56e5a9a45e03 `, but it made it work only for themes with global variations. This patch ensures the SidebarNavigationItem opens the Styles panel for all themes, regardless of variations.
 
 ```JS
 if ( hasGlobalStyleVariations ) {
		return (
			<SidebarNavigationItem
				{ ...props }
				to="/styles"
				uid="global-styles-navigation-item"
				aria-current={ name === 'styles' }
			/>
		);
	}
	return <SidebarNavigationItem { ...props } to="/styles" aria-current={ name === 'styles' } />;
```

## Testing Instructions

1. Use a block theme without style variations, like https://wordpress.org/themes/onyxpulse/
2. Ensure you're using at least GB 19.7.
3. Open this on your phone or use browser tools to pull up on mobile.
4. Open Appearance > Editor
5. Try to select Styles and notice it properly opens up the Styles panel.
6. Switch to a theme with style variations, like https://wordpress.org/themes/twentytwentyfive/
7. Open Appearance > Editor
8. Try to select Styles and notice it properly opens up the Styles panel.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f7a696b5-926c-4484-ae6e-8f1496007962


