### PR TITLE
Add a Playground blueprint json to the /assets/blueprints folder of Plugin Repo

### DIFF
--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,0 +1,21 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"landingPage": "/wp-admin/site-editor.php",
+	"plugins": [ "gutenberg" ],
+	"login": true,
+	"features": {
+		"networking": true
+	},
+	"preferredVersions": {
+		"php": "8.0",
+		"wp": "latest"
+	},
+	"steps": [
+		{
+			"step": "setSiteOptions",
+			"options": {
+				"blogname": "Testing Gutenberg"
+			}
+		}
+	]
+}

--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -16,6 +16,13 @@
 			"options": {
 				"blogname": "Testing Gutenberg"
 			}
+		},
+		{
+			"step": "updateUserMeta",
+			"meta": {
+				"admin_color": "modern"
+			},
+			"userId": 1
 		}
 	]
 }

--- a/assets/blueprints/blueprint.json
+++ b/assets/blueprints/blueprint.json
@@ -1,13 +1,13 @@
 {
 	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
-	"landingPage": "/wp-admin/site-editor.php",
+	"landingPage": "/wp-admin/post.php?post=1&action=edit",
 	"plugins": [ "gutenberg" ],
 	"login": true,
 	"features": {
 		"networking": true
 	},
 	"preferredVersions": {
-		"php": "8.0",
+		"php": "latest",
 		"wp": "latest"
 	},
 	"steps": [


### PR DESCRIPTION
## What?
Adds a blueprint.json to the assets/blueprints folder, to show a preview in the Plugins Directory for the plugin. 
Fix #67739
## Why?
To empower users to test and try out the latest Gutenberg plugin version. 

## How?
Following the[ Plugin Review Teams instructions.](https://developer.wordpress.org/plugins/wordpress-org/previews-and-blueprints/) 

## Testing Instructions

[Test via Playground](https://playground.wordpress.net/?networking=yes&blueprint-url=data%3Aapplication%2Fjson%3Bbase64%2CeyJsYW5kaW5nUGFnZSI6Ii93cC1hZG1pbi9wb3N0LnBocD9wb3N0PTEmYWN0aW9uPWVkaXQiLCJmZWF0dXJlcyI6eyJuZXR3b3JraW5nIjp0cnVlfSwic3RlcHMiOlt7InN0ZXAiOiJpbnN0YWxsUGx1Z2luIiwicGx1Z2luRGF0YSI6eyJyZXNvdXJjZSI6IndvcmRwcmVzcy5vcmcvcGx1Z2lucyIsInNsdWciOiJndXRlbmJlcmcifSwib3B0aW9ucyI6eyJhY3RpdmF0ZSI6dHJ1ZX19LHsic3RlcCI6ImxvZ2luIiwidXNlcm5hbWUiOiJhZG1pbiIsInBhc3N3b3JkIjoicGFzc3dvcmQifSx7InN0ZXAiOiJzZXRTaXRlT3B0aW9ucyIsIm9wdGlvbnMiOnsiYmxvZ25hbWUiOiJUZXN0aW5nIEd1dGVuYmVyZyIsImJsb2dkZXNjcmlwdGlvbiI6IiJ9fSx7InN0ZXAiOiJ1cGRhdGVVc2VyTWV0YSIsIm1ldGEiOnsiYWRtaW5fY29sb3IiOiJtb2Rlcm4ifSwidXNlcklkIjoxfV19) (updated 12/11/24)

- [x] Needs a second step from plugin committers on record to switch the blueprint from test to public. 
