### PR TITLE
Storybook: Revert "Preview: ArgsTable => Controls (#67582)"

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import {
-	Controls,
+	ArgsTable,
 	Description,
 	Primary,
 	Stories,
@@ -114,7 +114,8 @@ export const parameters = {
 				<Subtitle />
 				<Primary />
 				<Description />
-				<Controls />
+				{ /* `story="^"` enables Controls for the primary props table */ }
+				<ArgsTable story="^" />
 				<Stories includePrimary={ false } />
 			</>
 		),


### PR DESCRIPTION
## What?

Reverts #67582, which removed subcomponents from the Storybook props tables.

## Why?

Judging from the timing of events in https://github.com/storybookjs/storybook/pull/25614, I _think_ we have to wait until the actual Storybook 8 upgrade until we get back subcomponents support in the `Controls` block. Until then, let's keep the prior setup.

## Testing Instructions

Storybook should show subcomponent tabs in the props tables again, for example in the [Navigator component](http://localhost:50240/?path=/docs/components-navigator--docs).
