### PR TITLE
Remove .components-item-group selector in edit-site components[2]

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/index.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/index.js
@@ -26,7 +26,7 @@ export default function DataViewsSidebarContent( { postType } ) {
 
 	return (
 		<>
-			<ItemGroup>
+			<ItemGroup className="edit-site-sidebar-dataviews">
 				{ defaultViews.map( ( dataview ) => {
 					return (
 						<DataViewItem

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -7,6 +7,11 @@
 	}
 }
 
+.edit-site-sidebar-dataviews {
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+}
+
 .edit-site-sidebar-dataviews-dataview-item {
 	border-radius: $radius-small;
 	padding-right: $grid-unit-10;

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,8 +1,3 @@
-.edit-site-sidebar-navigation-screen-templates-browse {
-	margin-left: -$grid-unit-20;
-	margin-right: -$grid-unit-20;
-}
-
 .edit-site-sidebar-navigation-item.components-item {
 	color: $gray-600;
 	// 6px right padding to align with + button

--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -1,3 +1,8 @@
+.edit-site-sidebar-navigation-screen-templates-browse {
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+}
+
 .edit-site-sidebar-navigation-item.components-item {
 	color: $gray-600;
 	// 6px right padding to align with + button

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -18,7 +18,7 @@ import { store as editSiteStore } from '../../store';
 
 export function MainSidebarNavigationContent() {
 	return (
-		<ItemGroup>
+		<ItemGroup className="edit-site-sidebar-navigation-screen-main">
 			<SidebarNavigationItem
 				uid="navigation-navigation-item"
 				to="/navigation"

--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/style.scss
@@ -1,0 +1,4 @@
+.edit-site-sidebar-navigation-screen-main {
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/index.js
@@ -116,7 +116,7 @@ export default function SidebarNavigationScreenNavigationMenus( { backPath } ) {
 
 	return (
 		<SidebarNavigationScreenWrapper backPath={ backPath }>
-			<ItemGroup>
+			<ItemGroup className="edit-site-sidebar-navigation-screen-navigation-menus">
 				{ navigationMenus?.map( ( { id, title, status }, index ) => (
 					<NavMenuItem
 						postId={ id }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-navigation-menus/style.scss
@@ -2,6 +2,11 @@
 	margin: 0 0 $grid-unit-40 0;
 }
 
+.edit-site-sidebar-navigation-screen-navigation-menus {
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+}
+
 .edit-site-sidebar-navigation-screen-navigation-menus__content {
 	.block-editor-list-view-leaf .block-editor-list-view-block__contents-cell {
 		width: 100%;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-patterns/style.scss
@@ -1,5 +1,7 @@
 .edit-site-sidebar-navigation-screen-patterns__group {
 	margin-bottom: $grid-unit-30;
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
 
 	&:last-of-type {
 		border-bottom: 0;

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/content.js
@@ -57,7 +57,7 @@ export default function DataviewsTemplatesSidebarContent() {
 	}, [ records ] );
 
 	return (
-		<ItemGroup>
+		<ItemGroup className="edit-site-sidebar-navigation-screen-templates-browse">
 			<SidebarNavigationItem
 				to="/template"
 				icon={ layout }

--- a/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-templates-browse/style.scss
@@ -1,0 +1,4 @@
+.edit-site-sidebar-navigation-screen-templates-browse {
+	margin-left: -$grid-unit-20;
+	margin-right: -$grid-unit-20;
+}

--- a/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-screen/style.scss
@@ -18,11 +18,6 @@
 .edit-site-sidebar-navigation-screen__content {
 	padding: 0 $grid-unit-20;
 
-	.components-item-group {
-		margin-left: -$grid-unit-20;
-		margin-right: -$grid-unit-20;
-	}
-
 	.components-text {
 		color: $gray-400;
 	}

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -21,9 +21,11 @@
 @import "./components/sidebar-navigation-screen-details-footer/style.scss";
 @import "./components/sidebar-navigation-screen-navigation-menu/style.scss";
 @import "./components/sidebar-navigation-screen-patterns/style.scss";
+@import "./components/sidebar-navigation-screen-navigation-menus/style.scss";
+@import "./components/sidebar-navigation-screen-main/style.scss";
+@import "./components/sidebar-navigation-screen-templates-browse/style.scss";
 @import "./components/sidebar-dataviews/style.scss";
 @import "./components/site-hub/style.scss";
-@import "./components/sidebar-navigation-screen-navigation-menus/style.scss";
 @import "./components/site-icon/style.scss";
 @import "./components/style-book/style.scss";
 @import "./components/editor-canvas-container/style.scss";
@@ -35,7 +37,6 @@
 @import "./components/pagination/style.scss";
 @import "./components/global-styles/variations/style.scss";
 @import "./components/sidebar-global-styles-wrapper/style.scss";
-@import "./components/sidebar-navigation-screen-main/style.scss";
 
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 ::view-transition-image-pair(root) {

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -34,7 +34,7 @@
 @import "./components/global-styles/font-library-modal/style.scss";
 @import "./components/pagination/style.scss";
 @import "./components/global-styles/variations/style.scss";
-@import "./components/sidebar-global-styles-wrapper/style.scss";
+@import "./components/sidebar-navigation-screen-main/style.scss";
 
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */
 ::view-transition-image-pair(root) {

--- a/packages/edit-site/src/style.scss
+++ b/packages/edit-site/src/style.scss
@@ -34,6 +34,7 @@
 @import "./components/global-styles/font-library-modal/style.scss";
 @import "./components/pagination/style.scss";
 @import "./components/global-styles/variations/style.scss";
+@import "./components/sidebar-global-styles-wrapper/style.scss";
 @import "./components/sidebar-navigation-screen-main/style.scss";
 
 /* stylelint-disable -- Disable reason: View Transitions not supported properly by stylelint. */


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/67369

### What
The .components-item-group selector has been replaced with a custom class (.edit-site-sidebar-navigation-screen__item-group) that is scoped specifically to the sidebar navigation screen.

This change does not affect other components outside of the sidebar navigation screen and will prevent unintended side effects if the ItemGroup component is used elsewhere in the future.

As requested in the earlier PR now closed (#67384), to apply horizontal negative margins in 4 more places ([Reference](https://github.com/WordPress/gutenberg/pull/67384#issuecomment-2507685683))

1. Navigation
2. Pages
3. Templates
4. Patterns 

### Screenshots

<img width="1469" alt="Screenshot 2024-12-04 at 6 33 57 PM" src="https://github.com/user-attachments/assets/179229f5-44ab-46dd-9bb8-1134e1850052">


#### Screenshots of the negatively applied margins.

**Navigation Screen**
![Picture 1](https://github.com/user-attachments/assets/9197107a-6827-4ed2-b647-ab985773e087)  

**Pages Screen**
![Picture 2](https://github.com/user-attachments/assets/6c1ef56c-8f2c-4155-afee-0671b866d268)  

**Templates Screen**
![Picture 3](https://github.com/user-attachments/assets/28e023d7-86c8-497d-b80b-fd7d06da827e)  

**Patterns Screen**
![Picture 4](https://github.com/user-attachments/assets/fb2c9d55-9749-447a-9ada-a82bb9ee06f2)  