### PR TITLE
CreateTemplatePartModalContents: use native radio inputs

### DIFF
--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -202,10 +202,7 @@ export function CreateTemplatePartModalContents( {
 					required
 				/>
 				<fieldset>
-					<BaseControl.VisualLabel
-						as="legend"
-						className="fields-create-template-part-modal__area-radio-group-label"
-					>
+					<BaseControl.VisualLabel as="legend">
 						{ __( 'Area' ) }
 					</BaseControl.VisualLabel>
 					<div className="fields-create-template-part-modal__area-radio-group">

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -5,17 +5,11 @@ import {
 	Icon,
 	BaseControl,
 	TextControl,
-	Flex,
-	FlexItem,
-	FlexBlock,
 	Button,
 	Modal,
-	__experimentalRadioGroup as RadioGroup,
-	__experimentalRadio as Radio,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -39,6 +33,13 @@ import {
 	getUniqueTemplatePartTitle,
 	useExistingTemplateParts,
 } from './utils';
+
+function getAreaRadioId( value: string ) {
+	return `fields-create-template-part-modal__area-option-${ value }`;
+}
+function getAreaRadioDescriptionId( value: string ) {
+	return `fields-create-template-part-modal__area-option-description-${ value }`;
+}
 
 type CreateTemplatePartModalContentsProps = {
 	defaultArea?: string;
@@ -129,7 +130,6 @@ export function CreateTemplatePartModalContents( {
 	const [ title, setTitle ] = useState( defaultTitle );
 	const [ area, setArea ] = useState( defaultArea );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
-	const instanceId = useInstanceId( CreateTemplatePartModal );
 
 	const defaultTemplatePartAreas = useSelect(
 		( select ) =>
@@ -201,52 +201,61 @@ export function CreateTemplatePartModalContents( {
 					onChange={ setTitle }
 					required
 				/>
-				<BaseControl
-					__nextHasNoMarginBottom
-					label={ __( 'Area' ) }
-					id={ `fields-create-template-part-modal__area-selection-${ instanceId }` }
-					className="fields-create-template-part-modal__area-base-control"
-				>
-					<RadioGroup
-						label={ __( 'Area' ) }
-						className="fields-create-template-part-modal__area-radio-group"
-						id={ `fields-create-template-part-modal__area-selection-${ instanceId }` }
-						onChange={ ( value ) =>
-							value && typeof value === 'string'
-								? setArea( value )
-								: () => void 0
-						}
-						checked={ area }
+				<fieldset>
+					<BaseControl.VisualLabel
+						as="legend"
+						className="fields-create-template-part-modal__area-radio-group-label"
 					>
+						{ __( 'Area' ) }
+					</BaseControl.VisualLabel>
+					<div className="fields-create-template-part-modal__area-radio-group">
 						{ ( defaultTemplatePartAreas ?? [] ).map( ( item ) => {
 							const icon = getTemplatePartIcon( item.icon );
 							return (
-								<Radio
-									__next40pxDefaultSize
-									key={ item.label }
-									value={ item.area }
-									className="fields-create-template-part-modal__area-radio"
+								<div
+									key={ item.area }
+									className="fields-create-template-part-modal__area-radio-wrapper"
 								>
-									<Flex align="start" justify="start">
-										<FlexItem>
-											<Icon icon={ icon } />
-										</FlexItem>
-										<FlexBlock className="fields-create-template-part-modal__option-label">
-											{ item.label }
-											<div>{ item.description }</div>
-										</FlexBlock>
-
-										<FlexItem className="fields-create-template-part-modal__checkbox">
-											{ area === item.area && (
-												<Icon icon={ check } />
-											) }
-										</FlexItem>
-									</Flex>
-								</Radio>
+									<input
+										type="radio"
+										id={ getAreaRadioId( item.area ) }
+										name="fields-create-template-part-modal__area"
+										value={ item.area }
+										checked={ area === item.area }
+										onChange={ () => {
+											setArea( item.area );
+										} }
+										aria-describedby={ getAreaRadioDescriptionId(
+											item.area
+										) }
+									/>
+									<Icon
+										icon={ icon }
+										className="fields-create-template-part-modal__area-radio-icon"
+									/>
+									<label
+										htmlFor={ getAreaRadioId( item.area ) }
+										className="fields-create-template-part-modal__area-radio-label"
+									>
+										{ item.label }
+									</label>
+									<Icon
+										icon={ check }
+										className="fields-create-template-part-modal__area-radio-checkmark"
+									/>
+									<p
+										className="fields-create-template-part-modal__area-radio-description"
+										id={ getAreaRadioDescriptionId(
+											item.area
+										) }
+									>
+										{ item.description }
+									</p>
+								</div>
 							);
 						} ) }
-					</RadioGroup>
-				</BaseControl>
+					</div>
+				</fieldset>
 				<HStack justify="right">
 					<Button
 						__next40pxDefaultSize

--- a/packages/fields/src/components/create-template-part-modal/index.tsx
+++ b/packages/fields/src/components/create-template-part-modal/index.tsx
@@ -10,6 +10,7 @@ import {
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
+import { useInstanceId } from '@wordpress/compose';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
@@ -34,11 +35,11 @@ import {
 	useExistingTemplateParts,
 } from './utils';
 
-function getAreaRadioId( value: string ) {
-	return `fields-create-template-part-modal__area-option-${ value }`;
+function getAreaRadioId( value: string, instanceId: number ) {
+	return `fields-create-template-part-modal__area-option-${ value }-${ instanceId }`;
 }
-function getAreaRadioDescriptionId( value: string ) {
-	return `fields-create-template-part-modal__area-option-description-${ value }`;
+function getAreaRadioDescriptionId( value: string, instanceId: number ) {
+	return `fields-create-template-part-modal__area-option-description-${ value }-${ instanceId }`;
 }
 
 type CreateTemplatePartModalContentsProps = {
@@ -130,6 +131,7 @@ export function CreateTemplatePartModalContents( {
 	const [ title, setTitle ] = useState( defaultTitle );
 	const [ area, setArea ] = useState( defaultArea );
 	const [ isSubmitting, setIsSubmitting ] = useState( false );
+	const instanceId = useInstanceId( CreateTemplatePartModal );
 
 	const defaultTemplatePartAreas = useSelect(
 		( select ) =>
@@ -215,15 +217,19 @@ export function CreateTemplatePartModalContents( {
 								>
 									<input
 										type="radio"
-										id={ getAreaRadioId( item.area ) }
-										name="fields-create-template-part-modal__area"
+										id={ getAreaRadioId(
+											item.area,
+											instanceId
+										) }
+										name={ `fields-create-template-part-modal__area-${ instanceId }` }
 										value={ item.area }
 										checked={ area === item.area }
 										onChange={ () => {
 											setArea( item.area );
 										} }
 										aria-describedby={ getAreaRadioDescriptionId(
-											item.area
+											item.area,
+											instanceId
 										) }
 									/>
 									<Icon
@@ -231,7 +237,10 @@ export function CreateTemplatePartModalContents( {
 										className="fields-create-template-part-modal__area-radio-icon"
 									/>
 									<label
-										htmlFor={ getAreaRadioId( item.area ) }
+										htmlFor={ getAreaRadioId(
+											item.area,
+											instanceId
+										) }
 										className="fields-create-template-part-modal__area-radio-label"
 									>
 										{ item.label }
@@ -243,7 +252,8 @@ export function CreateTemplatePartModalContents( {
 									<p
 										className="fields-create-template-part-modal__area-radio-description"
 										id={ getAreaRadioDescriptionId(
-											item.area
+											item.area,
+											instanceId
 										) }
 									>
 										{ item.description }

--- a/packages/fields/src/components/create-template-part-modal/style.scss
+++ b/packages/fields/src/components/create-template-part-modal/style.scss
@@ -3,61 +3,86 @@
 }
 
 .fields-create-template-part-modal__area-radio-group {
-	width: 100%;
-	border: $border-width solid $gray-700;
+	border: $border-width solid $gray-600;
 	border-radius: $radius-small;
+}
 
-	.components-button.fields-create-template-part-modal__area-radio {
-		display: block;
-		width: 100%;
-		height: 100%;
-		text-align: left;
-		padding: $grid-unit-15;
+.fields-create-template-part-modal__area-radio-wrapper {
+	position: relative;
+	padding: $grid-unit-15;
 
-		&,
-		&.is-secondary:hover,
-		&.is-primary:hover {
-			margin: 0;
-			background-color: inherit;
-			border-bottom: $border-width solid $gray-700;
-			border-radius: 0;
+	display: grid;
+	align-items: center;
+	grid-template-columns: min-content 1fr min-content;
+	grid-gap: $grid-unit-05 $grid-unit-10;
 
-			&:not(:focus) {
-				box-shadow: none;
-			}
+	color: $gray-900;
 
-			&:focus {
-				border-bottom: $border-width solid $white;
-			}
+	& + & {
+		border-top: $border-width solid $gray-600;
+	}
 
-			&:last-of-type {
-				border-bottom: none;
-			}
-		}
+	input[type="radio"] {
+		position: absolute;
+		opacity: 0;
+	}
 
-		&:not(:hover),
-		&[aria-checked="true"] {
-			color: $gray-900;
-			cursor: auto;
+	&:has(input[type="radio"]:checked) {
+		// This is needed to make sure that the focus ring always renders on top
+		// of the sibling radio "wrapper"'s borders.
+		z-index: 1;
+	}
 
-			.fields-create-template-part-modal__option-label div {
-				color: $gray-600;
-			}
-		}
+	&:has(input[type="radio"]:not(:checked)):hover {
+		color: var(--wp-admin-theme-color);
+	}
 
-		.fields-create-template-part-modal__option-label {
-			padding-top: $grid-unit-05;
-			white-space: normal;
+	// Pass-through pointer events, so that the corresponding radio input
+	// gets checked when clicking on the underlying label
+	> *:not(.fields-create-template-part-modal__area-radio-label) {
+		pointer-events: none;
+	}
+}
 
-			div {
-				padding-top: $grid-unit-05;
-				font-size: $helptext-font-size;
-			}
-		}
+.fields-create-template-part-modal__area-radio-label {
+	// Capture pointer clicks for the whole radio wrapper
+	&::before {
+		content: "";
+		position: absolute;
+		inset: 0;
+	}
 
-		.fields-create-template-part-modal__checkbox {
-			margin-left: auto;
-			min-width: $grid-unit-30;
-		}
+	input[type="radio"]:not(:checked) ~ &::before {
+		cursor: pointer;
+	}
+
+	input[type="radio"]:focus-visible ~ &::before {
+		outline: 4px solid transparent;
+		box-shadow: 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+	}
+}
+
+.fields-create-template-part-modal__area-radio-icon,
+.fields-create-template-part-modal__area-radio-checkmark {
+	fill: currentColor;
+}
+
+.fields-create-template-part-modal__area-radio-checkmark {
+	input[type="radio"]:not(:checked) ~ & {
+		opacity: 0;
+	}
+}
+
+.fields-create-template-part-modal__area-radio-description {
+	grid-column: 2 / 3;
+	margin: 0;
+
+	color: $gray-600;
+	font-size: $helptext-font-size;
+	line-height: normal;
+	text-wrap: pretty;
+
+	input[type="radio"]:not(:checked):hover ~ & {
+		color: inherit;
 	}
 }

--- a/packages/fields/src/components/create-template-part-modal/style.scss
+++ b/packages/fields/src/components/create-template-part-modal/style.scss
@@ -77,7 +77,7 @@
 	grid-column: 2 / 3;
 	margin: 0;
 
-	color: $gray-600;
+	color: $gray-700;
 	font-size: $helptext-font-size;
 	line-height: normal;
 	text-wrap: pretty;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes #66569

Refactor the `CreateTemplatePartModalContents` component to use native `<input type="radio" />` elements instead of the deprecated `RadioGroup` component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The `RadioGroup` component is deprecated and we shouldn't use it in the repository.

This refactor brings in other several benefits:

- using native HTML elements ensures more semantic markup:
  - radios are grouped via `fieldset` and `legend`;
  - radios are properly labelled and described;
  - the radio group is a composite widget, and implements the correct keyboard navigation;
- small styles tweaks:
  - the radio group borders now match the ones of the text input in the same modal;
  - cleaner grid layout, better spacing;
- less style overrides and internal component classnames

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Removed the old code, and replaced it with semantic markup (`fieldset`, `legend`, `radio` and `label`)
- Tweaked the styles to meet the target design

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- In the site editor, visit the "Patterns" page
- Click the "Add new pattern" button in the top right part of the screen, and select "Add new template pattern" — a modal dialog should show;
- Make sure that the "Area" radio group in the modal (and the modal in general) looks and works like on `trunk` (apart from the differences listed above)

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![Screenshot 2024-12-07 at 00 57 00](https://github.com/user-attachments/assets/705e3427-2d23-4e85-86e0-87f63b2dac41) | ![Screenshot 2024-12-07 at 01 01 06](https://github.com/user-attachments/assets/98950b01-065f-4579-b467-19976fc0e934) |
| <video src="https://github.com/user-attachments/assets/e9cf3251-c22d-440b-a065-a6c9cccdd7d3" /> | <video src="https://github.com/user-attachments/assets/330a137f-c989-4dfb-8bf0-d4dc44af2bb1" /> |

