### PR TITLE
Remove extraneous content from block switcher aria menu

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -12,7 +12,7 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
-} from '@wordpress/	components';
+} from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { __, _x, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -63,6 +63,7 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 	);
 
 	const { selectBlock } = useDispatch( blockEditorStore );
+	const hasCustomName = !! name?.length;
 
 	return (
 		<div className={ clsx( 'block-editor-block-card', className ) }>
@@ -80,16 +81,16 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 				/>
 			) }
 			<BlockIcon icon={ icon } showColors />
-			<VStack spacing={ 1 }>
+			<VStack spacing={ hasCustomName || isUsingBindings ? 2 : 1 }>
 				<h2 className="block-editor-block-card__title">
 					<span className="block-editor-block-card__name">
-						{ !! name?.length ? name : title }
+						{ hasCustomName ? name : title }
 					</span>
-					{ !! name?.length && <Badge>{ title }</Badge> }
+					{ hasCustomName && <Badge>{ title }</Badge> }
 					{ isUsingBindings && (
 						<Badge>
 							{ _x(
-								'Connected.',
+								'Connected',
 								'block connected to a bound source'
 							) }
 						</Badge>

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -12,9 +12,9 @@ import {
 	__experimentalText as Text,
 	__experimentalVStack as VStack,
 	privateApis as componentsPrivateApis,
-} from '@wordpress/components';
+} from '@wordpress/	components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { __, isRTL } from '@wordpress/i18n';
+import { __, _x, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
@@ -86,6 +86,14 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 						{ !! name?.length ? name : title }
 					</span>
 					{ !! name?.length && <Badge>{ title }</Badge> }
+					{ isUsingBindings && (
+						<Badge>
+							{ _x(
+								'Connected.',
+								'block connected to a bound source'
+							) }
+						</Badge>
+					) }
 				</h2>
 				{ description && (
 					<Text
@@ -93,14 +101,6 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 						className="block-editor-block-card__description"
 					>
 						{ description }
-					</Text>
-				) }
-				{ isUsingBindings && (
-					<Text
-						as="p"
-						className="block-editor-block-card__description"
-					>
-						{ __( 'This blocks is connected.' ) }
 					</Text>
 				) }
 			</VStack>

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -35,20 +35,32 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 		( { title, icon, description } = blockType );
 	}
 
-	const { parentNavBlockClientId } = useSelect( ( select ) => {
-		const { getSelectedBlockClientId, getBlockParentsByBlockName } =
-			select( blockEditorStore );
+	const { parentNavBlockClientId, isUsingBindings } = useSelect(
+		( select ) => {
+			const {
+				getSelectedBlockClientId,
+				getSelectedBlockClientIds,
+				getBlockParentsByBlockName,
+				getBlockAttributes,
+			} = select( blockEditorStore );
 
-		const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockClientId = getSelectedBlockClientId();
+			const _selectedBlockClientIds = getSelectedBlockClientIds();
 
-		return {
-			parentNavBlockClientId: getBlockParentsByBlockName(
-				_selectedBlockClientId,
-				'core/navigation',
-				true
-			)[ 0 ],
-		};
-	}, [] );
+			return {
+				parentNavBlockClientId: getBlockParentsByBlockName(
+					_selectedBlockClientId,
+					'core/navigation',
+					true
+				)[ 0 ],
+				isUsingBindings: _selectedBlockClientIds.every(
+					( clientId ) =>
+						!! getBlockAttributes( clientId )?.metadata?.bindings
+				),
+			};
+		},
+		[]
+	);
 
 	const { selectBlock } = useDispatch( blockEditorStore );
 
@@ -76,8 +88,19 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 					{ !! name?.length && <Badge>{ title }</Badge> }
 				</h2>
 				{ description && (
-					<Text className="block-editor-block-card__description">
+					<Text
+						as="p"
+						className="block-editor-block-card__description"
+					>
 						{ description }
+					</Text>
+				) }
+				{ isUsingBindings && (
+					<Text
+						as="p"
+						className="block-editor-block-card__description"
+					>
+						{ __( 'This blocks is connected.' ) }
 					</Text>
 				) }
 			</VStack>

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -35,3 +35,14 @@
 	color: var(--wp-block-synced-color);
 }
 
