### PR TITLE
Enhance: Added toggle to apply styling in Lightbox conditionally

### DIFF
--- a/packages/block-library/src/image/block.json
+++ b/packages/block-library/src/image/block.json
@@ -4,7 +4,14 @@
 	"name": "core/image",
 	"title": "Image",
 	"category": "media",
-	"usesContext": [ "allowResize", "imageCrop", "fixedHeight", "postId", "postType", "queryId" ],
+	"usesContext": [
+		"allowResize",
+		"imageCrop",
+		"fixedHeight",
+		"postId",
+		"postType",
+		"queryId"
+	],
 	"description": "Insert an image to make a visual statement.",
 	"keywords": [ "img", "photo", "picture" ],
 	"textdomain": "default",
@@ -38,6 +45,10 @@
 			"type": "object",
 			"enabled": {
 				"type": "boolean"
+			},
+			"applyStyles": {
+				"type": "boolean",
+				"default": "true"
 			}
 		},
 		"title": {

--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -38,7 +38,13 @@ import { useEffect, useMemo, useState, useRef } from '@wordpress/element';
 import { __, _x, sprintf, isRTL } from '@wordpress/i18n';
 import { getFilename } from '@wordpress/url';
 import { getBlockBindingsSource, switchToBlockType } from '@wordpress/blocks';
-import { crop, overlayText, upload, chevronDown } from '@wordpress/icons';
+import {
+	crop,
+	overlayText,
+	upload,
+	chevronDown,
+	formatIndent,
+} from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { store as coreStore, useEntityProp } from '@wordpress/core-data';
 
@@ -424,7 +430,7 @@ export default function Image( {
 	function onSetLightbox( enable ) {
 		if ( enable && ! lightboxSetting?.enabled ) {
 			setAttributes( {
-				lightbox: { enabled: true },
+				lightbox: { enabled: true, applyStyles: true },
 			} );
 		} else if ( ! enable && lightboxSetting?.enabled ) {
 			setAttributes( {
@@ -433,6 +439,17 @@ export default function Image( {
 		} else {
 			setAttributes( {
 				lightbox: undefined,
+			} );
+		}
+	}
+
+	function toggleStylingLightbox() {
+		if ( lightbox?.enabled ) {
+			setAttributes( {
+				lightbox: {
+					enabled: true,
+					applyStyles: ! lightbox?.applyStyles,
+				},
 			} );
 		}
 	}
@@ -743,6 +760,14 @@ export default function Image( {
 							lightboxEnabled={ lightboxChecked }
 							onSetLightbox={ onSetLightbox }
 							resetLightbox={ resetLightbox }
+						/>
+					) }
+					{ lightboxChecked && showLightboxSetting && (
+						<ToolbarButton
+							icon={ formatIndent }
+							label={ __( 'Apply Custom Styles to lightbox' ) }
+							onClick={ toggleStylingLightbox }
+							isActive={ lightbox?.applyStyles ?? false }
 						/>
 					) }
 					{ allowCrop && (

--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -171,8 +171,12 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 
 	// Figure.
 	$p->seek( 'figure' );
-	$figure_class_names = $p->get_attribute( 'class' );
-	$figure_styles      = $p->get_attribute( 'style' );
+
+	$lightbox_settings = $block['attrs']['lightbox'];
+	if ( isset( $lightbox_settings ) && isset( $lightbox_settings['applyStyles'] ) && true === $lightbox_settings['applyStyles'] ) {
+		$figure_class_names = $p->get_attribute( 'class' );
+		$figure_styles      = $p->get_attribute( 'style' );
+	}
 
 	// Create unique id and set the image metadata in the state.
 	$unique_image_id = uniqid();
@@ -183,8 +187,8 @@ function block_core_image_render_lightbox( $block_content, $block ) {
 			'metadata' => array(
 				$unique_image_id => array(
 					'uploadedSrc'      => $img_uploaded_src,
-					'figureClassNames' => $figure_class_names,
-					'figureStyles'     => $figure_styles,
+					'figureClassNames' => $figure_class_names ?? '',
+					'figureStyles'     => $figure_styles ?? '',
 					'imgClassNames'    => $img_class_names,
 					'imgStyles'        => $img_styles,
 					'targetWidth'      => $img_width,


### PR DESCRIPTION
Attempt to resolve #67535, PR is aimed to explore the possibility.

## What?
This PR introduces a toggle for the lightbox feature to conditionally apply styles.

## Why?
Styles should only be applied within the site blocks and not inside the Lightbox. Since the Lightbox opens in a modal, there should be an option to disable custom site styles for it.

## How?

- The lightbox attribute is updated to include a new applyStyles property, which defaults to true.
- If the lightbox feature is enabled, a new toggle option is added to BlockControls.
- This gives users the flexibility to disable custom styles specifically for Lightbox images.

## Testing Instructions

- Add an image block to a Gutenberg-enabled page.
- Set the image block to the "Rounded" style within the "Styles" tab of the block settings sidebar.
- Use the link drop down of the contextual menu and select "Expand on click" on the image block.

## Screenshots or screencast 

https://github.com/user-attachments/assets/9fde8ad4-31fa-4b5a-8e3a-dbce6b2d8dbf
