### PR TITLE
Replace remaining custom deep cloning with 'structuredClone'

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -624,7 +624,7 @@ function pickStyleKeys( treeToPickFrom ) {
 	// clone the style objects so that `getFeatureDeclarations` can remove consumed keys from it
 	const clonedEntries = pickedEntries.map( ( [ key, style ] ) => [
 		key,
-		JSON.parse( JSON.stringify( style ) ),
+		structuredClone( style ),
 	] );
 	return Object.fromEntries( clonedEntries );
 }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -245,7 +245,7 @@ export function omitStyle( style, paths, preserveReference = false ) {
 
 	let newStyle = style;
 	if ( ! preserveReference ) {
-		newStyle = JSON.parse( JSON.stringify( style ) );
+		newStyle = structuredClone( style );
 	}
 
 	if ( ! Array.isArray( paths ) ) {

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -3,6 +3,7 @@
  */
 import { TextDecoder, TextEncoder } from 'node:util';
 import { Blob as BlobPolyfill, File as FilePolyfill } from 'node:buffer';
+import 'core-js/stable/structured-clone';
 
 jest.mock( '@wordpress/compose', () => {
 	return {
@@ -49,3 +50,6 @@ if ( ! global.TextEncoder ) {
 // Override jsdom built-ins with native node implementation.
 global.Blob = BlobPolyfill;
 global.File = FilePolyfill;
+
+// Polyfill structuredClone for jsdom.
+global.structuredClone = structuredClone;


### PR DESCRIPTION
## What?
This is similar to #64203.

PR updates remaining places in editors' codebase to use `structuredClone` instead of `JSON.parse( JSON.stringify( value ) )` hack.


## Testing Instructions
1. Open the Site Editor.
2. Verify that https://github.com/WordPress/gutenberg/pull/49806 tests as before. Instructions: https://github.com/WordPress/gutenberg/pull/49623.
3. The `omitStyles` unit tests are passing.

### Testing Instructions for Keyboard
Same.
