### PR TITLE
DataViews: Fix filters lost when switching layouts

### DIFF
--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Page List', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		// Activate a theme with permissions to access the site editor.
+		await requestUtils.activateTheme( 'emptytheme' );
+		await requestUtils.createPage( {
+			title: 'Privacy Policy',
+			status: 'publish',
+		} );
+		await requestUtils.createPage( {
+			title: 'Sample Page',
+			status: 'publish',
+		} );
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		// Go back to the default theme.
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllPages(),
+		] );
+	} );
+
+	test.beforeEach( async ( { admin, page } ) => {
+		// Go to the pages page, as it has the list layout enabled by default.
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Pages' } ).click();
+	} );
+
+	test( 'Persists filter/search when switching layout', async ( {
+		page,
+	} ) => {
+		// Search pages
+		await page
+			.getByRole( 'searchbox', { name: 'Search' } )
+			.fill( 'Privacy' );
+
+		// Switch layout
+		await page.getByRole( 'button', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
+		// Confirm the table is visible
+		await expect( page.getByRole( 'table' ) ).toContainText(
+			'Privacy Policy'
+		);
+
+		// The search should still contain the search term
+		await expect(
+			page.getByRole( 'searchbox', { name: 'Search' } )
+		).toHaveValue( 'Privacy' );
+	} );
+} );


### PR DESCRIPTION
Related #55083 

## What?

When switching layouts in the "pages" (or posts) dataviews, the filters, sorting... is lost. This PR fixes that.
The bug is still present for the moment in the templates dataviews (which I will tackle as well)

## Testing Instructions

1- Open the "pages" dataviews
2- Apply some random filter
3- Switch the layout
4- The filter should persist.