### PR TITLE
DataViews: Preserve filters when switching layouts in templates dataviews

### DIFF
--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -25,6 +25,7 @@ import {
 import { unlock } from '../../lock-unlock';
 import { useEditPostAction } from '../dataviews-actions';
 import { authorField, descriptionField, previewField } from './fields';
+import { useEvent } from '@wordpress/compose';
 
 const { usePostActions } = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
@@ -92,11 +93,22 @@ export default function PageTemplates() {
 		};
 	}, [ layout, activeView ] );
 	const [ view, setView ] = useState( defaultView );
-	useEffect( () => {
-		const usedType = layout ?? DEFAULT_VIEW.type;
+
+	// Sync the layout from the URL to the view state.
+	const onChangeUrlLayout = useEvent( () => {
 		setView( ( currentView ) => ( {
 			...currentView,
-			type: usedType,
+			type: layout ?? DEFAULT_VIEW.type,
+		} ) );
+	} );
+	useEffect( () => {
+		onChangeUrlLayout();
+	}, [ onChangeUrlLayout, layout ] );
+
+	// Sync the active view from the URL to the view state.
+	const onChangeActiveView = useEvent( () => {
+		setView( ( currentView ) => ( {
+			...currentView,
 			filters:
 				activeView !== 'all'
 					? [
@@ -108,7 +120,10 @@ export default function PageTemplates() {
 					  ]
 					: [],
 		} ) );
-	}, [ activeView, layout ] );
+	} );
+	useEffect( () => {
+		onChangeActiveView();
+	}, [ onChangeActiveView, activeView ] );
 
 	const { records, isResolving: isLoadingData } =
 		useEntityRecordsWithPermissions( 'postType', TEMPLATE_POST_TYPE, {
@@ -170,20 +185,16 @@ export default function PageTemplates() {
 		[ postTypeActions, editAction ]
 	);
 
-	const onChangeView = useCallback(
-		( newView ) => {
-			if ( newView.type !== view.type ) {
-				history.navigate(
-					addQueryArgs( path, {
-						layout: newView.type,
-					} )
-				);
-			}
-
-			setView( newView );
-		},
-		[ view.type, setView, history, path ]
-	);
+	const onChangeView = useEvent( ( newView ) => {
+		setView( newView );
+		if ( newView.type !== layout ) {
+			history.navigate(
+				addQueryArgs( path, {
+					layout: newView.type,
+				} )
+			);
+		}
+	} );
 
 	return (
 		<Page

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -95,18 +95,15 @@ export default function PageTemplates() {
 	const [ view, setView ] = useState( defaultView );
 
 	// Sync the layout from the URL to the view state.
-	const onChangeUrlLayout = useEvent( () => {
+	useEffect( () => {
 		setView( ( currentView ) => ( {
 			...currentView,
 			type: layout ?? DEFAULT_VIEW.type,
 		} ) );
-	} );
-	useEffect( () => {
-		onChangeUrlLayout();
-	}, [ onChangeUrlLayout, layout ] );
+	}, [ setView, layout ] );
 
 	// Sync the active view from the URL to the view state.
-	const onChangeActiveView = useEvent( () => {
+	useEffect( () => {
 		setView( ( currentView ) => ( {
 			...currentView,
 			filters:
@@ -120,10 +117,7 @@ export default function PageTemplates() {
 					  ]
 					: [],
 		} ) );
-	} );
-	useEffect( () => {
-		onChangeActiveView();
-	}, [ onChangeActiveView, activeView ] );
+	}, [ setView, activeView ] );
 
 	const { records, isResolving: isLoadingData } =
 		useEntityRecordsWithPermissions( 'postType', TEMPLATE_POST_TYPE, {

--- a/test/e2e/specs/site-editor/templates.spec.js
+++ b/test/e2e/specs/site-editor/templates.spec.js
@@ -40,4 +40,27 @@ test.describe( 'Templates', () => {
 			)
 		).toBeVisible();
 	} );
+
+	test( 'Persists filter/search when switching layout', async ( {
+		page,
+		admin,
+	} ) => {
+		await admin.visitSiteEditor();
+		await page.getByRole( 'button', { name: 'Templates' } ).click();
+
+		// Search templates
+		await page.getByRole( 'searchbox', { name: 'Search' } ).fill( 'Index' );
+
+		// Switch layout
+		await page.getByRole( 'button', { name: 'Layout' } ).click();
+		await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
+
+		// Confirm the table is visible
+		await expect( page.getByRole( 'table' ) ).toContainText( 'Index' );
+
+		// The search should still contain the search term
+		await expect(
+			page.getByRole( 'searchbox', { name: 'Search' } )
+		).toHaveValue( 'Index' );
+	} );
 } );


### PR DESCRIPTION
Related #55083 

## What?

When switching layouts in the "templates" dataviews, the filters, sorting... is lost. This PR fixes that.
Pages dataviews suffer from the same issue and it's being fixed in #67740 

## Testing Instructions

1- Open the "templates" dataviews
2- Apply some random filter
3- Switch the layout
4- The filter should persist.