### PR TITLE
Data: Include more details when shallow equality fails in 'useSelect'

### DIFF
--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -19,6 +19,23 @@ import useAsyncMode from '../async-mode-provider/use-async-mode';
 
 const renderQueue = createQueue();
 
+function warnOnUnstableReference( a, b ) {
+	let keys = [];
+	if ( a.constructor === Object && b.constructor === Object ) {
+		keys = Object.keys( a ).filter( ( k ) => a[ k ] !== b[ k ] );
+	} else if ( Array.isArray( a ) && Array.isArray( b ) ) {
+		keys = [ ...a.keys() ].filter( ( i ) => a[ i ] !== b[ i ] );
+	}
+
+	// eslint-disable-next-line no-console
+	console.warn(
+		'The `useSelect` hook returns different values when called with the same state and parameters.\n' +
+			'This can lead to unnecessary re-renders and performance issues if not fixed.\n\n' +
+			'Non-equal value keys: %s\n\n',
+		keys.join( ', ' )
+	);
+}
+
 /**
  * @typedef {import('../../types').StoreDescriptor<C>} StoreDescriptor
  * @template {import('../../types').AnyConfig} C
@@ -159,10 +176,7 @@ function Store( registry, suspense ) {
 				if ( ! didWarnUnstableReference ) {
 					const secondMapResult = mapSelect( select, registry );
 					if ( ! isShallowEqual( mapResult, secondMapResult ) ) {
-						// eslint-disable-next-line no-console
-						console.warn(
-							`The 'useSelect' hook returns different values when called with the same state and parameters. This can lead to unnecessary rerenders.`
-						);
+						warnOnUnstableReference( mapResult, secondMapResult );
 						didWarnUnstableReference = true;
 					}
 				}

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -20,12 +20,14 @@ import useAsyncMode from '../async-mode-provider/use-async-mode';
 const renderQueue = createQueue();
 
 function warnOnUnstableReference( a, b ) {
-	let keys = [];
-	if ( a.constructor === Object && b.constructor === Object ) {
-		keys = Object.keys( a ).filter( ( k ) => a[ k ] !== b[ k ] );
-	} else if ( Array.isArray( a ) && Array.isArray( b ) ) {
-		keys = [ ...a.keys() ].filter( ( i ) => a[ i ] !== b[ i ] );
+	if ( ! a && ! b ) {
+		return;
 	}
+
+	const keys =
+		typeof a === 'object' && typeof b === 'object'
+			? Object.keys( a ).filter( ( k ) => a[ k ] !== b[ k ] )
+			: [];
 
 	// eslint-disable-next-line no-console
 	console.warn(

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -20,7 +20,7 @@ import useAsyncMode from '../async-mode-provider/use-async-mode';
 const renderQueue = createQueue();
 
 function warnOnUnstableReference( a, b ) {
-	if ( ! a && ! b ) {
+	if ( ! a || ! b ) {
 		return;
 	}
 


### PR DESCRIPTION
## What?
This is a follow-up to #53666.
Closes #63608.

PR updates the warning that's logged when `useSelect` returns different values when run with the same state and parameters. The warning now also includes the keys that fail the check.

## Why?
A quality of life improvement when debugging `useSelect` issues.

## Testing Instructions
1. Open a post or page.
2. Add an example plugin via DevTools.
3. Confirm the notice message.

<details><summary>Test plugin</summary>
<p>

```javascript
const { createElement: el, useState } = wp.element;
const { useSelect } = wp.data;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editor.PluginDocumentSettingPanel;

function PluginBlocksOnPage() {
    const { names, total } = useSelect( ( select ) => {
        const blocks = select('core/block-editor').getBlocks();

        return {
            names: blocks.map( ( { name } ) => name ),
            total: blocks.length,
        };
    }, [] );

	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-blocks-on-page',
			title: `Blocks on Page: ${ total }`,
			name: 'test-blocks-on-page'
		},
		el( 'p', {}, 'Placeholder' )
	);
}

registerPlugin( 'test-blocks-on-page', {
	render: PluginBlocksOnPage,
} );
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-12-08 at 15 44 31](https://github.com/user-attachments/assets/1cd6ecb5-8fe2-459a-a236-f04446d1272d)
