### PR TITLE
Remove `__unstableMotionContext` from `@wordpress/components`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   Removed the unused `__unstableMotionContext` export ([#67623](https://github.com/WordPress/gutenberg/pull/67623)).
+
 ### Enhancements
 
 -   `GradientPicker`: Add `enableAlpha` prop ([#66974](https://github.com/WordPress/gutenberg/pull/66974))

--- a/packages/components/src/animation/index.tsx
+++ b/packages/components/src/animation/index.tsx
@@ -9,5 +9,4 @@
 export {
 	motion as __unstableMotion,
 	AnimatePresence as __unstableAnimatePresence,
-	MotionContext as __unstableMotionContext,
 } from 'framer-motion';

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -21,11 +21,7 @@ export {
 	default as Animate,
 	getAnimateClassName as __unstableGetAnimateClassName,
 } from './animate';
-export {
-	__unstableMotion,
-	__unstableAnimatePresence,
-	__unstableMotionContext,
-} from './animation';
+export { __unstableMotion, __unstableAnimatePresence } from './animation';
 export { default as AnglePickerControl } from './angle-picker-control';
 export {
 	default as Autocomplete,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Requires #67522 to be merged first

Remove the `__unstableMotionContext` export from the `@wordpress/components` package.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

As discussed in https://github.com/WordPress/gutenberg/pull/67522#discussion_r1867599876, the export is not needed anymore in Gutenberg, and there are no usages in plugins: Looks like there's no usage in plugins: https://wpdirectory.net/search/01JE66GHXATVJHR1K7PQQG074W.

This also reduces the number of `__unstable*` APIs.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Delete the export.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Make sure the project builds correctly and that there are no usages left across Gutenberg and third party plugins.
