### PR TITLE
Feature: Add `navigation.isLoading` state to core/router store

### DIFF
--- a/packages/interactivity-router/src/index.ts
+++ b/packages/interactivity-router/src/index.ts
@@ -223,6 +223,7 @@ interface Store {
 	state: {
 		url: string;
 		navigation: {
+			isLoading: boolean;
 			hasStarted: boolean;
 			hasFinished: boolean;
 		};
@@ -237,6 +238,7 @@ export const { state, actions } = store< Store >( 'core/router', {
 	state: {
 		url: window.location.href,
 		navigation: {
+			isLoading: false,
 			hasStarted: false,
 			hasFinished: false,
 		},
@@ -289,6 +291,7 @@ export const { state, actions } = store< Store >( 'core/router', {
 					return;
 				}
 
+				navigation.isLoading = true;
 				if ( loadingAnimation ) {
 					navigation.hasStarted = true;
 					navigation.hasFinished = false;
@@ -328,6 +331,7 @@ export const { state, actions } = store< Store >( 'core/router', {
 
 				// Update the navigation status once the the new page rendering
 				// has been completed.
+				navigation.isLoading = false;
 				if ( loadingAnimation ) {
 					navigation.hasStarted = false;
 					navigation.hasFinished = true;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Adds a new `navigation.isLoading` state to the `core/router` interactivity store

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Today the router only has the `navigation.hasStarted` and `navigation.hasFinished` states. These only get set if the `loadingAnimation` option is not set to false. 

Because of this it is not possible to hide the global loading indicator whilst still knowing whether or not the router is currently  loading something. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Adds a new state to the store
