### PR TITLE
Modal: Allow preventing close requests

### DIFF
--- a/packages/components/src/modal/index.tsx
+++ b/packages/components/src/modal/index.tsx
@@ -66,6 +66,7 @@ function UnforwardedModal(
 			describedby: undefined,
 		},
 		onRequestClose,
+		onValidateClose = () => true,
 		icon,
 		closeButtonLabel,
 		children,
@@ -341,11 +342,13 @@ function UnforwardedModal(
 											size="compact"
 											onClick={ (
 												event: React.MouseEvent< HTMLButtonElement >
-											) =>
-												closeModal().then( () =>
-													onRequestClose( event )
-												)
-											}
+											) => {
+												if ( onValidateClose() ) {
+													closeModal().then( () =>
+														onRequestClose( event )
+													);
+												}
+											} }
 											icon={ close }
 											label={
 												closeButtonLabel ||

--- a/packages/components/src/modal/stories/index.story.tsx
+++ b/packages/components/src/modal/stories/index.story.tsx
@@ -6,7 +6,7 @@ import type { StoryFn, Meta } from '@storybook/react';
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useRef, useState } from '@wordpress/element';
 import { fullscreen } from '@wordpress/icons';
 
 /**
@@ -117,4 +117,38 @@ WithHeaderActions.args = {
 };
 WithHeaderActions.parameters = {
 	...Default.parameters,
+};
+
+export const PreventCloseRequest = {
+	render: function Render() {
+		const [ isOpen, setOpen ] = useState( false );
+		const closableCbxRef = useRef< HTMLInputElement >( null );
+		const openModal = () => setOpen( true );
+		const closeModal = () => setOpen( false );
+
+		return (
+			<>
+				<Button variant="secondary" onClick={ openModal }>
+					Open Modal
+				</Button>
+				{ isOpen && (
+					<Modal
+						title="This is my modal"
+						onRequestClose={ closeModal }
+						onValidateClose={ () =>
+							closableCbxRef.current?.checked
+						}
+					>
+						<input
+							type="checkbox"
+							// eslint-disable-next-line no-restricted-syntax
+							id="allow-close"
+							ref={ closableCbxRef }
+						/>{ ' ' }
+						<label htmlFor="allow-close">Allow close</label>
+					</Modal>
+				) }
+			</>
+		);
+	},
 };

--- a/packages/components/src/modal/types.ts
+++ b/packages/components/src/modal/types.ts
@@ -103,6 +103,7 @@ export type ModalProps = {
 	onRequestClose: (
 		event?: React.KeyboardEvent< HTMLDivElement > | React.SyntheticEvent
 	) => void;
+	onValidateClose?: () => boolean | void;
 	/**
 	 * If this property is added, it will an additional class name to the modal
 	 * overlay `div`.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Demonstrates a way for the consumer to cancel the user's close request.

Currently only implemented for close button clicks, just as a proof of concept.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions

See the "Prevent Close Request" story for the Modal component.

