### PR TITLE
Update template-related messages to improve clarity for custom post types

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -26,7 +26,7 @@ function getEntityDescription( entity, count ) {
 				: __( 'These changes will affect your whole site.' );
 		case 'wp_template':
 			return __(
-				'This change will affect pages and posts that use this template.'
+				'This change will affect other parts of your site that use this template.'
 			);
 		case 'page':
 		case 'post':

--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -94,7 +94,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			size="medium"
 		>
 			{ __(
-				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?'
+				'You’ve tried to select a block that is part of a template that may be used elsewhere on your site. Would you like to edit the template?'
 			) }
 		</ConfirmDialog>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

closes https://github.com/WordPress/gutenberg/issues/67697

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR updates template-related messages in the Gutenberg editor to use generic phrasing, removing references to specific post types like "posts" and "pages." 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Template messages previously referred to "posts" and "pages," which could be confusing when working with custom post types or templates shared across different post types (e.g., products, orders). This change ensures the messages are more inclusive and clear for all scenarios. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Updated the dialog text when selecting a template block in template-lock mode to avoid post-type-specific references.
- Revised the Save Changes sidebar description to use generic phrasing, referring to "other parts of your site" instead.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open the Gutenberg editor.
2. Select a template block that is part of a locked template.
3. Verify the updated dialog message appears.
4. Make a change to a template and open the Save Changes sidebar.
5. Verify the updated Save Changes sidebar message appears.
