### PR TITLE
Feature: Allow Post Template block to get deeply nested within Query Block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -660,7 +660,7 @@ Contains the block elements used to render a post, like the title, date, feature
 
 -	**Name:** core/post-template
 -	**Category:** theme
--	**Parent:** core/query
+-	**Ancestor:** core/query
 -	**Supports:** align (full, wide), color (background, gradients, link, text), interactivity (clientNavigation), layout, spacing (blockGap), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Post Terms

--- a/packages/block-library/src/post-template/block.json
+++ b/packages/block-library/src/post-template/block.json
@@ -4,7 +4,7 @@
 	"name": "core/post-template",
 	"title": "Post Template",
 	"category": "theme",
-	"parent": [ "core/query" ],
+	"ancestor": [ "core/query" ],
 	"description": "Contains the block elements used to render a post, like the title, date, featured image, content or excerpt, and more.",
 	"textdomain": "default",
 	"usesContext": [


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allow the "Post Template" block to get nested deeply inside the "Query" block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Especially now with the advent of region-based routing in the interactivity API we need to be able to place more other controls into the "Query" block so they can talk to the correct region router. This means if we built a custom filtering sidebar for example we need to place that query filter block into the query itself. 

In order to actually be able to create rich layouts in these cases we also need to be able to move the actual list of posts around and nest it in a columns block for example. 

Moving from `parent` to `ancestor` allows just that. 

The "Post Template" block actually is the block that renders the `ul` element containing all the posts. So, moving this into a column still has 100% valid markup.

I've been running this on a few projects by manually overriding the `parent` to `ancestor` via the `block_type_metadata` filter.

Interestingly enough the Core TwentyTwentyFive theme even ships patterns that force this deeply nested structure in patterns.

https://github.com/WordPress/wordpress-develop/blob/8eb8d634095e9b6716e977abd1085bab8d703e6f/src/wp-content/themes/twentytwentyfive/patterns/template-query-loop-photo-blog.php#L30-L32

This would not be possible in the UI today but this PR will enable it.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Changing `parent` to `ancestor` in the `block.json`

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

 1. Add a query loop
 2. Add a columns block inside the query loop
 3. Move the Post Template into one of the columns
 4. See that it works as intended in the editor and on the frontend
