### PR TITLE
Storybook: Use manager-api instead of addons package

### DIFF
--- a/storybook/manager.js
+++ b/storybook/manager.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { addons } from '@storybook/addons';
+import { addons } from '@storybook/manager-api';
 
 /**
  * Internal dependencies


### PR DESCRIPTION
## What?
Import addons from `@storybook/manager-api`

Part of #67574

## Why?
This has been the case since v7, and we need to change it as it breaks in v8, see https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#addonssetconfig-should-now-be-imported-from-storybookmanager-api

## How?
Just changing the import

## Testing Instructions
Verify Storybook builds well and the theme and sidebar addons work well.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None