### PR TITLE
Site Editor: Fix featured image not appearing in pages dataviews

### DIFF
--- a/packages/editor/src/dataviews/store/private-actions.ts
+++ b/packages/editor/src/dataviews/store/private-actions.ts
@@ -162,7 +162,7 @@ export const registerPostTypeSchema =
 
 		const fields = [
 			postTypeConfig.supports?.thumbnail &&
-				currentTheme?.[ 'theme-supports' ]?.[ 'post-thumbnails' ] &&
+				currentTheme?.theme_supports?.[ 'post-thumbnails' ] &&
 				featuredImageField,
 			titleField,
 			postTypeConfig.supports?.author && authorField,


### PR DESCRIPTION
Fix small regression introduced in #67380

## What?

The featured image field was not appearing anymore in the site editor in the pages dataviews (list, quick edit...)
It was just a small typo.

## Testing Instructions

1- Open the site editor and verify that featured image thumbnails appear in the pages list.