### PR TITLE
Storybook: Fix table markup in Design Language - Radius docs

### DIFF
--- a/storybook/stories/foundations/design-language/radius.mdx
+++ b/storybook/stories/foundations/design-language/radius.mdx
@@ -31,25 +31,29 @@ These steps are defined as tokens. To view the values and understand how to use 
 -   Accessibility: Larger radius values can create a more approachable and friendly appearance, especially for larger components like cards and modals that demand more attention from users.
 
 <table>
-  <tr>
-    <th width="50%">✅ Do</th>
-    <th width="50%">🚫 Don't</th>
-  </tr>
-  <tr>
-    <td width="50%" valign="top">
-      <img src={ radiusDo } alt="Radius do" width="100%" />
+  <thead>
+    <tr>
+      <th width="50%">✅ Do</th>
+      <th width="50%">🚫 Don't</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td width="50%" valign="top">
+        <img src={ radiusDo } alt="Radius do" width="100%" />
 
-      - Scale application of radius with element or container size.
+        - Scale application of radius with element or container size.
 
-      - Use `radius-round` for circles and `radius-full` for pills.
-    </td>
-    <td width="50%" valign="top">
-      <img src={ radiusDont } alt="Radius don't" width="100%" />
+        - Use `radius-round` for circles and `radius-full` for pills.
+      </td>
+      <td width="50%" valign="top">
+        <img src={ radiusDont } alt="Radius don't" width="100%" />
 
-        -   Don't nest larger radii inside smaller radii.
+          -   Don't nest larger radii inside smaller radii.
 
-        -   Don't apply the same
-    radius value to container and immediate descendent.
-    </td>
-  </tr>
+          -   Don't apply the same
+      radius value to container and immediate descendent.
+      </td>
+    </tr>
+  </tbody>
 </table>


### PR DESCRIPTION
## What?
Fixes a warning in the Design Language - Radius docs.

## Why?
Just fixing a warning in the Storybook design system docs.

Found while working on #67574.

## How?
We're adding `thead` and `tbody` sections, respectively.

## Testing Instructions
* Open the Design Language - Radius page in Storybook: http://localhost:50240/?path=/docs/foundations-design-language-radius--page
* Verify that there is no DOM warning in the console.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
Error before this PR:

![Screenshot 2024-12-06 at 12 15 58](https://github.com/user-attachments/assets/0a159666-e214-4b2b-af9b-81684ea865b1)


