### PR TITLE
Theme: Fix contrast in nested story

### DIFF
--- a/packages/components/src/theme/stories/index.story.tsx
+++ b/packages/components/src/theme/stories/index.story.tsx
@@ -37,7 +37,7 @@ export const Default = Template.bind( {} );
 Default.args = {};
 
 export const Nested: StoryFn< typeof Theme > = ( args ) => (
-	<Theme accent="tomato">
+	<Theme accent="crimson">
 		<Button variant="primary">Outer theme (hardcoded)</Button>
 
 		<Theme { ...args }>


### PR DESCRIPTION
## What?
Fixes a warning in the `Themes` nested story.

## Why?
Just fixing a warning in the story.

Found while working on #67574.

## How?
We're using an accent color that achieves sufficient contrast against the background color.

## Testing Instructions
* Open the nested `Theme` story: http://localhost:50240/?path=/story/components-theme--nested
* Verify that there is no contrast warning in the console.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Error before this PR:

![Screenshot 2024-12-06 at 11 36 29](https://github.com/user-attachments/assets/83057f6e-d41f-4b0f-b9e0-1efa9dd29496)

