### PR TITLE
Add button interactive states in the stylebook

### DIFF
--- a/packages/edit-site/src/components/style-book/button-examples.tsx
+++ b/packages/edit-site/src/components/style-book/button-examples.tsx
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { __experimentalGrid as Grid } from '@wordpress/components';
+import { View } from '@wordpress/primitives';
+import {
+	BlockList,
+	privateApis as blockEditorPrivateApis,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../../lock-unlock';
+
+const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
+	blockEditorPrivateApis
+);
+
+const BUTTON_STATE_NAMES = [
+	'default',
+	':active',
+	':any-link',
+	':focus',
+	':hover',
+	':link',
+	':visited',
+];
+
+function ButtonExamples() {
+	const [ elementsButton ] = useGlobalStyle( 'elements.button' );
+	const blocks = BUTTON_STATE_NAMES.map( ( state ) => {
+		const styles =
+			( state !== 'default'
+				? elementsButton[ state ]
+				: elementsButton ) || {};
+		return createBlock( 'core/button', {
+			text: __( 'Call to Action' ),
+			style: styles,
+		} );
+	} );
+
+	return (
+		<Grid columns={ 2 } gap={ 6 }>
+			{ blocks.map( ( block, key ) => (
+				<View key={ `button-example-${ key }` }>
+					<ExperimentalBlockEditorProvider value={ [ block ] }>
+						<BlockList appender={ false } />
+					</ExperimentalBlockEditorProvider>
+
+					<span className="edit-site-style-book__example-subtitle">
+						{ BUTTON_STATE_NAMES[ key ] }
+					</span>
+				</View>
+			) ) }
+		</Grid>
+	);
+}
+
+export default ButtonExamples;

--- a/packages/edit-site/src/components/style-book/button-examples.tsx
+++ b/packages/edit-site/src/components/style-book/button-examples.tsx
@@ -19,23 +19,43 @@ const { ExperimentalBlockEditorProvider, useGlobalStyle } = unlock(
 	blockEditorPrivateApis
 );
 
