### PR TITLE
Block Tools: Don't render inserter in Zoom Out Dropzone when text is visible

### DIFF
--- a/docs/reference-guides/data/data-core-block-editor.md
+++ b/docs/reference-guides/data/data-core-block-editor.md
@@ -1227,6 +1227,18 @@ _Returns_
 
 -   `?boolean`: Whether the template is valid or not.
 
+### showZoomOutModeInserter
+
+Returns whether the zoom out mode inserter is enabled or not.
+
+_Parameters_
+
+-   _state_ `Object`: Global application state.
+
+_Returns_
+
+-   `boolean`: Whether the drop pattern is enabled or not.
+
 ### wasBlockJustInserted
 
 Tells if the block with the passed clientId was just inserted.
@@ -1720,6 +1732,18 @@ Action that enables or disables the navigation mode.
 _Parameters_
 
 -   _isNavigationMode_ `boolean`: Enable/Disable navigation mode.
+
+### setShowZoomOutModeInserter
+
+Action that shows the zoom out mode inserter.
+
+_Parameters_
+
+-   _showZoomOutModeInserter_ `boolean`: show the zoom out mode inserter.
+
+_Returns_
+
+-   `Object`: Action object.
 
 ### setTemplateValidity
 

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -44,6 +44,7 @@ function selector( select ) {
 		isTyping: isTyping(),
 		isZoomOutMode: isZoomOut(),
 		isDragging: isDragging(),
+		isInserterOpened: getSettings().__experimentalIsInserterOpened,
 	};
 }
 
