### PR TITLE
Menu granular subcomponents: refactor Storybook

### DIFF
--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -44,10 +44,15 @@ const meta: Meta< typeof Menu > = {
 		ItemLabel: Menu.ItemLabel,
 		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
 		ItemHelpText: Menu.ItemHelpText,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		TriggerButton: Menu.TriggerButton,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		SubmenuTriggerItem: Menu.SubmenuTriggerItem,
+		// @ts-expect-error - See https://github.com/storybookjs/storybook/issues/23170
+		Popover: Menu.Popover,
 	},
 	argTypes: {
 		children: { control: { type: null } },
-		trigger: { control: { type: null } },
 	},
 	tags: [ 'status-private' ],
 	parameters: {
@@ -63,86 +68,94 @@ export default meta;
 
 export const Default: StoryFn< typeof Menu > = ( props ) => (
 	<Menu { ...props }>
-		<Menu.Item>
-			<Menu.ItemLabel>Label</Menu.ItemLabel>
-		</Menu.Item>
-		<Menu.Item>
-			<Menu.ItemLabel>Label</Menu.ItemLabel>
-			<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
-		</Menu.Item>
-		<Menu.Item>
-			<Menu.ItemLabel>Label</Menu.ItemLabel>
-			<Menu.ItemHelpText>
-				The menu item help text is automatically truncated when there
-				are more than two lines of text
-			</Menu.ItemHelpText>
-		</Menu.Item>
-		<Menu.Item hideOnClick={ false }>
-			<Menu.ItemLabel>Label</Menu.ItemLabel>
-			<Menu.ItemHelpText>
-				This item doesn&apos;t close the menu on click
-			</Menu.ItemHelpText>
-		</Menu.Item>
-		<Menu.Item disabled>Disabled item</Menu.Item>
-		<Menu.Separator />
-		<Menu.Group>
-			<Menu.GroupLabel>Group label</Menu.GroupLabel>
-			<Menu.Item prefix={ <Icon icon={ customLink } size={ 24 } /> }>
-				<Menu.ItemLabel>With prefix</Menu.ItemLabel>
+		<Menu.TriggerButton
+			render={ <Button __next40pxDefaultSize variant="secondary" /> }
+		>
+			Open menu
+		</Menu.TriggerButton>
+		<Menu.Popover>
+			<Menu.Item>
+				<Menu.ItemLabel>Label</Menu.ItemLabel>
 			</Menu.Item>
-			<Menu.Item suffix="⌘S">With suffix</Menu.Item>
-			<Menu.Item
-				disabled
-				prefix={ <Icon icon={ formatCapitalize } size={ 24 } /> }
-				suffix="⌥⌘T"
-			>
-				<Menu.ItemLabel>Disabled with prefix and suffix</Menu.ItemLabel>
-				<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
+			<Menu.Item>
+				<Menu.ItemLabel>Label</Menu.ItemLabel>
+				<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
 			</Menu.Item>
-		</Menu.Group>
+			<Menu.Item>
+				<Menu.ItemLabel>Label</Menu.ItemLabel>
+				<Menu.ItemHelpText>
+					The menu item help text is automatically truncated when
+					there are more than two lines of text
+				</Menu.ItemHelpText>
+			</Menu.Item>
+			<Menu.Item hideOnClick={ false }>
+				<Menu.ItemLabel>Label</Menu.ItemLabel>
+				<Menu.ItemHelpText>
+					This item doesn&apos;t close the menu on click
+				</Menu.ItemHelpText>
+			</Menu.Item>
+			<Menu.Item disabled>Disabled item</Menu.Item>
+			<Menu.Separator />
+			<Menu.Group>
+				<Menu.GroupLabel>Group label</Menu.GroupLabel>
+				<Menu.Item prefix={ <Icon icon={ customLink } size={ 24 } /> }>
+					<Menu.ItemLabel>With prefix</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.Item suffix="⌘S">With suffix</Menu.Item>
+				<Menu.Item
+					disabled
+					prefix={ <Icon icon={ formatCapitalize } size={ 24 } /> }
+					suffix="⌥⌘T"
+				>
+					<Menu.ItemLabel>
+						Disabled with prefix and suffix
+					</Menu.ItemLabel>
+					<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
+				</Menu.Item>
+			</Menu.Group>
+		</Menu.Popover>
 	</Menu>
 );
-Default.args = {
-	trigger: (
-		<Button __next40pxDefaultSize variant="secondary">
-			Open menu
-		</Button>
-	),
-};
+Default.args = {};
 
 export const WithSubmenu: StoryFn< typeof Menu > = ( props ) => (
 	<Menu { ...props }>
-		<Menu.Item>Level 1 item</Menu.Item>
-		<Menu
-			trigger={
-				<Menu.Item suffix="Suffix">
+		<Menu.TriggerButton
+			render={ <Button __next40pxDefaultSize variant="secondary" /> }
+		>
+			Open menu
+		</Menu.TriggerButton>
+		<Menu.Popover>
+			<Menu.Item>Level 1 item</Menu.Item>
+			<Menu>
+				<Menu.SubmenuTriggerItem suffix="Suffix">
 					<Menu.ItemLabel>
 						Submenu trigger item with a long label
 					</Menu.ItemLabel>
-				</Menu.Item>
-			}
-		>
-			<Menu.Item>
-				<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-			</Menu.Item>
-			<Menu.Item>
-				<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-			</Menu.Item>
-			<Menu
-				trigger={
+				</Menu.SubmenuTriggerItem>
+				<Menu.Popover>
 					<Menu.Item>
-						<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
+						<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
 					</Menu.Item>
-				}
-			>
-				<Menu.Item>
-					<Menu.ItemLabel>Level 3 item</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item>
-					<Menu.ItemLabel>Level 3 item</Menu.ItemLabel>
-				</Menu.Item>
+					<Menu.Item>
+						<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu>
+						<Menu.SubmenuTriggerItem>
+							<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
+						</Menu.SubmenuTriggerItem>
+						<Menu.Popover>
+							<Menu.Item>
+								<Menu.ItemLabel>Level 3 item</Menu.ItemLabel>
+							</Menu.Item>
+							<Menu.Item>
+								<Menu.ItemLabel>Level 3 item</Menu.ItemLabel>
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</Menu.Popover>
 			</Menu>
-		</Menu>
+		</Menu.Popover>
 	</Menu>
 );
 WithSubmenu.args = {
@@ -169,94 +182,113 @@ export const WithCheckboxes: StoryFn< typeof Menu > = ( props ) => {
 
 	return (
 		<Menu { ...props }>
-			<Menu.Group>
-				<Menu.GroupLabel>
-					Single selection, uncontrolled
-				</Menu.GroupLabel>
-				<Menu.CheckboxItem
-					name="checkbox-individual-uncontrolled-a"
-					value="a"
-					suffix="⌥⌘T"
-				>
-					<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-				<Menu.CheckboxItem
-					name="checkbox-individual-uncontrolled-b"
-					value="b"
-					defaultChecked
-				>
-					<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-			</Menu.Group>
-			<Menu.Separator />
-			<Menu.Group>
-				<Menu.GroupLabel>Single selection, controlled</Menu.GroupLabel>
-				<Menu.CheckboxItem
-					name="checkbox-individual-controlled-a"
-					value="a"
-					checked={ isAChecked }
-					onChange={ ( e ) => setAChecked( e.target.checked ) }
-				>
-					<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-				<Menu.CheckboxItem
-					name="checkbox-individual-controlled-b"
-					value="b"
-					checked={ isBChecked }
-					onChange={ ( e ) => setBChecked( e.target.checked ) }
-				>
-					<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-			</Menu.Group>
-			<Menu.Separator />
-			<Menu.Group>
-				<Menu.GroupLabel>
-					Multiple selection, uncontrolled
-				</Menu.GroupLabel>
-				<Menu.CheckboxItem
-					name="checkbox-multiple-uncontrolled"
-					value="a"
-				>
-					<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-				<Menu.CheckboxItem
-					name="checkbox-multiple-uncontrolled"
-					value="b"
-					defaultChecked
-				>
-					<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-			</Menu.Group>
-			<Menu.Separator />
-			<Menu.Group>
-				<Menu.GroupLabel>
-					Multiple selection, controlled
-				</Menu.GroupLabel>
-				<Menu.CheckboxItem
-					name="checkbox-multiple-controlled"
-					value="a"
-					checked={ multipleCheckboxesValue.includes( 'a' ) }
-					onChange={ onMultipleCheckboxesCheckedChange }
-				>
-					<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-				<Menu.CheckboxItem
-					name="checkbox-multiple-controlled"
-					value="b"
-					checked={ multipleCheckboxesValue.includes( 'b' ) }
-					onChange={ onMultipleCheckboxesCheckedChange }
-				>
-					<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-				</Menu.CheckboxItem>
-			</Menu.Group>
+			<Menu.TriggerButton
+				render={ <Button __next40pxDefaultSize variant="secondary" /> }
+			>
+				Open menu
+			</Menu.TriggerButton>
+			<Menu.Popover>
+				<Menu.Group>
+					<Menu.GroupLabel>
+						Single selection, uncontrolled
+					</Menu.GroupLabel>
+					<Menu.CheckboxItem
+						name="checkbox-individual-uncontrolled-a"
+						value="a"
+						suffix="⌥⌘T"
+					>
+						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							Initially unchecked
+						</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+					<Menu.CheckboxItem
+						name="checkbox-individual-uncontrolled-b"
+						value="b"
+						defaultChecked
+					>
+						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+				</Menu.Group>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.GroupLabel>
+						Single selection, controlled
+					</Menu.GroupLabel>
+					<Menu.CheckboxItem
+						name="checkbox-individual-controlled-a"
+						value="a"
+						checked={ isAChecked }
+						onChange={ ( e ) => {
+							setAChecked( e.target.checked );
+						} }
+					>
+						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							Initially unchecked
+						</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+					<Menu.CheckboxItem
+						name="checkbox-individual-controlled-b"
+						value="b"
+						checked={ isBChecked }
+						onChange={ ( e ) => setBChecked( e.target.checked ) }
+					>
+						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+				</Menu.Group>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.GroupLabel>
+						Multiple selection, uncontrolled
+					</Menu.GroupLabel>
+					<Menu.CheckboxItem
+						name="checkbox-multiple-uncontrolled"
+						value="a"
+					>
+						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							Initially unchecked
+						</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+					<Menu.CheckboxItem
+						name="checkbox-multiple-uncontrolled"
+						value="b"
+						defaultChecked
+					>
+						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+				</Menu.Group>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.GroupLabel>
+						Multiple selection, controlled
+					</Menu.GroupLabel>
+					<Menu.CheckboxItem
+						name="checkbox-multiple-controlled"
+						value="a"
+						checked={ multipleCheckboxesValue.includes( 'a' ) }
+						onChange={ onMultipleCheckboxesCheckedChange }
+					>
+						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							Initially unchecked
+						</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+					<Menu.CheckboxItem
+						name="checkbox-multiple-controlled"
+						value="b"
+						checked={ multipleCheckboxesValue.includes( 'b' ) }
+						onChange={ onMultipleCheckboxesCheckedChange }
+					>
+						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
+					</Menu.CheckboxItem>
+				</Menu.Group>
+			</Menu.Popover>
 		</Menu>
 	);
 };
@@ -272,43 +304,54 @@ export const WithRadios: StoryFn< typeof Menu > = ( props ) => {
 
 	return (
 		<Menu { ...props }>
-			<Menu.Group>
-				<Menu.GroupLabel>Uncontrolled</Menu.GroupLabel>
-				<Menu.RadioItem name="radio-uncontrolled" value="one">
-					<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
-				</Menu.RadioItem>
-				<Menu.RadioItem
-					name="radio-uncontrolled"
-					value="two"
-					defaultChecked
-				>
-					<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-				</Menu.RadioItem>
-			</Menu.Group>
-			<Menu.Separator />
-			<Menu.Group>
-				<Menu.GroupLabel>Controlled</Menu.GroupLabel>
-				<Menu.RadioItem
-					name="radio-controlled"
-					value="one"
-					checked={ radioValue === 'one' }
-					onChange={ onRadioChange }
-				>
-					<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially unchecked</Menu.ItemHelpText>
-				</Menu.RadioItem>
-				<Menu.RadioItem
-					name="radio-controlled"
-					value="two"
-					checked={ radioValue === 'two' }
-					onChange={ onRadioChange }
-				>
-					<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
-					<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-				</Menu.RadioItem>
-			</Menu.Group>
+			<Menu.TriggerButton
+				render={ <Button __next40pxDefaultSize variant="secondary" /> }
+			>
+				Open menu
+			</Menu.TriggerButton>
+			<Menu.Popover>
+				<Menu.Group>
+					<Menu.GroupLabel>Uncontrolled</Menu.GroupLabel>
+					<Menu.RadioItem name="radio-uncontrolled" value="one">
+						<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							Initially unchecked
+						</Menu.ItemHelpText>
+					</Menu.RadioItem>
+					<Menu.RadioItem
+						name="radio-uncontrolled"
+						value="two"
+						defaultChecked
+					>
+						<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
+						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
+					</Menu.RadioItem>
+				</Menu.Group>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.GroupLabel>Controlled</Menu.GroupLabel>
+					<Menu.RadioItem
+						name="radio-controlled"
+						value="one"
+						checked={ radioValue === 'one' }
+						onChange={ onRadioChange }
+					>
+						<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							Initially unchecked
+						</Menu.ItemHelpText>
+					</Menu.RadioItem>
+					<Menu.RadioItem
+						name="radio-controlled"
+						value="two"
+						checked={ radioValue === 'two' }
+						onChange={ onRadioChange }
+					>
+						<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
+						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
+					</Menu.RadioItem>
+				</Menu.Group>
+			</Menu.Popover>
 		</Menu>
 	);
 };
@@ -333,29 +376,40 @@ export const WithModals: StoryFn< typeof Menu > = ( props ) => {
 	return (
 		<>
 			<Menu { ...props }>
-				<Menu.Item
-					onClick={ () => setOuterModalOpen( true ) }
-					hideOnClick={ false }
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
 				>
-					<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item
-					onClick={ () => setInnerModalOpen( true ) }
-					hideOnClick={ false }
-				>
-					<Menu.ItemLabel>Open inner modal</Menu.ItemLabel>
-				</Menu.Item>
-				{ isInnerModalOpen && (
-					<Modal
-						onRequestClose={ () => setInnerModalOpen( false ) }
-						overlayClassName={ modalOverlayClassName }
+					Open menu
+				</Menu.TriggerButton>
+				<Menu.Popover>
+					<Menu.Item
+						onClick={ () => setOuterModalOpen( true ) }
+						hideOnClick={ false }
 					>
-						Modal&apos;s contents
-						<button onClick={ () => setInnerModalOpen( false ) }>
-							Close
-						</button>
-					</Modal>
-				) }
+						<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu.Item
+						onClick={ () => setInnerModalOpen( true ) }
+						hideOnClick={ false }
+					>
+						<Menu.ItemLabel>Open inner modal</Menu.ItemLabel>
+					</Menu.Item>
+					{ isInnerModalOpen && (
+						<Modal
+							onRequestClose={ () => setInnerModalOpen( false ) }
+							overlayClassName={ modalOverlayClassName }
+						>
+							Modal&apos;s contents
+							<button
+								onClick={ () => setInnerModalOpen( false ) }
+							>
+								Close
+							</button>
+						</Modal>
+					) }
+				</Menu.Popover>
 			</Menu>
 			{ isOuterModalOpen && (
 				<Modal
@@ -427,26 +481,36 @@ export const WithSlotFill: StoryFn< typeof Menu > = ( props ) => {
 	return (
 		<SlotFillProvider>
 			<Menu { ...props }>
-				<Menu.Item>
-					<Menu.ItemLabel>Item</Menu.ItemLabel>
-				</Menu.Item>
-				<Slot />
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
+				>
+					Open menu
+				</Menu.TriggerButton>
+				<Menu.Popover>
+					<Menu.Item>
+						<Menu.ItemLabel>Item</Menu.ItemLabel>
+					</Menu.Item>
+					<Slot />
+				</Menu.Popover>
 			</Menu>
 
 			<Fill>
 				<Menu.Item>
 					<Menu.ItemLabel>Item from fill</Menu.ItemLabel>
 				</Menu.Item>
-				<Menu
-					trigger={
+				<Menu>
+					<Menu.SubmenuTriggerItem>
+						<Menu.ItemLabel>Submenu from fill</Menu.ItemLabel>
+					</Menu.SubmenuTriggerItem>
+					<Menu.Popover>
 						<Menu.Item>
-							<Menu.ItemLabel>Submenu from fill</Menu.ItemLabel>
+							<Menu.ItemLabel>
+								Submenu item from fill
+							</Menu.ItemLabel>
 						</Menu.Item>
-					}
-				>
-					<Menu.Item>
-						<Menu.ItemLabel>Submenu item from fill</Menu.ItemLabel>
-					</Menu.Item>
+					</Menu.Popover>
 				</Menu>
 			</Fill>
 		</SlotFillProvider>
@@ -465,24 +529,30 @@ export const ToolbarVariant: StoryFn< typeof Menu > = ( props ) => (
 	// TODO: add toolbar
 	<ContextSystemProvider value={ toolbarVariantContextValue }>
 		<Menu { ...props }>
-			<Menu.Item>
-				<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-			</Menu.Item>
-			<Menu.Item>
-				<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-			</Menu.Item>
-			<Menu.Separator />
-			<Menu
-				trigger={
-					<Menu.Item>
-						<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
-					</Menu.Item>
-				}
+			<Menu.TriggerButton
+				render={ <Button __next40pxDefaultSize variant="secondary" /> }
 			>
+				Open menu
+			</Menu.TriggerButton>
+			<Menu.Popover>
 				<Menu.Item>
-					<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+					<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
 				</Menu.Item>
-			</Menu>
+				<Menu.Item>
+					<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.Separator />
+				<Menu>
+					<Menu.SubmenuTriggerItem>
+						<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
+					</Menu.SubmenuTriggerItem>
+					<Menu.Popover>
+						<Menu.Item>
+							<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+						</Menu.Item>
+					</Menu.Popover>
+				</Menu>
+			</Menu.Popover>
 		</Menu>
 	</ContextSystemProvider>
 );
@@ -502,28 +572,44 @@ export const InsideModal: StoryFn< typeof Menu > = ( props ) => {
 				Open modal
 			</Button>
 			{ isModalOpen && (
-				<Modal onRequestClose={ () => setModalOpen( false ) }>
+				<Modal
+					onRequestClose={ () => setModalOpen( false ) }
+					title="Menu inside modal"
+				>
 					<Menu { ...props }>
-						<Menu.Item>
-							<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item>
-							<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Separator />
-						<Menu
-							trigger={
-								<Menu.Item>
+						<Menu.TriggerButton
+							render={
+								<Button
+									__next40pxDefaultSize
+									variant="secondary"
+								/>
+							}
+						>
+							Open menu
+						</Menu.TriggerButton>
+						<Menu.Popover>
+							<Menu.Item>
+								<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
+							</Menu.Item>
+							<Menu.Item>
+								<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
+							</Menu.Item>
+							<Menu.Separator />
+							<Menu>
+								<Menu.SubmenuTriggerItem>
 									<Menu.ItemLabel>
 										Submenu trigger
 									</Menu.ItemLabel>
-								</Menu.Item>
-							}
-						>
-							<Menu.Item>
-								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-							</Menu.Item>
-						</Menu>
+								</Menu.SubmenuTriggerItem>
+								<Menu.Popover>
+									<Menu.Item>
+										<Menu.ItemLabel>
+											Level 2 item
+										</Menu.ItemLabel>
+									</Menu.Item>
+								</Menu.Popover>
+							</Menu>
+						</Menu.Popover>
 					</Menu>
 					<Button onClick={ () => setModalOpen( false ) }>
 						Close modal


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the context of #67422, refactor the `Menu` component's Storybook file to adhere to the new APIs

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #67422

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor usages of the `Menu` component. See #67422 for more details on how to refactor from the old to the new APIs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Make sure that all `Menu`'s Storybook examples work as on `trunk`, while using the new sub-components and APIs.

> [!NOTE]
> Note that test failures and potential build/runtime errors are expected while the various PR extracted from #67422 (as the current one) are not merged back into #67422 yet.