### PR TITLE
Update react native tests to use `macos-13` as `macos-12` has been deprecated

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
+        runs-on: macos-13
         if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:


### PR DESCRIPTION
See related [core-editor slack](https://wordpress.slack.com/archives/C02QB2JS7/p1733330356596259) thread.

## What?

As of yesterday, December 3th, `macos-12` has been deprecated https://github.com/actions/runner-images/issues/10721 so GitHub Actions won't run. We need to upgrade it.

## How?

I've updated it to `macos-13` but I'm not experience on reactnative test setup, so I'd welcome reviews from people who are.

## Testing Instructions

React Native tests in CI should pass.