### PR TITLE
Remove patterns from the Quick Inserter to prevent misuse in block-specific contexts

### DIFF
--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -29,7 +29,6 @@ const defaultRenderToggle = ( {
 	blockTitle,
 	hasSingleBlockType,
 	toggleProps = {},
-	prioritizePatterns,
 } ) => {
 	const {
 		as: Wrapper = Button,
@@ -45,8 +44,6 @@ const defaultRenderToggle = ( {
 			_x( 'Add %s', 'directly add the only allowed block' ),
 			blockTitle
 		);
-	} else if ( ! label && prioritizePatterns ) {
-		label = __( 'Add pattern' );
 	} else if ( ! label ) {
 		label = _x( 'Add block', 'Generic label for block inserter button' );
 	}
@@ -113,7 +110,6 @@ class Inserter extends Component {
 			toggleProps,
 			hasItems,
 			renderToggle = defaultRenderToggle,
-			prioritizePatterns,
 		} = this.props;
 
 		return renderToggle( {
@@ -124,7 +120,6 @@ class Inserter extends Component {
 			hasSingleBlockType,
 			directInsertBlock,
 			toggleProps,
-			prioritizePatterns,
 		} );
 	}
 
@@ -147,7 +142,6 @@ class Inserter extends Component {
 			// This prop is experimental to give some time for the quick inserter to mature
 			// Feel free to make them stable after a few releases.
 			__experimentalIsQuick: isQuick,
-			prioritizePatterns,
 			onSelectOrClose,
 			selectBlockOnInsert,
 		} = this.props;
@@ -171,7 +165,6 @@ class Inserter extends Component {
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
-					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
 				/>
 			);
@@ -230,7 +223,6 @@ export default compose( [
 				hasInserterItems,
 				getAllowedBlocks,
 				getDirectInsertBlock,
-				getSettings,
 			} = select( blockEditorStore );
 
 			const { getBlockVariations } = select( blocksStore );
@@ -242,8 +234,6 @@ export default compose( [
 
 			const directInsertBlock =
 				shouldDirectInsert && getDirectInsertBlock( rootClientId );
-
-			const settings = getSettings();
 
 			const hasSingleBlockType =
 				allowedBlocks?.length === 1 &&
@@ -262,9 +252,6 @@ export default compose( [
 				allowedBlockType,
 				directInsertBlock,
 				rootClientId,
-				prioritizePatterns:
-					settings.__experimentalPreferPatternsOnRoot &&
-					! rootClientId,
 			};
 		}
 	),

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -16,14 +16,11 @@ import { useSelect } from '@wordpress/data';
  */
 import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
-// import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
 import { store as blockEditorStore } from '../../store';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
-// const SHOWN_BLOCK_PATTERNS = 2;
-// const SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION = 4;
 
 export default function QuickInserter( {
 	onSelect,
@@ -47,12 +44,6 @@ export default function QuickInserter( {
 		onInsertBlocks,
 		true
 	);
-	// const [ patterns ] = usePatternsState(
-	// 	onInsertBlocks,
-	// 	destinationRootClientId,
-	// 	undefined,
-	// 	true
-	// );
 
 	const { setInserterIsOpened, insertionIndex } = useSelect(
 		( select ) => {
@@ -70,8 +61,6 @@ export default function QuickInserter( {
 		[ clientId ]
 	);
 
-	// const showPatterns =
-	// 	patterns.length && ( !! filterValue || prioritizePatterns );
 	const showSearch = hasSearch && blockTypes.length > SEARCH_THRESHOLD;
 
 	useEffect( () => {
@@ -90,13 +79,6 @@ export default function QuickInserter( {
 			insertionIndex,
 		} );
 	};
-
-	// let maxBlockPatterns = 0;
-	// if ( showPatterns ) {
-	// 	maxBlockPatterns = prioritizePatterns
-	// 		? SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION
-	// 		: SHOWN_BLOCK_PATTERNS;
-	// }
 
 	return (
 		<div

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -16,14 +16,14 @@ import { useSelect } from '@wordpress/data';
  */
 import InserterSearchResults from './search-results';
 import useInsertionPoint from './hooks/use-insertion-point';
-import usePatternsState from './hooks/use-patterns-state';
+// import usePatternsState from './hooks/use-patterns-state';
 import useBlockTypesState from './hooks/use-block-types-state';
 import { store as blockEditorStore } from '../../store';
 
 const SEARCH_THRESHOLD = 6;
 const SHOWN_BLOCK_TYPES = 6;
-const SHOWN_BLOCK_PATTERNS = 2;
-const SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION = 4;
+// const SHOWN_BLOCK_PATTERNS = 2;
+// const SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION = 4;
 
 export default function QuickInserter( {
 	onSelect,
@@ -47,12 +47,12 @@ export default function QuickInserter( {
 		onInsertBlocks,
 		true
 	);
-	const [ patterns ] = usePatternsState(
-		onInsertBlocks,
-		destinationRootClientId,
-		undefined,
-		true
-	);
+	// const [ patterns ] = usePatternsState(
+	// 	onInsertBlocks,
+	// 	destinationRootClientId,
+	// 	undefined,
+	// 	true
+	// );
 
 	const { setInserterIsOpened, insertionIndex } = useSelect(
 		( select ) => {
@@ -70,12 +70,9 @@ export default function QuickInserter( {
 		[ clientId ]
 	);
 
-	const showPatterns =
-		patterns.length && ( !! filterValue || prioritizePatterns );
-	const showSearch =
-		hasSearch &&
-		( ( showPatterns && patterns.length > SEARCH_THRESHOLD ) ||
-			blockTypes.length > SEARCH_THRESHOLD );
+	// const showPatterns =
+	// 	patterns.length && ( !! filterValue || prioritizePatterns );
+	const showSearch = hasSearch && blockTypes.length > SEARCH_THRESHOLD;
 
 	useEffect( () => {
 		if ( setInserterIsOpened ) {
@@ -94,12 +91,12 @@ export default function QuickInserter( {
 		} );
 	};
 
-	let maxBlockPatterns = 0;
-	if ( showPatterns ) {
-		maxBlockPatterns = prioritizePatterns
-			? SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION
-			: SHOWN_BLOCK_PATTERNS;
-	}
+	// let maxBlockPatterns = 0;
+	// if ( showPatterns ) {
+	// 	maxBlockPatterns = prioritizePatterns
+	// 		? SHOWN_BLOCK_PATTERNS_WITH_PRIORITIZATION
+	// 		: SHOWN_BLOCK_PATTERNS;
+	// }
 
 	return (
 		<div
@@ -128,7 +125,7 @@ export default function QuickInserter( {
 					rootClientId={ rootClientId }
 					clientId={ clientId }
 					isAppender={ isAppender }
-					maxBlockPatterns={ maxBlockPatterns }
+					maxBlockPatterns={ 0 }
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }
 					prioritizePatterns={ prioritizePatterns }

--- a/packages/block-editor/src/components/inserter/quick-inserter.js
+++ b/packages/block-editor/src/components/inserter/quick-inserter.js
@@ -27,7 +27,6 @@ export default function QuickInserter( {
 	rootClientId,
 	clientId,
 	isAppender,
-	prioritizePatterns,
 	selectBlockOnInsert,
 	hasSearch = true,
 } ) {
@@ -110,7 +109,6 @@ export default function QuickInserter( {
 					maxBlockPatterns={ 0 }
 					maxBlockTypes={ SHOWN_BLOCK_TYPES }
 					isDraggable={ false }
-					prioritizePatterns={ prioritizePatterns }
 					selectBlockOnInsert={ selectBlockOnInsert }
 					isQuick
 				/>


### PR DESCRIPTION
## What?
- Removing patterns from the Quick Inserter.
- Fixes Issue: https://github.com/WordPress/gutenberg/issues/67693

## Why?
- We are removing Patterns from the quick inserter to prevent misuse in block-specific contexts.

## How?
- Set maxBlockPatterns to 0 which will help in not showing patterns in the quick inserter.

## Testing Instructions
- Open the block editor and add any block (e.g., Social Links).
- Click the “+” button in the block toolbar to open the Quick Inserter.
- Search for items, and observe that patterns are not included in the results.