### PR TITLE
Edit site: remove empty preview border and redirect to editor in global styles navigation

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -226,6 +226,10 @@
 	// The &#{&} is a workaround for the specificity of the Card component.
 	&#{&},
 	&#{&} .edit-site-global-styles-screen-root__active-style-tile-preview {
+		box-shadow: none;
 		border-radius: $radius-small;
+		.block-editor-iframe__container {
+			border: 1px solid $gray-200;
+		}
 	}
 }

--- a/packages/edit-site/src/components/site-editor-routes/styles.js
+++ b/packages/edit-site/src/components/site-editor-routes/styles.js
@@ -1,9 +1,28 @@
 /**
+ * WordPress dependencies
+ */
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+
+/**
  * Internal dependencies
  */
 import Editor from '../editor';
+import { unlock } from '../../lock-unlock';
 import SidebarNavigationScreenGlobalStyles from '../sidebar-navigation-screen-global-styles';
 import GlobalStylesUIWrapper from '../sidebar-global-styles-wrapper';
+
+const { useLocation } = unlock( routerPrivateApis );
+
+function MobileGlobalStylesUI() {
+	const { query = {} } = useLocation();
+	const { canvas } = query;
+
+	if ( canvas === 'edit' ) {
+		return <Editor />;
+	}
+
+	return <GlobalStylesUIWrapper />;
+}
 
 export const stylesRoute = {
 	name: 'styles',
@@ -12,7 +31,7 @@ export const stylesRoute = {
 		content: <GlobalStylesUIWrapper />,
 		sidebar: <SidebarNavigationScreenGlobalStyles backPath="/" />,
 		preview: <Editor />,
-		mobile: <GlobalStylesUIWrapper />,
+		mobile: <MobileGlobalStylesUI />,
 	},
 	widths: {
 		content: 380,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Some quality of life improvements for Edit Site styles navigation in mobile view.

1. Ensure that the empty frame border does not appear in mobile view.
2. Ensure that viewport changes while in edit mode **and** on the styles route `p=/styles` don't result in the user being stuck in the styles view without a WP logo or any way to exit.

## Why?

1. Removes a weird and useless grey border
2. `/wp-admin/site-editor.php?p=/styles&canvas=edit` never opens the editor. That means, if I change from landscape to portrait in my mobile while viewing global styles in edit mode, I'm stuck on the styles screen with no way out.


## How?

1. Applies the border to the internal element, the iframe wrapper. It was the best and easiest thing to do for now, other than fiddle with the iframe style props.
2. Shows the editor in edit more rather than the global styles UI.

## Testing Instructions

1. Reduce the width of your browser to mimic mobile mode. The order is important here. 
2. Go to Appearance > Editor to visit the Site Editor.
3. Click on "Styles"
4. See now that there is no empty border 😮 
5. Now edit a page or enter edit mode somehow to visit the editor. Or just head to `/wp-admin/site-editor.php?p=/styles&canvas=edit`.
6. Open global styles from the settings menu
7. Change to "landscape" view by widening the viewport width. O
8. See that you are not stuck in the style panel.

## Screenshots or screencast <!-- if applicable -->

### Before

#### The border 👎🏻 

https://github.com/user-attachments/assets/64ee288d-2fc8-43f4-a385-c75c4f2155a9

#### The editor 👎🏻 

https://github.com/user-attachments/assets/5035402a-8a1d-4082-a49e-b98300c5bbe1


### After




#### The border 👍🏻 

https://github.com/user-attachments/assets/5583906d-0fdb-42b1-83c1-1e87186a751b

#### The editor 👍🏻 




https://github.com/user-attachments/assets/26bd7390-134f-42ec-b1c0-5aa5becce9f6







