### PR TITLE
Adding page state in data view

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -63,12 +63,15 @@ add_action(
  *
  * @return array IDs of the pages in the format: array( 'privacyPolicyPageId' => int, ... )
  */
-function get_page_options() {
-	return array(
-		'privacyPolicyPageId' => get_option( 'wp_page_for_privacy_policy' ),
-		'cartPageId'          => get_option( 'woocommerce_cart_page_id' ),
-		'checkoutPageId'      => get_option( 'woocommerce_checkout_page_id' ),
-		'accountPageId'       => get_option( 'woocommerce_myaccount_page_id' ),
-		'shopPageId'          => get_option( 'woocommerce_shop_page_id' ),
-	);
+if (!function_exists('get_page_options')) {
+	function get_page_options()
+	{
+		return array(
+			'privacyPolicyPageId' => get_option('wp_page_for_privacy_policy'),
+			'cartPageId' => get_option('woocommerce_cart_page_id'),
+			'checkoutPageId' => get_option('woocommerce_checkout_page_id'),
+			'accountPageId' => get_option('woocommerce_myaccount_page_id'),
+			'shopPageId' => get_option('woocommerce_shop_page_id'),
+		);
+	}
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -36,3 +36,24 @@ function gutenberg_register_edit_site_export_controller_endpoints() {
 	$edit_site_export_controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_edit_site_export_controller_endpoints' );
+add_action( 'rest_api_init', function () {
+    register_rest_route(
+        'page-options/v1',
+        '/options',
+        [
+            'methods'  => 'GET',
+            'callback' => 'get_page_options',
+            'permission_callback' => '__return_true', // Adjust permissions as necessary
+        ]
+    );
+} );
+
+function get_page_options() {
+    return [
+        'privacyPolicyPageId' => get_option( 'wp_page_for_privacy_policy' ),
+		'cartPageId'           => get_option( 'woocommerce_cart_page_id' ),
+		'checkoutPageId'       => get_option( 'woocommerce_checkout_page_id' ),
+		'accountPageId'        => get_option( 'woocommerce_myaccount_page_id' ),
+		'shopPageId'           => get_option( 'woocommerce_shop_page_id' ),
+    ];
+}

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -36,24 +36,39 @@ function gutenberg_register_edit_site_export_controller_endpoints() {
 	$edit_site_export_controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_edit_site_export_controller_endpoints' );
-add_action( 'rest_api_init', function () {
-    register_rest_route(
-        'page-options/v1',
-        '/options',
-        [
-            'methods'  => 'GET',
-            'callback' => 'get_page_options',
-            'permission_callback' => '__return_true', // Adjust permissions as necessary
-        ]
-    );
-} );
+add_action(
+	'rest_api_init',
+	function () {
+		register_rest_route(
+			'page-options/v1',
+			'/options',
+			array(
+				'methods'             => 'GET',
+				'callback'            => 'get_page_options',
+				'permission_callback' => '__return_true',
+			)
+		);
+	}
+);
 
+/**
+ * Returns an array of page IDs used in various parts of WordPress.
+ *
+ * The pages included are:
+ * - Privacy policy page ID
+ * - Cart page ID (from WooCommerce)
+ * - Checkout page ID (from WooCommerce)
+ * - Account page ID (from WooCommerce)
+ * - Shop page ID (from WooCommerce)
+ *
+ * @return array IDs of the pages in the format: array( 'privacyPolicyPageId' => int, ... )
+ */
 function get_page_options() {
-    return [
-        'privacyPolicyPageId' => get_option( 'wp_page_for_privacy_policy' ),
-		'cartPageId'           => get_option( 'woocommerce_cart_page_id' ),
-		'checkoutPageId'       => get_option( 'woocommerce_checkout_page_id' ),
-		'accountPageId'        => get_option( 'woocommerce_myaccount_page_id' ),
-		'shopPageId'           => get_option( 'woocommerce_shop_page_id' ),
-    ];
+	return array(
+		'privacyPolicyPageId' => get_option( 'wp_page_for_privacy_policy' ),
+		'cartPageId'          => get_option( 'woocommerce_cart_page_id' ),
+		'checkoutPageId'      => get_option( 'woocommerce_checkout_page_id' ),
+		'accountPageId'       => get_option( 'woocommerce_myaccount_page_id' ),
+		'shopPageId'          => get_option( 'woocommerce_shop_page_id' ),
+	);
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -63,15 +63,14 @@ add_action(
  *
  * @return array IDs of the pages in the format: array( 'privacyPolicyPageId' => int, ... )
  */
-if (!function_exists('get_page_options')) {
-	function get_page_options()
-	{
+if ( ! function_exists( 'get_page_options' ) ) {
+	function get_page_options() {
 		return array(
-			'privacyPolicyPageId' => get_option('wp_page_for_privacy_policy'),
-			'cartPageId' => get_option('woocommerce_cart_page_id'),
-			'checkoutPageId' => get_option('woocommerce_checkout_page_id'),
-			'accountPageId' => get_option('woocommerce_myaccount_page_id'),
-			'shopPageId' => get_option('woocommerce_shop_page_id'),
+			'privacyPolicyPageId' => get_option( 'wp_page_for_privacy_policy' ),
+			'cartPageId'          => get_option( 'woocommerce_cart_page_id' ),
+			'checkoutPageId'      => get_option( 'woocommerce_checkout_page_id' ),
+			'accountPageId'       => get_option( 'woocommerce_myaccount_page_id' ),
+			'shopPageId'          => get_option( 'woocommerce_shop_page_id' ),
 		);
 	}
 }

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -52,25 +52,50 @@ add_action(
 );
 
 /**
- * Returns an array of page IDs used in various parts of WordPress.
+ * Returns an array of page IDs and their associated states.
  *
- * The pages included are:
- * - Privacy policy page ID
- * - Cart page ID (from WooCommerce)
- * - Checkout page ID (from WooCommerce)
- * - Account page ID (from WooCommerce)
- * - Shop page ID (from WooCommerce)
+ * Uses the `display_post_states` filter to allow themes and plugins to add their own page states.
  *
- * @return array IDs of the pages in the format: array( 'privacyPolicyPageId' => int, ... )
+ * @return array Page IDs and their states in the format: array( 'privacyPolicyPageId' => int, ... )
  */
 if ( ! function_exists( 'get_page_options' ) ) {
+	/**
+	 * Returns an array of page IDs and their associated states.
+	 *
+	 * This function returns an associative array where the keys are page states in camelCase and the values are the IDs of the pages associated with each state. The page states are determined by the `display_post_states` filter.
+	 *
+	 * The array will contain the following default keys:
+	 *  - `privacyPolicyPageId`: The ID of the privacy policy page.
+	 *  - `cartPageId`: The ID of the cart page.
+	 *  - `checkoutPageId`: The ID of the checkout page.
+	 *  - `accountPageId`: The ID of the account page.
+	 *  - `shopPageId`: The ID of the shop page.
+	 *
+	 * Themes and plugins can add their own page states using the `display_post_states` filter. The keys for these states will be determined by the filter.
+	 *
+	 * @return array Page IDs and their states in the format: array( 'privacyPolicyPageId' => int, ... )
+	 */
 	function get_page_options() {
-		return array(
+		$page_options = array(
 			'privacyPolicyPageId' => get_option( 'wp_page_for_privacy_policy' ),
 			'cartPageId'          => get_option( 'woocommerce_cart_page_id' ),
 			'checkoutPageId'      => get_option( 'woocommerce_checkout_page_id' ),
 			'accountPageId'       => get_option( 'woocommerce_myaccount_page_id' ),
 			'shopPageId'          => get_option( 'woocommerce_shop_page_id' ),
 		);
+		$pages        = get_pages();
+
+		foreach ( $pages as $page ) {
+
+			$post_states = apply_filters( 'display_post_states', array(), get_post( $page->ID ) );
+
+			if ( ! empty( $post_states ) ) {
+				foreach ( $post_states as $state => $label ) {
+					$key                  = lcfirst( str_replace( ' ', '', ucwords( str_replace( '_', ' ', $state ) ) ) ) . 'PageId';
+					$page_options[ $key ] = $page->ID;
+				}
+			}
+		}
+		return $page_options;
 	}
 }

--- a/packages/fields/src/fields/title/title-view.tsx
+++ b/packages/fields/src/fields/title/title-view.tsx
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 import type { Settings } from '@wordpress/core-data';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -26,6 +27,39 @@ const TitleView = ( { item }: { item: BasePost } ) => {
 			postsPageId: siteSettings?.page_for_posts,
 		};
 	}, [] );
+	const [ options, setOptions ] = useState< {
+		privacyPolicyPageId: number | null;
+		cartPageId: number | null;
+		shopPageId: number | null;
+		accountPageId: number | null;
+		checkoutPageId: number | null;
+	} | null >( null );
+
+	useEffect( () => {
+		const fetchOptions = async () => {
+			try {
+				const response = await fetch(
+					'/wp-json/page-options/v1/options'
+				);
+				const data = await response.json();
+				setOptions( data );
+			} catch ( error ) {}
+		};
+
+		fetchOptions();
+	}, [] );
+
+	if ( ! options ) {
+		return null; // Or a loader while options are being fetched
+	}
+
+	const {
+		privacyPolicyPageId,
+		cartPageId,
+		shopPageId,
+		accountPageId,
+		checkoutPageId,
+	} = options;
 
 	const renderedTitle = getItemTitle( item );
 
@@ -42,6 +76,38 @@ const TitleView = ( { item }: { item: BasePost } ) => {
 				{ __( 'Posts Page' ) }
 			</span>
 		);
+	} else if ( item.id === Number( privacyPolicyPageId ) ) {
+		suffix = (
+			<span className="edit-site-post-list__title-badge">
+				{ __( 'Privacy Policy' ) }
+			</span>
+		);
+	} else if ( item.id === Number( cartPageId ) ) {
+		suffix = (
+			<span className="edit-site-post-list__title-badge">
+				{ __( 'Cart' ) }
+			</span>
+		);
+	} else if ( item.id === Number( shopPageId ) ) {
+		suffix = (
+			<span className="edit-site-post-list__title-badge">
+				{ __( 'Shop' ) }
+			</span>
+		);
+	} else if ( item.id === Number( accountPageId ) ) {
+		suffix = (
+			<span className="edit-site-post-list__title-badge">
+				{ __( 'Account' ) }
+			</span>
+		);
+	} else if ( item.id === Number( checkoutPageId ) ) {
+		suffix = (
+			<span className="edit-site-post-list__title-badge">
+				{ __( 'Checkout' ) }
+			</span>
+		);
+	} else {
+		suffix = null;
 	}
 
 	return (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/67517

## Why?
Currently, page state is not showing in data view for Privacy policy and WooCommerce pages.

## How?
Added page state label in data view or Privacy policy and WooCommerce pages.

## Testing Instructions

- Go to WP admin dashboard
- Navigate to Appearance->Editor
- Choose Pages from site editor.
- Now the proper page state label will display to Privacy policy and WooCommerce pages if such pages are available.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![beforpostlabel](https://github.com/user-attachments/assets/642cdd1a-6672-4b39-b0df-1ec7034faef8)|![afterpostlabel](https://github.com/user-attachments/assets/40bac434-2d62-42c7-8782-2825cc2d63c6)|


