### PR TITLE
Shadows: Improve design and a11y of remove button

### DIFF
--- a/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-edit-panel.js
@@ -35,7 +35,7 @@ import {
 	reset,
 	moreVertical,
 } from '@wordpress/icons';
-import { useState, useMemo, useEffect } from '@wordpress/element';
+import { useState, useMemo, useEffect, useRef } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -300,6 +300,7 @@ function ShadowsPreview( { shadow } ) {
 }
 
 function ShadowEditor( { shadow, onChange } ) {
+	const addShadowButtonRef = useRef();
 	const shadowParts = useMemo( () => getShadowParts( shadow ), [ shadow ] );
 
 	const onChangeShadowPart = ( index, part ) => {
@@ -314,6 +315,7 @@ function ShadowEditor( { shadow, onChange } ) {
 
 	const onRemoveShadowPart = ( index ) => {
 		onChange( shadowParts.filter( ( p, i ) => i !== index ).join( ', ' ) );
+		addShadowButtonRef.current.focus();
 	};
 
 	return (
@@ -334,6 +336,7 @@ function ShadowEditor( { shadow, onChange } ) {
 							onClick={ () => {
 								onAddShadowPart();
 							} }
+							ref={ addShadowButtonRef }
 						/>
 					</FlexItem>
 				</HStack>
@@ -393,28 +396,24 @@ function ShadowItem( { shadow, onChange, canRemove, onRemove } ) {
 				};
 
 				return (
-					<HStack align="center" justify="flex-start" spacing={ 0 }>
-						<FlexItem style={ { flexGrow: 1 } }>
-							<Button
-								__next40pxDefaultSize
-								icon={ shadowIcon }
-								{ ...toggleProps }
-							>
-								{ shadowObj.inset
-									? __( 'Inner shadow' )
-									: __( 'Drop shadow' ) }
-							</Button>
-						</FlexItem>
+					<>
+						<Button
+							__next40pxDefaultSize
+							icon={ shadowIcon }
+							{ ...toggleProps }
+						>
+							{ shadowObj.inset
+								? __( 'Inner shadow' )
+								: __( 'Drop shadow' ) }
+						</Button>
 						{ canRemove && (
-							<FlexItem>
-								<Button
-									__next40pxDefaultSize
-									icon={ reset }
-									{ ...removeButtonProps }
-								/>
-							</FlexItem>
+							<Button
+								size="small"
+								icon={ reset }
+								{ ...removeButtonProps }
+							/>
 						) }
-					</HStack>
+					</>
 				);
 			} }
 			renderContent={ () => (

--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -146,20 +146,34 @@
 
 .edit-site-global-styles__shadow-editor__dropdown {
 	width: 100%;
+	position: relative;
+}
 
-	.edit-site-global-styles__shadow-editor__dropdown-toggle,
-	.edit-site-global-styles__shadow-editor__remove-button {
-		width: 100%;
-		height: auto;
-		padding-top: $grid-unit;
-		padding-bottom: $grid-unit;
-		text-align: left;
-		border-radius: inherit;
+.edit-site-global-styles__shadow-editor__dropdown-toggle {
+	width: 100%;
+	height: auto;
+	padding-top: $grid-unit;
+	padding-bottom: $grid-unit;
+	text-align: left;
+	border-radius: inherit;
 
-		&.is-open {
-			background: $gray-100;
-			color: var(--wp-admin-theme-color);
-		}
+	&.is-open {
+		background: $gray-100;
+		color: var(--wp-admin-theme-color);
+	}
+}
+
+.edit-site-global-styles__shadow-editor__remove-button {
+	position: absolute;
+	right: $grid-unit;
+	top: $grid-unit;
+	opacity: 0;
+
+	.edit-site-global-styles__shadow-editor__dropdown-toggle:hover + &,
+	&:focus,
+	&:hover {
+		border: none;
+		opacity: 1;
 	}
 }
 


### PR DESCRIPTION
## What?

This PR makes two improvements to the Shadow Panel reset button:

- Change the button to a small size and make it visible only on hover/focus
- Give the Add button focus so that it doesn't lose focus when the Reset button is pressed

## Why?

A reset button is being added to the color controls in #67116. That PR hasn't been merged yet, but it should eventually work like this:


https://github.com/user-attachments/assets/15c9d436-f7f1-45cd-9468-da4611e96081

The reset button in the Shadow panel also needs to be updated to match the design of that button.

## Testing Instructions

- Open the Shadow panel.
- The Reset button should only be visible when it has keyboard focus or when the mouse is over the toggle button.
- When the Reset button is pressed, the Add shadow button should get focus.

## Screenshots or screencast <!-- if applicable -->

Below is a list of states under which visual changes occur.

| Satte | Before | After |
|--------|--------|--------|
| Default | ![image](https://github.com/user-attachments/assets/43681ab7-a4d6-492d-aea2-b785b04cdf3e) | ![image](https://github.com/user-attachments/assets/6cb8c0fd-66f4-4515-b7d6-2663ce0ec76a) |
| Focus toggle button |  ![image](https://github.com/user-attachments/assets/253453fb-04c8-49db-b8f7-4125af3d71a6) | ![image](https://github.com/user-attachments/assets/89403107-4f5e-44b8-9b94-d0e5342ea77d) |
| Focus Reset button | ![image](https://github.com/user-attachments/assets/d0fd8ccf-6fef-4fbb-905e-141176a230fd) | ![image](https://github.com/user-attachments/assets/ee3eb6d7-0a4c-4867-9c15-75cf911ead05) |
| Dropdown opened | ![image](https://github.com/user-attachments/assets/14e40289-be01-46b7-bcc5-44cf7a49421d) | ![image](https://github.com/user-attachments/assets/522e5fad-978a-4cfd-879b-e1fbcb752c22) |
