### PR TITLE
Storybook: Fix `BlockPatternsList` fixtures

### DIFF
--- a/packages/block-editor/src/components/block-patterns-list/stories/fixtures.js
+++ b/packages/block-editor/src/components/block-patterns-list/stories/fixtures.js
@@ -530,6 +530,7 @@ export default [
 													background: '#000000',
 												},
 											},
+											tagName: 'hr',
 										},
 										innerBlocks: [],
 										originalContent:


### PR DESCRIPTION
## What?
Fixes an error in the `BlockPatternsList` story.

## Why?
Just fixing an error in the story.

Found while working on #67574.

## How?
The separator inner block fixture is missing a `tagName`.

## Testing Instructions
* Open the `BlockPatternsList` story: http://localhost:50240/?path=/story/blockeditor-blockpatternslist--default
* Verify after the patterns load, there is no error in the console

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Error before this PR:

![Screenshot 2024-12-06 at 10 53 40](https://github.com/user-attachments/assets/5bbd9ad0-80c6-4a7f-94c6-de420ef41e29)
