### PR TITLE
19.8 Edit Site: styles nav item does not open on mobile for themes without style variations 

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-global-styles/index.js
@@ -2,8 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect, useDispatch } from '@wordpress/data';
-import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
@@ -23,26 +22,15 @@ const { useLocation, useHistory } = unlock( routerPrivateApis );
 
 export function SidebarNavigationItemGlobalStyles( props ) {
 	const { params } = useLocation();
-	const hasGlobalStyleVariations = useSelect(
-		( select ) =>
-			!! select(
-				coreStore
-			).__experimentalGetCurrentThemeGlobalStylesVariations()?.length,
-		[]
+	return (
+		<SidebarNavigationItem
+			{ ...props }
+			params={ { path: '/wp_global_styles' } }
+			aria-current={
+				params.path && params.path.startsWith( '/wp_global_styles' )
+			}
+		/>
 	);
-	if ( hasGlobalStyleVariations ) {
-		return (
-			<SidebarNavigationItem
-				{ ...props }
-				params={ { path: '/wp_global_styles' } }
-				uid="global-styles-navigation-item"
-				aria-current={
-					params.path && params.path.startsWith( '/wp_global_styles' )
-				}
-			/>
-		);
-	}
-	return <SidebarNavigationItem { ...props } />;
 }
 
 export default function SidebarNavigationScreenGlobalStyles() {

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -33,7 +33,7 @@ export function MainSidebarNavigationContent() {
 				{ __( 'Navigation' ) }
 			</SidebarNavigationItem>
 			<SidebarNavigationItemGlobalStyles
-				uid="styles-navigation-item"
+				uid="global-styles-navigation-item"
 				icon={ styles }
 			>
 				{ __( 'Styles' ) }


### PR DESCRIPTION

## What?

Resolves https://github.com/WordPress/gutenberg/issues/67532 for 19.8
1. Remove `hasGlobalStyleVariations` condition to show the Styles menu item in the edit site sidebar.
2. Also, move its `uid` prop to `MainSidebarNavigationContent` for consistency and convenience.

## Why a hotfix for this branch?

Since https://github.com/WordPress/gutenberg/pull/67199 a few things have changed in trunk so this PR targets the state of 19.8 only.

In trunk this bug has been fixed by the following PRs:

- https://github.com/WordPress/gutenberg/pull/67537
- https://github.com/WordPress/gutenberg/pull/67545

## Why?

BUG! When a block theme doesn't have style variations, the newer experience for top level styles in the Site Editor does not open on mobile.

The sidebar navigation styles item [now contains the global styles UI](https://github.com/WordPress/gutenberg/pull/65619) and no longer just the variations. For this reason it's okay to remove the condition. 


## Testing Instructions


1. Use a block theme without style variations, like https://wordpress.org/themes/onyxpulse/
2. In "mobile" view (narrow viewport) open Appearance > Editor
4. Select Styles. Ensure that you can see the Global Styles UI
5. Switch to a theme with style variations, e.g., https://wordpress.org/themes/twentytwentyfive/
6. Select Styles. Ensure that you can see the Global Styles UI.

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/e75c3ab4-1040-4541-ab9a-19376fa7d41c

