### PR TITLE
Remove words count in the multi-selection inspector

### DIFF
--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -13,12 +13,10 @@ import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
 export default function MultiSelectionInspector() {
-	const { blocks } = useSelect( ( select ) => {
-		const { getMultiSelectedBlocks } = select( blockEditorStore );
-		return {
-			blocks: getMultiSelectedBlocks(),
-		};
-	}, [] );
+	const selectedBlockCount = useSelect(
+		( select ) => select( blockEditorStore ).getSelectedBlockCount(),
+		[]
+	);
 	return (
 		<HStack
 			justify="flex-start"
@@ -29,8 +27,8 @@ export default function MultiSelectionInspector() {
 			<div className="block-editor-multi-selection-inspector__card-title">
 				{ sprintf(
 					/* translators: %d: number of blocks */
-					_n( '%d Block', '%d Blocks', blocks.length ),
-					blocks.length
+					_n( '%d Block', '%d Blocks', selectedBlockCount ),
+					selectedBlockCount
 				) }
 			</div>
 		</HStack>

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -3,9 +3,8 @@
  */
 import { sprintf, _n } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import { serialize } from '@wordpress/blocks';
-import { count as wordCount } from '@wordpress/wordcount';
 import { copy } from '@wordpress/icons';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,27 +19,20 @@ export default function MultiSelectionInspector() {
 			blocks: getMultiSelectedBlocks(),
 		};
 	}, [] );
-	const words = wordCount( serialize( blocks ), 'words' );
-
 	return (
-		<div className="block-editor-multi-selection-inspector__card">
+		<HStack
+			justify="flex-start"
+			spacing={ 2 }
+			className="block-editor-multi-selection-inspector__card"
+		>
 			<BlockIcon icon={ copy } showColors />
-			<div className="block-editor-multi-selection-inspector__card-content">
-				<div className="block-editor-multi-selection-inspector__card-title">
-					{ sprintf(
-						/* translators: %d: number of blocks */
-						_n( '%d Block', '%d Blocks', blocks.length ),
-						blocks.length
-					) }
-				</div>
-				<div className="block-editor-multi-selection-inspector__card-description">
-					{ sprintf(
-						/* translators: %d: number of words */
-						_n( '%d word selected.', '%d words selected.', words ),
-						words
-					) }
-				</div>
+			<div className="block-editor-multi-selection-inspector__card-title">
+				{ sprintf(
+					/* translators: %d: number of blocks */
+					_n( '%d Block', '%d Blocks', blocks.length ),
+					blocks.length
+				) }
 			</div>
-		</div>
+		</HStack>
 	);
 }

--- a/packages/block-editor/src/components/multi-selection-inspector/style.scss
+++ b/packages/block-editor/src/components/multi-selection-inspector/style.scss
@@ -1,25 +1,13 @@
 .block-editor-multi-selection-inspector__card {
-	display: flex;
-	align-items: flex-start;
 	padding: $grid-unit-20;
-}
-
-.block-editor-multi-selection-inspector__card-content {
-	flex-grow: 1;
 }
 
 .block-editor-multi-selection-inspector__card-title {
 	font-weight: 500;
-	margin-bottom: 5px;
-}
-
-.block-editor-multi-selection-inspector__card-description {
-	font-size: $default-font-size;
 }
 
 .block-editor-multi-selection-inspector__card .block-editor-block-icon {
 	margin-left: -2px;
-	margin-right: 10px;
 	padding: 0 3px;
 	width: $button-size;
 	height: $button-size-small;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/67610

## Why?

When two or more blocks are selected, the block inspector shows the amount of selected blocks and the selected words count.

The specific words counts doesn't work properly right now and doesn't provide much value. Additionally given the alternative to properly check the cases with block bindings and controlled blocks is too much work with not much value, this PR removes that.



> When one of more of the selected blocks content is bound to a source, the words count still counts the words in the original content (the block markup) while visually the rendered content comes from the bound source, which likely contains a different amount of words.

## Testing Instructions
1. Select multiple blocks and observe that the words is not shown in the inspector controls card.

