### PR TITLE
Global styles: controls in grid should match between sidebar panel and editor

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -211,6 +211,10 @@
 	flex-direction: column;
 }
 
+.edit-site-global-styles-sidebar__navigator-screen .single-column {
+	grid-column: span 1;
+}
+
 .edit-site-global-styles-screen-root.edit-site-global-styles-screen-root,
 .edit-site-global-styles-screen-style-variations.edit-site-global-styles-screen-style-variations {
 	background: unset;


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Ensure that the single columns in the toolbar grid match the editor's global styles panel.


## Why?
They don't match.

## How?

Use the same CSS rule.


## Testing Instructions

Open the Site Editor > Style > Typography > Text, or any style with typography controls, e.g., paragraph block etc.

Check that the single column blocks span as they do in the editor global styles panel. 

Refer to screenshots below.

## Screenshots or screencast <!-- if applicable -->

### Typography > Text

| Before | After |
|--------|--------|
| <img width="280" alt="Screenshot 2024-12-05 at 11 00 41 am" src="https://github.com/user-attachments/assets/d8a9248a-09b5-4bfc-924a-bf22fc35a07d">  | <img width="280" alt="Screenshot 2024-12-05 at 10 59 28 am" src="https://github.com/user-attachments/assets/747dc26a-e154-4688-9152-4dd148856e12"> | 


### Paragraph block

| Before | After |
|--------|--------|
| <img width="280" alt="Screenshot 2024-12-05 at 11 00 49 am" src="https://github.com/user-attachments/assets/1528b727-78fa-426a-9067-e000f26e023d"> | <img width="280" alt="Screenshot 2024-12-05 at 10 59 15 am" src="https://github.com/user-attachments/assets/ef1cfd41-f1df-4bfc-9860-b774f24c72a9"> | 







### Global styles panel in editor for reference

| Typography > Text | Paragraph block |
|--------|--------|
| <img width="280" alt="Screenshot 2024-12-05 at 11 01 00 am" src="https://github.com/user-attachments/assets/8514c742-b97d-4d1d-a88a-7ac582f8dcd7"> | <img width="280" alt="Screenshot 2024-12-05 at 11 01 10 am" src="https://github.com/user-attachments/assets/8c707407-41e0-46f7-874e-cab53f7dbdee"> | 



