### PR TITLE
Enhance: Add singular templates in the Site Editor

### DIFF
--- a/packages/edit-site/src/components/add-new-template/index.js
+++ b/packages/edit-site/src/components/add-new-template/index.js
@@ -37,6 +37,7 @@ import {
 	verse,
 	search,
 	tag,
+	pencil,
 } from '@wordpress/icons';
 import { __, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
@@ -77,6 +78,7 @@ const DEFAULT_TEMPLATE_SLUGS = [
 	'tag',
 	'search',
 	'404',
+	'singular',
 ];
 
 const TEMPLATE_ICONS = {
@@ -94,6 +96,7 @@ const TEMPLATE_ICONS = {
 	date: calendar,
 	tag,
 	attachment: media,
+	singular: pencil,
 };
 
 function TemplateListItem( {


### PR DESCRIPTION
attempt resolves #67514 

## What?
The PR adds support for a new template type called "singular" in the add-new-template component. Specifically, it introduces the singular template slug and associates it with the pencil icon from @wordpress/icons.

## Why?
This PR is necessary to extend the template options available in the add-new-template component by including a new "singular" template type, which was not previously supported.

## How?

- Imported the pencil icon from @wordpress/icons.
- Added 'singular' to the DEFAULT_TEMPLATE_SLUGS array.
- Added the singular: pencil entry to the TEMPLATE_ICONS object.

## Testing Instructions

- Open the site editor.
- Navigate to the "Add New Template" section.
- Verify that the "singular" template option is available and correctly displays the pencil icon.
- Test creating a new template using the "singular" option to ensure it functions as expected.
 
## Screenshots 
![image](https://github.com/user-attachments/assets/750c5313-ff61-48e8-9283-9bd5bb25ca82)

 