+.block-editor-block-card__connected-block-description {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-05;
+	padding-top: $grid-unit-10;
+
+	svg {
+		flex-shrink: 0;
+		fill: var(--wp-block-synced-color);
+	}
+}

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -34,15 +34,3 @@
 .block-editor-block-card.is-synced .block-editor-block-icon {
 	color: var(--wp-block-synced-color);
 }
-
-.block-editor-block-card__connected-block-description {
-	display: flex;
-	align-items: center;
-	gap: $grid-unit-05;
-	padding-top: $grid-unit-10;
-
-	svg {
-		flex-shrink: 0;
-		fill: var(--wp-block-synced-color);
-	}
-}

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -229,7 +229,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 	const hideTooltip = blockSwitcherLabel === blockIndicatorText;
 
 	const hasPossibleBlockTransformations =
-		!! possibleBlockTransformations.length && canRemove && ! isTemplate;
+		!! possibleBlockTransformations?.length && canRemove && ! isTemplate;
 	const hasPossibleBlockVariationTransformations =
 		!! blockVariationTransformations?.length;
 	const hasPatternTransformation = !! patterns?.length && canRemove;

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -1,14 +1,12 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf, _x } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	DropdownMenu,
 	ToolbarButton,
 	ToolbarGroup,
 	ToolbarItem,
