### PR TITLE
Style book: scroll to top at styles root

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -67,11 +67,14 @@ function isObjectEmpty( object ) {
  * @param {HTMLIFrameElement} iframe   The target iframe.
  */
 const scrollToSection = ( anchorId, iframe ) => {
-	if ( ! iframe || ! iframe?.contentDocument ) {
+	if ( ! anchorId || ! iframe || ! iframe?.contentDocument ) {
 		return;
 	}
 
-	const element = iframe.contentDocument.getElementById( anchorId );
+	const element =
+		anchorId === 'top'
+			? iframe.contentDocument.body
+			: iframe.contentDocument.getElementById( anchorId );
 	if ( element ) {
 		element.scrollIntoView( {
 			behavior: 'smooth',
@@ -89,6 +92,12 @@ const scrollToSection = ( anchorId, iframe ) => {
  */
 const getStyleBookNavigationFromPath = ( path ) => {
 	if ( path && typeof path === 'string' ) {
+		if ( path === '/' ) {
+			return {
+				top: true,
+			};
+		}
+
 		if ( path.startsWith( '/typography' ) ) {
 			return {
 				block: 'typography',
@@ -365,10 +374,19 @@ const StyleBookBody = ( {
 
 	const handleLoad = () => setHasIframeLoaded( true );
 	useLayoutEffect( () => {
-		if ( goTo?.block && hasIframeLoaded && iframeRef?.current ) {
-			scrollToSection( `example-${ goTo?.block }`, iframeRef?.current );
+		if ( hasIframeLoaded && iframeRef?.current ) {
+			if ( goTo?.top ) {
+				scrollToSection( 'top', iframeRef?.current );
+				return;
+			}
+			if ( goTo?.block ) {
+				scrollToSection(
+					`example-${ goTo?.block }`,
+					iframeRef?.current
+				);
+			}
 		}
-	}, [ iframeRef?.current, goTo?.block, scrollToSection, hasIframeLoaded ] );
+	}, [ iframeRef?.current, goTo, scrollToSection, hasIframeLoaded ] );
 
 	return (
 		<Iframe


### PR DESCRIPTION
## What?
At the root of the styles panel, scroll to top.

## Why?
The theory is that it's convenient to the user to return to start of the block list. 

## How?
Scroll the body tag into view.

## Testing Instructions

In Desktop (wide viewport), and using a block theme like TT5, head to the Site Editor by clicking on Appearance > Editor.

Then click on Styles. 

Enable the style book in the drop down.

Navigate around various global styles such as Typography and several block styles.

Ensure that the page scrolls to the top when you return to the Style root.



## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/04bac9e3-12b6-408e-8907-47cff7769bfa

