### PR TITLE
Increase icon size of range selector

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -212,7 +212,7 @@ export default function SpacingInputControl( {
 				<Icon
 					className="spacing-sizes-control__icon"
 					icon={ icon }
-					size={ 24 }
+					size={ 32 }
 				/>
 			) }
 			{ showCustomValueControl && (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/67257

## Why?
The icons appear small and unclear at 24px, reducing usability.

## How?
Updated the gutenberg/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js for the range selector component to increase the icon size to 32px

## Testing Instructions
Open the WordPress block editor.
Add any block which having range selector support like dimension.
Navigate to the Block Settings in the right-hand sidebar.
Locate the Dimensions panel under the settings (e.g., for Margin or Padding).
Observe the range selector icons.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![rangeiconbefor](https://github.com/user-attachments/assets/9f072296-f679-46bc-9083-4d5a803fc05b)|![rangeicon](https://github.com/user-attachments/assets/5a68b1bb-3a15-47f4-bb9b-aefb5cd55ab2)|

