### PR TITLE
Disabled: Suppress `contentEditable` warning in story

### DIFF
--- a/packages/components/src/disabled/stories/index.story.tsx
+++ b/packages/components/src/disabled/stories/index.story.tsx
@@ -82,7 +82,7 @@ Default.args = {
 export const ContentEditable: StoryFn< typeof Disabled > = ( args ) => {
 	return (
 		<Disabled { ...args }>
-			<div contentEditable tabIndex={ 0 }>
+			<div contentEditable tabIndex={ 0 } suppressContentEditableWarning>
 				contentEditable
 			</div>
 		</Disabled>


### PR DESCRIPTION
## What?
Fixes a warning in the `Disabled` story.

## Why?
The behavior in the story is intentional, so the warning is not necessary.

Found while working on #67574.

## How?
We're adding the `suppressContentEditableWarning` prop to intentionally suppress the warning React generates.

## Testing Instructions
* Open the Disabled story: http://localhost:50240/?path=/story/components-disabled--content-editable
* Verify the warning no longer appears

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Warning before this PR:

![Screenshot 2024-12-06 at 11 28 57](https://github.com/user-attachments/assets/65519cc9-889f-4c16-9283-2c2b6eb50efe)

