### PR TITLE
DateTime: Add default date/time to stories

### DIFF
--- a/packages/components/src/date-time/stories/date-time.story.tsx
+++ b/packages/components/src/date-time/stories/date-time.story.tsx
@@ -51,6 +51,9 @@ const Template: StoryFn< typeof DateTimePicker > = ( {
 };
 
 export const Default: StoryFn< typeof DateTimePicker > = Template.bind( {} );
+Default.args = {
+	currentDate: new Date(),
+};
 
 export const WithEvents: StoryFn< typeof DateTimePicker > = Template.bind( {} );
 WithEvents.args = {

--- a/packages/components/src/date-time/stories/date.story.tsx
+++ b/packages/components/src/date-time/stories/date.story.tsx
@@ -51,6 +51,9 @@ const Template: StoryFn< typeof DatePicker > = ( {
 };
 
 export const Default: StoryFn< typeof DatePicker > = Template.bind( {} );
+Default.args = {
+	currentDate: new Date(),
+};
 
 export const WithEvents: StoryFn< typeof DatePicker > = Template.bind( {} );
 WithEvents.args = {

--- a/packages/components/src/date-time/stories/time.story.tsx
+++ b/packages/components/src/date-time/stories/time.story.tsx
@@ -52,6 +52,9 @@ const Template: StoryFn< typeof TimePicker > = ( {
 };
 
 export const Default: StoryFn< typeof TimePicker > = Template.bind( {} );
+Default.args = {
+	currentTime: new Date(),
+};
 
 const TimeInputTemplate: StoryFn< typeof TimePicker.TimeInput > = ( args ) => {
 	return <TimePicker.TimeInput { ...args } />;


### PR DESCRIPTION
## What?
Fixes a couple of warnings in the `DateTime` component family stories.

## Why?
There are warnings because we don't have an initial date or time.

Found while working on #67574.

## How?
We're updating the stories to have initial date or time set.

## Testing Instructions
* Open the Time & Date stories and verify the warning no longer appears:
  * `DateTimePicker`: http://localhost:50240/?path=/docs/components-datetimepicker--docs
  * `DatePicker`: http://localhost:50240/?path=/docs/components-datepicker--docs
  * `TimePicker`: http://localhost:50240/?path=/docs/components-timepicker--docs

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Warnings before this PR:
![Screenshot 2024-12-06 at 11 18 28](https://github.com/user-attachments/assets/bf901e57-2148-42ff-a7f3-193fd9568eb1)


