### PR TITLE
Template texts update

### DIFF
--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -26,7 +26,7 @@ function getEntityDescription( entity, count ) {
 				: __( 'These changes will affect your whole site.' );
 		case 'wp_template':
 			return __(
-				'This change will affect pages and posts that use this template.'
+				'This change will affect other parts of your site that use this template.'
 			);
 		case 'page':
 		case 'post':

--- a/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
+++ b/packages/editor/src/components/visual-editor/edit-template-blocks-notification.js
@@ -94,7 +94,7 @@ export default function EditTemplateBlocksNotification( { contentRef } ) {
 			size="medium"
 		>
 			{ __(
-				'You’ve tried to select a block that is part of a template, which may be used on other posts and pages. Would you like to edit the template?'
+				'You’ve tried to select a block that is part of a template that may be used elsewhere on the site. Would you like to edit the template?'
 			) }
 		</ConfirmDialog>
 	);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/67697

## Why?
A template can be used with a custom post type or multiple post types, so these messages can be confusing when a template is used, for example, for a product page or an email.

## How?
Following the first proposed change in the ticket description.
Updating template related texts with suggested texts.

## Testing Instructions
Open the GB editor.
Select a template block that is part of a locked template.
Confirm that the updated dialog message appears.
Make an update  to a template and open the Save Changes sidebar.
Verify the updated Changes sidebar message appears.


