### PR TITLE
Update global stylesheet docblocks with `custom-css` parameter.

### DIFF
--- a/backport-changelog/6.8/7976.md
+++ b/backport-changelog/6.8/7976.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/7976
+
+* https://github.com/WordPress/gutenberg/pull/67716

--- a/lib/class-wp-theme-json-gutenberg.php
+++ b/lib/class-wp-theme-json-gutenberg.php
@@ -1319,6 +1319,8 @@ class WP_Theme_JSON_Gutenberg {
 	 *                       - `variables`: only the CSS Custom Properties for presets & custom ones.
 	 *                       - `styles`: only the styles section in theme.json.
 	 *                       - `presets`: only the classes for the presets.
+	 *                       - `base-layout-styles`: only the base layout styles.
+	 *                       - `custom-css`: only the custom CSS.
 	 * @param array $origins A list of origins to include. By default it includes VALID_ORIGINS.
 	 * @param array $options An array of options for now used for internal purposes only (may change without notice).
 	 *                       The options currently supported are:

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -9,7 +9,7 @@
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *
  * @param array $types Types of styles to load. Optional.
- *                     It accepts as values: 'variables', 'presets', 'styles', 'base-layout-styles.
+ *                     It accepts as values: 'variables', 'presets', 'styles', 'base-layout-styles, 'custom-css'.
  *                     If empty, it'll load the following:
  *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'.
  *                     - for themes with theme.json: 'variables', 'presets', 'styles'.

--- a/lib/global-styles-and-settings.php
+++ b/lib/global-styles-and-settings.php
@@ -9,7 +9,7 @@
  * Returns the stylesheet resulting of merging core, theme, and user data.
  *
  * @param array $types Types of styles to load. Optional.
- *                     It accepts as values: 'variables', 'presets', 'styles', 'base-layout-styles, 'custom-css'.
+ *                     See {@see 'WP_Theme_JSON::get_stylesheet'} for all valid types.
  *                     If empty, it'll load the following:
  *                     - for themes without theme.json: 'variables', 'presets', 'base-layout-styles'.
  *                     - for themes with theme.json: 'variables', 'presets', 'styles'.
@@ -141,6 +141,8 @@ function gutenberg_get_global_settings( $path = array(), $context = array() ) {
 
 /**
  * Gets the global styles custom css from theme.json.
+ *
+ * @deprecated Gutenberg 18.6.0 Use {@see 'gutenberg_get_global_stylesheet'} instead for top-level custom CSS, or {@see 'WP_Theme_JSON_Gutenberg::get_styles_for_block'} for block-level custom CSS.
  *
  * @return string
  */


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

#62357 made some updates to the global styles custom CSS handling logic, but neglected to update the docblocks for both `gutenberg_get_global_stylesheet` and `WP_Theme_JSON_Gutenberg::get_stylesheet`. This PR fixes the omission.


