### PR TITLE
Add Additional CSS Classes setting to Link UI

### DIFF
--- a/packages/block-editor/src/components/link-control/settings.js
+++ b/packages/block-editor/src/components/link-control/settings.js
@@ -18,17 +18,26 @@ const LinkControlSettings = ( { value, onChange = noop, settings } ) => {
 		} );
 	};
 
-	const theSettings = settings.map( ( setting ) => (
-		<CheckboxControl
-			__nextHasNoMarginBottom
-			className="block-editor-link-control__setting"
-			key={ setting.id }
-			label={ setting.title }
-			onChange={ handleSettingChange( setting ) }
-			checked={ value ? !! value[ setting.id ] : false }
-			help={ setting?.help }
-		/>
-	) );
+	const theSettings = settings.map( ( setting ) =>
+		setting.render ? (
+			<div
+				key={ setting.id }
+				className="block-editor-link-control__setting"
+			>
+				{ setting.render( setting, value, onChange ) }
+			</div>
+		) : (
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				className="block-editor-link-control__setting"
+				key={ setting.id }
+				label={ setting.title }
+				onChange={ handleSettingChange( setting ) }
+				checked={ value ? !! value[ setting.id ] : false }
+				help={ setting?.help }
+			/>
+		)
+	);
 
 	return (
 		<fieldset className="block-editor-link-control__settings">

--- a/packages/block-editor/src/components/link-control/settings.js
+++ b/packages/block-editor/src/components/link-control/settings.js
@@ -18,26 +18,44 @@ const LinkControlSettings = ( { value, onChange = noop, settings } ) => {
 		} );
 	};
 
