### PR TITLE
QuickEdit: prevent site-editor from crashing when slug is not an object

### DIFF
--- a/packages/fields/src/fields/slug/slug-view.tsx
+++ b/packages/fields/src/fields/slug/slug-view.tsx
@@ -10,7 +10,7 @@ import type { BasePost } from '../../types';
 import { getSlug } from './utils';
 
 const SlugView = ( { item }: { item: BasePost } ) => {
-	const slug = typeof item === 'object' ? getSlug( item ) : '';
+	const slug = getSlug( item );
 	const originalSlugRef = useRef( slug );
 
 	useEffect( () => {

--- a/packages/fields/src/fields/slug/utils.ts
+++ b/packages/fields/src/fields/slug/utils.ts
@@ -9,6 +9,10 @@ import type { BasePost } from '../../types';
 import { getItemTitle } from '../../actions/utils';
 
 export const getSlug = ( item: BasePost ): string => {
+	if ( typeof item !== 'object' ) {
+		return '';
+	}
+
 	return (
 		item.slug || cleanForSlug( getItemTitle( item ) ) || item.id.toString()
 	);


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/issues/66599 https://github.com/WordPress/gutenberg/pull/66559

## What?

This fixes a hidden bug: in some situations, the data received by slug is not an object.

## How?

We've covered against that in the view, but didn't in the edit control. I've moved the check in the view to within the `getSlug` util, so it covers all the cases.

## Testing Instructions

- Modify [this line](https://github.com/WordPress/gutenberg/blame/be60bebeff7f6f699fd33d1c35840d9b549cbaa7/packages/edit-site/src/components/post-edit/index.js#L73) to `type: 'regular'`. 
- Go to Site Editor > Pages, switch to table and open the QuickEdit experiment.
- Verify that it loads:

<img width="395" alt="Screenshot 2024-12-04 at 14 26 02" src="https://github.com/user-attachments/assets/11f1ca6f-cf38-4ba6-9a62-59683531f7d6">
