### PR TITLE
Site Editor: remove default page slug

### DIFF
--- a/packages/edit-site/src/components/add-new-post/index.js
+++ b/packages/edit-site/src/components/add-new-post/index.js
@@ -45,7 +45,6 @@ export default function AddNewPostModal( { postType, onSave, onClose } ) {
 				{
 					status: 'draft',
 					title,
-					slug: title || __( 'No title' ),
 					content:
 						!! postTypeObject.template &&
 						postTypeObject.template.length

--- a/packages/edit-site/src/components/add-new-post/index.js
+++ b/packages/edit-site/src/components/add-new-post/index.js
@@ -45,6 +45,7 @@ export default function AddNewPostModal( { postType, onSave, onClose } ) {
 				{
 					status: 'draft',
 					title,
+					slug: title ?? undefined,
 					content:
 						!! postTypeObject.template &&
 						postTypeObject.template.length


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
 Resolves https://github.com/WordPress/gutenberg/issues/67539

Removes the default slug assignment when creating an untitled page in the site editor.


## Why?

WordPress will try to create a slug from the title. WordPress will also look for a corresponding `page-` template that [matches the slug name](https://github.com/wordpress/wordpress-develop/blob/8eb8d634095e9b6716e977abd1085bab8d703e6f/src/wp-includes/template.php#L460-L460). 

Therefore if a page template exists with the name page-no-title, WordPress will apply that template to any page with that unique slug. 

This causes unexpected template assignment. TT4 and TT5 most notably, both of which have `page-no-title` templates! 

It's also inconsistent since subsequent untitled pages created in the site editor will use the default template, slugs being unique. 


## How?

Anyway, let's just use WordPress's default behavior, which is to create a unique slug using [wp_unique_post_slug](https://developer.wordpress.org/reference/functions/wp_unique_post_slug/)  if none exists.

This is what happens in the post editor. Why should the site editor get special treatment?

It shouldn't! That's why.

I have spoken.

## Testing Instructions

Head to the Site Editor and create page.

Don't give it a title!!

Once created, check out the slug in the page settings in the right hand side panel. It should be something like `"$page_id-$suffix"`, e.g., `12-2`

That's it!