### PR TITLE
New Block: Add Query Total block for displaying total query results or ranges

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -777,6 +777,16 @@ Display the query title. ([Source](https://github.com/WordPress/gutenberg/tree/t
 -	**Supports:** align (full, wide), color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** level, levelOptions, showPrefix, showSearchTerm, textAlign, type
 
+## Query Total
+
+Display the total number of results in a query. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/query-total))
+
+-	**Name:** core/query-total
+-	**Category:** theme
+-	**Parent:** core/query-pagination, core/query
+-	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
+-	**Attributes:** displayType
+
 ## Quote
 
 Give quoted text visual emphasis. "In quoting others, we cite ourselves." — Julio Cortázar ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/quote))

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -783,7 +783,7 @@ Display the total number of results in a query. ([Source](https://github.com/Wor
 
 -	**Name:** core/query-total
 -	**Category:** theme
--	**Parent:** core/query-pagination, core/query
+-	**Ancestor:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, text), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
 -	**Attributes:** displayType
 

--- a/lib/blocks.php
+++ b/lib/blocks.php
@@ -108,6 +108,7 @@ function gutenberg_reregister_core_block_types() {
 				'query-pagination-numbers.php'     => 'core/query-pagination-numbers',
 				'query-pagination-previous.php'    => 'core/query-pagination-previous',
 				'query-title.php'                  => 'core/query-title',
+				'query-total.php'                  => 'core/query-total',
 				'read-more.php'                    => 'core/read-more',
 				'rss.php'                          => 'core/rss',
 				'search.php'                       => 'core/search',

--- a/packages/block-library/src/index.js
+++ b/packages/block-library/src/index.js
@@ -99,6 +99,7 @@ import * as queryPaginationNext from './query-pagination-next';
 import * as queryPaginationNumbers from './query-pagination-numbers';
 import * as queryPaginationPrevious from './query-pagination-previous';
 import * as queryTitle from './query-title';
+import * as queryTotal from './query-total';
 import * as quote from './quote';
 import * as reusableBlock from './block';
 import * as readMore from './read-more';
@@ -211,6 +212,7 @@ const getAllBlocks = () => {
 		queryPaginationNumbers,
 		queryPaginationPrevious,
 		queryNoResults,
+		queryTotal,
 		readMore,
 		comments,
 		commentAuthorName,

--- a/packages/block-library/src/query-total/block.json
+++ b/packages/block-library/src/query-total/block.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "https://schemas.wp.org/trunk/block.json",
+	"apiVersion": 2,
+	"name": "core/query-total",
+	"title": "Query Total",
+	"category": "theme",
+	"parent": [ "core/query-pagination", "core/query" ],
+	"description": "Display the total number of results in a query.",
+	"textdomain": "default",
+	"attributes": {
+		"displayType": {
+			"type": "string",
+			"default": "total-results"
+		}
+	},
+	"usesContext": [ "queryId", "query" ],
+	"supports": {
+		"align": [ "wide", "full" ],
+		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true
+		},
+		"color": {
+			"gradients": true,
+			"text": true,
+			"__experimentalDefaultControls": {
+				"background": true
+			}
+		},
+		"typography": {
+			"fontSize": true,
+			"lineHeight": true,
+			"__experimentalFontFamily": true,
+			"__experimentalFontWeight": true,
+			"__experimentalFontStyle": true,
+			"__experimentalTextTransform": true,
+			"__experimentalTextDecoration": true,
+			"__experimentalLetterSpacing": true,
+			"__experimentalDefaultControls": {
+				"fontSize": true
+			}
+		}
+	}
+}

--- a/packages/block-library/src/query-total/block.json
+++ b/packages/block-library/src/query-total/block.json
@@ -4,7 +4,7 @@
 	"name": "core/query-total",
 	"title": "Query Total",
 	"category": "theme",
-	"parent": [ "core/query-pagination", "core/query" ],
+	"ancestor": [ "core/query" ],
 	"description": "Display the total number of results in a query.",
 	"textdomain": "default",
 	"attributes": {

--- a/packages/block-library/src/query-total/block.json
+++ b/packages/block-library/src/query-total/block.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://schemas.wp.org/trunk/block.json",
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "core/query-total",
 	"title": "Query Total",
 	"category": "theme",

--- a/packages/block-library/src/query-total/edit.js
+++ b/packages/block-library/src/query-total/edit.js
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
+ * WordPress dependencies
+ */
+import {
+	useBlockProps,
+	InspectorControls,
+	BlockControls,
+} from '@wordpress/block-editor';
+import {
+	PanelBody,
+	ToolbarGroup,
+	ToolbarDropdownMenu,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { resultsFound, displayingResults } from './icons';
+
+export default function QueryTotalEdit( {
+	attributes,
+	setAttributes,
+	className,
+} ) {
+	const { displayType } = attributes;
+
+	const [ totalResults, setTotalResults ] = useState( 0 );
+	const [ currentPage, setCurrentPage ] = useState( 1 );
+	const [ resultsPerPage, setResultsPerPage ] = useState( 10 );
+
+	// Fetch or calculate the total results, current page, and results per page.
+	useEffect( () => {
+		// Mock values for demonstration. Replace with actual query data.
+		const mockTotalResults = 12;
+		const mockCurrentPage = 1;
+		const mockResultsPerPage = 10;
+
+		setTotalResults( mockTotalResults );
+		setCurrentPage( mockCurrentPage );
+		setResultsPerPage( mockResultsPerPage );
+	}, [] );
+
+	// Helper to calculate the range for "Displaying X – Y of Z".
+	const calculateRange = () => {
+		const start = ( currentPage - 1 ) * resultsPerPage + 1;
+		const end = Math.min( currentPage * resultsPerPage, totalResults );
+		return `${ start } – ${ end }`;
+	};
+
+	// Block properties and classes.
+	const blockProps = useBlockProps( {
+		className: clsx( className, 'query-total-block' ),
+	} );
+
+	const getButtonPositionIcon = () => {
+		switch ( displayType ) {
+			case 'total-results':
+				return resultsFound;
+			case 'range-display':
+				return displayingResults;
+		}
+	};
+
+	const buttonPositionControls = [
+		{
+			role: 'menuitemradio',
+			title: __( 'Total results' ),
+			isActive: displayType === 'total-results',
+			icon: resultsFound,
+			onClick: () => {
+				setAttributes( { displayType: 'total-results' } );
+			},
+		},
+		{
+			role: 'menuitemradio',
+			title: __( 'Range display' ),
+			isActive: displayType === 'range-display',
+			icon: displayingResults,
+			onClick: () => {
+				setAttributes( { displayType: 'range-display' } );
+			},
+		},
+	];
+
+	// Controls for the block.
+	const controls = (
+		<>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarDropdownMenu
+						icon={ getButtonPositionIcon() }
+						label={ __( 'Change display type' ) }
+						controls={ buttonPositionControls }
+					/>
+				</ToolbarGroup>
+			</BlockControls>
+			<InspectorControls>
+				<PanelBody title={ __( 'Display Settings' ) }>
+					<p>
+						{ __( 'Choose the type of information to display.' ) }
+					</p>
+				</PanelBody>
+			</InspectorControls>
+		</>
+	);
+
+	// Render output based on the selected display type.
+	const renderDisplay = () => {
+		if ( displayType === 'total-results' ) {
+			return <div>{ `${ totalResults } results found` }</div>;
+		}
+
+		if ( displayType === 'range-display' ) {
+			return (
+				<div>{ `Displaying ${ calculateRange() } of ${ totalResults }` }</div>
+			);
+		}
+
+		return null;
+	};
+
+	return (
+		<div { ...blockProps }>
+			{ controls }
+			{ renderDisplay() }
+		</div>
+	);
+}

--- a/packages/block-library/src/query-total/edit.js
+++ b/packages/block-library/src/query-total/edit.js
@@ -11,7 +11,7 @@ import {
 	ToolbarGroup,
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -20,18 +20,6 @@ import { resultsFound, displayingResults } from './icons';
 
 export default function QueryTotalEdit( { attributes, setAttributes } ) {
 	const { displayType } = attributes;
-
-	// Mock values.
-	const totalResults = 12;
-	const currentPage = 1;
-	const resultsPerPage = 10;
-
-	// Helper to calculate the range for "Displaying X – Y of Z".
-	const calculateRange = () => {
-		const start = ( currentPage - 1 ) * resultsPerPage + 1;
-		const end = Math.min( currentPage * resultsPerPage, totalResults );
-		return `${ start } – ${ end }`;
-	};
 
 	// Block properties and classes.
 	const blockProps = useBlockProps();
@@ -91,28 +79,11 @@ export default function QueryTotalEdit( { attributes, setAttributes } ) {
 	// Render output based on the selected display type.
 	const renderDisplay = () => {
 		if ( displayType === 'total-results' ) {
-			return (
-				<div>
-					{ sprintf(
-						/* translators: %d is the total number of results found. */
-						__( '%d results found' ),
-						totalResults
-					) }
-				</div>
-			);
+			return <div>{ __( '12 results found' ) }</div>;
 		}
 
 		if ( displayType === 'range-display' ) {
-			return (
-				<div>
-					{ sprintf(
-						/* translators: %1$s is the range (e.g., 1–10), %2$d is the total number of results. */
-						__( 'Displaying %1$s of %2$d' ),
-						calculateRange(),
-						totalResults
-					) }
-				</div>
-			);
+			return <div>{ __( 'Displaying 1 – 10 of 12' ) }</div>;
 		}
 
 		return null;

--- a/packages/block-library/src/query-total/edit.js
+++ b/packages/block-library/src/query-total/edit.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import {
@@ -16,36 +11,20 @@ import {
 	ToolbarGroup,
 	ToolbarDropdownMenu,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
-import { useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { resultsFound, displayingResults } from './icons';
 
-export default function QueryTotalEdit( {
-	attributes,
-	setAttributes,
-	className,
-} ) {
+export default function QueryTotalEdit( { attributes, setAttributes } ) {
 	const { displayType } = attributes;
 
-	const [ totalResults, setTotalResults ] = useState( 0 );
-	const [ currentPage, setCurrentPage ] = useState( 1 );
-	const [ resultsPerPage, setResultsPerPage ] = useState( 10 );
-
-	// Fetch or calculate the total results, current page, and results per page.
-	useEffect( () => {
-		// Mock values for demonstration. Replace with actual query data.
-		const mockTotalResults = 12;
-		const mockCurrentPage = 1;
-		const mockResultsPerPage = 10;
-
-		setTotalResults( mockTotalResults );
-		setCurrentPage( mockCurrentPage );
-		setResultsPerPage( mockResultsPerPage );
-	}, [] );
+	// Mock values.
+	const totalResults = 12;
+	const currentPage = 1;
+	const resultsPerPage = 10;
 
 	// Helper to calculate the range for "Displaying X – Y of Z".
 	const calculateRange = () => {
@@ -55,9 +34,7 @@ export default function QueryTotalEdit( {
 	};
 
 	// Block properties and classes.
-	const blockProps = useBlockProps( {
-		className: clsx( className, 'query-total-block' ),
-	} );
+	const blockProps = useBlockProps();
 
 	const getButtonPositionIcon = () => {
 		switch ( displayType ) {
@@ -114,12 +91,27 @@ export default function QueryTotalEdit( {
 	// Render output based on the selected display type.
 	const renderDisplay = () => {
 		if ( displayType === 'total-results' ) {
-			return <div>{ `${ totalResults } results found` }</div>;
+			return (
+				<div>
+					{ sprintf(
+						/* translators: %d is the total number of results found. */
+						__( '%d results found' ),
+						totalResults
+					) }
+				</div>
+			);
 		}
 
 		if ( displayType === 'range-display' ) {
 			return (
-				<div>{ `Displaying ${ calculateRange() } of ${ totalResults }` }</div>
+				<div>
+					{ sprintf(
+						/* translators: %1$s is the range (e.g., 1–10), %2$d is the total number of results. */
+						__( 'Displaying %1$s of %2$d' ),
+						calculateRange(),
+						totalResults
+					) }
+				</div>
 			);
 		}
 

--- a/packages/block-library/src/query-total/edit.js
+++ b/packages/block-library/src/query-total/edit.js
@@ -1,16 +1,8 @@
 /**
  * WordPress dependencies
  */
-import {
-	useBlockProps,
-	InspectorControls,
-	BlockControls,
-} from '@wordpress/block-editor';
-import {
-	PanelBody,
-	ToolbarGroup,
-	ToolbarDropdownMenu,
-} from '@wordpress/components';
+import { useBlockProps, BlockControls } from '@wordpress/block-editor';
+import { ToolbarGroup, ToolbarDropdownMenu } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -66,13 +58,6 @@ export default function QueryTotalEdit( { attributes, setAttributes } ) {
 					/>
 				</ToolbarGroup>
 			</BlockControls>
-			<InspectorControls>
-				<PanelBody title={ __( 'Display Settings' ) }>
-					<p>
-						{ __( 'Choose the type of information to display.' ) }
-					</p>
-				</PanelBody>
-			</InspectorControls>
 		</>
 	);
 

--- a/packages/block-library/src/query-total/icons.js
+++ b/packages/block-library/src/query-total/icons.js
@@ -29,4 +29,15 @@ export const displayingResults = (
 	</SVG>
 );
 
-export const queryTotal = <span>&#931;</span>;
+export const queryTotal = (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<Path d="M18 4H6c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h12c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2Zm.5 14c0 .3-.2.5-.5.5H6c-.3 0-.5-.2-.5-.5V6c0-.3.2-.5.5-.5h12c.3 0 .5.2.5.5v12Zm-7-6-4.1 5h8.8v-3h-1.5v1.5h-4.2l2.9-3.5-2.9-3.5h4.2V10h1.5V7H7.4l4.1 5Z" />
+	</SVG>
+);

--- a/packages/block-library/src/query-total/icons.js
+++ b/packages/block-library/src/query-total/icons.js
@@ -1,0 +1,32 @@
+/**
+ * WordPress dependencies
+ */
+import { SVG, Path } from '@wordpress/components';
+
+export const resultsFound = (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<Path d="M4 11h4v2H4v-2zm6 0h6v2h-6v-2zm8 0h2v2h-2v-2z" />
+	</SVG>
+);
+
+export const displayingResults = (
+	<SVG
+		xmlns="http://www.w3.org/2000/svg"
+		viewBox="0 0 24 24"
+		width="24"
+		height="24"
+		aria-hidden="true"
+		focusable="false"
+	>
+		<Path d="M4 13h2v-2H4v2zm4 0h10v-2H8v2zm12 0h2v-2h-2v2z" />
+	</SVG>
+);
+
+export const queryTotal = <span>&#931;</span>;

--- a/packages/block-library/src/query-total/index.js
+++ b/packages/block-library/src/query-total/index.js
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './edit';
+import initBlock from '../utils/init-block';
+import { queryTotal } from './icons';
+
+/* Block settings */
+const { name } = metadata;
+export { metadata, name };
+
+export const settings = {
+	icon: queryTotal,
+	edit,
+};
+
+export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -38,15 +38,6 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	// Prepare the display based on the `displayType` attribute.
 	$output = '';
 	switch ( $attributes['displayType'] ) {
-		case 'total-results':
-		default:
-			$output = sprintf(
-				'<p><strong>%d</strong> %s</p>',
-				$max_rows,
-				_n( 'result found', 'results found', $max_rows )
-			);
-			break;
-
 		case 'range-display':
 			if ( $start === $end ) {
 				$range_text = sprintf(
@@ -66,6 +57,15 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 			}
 
 			$output = sprintf( '<p>%s</p>', $range_text );
+			break;
+
+		case 'total-results':
+		default:
+			$output = sprintf(
+				'<p><strong>%d</strong> %s</p>',
+				$max_rows,
+				_n( 'result found', 'results found', $max_rows )
+			);
 			break;
 	}
 

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -7,6 +7,8 @@
 
 /**
  * Renders the `query-total` block on the server.
+ * 
+ * @since 6.7.0
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
@@ -70,6 +72,8 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 
 /**
  * Registers the `query-total` block.
+ * 
+ * @since 6.7.0
  */
 function register_block_core_query_total() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -8,7 +8,7 @@
 /**
  * Renders the `query-total` block on the server.
  *
- * @since 6.7.0
+ * @since 6.8.0
  *
  * @param array    $attributes Block attributes.
  * @param string   $content    Block default content.
@@ -73,7 +73,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 /**
  * Registers the `query-total` block.
  *
- * @since 6.7.0
+ * @since 6.8.0
  */
 function register_block_core_query_total() {
 	register_block_type_from_metadata(

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -42,25 +42,27 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 			$output = sprintf(
 				'<p><strong>%d</strong> %s</p>',
 				$max_rows,
-				_n( 'result found', 'results found', $max_rows, 'default' )
+				_n( 'result found', 'results found', $max_rows )
 			);
 			break;
 
 		case 'range-display':
-			$range_text = $start === $end
-				? sprintf(
+			if ( $start === $end ) {
+				$range_text = sprintf(
 					/* translators: 1: Start index of posts, 2: Total number of posts */
-					__( 'Displaying <strong>%1$d</strong> of <strong>%2$d</strong>', 'default' ),
-					$start,
-					$max_rows
-				)
-				: sprintf(
-					/* translators: 1: Start index of posts, 2: End index of posts, 3: Total number of posts */
-					__( 'Displaying <strong>%1$d – %2$d</strong> of <strong>%3$d</strong>', 'default' ),
-					$start,
-					$end,
-					$max_rows
+					__( 'Displaying %1$s of %2$s' ),
+					'<strong>' . $start . '</strong>',
+					'<strong>' . $max_rows . '</strong>'
 				);
+			} else {
+				$range_text = sprintf(
+					/* translators: 1: Start index of posts, 2: End index of posts, 3: Total number of posts */
+					__( 'Displaying %1$s – %2$s of %3$s' ),
+					'<strong>' . $start . '</strong>',
+					'<strong>' . $end . '</strong>',
+					'<strong>' . $max_rows . '</strong>'
+				);
+			}
 
 			$output = sprintf( '<p>%s</p>', $range_text );
 			break;
@@ -69,7 +71,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 			$output = sprintf(
 				'<p><strong>%d</strong> %s</p>',
 				$max_rows,
-				_n( 'result found', 'results found', $max_rows, 'default' )
+				_n( 'result found', 'results found', $max_rows )
 			);
 			break;
 	}

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -40,25 +40,36 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	switch ( $attributes['displayType'] ) {
 		case 'total-results':
 			$output = sprintf(
-				'<p><strong>%d</strong> %s found</p>',
+				'<p><strong>%d</strong> %s</p>',
 				$max_rows,
-				_n( 'result', 'results', $max_rows, 'default' )
+				_n( 'result found', 'results found', $max_rows, 'default' )
 			);
 			break;
 
 		case 'range-display':
 			$range_text = $start === $end
-				? sprintf( 'Displaying <strong>%d</strong> of <strong>%d</strong>', $start, $max_rows )
-				: sprintf( 'Displaying <strong>%d – %d</strong> of <strong>%d</strong>', $start, $end, $max_rows );
+				? sprintf(
+					/* translators: 1: Start index of posts, 2: Total number of posts */
+					__( 'Displaying <strong>%1$d</strong> of <strong>%2$d</strong>', 'default' ),
+					$start,
+					$max_rows
+				)
+				: sprintf(
+					/* translators: 1: Start index of posts, 2: End index of posts, 3: Total number of posts */
+					__( 'Displaying <strong>%1$d – %2$d</strong> of <strong>%3$d</strong>', 'default' ),
+					$start,
+					$end,
+					$max_rows
+				);
 
 			$output = sprintf( '<p>%s</p>', $range_text );
 			break;
 
 		default:
 			$output = sprintf(
-				'<p><strong>%d</strong> %s found</p>',
+				'<p><strong>%d</strong> %s</p>',
 				$max_rows,
-				_n( 'result', 'results', $max_rows, 'default' )
+				_n( 'result found', 'results found', $max_rows, 'default' )
 			);
 			break;
 	}

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Server-side rendering of the `core/query-total` block.
+ *
+ * @package WordPress
+ */
+
+/**
+ * Renders the `query-total` block on the server.
+ *
+ * @param array    $attributes Block attributes.
+ * @param string   $content    Block default content.
+ * @param WP_Block $block      Block instance.
+ *
+ * @return string The rendered block content.
+ */
+function render_block_core_query_total( $attributes, $content, $block ) {
+	global $wp_query;
+	$wrapper_attributes = get_block_wrapper_attributes();
+	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
+		$query_to_use = $wp_query;
+		$current_page   = max( 1, get_query_var( 'paged', 1 ) );
+	} else {
+		$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
+		$current_page = isset( $_GET[ $page_key ] ) ? (int) $_GET[ $page_key ] : 1;
+		$query_to_use = new WP_Query( build_query_vars_from_query_block( $block, $current_page ) );
+	}
+
+	$max_rows = $query_to_use->found_posts;
+	$posts_per_page = $query_to_use->get( 'posts_per_page' );
+
+	// Calculate the range of posts being displayed.
+	$start = ( $current_page - 1 ) * $posts_per_page + 1;
+	$end   = min( $start + $posts_per_page - 1, $max_rows );
+
+	// Prepare the display based on the `displayType` attribute.
+	$output = '';
+	switch ( $attributes['displayType'] ) {
+		case 'total-results':
+			$output = sprintf(
+				'<p><strong>%d</strong> %s found</p>',
+				$max_rows,
+				_n( 'result', 'results', $max_rows, 'default' )
+			);
+			break;
+
+		case 'range-display':
+			$range_text = $start === $end
+				? sprintf( 'Displaying <strong>%d</strong> of <strong>%d</strong>', $start, $max_rows )
+				: sprintf( 'Displaying <strong>%d – %d</strong> of <strong>%d</strong>', $start, $end, $max_rows );
+
+			$output = sprintf( '<p>%s</p>', $range_text );
+			break;
+
+		default:
+			$output = sprintf(
+				'<p><strong>%d</strong> %s found</p>',
+				$max_rows,
+				_n( 'result', 'results', $max_rows, 'default' )
+			);
+			break;
+	}
+
+	return sprintf(
+		'<div %1$s>%2$s</div>',
+		$wrapper_attributes,
+		$output
+	);
+}
+
+/**
+ * Registers the `query-total` block.
+ */
+function register_block_core_query_total() {
+	register_block_type_from_metadata(
+		__DIR__ . '/query-total',
+		array(
+			'render_callback' => 'render_block_core_query_total',
+		)
+	);
+}
+add_action( 'init', 'register_block_core_query_total' );

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -7,7 +7,7 @@
 
 /**
  * Renders the `query-total` block on the server.
- * 
+ *
  * @since 6.7.0
  *
  * @param array    $attributes Block attributes.
@@ -72,7 +72,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 
 /**
  * Registers the `query-total` block.
- * 
+ *
  * @since 6.7.0
  */
 function register_block_core_query_total() {

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -39,6 +39,7 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	$output = '';
 	switch ( $attributes['displayType'] ) {
 		case 'total-results':
+		default:
 			$output = sprintf(
 				'<p><strong>%d</strong> %s</p>',
 				$max_rows,
@@ -65,14 +66,6 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 			}
 
 			$output = sprintf( '<p>%s</p>', $range_text );
-			break;
-
-		default:
-			$output = sprintf(
-				'<p><strong>%d</strong> %s</p>',
-				$max_rows,
-				_n( 'result found', 'results found', $max_rows )
-			);
 			break;
 	}
 

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -19,14 +19,14 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	$wrapper_attributes = get_block_wrapper_attributes();
 	if ( isset( $block->context['query']['inherit'] ) && $block->context['query']['inherit'] ) {
 		$query_to_use = $wp_query;
-		$current_page   = max( 1, get_query_var( 'paged', 1 ) );
+		$current_page = max( 1, get_query_var( 'paged', 1 ) );
 	} else {
-		$page_key = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
+		$page_key     = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 		$current_page = isset( $_GET[ $page_key ] ) ? (int) $_GET[ $page_key ] : 1;
 		$query_to_use = new WP_Query( build_query_vars_from_query_block( $block, $current_page ) );
 	}
 
-	$max_rows = $query_to_use->found_posts;
+	$max_rows       = $query_to_use->found_posts;
 	$posts_per_page = $query_to_use->get( 'posts_per_page' );
 
 	// Calculate the range of posts being displayed.

--- a/packages/block-library/src/query-total/init.js
+++ b/packages/block-library/src/query-total/init.js
@@ -1,0 +1,6 @@
+/**
+ * Internal dependencies
+ */
+import { init } from './';
+
+export default init();

--- a/test/integration/fixtures/blocks/core__query-total.html
+++ b/test/integration/fixtures/blocks/core__query-total.html
@@ -1,0 +1,1 @@
+<!-- wp:query-total /-->

--- a/test/integration/fixtures/blocks/core__query-total.json
+++ b/test/integration/fixtures/blocks/core__query-total.json
@@ -1,0 +1,10 @@
+[
+	{
+		"name": "core/query-total",
+		"isValid": true,
+		"attributes": {
+			"displayType": "total-results"
+		},
+		"innerBlocks": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__query-total.parsed.json
+++ b/test/integration/fixtures/blocks/core__query-total.parsed.json
@@ -1,0 +1,9 @@
+[
+	{
+		"blockName": "core/query-total",
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "",
+		"innerContent": []
+	}
+]

--- a/test/integration/fixtures/blocks/core__query-total.serialized.html
+++ b/test/integration/fixtures/blocks/core__query-total.serialized.html
@@ -1,0 +1,1 @@
+<!-- wp:query-total /-->


### PR DESCRIPTION
Closes: #62423

## What?
This PR adds a core/query-total block to display query-related information, such as the total number of results or the range of results currently displayed.

## Why?
Currently, there is no block that displays the total number of query results or the range of displayed results, limiting users' ability to convey query information effectively. This block enhances usability and customization options in the block editor.

## How?

- Block Features
  - Attributes: Includes `displayType` to toggle between "Total Results" and "Range Display."
  - Server-Side Rendering: Dynamic data fetched using `query context` (queryId, query).
  - Customization: Supports typography, color, spacing, and alignment options.
- Key Functionalities
  - "Total Results" mode: Displays the total number of query results.
  - "Range Display" mode: Shows the current range and total number of results.

## Testing Instructions

1. Add a Query Loop block to a post or page.
2. Insert the Query Total block inside or alongside the Query Loop.
3. Set the `displayType` attribute to "Total Results" or "Range Display" via block controls.
4. Preview and verify the output:
5. Ensure total results are displayed correctly in "Total Results" mode.
6. Verify range calculations in "Range Display" mode.
7. Test with various query contexts to ensure accurate dynamic rendering.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f9497eab-552a-4586-b7c3-1c19ddda821c


<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. 

|Before|After|
|-|-| -->
<!-- | Before screenshot here | --><!-- After screenshot here | -->