-	__experimentalText as Text,
-	MenuGroup,
 } from '@wordpress/components';
 import {
 	switchToBlockType,
@@ -39,37 +37,30 @@ function BlockSwitcherDropdownMenuContents( {
 } ) {
 	const { replaceBlocks, multiSelect, updateBlockAttributes } =
 		useDispatch( blockEditorStore );
-	const { possibleBlockTransformations, patterns, blocks, isUsingBindings } =
-		useSelect(
-			( select ) => {
-				const {
-					getBlockAttributes,
-					getBlocksByClientId,
-					getBlockRootClientId,
-					getBlockTransformItems,
-					__experimentalGetPatternTransformItems,
-				} = select( blockEditorStore );
-				const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
-				const _blocks = getBlocksByClientId( clientIds );
-				return {
-					blocks: _blocks,
-					possibleBlockTransformations: getBlockTransformItems(
-						_blocks,
-						rootClientId
-					),
-					patterns: __experimentalGetPatternTransformItems(
-						_blocks,
-						rootClientId
-					),
-					isUsingBindings: clientIds.every(
-						( clientId ) =>
-							!! getBlockAttributes( clientId )?.metadata
-								?.bindings
-					),
-				};
-			},
-			[ clientIds ]
-		);
+	const { possibleBlockTransformations, patterns, blocks } = useSelect(
+		( select ) => {
+			const {
+				getBlocksByClientId,
+				getBlockRootClientId,
+				getBlockTransformItems,
+				__experimentalGetPatternTransformItems,
+			} = select( blockEditorStore );
+			const rootClientId = getBlockRootClientId( clientIds[ 0 ] );
+			const _blocks = getBlocksByClientId( clientIds );
+			return {
+				blocks: _blocks,
+				possibleBlockTransformations: getBlockTransformItems(
+					_blocks,
+					rootClientId
+				),
+				patterns: __experimentalGetPatternTransformItems(
+					_blocks,
+					rootClientId
+				),
+			};
+		},
+		[ clientIds ]
+	);
 	const blockVariationTransformations = useBlockVariationTransforms( {
 		clientIds,
 		blocks,
@@ -127,16 +118,6 @@ function BlockSwitcherDropdownMenuContents( {
 		);
 	}
 
-	const connectedBlockDescription = isSingleBlock
-		? _x(
-				'This block is connected.',
-				'block toolbar button label and description'
-		  )
-		: _x(
-				'These blocks are connected.',
-				'block toolbar button label and description'
-		  );
-
 	return (
 		<div className="block-editor-block-switcher__container">
 			{ hasPatternTransformation && (
@@ -174,13 +155,6 @@ function BlockSwitcherDropdownMenuContents( {
 					hoveredBlock={ blocks[ 0 ] }
 					onSwitch={ onClose }
 				/>
-			) }
-			{ isUsingBindings && (
-				<MenuGroup>
-					<Text className="block-editor-block-switcher__binding-indicator">
-						{ connectedBlockDescription }
-					</Text>
-				</MenuGroup>
 			) }
 		</div>
 	);

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -160,8 +160,3 @@
 	padding: 6px $grid-unit;
 	margin: 0;
 }
-
-.block-editor-block-switcher__binding-indicator {
-	display: block;
-	padding: $grid-unit;
-}

--- a/packages/block-editor/src/components/block-switcher/test/index.js
+++ b/packages/block-editor/src/components/block-switcher/test/index.js
@@ -149,7 +149,7 @@ describe( 'BlockSwitcher', () => {
 		expect( blockSwitcher ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 
-	test( 'should render message for no available transforms', async () => {
+	test( 'should render accessibly disabled block switcher when there are no available transforms', async () => {
 		useSelect.mockImplementation( () => ( {
 			possibleBlockTransformations: [],
 			blocks: [ headingBlock1 ],
@@ -157,26 +157,10 @@ describe( 'BlockSwitcher', () => {
 			canRemove: true,
 		} ) );
 		render( <BlockSwitcher clientIds={ [ headingBlock1.clientId ] } /> );
-		const user = userEvent.setup();
-		await user.type(
-			screen.getByRole( 'button', {
-				name: 'Block Name',
-				expanded: false,
-			} ),
-			'[ArrowDown]'
-		);
-		await waitFor( () =>
-			expect(
-				screen.getByRole( 'button', {
-					name: 'Block Name',
-					expanded: true,
-				} )
-			).toBeVisible()
-		);
-		expect(
-			screen.getByRole( 'menu', {
-				name: 'Block Name',
-			} )
-		).toHaveTextContent( 'No transforms.' );
+		const blockSwitcher = screen.getByRole( 'button', {
+			name: 'Block Name',
+		} );
+		expect( blockSwitcher ).toBeEnabled();
+		expect( blockSwitcher ).toHaveAttribute( 'aria-disabled', 'true' );
 	} );
 } );

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -40,18 +40,18 @@ export default function MultiSelectionInspector() {
 		<HStack
 			justify="flex-start"
 			align="flex-start"
-			spacing={ 2 }
+			spacing={ 0 }
 			className="block-editor-multi-selection-inspector__card"
 		>
 			<BlockIcon icon={ copy } showColors />
 			<VStack spacing={ 1 }>
-				<p className="block-editor-multi-selection-inspector__card-title">
+				<h2 className="block-editor-multi-selection-inspector__card-title">
 					{ sprintf(
 						/* translators: %d: number of blocks */
 						_n( '%d Block', '%d Blocks', selectedBlockCount ),
 						selectedBlockCount
 					) }
-				</p>
+				</h2>
 				{ isUsingBindings && (
 					<Badge>
 						{ _x(

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -1,10 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, _n } from '@wordpress/i18n';
+import { sprintf, __, _n } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { copy } from '@wordpress/icons';
-import { __experimentalHStack as HStack } from '@wordpress/components';
+import {
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	__experimentalText as Text,
+} from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -13,24 +17,47 @@ import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
 export default function MultiSelectionInspector() {
-	const selectedBlockCount = useSelect(
-		( select ) => select( blockEditorStore ).getSelectedBlockCount(),
-		[]
-	);
+	const { selectedBlockCount, isUsingBindings } = useSelect( ( select ) => {
+		const {
+			getSelectedBlockCount,
+			getBlockAttributes,
+			getSelectedBlockClientIds,
+		} = select( blockEditorStore );
+
+		return {
+			selectedBlockCount: getSelectedBlockCount(),
+			isUsingBindings: getSelectedBlockClientIds().every(
+				( clientId ) =>
+					!! getBlockAttributes( clientId )?.metadata?.bindings
+			),
+		};
+	}, [] );
+
 	return (
 		<HStack
 			justify="flex-start"
+			align="flex-start"
 			spacing={ 2 }
 			className="block-editor-multi-selection-inspector__card"
 		>
 			<BlockIcon icon={ copy } showColors />
-			<div className="block-editor-multi-selection-inspector__card-title">
-				{ sprintf(
-					/* translators: %d: number of blocks */
-					_n( '%d Block', '%d Blocks', selectedBlockCount ),
-					selectedBlockCount
+			<VStack spacing={ 1 }>
+				<p className="block-editor-multi-selection-inspector__card-title">
+					{ sprintf(
+						/* translators: %d: number of blocks */
+						_n( '%d Block', '%d Blocks', selectedBlockCount ),
+						selectedBlockCount
+					) }
+				</p>
+				{ isUsingBindings && (
+					<Text
+						as="p"
+						className="block-editor-multi-selection-inspector__card-description"
+					>
+						{ __( 'These blocks are connected.' ) }
+					</Text>
 				) }
-			</div>
+			</VStack>
 		</HStack>
 	);
 }

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -51,15 +51,15 @@ export default function MultiSelectionInspector() {
 						_n( '%d Block', '%d Blocks', selectedBlockCount ),
 						selectedBlockCount
 					) }
+					{ isUsingBindings && (
+						<Badge>
+							{ _x(
+								'Connected',
+								'multiple blocks connected to a bound source'
+							) }
+						</Badge>
+					) }
 				</h2>
-				{ isUsingBindings && (
-					<Badge>
-						{ _x(
-							'Connected.',
-							'multiple blocks connected to a bound source'
-						) }
-					</Badge>
-				) }
 			</VStack>
 		</HStack>
 	);

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -1,13 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { sprintf, __, _n } from '@wordpress/i18n';
+import { sprintf, _n, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { copy } from '@wordpress/icons';
 import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
-	__experimentalText as Text,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 
 /**
@@ -15,6 +15,9 @@ import {
  */
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
+import { unlock } from '../../lock-unlock';
+
+const { Badge } = unlock( componentsPrivateApis );
 
 export default function MultiSelectionInspector() {
 	const { selectedBlockCount, isUsingBindings } = useSelect( ( select ) => {
@@ -50,12 +53,12 @@ export default function MultiSelectionInspector() {
 					) }
 				</p>
 				{ isUsingBindings && (
-					<Text
-						as="p"
-						className="block-editor-multi-selection-inspector__card-description"
-					>
-						{ __( 'These blocks are connected.' ) }
-					</Text>
+					<Badge>
+						{ _x(
+							'Connected.',
+							'multiple blocks connected to a bound source'
+						) }
+					</Badge>
 				) }
 			</VStack>
 		</HStack>

--- a/packages/block-editor/src/components/multi-selection-inspector/style.scss
+++ b/packages/block-editor/src/components/multi-selection-inspector/style.scss
@@ -12,3 +12,15 @@
 	width: $button-size;
 	height: $button-size-small;
 }
+
+.block-editor-multi-selection-inspector__connected-block-description {
+	display: flex;
+	align-items: center;
+	gap: $grid-unit-05;
+	padding-top: $grid-unit-20;
+
+	svg {
+		flex-shrink: 0;
+		fill: var(--wp-block-synced-color);
+	}
+}

--- a/packages/block-editor/src/components/multi-selection-inspector/style.scss
+++ b/packages/block-editor/src/components/multi-selection-inspector/style.scss
@@ -4,12 +4,20 @@
 
 .block-editor-multi-selection-inspector__card-title {
 	font-weight: 500;
+
+	&.block-editor-multi-selection-inspector__card-title {
+		font-size: $default-font-size;
+		line-height: $default-line-height;
+		margin: 0;
+		padding: 3px 0; // This makes the title as high as the icon.
+	}
 }
 
 .block-editor-multi-selection-inspector__card .block-editor-block-icon {
-	margin-left: -2px;
-	padding: 0 3px;
-	width: $button-size;
+	flex: 0 0 $button-size-small;
+	margin-left: 0;
+	margin-right: $grid-unit-15;
+	width: $button-size-small;
 	height: $button-size-small;
 }
 
@@ -17,7 +25,7 @@
 	display: flex;
 	align-items: center;
 	gap: $grid-unit-05;
-	padding-top: $grid-unit-20;
+	padding-top: $grid-unit-10;
 
 	svg {
 		flex-shrink: 0;

--- a/packages/block-editor/src/components/multi-selection-inspector/style.scss
+++ b/packages/block-editor/src/components/multi-selection-inspector/style.scss
@@ -4,12 +4,15 @@
 
 .block-editor-multi-selection-inspector__card-title {
 	font-weight: 500;
+	display: flex;
+	align-items: center;
+	flex-wrap: wrap;
+	gap: calc($grid-unit-10 / 2) $grid-unit-10;
 
 	&.block-editor-multi-selection-inspector__card-title {
 		font-size: $default-font-size;
 		line-height: $default-line-height;
 		margin: 0;
-		padding: 3px 0; // This makes the title as high as the icon.
 	}
 }
 
@@ -19,16 +22,4 @@
 	margin-right: $grid-unit-15;
 	width: $button-size-small;
 	height: $button-size-small;
-}
-
-.block-editor-multi-selection-inspector__connected-block-description {
-	display: flex;
-	align-items: center;
-	gap: $grid-unit-05;
-	padding-top: $grid-unit-10;
-
-	svg {
-		flex-shrink: 0;
-		fill: var(--wp-block-synced-color);
-	}
 }

--- a/test/e2e/specs/editor/various/block-switcher.spec.js
+++ b/test/e2e/specs/editor/various/block-switcher.spec.js
@@ -114,7 +114,7 @@ test.describe( 'Block Switcher', () => {
 		await expect( button ).toBeDisabled();
 	} );
 
-	test( 'Should show a message if there are no transforms or styles available', async ( {
+	test( 'Should be disabled when there are no transforms or styles available', async ( {
 		editor,
 		page,
 		pageUtils,
@@ -126,11 +126,11 @@ test.describe( 'Block Switcher', () => {
 		await page.keyboard.type( '- List content' );
 		await pageUtils.pressKeys( 'alt+F10' );
 
-		await page
+		const button = page
 			.getByRole( 'toolbar', { name: 'Block tools' } )
-			.getByRole( 'button', { name: 'List item' } )
-			.click();
-		await expect( page.getByText( 'No transforms.' ) ).toBeVisible();
+			.getByRole( 'button', { name: 'List item' } );
+		// Verify the block switcher isn't enabled.
+		await expect( button ).toBeDisabled();
 	} );
 
 	test( 'Should show Columns block only if selected blocks are between limits (1-6)', async ( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/67579

## What?
<!-- In a few words, what is the PR actually doing? -->
The block switcher menu contains informative paragraphs that break the ARIA menu pattern.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block switcher menu is an ARIA menu and should only contain menu items. Any other content such as paragraphs etc. should not be part of an ARIA menu and should be moved elsewhere.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Moves the 'is connected' info to the settings panel card.
- Removes the 'No transforms' text and disables (with aria-disabled) the menu when there are no transforms.
- Moves the logic to determine whether the menu has transforms from `BlockSwitcherDropdownMenuContents` to `BlockSwitcher`. This is necessary to disable the menu when there are no transforms.
- Minor adjustments to make the multi-selection panel card be more consistent with the block card in terms of markup and styling.
- Minor: prevents the block switcher to show a tooltip when it already shows visible label with the same text.

Design Cc @WordPress/gutenberg-design 
So far, I moved the 'is connected' message to the settings panel card and used the 'connection' icon. Any design feedback welcome. Screenshot:

![Screenshot 2024-12-06 at 13 39 44](https://github.com/user-attachments/assets/1ff65c39-2e67-4092-8ab5-ba3122102cb8)


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Have two or more blocks with attributes connected to a Bindings API source.
- Select one of the bound blocks,
- Observe the 'is connected' info is no longer shown in the block switcher menu and has moved to the settings panel.
- Select two bound blocks.
- Observe again the 'is connected' info is no longer shown in the block switcher menu and has moved to the settings panel.
- Add a List block with a list item.
- Select the List item.
- Observe the block switcher button in the list item block toolbar is disabled. Previously, it was still enabled and the menu only used to show a 'No transforms.' text.
- Go to the Site editor and select a template part in the canvas e.g. a `Header`.
- Observe the block switcher button in the block toolbar is disabled (with aria-disabled). Previously, it was still enabled and the menu only used to show a 'No transforms.' text.
- Double check the block switcher menu and the transforms always work as expected under all conditions:
  - with various block types to check normal transforms, cariaation transforms (e.g. a Group block), Styles, etc.
  - with templates
  - with single and multiple block selected


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

The block switcher menu when:
1. it's disabled because there are no transforms and no other content
2. With multiple selection, it shows a tooltip 'Multiple blocks selected', as expected

![Screenshot 2024-12-06 at 13 42 04](https://github.com/user-attachments/assets/0ef7ac4c-ed45-4392-9ac4-10872d61549f)


<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
