### PR TITLE
DataViews build-wp: don't bundle singleton WordPress packages

### DIFF
--- a/packages/dataviews/build.js
+++ b/packages/dataviews/build.js
@@ -7,8 +7,15 @@ const esbuild = require( 'esbuild' );
 const wpExternals = {
 	name: 'wordpress-externals',
 	setup( build ) {
+		build.onResolve(
+			{ filter: /^@wordpress\/(data|hooks|i18n)(\/|$)/ },
+			( args ) => {
+				// Don't bundle WordPress signleton packages
+				return { path: args.path, external: true };
+			}
+		);
 		build.onResolve( { filter: /^@wordpress\// }, () => {
-			// Bundle wordpress packages
+			// Bundle WordPress packages
 			return { external: false };
 		} );
 		build.onResolve( { filter: /^\.[\.\/]/ }, () => {


### PR DESCRIPTION
This patch excludes singleton-ish WordPress packages from the `dataviews/wp` bundle. A script that bundles `data`, `hooks` or `i18n` can't really use them as intended because it has its own store/hooks/translations registry and can't use the data that other parts of WordPress put there.

The bundle will now contain plain ES imports like:
```js
import { isRTL } from "@wordpress/i18n";
```
which the build tool for the plugin that uses `@wordpress/dataviews/wp` is supposed to interpret and replace them with `wp.i18n` references.

I'm also inclined to bundle "trivial" WP packages like `deprecated`, `warning` or `is-shallow-equal`. There is not risk of missing backward compatibility. But that's not very important.

Context: https://github.com/WordPress/gutenberg/pull/66825#issuecomment-2517424511