@@ -61,8 +62,14 @@ export default function BlockTools( {
 	__unstableContentRef,
 	...props
 } ) {
-	const { clientId, hasFixedToolbar, isTyping, isZoomOutMode, isDragging } =
-		useSelect( selector, [] );
+	const {
+		clientId,
+		hasFixedToolbar,
+		isTyping,
+		isZoomOutMode,
+		isDragging,
+		isInserterOpened,
+	} = useSelect( selector, [] );
 
 	const isMatch = useShortcutEventMatch();
 	const {
@@ -234,7 +241,7 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
-				{ isZoomOutMode && ! isDragging && (
+				{ isZoomOutMode && ! isDragging && ! isInserterOpened && (
 					<ZoomOutModeInserters
 						__unstableContentRef={ __unstableContentRef }
 					/>

--- a/packages/block-editor/src/components/block-tools/index.js
+++ b/packages/block-editor/src/components/block-tools/index.js
@@ -33,6 +33,7 @@ function selector( select ) {
 		isTyping,
 		isDragging,
 		isZoomOut,
+		showZoomOutModeInserter,
 	} = unlock( select( blockEditorStore ) );
 
 	const clientId =
@@ -44,7 +45,7 @@ function selector( select ) {
 		isTyping: isTyping(),
 		isZoomOutMode: isZoomOut(),
 		isDragging: isDragging(),
-		isInserterOpened: getSettings().__experimentalIsInserterOpened,
+		showZoomOutModeInserter: showZoomOutModeInserter(),
 	};
 }
 
@@ -68,7 +69,7 @@ export default function BlockTools( {
 		isTyping,
 		isZoomOutMode,
 		isDragging,
-		isInserterOpened,
+		showZoomOutModeInserter,
 	} = useSelect( selector, [] );
 
 	const isMatch = useShortcutEventMatch();
@@ -200,6 +201,7 @@ export default function BlockTools( {
 			}
 		}
 	}
+
 	const blockToolbarRef = usePopoverScroll( __unstableContentRef );
 	const blockToolbarAfterRef = usePopoverScroll( __unstableContentRef );
 
@@ -241,7 +243,7 @@ export default function BlockTools( {
 					name="__unstable-block-tools-after"
 					ref={ blockToolbarAfterRef }
 				/>
-				{ isZoomOutMode && ! isDragging && ! isInserterOpened && (
+				{ isZoomOutMode && ! isDragging && showZoomOutModeInserter && (
 					<ZoomOutModeInserters
 						__unstableContentRef={ __unstableContentRef }
 					/>

--- a/packages/block-editor/src/store/actions.js
+++ b/packages/block-editor/src/store/actions.js
@@ -657,6 +657,20 @@ export function setTemplateValidity( isValid ) {
 }
 
 /**
+ * Action that shows the zoom out mode inserter.
+ *
+ * @param {boolean} showZoomOutModeInserter show the zoom out mode inserter.
+ *
+ * @return {Object} Action object.
+ */
+export function setShowZoomOutModeInserter( showZoomOutModeInserter ) {
+	return {
+		type: 'SET_ZOOM_OUT_MODE_INSERTER',
+		showZoomOutModeInserter,
+	};
+}
+
+/**
  * Action that synchronizes the template with the list of blocks.
  *
  * @return {Object} Action object.

--- a/packages/block-editor/src/store/defaults.js
+++ b/packages/block-editor/src/store/defaults.js
@@ -170,6 +170,8 @@ export const SETTINGS_DEFAULTS = {
 
 	isPreviewMode: false,
 
+	showZoomOutModeInserter: true,
+
 	// These settings will be completely revamped in the future.
 	// The goal is to evolve this into an API which will instruct
 	// the block inspector to animate transitions between what it

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -1660,6 +1660,29 @@ export function template( state = { isValid: true }, action ) {
 }
 
 /**
+ * Reducer returning whether the zoom out mode inserter should be shown or not.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Dispatched action.
+ *
+ * @return {Object} Updated state.
+ */
+export function zoomOutModeInserter(
+	state = { showZoomOutModeInserter: true },
+	action
+) {
+	switch ( action.type ) {
+		case 'SET_ZOOM_OUT_MODE_INSERTER':
+			return {
+				...state,
+				showZoomOutModeInserter: action.showZoomOutModeInserter,
+			};
+	}
+
+	return state;
+}
+
+/**
  * Reducer returning the editor setting.
  *
  * @param {Object} state  Current state.
@@ -2119,6 +2142,7 @@ const combinedReducers = combineReducers( {
 	insertionPoint,
 	insertionCue,
 	template,
+	zoomOutModeInserter,
 	settings,
 	preferences,
 	lastBlockAttributesChange,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1538,6 +1538,17 @@ export function isBlockInsertionPointVisible( state ) {
 }
 
 /**
+ * Returns whether the zoom out mode inserter is enabled or not.
+ *
+ * @param {Object} state Global application state.
+ *
+ * @return {boolean} Whether the drop pattern is enabled or not.
+ */
+export function showZoomOutModeInserter( state ) {
+	return state.zoomOutModeInserter.showZoomOutModeInserter;
+}
+
+/**
  * Returns whether the blocks matches the template or not.
  *
  * @param {boolean} state

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -274,11 +274,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 
 	const forceDisableFocusMode = settings.focusMode === false;
 
-	const isInserterOpened = useSelect(
-		( select ) => select( editorStore ).isInserterOpened(),
-		[]
-	);
-
 	return useMemo( () => {
 		const blockEditorSettings = {
 			...Object.fromEntries(
@@ -331,7 +326,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				postType === 'wp_navigation'
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
-			__experimentalIsInserterOpened: isInserterOpened,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			[ sectionRootClientIdKey ]: sectionRootClientId,
 			editorTool:
@@ -366,7 +360,6 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		globalStylesData,
 		globalStylesLinksData,
 		renderingMode,
-		isInserterOpened,
 	] );
 }
 

--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -274,6 +274,11 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 
 	const forceDisableFocusMode = settings.focusMode === false;
 
+	const isInserterOpened = useSelect(
+		( select ) => select( editorStore ).isInserterOpened(),
+		[]
+	);
+
 	return useMemo( () => {
 		const blockEditorSettings = {
 			...Object.fromEntries(
@@ -326,6 +331,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 				postType === 'wp_navigation'
 					? [ [ 'core/navigation', {}, [] ] ]
 					: settings.template,
+			__experimentalIsInserterOpened: isInserterOpened,
 			__experimentalSetIsInserterOpened: setIsInserterOpened,
 			[ sectionRootClientIdKey ]: sectionRootClientId,
 			editorTool:
@@ -360,6 +366,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 		globalStylesData,
 		globalStylesLinksData,
 		renderingMode,
+		isInserterOpened,
 	] );
 }
 


### PR DESCRIPTION
Fixes: #67568 

## What?
This PR introduces a new state handling logic to determine whether or not the Inserter should be rendered on zoom out to prevent possible overlap with the pre-existing text.

## Testing Instructions
1. Navigate to Edit a Page screen.
2. Zoom Out the Page.
3. Click on the + Button to open up the pattern inserter.
4. Notice the + Button from inserter disappears and the Drop Pattern is now visible instead of the previous overlap.

## Screencast


https://github.com/user-attachments/assets/aab7ca0c-e3dd-454d-8ae2-e68b60b57a4c



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

## Screenshots

**Before:**
<img width="1734" alt="before" src="https://github.com/user-attachments/assets/154fafd4-f1dc-4872-9def-5325e8d31504">

**After:**
![Screenshot 2024-12-06 at 10 36 04 AM](https://github.com/user-attachments/assets/296d45c7-3470-4240-ae96-31356baa6af3)

