### PR TITLE
Menu granular subcomponents: Refactor dataviews table layout header menu

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -102,151 +102,160 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 
 	return (
 		<Menu
-			align="start"
-			trigger={
-				<Button
-					size="compact"
-					className="dataviews-view-table-header-button"
-					ref={ ref }
-					variant="tertiary"
-				>
-					{ header }
-					{ view.sort && isSorted && (
-						<span aria-hidden="true">
-							{ sortArrows[ view.sort.direction ] }
-						</span>
-					) }
-				</Button>
-			}
-			style={ { minWidth: '240px' } }
+		// align="start" TODO: align prop doesn't exist on Menu — is it ok to just remove
 		>
-			<WithMenuSeparators>
-				{ isSortable && (
-					<Menu.Group>
-						{ SORTING_DIRECTIONS.map(
-							( direction: SortDirection ) => {
-								const isChecked =
-									view.sort &&
-									isSorted &&
-									view.sort.direction === direction;
-
-								const value = `${ fieldId }-${ direction }`;
-
-								return (
-									<Menu.RadioItem
-										key={ value }
-										// All sorting radio items share the same name, so that
-										// selecting a sorting option automatically deselects the
-										// previously selected one, even if it is displayed in
-										// another submenu. The field and direction are passed via
-										// the `value` prop.
-										name="view-table-sorting"
-										value={ value }
-										checked={ isChecked }
-										onChange={ () => {
-											onChangeView( {
-												...view,
-												sort: {
-													field: fieldId,
-													direction,
-												},
-											} );
-										} }
-									>
-										<Menu.ItemLabel>
-											{ sortLabels[ direction ] }
-										</Menu.ItemLabel>
-									</Menu.RadioItem>
-								);
-							}
-						) }
-					</Menu.Group>
+			<Menu.TriggerButton
+				render={
+					<Button
+						size="compact"
+						className="dataviews-view-table-header-button"
+						ref={ ref }
+						variant="tertiary"
+					/>
+				}
+			>
+				{ header }
+				{ view.sort && isSorted && (
+					<span aria-hidden="true">
+						{ sortArrows[ view.sort.direction ] }
+					</span>
 				) }
-				{ canAddFilter && (
+			</Menu.TriggerButton>
+			<Menu.Popover style={ { minWidth: '240px' } }>
+				<WithMenuSeparators>
+					{ isSortable && (
+						<Menu.Group>
+							{ SORTING_DIRECTIONS.map(
+								( direction: SortDirection ) => {
+									const isChecked =
+										view.sort &&
+										isSorted &&
+										view.sort.direction === direction;
+
+									const value = `${ fieldId }-${ direction }`;
+
+									return (
+										<Menu.RadioItem
+											key={ value }
+											// All sorting radio items share the same name, so that
+											// selecting a sorting option automatically deselects the
+											// previously selected one, even if it is displayed in
+											// another submenu. The field and direction are passed via
+											// the `value` prop.
+											name="view-table-sorting"
+											value={ value }
+											checked={ isChecked }
+											onChange={ () => {
+												onChangeView( {
+													...view,
+													sort: {
+														field: fieldId,
+														direction,
+													},
+												} );
+											} }
+										>
+											<Menu.ItemLabel>
+												{ sortLabels[ direction ] }
+											</Menu.ItemLabel>
+										</Menu.RadioItem>
+									);
+								}
+							) }
+						</Menu.Group>
+					) }
+					{ canAddFilter && (
+						<Menu.Group>
+							<Menu.Item
+								prefix={ <Icon icon={ funnel } /> }
+								onClick={ () => {
+									setOpenedFilter( fieldId );
+									onChangeView( {
+										...view,
+										page: 1,
+										filters: [
+											...( view.filters || [] ),
+											{
+												field: fieldId,
+												value: undefined,
+												operator: operators[ 0 ],
+											},
+										],
+									} );
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Add filter' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						</Menu.Group>
+					) }
 					<Menu.Group>
 						<Menu.Item
-							prefix={ <Icon icon={ funnel } /> }
+							prefix={ <Icon icon={ arrowLeft } /> }
+							disabled={ index < 1 }
 							onClick={ () => {
-								setOpenedFilter( fieldId );
 								onChangeView( {
 									...view,
-									page: 1,
-									filters: [
-										...( view.filters || [] ),
-										{
-											field: fieldId,
-											value: undefined,
-											operator: operators[ 0 ],
-										},
+									fields: [
+										...( visibleFieldIds.slice(
+											0,
+											index - 1
+										) ?? [] ),
+										fieldId,
+										visibleFieldIds[ index - 1 ],
+										...visibleFieldIds.slice( index + 1 ),
 									],
 								} );
 							} }
 						>
 							<Menu.ItemLabel>
-								{ __( 'Add filter' ) }
+								{ __( 'Move left' ) }
 							</Menu.ItemLabel>
 						</Menu.Item>
-					</Menu.Group>
-				) }
-				<Menu.Group>
-					<Menu.Item
-						prefix={ <Icon icon={ arrowLeft } /> }
-						disabled={ index < 1 }
-						onClick={ () => {
-							onChangeView( {
-								...view,
-								fields: [
-									...( visibleFieldIds.slice(
-										0,
-										index - 1
-									) ?? [] ),
-									fieldId,
-									visibleFieldIds[ index - 1 ],
-									...visibleFieldIds.slice( index + 1 ),
-								],
-							} );
-						} }
-					>
-						<Menu.ItemLabel>{ __( 'Move left' ) }</Menu.ItemLabel>
-					</Menu.Item>
-					<Menu.Item
-						prefix={ <Icon icon={ arrowRight } /> }
-						disabled={ index >= visibleFieldIds.length - 1 }
-						onClick={ () => {
-							onChangeView( {
-								...view,
-								fields: [
-									...( visibleFieldIds.slice( 0, index ) ??
-										[] ),
-									visibleFieldIds[ index + 1 ],
-									fieldId,
-									...visibleFieldIds.slice( index + 2 ),
-								],
-							} );
-						} }
-					>
-						<Menu.ItemLabel>{ __( 'Move right' ) }</Menu.ItemLabel>
-					</Menu.Item>
-					{ isHidable && field && (
 						<Menu.Item
-							prefix={ <Icon icon={ unseen } /> }
+							prefix={ <Icon icon={ arrowRight } /> }
+							disabled={ index >= visibleFieldIds.length - 1 }
 							onClick={ () => {
-								onHide( field );
 								onChangeView( {
 									...view,
-									fields: visibleFieldIds.filter(
-										( id ) => id !== fieldId
-									),
+									fields: [
+										...( visibleFieldIds.slice(
+											0,
+											index
+										) ?? [] ),
+										visibleFieldIds[ index + 1 ],
+										fieldId,
+										...visibleFieldIds.slice( index + 2 ),
+									],
 								} );
 							} }
 						>
 							<Menu.ItemLabel>
-								{ __( 'Hide column' ) }
+								{ __( 'Move right' ) }
 							</Menu.ItemLabel>
 						</Menu.Item>
-					) }
-				</Menu.Group>
-			</WithMenuSeparators>
+						{ isHidable && field && (
+							<Menu.Item
+								prefix={ <Icon icon={ unseen } /> }
+								onClick={ () => {
+									onHide( field );
+									onChangeView( {
+										...view,
+										fields: visibleFieldIds.filter(
+											( id ) => id !== fieldId
+										),
+									} );
+								} }
+							>
+								<Menu.ItemLabel>
+									{ __( 'Hide column' ) }
+								</Menu.ItemLabel>
+							</Menu.Item>
+						) }
+					</Menu.Group>
+				</WithMenuSeparators>
+			</Menu.Popover>
 		</Menu>
 	);
 } );

--- a/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/column-header-menu.tsx
@@ -101,9 +101,7 @@ const _HeaderMenu = forwardRef( function HeaderMenu< Item >(
 	}
 
 	return (
-		<Menu
-		// align="start" TODO: align prop doesn't exist on Menu — is it ok to just remove
-		>
+		<Menu>
 			<Menu.TriggerButton
 				render={
 					<Button


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the context of #67422, refactor the `Menu` component used in the header of the table layout in the dataviews package

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #67422

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor usages of the `Menu` component. See #67422 for more details on how to refactor from the old to the new APIs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Open the "Pages" view in the site editor with the "table" layout by visiting the link `/wp-admin/site-editor.php?p=%2Fpage&layout=table` (visiting the link is necessary because the layout switcher dropdown menu is being refactored in a separate PR and therefore won't work in this PR)
- Make sure that the dropdown menus in the table header look and work like on trunk


> [!NOTE]
> Note that test failures and potential build/runtime errors are expected while the various PR extracted from #67422 (as the current one) are not merged back into #67422 yet.

![Screenshot 2024-12-05 at 16 56 43](https://github.com/user-attachments/assets/c4bc1f51-47c6-489b-a39c-b09cf114daaa)
