### PR TITLE
Block Editor: Reduce the 'isZoomOut' selector calls in the block toolbar

### DIFF
--- a/packages/block-editor/src/components/block-toolbar/index.js
+++ b/packages/block-editor/src/components/block-toolbar/index.js
@@ -124,6 +124,8 @@ export function PrivateBlockToolbar( {
 			( id ) => getTemplateLock( id ) === 'contentOnly'
 		);
 
+		const _isZoomOut = isZoomOut();
+
 		return {
 			blockClientId: selectedBlockClientId,
 			blockClientIds: selectedBlockClientIds,
@@ -132,7 +134,7 @@ export function PrivateBlockToolbar( {
 			shouldShowVisualToolbar: isValid && isVisual,
 			toolbarKey: `${ selectedBlockClientId }${ parentClientId }`,
 			showParentSelector:
-				! isZoomOut() &&
+				! _isZoomOut &&
 				parentBlockType &&
 				getBlockEditingMode( parentClientId ) !== 'disabled' &&
 				hasBlockSupport(
@@ -144,11 +146,11 @@ export function PrivateBlockToolbar( {
 			isUsingBindings: _isUsingBindings,
 			hasParentPattern: _hasParentPattern,
 			hasContentOnlyLocking: _hasTemplateLock,
-			showShuffleButton: isZoomOut(),
-			showSlots: ! isZoomOut(),
-			showGroupButtons: ! isZoomOut(),
-			showLockButtons: ! isZoomOut(),
-			showSwitchSectionStyleButton: isZoomOut(),
+			showShuffleButton: _isZoomOut,
+			showSlots: ! _isZoomOut,
+			showGroupButtons: ! _isZoomOut,
+			showLockButtons: ! _isZoomOut,
+			showSwitchSectionStyleButton: _isZoomOut,
 			hasFixedToolbar: getSettings().hasFixedToolbar,
 			isNavigationMode: _isNavigationMode(),
 		};


### PR DESCRIPTION
## What?
PR updates the `PrivateBlockToolbar` component to only call the `isZoomOut` selector once (instead of 6 times).

## Why?
A micro-optimization. The selector accepts no arguments, so its value can be easily reused.

## Testing Instructions
1. Open a post or page.
2. Add a block and locking.
3. Engage zoom-out mode.
4. Confirm that the lock icon isn't displayed in the toolbar.

### Testing Instructions for Keyboard
Same.
