### PR TITLE
Try moving hover animation from resizable frame to editor

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -263,6 +263,18 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 			) }
 			{ isReady && (
 				<Editor
+					as={ motion.div }
+					whileHover={
+						canvas === 'view'
+							? {
+									scale: 1.005,
+									transition: {
+										duration: disableMotion ? 0 : 0.5,
+										ease: 'easeOut',
+									},
+							  }
+							: {}
+					}
 					postType={ postWithTemplate ? context.postType : postType }
 					postId={ postWithTemplate ? context.postId : postId }
 					templateId={ postWithTemplate ? postId : undefined }

--- a/packages/edit-site/src/components/editor/style.scss
+++ b/packages/edit-site/src/components/editor/style.scss
@@ -1,7 +1,7 @@
 .edit-site-editor__editor-interface {
 	opacity: 1;
-	transition: opacity 0.1s ease-out;
-	@include reduce-motion( "transition" );
+	// transition: opacity 0.1s ease-out;
+	// @include reduce-motion( "transition" );
 
 	&.is-loading {
 		opacity: 0;

--- a/packages/edit-site/src/components/resizable-frame/index.js
+++ b/packages/edit-site/src/components/resizable-frame/index.js
@@ -12,7 +12,7 @@ import {
 	Tooltip,
 	__unstableMotion as motion,
 } from '@wordpress/components';
-import { useInstanceId, useReducedMotion } from '@wordpress/compose';
+import { useInstanceId } from '@wordpress/compose';
 import { __, isRTL } from '@wordpress/i18n';
 import { privateApis as routerPrivateApis } from '@wordpress/router';
 
@@ -91,7 +91,6 @@ function ResizableFrame( {
 	const history = useHistory();
 	const { path, query } = useLocation();
 	const { canvas = 'view' } = query;
-	const disableMotion = useReducedMotion();
 	const [ frameSize, setFrameSize ] = useState( INITIAL_FRAME_SIZE );
 	// The width of the resizable frame when a new resize gesture starts.
 	const [ startingWidth, setStartingWidth ] = useState();
@@ -244,17 +243,6 @@ function ResizableFrame( {
 					setFrameSize( { width: '100%', height: '100%' } );
 				}
 			} }
-			whileHover={
-				canvas === 'view'
-					? {
-							scale: 1.005,
-							transition: {
-								duration: disableMotion ? 0 : 0.5,
-								ease: 'easeOut',
-							},
-					  }
-					: {}
-			}
 			transition={ FRAME_TRANSITION }
 			size={ frameSize }
 			enable={ {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Addressing [this comment](https://github.com/WordPress/gutenberg/pull/66851#issuecomment-2519608938).

I'm not sure yet why this isn't working. No styles added to `whileHover` actually come through at all.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
