### PR TITLE
Menu granular subcomponents: Refactor dataviews item actions menu

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -72,7 +72,7 @@ interface ActionsListProps< Item > {
 	ActionTrigger: ( props: ActionTriggerProps< Item > ) => ReactElement;
 }
 
-function ButtonTrigger< Item >( {
+function ActionButtonTrigger< Item >( {
 	action,
 	onClick,
 	items,
@@ -90,7 +90,7 @@ function ButtonTrigger< Item >( {
 	);
 }
 
-function MenuItemTrigger< Item >( {
+function ActionMenuItemTrigger< Item >( {
 	action,
 	onClick,
 	items,
@@ -170,7 +170,7 @@ export function ActionsMenuGroup< Item >( {
 				actions={ actions }
 				item={ item }
 				registry={ registry }
-				ActionTrigger={ MenuItemTrigger }
+				ActionTrigger={ ActionMenuItemTrigger }
 			/>
 		</Menu.Group>
 	);
@@ -250,20 +250,22 @@ function CompactItemActions< Item >( {
 	isSmall,
 }: CompactItemActionsProps< Item > ) {
 	return (
-		<Menu
-			trigger={
-				<Button
-					size={ isSmall ? 'small' : 'compact' }
-					icon={ moreVertical }
-					label={ __( 'Actions' ) }
-					accessibleWhenDisabled
-					disabled={ ! actions.length }
-					className="dataviews-all-actions-button"
-				/>
-			}
-			placement="bottom-end"
-		>
-			<ActionsMenuGroup actions={ actions } item={ item } />
+		<Menu placement="bottom-end">
+			<Menu.TriggerButton
+				render={
+					<Button
+						size={ isSmall ? 'small' : 'compact' }
+						icon={ moreVertical }
+						label={ __( 'Actions' ) }
+						accessibleWhenDisabled
+						disabled={ ! actions.length }
+						className="dataviews-all-actions-button"
+					/>
+				}
+			/>
+			<Menu.Popover>
+				<ActionsMenuGroup actions={ actions } item={ item } />
+			</Menu.Popover>
 		</Menu>
 	);
 }
@@ -281,7 +283,7 @@ function PrimaryActions< Item >( {
 			actions={ actions }
 			item={ item }
 			registry={ registry }
-			ActionTrigger={ ButtonTrigger }
+			ActionTrigger={ ActionButtonTrigger }
 		/>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the context of #67422, refactor the `Menu` component for the item actions dropdown menu in dataviews.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #67422

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor usages of the `Menu` component. See #67422 for more details on how to refactor from the old to the new APIs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the site editor, visit any page that renders dataviews layouts (for example, Templates)
- Make sure that, regardless of the "layout" selected (list, table, grid), the dropdown menu(s) containing item actions work as on trunk

> [!NOTE]
> Note that test failures and potential build/runtime errors are expected while the various PR extracted from #67422 (as the current one) are not merged back into #67422 yet.

![Screenshot 2024-12-05 at 16 47 39](https://github.com/user-attachments/assets/04e6c79a-09c4-4d58-a68f-18ff0e31e337)
