### PR TITLE
Inserter: Hide child blocks from the inserter when needed

### DIFF
--- a/packages/block-editor/src/components/inserter/block-types-tab.js
+++ b/packages/block-editor/src/components/inserter/block-types-tab.js
@@ -186,7 +186,7 @@ export function BlockTypesTab(
 			continue;
 		}
 
-		if ( rootClientId && item.isAllowedInCurrentRoot ) {
+		if ( item.isAllowedInCurrentRoot ) {
 			itemsForCurrentRoot.push( item );
 		} else {
 			itemsRemaining.push( item );

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1587,15 +1587,13 @@ export function getTemplateLock( state, rootClientId ) {
  *                                        from the block directory; or a string name of
  *                                        an installed block type, e.g.' core/paragraph'.
  * @param {?string}       rootClientId    Optional root client ID of block list.
- * @param {Set}           checkedBlocks   Set of block names that have already been checked.
  *
  * @return {boolean} Whether the given block type is allowed to be inserted.
  */
 const isBlockVisibleInTheInserter = (
 	state,
 	blockNameOrType,
-	rootClientId = null,
-	checkedBlocks = new Set()
+	rootClientId = null
 ) => {
 	let blockType;
 	let blockName;
@@ -1623,43 +1621,19 @@ const isBlockVisibleInTheInserter = (
 		return false;
 	}
 
-	if ( checkedBlocks.has( blockName ) ) {
-		return false;
-	}
-
-	checkedBlocks.add( blockName );
-
 	// If parent blocks are not visible, child blocks should be hidden too.
 	const parents = (
 		Array.isArray( blockType.parent ) ? blockType.parent : []
 	).concat( blockType.ancestor ? blockType.ancestor : [] );
 	if ( parents.length > 0 ) {
-		const visibleParentBlocks = parents.filter(
-			( name ) =>
-				( blockName !== name &&
-					isBlockVisibleInTheInserter(
-						state,
-						name,
-						rootClientId,
-						checkedBlocks
-					) ) ||
-				// Exception for blocks with post-content parent,
-				// the root level is often consider as "core/post-content".
-				// This exception should only apply to the post editor ideally though.
-				name === 'core/post-content'
-		);
-
 		const rootBlockName = getBlockName( state, rootClientId );
 		// This is an exception to the rule that says that all blocks are visible in the inserter.
 		// Blocks that require a given parent or ancestor are only visible if we're within that parent.
 		return (
-			visibleParentBlocks.includes( 'core/post-content' ) ||
-			visibleParentBlocks.includes( rootBlockName ) ||
-			getBlockParentsByBlockName(
-				state,
-				rootClientId,
-				visibleParentBlocks
-			).length > 0
+			parents.includes( 'core/post-content' ) ||
+			parents.includes( rootBlockName ) ||
+			getBlockParentsByBlockName( state, rootClientId, parents ).length >
+				0
 		);
 	}
 
@@ -2527,7 +2501,11 @@ export const __experimentalGetAllowedPatterns = createRegistrySelector(
 										name,
 										rootClientId
 								  )
-								: isBlockVisibleInTheInserter( state, name )
+								: isBlockVisibleInTheInserter(
+										state,
+										name,
+										rootClientId
+								  )
 						)
 				);
 

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -2065,6 +2065,7 @@ const buildBlockTypeItem =
 			category: blockType.category,
 			keywords: blockType.keywords,
 			parent: blockType.parent,
+			ancestor: blockType.ancestor,
 			variations: inserterVariations,
 			example: blockType.example,
 			utility: 1, // Deprecated.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1586,6 +1586,7 @@ export function getTemplateLock( state, rootClientId ) {
  * @param {string|Object} blockNameOrType The block type object, e.g., the response
  *                                        from the block directory; or a string name of
  *                                        an installed block type, e.g.' core/paragraph'.
+ * @param {?string}       rootClientId    Optional root client ID of block list.
  * @param {Set}           checkedBlocks   Set of block names that have already been checked.
  *
  * @return {boolean} Whether the given block type is allowed to be inserted.
@@ -1593,6 +1594,7 @@ export function getTemplateLock( state, rootClientId ) {
 const isBlockVisibleInTheInserter = (
 	state,
 	blockNameOrType,
+	rootClientId = null,
 	checkedBlocks = new Set()
 ) => {
 	let blockType;
@@ -1628,13 +1630,17 @@ const isBlockVisibleInTheInserter = (
 	checkedBlocks.add( blockName );
 
 	// If parent blocks are not visible, child blocks should be hidden too.
-	if ( Array.isArray( blockType.parent ) ) {
-		return blockType.parent.some(
+	const parents = (
+		Array.isArray( blockType.parent ) ? blockType.parent : []
+	).concat( blockType.ancestor ? blockType.ancestor : [] );
+	if ( parents.length > 0 ) {
+		const visibleParentBlocks = parents.filter(
 			( name ) =>
 				( blockName !== name &&
 					isBlockVisibleInTheInserter(
 						state,
 						name,
+						rootClientId,
 						checkedBlocks
 					) ) ||
 				// Exception for blocks with post-content parent,
@@ -1642,6 +1648,22 @@ const isBlockVisibleInTheInserter = (
 				// This exception should only apply to the post editor ideally though.
 				name === 'core/post-content'
 		);
+
+		const rootBlockName = getBlockName( state, rootClientId );
+		// This is an exception to the rule that says that all blocks are visible in the inserter.
+		// Blocks that require a given parent or ancestor are only visible if we're within that parent.
+		return (
+			visibleParentBlocks.includes( 'core/post-content' ) ||
+			visibleParentBlocks.includes( rootBlockName ) ||
+			getBlockParentsByBlockName(
+				state,
+				rootClientId,
+				visibleParentBlocks
+			).length > 0
+		);
+	}
+
+	if ( parents.length > 0 ) {
 	}
 
 	return true;
@@ -1665,7 +1687,7 @@ const canInsertBlockTypeUnmemoized = (
 	blockName,
 	rootClientId = null
 ) => {
-	if ( ! isBlockVisibleInTheInserter( state, blockName ) ) {
+	if ( ! isBlockVisibleInTheInserter( state, blockName, rootClientId ) ) {
 		return false;
 	}
 
@@ -2169,7 +2191,11 @@ export const getInserterItems = createRegistrySelector( ( select ) =>
 			} else {
 				blockTypeInserterItems = blockTypeInserterItems
 					.filter( ( blockType ) =>
-						isBlockVisibleInTheInserter( state, blockType )
+						isBlockVisibleInTheInserter(
+							state,
+							blockType,
+							rootClientId
+						)
 					)
 					.map( ( blockType ) => ( {
 						...blockType,

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1624,7 +1624,7 @@ const isBlockVisibleInTheInserter = (
 	// If parent blocks are not visible, child blocks should be hidden too.
 	const parents = (
 		Array.isArray( blockType.parent ) ? blockType.parent : []
-	).concat( blockType.ancestor ? blockType.ancestor : [] );
+	).concat( Array.isArray( blockType.ancestor ) ? blockType.ancestor : [] );
 	if ( parents.length > 0 ) {
 		const rootBlockName = getBlockName( state, rootClientId );
 		// This is an exception to the rule that says that all blocks are visible in the inserter.

--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -1637,9 +1637,6 @@ const isBlockVisibleInTheInserter = (
 		);
 	}
 
-	if ( parents.length > 0 ) {
-	}
-
 	return true;
 };
 

--- a/packages/block-editor/src/store/test/selectors.js
+++ b/packages/block-editor/src/store/test/selectors.js
@@ -3324,7 +3324,7 @@ describe( 'selectors', () => {
 				settings: {},
 				blockEditingModes: new Map(),
 			};
-			expect( canInsertBlocks( state, [ '2', '3' ], '1' ) ).toBe( true );
+			expect( canInsertBlocks( state, [ '2' ], '1' ) ).toBe( true );
 		} );
 
 		it( 'should deny blocks', () => {


### PR DESCRIPTION
closes #65687 

## What?

In a previous iteration, we allowed all blocks to be visible in the inserter at any time. This has proven a bit confusing for blocks that require a parent block. These blocks should only be visible within their parent blocks. This PR solves that.

## Testing Instructions

1- The "column" block shouldn't be visible when you're at the root level in the inserter
2- The "column" block should be visible when you're within a columns block.