### PR TITLE
Visual Refactor: Add Chevron Icon for Shadows in Global Styles

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
@@ -114,7 +114,7 @@ function FontSizeGroup( {
 									<FlexItem className="edit-site-font-size__item">
 										{ size.name }
 									</FlexItem>
-									<FlexItem>
+									<FlexItem display="flex">
 										<Icon
 											icon={
 												isRTL()

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
@@ -11,7 +11,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalHStack as HStack,
 	FlexItem,
-	FlexBlock,
 	Button,
 } from '@wordpress/components';
 import {
@@ -117,9 +116,6 @@ function FontSizeGroup( {
 									</FlexItem>
 									<FlexItem>
 										<HStack justify="flex-end">
-											<FlexBlock className="edit-site-font-size__item edit-site-font-size__item-value">
-												{ size.size }
-											</FlexBlock>
 											<Icon
 												icon={
 													isRTL()

--- a/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
+++ b/packages/edit-site/src/components/global-styles/font-sizes/font-sizes.js
@@ -110,20 +110,18 @@ function FontSizeGroup( {
 								key={ size.slug }
 								path={ `/typography/font-sizes/${ origin }/${ size.slug }` }
 							>
-								<HStack direction="row">
+								<HStack>
 									<FlexItem className="edit-site-font-size__item">
 										{ size.name }
 									</FlexItem>
 									<FlexItem>
-										<HStack justify="flex-end">
-											<Icon
-												icon={
-													isRTL()
-														? chevronLeft
-														: chevronRight
-												}
-											/>
-										</HStack>
+										<Icon
+											icon={
+												isRTL()
+													? chevronLeft
+													: chevronRight
+											}
+										/>
 									</FlexItem>
 								</HStack>
 							</NavigationButtonAsItem>

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -138,7 +138,7 @@ function ShadowItem( { shadow, category } ) {
 		>
 			<HStack>
 				<FlexItem>{ shadow.name }</FlexItem>
-				<FlexItem display="flex">
+				<FlexItem>
 					<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 				</FlexItem>
 			</HStack>

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -136,14 +136,10 @@ function ShadowItem( { shadow, category } ) {
 		<NavigationButtonAsItem
 			path={ `/shadows/edit/${ category }/${ shadow.slug }` }
 		>
-			<HStack direction="row">
-				<FlexItem className="edit-site-shadows-panel__item">
-					{ shadow.name }
-				</FlexItem>
-				<FlexItem>
-					<HStack justify="flex-end">
-						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
-					</HStack>
+			<HStack>
+				<FlexItem>{ shadow.name }</FlexItem>
+				<FlexItem display="flex">
+					<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 				</FlexItem>
 			</HStack>
 		</NavigationButtonAsItem>

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -137,7 +137,7 @@ function ShadowItem( { shadow, category } ) {
 			path={ `/shadows/edit/${ category }/${ shadow.slug }` }
 		>
 			<HStack direction="row">
-				<FlexItem className="edit-site-font-size__item">
+				<FlexItem className="edit-site-shadows-panel__item">
 					{ shadow.name }
 				</FlexItem>
 				<FlexItem>

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -9,9 +9,9 @@ import {
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, sprintf, isRTL } from '@wordpress/i18n';
 import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-import { plus, shadow as shadowIcon } from '@wordpress/icons';
+import { plus, Icon, chevronLeft, chevronRight } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -135,9 +135,17 @@ function ShadowItem( { shadow, category } ) {
 	return (
 		<NavigationButtonAsItem
 			path={ `/shadows/edit/${ category }/${ shadow.slug }` }
-			icon={ shadowIcon }
 		>
-			{ shadow.name }
+			<HStack direction="row">
+				<FlexItem className="edit-site-font-size__item">
+					{ shadow.name }
+				</FlexItem>
+				<FlexItem>
+					<HStack justify="flex-end">
+						<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
+					</HStack>
+				</FlexItem>
+			</HStack>
 		</NavigationButtonAsItem>
 	);
 }

--- a/packages/edit-site/src/components/global-styles/shadows-panel.js
+++ b/packages/edit-site/src/components/global-styles/shadows-panel.js
@@ -138,7 +138,7 @@ function ShadowItem( { shadow, category } ) {
 		>
 			<HStack>
 				<FlexItem>{ shadow.name }</FlexItem>
-				<FlexItem>
+				<FlexItem display="flex">
 					<Icon icon={ isRTL() ? chevronLeft : chevronRight } />
 				</FlexItem>
 			</HStack>


### PR DESCRIPTION
Fixes: #67696 

## What?
This PR addresses the following improvements:

1. **Chevron Icon Addition**: Adds the missing chevron icon to shadow menu items, as detailed in the issue description.
2. **Font-Size Label Adjustment**: Removes the logic responsible for rendering font-size values alongside labels, following the guidance outlined in (https://github.com/WordPress/gutenberg/issues/67696#issuecomment-2523721158). 

These updates align the implementation with the expected design and functionality specifications.

## Testing Instructions
1. Go to the Site editor > Styles > Shadows
2. Observe the shadows menu items now have chevron icon.

## Screenshots ( After the changes made )

![Screenshot 2024-12-09 at 11 12 58 AM](https://github.com/user-attachments/assets/9bc8b259-eaae-48b7-98a9-2c19dd69e600)

![Screenshot 2024-12-09 at 11 14 40 AM](https://github.com/user-attachments/assets/5c1a43be-b9af-46cb-aee0-2790122cfd46)

