### PR TITLE
[a11y] Fix: Media button on the page view grid does not have an accessible name.

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -15,6 +15,7 @@ import {
 	FlexItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useInstanceId } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -66,6 +67,7 @@ function GridItem< Item >( {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
 	const id = getItemId( item );
+	const instanceId = useInstanceId( GridItem );
 	const isSelected = selection.includes( id );
 	const renderedMediaField = mediaField?.render ? (
 		<mediaField.render item={ item } />
@@ -88,6 +90,21 @@ function GridItem< Item >( {
 		onClickItem,
 		className: 'dataviews-view-grid__title-field dataviews-title-field',
 	} );
+
+	let mediaA11yProps;
+	let titleA11yProps;
+	if ( isItemClickable( item ) && onClickItem ) {
+		mediaA11yProps = renderedTitleField
+			? {
+					'aria-labelledby': `dataviews-view-grid__title-field-${ instanceId }`,
+			  }
+			: {
+					'aria-label': __( 'Navigate to item' ),
+			  };
+		titleA11yProps = {
+			id: `dataviews-view-grid__title-field-${ instanceId }`,
+		};
+	}
 
 	return (
 		<VStack
@@ -112,7 +129,9 @@ function GridItem< Item >( {
 			} }
 		>
 			{ showMedia && renderedMediaField && (
-				<div { ...clickableMediaItemProps }>{ renderedMediaField }</div>
+				<div { ...clickableMediaItemProps } { ...mediaA11yProps }>
+					{ renderedMediaField }
+				</div>
 			) }
 			{ showMedia && renderedMediaField && (
 				<DataViewsSelectionCheckbox
@@ -128,7 +147,9 @@ function GridItem< Item >( {
 				justify="space-between"
 				className="dataviews-view-grid__title-actions"
 			>
-				<div { ...clickableTitleItemProps }>{ renderedTitleField }</div>
+				<div { ...clickableTitleItemProps } { ...titleA11yProps }>
+					{ renderedTitleField }
+				</div>
 				<ItemActions item={ item } actions={ actions } isCompact />
 			</HStack>
 			<VStack spacing={ 1 }>

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -94,16 +94,18 @@ function GridItem< Item >( {
 	let mediaA11yProps;
 	let titleA11yProps;
 	if ( isItemClickable( item ) && onClickItem ) {
-		mediaA11yProps = renderedTitleField
-			? {
-					'aria-labelledby': `dataviews-view-grid__title-field-${ instanceId }`,
-			  }
-			: {
-					'aria-label': __( 'Navigate to item' ),
-			  };
-		titleA11yProps = {
-			id: `dataviews-view-grid__title-field-${ instanceId }`,
-		};
+		if ( renderedTitleField ) {
+			mediaA11yProps = {
+				'aria-labelledby': `dataviews-view-grid__title-field-${ instanceId }`,
+			};
+			titleA11yProps = {
+				id: `dataviews-view-grid__title-field-${ instanceId }`,
+			};
+		} else {
+			mediaA11yProps = {
+				'aria-label': __( 'Navigate to item' ),
+			};
+		}
 	}
 
 	return (


### PR DESCRIPTION
All elements with an aria role of a button, such as the media item on the page's grid, should have a label, either nested inner text, an aria-label, or an aria-labeled by.
This PR fixes the issue by labeling the media field with the title field.

## Testing
Navigate to ´wp-admin/site-editor.php?p=%2Fpage&layout=grid´.
With the developer tools inspect the media field (element with class dataviews-view-grid__media--clickable)
Go to the element a11y tab and verify the computed name for the element is correct.
