### PR TITLE
Popover: Use `anchor` instead of `anchorRef` in story

### DIFF
--- a/packages/components/src/popover/stories/index.story.tsx
+++ b/packages/components/src/popover/stories/index.story.tsx
@@ -58,7 +58,9 @@ const meta: Meta< typeof Popover > = {
 export default meta;
 
 const PopoverWithAnchor = ( args: PopoverProps ) => {
-	const anchorRef = useRef( null );
+	const [ popoverAnchor, setPopoverAnchor ] = useState< Element | null >(
+		null
+	);
 
 	return (
 		<div
@@ -71,11 +73,11 @@ const PopoverWithAnchor = ( args: PopoverProps ) => {
 		>
 			<p
 				style={ { padding: '8px', background: 'salmon' } }
-				ref={ anchorRef }
+				ref={ setPopoverAnchor }
 			>
 				Popover&apos;s anchor
 			</p>
-			<Popover { ...args } anchorRef={ anchorRef } />
+			<Popover { ...args } anchor={ popoverAnchor } />
 		</div>
 	);
 };


### PR DESCRIPTION
## What?
Fixes a warning in the `Popover` stories.

## Why?
The `anchor` prop is recommended in favor of the deprecated `anchorRef`.
Found while working on #67574.

## How?
We're updating the story to reflect that `anchor` is now recommended in favor of the deprecated `anchorRef` prop.

## Testing Instructions
* Open the Popover > All Placements story
* Verify the `anchorRef` prop warning no longer appears

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Warning before this PR:

![Screenshot 2024-12-06 at 11 08 03](https://github.com/user-attachments/assets/8080001d-b4d3-41be-bb29-b2ada5d94f48)
