### PR TITLE
Site Editor Sidebar: remove `hasGlobalStyleVariations` condition for the Styles nav item

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -24,27 +23,9 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 export function SidebarNavigationItemGlobalStyles( props ) {
 	const { name } = useLocation();
-	const hasGlobalStyleVariations = useSelect(
-		( select ) =>
-			!! select(
-				coreStore
-			).__experimentalGetCurrentThemeGlobalStylesVariations()?.length,
-		[]
-	);
-	if ( hasGlobalStyleVariations ) {
-		return (
-			<SidebarNavigationItem
-				{ ...props }
-				to="/styles"
-				uid="global-styles-navigation-item"
-				aria-current={ name === 'styles' }
-			/>
-		);
-	}
 	return (
 		<SidebarNavigationItem
 			{ ...props }
-			to="/styles"
 			aria-current={ name === 'styles' }
 		/>
 	);

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -28,7 +28,8 @@ export function MainSidebarNavigationContent() {
 				{ __( 'Navigation' ) }
 			</SidebarNavigationItem>
 			<SidebarNavigationItemGlobalStyles
-				uid="styles-navigation-item"
+				to="/styles"
+				uid="global-styles-navigation-item"
 				icon={ styles }
 			>
 				{ __( 'Styles' ) }


### PR DESCRIPTION

## What?

Follow up to https://github.com/WordPress/gutenberg/pull/67537

cc @Mayank-Tripathi32  

👋🏻 

1. Remove `hasGlobalStyleVariations` condition to show the Styles menu item in the edit site sidebar.
2. Also, move its `uid` and `to` props to `MainSidebarNavigationContent` for consistency and convenience.

## Why?

The sidebar navigation styles item [now contains the global styles UI](https://github.com/WordPress/gutenberg/pull/65619) and no longer just the variations. For this reason it's okay to remove the condition. 


## Testing Instructions


1. Use a block theme without style variations, like https://wordpress.org/themes/onyxpulse/
2. In "mobile" view (narrow viewport) open Appearance > Editor
3. Select Styles. Ensure that you can see the Global Styles UI
4. Switch to a theme with style variations, e.g., https://wordpress.org/themes/twentytwentyfive/
5. Select Styles. Ensure that you can see the Global Styles UI.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/71457419-2fcd-47c8-a622-f5e1b5d16dff