-const BUTTON_STATE_NAMES = [
-	'default',
-	':active',
-	':any-link',
-	':focus',
-	':hover',
-	':link',
-	':visited',
+const BUTTON_STATES = [
+	{
+		key: 'default',
+		title: __( 'Button' ),
+	},
+	{
+		key: ':active',
+		title: __( 'Button (Active)' ),
+	},
+	{
+		key: ':any-link',
+		title: __( 'Button (Any Link)' ),
+	},
+	{
+		key: ':focus',
+		title: __( 'Button (Focus)' ),
+	},
+	{
+		key: ':hover',
+		title: __( 'Button (Hover)' ),
+	},
+	{
+		key: ':link',
+		title: __( 'Button (Link)' ),
+	},
+	{
+		key: ':visited',
+		title: __( 'Button (Visited)' ),
+	},
 ];
 
 function ButtonExamples() {
 	const [ elementsButton ] = useGlobalStyle( 'elements.button' );
-	const blocks = BUTTON_STATE_NAMES.map( ( state ) => {
+	const blocks = BUTTON_STATES.map( ( { key } ) => {
 		const styles =
-			( state !== 'default'
-				? elementsButton[ state ]
-				: elementsButton ) || {};
+			( key !== 'default' ? elementsButton[ key ] : elementsButton ) ||
+			{};
 		return createBlock( 'core/button', {
 			text: __( 'Call to Action' ),
 			style: styles,
@@ -44,15 +64,14 @@ function ButtonExamples() {
 
 	return (
 		<Grid columns={ 2 } gap={ 6 }>
-			{ blocks.map( ( block, key ) => (
-				<View key={ `button-example-${ key }` }>
+			{ blocks.map( ( block, index ) => (
+				<View key={ `button-example-${ BUTTON_STATES[ index ].key }` }>
+					<span className="edit-site-style-book__example-subtitle">
+						{ BUTTON_STATES[ index ].title }
+					</span>
 					<ExperimentalBlockEditorProvider value={ [ block ] }>
 						<BlockList appender={ false } />
 					</ExperimentalBlockEditorProvider>
-
-					<span className="edit-site-style-book__example-subtitle">
-						{ BUTTON_STATE_NAMES[ key ] }
-					</span>
 				</View>
 			) ) }
 		</Grid>

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -239,6 +239,11 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 		text-transform: uppercase;
 	}
 
+	.edit-site-style-book__example-subtitle {
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		font-size: 9px;
+	}
+
 	.edit-site-style-book__subcategory-title {
 		font-size: 16px;
 		margin-bottom: 40px;

--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -16,6 +16,7 @@ import type { BlockExample, ColorOrigin, MultiOriginPalettes } from './types';
 import ColorExamples from './color-examples';
 import DuotoneExamples from './duotone-examples';
 import { STYLE_BOOK_COLOR_GROUPS } from './constants';
+import ButtonExamples from './button-examples';
 
 /**
  * Returns examples color examples for each origin
@@ -177,11 +178,14 @@ function getOverviewBlockExamples(
  * @return {BlockExample[]} An array of block examples.
  */
 export function getExamples( colors: MultiOriginPalettes ): BlockExample[] {
+	// Exclude default examples from block to include custom examples for those blocks.
+	const excludedDefaultExamples = [ 'core/heading', 'core/button' ];
+
 	const nonHeadingBlockExamples = getBlockTypes()
 		.filter( ( blockType ) => {
 			const { name, example, supports } = blockType;
 			return (
-				name !== 'core/heading' &&
+				! excludedDefaultExamples.includes( name ) &&
 				!! example &&
 				supports?.inserter !== false
 			);
@@ -227,10 +231,17 @@ export function getExamples( colors: MultiOriginPalettes ): BlockExample[] {
 		} ),
 	};
 	const colorExamples = getColorExamples( colors );
-
 	const overviewBlockExamples = getOverviewBlockExamples( colors );
 
+	const buttonExample = {
+		name: 'core/button',
+		title: __( 'Button' ),
+		category: 'design',
+		content: <ButtonExamples />,
+	};
+
 	return [
+		buttonExample,
 		headingsExample,
 		...colorExamples,
 		...nonHeadingBlockExamples,


### PR DESCRIPTION
## What?
Add button interactive states in the stylebook

## Why?
To showcase the different interactive states of the button in the stylebook.
This is part of the effort around adding a UI to define the styles of those interactive states: https://github.com/WordPress/gutenberg/issues/38277
Fixes: https://github.com/WordPress/gutenberg/issues/67542

## How?
Bu adding one button for each interactive state in the stylebook.

## Testing Instructions
1. Checkout this PR.
2. Add some styles for the interactive states of the button elements in your `theme.json` file. Example:
```json
"styles":{
		"elements": {
			"button":{
				
				"color": {
					"background": "yellow",
					"text": "blue"
				},
				":hover": {
					"color": {
						"background": "orange",
						"text": "red"

					}
				},
				":visited": {
					"color": {
						"background": "green",
						"text": "blue"
					}
				},
				":active": {
					"color": {
						"background": "red",
						"text": "yellow"
					}
				},
				":focus": {
					"color": {
						"background": "blue",
						"text": "green"
					}
				},
				":any-link": {
					"color": {
						"background": "purple",
						"text": "white"
					}
				},
				":link": {
					"color": {
						"background": "pink",
						"text": "black"
					}
				}
			}
		}
	},
````
3. Browse the stylebook and got to the 'design' tab.
4. Check that the styles defined in theme.json are observable in the button

---

Maybe it's simpler for you to download and try this theme featuring only the button interactive states as in the screenshot: 
[testing-button-states.zip](https://github.com/user-attachments/files/17999058/testing-button-states.zip)


## Screenshots or screencast <!-- if applicable -->



|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/0b4fcef3-87eb-4dc4-9a71-6af30d64977a) |![image](https://github.com/user-attachments/assets/0268fd1a-ad63-4c1d-bd42-74879d4cd442) |
