### PR TITLE
Navigation Link: Use optional chaining for linkUIref

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -578,7 +578,7 @@ export default function NavigationLinkEdit( {
 									// the popover, it's because something has taken the focus from the popover, and
 									// we don't want to steal it back.
 									if (
-										linkUIref.current.contains(
+										linkUIref?.current?.contains(
 											window.document.activeElement
 										)
 									) {


### PR DESCRIPTION
Fixes: #67712 

## What?
An optional chaining for property access was introduced to access the properties of linkUIref to prevent the error described in the issue.

## Why?
The absence of this optional chaining caused Uncaught TypeError and this PR is a fix in response to it.

## How?
This PR fixes the issue by implementing optional chaining to resolve the error condition.

## Testing Instructions
1. Navigate to Patterns → Header, and select any pattern containing the Navigation Core Block.
2. Select the Navigation Core Block and click the "plus" button.
3. Click "+ Add block," then select "Browse All" to open the sidebar with available blocks.
4. Click on any block in the sidebar to add it to the Navigation Core Block.
5. Observe that there's no error in the console.

## Screencast

**Before:**

https://github.com/user-attachments/assets/b6be9b58-f346-4fce-bfa6-7bcddcceb249



**After:**
![After](https://github.com/user-attachments/assets/c214b66f-8191-41cd-830a-b7d74f1b9d01)



