### PR TITLE
Data views: expand config drop down on mobile

### DIFF
--- a/packages/dataviews/src/components/dataviews-view-config/index.tsx
+++ b/packages/dataviews/src/components/dataviews-view-config/index.tsx
@@ -53,7 +53,11 @@ interface ViewTypeMenuProps {
 	defaultLayouts?: SupportedLayouts;
 }
 
-const DATAVIEWS_CONFIG_POPOVER_PROPS = { placement: 'bottom-end', offset: 9 };
+const DATAVIEWS_CONFIG_POPOVER_PROPS = {
+	className: 'dataviews-config__popover',
+	placement: 'bottom-end',
+	offset: 9,
+};
 
 function ViewTypeMenu( {
 	defaultLayouts = { list: {}, grid: {}, table: {} },
@@ -619,6 +623,7 @@ function DataviewsViewConfigDropdown() {
 	);
 	return (
 		<Dropdown
+			expandOnMobile
 			popoverProps={ {
 				...DATAVIEWS_CONFIG_POPOVER_PROPS,
 				id: popoverId,
@@ -636,7 +641,10 @@ function DataviewsViewConfigDropdown() {
 				);
 			} }
 			renderContent={ () => (
-				<DropdownContentWrapper paddingSize="medium">
+				<DropdownContentWrapper
+					paddingSize="medium"
+					className="dataviews-config__popover-content-wrapper"
+				>
 					<VStack className="dataviews-view-config" spacing={ 6 }>
 						<SettingsSection title={ __( 'Appearance' ) }>
 							<HStack expanded className="is-divided-in-two">

--- a/packages/dataviews/src/components/dataviews-view-config/style.scss
+++ b/packages/dataviews/src/components/dataviews-view-config/style.scss
@@ -6,6 +6,14 @@
 	line-height: $default-line-height;
 }
 
+.dataviews-config__popover.is-expanded .dataviews-config__popover-content-wrapper {
+	overflow-y: scroll;
+	height: 100%;
+	.dataviews-view-config {
+		width: auto;
+	}
+}
+
 .dataviews-view-config__sort-direction .components-toggle-group-control-option-base {
 	text-transform: uppercase;
 }


### PR DESCRIPTION

## What?

Fixes https://github.com/WordPress/gutenberg/issues/65955

The PR ensures that the dataviews filter config is accessible visually in mobile viewports.


## Why?

The data views filter config is currently a popover and doesn't expand on narrow viewport widths, rather, it floats on the screen as does a sheet of tissue in fair wind doesn't.

## How?

The data view config popover `is-expanded` class indicates that the popover is expanded in mobile view.

In this view, ensure that the content is horizontally scrollable and the width takes up the screen.


## Testing Instructions

1. Head to the site editor pages list: **Appearance > Editor > Pages**
2. Click on the filters cog wheel. Ensure it looks the same as trunk.
3. Now simulate a narrow viewport width (mobile)
4. Click on the filters cog wheel, and check that the filters config is expanded. Like your mind now is.


## Screenshots or screencast <!-- if applicable -->

### 🐝fore


https://github.com/user-attachments/assets/6e3bdf96-0d78-432a-9e57-66892c7e2b3f



### 🅰️ fter


https://github.com/user-attachments/assets/220a3038-4711-465e-aac8-416ace623daa


