### PR TITLE
Query block: style the change design drop down to match the zoomed out section toolbar

### DIFF
--- a/packages/block-library/src/query/edit/query-toolbar.js
+++ b/packages/block-library/src/query/edit/query-toolbar.js
@@ -14,6 +14,10 @@ import { __ } from '@wordpress/i18n';
  */
 import PatternSelection, { useBlockPatterns } from './pattern-selection';
 
+const POPOVER_PROPS = {
+	placement: 'bottom-start',
+};
+
 export default function QueryToolbar( {
 	clientId,
 	attributes,
@@ -29,31 +33,33 @@ export default function QueryToolbar( {
 		: __( 'Choose pattern' );
 
 	return (
-		<ToolbarGroup className="wp-block-template-part__block-control-group">
-			<DropdownContentWrapper>
-				<Dropdown
-					contentClassName="block-editor-block-settings-menu__popover"
-					focusOnMount="firstElement"
-					expandOnMobile
-					renderToggle={ ( { isOpen, onToggle } ) => (
-						<ToolbarButton
-							aria-haspopup="true"
-							aria-expanded={ isOpen }
-							onClick={ onToggle }
-						>
-							{ buttonLabel }
-						</ToolbarButton>
-					) }
-					renderContent={ () => (
-						<PatternSelection
-							clientId={ clientId }
-							attributes={ attributes }
-							showSearch={ false }
-							showTitlesAsTooltip
-						/>
-					) }
-				/>
-			</DropdownContentWrapper>
-		</ToolbarGroup>
+		<Dropdown
+			popoverProps={ POPOVER_PROPS }
+			expandOnMobile
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<ToolbarGroup>
+					<ToolbarButton
+						aria-haspopup="true"
+						aria-expanded={ isOpen }
+						onClick={ onToggle }
+					>
+						{ buttonLabel }
+					</ToolbarButton>
+				</ToolbarGroup>
+			) }
+			renderContent={ () => (
+				<DropdownContentWrapper
+					className="block-library-query__toolbar-popover-content-wrapper"
+					paddingSize="none"
+				>
+					<PatternSelection
+						clientId={ clientId }
+						attributes={ attributes }
+						showSearch={ false }
+						showTitlesAsTooltip
+					/>
+				</DropdownContentWrapper>
+			) }
+		/>
 	);
 }

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -36,7 +36,7 @@
 .block-library-query__toolbar-popover-content-wrapper {
 	padding: $grid-unit-15;
 	width: auto;
-	@include break-small() {
+	@include break-medium() {
 		width: 320px;
 	}
 	.block-editor-block-patterns-list {
@@ -54,12 +54,6 @@
 			min-height: 100px;
 		}
 	}
-}
-
-// Provide special styling for the placeholder.
-// @todo this particular minimal style of placeholder could be componentized further.
-.wp-block-query > .block-editor-media-placeholder.is-small {
-	min-height: 60px;
 }
 
 // Provide special styling for the placeholder.

--- a/packages/block-library/src/query/editor.scss
+++ b/packages/block-library/src/query/editor.scss
@@ -29,12 +29,15 @@
 	}
 }
 
-.block-editor-block-settings-menu__popover {
-	&.is-expanded {
-		overflow-y: scroll;
-	}
-	.block-library-query-pattern__selection-content {
-		height: 100%;
+.wp-block-query__enhanced-pagination-notice {
+	margin: 0;
+}
+
+.block-library-query__toolbar-popover-content-wrapper {
+	padding: $grid-unit-15;
+	width: auto;
+	@include break-small() {
+		width: 320px;
 	}
 	.block-editor-block-patterns-list {
 		display: grid;
@@ -43,14 +46,20 @@
 			grid-template-columns: 1fr 1fr;
 		}
 		grid-gap: $grid-unit-15;
-		min-width: $break-zoomed-in;
-		@include break-small() {
-			min-width: $break-mobile;
+		.block-editor-block-patterns-list__list-item {
+			margin-bottom: 0;
+		}
+
+		.block-editor-inserter__media-list__list-item {
+			min-height: 100px;
 		}
 	}
-	.block-editor-block-patterns-list__list-item {
-		margin-bottom: 0;
-	}
+}
+
+// Provide special styling for the placeholder.
+// @todo this particular minimal style of placeholder could be componentized further.
+.wp-block-query > .block-editor-media-placeholder.is-small {
+	min-height: 60px;
 }
 
 // Provide special styling for the placeholder.


### PR DESCRIPTION
## What?

Follow up to https://github.com/WordPress/gutenberg/pull/66993

See also: https://github.com/WordPress/gutenberg/issues/67451#issuecomment-2513370819

This commit tweaks the "Change Design" dropdown to resemble the "Change Design" dropdown for the zoomed out section toolbar.

## Why?

So they look the same.

## How?

Bringing over the styles from the [ChangeDesign](https://github.com/WordPress/gutenberg/blob/7552bf5b38b26329970a9de7de96122ac9b2c2e7/packages/block-editor/src/components/block-toolbar/change-design.js#L99-L99) component. 

## Testing Instructions

1. Fire up the site editor, and open a template with an existing query block, or create one yourself! TT5 theme is a worthy choice.
2. Then select the query block. Check out the block toolbar. Do you see the "Change design" button? Click on it to display the patterns. Everything should work as expected.
3. Replace a pattern, make sure that works. 
4. Now narrow the viewport width and ensure it's usable in mobile view.
5. To compare drop downs, enable "Zoomed out" mode and insert a pattern. Select the pattern and select "Change design". 


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

| Before | After | Zoomed out section toolbar (for comparison |
|--------|--------|--------|
| <img width="300" alt="Screenshot 2024-12-04 at 5 53 38 pm" src="https://github.com/user-attachments/assets/6b9cb86e-73d0-4103-b75f-c73fa615c439"> | <img width="300" alt="Screenshot 2024-12-04 at 6 19 01 pm" src="https://github.com/user-attachments/assets/1c29bdc2-b37e-401a-a53e-d44792f84f34"> | <img width="300" alt="Screenshot 2024-12-04 at 5 50 27 pm" src="https://github.com/user-attachments/assets/cc78b222-8b53-4487-a6bf-e7addbc0d09b"> | 





## Desktop


https://github.com/user-attachments/assets/f867f557-7bfa-441a-800b-9236f3492e4b



### Mobile

https://github.com/user-attachments/assets/f1a5a0d8-3ebb-40d6-8edd-65dc2010b428

