### PR TITLE
Fix useZoomOut inserter behavior

### DIFF
--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -13,31 +13,24 @@ import { unlock } from '../lock-unlock';
 /**
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
  *
- * @param {boolean} zoomOut If we should enter into zoomOut mode or not
+ * @param {boolean} enabled If we should enter into zoomOut mode or not
  */
-export function useZoomOut( zoomOut = true ) {
+export function useZoomOut( enabled = true ) {
 	const { setZoomLevel, resetZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	useEffect( () => {
-		const isZoomOutOnMount = isZoomOut();
-
-		return () => {
-			if ( isZoomOutOnMount ) {
-				setZoomLevel( 'auto-scaled' );
-			} else {
-				resetZoomLevel();
-			}
-		};
-	}, [] );
-
-	useEffect( () => {
-		if ( zoomOut ) {
-			setZoomLevel( 'auto-scaled' );
-		} else {
-			resetZoomLevel();
+		if ( ! enabled ) {
+			return;
 		}
-	}, [ zoomOut, setZoomLevel, resetZoomLevel ] );
+
+		const isAlreadyInZoomOut = isZoomOut();
+		if ( ! isAlreadyInZoomOut ) {
+			setZoomLevel( 'auto-scaled' );
+		}
+
+		return () => ! isAlreadyInZoomOut && resetZoomLevel();
+	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useSelect, useDispatch } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -21,16 +21,43 @@ export function useZoomOut( enabled = true ) {
 	);
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
+	const isZoomedOut = isZoomOut();
+	// If starting from zoom out engaged, do not control zoom level for the user.
+	const controlZoomLevel = useRef( ! isZoomedOut );
+
 	useEffect( () => {
-		if ( ! enabled ) {
+		if ( ! enabled || ! controlZoomLevel.current ) {
 			return;
 		}
-
 		const isAlreadyInZoomOut = isZoomOut();
 		if ( ! isAlreadyInZoomOut ) {
 			setZoomLevel( 'auto-scaled' );
 		}
 
-		return () => ! isAlreadyInZoomOut && resetZoomLevel();
+		return () => {
+			return (
+				controlZoomLevel.current &&
+				! isAlreadyInZoomOut &&
+				resetZoomLevel()
+			);
+		};
 	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
+
+	/**
+	 * This hook tracks if the zoom state was changed manually by the user via clicking
+	 * the zoom out button.
+	 */
+	useEffect( () => {
+		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
+		// state (zoomOut), then it means the user manually changed the zoom state while
+		// this hook was mounted, and we should no longer control the zoom state.
+		if ( isZoomedOut !== enabled ) {
+			// Turn off all automatic zooming control.
+			controlZoomLevel.current = false;
+		}
+
+		// Intentionally excluding `enabled` from the dependency array. We want to catch instances where
+		// the zoom out state changes due to user interaction and not due to the hook.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ isZoomedOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -44,9 +44,8 @@ export function useZoomOut( enabled = true ) {
 
 	useEffect( () => {
 		isEnabledRef.current = enabled;
-		const isAlreadyZoomedOut = isZoomOut();
 
-		if ( enabled !== isAlreadyZoomedOut ) {
+		if ( enabled !== isZoomOut() ) {
 			controlZoomLevelRef.current = true;
 
 			if ( enabled ) {
@@ -57,10 +56,10 @@ export function useZoomOut( enabled = true ) {
 		}
 
 		return () => {
-			return (
-				// If we are controlling zoom level and are zoomed out, reset the zoom level.
-				controlZoomLevelRef.current && isZoomOut() && resetZoomLevel()
-			);
+			// If we are controlling zoom level and are zoomed out, reset the zoom level.
+			if ( controlZoomLevelRef.current && isZoomOut() ) {
+				resetZoomLevel();
+			}
 		};
 	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -46,12 +46,14 @@ export function useZoomOut( enabled = true ) {
 		isEnabledRef.current = enabled;
 		const isAlreadyZoomedOut = isZoomOut();
 
-		if ( enabled && ! isAlreadyZoomedOut ) {
-			setZoomLevel( 'auto-scaled' );
+		if ( enabled !== isAlreadyZoomedOut ) {
 			controlZoomLevelRef.current = true;
-		} else if ( ! enabled && isAlreadyZoomedOut ) {
-			resetZoomLevel();
-			controlZoomLevelRef.current = true;
+
+			if ( enabled ) {
+				setZoomLevel( 'auto-scaled' );
+			} else {
+				resetZoomLevel();
+			}
 		}
 
 		return () => {

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -28,6 +28,20 @@ export function useZoomOut( enabled = true ) {
 	const controlZoomLevelRef = useRef( false );
 	const isEnabledRef = useRef( enabled );
 
+	/**
+	 * This hook tracks if the zoom state was changed manually by the user via clicking
+	 * the zoom out button. We only want this to run when isZoomedOut changes, so we use
+	 * a ref to track the enabled state.
+	 */
+	useEffect( () => {
+		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
+		// state (zoomOut), then it means the user manually changed the zoom state while
+		// this hook was mounted, and we should no longer control the zoom state.
+		if ( isZoomedOut !== isEnabledRef.current ) {
+			controlZoomLevelRef.current = false;
+		}
+	}, [ isZoomedOut ] );
+
 	useEffect( () => {
 		isEnabledRef.current = enabled;
 		const isAlreadyZoomedOut = isZoomOut();
@@ -47,18 +61,4 @@ export function useZoomOut( enabled = true ) {
 			);
 		};
 	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
-
-	/**
-	 * This hook tracks if the zoom state was changed manually by the user via clicking
-	 * the zoom out button. We only want this to run when isZoomedOut changes, so we use
-	 * a ref to track the enabled state.
-	 */
-	useEffect( () => {
-		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
-		// state (zoomOut), then it means the user manually changed the zoom state while
-		// this hook was mounted, and we should no longer control the zoom state.
-		if ( isZoomedOut !== isEnabledRef.current ) {
-			controlZoomLevelRef.current = false;
-		}
-	}, [ isZoomedOut ] );
 }

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -22,9 +22,19 @@ export function useZoomOut( enabled = true ) {
 	const { setZoomLevel, resetZoomLevel } = unlock(
 		useDispatch( blockEditorStore )
 	);
-	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
-	const isZoomedOut = isZoomOut();
+	/**
+	 * We need access to both the value and the function. The value is to trigger a useEffect hook
+	 * and the function is to check zoom out within another hook without triggering a re-render.
+	 */
+	const { isZoomedOut, isZoomOut } = useSelect( ( select ) => {
+		const { isZoomOut: _isZoomOut } = unlock( select( blockEditorStore ) );
+		return {
+			isZoomedOut: _isZoomOut(),
+			isZoomOut: _isZoomOut,
+		};
+	}, [] );
+
 	const controlZoomLevelRef = useRef( false );
 	const isEnabledRef = useRef( enabled );
 

--- a/packages/block-editor/src/hooks/use-zoom-out.js
+++ b/packages/block-editor/src/hooks/use-zoom-out.js
@@ -12,6 +12,9 @@ import { unlock } from '../lock-unlock';
 
 /**
  * A hook used to set the editor mode to zoomed out mode, invoking the hook sets the mode.
+ * Concepts:
+ * - If we most recently changed the zoom level for them (in or out), we always resetZoomLevel() level when unmounting.
+ * - If the user most recently changed the zoom level (manually toggling), we do nothing when unmounting.
  *
  * @param {boolean} enabled If we should enter into zoomOut mode or not
  */
@@ -22,42 +25,40 @@ export function useZoomOut( enabled = true ) {
 	const { isZoomOut } = unlock( useSelect( blockEditorStore ) );
 
 	const isZoomedOut = isZoomOut();
-	// If starting from zoom out engaged, do not control zoom level for the user.
-	const controlZoomLevel = useRef( ! isZoomedOut );
+	const controlZoomLevelRef = useRef( false );
+	const isEnabledRef = useRef( enabled );
 
 	useEffect( () => {
-		if ( ! enabled || ! controlZoomLevel.current ) {
-			return;
-		}
-		const isAlreadyInZoomOut = isZoomOut();
-		if ( ! isAlreadyInZoomOut ) {
+		isEnabledRef.current = enabled;
+		const isAlreadyZoomedOut = isZoomOut();
+
+		if ( enabled && ! isAlreadyZoomedOut ) {
 			setZoomLevel( 'auto-scaled' );
+			controlZoomLevelRef.current = true;
+		} else if ( ! enabled && isAlreadyZoomedOut ) {
+			resetZoomLevel();
+			controlZoomLevelRef.current = true;
 		}
 
 		return () => {
 			return (
-				controlZoomLevel.current &&
-				! isAlreadyInZoomOut &&
-				resetZoomLevel()
+				// If we are controlling zoom level and are zoomed out, reset the zoom level.
+				controlZoomLevelRef.current && isZoomOut() && resetZoomLevel()
 			);
 		};
 	}, [ enabled, isZoomOut, resetZoomLevel, setZoomLevel ] );
 
 	/**
 	 * This hook tracks if the zoom state was changed manually by the user via clicking
-	 * the zoom out button.
+	 * the zoom out button. We only want this to run when isZoomedOut changes, so we use
+	 * a ref to track the enabled state.
 	 */
 	useEffect( () => {
 		// If the zoom state changed (isZoomOut) and it does not match the requested zoom
 		// state (zoomOut), then it means the user manually changed the zoom state while
 		// this hook was mounted, and we should no longer control the zoom state.
-		if ( isZoomedOut !== enabled ) {
-			// Turn off all automatic zooming control.
-			controlZoomLevel.current = false;
+		if ( isZoomedOut !== isEnabledRef.current ) {
+			controlZoomLevelRef.current = false;
 		}
-
-		// Intentionally excluding `enabled` from the dependency array. We want to catch instances where
-		// the zoom out state changes due to user interaction and not due to the hook.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isZoomedOut ] );
 }

--- a/test/e2e/specs/site-editor/preload.spec.js
+++ b/test/e2e/specs/site-editor/preload.spec.js
@@ -6,6 +6,7 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Preload', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.resetPreferences();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -6,7 +6,11 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 test.describe( 'Site Editor Inserter', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		// We need the theme to have a section root so zoom out is enabled
-		await requestUtils.activateTheme( 'twentytwentyfour' );
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyfour' ),
+			requestUtils.deleteAllTemplates( 'wp_template' ),
+			requestUtils.deleteAllTemplates( 'wp_template_part' ),
+		] );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -5,11 +5,8 @@ const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
 test.describe( 'Site Editor Inserter', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
-		await Promise.all( [
-			requestUtils.activateTheme( 'emptytheme' ),
-			requestUtils.deleteAllTemplates( 'wp_template' ),
-			requestUtils.deleteAllTemplates( 'wp_template_part' ),
-		] );
+		// We need the theme to have a section root so zoom out is enabled
+		await requestUtils.activateTheme( 'twentytwentyfour' );
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
@@ -21,39 +18,40 @@ test.describe( 'Site Editor Inserter', () => {
 		await editor.canvas.locator( 'body' ).click();
 	} );
 
+	test.use( {
+		InserterUtils: async ( { editor, page }, use ) => {
+			await use( new InserterUtils( { editor, page } ) );
+		},
+	} );
+
 	test( 'inserter toggle button should toggle global inserter', async ( {
-		page,
+		InserterUtils,
 	} ) => {
-		await page.click( 'role=button[name="Block Inserter"i]' );
+		const inserterButton = InserterUtils.getInserterButton();
+
+		await inserterButton.click();
+
+		const blockLibrary = InserterUtils.getBlockLibrary();
 
 		// Visibility check
-		await expect(
-			page.locator( 'role=searchbox[name="Search"i]' )
-		).toBeVisible();
-		await page.click( 'role=button[name="Block Inserter"i]' );
+		await expect( blockLibrary ).toBeVisible();
+		await inserterButton.click();
 		//Hidden State check
-		await expect(
-			page.locator( 'role=searchbox[name="Search"i]' )
-		).toBeHidden();
+		await expect( blockLibrary ).toBeHidden();
 	} );
 
 	// A test for https://github.com/WordPress/gutenberg/issues/43090.
 	test( 'should close the inserter when clicking on the toggle button', async ( {
-		page,
 		editor,
+		InserterUtils,
 	} ) => {
-		const inserterButton = page.getByRole( 'button', {
-			name: 'Block Inserter',
-			exact: true,
-		} );
-		const blockLibrary = page.getByRole( 'region', {
-			name: 'Block Library',
-		} );
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
 
 		const beforeBlocks = await editor.getBlocks();
 
 		await inserterButton.click();
-		await blockLibrary.getByRole( 'tab', { name: 'Blocks' } ).click();
+		await InserterUtils.getBlockLibraryTab( 'Blocks' ).click();
 		await blockLibrary.getByRole( 'option', { name: 'Buttons' } ).click();
 
 		await expect
@@ -64,4 +62,344 @@ test.describe( 'Site Editor Inserter', () => {
 
 		await expect( blockLibrary ).toBeHidden();
 	} );
+
+	test( 'should open the inserter to patterns tab if using zoom out and stay in zoom out when closing the inserter', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should still be in Zoom Out
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
+
+	test( 'should enter zoom out from patterns tab and exit zoom out when closing the inserter', async ( {
+		InserterUtils,
+	} ) => {
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await patternsTab.click();
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeHidden();
+
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
+
+	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter', async ( {
+		InserterUtils,
+	} ) => {
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		// Open inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+
+		// Blocks tab should be active, not in zoomed out state
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Click to patterns, should enter zoom out
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await patternsTab.click();
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Click to blocks tab, zooms back in
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Close inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// Canvas stays zoomed in
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
+
+	// Same test as above, but starting from zoom out
+	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter (even if starting from zoom out)', async ( {
+		InserterUtils,
+	} ) => {
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		// Open inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+
+		// Patterns tab should be active
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Click to blocks tab, zooms back in
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Close inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// Canvas stays zoomed in
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
+
+	// Same test as above but exiting from zoom out
+	test( 'If we change the zoom level for them via an inserter tab change, always exit zoom out when closing the inserter', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		const mediaTab = InserterUtils.getBlockLibraryTab( 'Media' );
+
+		// Should start with pattern tab selected in zoom out state
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Go to blocks tab which should exit zoom out
+		// We changed the zoom state for them here, so we "take over" control of the zoom state
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Go to media tab which should enter zoom out again since that's the starting state
+		await mediaTab.click();
+		await expect( mediaTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close the inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should stay in zoomed out state since we had control over the zoom state and we always exit zoom out when closing the inserter
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
+
+	test( 'should always exit zoom out if we have most recently changed zoom level for them', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		// Enter zoom out
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		// Open inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+
+		// Patterns tab should be active
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Click to blocks tab, zooms back in
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await blocksTab.click();
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Click to media tab, to zoom back out
+		const mediaTab = InserterUtils.getBlockLibraryTab( 'Media' );
+		await mediaTab.click();
+		await expect( mediaTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We have taken over zoom state control, so we should exit for them.
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
+
+	// Test for https://github.com/WordPress/gutenberg/issues/66328
+	test( 'should not return you to zoom out if manually disengaged', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Close the inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should not return to zoom out since it was manually disengaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+	} );
+
+	// Similar test to the above but starting from not zoomed in and toggle zoom level twice
+	test( 'starting from zoomed in, should not toggle zoom state when closing the inserter if the user manually changed zoom state', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await inserterButton.click();
+
+		// Go to patterns tab which should enter zoom out
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await patternsTab.click();
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Manually toggle zoom out off
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close the inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should stay in zoomed out state since it was manually engaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
+
+	// Similar to above ones, but doing it from the blocks tab (zoomed out) to zoom in
+	test( 'should not return you to zoom out if manually disengaged from blocks tab', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close the inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should not return to zoom in since it was manually disengaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
 } );
+
+class InserterUtils {
+	constructor( { editor, page } ) {
+		this.editor = editor;
+		this.page = page;
+	}
+
+	getInserterButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Block Inserter',
+			exact: true,
+		} );
+	}
+
+	getBlockLibrary() {
+		return this.page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
+	}
+
+	getBlockLibraryTab( name ) {
+		return this.page.getByRole( 'tab', { name } );
+	}
+
+	getZoomOutButton() {
+		return this.page.getByRole( 'button', {
+			name: 'Zoom Out',
+			exact: true,
+		} );
+	}
+
+	getZoomCanvas() {
+		return this.page.locator( '.is-zoomed-out' );
+	}
+}

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -263,9 +263,6 @@ class InserterUtils {
 			name: 'Block Inserter',
 			exact: true,
 		} );
-		this.blocksTab = this.getBlockLibraryTab( 'Blocks' );
-		this.patternsTab = this.getBlockLibraryTab( 'Patterns' );
-		this.mediaTab = this.getBlockLibraryTab( 'Media' );
 	}
 
 	// Manually naming as open and close these makes it clearer when reading

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -370,7 +370,6 @@ test.describe( 'Site Editor Inserter', () => {
 
 		// Go to patterns tab which should enter zoom out
 		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await patternsTab.click();
 		await expect( patternsTab ).toHaveAttribute(
 			'data-active-item',
 			'true'

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -24,16 +24,12 @@ test.describe( 'Site Editor Inserter', () => {
 		},
 	} );
 
+	// eslint-disable-next-line playwright/expect-expect
 	test( 'inserter toggle button should toggle global inserter', async ( {
 		InserterUtils,
 	} ) => {
-		await InserterUtils.toggleBlockLibrary();
-
-		// Visibility check
-		await expect( InserterUtils.blockLibrary ).toBeVisible();
-		await InserterUtils.toggleBlockLibrary();
-		//Hidden State check
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+		await InserterUtils.openBlockLibrary();
+		await InserterUtils.closeBlockLibrary();
 	} );
 
 	// A test for https://github.com/WordPress/gutenberg/issues/43090.
@@ -43,8 +39,8 @@ test.describe( 'Site Editor Inserter', () => {
 	} ) => {
 		const beforeBlocks = await editor.getBlocks();
 
-		await InserterUtils.toggleBlockLibrary();
-		await InserterUtils.activateTab( 'Blocks' );
+		await InserterUtils.openBlockLibrary();
+		await InserterUtils.expectActiveTab( 'Blocks' );
 		await InserterUtils.blockLibrary
 			.getByRole( 'option', { name: 'Buttons' } )
 			.click();
@@ -53,9 +49,7 @@ test.describe( 'Site Editor Inserter', () => {
 			.poll( editor.getBlocks )
 			.toMatchObject( [ ...beforeBlocks, { name: 'core/buttons' } ] );
 
-		await InserterUtils.toggleBlockLibrary();
-
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+		await InserterUtils.closeBlockLibrary();
 	} );
 
 	test.describe( 'Inserter Zoom Level UX', () => {
@@ -70,36 +64,27 @@ test.describe( 'Site Editor Inserter', () => {
 			ZoomUtils,
 		} ) => {
 			await test.step( 'should open the inserter to blocks tab from default zoom level', async () => {
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 
 				// Zoom canvas should not be active
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-				// Close Block Library
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Zoom canvas should not be active
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 			} );
 
 			await test.step( 'should open the inserter to patterns tab if zoomed out', async () => {
-				// Toggle Zoom Level
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
-
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await ZoomUtils.enterZoomOut();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Patterns' );
 
 				// Zoom canvas should still be active
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-				// Close Block Library
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// We should still be in Zoom Out
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
@@ -110,8 +95,7 @@ test.describe( 'Site Editor Inserter', () => {
 			InserterUtils,
 			ZoomUtils,
 		} ) => {
-			// Open inserter
-			await InserterUtils.toggleBlockLibrary();
+			await InserterUtils.openBlockLibrary();
 			await InserterUtils.expectActiveTab( 'Blocks' );
 			await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
@@ -136,25 +120,21 @@ test.describe( 'Site Editor Inserter', () => {
 			ZoomUtils,
 		} ) => {
 			await test.step( 'should reset zoom when closing from patterns tab', async () => {
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 				await InserterUtils.activateTab( 'Patterns' );
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-				// Close inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Zoom Level should be reset
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 			} );
 
 			await test.step( 'should preserve default zoom level when closing from blocks tab', async () => {
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
@@ -164,17 +144,14 @@ test.describe( 'Site Editor Inserter', () => {
 				await InserterUtils.activateTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-				// Close inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Zoom Level should stay at default level
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 			} );
 
 			await test.step( 'should preserve default zoom level when closing from blocks tab even if user manually toggled zoom level on previous tab', async () => {
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
@@ -182,15 +159,12 @@ test.describe( 'Site Editor Inserter', () => {
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 				// Toggle zoom level manually
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				await ZoomUtils.exitZoomOut();
 
 				await InserterUtils.activateTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-				// Close inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Zoom Level should stay at default level
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
@@ -198,7 +172,7 @@ test.describe( 'Site Editor Inserter', () => {
 
 			await test.step( 'should preserve default zoom level when closing from blocks tab even if user manually toggled zoom level on previous tab twice', async () => {
 				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
@@ -206,17 +180,13 @@ test.describe( 'Site Editor Inserter', () => {
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 				// Toggle zoom level manually twice
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await ZoomUtils.exitZoomOut();
+				await ZoomUtils.enterZoomOut();
 
 				await InserterUtils.activateTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-				// Close inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Zoom Level should stay at default level
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
@@ -228,65 +198,52 @@ test.describe( 'Site Editor Inserter', () => {
 			ZoomUtils,
 		} ) => {
 			await test.step( 'should respect manual zoom level set when closing from patterns tab', async () => {
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 				await InserterUtils.activateTab( 'Patterns' );
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				await ZoomUtils.exitZoomOut();
 
-				// Close inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Zoom Level should stay reset
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 			} );
 
 			await test.step( 'should respect manual zoom level set when closing from patterns tab when toggled twice', async () => {
-				// Open inserter
-				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.openBlockLibrary();
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 				await InserterUtils.activateTab( 'Patterns' );
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				await ZoomUtils.exitZoomOut();
 
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await ZoomUtils.enterZoomOut();
 
-				// Close inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Should stay zoomed out since it was manually engaged
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-				// Toggle to reset test
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				// Reset test
+				await ZoomUtils.exitZoomOut();
 			} );
 
-			await test.step( 'should not reset zoom level if zoom level manually toggled from blocks tab', async () => {
-				await InserterUtils.toggleBlockLibrary();
+			await test.step( 'should not reset zoom level if zoom level manually changed from blocks tab', async () => {
+				await InserterUtils.openBlockLibrary();
 				await expect( InserterUtils.blockLibrary ).toBeVisible();
 
 				await InserterUtils.expectActiveTab( 'Blocks' );
 				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-				await ZoomUtils.toggleZoomLevel();
-				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await ZoomUtils.enterZoomOut();
 
-				// Close the inserter
-				await InserterUtils.toggleBlockLibrary();
-				await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.closeBlockLibrary();
 
 				// Should stay zoomed out since it was manually engaged
 				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
@@ -311,8 +268,16 @@ class InserterUtils {
 		this.mediaTab = this.getBlockLibraryTab( 'Media' );
 	}
 
-	async toggleBlockLibrary() {
+	// Manually naming as open and close these makes it clearer when reading
+	// through the test instead of using a toggle method with a boolean
+	async openBlockLibrary() {
 		await this.inserterButton.click();
+		await expect( this.blockLibrary ).toBeVisible();
+	}
+
+	async closeBlockLibrary() {
+		await this.inserterButton.click();
+		await expect( this.blockLibrary ).toBeHidden();
 	}
 
 	getBlockLibraryTab( name ) {
@@ -344,7 +309,15 @@ class ZoomUtils {
 		} );
 	}
 
-	async toggleZoomLevel() {
+	// Manually naming as enter and exit these makes it clearer when reading
+	// through the test instead of using a toggle method with a boolean
+	async enterZoomOut() {
 		await this.zoomButton.click();
+		await expect( this.zoomCanvas ).toBeVisible();
+	}
+
+	async exitZoomOut() {
+		await this.zoomButton.click();
+		await expect( this.zoomCanvas ).toBeHidden();
 	}
 }

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -24,20 +24,22 @@ test.describe( 'Site Editor Inserter', () => {
 		},
 	} );
 
+	test.use( {
+		ZoomUtils: async ( { editor, page }, use ) => {
+			await use( new ZoomUtils( { editor, page } ) );
+		},
+	} );
+
 	test( 'inserter toggle button should toggle global inserter', async ( {
 		InserterUtils,
 	} ) => {
-		const inserterButton = InserterUtils.getInserterButton();
-
-		await inserterButton.click();
-
-		const blockLibrary = InserterUtils.getBlockLibrary();
+		await InserterUtils.toggleBlockLibrary();
 
 		// Visibility check
-		await expect( blockLibrary ).toBeVisible();
-		await inserterButton.click();
+		await expect( InserterUtils.blockLibrary ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
 		//Hidden State check
-		await expect( blockLibrary ).toBeHidden();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 	} );
 
 	// A test for https://github.com/WordPress/gutenberg/issues/43090.
@@ -45,379 +47,281 @@ test.describe( 'Site Editor Inserter', () => {
 		editor,
 		InserterUtils,
 	} ) => {
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
 		const beforeBlocks = await editor.getBlocks();
 
-		await inserterButton.click();
-		await InserterUtils.getBlockLibraryTab( 'Blocks' ).click();
-		await blockLibrary.getByRole( 'option', { name: 'Buttons' } ).click();
+		await InserterUtils.toggleBlockLibrary();
+		await InserterUtils.activateTab( 'Blocks' );
+		await InserterUtils.blockLibrary
+			.getByRole( 'option', { name: 'Buttons' } )
+			.click();
 
 		await expect
 			.poll( editor.getBlocks )
 			.toMatchObject( [ ...beforeBlocks, { name: 'core/buttons' } ] );
 
-		await inserterButton.click();
+		await InserterUtils.toggleBlockLibrary();
 
-		await expect( blockLibrary ).toBeHidden();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 	} );
 
 	test( 'should open the inserter to patterns tab if using zoom out and stay in zoom out when closing the inserter', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
+		await InserterUtils.expectActiveTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await inserterButton.click();
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
 
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We should still be in Zoom Out
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 	} );
 
 	test( 'should enter zoom out from patterns tab and exit zoom out when closing the inserter', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
+		// Open inserter
+		await InserterUtils.toggleBlockLibrary();
+		await InserterUtils.expectActiveTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await patternsTab.click();
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
-
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeHidden();
-
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 	} );
 
 	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
 		// Open inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
+		await InserterUtils.expectActiveTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Blocks tab should be active, not in zoomed out state
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
-
-		// Click to patterns, should enter zoom out
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await patternsTab.click();
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		// Click to patterns should enter zoom out
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Click to blocks tab, zooms back in
-		await blocksTab.click();
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.activateTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Close inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// Canvas stays zoomed in
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 	} );
 
 	// Same test as above, but starting from zoom out
 	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter (even if starting from zoom out)', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Open inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeVisible();
 
 		// Patterns tab should be active
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Click to blocks tab, zooms back in
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await blocksTab.click();
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.activateTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Close inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// Canvas stays zoomed in
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 	} );
 
 	// Same test as above but exiting from zoom out
 	test( 'If we change the zoom level for them via an inserter tab change, always exit zoom out when closing the inserter', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
-
-		await inserterButton.click();
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		const mediaTab = InserterUtils.getBlockLibraryTab( 'Media' );
+		await InserterUtils.toggleBlockLibrary();
 
 		// Should start with pattern tab selected in zoom out state
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.expectActiveTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Go to blocks tab which should exit zoom out
-		// We changed the zoom state for them here, so we "take over" control of the zoom state
-		await blocksTab.click();
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.activateTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Go to media tab which should enter zoom out again since that's the starting state
-		await mediaTab.click();
-		await expect( mediaTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.activateTab( 'Media' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Close the inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We should stay in zoomed out state since we had control over the zoom state and we always exit zoom out when closing the inserter
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 	} );
 
 	test( 'should always exit zoom out if we have most recently changed zoom level for them', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
 		// Enter zoom out
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 		// Open inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
 
 		// Patterns tab should be active
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Click to blocks tab, zooms back in
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await blocksTab.click();
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.activateTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Click to media tab, to zoom back out
-		const mediaTab = InserterUtils.getBlockLibraryTab( 'Media' );
-		await mediaTab.click();
-		await expect( mediaTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.activateTab( 'Media' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Close inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We have taken over zoom state control, so we should exit for them.
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 	} );
 
 	// Test for https://github.com/WordPress/gutenberg/issues/66328
 	test( 'should not return you to zoom out if manually disengaged', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeVisible();
 
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Close the inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We should not return to zoom out since it was manually disengaged
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 	} );
 
 	// Similar test to the above but toggle zoom level twice
-	test( 'should not toggle zoom state from pattern tab when closing the inserter if the user manually changed zoom state', async ( {
+	test( 'starting from default view, should not toggle zoom state from pattern tab when closing the inserter if the user manually changed zoom state tweice', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
 		// Open inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeVisible();
 
-		// Start from blocks stab
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await InserterUtils.activateTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Go to patterns tab which should enter zoom out
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await patternsTab.click();
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Manually toggle zoom out off
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Close the inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We should stay in zoomed out state since it was manually engaged
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 	} );
 
-	// Similar test to the above but starting from not zoomed in and toggle zoom level twice
-	test( 'starting from zoomed in, should not toggle zoom state when closing the inserter if the user manually changed zoom state', async ( {
+	test( 'starting from zoomed out, should not toggle zoom state when closing the inserter if the user manually changed zoom state twice', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
-
 		// Enter zoom out
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Open inserter
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeVisible();
 
-		// Go to patterns tab which should enter zoom out
-		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
-		await expect( patternsTab ).toHaveAttribute(
-			'data-active-item',
-			'true'
-		);
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		// Go to patterns tab which should remain in zoom out
+		await InserterUtils.activateTab( 'Patterns' );
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Manually toggle zoom out off
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
 		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Close the inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We should stay in zoomed out state since it was manually engaged
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 	} );
 
 	// Similar to above ones, but doing it from the blocks tab (zoomed out) to zoom in
-	test( 'should not return you to zoom out if manually disengaged from blocks tab', async ( {
+	test( 'should not reset zoom level if zoom level manually toggled from blocks tab', async ( {
 		InserterUtils,
+		ZoomUtils,
 	} ) => {
-		const zoomOutButton = InserterUtils.getZoomOutButton();
-		const inserterButton = InserterUtils.getInserterButton();
-		const blockLibrary = InserterUtils.getBlockLibrary();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeVisible();
 
-		await inserterButton.click();
-		await expect( blockLibrary ).toBeVisible();
+		await InserterUtils.expectActiveTab( 'Blocks' );
+		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
-		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
-		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
-
-		await zoomOutButton.click();
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await ZoomUtils.toggleZoomLevel();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
 		// Close the inserter
-		await inserterButton.click();
-
-		await expect( blockLibrary ).toBeHidden();
+		await InserterUtils.toggleBlockLibrary();
+		await expect( InserterUtils.blockLibrary ).toBeHidden();
 
 		// We should not return to zoom in since it was manually disengaged
-		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 	} );
 } );
 
@@ -425,33 +329,52 @@ class InserterUtils {
 	constructor( { editor, page } ) {
 		this.editor = editor;
 		this.page = page;
-	}
-
-	getInserterButton() {
-		return this.page.getByRole( 'button', {
+		this.blockLibrary = this.page.getByRole( 'region', {
+			name: 'Block Library',
+		} );
+		this.inserterButton = this.page.getByRole( 'button', {
 			name: 'Block Inserter',
 			exact: true,
 		} );
+		this.blocksTab = this.getBlockLibraryTab( 'Blocks' );
+		this.patternsTab = this.getBlockLibraryTab( 'Patterns' );
+		this.mediaTab = this.getBlockLibraryTab( 'Media' );
 	}
 
-	getBlockLibrary() {
-		return this.page.getByRole( 'region', {
-			name: 'Block Library',
-		} );
+	async toggleBlockLibrary() {
+		await this.inserterButton.click();
 	}
 
 	getBlockLibraryTab( name ) {
 		return this.page.getByRole( 'tab', { name } );
 	}
 
-	getZoomOutButton() {
-		return this.page.getByRole( 'button', {
+	async expectActiveTab( name ) {
+		await expect( this.getBlockLibraryTab( name ) ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+	}
+
+	async activateTab( name ) {
+		await this.getBlockLibraryTab( name ).click();
+		// For brevity, adding this check here. It should always be done after the tab is clicked
+		await this.expectActiveTab( name );
+	}
+}
+
+class ZoomUtils {
+	constructor( { editor, page } ) {
+		this.editor = editor;
+		this.page = page;
+		this.zoomCanvas = this.page.locator( '.is-zoomed-out' );
+		this.zoomButton = this.page.getByRole( 'button', {
 			name: 'Zoom Out',
 			exact: true,
 		} );
 	}
 
-	getZoomCanvas() {
-		return this.page.locator( '.is-zoomed-out' );
+	async toggleZoomLevel() {
+		await this.zoomButton.click();
 	}
 }

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -158,8 +158,12 @@ test.describe( 'Site Editor Inserter', () => {
 	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter (even if starting from zoom out)', async ( {
 		InserterUtils,
 	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
 		const inserterButton = InserterUtils.getInserterButton();
 		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
 
 		// Open inserter
 		await inserterButton.click();
@@ -305,6 +309,49 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
 	} );
 
+	// Similar test to the above but toggle zoom level twice
+	test( 'should not toggle zoom state from pattern tab when closing the inserter if the user manually changed zoom state', async ( {
+		InserterUtils,
+	} ) => {
+		const zoomOutButton = InserterUtils.getZoomOutButton();
+		const inserterButton = InserterUtils.getInserterButton();
+		const blockLibrary = InserterUtils.getBlockLibrary();
+
+		// Open inserter
+		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
+
+		// Start from blocks stab
+		const blocksTab = InserterUtils.getBlockLibraryTab( 'Blocks' );
+		await expect( blocksTab ).toHaveAttribute( 'data-active-item', 'true' );
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Go to patterns tab which should enter zoom out
+		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );
+		await patternsTab.click();
+		await expect( patternsTab ).toHaveAttribute(
+			'data-active-item',
+			'true'
+		);
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Manually toggle zoom out off
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeHidden();
+
+		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Close the inserter
+		await inserterButton.click();
+
+		await expect( blockLibrary ).toBeHidden();
+
+		// We should stay in zoomed out state since it was manually engaged
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+	} );
+
 	// Similar test to the above but starting from not zoomed in and toggle zoom level twice
 	test( 'starting from zoomed in, should not toggle zoom state when closing the inserter if the user manually changed zoom state', async ( {
 		InserterUtils,
@@ -313,7 +360,13 @@ test.describe( 'Site Editor Inserter', () => {
 		const inserterButton = InserterUtils.getInserterButton();
 		const blockLibrary = InserterUtils.getBlockLibrary();
 
+		// Enter zoom out
+		await zoomOutButton.click();
+		await expect( await InserterUtils.getZoomCanvas() ).toBeVisible();
+
+		// Open inserter
 		await inserterButton.click();
+		await expect( blockLibrary ).toBeVisible();
 
 		// Go to patterns tab which should enter zoom out
 		const patternsTab = InserterUtils.getBlockLibraryTab( 'Patterns' );

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -24,12 +24,6 @@ test.describe( 'Site Editor Inserter', () => {
 		},
 	} );
 
-	test.use( {
-		ZoomUtils: async ( { editor, page }, use ) => {
-			await use( new ZoomUtils( { editor, page } ) );
-		},
-	} );
-
 	test( 'inserter toggle button should toggle global inserter', async ( {
 		InserterUtils,
 	} ) => {
@@ -64,264 +58,240 @@ test.describe( 'Site Editor Inserter', () => {
 		await expect( InserterUtils.blockLibrary ).toBeHidden();
 	} );
 
-	test( 'should open the inserter to patterns tab if using zoom out and stay in zoom out when closing the inserter', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+	test.describe( 'Inserter Zoom Level UX', () => {
+		test.use( {
+			ZoomUtils: async ( { editor, page }, use ) => {
+				await use( new ZoomUtils( { editor, page } ) );
+			},
+		} );
 
-		await InserterUtils.toggleBlockLibrary();
-		await InserterUtils.expectActiveTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+		test( 'should intialize correct active tab based on zoom level', async ( {
+			InserterUtils,
+			ZoomUtils,
+		} ) => {
+			await test.step( 'should open the inserter to blocks tab from default zoom level', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
 
-		await InserterUtils.toggleBlockLibrary();
+				// Zoom canvas should not be active
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				// Close Block Library
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		// We should still be in Zoom Out
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
-	} );
+				// Zoom canvas should not be active
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-	test( 'should enter zoom out from patterns tab and exit zoom out when closing the inserter', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		// Open inserter
-		await InserterUtils.toggleBlockLibrary();
-		await InserterUtils.expectActiveTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			await test.step( 'should open the inserter to patterns tab if zoomed out', async () => {
+				// Toggle Zoom Level
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Patterns' );
 
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-	} );
+				// Zoom canvas should still be active
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		// Open inserter
-		await InserterUtils.toggleBlockLibrary();
-		await InserterUtils.expectActiveTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				// Close Block Library
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		// Click to patterns should enter zoom out
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// We should still be in Zoom Out
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			} );
+		} );
 
-		// Click to blocks tab, zooms back in
-		await InserterUtils.activateTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+		test( 'should set the correct zoom level when changing tabs', async ( {
+			InserterUtils,
+			ZoomUtils,
+		} ) => {
+			// Open inserter
+			await InserterUtils.toggleBlockLibrary();
+			await InserterUtils.expectActiveTab( 'Blocks' );
+			await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Close inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+			await test.step( 'should zoom out when activating patterns tab', async () => {
+				await InserterUtils.activateTab( 'Patterns' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			} );
 
-		// Canvas stays zoomed in
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-	} );
+			await test.step( 'should reset zoom level when activating blocks tab', async () => {
+				await InserterUtils.activateTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-	// Same test as above, but starting from zoom out
-	test( 'should always exit zoom out from blocks tab and does not change mode when closing the inserter (even if starting from zoom out)', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			await test.step( 'should zoom out when activating media tab', async () => {
+				await InserterUtils.activateTab( 'Media' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			} );
+		} );
 
-		// Open inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeVisible();
+		test( 'should reset the zoom level when closing the inserter if we most recently changed the zoom level', async ( {
+			InserterUtils,
+			ZoomUtils,
+		} ) => {
+			await test.step( 'should reset zoom when closing from patterns tab', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Patterns tab should be active
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await InserterUtils.activateTab( 'Patterns' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// Click to blocks tab, zooms back in
-		await InserterUtils.activateTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				// Close inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		// Close inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				// Zoom Level should be reset
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-		// Canvas stays zoomed in
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-	} );
+			await test.step( 'should preserve default zoom level when closing from blocks tab', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-	// Same test as above but exiting from zoom out
-	test( 'If we change the zoom level for them via an inserter tab change, always exit zoom out when closing the inserter', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await InserterUtils.activateTab( 'Media' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.activateTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Should start with pattern tab selected in zoom out state
-		await InserterUtils.expectActiveTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// Close inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		// Go to blocks tab which should exit zoom out
-		await InserterUtils.activateTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				// Zoom Level should stay at default level
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-		// Go to media tab which should enter zoom out again since that's the starting state
-		await InserterUtils.activateTab( 'Media' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			await test.step( 'should preserve default zoom level when closing from blocks tab even if user manually toggled zoom level on previous tab', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Close the inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.activateTab( 'Media' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// We should stay in zoomed out state since we had control over the zoom state and we always exit zoom out when closing the inserter
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-	} );
+				// Toggle zoom level manually
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-	test( 'should always exit zoom out if we have most recently changed zoom level for them', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		// Enter zoom out
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
-		// Open inserter
-		await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.activateTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Patterns tab should be active
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// Close inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		// Click to blocks tab, zooms back in
-		await InserterUtils.activateTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				// Zoom Level should stay at default level
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-		// Click to media tab, to zoom back out
-		await InserterUtils.activateTab( 'Media' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			await test.step( 'should preserve default zoom level when closing from blocks tab even if user manually toggled zoom level on previous tab twice', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Close inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.activateTab( 'Media' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// We have taken over zoom state control, so we should exit for them.
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-	} );
+				// Toggle zoom level manually twice
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-	// Test for https://github.com/WordPress/gutenberg/issues/66328
-	test( 'should not return you to zoom out if manually disengaged', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await InserterUtils.activateTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeVisible();
+				// Close inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// Zoom Level should stay at default level
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
+		} );
 
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+		test( 'should keep the zoom level manually set by the user if the user most recently set the zoom level', async ( {
+			InserterUtils,
+			ZoomUtils,
+		} ) => {
+			await test.step( 'should respect manual zoom level set when closing from patterns tab', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Close the inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await InserterUtils.activateTab( 'Patterns' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// We should not return to zoom out since it was manually disengaged
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-	} );
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-	// Similar test to the above but toggle zoom level twice
-	test( 'starting from default view, should not toggle zoom state from pattern tab when closing the inserter if the user manually changed zoom state tweice', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		// Open inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeVisible();
+				// Close inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		await InserterUtils.activateTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				// Zoom Level should stay reset
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-		// Go to patterns tab which should enter zoom out
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			await test.step( 'should respect manual zoom level set when closing from patterns tab when toggled twice', async () => {
+				// Open inserter
+				await InserterUtils.toggleBlockLibrary();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Manually toggle zoom out off
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				await InserterUtils.activateTab( 'Patterns' );
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Close the inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// We should stay in zoomed out state since it was manually engaged
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
-	} );
+				// Close inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-	test( 'starting from zoomed out, should not toggle zoom state when closing the inserter if the user manually changed zoom state twice', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		// Enter zoom out
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// Should stay zoomed out since it was manually engaged
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// Open inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeVisible();
+				// Toggle to reset test
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+			} );
 
-		// Go to patterns tab which should remain in zoom out
-		await InserterUtils.activateTab( 'Patterns' );
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			await test.step( 'should not reset zoom level if zoom level manually toggled from blocks tab', async () => {
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeVisible();
 
-		// Manually toggle zoom out off
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
+				await InserterUtils.expectActiveTab( 'Blocks' );
+				await expect( ZoomUtils.zoomCanvas ).toBeHidden();
 
-		// Manually toggle zoom out again to return to zoomed-in state set by the patterns tab.
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				await ZoomUtils.toggleZoomLevel();
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
 
-		// Close the inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
+				// Close the inserter
+				await InserterUtils.toggleBlockLibrary();
+				await expect( InserterUtils.blockLibrary ).toBeHidden();
 
-		// We should stay in zoomed out state since it was manually engaged
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
-	} );
-
-	// Similar to above ones, but doing it from the blocks tab (zoomed out) to zoom in
-	test( 'should not reset zoom level if zoom level manually toggled from blocks tab', async ( {
-		InserterUtils,
-		ZoomUtils,
-	} ) => {
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeVisible();
-
-		await InserterUtils.expectActiveTab( 'Blocks' );
-		await expect( ZoomUtils.zoomCanvas ).toBeHidden();
-
-		await ZoomUtils.toggleZoomLevel();
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
-
-		// Close the inserter
-		await InserterUtils.toggleBlockLibrary();
-		await expect( InserterUtils.blockLibrary ).toBeHidden();
-
-		// We should not return to zoom in since it was manually disengaged
-		await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+				// Should stay zoomed out since it was manually engaged
+				await expect( ZoomUtils.zoomCanvas ).toBeVisible();
+			} );
+		} );
 	} );
 } );
 

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -286,7 +286,7 @@ class InserterUtils {
 
 	async expectActiveTab( name ) {
 		await expect( this.getBlockLibraryTab( name ) ).toHaveAttribute(
-			'data-active-item',
+			'aria-selected',
 			'true'
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/66328

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Track if the useZoomOut hook changed the zoom level for the user. If we never changed it, don't change the zoom level on unmount.

Request from @richtabor: If we did change zoom level via the `useZoomOut` hook (controlled mode) _always `resetZoomLevel()` on unmount_.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes a bug where zoom out was engaged/disengaged incorrectly on unmount. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Adds a ` controlZoomLevelRef`  that tracks if we ever changed the zoom level for the user. When unmounting, if we changed the zoom level, reset it _unless they manually toggled the zoom level after us_. In that condition, `controlZoomLevelRef` is set to `false`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

The key concepts here are:
- If we most recently changed the zoom level for them (in or out), we always resetZoomLevel() level when unmounting.
- If the user most recently changed the zoom level (manually toggling), we do nothing when unmounting.
 
So, with these in mind, we have two scenarios to watch for:
- Closing the inserter always resets the zoom level if the inserter changed the zoom level (clicking on blocks tab from zoomed out state OR clicking on patterns or media tab from zoomed in state)
- Closing the inserter NEVER affects zoom level if zoom state was manually toggled via the zoom out button. However, if you manually toggle, then click to a tab that sets the zoom state, we are now controlling it again.


1. Enter Zoom out manually
2. Open the inserter.
3. The pattern tab should be selected.
4. Exit zoom out manually.
5. Close the inserter.
6. Editor should remain in non-zoomed state (regular editing)

From full screen mode
1. Open inserter
2. Click patterns tab
3. Zoom out should engage
4. Close inserter
5. Zoom out should disengage

From full screen mode, exit zoom out manually
1. Open inserter
2. Click patterns tab
3. Zoom out should engage
4. Manually exit zoom out
5. Close inserter
6. Zoom out should not engage (remain in full screen mode)

## Screen Recording

https://github.com/user-attachments/assets/082ce511-c038-4de4-aa92-5c35f7ef6a5f

