### PR TITLE
Preserve styling attributes during transformation to list blocks.

### DIFF
--- a/packages/block-library/src/list/transforms.js
+++ b/packages/block-library/src/list/transforms.js
@@ -47,6 +47,13 @@ const transforms = {
 			blocks: [ 'core/paragraph', 'core/heading' ],
 			transform: ( blockAttributes ) => {
 				let childBlocks = [];
+				const listAttributes = {
+					anchor: blockAttributes.anchor,
+					fontSize: blockAttributes[ 0 ]?.fontSize,
+					textColor: blockAttributes[ 0 ]?.textColor,
+					backgroundColor: blockAttributes[ 0 ]?.backgroundColor,
+				};
+
 				if ( blockAttributes.length > 1 ) {
 					childBlocks = blockAttributes.map( ( { content } ) => {
 						return createBlock( 'core/list-item', { content } );
@@ -61,13 +68,7 @@ const transforms = {
 						} );
 					} );
 				}
-				return createBlock(
-					'core/list',
-					{
-						anchor: blockAttributes.anchor,
-					},
-					childBlocks
-				);
+				return createBlock( 'core/list', listAttributes, childBlocks );
 			},
 		},
 		{


### PR DESCRIPTION
Resolves https://github.com/WordPress/gutenberg/issues/67619

## What?
This PR ensures that styling, such as fontSize, textColor and backGround, is preserved when transforming a block into a List block. Previously, these styles were lost when transforming the block.

## Why?
This PR addresses the issue and ensures that the styles are carried over, improving the block transformation experience.

## How?

- The logic in block-library/src/list/transforms.js has been updated to capture the attributes from blocks during transformation. 
- These attributes are then retained when transforming into a List block, preventing the styling loss.

## Testing Instructions
1. Open the block editor in Gutenberg.
2. Add a Paragraph block and apply typography styles (e.g., font size, text color).
3. Transform the Paragraph block into a Heading block and verify that the styles are preserved.
4. Revert the Heading block back to the Paragraph block and ensure the styles remain.
5. Transform the Paragraph block into a List block and confirm the styles carry over.
6. Revert the List block back to a Paragraph block and verify the original styles are maintained.

### Testing Instructions for Keyboard
- Use the Tab key to navigate and select the Paragraph block.
- Apply styles using the block toolbar.
- Transform the block using the block options menu and verify the styling persists in the List block.
- Use the keyboard to navigate between blocks and check that styles are correctly preserved.

### video

https://github.com/user-attachments/assets/d068d7d2-ee43-4484-a748-3070f0888217
