### PR TITLE
Welcome guide headline update

### DIFF
--- a/packages/edit-post/src/components/welcome-guide/default.js
+++ b/packages/edit-post/src/components/welcome-guide/default.js
@@ -18,7 +18,7 @@ export default function WelcomeGuideDefault() {
 	return (
 		<Guide
 			className="edit-post-welcome-guide"
-			contentLabel={ __( 'Welcome to the block editor' ) }
+			contentLabel={ __( 'Welcome to the editor' ) }
 			finishButtonText={ __( 'Get started' ) }
 			onFinish={ () => toggleFeature( 'welcomeGuide' ) }
 			pages={ [
@@ -32,7 +32,7 @@ export default function WelcomeGuideDefault() {
 					content: (
 						<>
 							<h1 className="edit-post-welcome-guide__heading">
-								{ __( 'Welcome to the block editor' ) }
+								{ __( 'Welcome to the editor' ) }
 							</h1>
 							<p className="edit-post-welcome-guide__text">
 								{ __(
@@ -52,7 +52,7 @@ export default function WelcomeGuideDefault() {
 					content: (
 						<>
 							<h1 className="edit-post-welcome-guide__heading">
-								{ __( 'Make each block your own' ) }
+								{ __( 'Customize each block' ) }
 							</h1>
 							<p className="edit-post-welcome-guide__text">
 								{ __(
@@ -72,7 +72,7 @@ export default function WelcomeGuideDefault() {
 					content: (
 						<>
 							<h1 className="edit-post-welcome-guide__heading">
-								{ __( 'Get to know the block library' ) }
+								{ __( 'Explore all blocks' ) }
 							</h1>
 							<p className="edit-post-welcome-guide__text">
 								{ createInterpolateElement(
@@ -102,7 +102,7 @@ export default function WelcomeGuideDefault() {
 					content: (
 						<>
 							<h1 className="edit-post-welcome-guide__heading">
-								{ __( 'Learn how to use the block editor' ) }
+								{ __( 'Learn more' ) }
 							</h1>
 							<p className="edit-post-welcome-guide__text">
 								{ createInterpolateElement(

--- a/packages/edit-widgets/src/components/welcome-guide/index.js
+++ b/packages/edit-widgets/src/components/welcome-guide/index.js
@@ -118,7 +118,7 @@ export default function WelcomeGuide() {
 					content: (
 						<>
 							<h1 className="edit-widgets-welcome-guide__heading">
-								{ __( 'Make each block your own' ) }
+								{ __( 'Customize each block' ) }
 							</h1>
 							<p className="edit-widgets-welcome-guide__text">
 								{ __(
@@ -138,7 +138,7 @@ export default function WelcomeGuide() {
 					content: (
 						<>
 							<h1 className="edit-widgets-welcome-guide__heading">
-								{ __( 'Get to know the block library' ) }
+								{ __( 'Explore all blocks' ) }
 							</h1>
 							<p className="edit-widgets-welcome-guide__text">
 								{ createInterpolateElement(
@@ -169,7 +169,7 @@ export default function WelcomeGuide() {
 					content: (
 						<>
 							<h1 className="edit-widgets-welcome-guide__heading">
-								{ __( 'Learn how to use the block editor' ) }
+								{ __( 'Learn more' ) }
 							</h1>
 							<p className="edit-widgets-welcome-guide__text">
 								{ createInterpolateElement(

--- a/test/e2e/specs/editor/various/nux.spec.js
+++ b/test/e2e/specs/editor/various/nux.spec.js
@@ -12,7 +12,7 @@ test.describe( 'New User Experience (NUX)', () => {
 		await admin.createNewPost( { showWelcomeGuide: true } );
 
 		const welcomeGuide = page.getByRole( 'dialog', {
-			name: 'Welcome to the block editor',
+			name: 'Welcome to the editor',
 		} );
 		const guideHeading = welcomeGuide.getByRole( 'heading', { level: 1 } );
 		const nextButton = welcomeGuide.getByRole( 'button', { name: 'Next' } );
@@ -20,36 +20,28 @@ test.describe( 'New User Experience (NUX)', () => {
 			name: 'Previous',
 		} );
 
-		await expect( guideHeading ).toHaveText(
-			'Welcome to the block editor'
-		);
+		await expect( guideHeading ).toHaveText( 'Welcome to the editor' );
 
 		await nextButton.click();
-		await expect( guideHeading ).toHaveText( 'Make each block your own' );
+		await expect( guideHeading ).toHaveText( 'Customize each block' );
 
 		await prevButton.click();
 		// Guide should be on page 1 of 4
-		await expect( guideHeading ).toHaveText(
-			'Welcome to the block editor'
-		);
+		await expect( guideHeading ).toHaveText( 'Welcome to the editor' );
 
 		// Press the button for Page 2.
 		await welcomeGuide
 			.getByRole( 'button', { name: 'Page 2 of 4' } )
 			.click();
-		await expect( guideHeading ).toHaveText( 'Make each block your own' );
+		await expect( guideHeading ).toHaveText( 'Customize each block' );
 
 		// Press the right arrow key for Page 3.
 		await page.keyboard.press( 'ArrowRight' );
-		await expect( guideHeading ).toHaveText(
-			'Get to know the block library'
-		);
+		await expect( guideHeading ).toHaveText( 'Explore all blocks' );
 
 		// Press the right arrow key for Page 4.
 		await page.keyboard.press( 'ArrowRight' );
-		await expect( guideHeading ).toHaveText(
-			'Learn how to use the block editor'
-		);
+		await expect( guideHeading ).toHaveText( 'Learn more' );
 
 		// Click on the *visible* 'Get started' button.
 		await welcomeGuide
@@ -77,7 +69,7 @@ test.describe( 'New User Experience (NUX)', () => {
 		await admin.createNewPost( { showWelcomeGuide: true } );
 
 		const welcomeGuide = page.getByRole( 'dialog', {
-			name: 'Welcome to the block editor',
+			name: 'Welcome to the editor',
 		} );
 
 		await expect( welcomeGuide ).toBeVisible();
@@ -100,7 +92,7 @@ test.describe( 'New User Experience (NUX)', () => {
 		await admin.createNewPost( { showWelcomeGuide: true } );
 
 		const welcomeGuide = page.getByRole( 'dialog', {
-			name: 'Welcome to the block editor',
+			name: 'Welcome to the editor',
 		} );
 
 		await expect( welcomeGuide ).toBeVisible();
@@ -117,7 +109,7 @@ test.describe( 'New User Experience (NUX)', () => {
 	} ) => {
 		await admin.createNewPost();
 		const welcomeGuide = page.getByRole( 'dialog', {
-			name: 'Welcome to the block editor',
+			name: 'Welcome to the editor',
 		} );
 
 		await expect( welcomeGuide ).toBeHidden();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix for https://github.com/WordPress/gutenberg/issues/67601

## Why?
There is widows for each frame of the welcome guide.

## How?
Updated the headline text as mentioned.

- Welcome to the block editor > Welcome to the editor
- Make each block your own > Customize each block
- Get to know the block library > Explore all blocks
- Learn how to use the block editor > Learn more

## Testing Instructions

- Go to page/post edit screen.
- Make sure Welcome guide option is enable from page/post settings.
- Check and verify each headlines of the welcome guide.
- All are updated as mentioned



## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

![customise](https://github.com/user-attachments/assets/ca1f3c3a-ca8c-49ae-be8a-09a84a4fae5c)
![explore](https://github.com/user-attachments/assets/0080ab8a-878d-4e0b-9097-e8251c171a72)
![learnmore](https://github.com/user-attachments/assets/449f3bff-8d2f-4a51-93a5-cea079135636)
![welcome](https://github.com/user-attachments/assets/0f811351-1efa-4247-9ffa-02ae4cdfb56b)
