### PR TITLE
Menu granular subcomponents: Refactor post actions menu

### DIFF
--- a/packages/editor/src/components/post-actions/index.js
+++ b/packages/editor/src/components/post-actions/index.js
@@ -56,29 +56,33 @@ export default function PostActions( { postType, postId, onActionPerformed } ) {
 	return (
 		<Menu
 			open={ isActionsMenuOpen }
-			trigger={
-				<Button
-					size="small"
-					icon={ moreVertical }
-					label={ __( 'Actions' ) }
-					disabled={ ! actions.length }
-					accessibleWhenDisabled
-					className="editor-all-actions-button"
-					onClick={ () =>
-						setIsActionsMenuOpen( ! isActionsMenuOpen )
-					}
-				/>
-			}
 			onOpenChange={ setIsActionsMenuOpen }
 			placement="bottom-end"
 		>
-			<ActionsDropdownMenuGroup
-				actions={ actions }
-				item={ itemWithPermissions }
-				onClose={ () => {
-					setIsActionsMenuOpen( false );
-				} }
+			<Menu.TriggerButton
+				render={
+					<Button
+						size="small"
+						icon={ moreVertical }
+						label={ __( 'Actions' ) }
+						disabled={ ! actions.length }
+						accessibleWhenDisabled
+						className="editor-all-actions-button"
+						onClick={ () =>
+							setIsActionsMenuOpen( ! isActionsMenuOpen )
+						}
+					/>
+				}
 			/>
+			<Menu.Popover>
+				<ActionsDropdownMenuGroup
+					actions={ actions }
+					item={ itemWithPermissions }
+					onClose={ () => {
+						setIsActionsMenuOpen( false );
+					} }
+				/>
+			</Menu.Popover>
 		</Menu>
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In the context of #67422, refactor the `Menu` component used in the post actions dropdown menu

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See #67422

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Refactor usages of the `Menu` component. See #67422 for more details on how to refactor from the old to the new APIs.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Edit a post
- In the right sidebar, make sure that the "Post" tab is selecter
- Make sure that the "..." dropdown menu next to the post title looks and works like on trunk

> [!NOTE]
> Note that test failures and potential build/runtime errors are expected while the various PR extracted from #67422 (as the current one) are not merged back into #67422 yet.

![Screenshot 2024-12-05 at 17 54 51](https://github.com/user-attachments/assets/38dabe6c-ac70-4dab-b9bc-c44afb34a841)
