### PR TITLE
Navigation: Enable all non-interactive formats

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -527,12 +527,6 @@ export default function NavigationLinkEdit( {
 											) }
 											placeholder={ itemLabelPlaceholder }
 											withoutInteractiveFormatting
-											allowedFormats={ [
-												'core/bold',
-												'core/italic',
-												'core/image',
-												'core/strikethrough',
-											] }
 										/>
 										{ description && (
 											<span className="wp-block-navigation-item__description">

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -461,12 +461,6 @@ export default function NavigationSubmenuEdit( {
 						aria-label={ __( 'Navigation link text' ) }
 						placeholder={ itemLabelPlaceholder }
 						withoutInteractiveFormatting
-						allowedFormats={ [
-							'core/bold',
-							'core/italic',
-							'core/image',
-							'core/strikethrough',
-						] }
 						onClick={ () => {
 							if ( ! openSubmenusOnClick && ! url ) {
 								setIsLinkOpen( true );


### PR DESCRIPTION
## What?
Closes #67559.

PR removes hardcoded allowlist for RichText formats in the Navigation link and submenu blocks. Now, all non-interactive formats are allowed within these blocks.

This matches behavior of Button block

## Why?
Allows consumers to register custom formats that can be used with navigation blocks.

## Testing Instructions
1. Open a post or page.
2. Insert a navigation block.
3. Confirm that all non-interactive formats are visible for the navigation link and submenu.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-12-04 at 19 23 40](https://github.com/user-attachments/assets/9f12b564-6210-45e3-89f3-78cf6bcc0977)

