### PR TITLE
Weight Link UI search results slightly towards Posts

### DIFF
--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -249,6 +249,23 @@ export default async function fetchLinkSuggestions(
 	return results;
 }
 
+/**
+ * Sort search results by relevance to the given query.
+ *
+ * Sorting is necessary as we're querying multiple endpoints and merging the results. For example
+ * a taxonomy title might be more relevant than a post title, but by default taxonomy results will
+ * be ordered after all the (potentially irrelevant) post results.
+ *
+ * We sort by scoring each result, where the score is a combination of the number of exact matches
+ * and sub-matches for tokens in the title that are also in the search query, divided by the total
+ * number of tokens in the title. This gives us a score between 0 and 1, where 1 is a perfect match.
+ *
+ * We then apply various "weights" to the score to influence the sorting order with exact matches
+ * being more important than sub-matches. We also give a slight bonus to post-type results.
+ *
+ * @param results
+ * @param search
+ */
 export function sortResults( results: SearchResult[], search: string ) {
 	const searchTokens = tokenize( search );
 

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -299,7 +299,7 @@ export function sortResults( results: SearchResult[], search: string ) {
 
 		// Add a slight bonus for 'post-type' results
 		if ( result.kind === 'post-type' ) {
-			score += 5;
+			score *= 1.1;
 		}
 
 		scores[ result.id ] = score;

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -430,6 +430,43 @@ describe( 'sortResults', () => {
 		);
 		expect( order ).toEqual( [ 1, 4, 3, 2 ] );
 	} );
+
+	it( 'weight results towards Posts even if less relevant', () => {
+		const results = [
+			{
+				id: 1,
+				title: 'Newspapers',
+				url: 'http://wordpress.local/more-relevant-news/',
+				type: 'page',
+				kind: 'taxonomy',
+			},
+			{
+				id: 2,
+				title: 'News',
+				url: 'http://wordpress.local/most-relevant-news/',
+				type: 'page',
+				kind: 'media',
+			},
+			{
+				id: 3,
+				title: 'Less Relevant News because it has a very long title',
+				url: 'http://wordpress.local/less-relevant-news/',
+				type: 'page',
+				kind: 'post-type',
+			},
+			{
+				id: 4,
+				title: 'News',
+				url: 'http://wordpress.local/same-relevant-news/',
+				type: 'page',
+				kind: 'post-type',
+			},
+		];
+		const order = sortResults( results, 'News' ).map(
+			( result ) => result.id
+		);
+		expect( order ).toEqual( [ 4, 2, 3, 1 ] );
+	} );
 } );
 
 describe( 'tokenize', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Weights the Link UI search results slightly towards Posts

Closes https://github.com/WordPress/gutenberg/issues/67561 and https://github.com/WordPress/gutenberg/issues/63683

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

In general Link UI search Posts are likely the most relevant results. Therefore slightly weighting towards them is important when sorting the results.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Apply a slight weighting factor in favour of sorting for `kind: post-type` in search results.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

- Create lots of Posts, Pages, Taxonomy Terms, Attachments
- Make sure you have some of them that are named identically.
- Create a link and perform a search for a term that you know has results that have matches across all of the above types.
- See that the Post results (Posts, Pages...etc) are returned in preference to other types (e.g. Attachments)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
