### PR TITLE
Fix: Write Mode mode persists as enabled in widget editor.

### DIFF
--- a/packages/customize-widgets/src/components/sidebar-block-editor/index.js
+++ b/packages/customize-widgets/src/components/sidebar-block-editor/index.js
@@ -87,6 +87,7 @@ export default function SidebarBlockEditor( {
 			mediaUpload: mediaUploadBlockEditor,
 			hasFixedToolbar: isFixedToolbarActive || ! isMediumViewport,
 			keepCaretInsideBlock,
+			editorTool: 'edit',
 			__unstableHasCustomAppender: true,
 		};
 	}, [

--- a/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
+++ b/packages/edit-widgets/src/components/widget-areas-block-editor-provider/index.js
@@ -94,6 +94,7 @@ export default function WidgetAreasBlockEditorProvider( {
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			pageOnFront,
 			pageForPosts,
+			editorTool: 'edit',
 		};
 	}, [
 		hasUploadPermissions,


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/67361

This PR makes sure the widget and customizer blocks are in normal mode and not in write mode. In write mode, it is impossible to select the widgets making the screen unusable.

cc: @talldan 

## Testing Instructions
Enable the "Editor write mode" experiment.
With a block theme enabled (e.g.: 2024) open the site editor.
Enable the write mode.
Switch to a classic theme e.g.: 2011.
Open the widget screen and verify you can select blocks/widgets.