-	const theSettings = settings.map( ( setting ) =>
-		setting.render ? (
-			<div
-				key={ setting.id }
-				className="block-editor-link-control__setting"
-			>
-				{ setting.render( setting, value, onChange ) }
-			</div>
-		) : (
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				className="block-editor-link-control__setting"
-				key={ setting.id }
-				label={ setting.title }
-				onChange={ handleSettingChange( setting ) }
-				checked={ value ? !! value[ setting.id ] : false }
-				help={ setting?.help }
-			/>
-		)
-	);
+	const theSettings = settings
+		.map( ( setting ) => {
+			// If render property is provided
+			if ( 'render' in setting ) {
+				// If it's a valid function, use it
+				if ( typeof setting.render === 'function' ) {
+					const renderedContent = setting.render(
+						setting,
+						value,
+						onChange
+					);
+					return (
+						<div
+							key={ setting.id }
+							className="block-editor-link-control__setting"
+						>
+							{ renderedContent }
+						</div>
+					);
+				}
+				// If render is provided but invalid, return null
+				return null;
+			}
+
+			// If render property is not provided, use CheckboxControl
+			return (
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					className="block-editor-link-control__setting"
+					key={ setting.id }
+					label={ setting.title }
+					onChange={ handleSettingChange( setting ) }
+					checked={ value ? !! value[ setting.id ] : false }
+					help={ setting?.help }
+				/>
+			);
+		} )
+		.filter( Boolean ); // Remove null entries
 
 	return (
 		<fieldset className="block-editor-link-control__settings">

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -363,11 +363,15 @@ $block-editor-link-control-number-of-actions: 1;
 .block-editor-link-control__setting {
 	margin-bottom: 0;
 	flex: 1;
-	padding: $grid-unit-10 0 $grid-unit-10 $grid-unit-30;
+	padding: $grid-unit-10 $grid-unit-30;
+
+	.components-base-control:not(.components-input-control) {
+		.components-base-control__field {
+			display: flex; // don't allow label to wrap under checkbox.
+		}
+	}
 
 	.components-base-control__field {
-		display: flex; // don't allow label to wrap under checkbox.
-
 		.components-checkbox-control__label {
 			color: $gray-900;
 		}

--- a/packages/format-library/src/link/css-classes-setting.js
+++ b/packages/format-library/src/link/css-classes-setting.js
@@ -28,10 +28,15 @@ const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 	const instanceId = useInstanceId( CSSClassesSettingComponent );
 	const controlledRegionId = `css-classes-setting-${ instanceId }`;
 
+	// Sanitize user input: replace commas with spaces, collapse repeated spaces, and trim
 	const handleSettingChange = ( newValue ) => {
+		const sanitizedValue =
+			typeof newValue === 'string'
+				? newValue.replace( /,/g, ' ' ).replace( /\s+/g, ' ' ).trim()
+				: newValue;
 		onChange( {
 			...value,
-			[ setting.id ]: newValue,
+			[ setting.id ]: sanitizedValue,
 		} );
 	};
 

--- a/packages/format-library/src/link/css-classes-setting.js
+++ b/packages/format-library/src/link/css-classes-setting.js
@@ -8,6 +8,7 @@ import {
 	__experimentalInputControl as InputControl,
 	CheckboxControl,
 	VisuallyHidden,
+	__experimentalVStack as VStack,
 } from '@wordpress/components';
 
 /**
@@ -53,30 +54,34 @@ const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 	};
 
 	return (
-		<fieldset className="block-editor-link-control__css-classes-setting">
+		<fieldset>
 			<VisuallyHidden as="legend">{ setting.title }</VisuallyHidden>
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				label={ setting.title }
-				onChange={ handleCheckboxChange }
-				checked={ isSettingActive || hasValue }
-				aria-expanded={ isSettingActive }
-				aria-controls={
-					isSettingActive ? controlledRegionId : undefined
-				}
-			/>
-			{ isSettingActive && (
-				<div id={ controlledRegionId }>
-					<InputControl
-						label={ __( 'CSS classes' ) }
-						value={ value?.cssClasses }
-						onChange={ handleSettingChange }
-						help={ __( 'Separate multiple classes with spaces.' ) }
-						__unstableInputWidth="100%"
-						__next40pxDefaultSize
-					/>
-				</div>
-			) }
+			<VStack spacing={ 3 }>
+				<CheckboxControl
+					__nextHasNoMarginBottom
+					label={ setting.title }
+					onChange={ handleCheckboxChange }
+					checked={ isSettingActive || hasValue }
+					aria-expanded={ isSettingActive }
+					aria-controls={
+						isSettingActive ? controlledRegionId : undefined
+					}
+				/>
+				{ isSettingActive && (
+					<div id={ controlledRegionId }>
+						<InputControl
+							label={ __( 'CSS classes' ) }
+							value={ value?.cssClasses }
+							onChange={ handleSettingChange }
+							help={ __(
+								'Separate multiple classes with spaces.'
+							) }
+							__unstableInputWidth="100%"
+							__next40pxDefaultSize
+						/>
+					</div>
+				) }
+			</VStack>
 		</fieldset>
 	);
 };

--- a/packages/format-library/src/link/css-classes-setting.js
+++ b/packages/format-library/src/link/css-classes-setting.js
@@ -1,0 +1,68 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	__experimentalInputControl as InputControl,
+	CheckboxControl,
+} from '@wordpress/components';
+
+/**
+ * CSSClassesSettingComponent
+ *
+ * Presents a toggleable text input for editing link CSS classes. The input
+ * is shown when the toggle is enabled or when there is already a value. When
+ * toggled off and a value exists, it resets the value to an empty string.
+ *
+ * @param {Object}   props          - Component props.
+ * @param {Object}   props.setting  - Setting configuration object.
+ * @param {Object}   props.value    - Current link value object.
+ * @param {Function} props.onChange - Callback when value changes.
+ */
+const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
+	const hasValue = value ? value?.cssClasses?.length > 0 : false;
+	const [ isSettingActive, setIsSettingActive ] = useState( hasValue );
+
+	const handleSettingChange = ( newValue ) => {
+		onChange( {
+			...value,
+			[ setting.id ]: newValue,
+		} );
+	};
+
+	const handleCheckboxChange = () => {
+		if ( isSettingActive ) {
+			if ( hasValue ) {
+				// Reset the value when hiding the input and a value exists.
+				handleSettingChange( '' );
+			}
+			setIsSettingActive( false );
+		} else {
+			setIsSettingActive( true );
+		}
+	};
+
+	return (
+		<div className="block-editor-link-control__css-classes-setting">
+			<CheckboxControl
+				__nextHasNoMarginBottom
+				label={ setting.title }
+				onChange={ handleCheckboxChange }
+				checked={ isSettingActive || hasValue }
+			/>
+			{ isSettingActive && (
+				<InputControl
+					label={ setting.title }
+					value={ value?.cssClasses }
+					onChange={ handleSettingChange }
+					help={ __( 'Separate multiple classes with spaces.' ) }
+					__unstableInputWidth="100%"
+					__next40pxDefaultSize
+				/>
+			) }
+		</div>
+	);
+};
+
+export default CSSClassesSettingComponent;

--- a/packages/format-library/src/link/css-classes-setting.js
+++ b/packages/format-library/src/link/css-classes-setting.js
@@ -2,10 +2,12 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import {
 	__experimentalInputControl as InputControl,
 	CheckboxControl,
+	VisuallyHidden,
 } from '@wordpress/components';
 
 /**
@@ -23,6 +25,8 @@ import {
 const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 	const hasValue = value ? value?.cssClasses?.length > 0 : false;
 	const [ isSettingActive, setIsSettingActive ] = useState( hasValue );
+	const instanceId = useInstanceId( CSSClassesSettingComponent );
+	const controlledRegionId = `css-classes-setting-${ instanceId }`;
 
 	const handleSettingChange = ( newValue ) => {
 		onChange( {
@@ -44,24 +48,31 @@ const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 	};
 
 	return (
-		<div className="block-editor-link-control__css-classes-setting">
+		<fieldset className="block-editor-link-control__css-classes-setting">
+			<VisuallyHidden as="legend">{ setting.title }</VisuallyHidden>
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ setting.title }
 				onChange={ handleCheckboxChange }
 				checked={ isSettingActive || hasValue }
+				aria-expanded={ isSettingActive }
+				aria-controls={
+					isSettingActive ? controlledRegionId : undefined
+				}
 			/>
 			{ isSettingActive && (
-				<InputControl
-					label={ setting.title }
-					value={ value?.cssClasses }
-					onChange={ handleSettingChange }
-					help={ __( 'Separate multiple classes with spaces.' ) }
-					__unstableInputWidth="100%"
-					__next40pxDefaultSize
-				/>
+				<div id={ controlledRegionId }>
+					<InputControl
+						label={ __( 'CSS classes' ) }
+						value={ value?.cssClasses }
+						onChange={ handleSettingChange }
+						help={ __( 'Separate multiple classes with spaces.' ) }
+						__unstableInputWidth="100%"
+						__next40pxDefaultSize
+					/>
+				</div>
 			) }
-		</div>
+		</fieldset>
 	);
 };
 

--- a/packages/format-library/src/link/index.js
+++ b/packages/format-library/src/link/index.js
@@ -231,6 +231,7 @@ export const link = {
 		_id: 'id',
 		target: 'target',
 		rel: 'rel',
+		class: 'class',
 	},
 	[ essentialFormatKey ]: true,
 	__unstablePasteRule( value, { html, plainText } ) {

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -41,7 +41,7 @@ const LINK_SETTINGS = [
 	},
 	{
 		id: 'cssClasses',
-		title: __( 'Additional CSS Classes' ),
+		title: __( 'Additional CSS class(es)' ),
 		render: ( setting, value, onChange ) => (
 			<InputControl
 				label={ setting.title }
@@ -49,9 +49,9 @@ const LINK_SETTINGS = [
 				onChange={ ( cssClasses ) =>
 					onChange( { ...value, cssClasses } )
 				}
-				help={ setting?.help }
-				__next40pxDefaultSize
+				help={ __( 'Separate multiple classes with spaces.' ) }
 				__unstableInputWidth="100%"
+				__next40pxDefaultSize
 			/>
 		),
 	},

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -97,10 +97,10 @@ function InlineLinkUI( {
 			opensInNewTab: activeAttributes.target === '_blank',
 			nofollow: activeAttributes.rel?.includes( 'nofollow' ),
 			title: richTextText,
-			cssClasses: activeAttributes.className,
+			cssClasses: activeAttributes.class,
 		} ),
 		[
-			activeAttributes.className,
+			activeAttributes.class,
 			activeAttributes.id,
 			activeAttributes.rel,
 			activeAttributes.target,

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -4,7 +4,10 @@
 import { useMemo, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import { Popover } from '@wordpress/components';
+import {
+	Popover,
+	__experimentalInputControl as InputControl,
+} from '@wordpress/components';
 import { prependHTTP } from '@wordpress/url';
 import {
 	create,
@@ -35,6 +38,22 @@ const LINK_SETTINGS = [
 	{
 		id: 'nofollow',
 		title: __( 'Mark as nofollow' ),
+	},
+	{
+		id: 'cssClasses',
+		title: __( 'Additional CSS Classes' ),
+		render: ( setting, value, onChange ) => (
+			<InputControl
+				label={ setting.title }
+				value={ value?.cssClasses }
+				onChange={ ( cssClasses ) =>
+					onChange( { ...value, cssClasses } )
+				}
+				help={ setting?.help }
+				__next40pxDefaultSize
+				__unstableInputWidth="100%"
+			/>
+		),
 	},
 ];
 
@@ -78,8 +97,10 @@ function InlineLinkUI( {
 			opensInNewTab: activeAttributes.target === '_blank',
 			nofollow: activeAttributes.rel?.includes( 'nofollow' ),
 			title: richTextText,
+			cssClasses: activeAttributes.className,
 		} ),
 		[
+			activeAttributes.className,
 			activeAttributes.id,
 			activeAttributes.rel,
 			activeAttributes.target,
@@ -116,6 +137,7 @@ function InlineLinkUI( {
 					: undefined,
 			opensInNewWindow: nextValue.opensInNewTab,
 			nofollow: nextValue.nofollow,
+			cssClasses: nextValue.cssClasses,
 		} );
 
 		const newText = nextValue.title || newUrl;

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -1,18 +1,10 @@
 /**
  * WordPress dependencies
  */
-import {
-	useState,
-	useMemo,
-	createInterpolateElement,
-} from '@wordpress/element';
+import { useMemo, createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { speak } from '@wordpress/a11y';
-import {
-	Popover,
-	__experimentalInputControl as InputControl,
-	CheckboxControl,
-} from '@wordpress/components';
+import { Popover } from '@wordpress/components';
 import { prependHTTP } from '@wordpress/url';
 import {
 	create,
@@ -37,52 +29,9 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
+import CSSClassesSettingComponent from './css-classes-setting';
 
-const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
-	const hasValue = value ? value?.cssClasses?.length > 0 : false;
-	const [ inputVisible, setInputVisible ] = useState( hasValue );
-
-	const handleSettingChange = ( newValue ) => {
-		onChange( {
-			...value,
-			[ setting.id ]: newValue,
-		} );
-	};
-
-	const handleCheckboxChange = () => {
-		if ( inputVisible ) {
-			if ( hasValue ) {
-				// Reset the value.
-				handleSettingChange( '' );
-			}
-			setInputVisible( false );
-		} else {
-			setInputVisible( true );
-		}
-	};
-
-	return (
-		<div className="block-editor-link-control__css-classes-setting">
-			<CheckboxControl
-				__nextHasNoMarginBottom
-				label={ setting.title }
-				onChange={ handleCheckboxChange }
-				checked={ inputVisible || hasValue }
-				help={ setting?.help }
-			/>
-			{ inputVisible && (
-				<InputControl
-					label={ setting.title }
-					value={ value?.cssClasses }
-					onChange={ handleSettingChange }
-					help={ __( 'Separate multiple classes with spaces.' ) }
-					__unstableInputWidth="100%"
-					__next40pxDefaultSize
-				/>
-			) }
-		</div>
-	);
-};
+// CSSClassesSettingComponent moved to its own file and imported above.
 
 const LINK_SETTINGS = [
 	...LinkControl.DEFAULT_LINK_SETTINGS,

--- a/packages/format-library/src/link/inline.js
+++ b/packages/format-library/src/link/inline.js
@@ -38,7 +38,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { createLinkFormat, isValidHref, getFormatBoundary } from './utils';
 import { link as settings } from './index';
 
-const TogglableSettingComponent = ( { setting, value, onChange } ) => {
+const CSSClassesSettingComponent = ( { setting, value, onChange } ) => {
 	const hasValue = value ? value?.cssClasses?.length > 0 : false;
 	const [ inputVisible, setInputVisible ] = useState( hasValue );
 
@@ -62,7 +62,7 @@ const TogglableSettingComponent = ( { setting, value, onChange } ) => {
 	};
 
 	return (
-		<div className="block-editor-link-control__toggleable-setting">
+		<div className="block-editor-link-control__css-classes-setting">
 			<CheckboxControl
 				__nextHasNoMarginBottom
 				label={ setting.title }
@@ -95,7 +95,7 @@ const LINK_SETTINGS = [
 		title: __( 'Additional CSS class(es)' ),
 		render: ( setting, value, onChange ) => {
 			return (
-				<TogglableSettingComponent
+				<CSSClassesSettingComponent
 					setting={ setting }
 					value={ value }
 					onChange={ onChange }

--- a/packages/format-library/src/link/style.scss
+++ b/packages/format-library/src/link/style.scss
@@ -17,3 +17,9 @@
 		color: $alert-red;
 	}
 }
+
+.block-editor-link-control__toggleable-setting {
+	display: flex;
+	flex-direction: column;
+	gap: $grid-unit-20 0;
+}

--- a/packages/format-library/src/link/style.scss
+++ b/packages/format-library/src/link/style.scss
@@ -18,7 +18,7 @@
 	}
 }
 
-.block-editor-link-control__toggleable-setting {
+.block-editor-link-control__css-classes-setting {
 	display: flex;
 	flex-direction: column;
 	gap: $grid-unit-20 0;

--- a/packages/format-library/src/link/style.scss
+++ b/packages/format-library/src/link/style.scss
@@ -17,4 +17,3 @@
 		color: $alert-red;
 	}
 }
-

--- a/packages/format-library/src/link/style.scss
+++ b/packages/format-library/src/link/style.scss
@@ -18,8 +18,3 @@
 	}
 }
 
-.block-editor-link-control__css-classes-setting {
-	display: flex;
-	flex-direction: column;
-	gap: $grid-unit-20 0;
-}

--- a/packages/format-library/src/link/test/css-classes-setting.js
+++ b/packages/format-library/src/link/test/css-classes-setting.js
@@ -32,10 +32,16 @@ describe( 'CSSClassesSettingComponent', () => {
 		} );
 		expect( checkbox ).toBeVisible();
 
+		// aria-expanded should reflect collapsed state
+		expect( checkbox ).toHaveAttribute( 'aria-expanded', 'false' );
+
+		// aria-controls should not be present when region is not rendered
+		expect( checkbox ).not.toHaveAttribute( 'aria-controls' );
+
 		// Input should not be in the document initially
 		expect(
 			screen.queryByRole( 'textbox', {
-				name: 'Additional CSS class(es)',
+				name: 'CSS classes',
 			} )
 		).not.toBeInTheDocument();
 	} );
@@ -59,11 +65,19 @@ describe( 'CSSClassesSettingComponent', () => {
 		const checkbox = screen.getByRole( 'checkbox', {
 			name: 'Additional CSS class(es)',
 		} );
+		// starts collapsed
+		expect( checkbox ).toHaveAttribute( 'aria-expanded', 'false' );
 		await user.click( checkbox );
+		// now expanded
+		expect( checkbox ).toHaveAttribute( 'aria-expanded', 'true' );
+
+		// aria-controls should be present when expanded
+		const regionId = checkbox.getAttribute( 'aria-controls' );
+		expect( regionId ).toBeTruthy();
 
 		// Input should appear
 		const input = screen.getByRole( 'textbox', {
-			name: 'Additional CSS class(es)',
+			name: 'CSS classes',
 		} );
 		expect( input ).toBeVisible();
 
@@ -95,14 +109,21 @@ describe( 'CSSClassesSettingComponent', () => {
 			name: 'Additional CSS class(es)',
 		} );
 
+		// Initially expanded and has aria-controls
+		expect( checkbox ).toHaveAttribute( 'aria-expanded', 'true' );
+		const initialRegionId = checkbox.getAttribute( 'aria-controls' );
+		expect( initialRegionId ).toBeTruthy();
+
 		// Initially visible because there is a value
 		const input = screen.getByRole( 'textbox', {
-			name: 'Additional CSS class(es)',
+			name: 'CSS classes',
 		} );
 		expect( input ).toBeVisible();
 
 		// Toggle off
 		await user.click( checkbox );
+		// aria-expanded should now be false
+		expect( checkbox ).toHaveAttribute( 'aria-expanded', 'false' );
 
 		// Should have called onChange with cleared value
 		expect( onChange ).toHaveBeenCalledWith(
@@ -111,8 +132,11 @@ describe( 'CSSClassesSettingComponent', () => {
 		// Input should be hidden afterwards
 		expect(
 			screen.queryByRole( 'textbox', {
-				name: 'Additional CSS class(es)',
+				name: 'CSS classes',
 			} )
 		).not.toBeInTheDocument();
+
+		// aria-controls should be removed when collapsed
+		expect( checkbox ).not.toHaveAttribute( 'aria-controls' );
 	} );
 } );

--- a/packages/format-library/src/link/test/css-classes-setting.js
+++ b/packages/format-library/src/link/test/css-classes-setting.js
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+/**
+ * WordPress dependencies
+ */
+
+/**
+ * Internal dependencies
+ */
+import CSSClassesSettingComponent from '../css-classes-setting';
+
+describe( 'CSSClassesSettingComponent', () => {
+	it( 'renders checkbox and hides input by default when no value', async () => {
+		render(
+			<CSSClassesSettingComponent
+				setting={ {
+					id: 'cssClasses',
+					title: 'Additional CSS class(es)',
+				} }
+				value={ { cssClasses: '' } }
+				onChange={ () => {} }
+			/>
+		);
+
+		// Checkbox should be visible
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: 'Additional CSS class(es)',
+		} );
+		expect( checkbox ).toBeVisible();
+
+		// Input should not be in the document initially
+		expect(
+			screen.queryByRole( 'textbox', {
+				name: 'Additional CSS class(es)',
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'shows input when toggled on and calls onChange when typing', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<CSSClassesSettingComponent
+				setting={ {
+					id: 'cssClasses',
+					title: 'Additional CSS class(es)',
+				} }
+				value={ { cssClasses: '' } }
+				onChange={ onChange }
+			/>
+		);
+
+		// Toggle on
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: 'Additional CSS class(es)',
+		} );
+		await user.click( checkbox );
+
+		// Input should appear
+		const input = screen.getByRole( 'textbox', {
+			name: 'Additional CSS class(es)',
+		} );
+		expect( input ).toBeVisible();
+
+		// Type classes
+		await user.type( input, 'btn btn-primary' );
+
+		// onChange should have been called with the updated value object
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( { cssClasses: 'btn btn-primary' } )
+		);
+	} );
+
+	it( 'hides input and clears value when toggled off with existing value', async () => {
+		const user = userEvent.setup();
+		const onChange = jest.fn();
+
+		render(
+			<CSSClassesSettingComponent
+				setting={ {
+					id: 'cssClasses',
+					title: 'Additional CSS class(es)',
+				} }
+				value={ { cssClasses: 'foo bar' } }
+				onChange={ onChange }
+			/>
+		);
+
+		const checkbox = screen.getByRole( 'checkbox', {
+			name: 'Additional CSS class(es)',
+		} );
+
+		// Initially visible because there is a value
+		const input = screen.getByRole( 'textbox', {
+			name: 'Additional CSS class(es)',
+		} );
+		expect( input ).toBeVisible();
+
+		// Toggle off
+		await user.click( checkbox );
+
+		// Should have called onChange with cleared value
+		expect( onChange ).toHaveBeenCalledWith(
+			expect.objectContaining( { cssClasses: '' } )
+		);
+		// Input should be hidden afterwards
+		expect(
+			screen.queryByRole( 'textbox', {
+				name: 'Additional CSS class(es)',
+			} )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/format-library/src/link/test/css-classes-setting.js
+++ b/packages/format-library/src/link/test/css-classes-setting.js
@@ -81,12 +81,14 @@ describe( 'CSSClassesSettingComponent', () => {
 		} );
 		expect( input ).toBeVisible();
 
-		// Type classes
-		await user.type( input, 'btn btn-primary' );
+		// Type classes (including commas) - commas should be converted to spaces
+		await user.type( input, 'btn,btn-primary  ,  btn-secondary' );
 
 		// onChange should have been called with the updated value object
 		expect( onChange ).toHaveBeenCalledWith(
-			expect.objectContaining( { cssClasses: 'btn btn-primary' } )
+			expect.objectContaining( {
+				cssClasses: 'btn btn-primary btn-secondary',
+			} )
 		);
 	} );
 

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -86,6 +86,7 @@ export function isValidHref( href ) {
  * @param {string}  options.id               The ID of the link.
  * @param {boolean} options.opensInNewWindow Whether this link will open in a new window.
  * @param {boolean} options.nofollow         Whether this link is marked as no follow relationship.
+ * @param {string}  options.cssClasses       The CSS classes to apply to the link.
  * @return {Object} The final format object.
  */
 export function createLinkFormat( {
@@ -94,6 +95,7 @@ export function createLinkFormat( {
 	id,
 	opensInNewWindow,
 	nofollow,
+	cssClasses,
 } ) {
 	const format = {
 		type: 'core/link',
@@ -120,6 +122,12 @@ export function createLinkFormat( {
 		format.attributes.rel = format.attributes.rel
 			? format.attributes.rel + ' nofollow'
 			: 'nofollow';
+	}
+
+	const trimmedCssClasses = cssClasses?.trim();
+
+	if ( trimmedCssClasses?.length ) {
+		format.attributes.className = trimmedCssClasses;
 	}
 
 	return format;

--- a/packages/format-library/src/link/utils.js
+++ b/packages/format-library/src/link/utils.js
@@ -127,7 +127,7 @@ export function createLinkFormat( {
 	const trimmedCssClasses = cssClasses?.trim();
 
 	if ( trimmedCssClasses?.length ) {
-		format.attributes.className = trimmedCssClasses;
+		format.attributes.class = trimmedCssClasses;
 	}
 
 	return format;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds and `Additional CSS Classes` to the Link UI for inline links.

Closes https://github.com/WordPress/gutenberg/issues/13368

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Much requested feature. Brings parity with Classic Editor.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Add requisite logic to allow for rendering custom settings.
Apply to inline links.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- New Post
- Type text
- Create a link
- Click link to activate
- Open the "Settings" drawer
- See `Additional CSS Classes` field
- Type some classes
- Click `Save`
- Re-activate link
- See classes are shown in the `Additional CSS Classes` field
- Switch Editor to code view
- See that a `class` attribute is correct added to the link.
- Publish post and go to the post on the front of the site
- Check the link works
- Inspect the link using dev tools
- Check it has a `class` attribute corresponding to that which you added

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

<img width="1134" alt="Screen Shot 2024-12-17 at 13 45 48" src="https://github.com/user-attachments/assets/e052d48c-1aaf-4812-bfc0-b5c7979243f1" />



|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
