### PR TITLE
Update style book headings to new design

### DIFF
--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -216,12 +216,12 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	}
 	.edit-site-style-book__duotone-example > div:not(:first-child) {
 		height: 20px;
-		border: 1px solid #ddd;
+		border: 1px solid color-mix( in srgb, currentColor 10%, transparent );
 	}
 
 	.edit-site-style-book__color-example {
-		height: 52px;
-		border: 1px solid #ddd;
+		height: 32px;
+		border: 1px solid color-mix( in srgb, currentColor 10%, transparent );
 	}
 
 	.edit-site-style-book__subcategory-title,

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -224,19 +224,16 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 		border: 1px solid #ddd;
 	}
 
-	.edit-site-style-book__examples.is-wide .edit-site-style-book__example {
-		flex-direction: row;
-	}
-
 	.edit-site-style-book__subcategory-title,
 	.edit-site-style-book__example-title {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		font-size: 11px;
-		font-weight: 500;
+		font-size: 13px;
+		font-weight: normal;
 		line-height: normal;
 		margin: 0;
 		text-align: left;
-		text-transform: uppercase;
+		padding-top: 4px;
+		border-top: 1px solid currentColor;
 	}
 
 	.edit-site-style-book__subcategory-title {
@@ -246,17 +243,8 @@ export const STYLE_BOOK_IFRAME_STYLES = `
     	padding-bottom: 8px;
 	}
 
-	.edit-site-style-book__examples.is-wide .edit-site-style-book__example-title {
-		text-align: right;
-		width: 120px;
-	}
-
 	.edit-site-style-book__example-preview {
 		width: 100%;
-	}
-	
-	.is-wide .edit-site-style-book__example-preview {
-		width: calc(100% - 120px);
 	}
 
 	.edit-site-style-book__example-preview .block-editor-block-list__insertion-point,

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -232,8 +232,9 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 		line-height: normal;
 		margin: 0;
 		text-align: left;
-		padding-top: 4px;
-		border-top: 1px solid currentColor;
+		padding-top: 8px;
+		border-top: 1px solid color-mix( in srgb, currentColor 10%, transparent );
+		color: color-mix( in srgb, currentColor 60%, transparent );
 	}
 
 	.edit-site-style-book__subcategory-title {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Part of #53431.

Updates the styles of stylebook headings to match designs on that issue.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With a block theme active, go to "Styles" in the site editor and select "Style book" from the Preview dropdown.
2. Check that style book headings look as expected.

The one thing in the design that I'm not sure how to best implement is the color difference between headings and actual theme text color:

<img width="742" alt="Screenshot 2024-12-04 at 11 02 01 am" src="https://github.com/user-attachments/assets/202c3639-642f-46b6-ad57-d453f0d970cd">

Hardcoding a color in here won't work because the style book uses whatever background color is defined by the theme (and text color as well). The design seems to use always the same color, but what happens if the theme background color happens to be that exact color, or one very close to it?

We should also ensure that these headings have accessible levels of contrast, which some of the variations in the design don't seem to have.

Before I jump into making complicated JS calculations around text/background color in order to dynamically find the appropriate heading color, I just want to make sure we're all on the same page about this 😅 so:

* Is the intention that the heading color be always a little bit lighter than text color when the background is light, and a little darker when the background is dark? 
* Do we want it to always be grey, or should it match the theme text color?

Current headings match theme text color, and I haven't changed that yet in this PR:

<img width="914" alt="Screenshot 2024-12-04 at 10 58 17 am" src="https://github.com/user-attachments/assets/17fb6a8a-f483-4eee-8c84-19aac0f61a37">

<img width="907" alt="Screenshot 2024-12-04 at 10 58 28 am" src="https://github.com/user-attachments/assets/b607aa49-9255-4763-9603-28b3710508e3">

<img width="909" alt="Screenshot 2024-12-04 at 10 58 50 am" src="https://github.com/user-attachments/assets/3adde7f7-a49c-487a-b951-7e1d3ba207e2">


