### PR TITLE
PostScheduleLabel: Updated the component to return a translatable string for postpublish component.

### DIFF
--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -1742,6 +1742,7 @@ _Parameters_
 
 -   _options_ `Object`: Options for the hook.
 -   _options.full_ `boolean`: Whether to get the full label or not. Default is false.
+-   _options.forPostPublish_ `boolean`: Whether to return a full sentence for post publish panel or not. Default is false.
 
 _Returns_
 

--- a/packages/editor/src/components/post-publish-panel/postpublish.js
+++ b/packages/editor/src/components/post-publish-panel/postpublish.js
@@ -101,8 +101,8 @@ class PostPublishPanelPostpublish extends Component {
 
 		const postPublishNonLinkHeader = isScheduled ? (
 			<>
-				{ __( 'is now scheduled. It will go live on' ) }{ ' ' }
-				<PostScheduleLabel />.
+				{ __( 'is now scheduled.' ) }{ ' ' }
+				<PostScheduleLabel forPostPublish />
 			</>
 		) : (
 			__( 'is now live.' )

--- a/packages/editor/src/components/post-schedule/label.js
+++ b/packages/editor/src/components/post-schedule/label.js
@@ -24,12 +24,16 @@ export default function PostScheduleLabel( props ) {
 /**
  * Custom hook to get the label for post schedule.
  *
- * @param {Object}  options      Options for the hook.
- * @param {boolean} options.full Whether to get the full label or not. Default is false.
+ * @param {Object}  options                Options for the hook.
+ * @param {boolean} options.full           Whether to get the full label or not. Default is false.
+ * @param {boolean} options.forPostPublish Whether to return a full sentence for post publish panel or not. Default is false.
  *
  * @return {string} The label for post schedule.
  */
-export function usePostScheduleLabel( { full = false } = {} ) {
+export function usePostScheduleLabel( {
+	full = false,
+	forPostPublish = false,
+} = {} ) {
 	const { date, isFloating } = useSelect(
 		( select ) => ( {
 			date: select( editorStore ).getEditedPostAttribute( 'date' ),
@@ -38,9 +42,18 @@ export function usePostScheduleLabel( { full = false } = {} ) {
 		[]
 	);
 
-	return full
-		? getFullPostScheduleLabel( date )
-		: getPostScheduleLabel( date, { isFloating } );
+	if ( full ) {
+		return getFullPostScheduleLabel( date );
+	}
+	if ( forPostPublish ) {
+		return sprintf(
+			// translators: %s: It will be a post schedule label like "Today at 5:00 PM".
+			__( 'It will go live on %s.' ),
+			getPostScheduleLabel( date, { isFloating, forPostPublish } )
+		);
+	}
+
+	return getPostScheduleLabel( date, { isFloating, forPostPublish } );
 }
 
 export function getFullPostScheduleLabel( dateAttribute ) {


### PR DESCRIPTION
Description:
1. Added a prop to return a proper translatable string for post publish panel.
2. This doesn't affect any existing usage of the component.

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
As mentioned in the https://github.com/WordPress/gutenberg/issues/67487 issue, we need to break the string mentioned here
https://github.com/WordPress/gutenberg/blob/7e9e53d0581e8f21ad029fb3ffd03f43680326b1/packages/editor/src/components/post-schedule/label.js#L60-L95

Such that translators can easily translate the string.
So I have updated the `usePostScheduleLabel` with a prop for which will be used to identify where we are using this, so that if it's used in the Post Publish Panel, it will return an output which says "It will go live on %s", this allows the translators to translate the string for most of the langugages, providing them better context.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This was mentioned in the following issue https://github.com/WordPress/gutenberg/issues/67487 and also suggested to break the string so it will be easy for translations.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Basically we have broken down the initial string such that now it will be returning a full label with string for the provided post publish panel, while it will work normally for the rest of the instances.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Go to Posts > Add New
2. Write a new post
3. Schedule it to be published tomorrow
4. See the post-publish panel.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-12-05 at 2 48 04 PM](https://github.com/user-attachments/assets/90a78bbc-06f6-4e64-bddc-a282e5bcfbd9)
