### PR TITLE
BoxControl: Add support for presets

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -24,7 +24,8 @@
 -   `Menu`: Replace hardcoded white color with theme-ready variable ([#67649](https://github.com/WordPress/gutenberg/pull/67649)).
 -   `Navigation` (deprecated): Replace hardcoded white color with theme-ready variable ([#67649](https://github.com/WordPress/gutenberg/pull/67649)).
 -   `ToggleGroupControl`: Replace hardcoded white color with theme-ready variable ([#67649](https://github.com/WordPress/gutenberg/pull/67649)).
--   `RangeControl`: Update the design of the range control marks ([#67611](https://github.com/WordPress/gutenberg/pull/67611))
+-   `RangeControl`: Update the design of the range control marks ([#67611](https://github.com/WordPress/gutenberg/pull/67611)).
+-   `BoxControl`: Add presets support ([#67688](https://github.com/WordPress/gutenberg/pull/67688)).
 -   `BorderBoxControl`: Reduce gap value when unlinked ([#67049](https://github.com/WordPress/gutenberg/pull/67049)).
 -   `DropdownMenu`: Increase option height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).
 -   `MenuItem`: Increase height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   `BoxControl`: Add presets support ([#67688](https://github.com/WordPress/gutenberg/pull/67688)).
+
 ### Deprecations
 
 -   `SelectControl`: Deprecate 36px default size ([#66898](https://github.com/WordPress/gutenberg/pull/66898)).
@@ -25,7 +29,6 @@
 -   `Navigation` (deprecated): Replace hardcoded white color with theme-ready variable ([#67649](https://github.com/WordPress/gutenberg/pull/67649)).
 -   `ToggleGroupControl`: Replace hardcoded white color with theme-ready variable ([#67649](https://github.com/WordPress/gutenberg/pull/67649)).
 -   `RangeControl`: Update the design of the range control marks ([#67611](https://github.com/WordPress/gutenberg/pull/67611)).
--   `BoxControl`: Add presets support ([#67688](https://github.com/WordPress/gutenberg/pull/67688)).
 -   `BorderBoxControl`: Reduce gap value when unlinked ([#67049](https://github.com/WordPress/gutenberg/pull/67049)).
 -   `DropdownMenu`: Increase option height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).
 -   `MenuItem`: Increase height to 40px ([#67435](https://github.com/WordPress/gutenberg/pull/67435)).

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -124,3 +124,18 @@ The current values of the control, expressed as an object of `top`, `right`, `bo
 
  - Type: `BoxControlValue`
  - Required: No
+
+### `presets`
+
+The list of presets to pick from.
+
+ - Type: `Preset`
+ - Required: No
+
+### `presetKey`
+
+The key of the preset to apply. If you provide a list of presets, you must provide a preset key to use. The format of preset selected values is going to be `var:preset|${ presetKey }|${ presetSlug }`
+
+ - Type: `string`
+ - Required: No
+

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -79,6 +79,22 @@ A callback function when an input value changes.
  - Required: No
  - Default: `() => {}`
 
+### `presets`
+
+Available presets to pick from.
+
+ - Type: `Preset[]`
+ - Required: No
+
+### `presetKey`
+
+The key of the preset to apply.
+If you provide a list of presets, you must provide a preset key to use.
+The format of preset selected values is going to be `var:preset|${ presetKey }|${ presetSlug }`
+
+ - Type: `string`
+ - Required: No
+
 ### `resetValues`
 
 The `top`, `right`, `bottom`, and `left` box dimension values to use when the control is reset.
@@ -124,18 +140,3 @@ The current values of the control, expressed as an object of `top`, `right`, `bo
 
  - Type: `BoxControlValue`
  - Required: No
-
-### `presets`
-
-The list of presets to pick from.
-
- - Type: `Preset`
- - Required: No
-
-### `presetKey`
-
-The key of the preset to apply. If you provide a list of presets, you must provide a preset key to use. The format of preset selected values is going to be `var:preset|${ presetKey }|${ presetSlug }`
-
- - Type: `string`
- - Required: No
-

--- a/packages/components/src/box-control/index.tsx
+++ b/packages/components/src/box-control/index.tsx
@@ -83,6 +83,8 @@ function BoxControl( {
 	splitOnAxis = false,
 	allowReset = true,
 	resetValues = DEFAULT_VALUES,
+	presets,
+	presetKey,
 	onMouseOver,
 	onMouseOut,
 }: BoxControlProps ) {
@@ -153,6 +155,8 @@ function BoxControl( {
 		sides,
 		values: inputValues,
 		__next40pxDefaultSize,
+		presets,
+		presetKey,
 	};
 
 	maybeWarnDeprecated36pxSize( {

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -179,10 +179,11 @@ export default function BoxInputControl( {
 		? getPresetIndexFromValue( mergedValue, presetKey, presets )
 		: undefined;
 	const marks = hasPresets
-		? [ { value: 0, label: __( 'None' ) } ].concat(
+		? [ { value: 0, label: '', tooltip: __( 'None' ) } ].concat(
 				presets.map( ( preset, index ) => ( {
 					value: index + 1,
-					label: preset.name,
+					label: '',
+					tooltip: preset.name ?? preset.slug,
 				} ) )
 		  )
 		: [];
@@ -266,7 +267,7 @@ export default function BoxInputControl( {
 							.label
 					}
 					renderTooltipContent={ ( index ) =>
-						marks[ ! index ? 0 : index ].label
+						marks[ ! index ? 0 : index ].tooltip
 					}
 					min={ 0 }
 					max={ marks.length - 1 }

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -175,7 +175,6 @@ export default function BoxInputControl( {
 		! hasPresets ||
 			( ! hasPresetValue && ! isMixed && mergedValue !== undefined )
 	);
-	const showRangeControl = true;
 	const presetIndex = hasPresetValue
 		? getPresetIndexFromValue( mergedValue, presetKey, presets )
 		: undefined;
@@ -242,7 +241,7 @@ export default function BoxInputControl( {
 				</>
 			) }
 
-			{ hasPresets && ! showCustomValueControl && showRangeControl && (
+			{ hasPresets && ! showCustomValueControl && (
 				<FlexedRangeControl
 					__next40pxDefaultSize
 					className="spacing-sizes-control__range-control"
@@ -291,7 +290,6 @@ export default function BoxInputControl( {
 					} }
 					isPressed={ showCustomValueControl }
 					size="small"
-					className="spacing-sizes-control__custom-toggle"
 					iconSize={ 24 }
 				/>
 			) }

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -99,7 +99,7 @@ export default function BoxInputControl( {
 		onChange( nextValues );
 	};
 
-	const handleRewOnValueChange = ( next?: string ) => {
+	const handleRawOnValueChange = ( next?: string ) => {
 		const nextValues = { ...values };
 		defaultValuesToModify.forEach( ( modifiedSide ) => {
 			nextValues[ modifiedSide ] = next;
@@ -255,7 +255,7 @@ export default function BoxInputControl( {
 										presetKey,
 										presets
 								  );
-						handleRewOnValueChange( newValue );
+						handleRawOnValueChange( newValue );
 					} }
 					withInputField={ false }
 					aria-valuenow={

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -3,6 +3,8 @@
  */
 import { useInstanceId } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { settings } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -11,10 +13,13 @@ import Tooltip from '../tooltip';
 import { parseQuantityAndUnitFromRawValue } from '../unit-control/utils';
 import {
 	CUSTOM_VALUE_SETTINGS,
-	getAllowedSides,
 	getMergedValue,
-	isValueMixed,
+	getAllowedSides,
+	getPresetIndexFromValue,
+	getPresetValueFromIndex,
+	isValuePreset,
 	isValuesDefined,
+	isValueMixed,
 	LABELS,
 } from './utils';
 import {
@@ -24,6 +29,7 @@ import {
 	StyledUnitControl,
 } from './styles/box-control-styles';
 import type { BoxControlInputControlProps, BoxControlValue } from './types';
+import Button from '../button';
 
 const noop = () => {};
 
@@ -79,6 +85,8 @@ export default function BoxInputControl( {
 	sides,
 	side,
 	min = 0,
+	presets,
+	presetKey,
 	...props
 }: BoxControlInputControlProps ) {
 	const defaultValuesToModify = getSidesToModify( side, sides );
@@ -89,6 +97,15 @@ export default function BoxInputControl( {
 
 	const handleOnChange = ( nextValues: BoxControlValue ) => {
 		onChange( nextValues );
+	};
+
+	const handleRewOnValueChange = ( next?: string ) => {
+		const nextValues = { ...values };
+		defaultValuesToModify.forEach( ( modifiedSide ) => {
+			nextValues[ modifiedSide ] = next;
+		} );
+
+		handleOnChange( nextValues );
 	};
 
 	const handleOnValueChange = (
@@ -148,52 +165,136 @@ export default function BoxInputControl( {
 	const usedValue =
 		mergedValue === undefined && computedUnit ? computedUnit : mergedValue;
 	const mixedPlaceholder = isMixed || isMixedUnit ? __( 'Mixed' ) : undefined;
+	const hasPresets = presets && presets.length > 0 && presetKey;
+	const hasPresetValue =
+		hasPresets &&
+		mergedValue !== undefined &&
+		! isMixed &&
+		isValuePreset( mergedValue, presetKey );
+	const [ showCustomValueControl, setShowCustomValueControl ] = useState(
+		! hasPresets ||
+			( ! hasPresetValue && ! isMixed && mergedValue !== undefined )
+	);
+	const showRangeControl = true;
+	const presetIndex = hasPresetValue
+		? getPresetIndexFromValue( mergedValue, presetKey, presets )
+		: undefined;
+	const marks = hasPresets
+		? [ { value: 0, label: __( 'None' ) } ].concat(
+				presets.map( ( preset, index ) => ( {
+					value: index + 1,
+					label: preset.name,
+				} ) )
+		  )
+		: [];
 
 	return (
 		<InputWrapper key={ `box-control-${ side }` } expanded>
 			<FlexedBoxControlIcon side={ side } sides={ sides } />
-			<Tooltip placement="top-end" text={ LABELS[ side ] }>
-				<StyledUnitControl
-					{ ...props }
-					min={ min }
-					__shouldNotWarnDeprecated36pxSize
-					__next40pxDefaultSize={ __next40pxDefaultSize }
-					className="component-box-control__unit-control"
-					id={ inputId }
-					isPressEnterToChange
-					disableUnits={ isMixed || isMixedUnit }
-					value={ usedValue }
-					onChange={ handleOnValueChange }
-					onUnitChange={ handleOnUnitChange }
-					onFocus={ handleOnFocus }
-					label={ LABELS[ side ] }
-					placeholder={ mixedPlaceholder }
-					hideLabelFromVision
-				/>
-			</Tooltip>
+			{ showCustomValueControl && (
+				<>
+					<Tooltip placement="top-end" text={ LABELS[ side ] }>
+						<StyledUnitControl
+							{ ...props }
+							min={ min }
+							__shouldNotWarnDeprecated36pxSize
+							__next40pxDefaultSize={ __next40pxDefaultSize }
+							className="component-box-control__unit-control"
+							id={ inputId }
+							isPressEnterToChange
+							disableUnits={ isMixed || isMixedUnit }
+							value={ usedValue }
+							onChange={ handleOnValueChange }
+							onUnitChange={ handleOnUnitChange }
+							onFocus={ handleOnFocus }
+							label={ LABELS[ side ] }
+							placeholder={ mixedPlaceholder }
+							hideLabelFromVision
+						/>
+					</Tooltip>
 
-			<FlexedRangeControl
-				__nextHasNoMarginBottom
-				__next40pxDefaultSize={ __next40pxDefaultSize }
-				__shouldNotWarnDeprecated36pxSize
-				aria-controls={ inputId }
-				label={ LABELS[ side ] }
-				hideLabelFromVision
-				onChange={ ( newValue ) => {
-					handleOnValueChange(
-						newValue !== undefined
-							? [ newValue, computedUnit ].join( '' )
-							: undefined
-					);
-				} }
-				min={ isFinite( min ) ? min : 0 }
-				max={ CUSTOM_VALUE_SETTINGS[ computedUnit ?? 'px' ]?.max ?? 10 }
-				step={
-					CUSTOM_VALUE_SETTINGS[ computedUnit ?? 'px' ]?.step ?? 0.1
-				}
-				value={ parsedQuantity ?? 0 }
-				withInputField={ false }
-			/>
+					<FlexedRangeControl
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize={ __next40pxDefaultSize }
+						__shouldNotWarnDeprecated36pxSize
+						aria-controls={ inputId }
+						label={ LABELS[ side ] }
+						hideLabelFromVision
+						onChange={ ( newValue ) => {
+							handleOnValueChange(
+								newValue !== undefined
+									? [ newValue, computedUnit ].join( '' )
+									: undefined
+							);
+						} }
+						min={ isFinite( min ) ? min : 0 }
+						max={
+							CUSTOM_VALUE_SETTINGS[ computedUnit ?? 'px' ]
+								?.max ?? 10
+						}
+						step={
+							CUSTOM_VALUE_SETTINGS[ computedUnit ?? 'px' ]
+								?.step ?? 0.1
+						}
+						value={ parsedQuantity ?? 0 }
+						withInputField={ false }
+					/>
+				</>
+			) }
+
+			{ hasPresets && ! showCustomValueControl && showRangeControl && (
+				<FlexedRangeControl
+					__next40pxDefaultSize
+					className="spacing-sizes-control__range-control"
+					value={ presetIndex !== undefined ? presetIndex + 1 : 0 }
+					onChange={ ( newIndex ) => {
+						const newValue =
+							newIndex === 0 || newIndex === undefined
+								? undefined
+								: getPresetValueFromIndex(
+										newIndex - 1,
+										presetKey,
+										presets
+								  );
+						handleRewOnValueChange( newValue );
+					} }
+					withInputField={ false }
+					aria-valuenow={
+						presetIndex !== undefined ? presetIndex + 1 : 0
+					}
+					aria-valuetext={
+						marks[ presetIndex !== undefined ? presetIndex + 1 : 0 ]
+							.label
+					}
+					renderTooltipContent={ ( index ) =>
+						marks[ ! index ? 0 : index ].label
+					}
+					min={ 0 }
+					max={ marks.length - 1 }
+					marks={ marks }
+					label={ LABELS[ side ] }
+					hideLabelFromVision
+					__nextHasNoMarginBottom
+				/>
+			) }
+
+			{ hasPresets && (
+				<Button
+					label={
+						showCustomValueControl
+							? __( 'Use size preset' )
+							: __( 'Set custom size' )
+					}
+					icon={ settings }
+					onClick={ () => {
+						setShowCustomValueControl( ! showCustomValueControl );
+					} }
+					isPressed={ showCustomValueControl }
+					size="small"
+					className="spacing-sizes-control__custom-toggle"
+					iconSize={ 24 }
+				/>
+			) }
 		</InputWrapper>
 	);
 }

--- a/packages/components/src/box-control/stories/index.story.tsx
+++ b/packages/components/src/box-control/stories/index.story.tsx
@@ -81,3 +81,15 @@ AxialControlsWithSingleSide.args = {
 	sides: [ 'horizontal' ],
 	splitOnAxis: true,
 };
+
+export const ControlWithPresets = TemplateControlled.bind( {} );
+ControlWithPresets.args = {
+	...Default.args,
+	presets: [
+		{ name: 'Small', slug: 'small', value: '4px' },
+		{ name: 'Medium', slug: 'medium', value: '8px' },
+		{ name: 'Large', slug: 'large', value: '12px' },
+		{ name: 'Extra Large', slug: 'extra-large', value: '16px' },
+	],
+	presetKey: 'padding',
+};

--- a/packages/components/src/box-control/types.ts
+++ b/packages/components/src/box-control/types.ts
@@ -15,6 +15,12 @@ export type CustomValueUnits = {
 	[ key: string ]: { max: number; step: number };
 };
 
+export interface Preset {
+	name: string;
+	slug: string;
+	value: string;
+}
+
 type UnitControlPassthroughProps = Omit<
 	UnitControlProps,
 	'label' | 'onChange' | 'onFocus' | 'units'
@@ -94,6 +100,16 @@ export type BoxControlProps = Pick< UnitControlProps, 'units' > &
 		 * @default false
 		 */
 		__next40pxDefaultSize?: boolean;
+		/**
+		 * Available presets to pick from.
+		 */
+		presets?: Preset[];
+		/**
+		 * The key of the preset to apply.
+		 * If you provide a list of presets, you must provide a preset key to use.
+		 * The format of preset selected values is going to be `var:preset|${ presetKey }|${ presetSlug }`
+		 */
+		presetKey?: string;
 	};
 
 export type BoxControlInputControlProps = UnitControlPassthroughProps & {
@@ -120,6 +136,8 @@ export type BoxControlInputControlProps = UnitControlPassthroughProps & {
 	 * It can be a concrete side like: left, right, top, bottom or a combined one like: horizontal, vertical.
 	 */
 	side: keyof typeof LABELS;
+	presets?: Preset[];
+	presetKey?: string;
 };
 
 export type BoxControlIconProps = {

--- a/packages/components/src/box-control/types.ts
+++ b/packages/components/src/box-control/types.ts
@@ -18,7 +18,7 @@ export type CustomValueUnits = {
 export interface Preset {
 	name: string;
 	slug: string;
-	value: string;
+	value?: string;
 }
 
 type UnitControlPassthroughProps = Omit<

--- a/packages/components/src/box-control/utils.ts
+++ b/packages/components/src/box-control/utils.ts
@@ -298,14 +298,17 @@ export function getPresetIndexFromValue(
 	presetKey: string,
 	presets: Preset[]
 ) {
-	if ( ! isValuePreset( value, presetKey ) === undefined ) {
+	if ( ! isValuePreset( value, presetKey ) ) {
 		return undefined;
 	}
 
 	const match = value.match(
 		new RegExp( `^var:preset\\|${ presetKey }\\|(.+)$` )
 	);
-	const slug = match ? match[ 1 ] : undefined;
+	if ( ! match ) {
+		return undefined;
+	}
+	const slug = match[ 1 ];
 	const index = presets.findIndex( ( preset ) => {
 		return preset.slug === slug;
 	} );

--- a/packages/components/src/box-control/utils.ts
+++ b/packages/components/src/box-control/utils.ts
@@ -11,6 +11,7 @@ import type {
 	BoxControlProps,
 	BoxControlValue,
 	CustomValueUnits,
+	Preset,
 } from './types';
 import deprecated from '@wordpress/deprecated';
 
@@ -271,4 +272,60 @@ export function getAllowedSides(
 		}
 	} );
 	return allowedSides;
+}
+
+/**
+ * Checks if a value is a preset value.
+ *
+ * @param value     The value to check.
+ * @param presetKey The preset key to check against.
+ * @return Whether the value is a preset value.
+ */
+export function isValuePreset( value: string, presetKey: string ) {
+	return value.startsWith( `var:preset|${ presetKey }|` );
+}
+
+/**
+ * Returns the index of the preset value in the presets array.
+ *
+ * @param value     The value to check.
+ * @param presetKey The preset key to check against.
+ * @param presets   The array of presets to search.
+ * @return The index of the preset value in the presets array.
+ */
+export function getPresetIndexFromValue(
+	value: string,
+	presetKey: string,
+	presets: Preset[]
+) {
+	if ( ! isValuePreset( value, presetKey ) === undefined ) {
+		return undefined;
+	}
+
+	const match = value.match(
+		new RegExp( `^var:preset\\|${ presetKey }\\|(.+)$` )
+	);
+	const slug = match ? match[ 1 ] : undefined;
+	const index = presets.findIndex( ( preset ) => {
+		return preset.slug === slug;
+	} );
+
+	return index !== -1 ? index : undefined;
+}
+
+/**
+ * Returns the preset value from the index.
+ *
+ * @param index     The index of the preset value in the presets array.
+ * @param presetKey The preset key to check against.
+ * @param presets   The array of presets to search.
+ * @return The preset value from the index.
+ */
+export function getPresetValueFromIndex(
+	index: number,
+	presetKey: string,
+	presets: Preset[]
+) {
+	const preset = presets[ index ];
+	return `var:preset|${ presetKey }|${ preset.slug }`;
 }


### PR DESCRIPTION
Related #67625

## What?

This PR implements "presets" support in the BoxControl component (borrowing the behavior from the spacing sizes with some subtle differences)

 - When the presets are provided, there's a button to switch between a custom value and a preset value.
 - A range control is used always for presets (this is to allow iteration, in the next PR I'll add a Select control for long presets)
 - If I switch back and forth between presets and custom value, I don't try to "guess" the value from the preset or the opposite, this is a conscious decision because for me, setting a preset who's current value is 4px is different than setting 4px custom value. The preset value can change over time.
 - I added a storybook story to try this
 
## Testing Instructions

 - Run storybook locally `npm run storybook:dev`
 - You can check the "BoxControl with presets" story.