### PR TITLE
Update misc types and revert WPCompleter export from components

### DIFF
--- a/packages/block-editor/src/autocompleters/block.js
+++ b/packages/block-editor/src/autocompleters/block.js
@@ -23,12 +23,10 @@ import { orderInserterBlockItems } from '../utils/order-inserter-block-items';
 const noop = () => {};
 const SHOWN_BLOCK_TYPES = 9;
 
-/** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */
-
 /**
  * Creates a blocks repeater for replacing the current block with a selected block type.
  *
- * @return {WPCompleter} A blocks completer.
+ * @return {Object} A blocks completer.
  */
 function createBlockCompleter() {
 	return {
@@ -157,6 +155,6 @@ function createBlockCompleter() {
 /**
  * Creates a blocks repeater for replacing the current block with a selected block type.
  *
- * @return {WPCompleter} A blocks completer.
+ * @return {Object} A blocks completer.
  */
 export default createBlockCompleter();

--- a/packages/block-editor/src/autocompleters/link.js
+++ b/packages/block-editor/src/autocompleters/link.js
@@ -10,12 +10,10 @@ import { decodeEntities } from '@wordpress/html-entities';
 
 const SHOWN_SUGGESTIONS = 10;
 
-/** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */
-
 /**
  * Creates a suggestion list for links to posts or pages.
  *
- * @return {WPCompleter} A links completer.
+ * @return {Object} A links completer.
  */
 function createLinkCompleter() {
 	return {
@@ -60,6 +58,6 @@ function createLinkCompleter() {
 /**
  * Creates a suggestion list for links to posts or pages..
  *
- * @return {WPCompleter} A link completer.
+ * @return {Object} A link completer.
  */
 export default createLinkCompleter();

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -34,7 +34,6 @@
 -   Upgraded `@ariakit/react` (v0.4.13) and `@ariakit/test` (v0.4.5) ([#65907](https://github.com/WordPress/gutenberg/pull/65907)).
 -   Upgraded `@ariakit/react` (v0.4.15) and `@ariakit/test` (v0.4.7) ([#67404](https://github.com/WordPress/gutenberg/pull/67404)).
 -   `ToolbarButton`: Set size to "compact" ([#67440](https://github.com/WordPress/gutenberg/pull/67440)).
--   Exported the `WPCompleter` type as it was being used in block-editor/autocompleters ([#67410](https://github.com/WordPress/gutenberg/pull/67410)).
 -   `SlotFill`: remove manual rerenders from the portal `Fill` component ([#67471](https://github.com/WordPress/gutenberg/pull/67471)).
 
 ### Bug Fixes

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -108,7 +108,6 @@ export { Heading as __experimentalHeading } from './heading';
 export { HStack as __experimentalHStack } from './h-stack';
 export { default as Icon } from './icon';
 export type { IconType } from './icon';
-export type { WPCompleter } from './autocomplete/types.ts';
 export { default as IconButton } from './button/deprecated';
 export {
 	ItemGroup as __experimentalItemGroup,

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1457,16 +1457,16 @@ _Returns_
 
 ### PostTrashCheck
 
-Wrapper component that renders its children only if the post can trashed.
+Wrapper component that renders its children only if the post can be trashed.
 
 _Parameters_
 
--   _props_ `Object`: - The component props.
--   _props.children_ `React.ReactNode`: - The child components to render.
+-   _props_ `Object`: The component props.
+-   _props.children_ `React.ReactElement`: The child components.
 
 _Returns_
 
--   `React.ReactNode`: The rendered child components or null if the post can not trashed.
+-   `React.ReactElement | null`: The rendered child components or null if the post can't be trashed.
 
 ### PostTypeSupportCheck
 
@@ -1762,7 +1762,7 @@ A user mentions completer.
 
 _Type_
 
--   `WPCompleter`
+-   `Object`
 
 ### VisualEditorGlobalKeyboardShortcuts
 

--- a/packages/editor/src/components/autocompleters/user.js
+++ b/packages/editor/src/components/autocompleters/user.js
@@ -5,8 +5,6 @@ import { useMemo } from '@wordpress/element';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
-/** @typedef {import('@wordpress/components').WPCompleter} WPCompleter */
-
 export function getUserLabel( user ) {
 	const avatar =
 		user.avatar_urls && user.avatar_urls[ 24 ] ? (
@@ -35,7 +33,7 @@ export function getUserLabel( user ) {
 /**
  * A user mentions completer.
  *
- * @type {WPCompleter}
+ * @type {Object}
  */
 export default {
 	name: 'users',

--- a/packages/editor/src/components/post-trash/check.js
+++ b/packages/editor/src/components/post-trash/check.js
@@ -11,12 +11,12 @@ import { store as editorStore } from '../../store';
 import { GLOBAL_POST_TYPES } from '../../store/constants';
 
 /**
- * Wrapper component that renders its children only if the post can trashed.
+ * Wrapper component that renders its children only if the post can be trashed.
  *
- * @param {Object}          props          - The component props.
- * @param {React.ReactNode} props.children - The child components to render.
+ * @param {Object}             props          The component props.
+ * @param {React.ReactElement} props.children The child components.
  *
- * @return {React.ReactNode} The rendered child components or null if the post can not trashed.
+ * @return {React.ReactElement | null} The rendered child components or null if the post can't be trashed.
  */
 export default function PostTrashCheck( { children } ) {
 	const { canTrashPost } = useSelect( ( select ) => {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Implements feedback from https://github.com/WordPress/gutenberg/pull/67410:

1. Revert WPCompleter export and just update types to `Object` for now. 
2. Use ReactElement instead of ReactNode


### Testing Instructions for Keyboard

Build should pass as expected
