### PR TITLE
Pages: Add posts page option to Add New Page

### DIFF
--- a/packages/edit-site/src/components/add-new-post/index.js
+++ b/packages/edit-site/src/components/add-new-post/index.js
@@ -6,6 +6,7 @@ import {
 	Modal,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
+	__experimentalText as Text,
 	TextControl,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
@@ -98,12 +99,15 @@ export default function AddNewPostModal( {
 	}
 
 	const modalTitle = pageForPosts
-		? __( 'Create new latest posts page' )
+		? __( 'Create new posts page' )
 		: // translators: %s: post type singular_name label e.g: "Page".
 		  sprintf( __( 'Draft new: %s' ), labels?.singular_name );
 	const modalSubmitLabel = pageForPosts
 		? __( 'Publish page' )
 		: __( 'Create draft' );
+	const postsPageNote = __(
+		'Note: The posts page cannot be a draft, so it will be published immediately.'
+	);
 
 	return (
 		<Modal
@@ -122,6 +126,9 @@ export default function AddNewPostModal( {
 						placeholder={ __( 'No title' ) }
 						value={ title }
 					/>
+					{ pageForPosts && (
+						<Text variant="muted">{ postsPageNote }</Text>
+					) }
 					<HStack spacing={ 2 } justify="end">
 						<Button
 							__next40pxDefaultSize

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -350,7 +350,11 @@ export default function PostList( { postType } ) {
 			const siteSettings = getEntityRecord( 'root', 'site' );
 			const isPagePostType = getPostType( postType )?.slug === 'page';
 			const isStaticHomepage = siteSettings?.show_on_front === 'page';
-			const pageForPosts = siteSettings?.page_for_posts;
+			const isPageForPostsSet = getEntityRecord(
+				'postType',
+				'page',
+				siteSettings?.page_for_posts
+			);
 			return {
 				labels: getPostType( postType )?.labels,
 				canCreateRecord: canUser( 'create', {
@@ -358,7 +362,7 @@ export default function PostList( { postType } ) {
 					name: postType,
 				} ),
 				showPageForPostsOption:
-					isPagePostType && isStaticHomepage && ! pageForPosts,
+					isPagePostType && isStaticHomepage && ! isPageForPostsSet,
 			};
 		},
 		[ postType ]

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -39,6 +39,7 @@ import {
 import AddNewPostModal from '../add-new-post';
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
+import { useIsSiteEditorLoading } from './../layout/hooks';
 
 const { usePostActions, usePostFields } = unlock( editorPrivateApis );
 const { useLocation, useHistory } = unlock( routerPrivateApis );
@@ -390,6 +391,8 @@ export default function PostList( { postType } ) {
 		setShowAddPostModal( false );
 	};
 
+	const isEditorLoading = useIsSiteEditorLoading();
+
 	const NewPageDropdownButton = () => {
 		return (
 			<Dropdown
@@ -405,6 +408,8 @@ export default function PostList( { postType } ) {
 						<Button
 							variant="primary"
 							__next40pxDefaultSize
+							disabled={ isEditorLoading }
+							accessibleWhenDisabled
 							{ ...toggleProps }
 						>
 							{ toggleProps.label }

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -375,9 +375,16 @@ export default function PostList( { postType } ) {
 	);
 
 	const [ showAddPostModal, setShowAddPostModal ] = useState( false );
+	const [ typeOfPageToCreate, setTypeOfPageToCreate ] = useState( '' );
 
-	const openModal = () => setShowAddPostModal( true );
-	const closeModal = () => setShowAddPostModal( false );
+	const openModal = ( typeOfPage ) => {
+		setTypeOfPageToCreate( typeOfPage );
+		setShowAddPostModal( true );
+	};
+	const closeModal = () => {
+		setTypeOfPageToCreate( '' );
+		setShowAddPostModal( false );
+	};
 
 	const NewPageDropdownButton = () => {
 		return (
@@ -407,11 +414,15 @@ export default function PostList( { postType } ) {
 							spacing={ 1 }
 							style={ { minWidth: '250px' } }
 						>
-							<Button __next40pxDefaultSize>
+							<Button
+								__next40pxDefaultSize
+								onClick={ () => openModal() }
+							>
 								{ __( 'Regular page' ) }
 							</Button>
 							<Button
 								__next40pxDefaultSize
+								onClick={ () => openModal( 'pageForPosts' ) }
 								style={ {
 									flexDirection: 'column',
 									alignItems: 'flex-start',
@@ -463,6 +474,7 @@ export default function PostList( { postType } ) {
 						{ showAddPostModal && (
 							<AddNewPostModal
 								postType={ postType }
+								typeOfPage={ typeOfPageToCreate }
 								onSave={ handleNewPage }
 								onClose={ closeModal }
 							/>

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -435,6 +435,7 @@ export default function PostList( { postType } ) {
 								style={ {
 									flexDirection: 'column',
 									alignItems: 'flex-start',
+									height: '46px',
 								} }
 							>
 								{ __( 'Blog' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This adds an additional page option to the Add New Page button on the Pages view, "Blog", when a static homepage is set, but `page_for_posts` is unset.

I've also opened a separate PR that includes adding an action to reset the posts page from the Pages view, as I think it's important these options are introduced at a similar time to this PR: https://github.com/WordPress/gutenberg/pull/67650.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Addresses https://github.com/WordPress/gutenberg/issues/63667.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updates the `AddNewPostModal` function to handle creating a posts page in addition to creating a regular page. Based on the design in https://github.com/WordPress/gutenberg/issues/63667.

When the new option is selected, a new page is created, published, and set as the latest posts page. The new page must be published immediately as the posts page cannot be a draft.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Ensure the homepage is set to a static page
2. Go to Editor -> Pages
3. Click "Add New Page" at the top
4. You should see a new dropdown menu with "Regular page" and "Blog" as options
5. Click "Blog"
6. Create a new posts page

## Screenshots or screencast <!-- if applicable -->

Dropdown:
![image](https://github.com/user-attachments/assets/58854318-5de4-46b4-ac10-b98e67d59f3d)

Modal:
![image](https://github.com/user-attachments/assets/5fc80a40-0d4f-4e9a-accf-7048e120916f)
