### PR TITLE
Fixed inconsistent design of the Save button

### DIFF
--- a/packages/edit-site/src/components/save-hub/index.js
+++ b/packages/edit-site/src/components/save-hub/index.js
@@ -31,9 +31,9 @@ export default function SaveHub() {
 		<HStack className="edit-site-save-hub" alignment="right" spacing={ 4 }>
 			<SaveButton
 				className="edit-site-save-hub__button"
-				variant={ isDisabled ? null : 'primary' }
+				variant={  'primary' }
 				showTooltip={ false }
-				icon={ isDisabled && ! isSaving ? check : null }
+				icon={  null }
 				showReviewMessage
 				__next40pxDefaultSize
 			/>


### PR DESCRIPTION
Part of #67396 

## What?
Fixed inconsistent design of the Save button in the Site Editor and Preview theme editor


## Screenshots or screencast <!-- if applicable -->
<img width="1440" alt="Untitled" src="https://github.com/user-attachments/assets/1a224b43-8f42-4115-a4b5-06976632f9f6">
<img width="1440" alt="Untitled 2" src="https://github.com/user-attachments/assets/08c1392c-c814-46e5-8842-e6c3cbab6222">

