### PR TITLE
Keycodes: improve tree shaking by annotating exports as pure

### DIFF
--- a/packages/keycodes/src/index.js
+++ b/packages/keycodes/src/index.js
@@ -211,9 +211,9 @@ export const modifiers = {
  * @type {WPModifierHandler<WPKeyHandler<string>>} Keyed map of functions to raw
  *                                                 shortcuts.
  */
-export const rawShortcut = mapValues(
-	modifiers,
-	( /** @type {WPModifier} */ modifier ) => {
+export const rawShortcut =
+	/* @__PURE__ */
+	mapValues( modifiers, ( /** @type {WPModifier} */ modifier ) => {
 		return /** @type {WPKeyHandler<string>} */ (
 			character,
 			_isApple = isAppleOS
@@ -222,8 +222,7 @@ export const rawShortcut = mapValues(
 				'+'
 			);
 		};
-	}
-);
+	} );
 
 /**
  * Return an array of the parts of a keyboard shortcut chord for display.
@@ -238,9 +237,9 @@ export const rawShortcut = mapValues(
  * @type {WPModifierHandler<WPKeyHandler<string[]>>} Keyed map of functions to
  *                                                   shortcut sequences.
  */
-export const displayShortcutList = mapValues(
-	modifiers,
-	( /** @type {WPModifier} */ modifier ) => {
+export const displayShortcutList =
+	/* @__PURE__ */
+	mapValues( modifiers, ( /** @type {WPModifier} */ modifier ) => {
 		return /** @type {WPKeyHandler<string[]>} */ (
 			character,
 			_isApple = isAppleOS
@@ -268,8 +267,7 @@ export const displayShortcutList = mapValues(
 
 			return [ ...modifierKeys, capitaliseFirstCharacter( character ) ];
 		};
-	}
-);
+	} );
 
 /**
  * An object that contains functions to display shortcuts.
@@ -284,15 +282,17 @@ export const displayShortcutList = mapValues(
  * @type {WPModifierHandler<WPKeyHandler<string>>} Keyed map of functions to
  *                                                 display shortcuts.
  */
-export const displayShortcut = mapValues(
-	displayShortcutList,
-	( /** @type {WPKeyHandler<string[]>} */ shortcutList ) => {
-		return /** @type {WPKeyHandler<string>} */ (
-			character,
-			_isApple = isAppleOS
-		) => shortcutList( character, _isApple ).join( '' );
-	}
-);
+export const displayShortcut =
+	/* @__PURE__ */
+	mapValues(
+		displayShortcutList,
+		( /** @type {WPKeyHandler<string[]>} */ shortcutList ) => {
+			return /** @type {WPKeyHandler<string>} */ (
+				character,
+				_isApple = isAppleOS
+			) => shortcutList( character, _isApple ).join( '' );
+		}
+	);
 
 /**
  * An object that contains functions to return an aria label for a keyboard
@@ -308,9 +308,9 @@ export const displayShortcut = mapValues(
  * @type {WPModifierHandler<WPKeyHandler<string>>} Keyed map of functions to
  *                                                 shortcut ARIA labels.
  */
-export const shortcutAriaLabel = mapValues(
-	modifiers,
-	( /** @type {WPModifier} */ modifier ) => {
+export const shortcutAriaLabel =
+	/* @__PURE__ */
+	mapValues( modifiers, ( /** @type {WPModifier} */ modifier ) => {
 		return /** @type {WPKeyHandler<string>} */ (
 			character,
 			_isApple = isAppleOS
@@ -338,8 +338,7 @@ export const shortcutAriaLabel = mapValues(
 				)
 				.join( isApple ? ' ' : ' + ' );
 		};
-	}
-);
+	} );
 
 /**
  * From a given KeyboardEvent, returns an array of active modifier constants for
@@ -379,9 +378,9 @@ function getEventModifiers( event ) {
  * @type {WPModifierHandler<WPEventKeyHandler>} Keyed map of functions
  *                                                       to match events.
  */
-export const isKeyboardEvent = mapValues(
-	modifiers,
-	( /** @type {WPModifier} */ getModifiers ) => {
+export const isKeyboardEvent =
+	/* @__PURE__ */
+	mapValues( modifiers, ( /** @type {WPModifier} */ getModifiers ) => {
 		return /** @type {WPEventKeyHandler} */ (
 			event,
 			character,
@@ -439,5 +438,4 @@ export const isKeyboardEvent = mapValues(
 
 			return key === character.toLowerCase();
 		};
-	}
-);
+	} );


### PR DESCRIPTION
The `keycodes` package has a few exports whose values are result of a function call:
```js
export const rawShortcut = mapValues( modifiers, createShortcut );
```
The problem with this is that bundlers like esbuild cannot tree shake this code when the `rawShortcut` export is unused. Because the bundler doesn't know if `mapValues` has any side effects.

The [esbuild docs](https://esbuild.github.io/api/#tree-shaking-and-side-effects) recommend using a `/* @__PURE__ */` comment:
```js
export const rawShortcut = /* @__PURE__ */ mapValues( modifiers, createShortcut );
```
They also recommend using an IIFE but in our case the expression is already a `mapValues` function call, so we don't need to wrap it.

The packages has the `sideEffects: false` flag in `package.json` but it doesn't help here.

**How to test:**
This is very visible in the `packages/dataviews/build-wp/index.js` bundle. The only thing that the bundle uses from `keycodes` is the `ESCAPE` constant. But the bundle contains also all the code with possible side effects.

After this PR, the definition of `ESCAPE` is all that remains from `keycodes`.

It would be nice to also test this with webpack, but I didn't do that yet.