### PR TITLE
Style book: Fix critical error when blocks are not registered

### DIFF
--- a/packages/edit-site/src/components/style-book/examples.tsx
+++ b/packages/edit-site/src/components/style-book/examples.tsx
@@ -12,7 +12,12 @@ import {
 /**
  * Internal dependencies
  */
-import type { BlockExample, ColorOrigin, MultiOriginPalettes } from './types';
+import type {
+	Block,
+	BlockExample,
+	ColorOrigin,
+	MultiOriginPalettes,
+} from './types';
 import ColorExamples from './color-examples';
 import DuotoneExamples from './duotone-examples';
 import { STYLE_BOOK_COLOR_GROUPS } from './constants';
@@ -91,30 +96,33 @@ function getOverviewBlockExamples(
 		examples.push( themeColorexample );
 	}
 
-	const headingBlock = createBlock( 'core/heading', {
-		content: __(
-			`AaBbCcDdEeFfGgHhiiJjKkLIMmNnOoPpQakRrssTtUuVVWwXxxYyZzOl23356789X{(…)},2!*&:/A@HELFO™`
-		),
-		level: 1,
-	} );
-	const firstParagraphBlock = createBlock( 'core/paragraph', {
-		content: __(
-			`A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the text into smaller, manageable chunks, allowing readers to scan the content more easily.`
-		),
-	} );
-	const secondParagraphBlock = createBlock( 'core/paragraph', {
-		content: __(
-			`Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block of text. This visual separation helps visually distinguish one paragraph from another, creating a clear and organized layout that guides the reader through the content smoothly.`
-		),
-	} );
+	// Get examples for typography blocks.
+	const typographyBlockExamples: Block[] = [];
 
-	const textExample = {
-		name: 'typography',
-		title: __( 'Typography' ),
-		category: 'overview',
-		blocks: [
-			headingBlock,
-			createBlock(
+	if ( getBlockType( 'core/heading' ) ) {
+		const headingBlock = createBlock( 'core/heading', {
+			content: __(
+				`AaBbCcDdEeFfGgHhiiJjKkLIMmNnOoPpQakRrssTtUuVVWwXxxYyZzOl23356789X{(…)},2!*&:/A@HELFO™`
+			),
+			level: 1,
+		} );
+		typographyBlockExamples.push( headingBlock );
+	}
+
+	if ( getBlockType( 'core/paragraph' ) ) {
+		const firstParagraphBlock = createBlock( 'core/paragraph', {
+			content: __(
+				`A paragraph in a website refers to a distinct block of text that is used to present and organize information. It is a fundamental unit of content in web design and is typically composed of a group of related sentences or thoughts focused on a particular topic or idea. Paragraphs play a crucial role in improving the readability and user experience of a website. They break down the text into smaller, manageable chunks, allowing readers to scan the content more easily.`
+			),
+		} );
+		const secondParagraphBlock = createBlock( 'core/paragraph', {
+			content: __(
+				`Additionally, paragraphs help structure the flow of information and provide logical breaks between different concepts or pieces of information. In terms of formatting, paragraphs in websites are commonly denoted by a vertical gap or indentation between each block of text. This visual separation helps visually distinguish one paragraph from another, creating a clear and organized layout that guides the reader through the content smoothly.`
+			),
+		} );
+
+		if ( getBlockType( 'core/group' ) ) {
+			const groupBlock = createBlock(
 				'core/group',
 				{
 					layout: {
@@ -129,10 +137,21 @@ function getOverviewBlockExamples(
 					},
 				},
 				[ firstParagraphBlock, secondParagraphBlock ]
-			),
-		],
-	};
-	examples.push( textExample );
+			);
+			typographyBlockExamples.push( groupBlock );
+		} else {
+			typographyBlockExamples.push( firstParagraphBlock );
+		}
+	}
+
+	if ( !! typographyBlockExamples.length ) {
+		examples.push( {
+			name: 'typography',
+			title: __( 'Typography' ),
+			category: 'overview',
+			blocks: typographyBlockExamples,
+		} );
+	}
 
 	const otherBlockExamples = [
 		'core/image',

--- a/packages/edit-site/src/components/style-book/types.ts
+++ b/packages/edit-site/src/components/style-book/types.ts
@@ -1,4 +1,4 @@
-type Block = {
+export type Block = {
 	name: string;
 	attributes: Record< string, unknown >;
 	innerBlocks?: Block[];


### PR DESCRIPTION
## What?

I have noticed that if I open StyleBook when the following blocks are not registered, a critical error will occur:

- core/heading
- core/paragraph
- core/group

https://github.com/user-attachments/assets/15e6bd95-7f94-4605-a90d-201d2a8c576d

## Why?

The Typography section of the Overview tab generates examples using the Heading block, Paragraph block, and Group block. However, if these blocks are not registered, `createBlock()` (`__experimentalSanitizeBlockAttributes()`) will [throw an exception](https://github.com/WordPress/gutenberg/blob/959bb6b006a8e3deecff9aad4e07658878029c26/packages/blocks/src/api/utils.js#L281-L283).

## How?

Checks whether each block is registered and generates an example.

- If the Heading block is registered: Generate a Heading block example.
- If the Paragraph block is registered:
  - If the Group block is registered: As before, generate two Paragraph block examples for the two-column layout.
  - If the Group block is not registered: generate one Paragraph block example for the one-column layout.

## Testing Instructions

- Open the site editor.
- In your browser console, run one or both of the following:
  ```javascript
  wp.blocks.unregisterBlockType( 'core/group' );
  wp.blocks.unregisterBlockType( 'core/paragraph' );
  ```
- Confirm that the StyleBook opens correctly.

> [!NOTE]
> Note that this PR cannot test the scenario when the Heading block is unregistered. Because a different error occurs when the Heading block is unregistered, this will need to be addressed in a separate PR:
> ```
> Uncaught TypeError: Cannot read properties of undefined (reading 'examples') at StyleBook (index.js:225:61)
> ```

## Screenshots or screencast <!-- if applicable -->

###  When the  Paragraph block is not registered

![image](https://github.com/user-attachments/assets/8883b81c-84f0-4a84-a5f7-df6fc73f2c09)

### When the Group block is not registered

![image](https://github.com/user-attachments/assets/1ba69b85-ab1f-49a3-8de4-851a21793d44)
