### PR TITLE
Site Editor: Fix the templates route on mobile

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/templates.js
+++ b/packages/edit-site/src/components/site-editor-routes/templates.js
@@ -1,28 +1,9 @@
 /**
- * WordPress dependencies
- */
-import { privateApis as routerPrivateApis } from '@wordpress/router';
-
-/**
  * Internal dependencies
  */
 import Editor from '../editor';
 import SidebarNavigationScreenTemplatesBrowse from '../sidebar-navigation-screen-templates-browse';
-import { unlock } from '../../lock-unlock';
 import PageTemplates from '../page-templates';
-
-const { useLocation } = unlock( routerPrivateApis );
-
-function MobileTemplatesView() {
-	const { query = {} } = useLocation();
-	const { canvas = 'view' } = query;
-
-	return canvas === 'edit' ? (
-		<Editor />
-	) : (
-		<SidebarNavigationScreenTemplatesBrowse backPath="/" />
-	);
-}
 
 export const templatesRoute = {
 	name: 'templates',
@@ -34,7 +15,7 @@ export const templatesRoute = {
 			const isListView = query.layout === 'list';
 			return isListView ? <Editor /> : undefined;
 		},
-		mobile: <MobileTemplatesView />,
+		mobile: <PageTemplates />,
 	},
 	widths: {
 		content( { query } ) {


### PR DESCRIPTION


## What?

Follow up to https://github.com/WordPress/gutenberg/pull/67467

Similar to https://github.com/WordPress/gutenberg/pull/67467, template routes do not work on mobile view

## Why?
Fixes a regression.



## Testing Instructions

1- Open the site editor on mobile view (narrow width)
2- Click "Templates"

You should see the grid of templates.

## Screenshots or screencast <!-- if applicable -->

### Before


https://github.com/user-attachments/assets/c936ea7e-a086-4413-98c4-5c722da597f9



### After


https://github.com/user-attachments/assets/3a76b733-cc3f-4bb2-a6e5-d7fbb4e4b330


