### PR TITLE
Global Styles: Fix handling of booleans when stabilizing block supports

### DIFF
--- a/backport-changelog/6.8/7069.md
+++ b/backport-changelog/6.8/7069.md
@@ -3,3 +3,4 @@ https://github.com/WordPress/wordpress-develop/pull/7069
 * https://github.com/WordPress/gutenberg/pull/63401
 * https://github.com/WordPress/gutenberg/pull/66918
 * https://github.com/WordPress/gutenberg/pull/67018
+* https://github.com/WordPress/gutenberg/pull/67552

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -71,6 +71,10 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 		}
 
 		$stabilize_config = function ( $unstable_config, $stable_support_key ) use ( $experimental_support_properties, $common_experimental_properties ) {
+			if ( ! is_array( $unstable_config ) ) {
+				return $unstable_config;
+			}
+
 			$stable_config = array();
 			foreach ( $unstable_config as $key => $value ) {
 				// Get stable key from support-specific map, common properties map, or keep original.
@@ -116,18 +120,19 @@ function gutenberg_stabilize_experimental_block_supports( $args ) {
 				( $key_positions[ $support ] ?? PHP_INT_MAX ) <
 				( $key_positions[ $stable_support_key ] ?? PHP_INT_MAX );
 
-			if ( is_array( $args['supports'][ $stable_support_key ] ) ) {
-				/*
-				 * To merge the alternative support config effectively, it also needs to be
-				 * stabilized before merging to keep stabilized and experimental flags in
-				 * sync.
-				 */
-				$args['supports'][ $stable_support_key ] = $stabilize_config( $args['supports'][ $stable_support_key ], $stable_support_key );
-				$stable_config                           = $experimental_first
+			/*
+			 * To merge the alternative support config effectively, it also needs to be
+			 * stabilized before merging to keep stabilized and experimental flags in
+			 * sync.
+			 */
+			$args['supports'][ $stable_support_key ] = $stabilize_config( $args['supports'][ $stable_support_key ], $stable_support_key );
+			// Prevents reprocessing this support as it was stabilized above.
+			$done[ $stable_support_key ] = true;
+
+			if ( is_array( $stable_config ) && is_array( $args['supports'][ $stable_support_key ] ) ) {
+				$stable_config = $experimental_first
 					? array_merge( $stable_config, $args['supports'][ $stable_support_key ] )
 					: array_merge( $args['supports'][ $stable_support_key ], $stable_config );
-				// Prevents reprocessing this support as it was merged above.
-				$done[ $stable_support_key ] = true;
 			} else {
 				$stable_config = $experimental_first
 					? $args['supports'][ $stable_support_key ]

--- a/phpunit/block-supports/border-test.php
+++ b/phpunit/block-supports/border-test.php
@@ -730,4 +730,104 @@ class WP_Block_Supports_Border_Test extends WP_UnitTestCase {
 		);
 		$this->assertSame( $expected, $actual, 'Merged stabilized border block support config does not match when stable keys are first.' );
 	}
+
+	/**
+	 * Tests that boolean border support configurations are handled correctly.
+	 *
+	 * @dataProvider data_boolean_border_supports
+	 *
+	 * @param array         $supports       The supports configuration to test.
+	 * @param boolean|array $expected_value The expected final border support value.
+	 */
+	public function test_should_handle_boolean_border_supports( $supports, $expected_value ) {
+		$args = array(
+			'supports' => $supports,
+		);
+
+		$actual = gutenberg_stabilize_experimental_block_supports( $args );
+
+		$this->assertSame( $expected_value, $actual['supports']['border'] );
+	}
+
+	/**
+	 * Data provider for boolean border support tests.
+	 *
+	 * @return array Test parameters.
+	 */
+	public function data_boolean_border_supports() {
+		return array(
+			'experimental true only'                   => array(
+				array(
+					'__experimentalBorder' => true,
+				),
+				true,
+			),
+			'experimental false only'                  => array(
+				array(
+					'__experimentalBorder' => false,
+				),
+				false,
+			),
+			'experimental true before stable false'    => array(
+				array(
+					'__experimentalBorder' => true,
+					'border'               => false,
+				),
+				false,
+			),
+			'stable true before experimental false'    => array(
+				array(
+					'border'               => true,
+					'__experimentalBorder' => false,
+				),
+				false,
+			),
+			'experimental array before stable boolean' => array(
+				array(
+					'__experimentalBorder' => array(
+						'color' => true,
+						'width' => true,
+					),
+					'border'               => false,
+				),
+				false,
+			),
+			'stable array before experimental boolean' => array(
+				array(
+					'border'               => array(
+						'color' => true,
+						'width' => true,
+					),
+					'__experimentalBorder' => true,
+				),
+				true,
+			),
+			'experimental boolean before stable array' => array(
+				array(
+					'__experimentalBorder' => true,
+					'border'               => array(
+						'color' => true,
+						'width' => true,
+					),
+				),
+				array(
+					'color' => true,
+					'width' => true,
+				),
+			),
+			'stable boolean before experimental array' => array(
+				array(
+					'border'               => false,
+					'__experimentalBorder' => array(
+						'color' => true,
+						'width' => true,
+					),
+				),
+				array(
+					'color' => true,
+					'width' => true,
+				),
+			),
+		);
+	}
 }


### PR DESCRIPTION
Related:
- https://github.com/WordPress/gutenberg/pull/67018

## What?

Fixes issue introduced by https://github.com/WordPress/gutenberg/pull/67018 resulting in mishandling of boolean config values for experimental block supports that are being stabilized e.g. `__experimentalBorder`.

This problem was [raised](https://github.com/WordPress/wordpress-develop/pull/7069#discussion_r1868702369) on the backport PR for block support stabilization.

## Why?

Without a fix, this bug will throw a fatal error when experimental block supports with boolean config values are stabilized.

## How?

- Early return has been added to the util function stabilizing experimental configs if we're working with a boolean value.
- When both experimental and stable keys are present, there's now a safeguard preventing the attempted merge of a boolean with an array that previously resulted in the fatal error

## Testing Instructions

1. Pick a block that adopts border support e.g. Group
2. Add a `register_block_type_args` filter that replaces the `supports.__experimentalBorder` config with a boolean true or false
3. Check that there are no errors and the block support functions or doesn't function as you configured
4. Update the filter to replace the previous tweak with the addition of a stable `border` key that uses a boolean value.
5. Confirm again there are no errors and its working as expected.
6. Unit tests have also been added to the border support tests. Make sure they are passing.

