### PR TITLE
DataViews build-wp: don't bundle the date package

### DIFF
--- a/packages/dataviews/build.js
+++ b/packages/dataviews/build.js
@@ -8,7 +8,7 @@ const wpExternals = {
 	name: 'wordpress-externals',
 	setup( build ) {
 		build.onResolve(
-			{ filter: /^@wordpress\/(data|hooks|i18n)(\/|$)/ },
+			{ filter: /^@wordpress\/(data|hooks|i18n|date)(\/|$)/ },
 			( args ) => {
 				// Don't bundle WordPress signleton packages
 				return { path: args.path, external: true };


### PR DESCRIPTION
Followup to #67590: let's unbundle also the `@wordpress/date` package because internally it has a "settings" object that is also a singleton. These global settings are initialized by the `wp-date-js-after` inline script:

<img width="1087" alt="Screenshot 2024-12-05 at 10 21 54" src="https://github.com/user-attachments/assets/f46a1298-8c86-464f-8b11-12015b4f9daa">

However, if `@wordpress/date` is bundled, it doesn't see these initialized settings. And `getSettings().timezone` is the only thing that the `dataviews/wp` bundle uses: in the `DateTimePicker` component from `components`.

**How to test:**
Build the `dataviews/wp` bundle and verify that the new build doesn't bundle `date` modules. They can be identified by the comment that every bundled module starts with:
```
// ../date/build-module/...
```
These bundled modules should be replaced with
```
import { getSettings as getDateSettings } from "@wordpress/date";
```