### PR TITLE
DataViews: Move Spinner and No results text at the top.

### DIFF
--- a/packages/dataviews/src/components/dataviews/style.scss
+++ b/packages/dataviews/src/components/dataviews/style.scss
@@ -27,7 +27,6 @@
 .dataviews-no-results,
 .dataviews-loading {
 	padding: 0 $grid-unit-60;
-	flex-grow: 1;
 	display: flex;
 	align-items: center;
 	justify-content: center;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/67730

## What?
<!-- In a few words, what is the PR actually doing? -->
Moves the dataviews Spinner and 'No results' text at the top of the list panel.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Important information should be shown in proximity with the UI it relates to.
Low vision users, screen magnifier users, may entirely miss light shapes or small text shown in the middle of a big white space.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the flex-grow propertuy that was responsible to make this content vertically centered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue.
- Observe the Spinner and the 'No results' text are now shown at the top of the list panel.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![before](https://github.com/user-attachments/assets/0f5d754f-8443-4347-87ac-bc9115e3fdce) | ![after](https://github.com/user-attachments/assets/39966e8b-d952-419c-a045-6a7cacded597) |
