### PR TITLE
Storybook: Update `ArgsTable` to `Controls` in preview

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	ArgsTable,
+	Controls,
 	Description,
 	Primary,
 	Stories,
@@ -114,8 +114,7 @@ export const parameters = {
 				<Subtitle />
 				<Primary />
 				<Description />
-				{ /* `story="^"` enables Controls for the primary props table */ }
-				<ArgsTable story="^" />
+				<Controls />
 				<Stories includePrimary={ false } />
 			</>
 		),


### PR DESCRIPTION
## What?
This PR updates `ArgsTable` to `Controls` in storybook's preview.

Part of #67574

## Why?
Preparatory work for upgrading Storybook v8 - `ArgsTable` is [removed in v8](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#argstable-doc-block-removed), and it [was deprecated in v7](https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#argstable-block), so time to replace it with `Controls`.

## How?
Just using the recommended features.

## Testing Instructions
Verify Storybook builds well and check a few stories to ensure controls appear the same way as before.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
None