### PR TITLE
Fix: Dataviews remove primary field concept from some classes.

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -82,11 +82,11 @@ function GridItem< Item >( {
 		className: 'dataviews-view-grid__media',
 	} );
 
-	const clickablePrimaryItemProps = getClickableItemProps( {
+	const clickableTitleItemProps = getClickableItemProps( {
 		item,
 		isItemClickable,
 		onClickItem,
-		className: 'dataviews-view-grid__primary-field dataviews-title-field',
+		className: 'dataviews-view-grid__title-field dataviews-title-field',
 	} );
 
 	return (
@@ -128,9 +128,7 @@ function GridItem< Item >( {
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
 			>
-				<div { ...clickablePrimaryItemProps }>
-					{ renderedTitleField }
-				</div>
+				<div { ...clickableTitleItemProps }>{ renderedTitleField }</div>
 				<ItemActions item={ item } actions={ actions } isCompact />
 			</HStack>
 			<VStack spacing={ 1 }>

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -15,7 +15,7 @@
 			padding: $grid-unit-10 0 $grid-unit-05;
 		}
 
-		.dataviews-view-grid__primary-field {
+		.dataviews-view-grid__title-field  {
 			min-height: $grid-unit-30; // Preserve layout when there is no ellipsis button
 			display: flex;
 			align-items: center;

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -15,7 +15,7 @@
 			padding: $grid-unit-10 0 $grid-unit-05;
 		}
 
-		.dataviews-view-grid__title-field  {
+		.dataviews-view-grid__title-field {
 			min-height: $grid-unit-30; // Preserve layout when there is no ellipsis button
 			display: flex;
 			align-items: center;

--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -50,7 +50,7 @@ ul.dataviews-view-list {
 		}
 
 		&:not(.is-selected) {
-			.dataviews-view-list__primary-field {
+			.dataviews-view-list__title-field {
 				color: $gray-900;
 			}
 			&:hover,
@@ -59,7 +59,7 @@ ul.dataviews-view-list {
 				color: var(--wp-admin-theme-color);
 				background-color: #f8f8f8;
 
-				.dataviews-view-list__primary-field,
+				.dataviews-view-list__title-field,
 				.dataviews-view-list__fields {
 					color: var(--wp-admin-theme-color);
 				}
@@ -74,7 +74,7 @@ ul.dataviews-view-list {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.04);
 			color: $gray-900;
 
-			.dataviews-view-list__primary-field,
+			.dataviews-view-list__title-field,
 			.dataviews-view-list__fields {
 				color: var(--wp-admin-theme-color);
 			}
@@ -106,7 +106,7 @@ ul.dataviews-view-list {
 			}
 		}
 	}
-	.dataviews-view-list__primary-field {
+	.dataviews-view-list__title-field {
 		flex: 1;
 		min-height: $grid-unit-30;
 		line-height: $grid-unit-30;


### PR DESCRIPTION
On https://github.com/WordPress/gutenberg/pull/67477 we removed the concept of primary field, but we missed the update on some CSS classes, in order to consistent with the prop/API name. This PR updates the missing classes I found.

## Testing Instructions
Verified the dataviews layouts still look the same.