### PR TITLE
Tabs: add "with links" Storybook example

### DIFF
--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -151,9 +151,11 @@ export const StyledTabList = styled( Ariakit.TabList )`
 export const Tab = styled( Ariakit.Tab )`
 	& {
 		/* Resets */
+		appearance: auto;
 		border-radius: 0;
 		background: transparent;
 		border: none;
+		box-sizing: border-box;
 		box-shadow: none;
 
 		flex: 1 0 auto;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Add an example to `Tabs` to show how to use the component with links and a sample router

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is a valid usecase and consumers could benefit from finding an example

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Added a new Storybook example, with a custom, stripped-down "memory" router
- Added a couple of extra styles to make sure the component keeps working as expected

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Review and test the new Storybook example, make sure it works as expected