### PR TITLE
Menu granular subcomponents: Refactor global styles sidebar wrapper preview menu

### DIFF
--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
@@ -28,36 +28,43 @@ const GlobalStylesPageActions = ( {
 	setIsStyleBookOpened,
 } ) => {
 	return (
-		<Menu
-			trigger={
-				<Button __next40pxDefaultSize variant="tertiary" size="compact">
-					{ __( 'Preview' ) }
-				</Button>
-			}
-		>
-			<Menu.RadioItem
-				value
-				checked={ isStyleBookOpened }
-				name="styles-preview-actions"
-				onChange={ () => setIsStyleBookOpened( true ) }
-				defaultChecked
+		<Menu>
+			<Menu.TriggerButton
+				render={
+					<Button
+						__next40pxDefaultSize
+						variant="tertiary"
+						size="compact"
+					/>
+				}
 			>
-				<Menu.ItemLabel>{ __( 'Style book' ) }</Menu.ItemLabel>
-				<Menu.ItemHelpText>
-					{ __( 'Preview blocks and styles.' ) }
-				</Menu.ItemHelpText>
-			</Menu.RadioItem>
-			<Menu.RadioItem
-				value={ false }
-				checked={ ! isStyleBookOpened }
-				name="styles-preview-actions"
-				onChange={ () => setIsStyleBookOpened( false ) }
-			>
-				<Menu.ItemLabel>{ __( 'Site' ) }</Menu.ItemLabel>
-				<Menu.ItemHelpText>
-					{ __( 'Preview your site.' ) }
-				</Menu.ItemHelpText>
-			</Menu.RadioItem>
+				{ __( 'Preview' ) }
+			</Menu.TriggerButton>
+			<Menu.Popover>
+				<Menu.RadioItem
+					value
+					checked={ isStyleBookOpened }
+					name="styles-preview-actions"
+					onChange={ () => setIsStyleBookOpened( true ) }
+					defaultChecked
+				>
+					<Menu.ItemLabel>{ __( 'Style book' ) }</Menu.ItemLabel>
+					<Menu.ItemHelpText>
+						{ __( 'Preview blocks and styles.' ) }
+					</Menu.ItemHelpText>
+				</Menu.RadioItem>
+				<Menu.RadioItem
+					value={ false }
+					checked={ ! isStyleBookOpened }
+					name="styles-preview-actions"
+					onChange={ () => setIsStyleBookOpened( false ) }
+				>
+					<Menu.ItemLabel>{ __( 'Site' ) }</Menu.ItemLabel>
+					<Menu.ItemHelpText>
+						{ __( 'Preview your site.' ) }
+					</Menu.ItemHelpText>
+				</Menu.RadioItem>
+			</Menu.Popover>
 		</Menu>
 	);
 };

--- a/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
+++ b/packages/edit-site/src/components/sidebar-global-styles-wrapper/index.js
@@ -32,7 +32,6 @@ const GlobalStylesPageActions = ( {
 			<Menu.TriggerButton
 				render={
 					<Button
-						__next40pxDefaultSize
 						variant="tertiary"
 						size="compact"
 					/>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the context of #67422, refactor the `Menu` component used for the preview dropdown menu in the global styles sidebar

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #67422

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor usages of the `Menu` component. See #67422 for more details on how to refactor from the old to the new APIs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

In the site editor, open the global styles panel. Make sure that the "Preview" dropdown menu (used to toggle between style book and site) looks and works like on trunk.

> [!NOTE]
> Note that test failures and potential build/runtime errors are expected while the various PR extracted from #67422 (as the current one) are not merged back into #67422 yet.

![Screenshot 2024-12-05 at 17 52 34](https://github.com/user-attachments/assets/2221f8fe-61ba-49a6-b7ed-2e87b90c27fc)
