### PR TITLE
Data: Expose 'useSelect' warning to third-party consumers

### DIFF
--- a/packages/block-editor/src/hooks/test/font-size.js
+++ b/packages/block-editor/src/hooks/test/font-size.js
@@ -19,6 +19,15 @@ import {
 import _fontSize from '../font-size';
 
 const noop = () => {};
+const EMPTY_ARRAY = [];
+const EMPTY_OBJECT = {};
+const fontSizes = [
+	{
+		name: 'A larger font',
+		size: '32px',
+		slug: 'larger',
+	},
+];
 
 function addUseSettingFilter( callback ) {
 	addFilter(
@@ -55,13 +64,7 @@ describe( 'useBlockProps', () => {
 		registerBlockType( blockSettings.name, blockSettings );
 		addUseSettingFilter( ( result, path ) => {
 			if ( 'typography.fontSizes' === path ) {
-				return [
-					{
-						name: 'A larger font',
-						size: '32px',
-						slug: 'larger',
-					},
-				];
+				return fontSizes;
 			}
 
 			if ( 'typography.fluid' === path ) {
@@ -69,7 +72,7 @@ describe( 'useBlockProps', () => {
 			}
 
 			if ( 'layout' === path ) {
-				return {};
+				return EMPTY_OBJECT;
 			}
 
 			return result;
@@ -95,7 +98,7 @@ describe( 'useBlockProps', () => {
 		registerBlockType( blockSettings.name, blockSettings );
 		addUseSettingFilter( ( result, path ) => {
 			if ( 'typography.fontSizes' === path ) {
-				return [];
+				return EMPTY_ARRAY;
 			}
 
 			if ( 'typography.fluid' === path ) {
@@ -103,7 +106,7 @@ describe( 'useBlockProps', () => {
 			}
 
 			if ( 'layout' === path ) {
-				return {};
+				return EMPTY_OBJECT;
 			}
 
 			return result;
@@ -132,7 +135,7 @@ describe( 'useBlockProps', () => {
 		registerBlockType( blockSettings.name, blockSettings );
 		addUseSettingFilter( ( result, path ) => {
 			if ( 'typography.fontSizes' === path ) {
-				return [];
+				return EMPTY_ARRAY;
 			}
 
 			if ( 'typography.fluid' === path ) {
@@ -140,7 +143,7 @@ describe( 'useBlockProps', () => {
 			}
 
 			if ( 'layout' === path ) {
-				return {};
+				return EMPTY_OBJECT;
 			}
 
 			return result;

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -17,8 +17,15 @@ import { render, screen, waitFor } from '@testing-library/react';
  */
 import useQuerySelect from '../use-query-select';
 
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable @wordpress/wp-global-usage */
 describe( 'useQuerySelect', () => {
+	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
 	let registry;
+
+	beforeAll( () => {
+		globalThis.SCRIPT_DEBUG = false;
+	} );
 
 	beforeEach( () => {
 		registry = createRegistry();
@@ -29,6 +36,10 @@ describe( 'useQuerySelect', () => {
 				testSelector: ( state, key ) => state[ key ],
 			},
 		} );
+	} );
+
+	afterAll( () => {
+		globalThis.SCRIPT_DEBUG = initialScriptDebug;
 	} );
 
 	const getTestComponent = ( mapSelectSpy, dependencyKey ) => ( props ) => {

--- a/packages/core-data/src/hooks/test/use-query-select.js
+++ b/packages/core-data/src/hooks/test/use-query-select.js
@@ -17,13 +17,13 @@ import { render, screen, waitFor } from '@testing-library/react';
  */
 import useQuerySelect from '../use-query-select';
 
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @wordpress/wp-global-usage */
 describe( 'useQuerySelect', () => {
 	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
 	let registry;
 
 	beforeAll( () => {
+		// Do not run hook in development mode; it will call `mapSelect` an extra time.
 		globalThis.SCRIPT_DEBUG = false;
 	} );
 
@@ -199,3 +199,4 @@ describe( 'useQuerySelect', () => {
 		);
 	} );
 } );
+/* eslint-enable @wordpress/wp-global-usage */

--- a/packages/data/src/components/use-select/index.js
+++ b/packages/data/src/components/use-select/index.js
@@ -174,7 +174,7 @@ function Store( registry, suspense ) {
 				listeningStores
 			);
 
-			if ( process.env.NODE_ENV === 'development' ) {
+			if ( globalThis.SCRIPT_DEBUG ) {
 				if ( ! didWarnUnstableReference ) {
 					const secondMapResult = mapSelect( select, registry );
 					if ( ! isShallowEqual( mapResult, secondMapResult ) ) {

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -32,10 +32,22 @@ function counterStore( initialCount = 0, step = 1 ) {
 	};
 }
 
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable @wordpress/wp-global-usage */
 describe( 'useSelect', () => {
+	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
 	let registry;
+
+	beforeAll( () => {
+		globalThis.SCRIPT_DEBUG = false;
+	} );
+
 	beforeEach( () => {
 		registry = createRegistry();
+	} );
+
+	afterAll( () => {
+		globalThis.SCRIPT_DEBUG = initialScriptDebug;
 	} );
 
 	it( 'passes the relevant data to the component', () => {

--- a/packages/data/src/components/use-select/test/index.js
+++ b/packages/data/src/components/use-select/test/index.js
@@ -32,13 +32,13 @@ function counterStore( initialCount = 0, step = 1 ) {
 	};
 }
 
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @wordpress/wp-global-usage */
 describe( 'useSelect', () => {
 	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
 	let registry;
 
 	beforeAll( () => {
+		// Do not run hook in development mode; it will call `mapSelect` an extra time.
 		globalThis.SCRIPT_DEBUG = false;
 	} );
 
@@ -1269,3 +1269,4 @@ describe( 'useSelect', () => {
 		} );
 	} );
 } );
+/* eslint-enable @wordpress/wp-global-usage */

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -18,7 +18,19 @@ import withDispatch from '../../with-dispatch';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
+// eslint-disable-next-line eslint-comments/disable-enable-pair
+/* eslint-disable @wordpress/wp-global-usage */
 describe( 'withSelect', () => {
+	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
+
+	beforeAll( () => {
+		globalThis.SCRIPT_DEBUG = false;
+	} );
+
+	afterAll( () => {
+		globalThis.SCRIPT_DEBUG = initialScriptDebug;
+	} );
+
 	it( 'passes the relevant data to the component', () => {
 		const registry = createRegistry();
 		registry.registerStore( 'reactReducer', {

--- a/packages/data/src/components/with-select/test/index.js
+++ b/packages/data/src/components/with-select/test/index.js
@@ -18,12 +18,12 @@ import withDispatch from '../../with-dispatch';
 import { createRegistry } from '../../../registry';
 import { RegistryProvider } from '../../registry-provider';
 
-// eslint-disable-next-line eslint-comments/disable-enable-pair
 /* eslint-disable @wordpress/wp-global-usage */
 describe( 'withSelect', () => {
 	const initialScriptDebug = globalThis.SCRIPT_DEBUG;
 
 	beforeAll( () => {
+		// Do not run HOC in development mode; it will call `mapSelect` an extra time.
 		globalThis.SCRIPT_DEBUG = false;
 	} );
 
@@ -627,3 +627,4 @@ describe( 'withSelect', () => {
 		expect( screen.getByRole( 'status' ) ).toHaveTextContent( 'second' );
 	} );
 } );
+/* eslint-enable @wordpress/wp-global-usage */


### PR DESCRIPTION
## What?
PR exposes the `useSelect` performance warning to third-party consumers. It would help them catch any possible issues while extending the block editor.

The warning is only available when `globalThis.SCRIPT_DEBUG` is true:

* In WordPress, this means setting `SCRIPT_DEBUG` constant in `wp-config.php`.
* Project behavior remains the same: `npm run dev`.

The bundle size increase should be negligible.

## Why?
Everyone benefits 

## Testing Instructions
1. Open a post or page.
2. Add an example plugin via DevTools.
3. Confirm the notice message.

<details><summary>Test plugin</summary>
<p>

```javascript
const { createElement: el, useState } = wp.element;
const { useSelect } = wp.data;
const registerPlugin = wp.plugins.registerPlugin;
const PluginDocumentSettingPanel = wp.editor.PluginDocumentSettingPanel;

function PluginBlocksOnPage() {
    const { names, total } = useSelect( ( select ) => {
        const blocks = select('core/block-editor').getBlocks();

        return {
            names: blocks.map( ( { name } ) => name ),
            total: blocks.length,
        };
    }, [] );

	return el(
		PluginDocumentSettingPanel,
		{
			className: 'test-blocks-on-page',
			title: `Blocks on Page: ${ total }`,
			name: 'test-blocks-on-page'
		},
		el( 'p', {}, 'Placeholder' )
	);
}

registerPlugin( 'test-blocks-on-page', {
	render: PluginBlocksOnPage,
} );
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-12-08 at 15 44 31](https://github.com/user-attachments/assets/1cd6ecb5-8fe2-459a-a236-f04446d1272d)