### PR TITLE
Scrollable: Fix story by declaring field as readonly

### DIFF
--- a/packages/components/src/scrollable/stories/index.story.tsx
+++ b/packages/components/src/scrollable/stories/index.story.tsx
@@ -70,6 +70,7 @@ const Template: StoryFn< typeof Scrollable > = ( { ...args } ) => {
 					} }
 					type="text"
 					value="Focus me"
+					readOnly
 				/>
 			</View>
 		</Scrollable>


### PR DESCRIPTION
## What?
Fixes a warning in the `Scrollable` story.

## Why?
Just fixing a warning in the story.

Found while working on #67574.

## How?
We're using the field as a read-only field, so React will complain if there's no `onChange` or `readOnly` provided to it.

## Testing Instructions
* Open the `Scrollable` story: http://localhost:50240/?path=/docs/components-experimental-scrollable--docs
* Verify that there is no read-only warning anymore

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Error before this PR:

![Screenshot 2024-12-06 at 12 02 31](https://github.com/user-attachments/assets/e4e27fe5-c232-4404-a4f0-7836c744e09c)


