### PR TITLE
Block Bindings: Use role content to enable block bindings attributes/

### DIFF
--- a/packages/block-editor/src/hooks/use-bindings-attributes.js
+++ b/packages/block-editor/src/hooks/use-bindings-attributes.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { store as blocksStore } from '@wordpress/blocks';
+import { store as blocksStore, getBlockType } from '@wordpress/blocks';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useRegistry, useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useContext } from '@wordpress/element';
@@ -93,7 +93,14 @@ export function canBindAttribute( blockName, attributeName ) {
 }
 
 export function getBindableAttributes( blockName ) {
-	return BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ];
+	const blockType = getBlockType( blockName );
+	const allowedAttributes = BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ] || [];
+	// Still comparing with the allowed blocks constant until we can automate the bindings server process.
+	return Object.keys( blockType.attributes ).filter(
+		( key ) =>
+			blockType.attributes[ key ].role === 'content' &&
+			allowedAttributes.includes( key )
+	);
 }
 
 export const withBlockBindingSupport = createHigherOrderComponent(

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useDispatch, useRegistry } from '@wordpress/data';
+import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -11,6 +12,50 @@ import { useBlockEditContext } from '../components/block-edit';
 
 function isObjectEmpty( object ) {
 	return ! object || Object.keys( object ).length === 0;
+}
+
+export const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
+	'core/paragraph': [ 'content' ],
+	'core/heading': [ 'content' ],
+	'core/image': [ 'id', 'url', 'title', 'alt' ],
+	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
+};
+
+/**
+ * Based on the given block name,
+ * check if it is possible to bind the block.
+ *
+ * @param {string} blockName - The block name.
+ * @return {boolean} Whether it is possible to bind the block to sources.
+ */
+export function canBindBlock( blockName ) {
+	return blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS;
+}
+
+/**
+ * Based on the given block name and attribute name,
+ * check if it is possible to bind the block attribute.
+ *
+ * @param {string} blockName     - The block name.
+ * @param {string} attributeName - The attribute name.
+ * @return {boolean} Whether it is possible to bind the block attribute.
+ */
+export function canBindAttribute( blockName, attributeName ) {
+	return (
+		canBindBlock( blockName ) &&
+		BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes( attributeName )
+	);
+}
+
+export function getBindableAttributes( blockName ) {
+	const blockType = getBlockType( blockName );
+	const allowedAttributes = BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ] || [];
+	// Still comparing with the allowed blocks constant until we can automate the bindings server process.
+	return Object.keys( blockType.attributes ).filter(
+		( key ) =>
+			blockType.attributes[ key ].role === 'content' &&
+			allowedAttributes.includes( key )
+	);
 }
 
 /**

--- a/packages/block-editor/src/utils/block-bindings.js
+++ b/packages/block-editor/src/utils/block-bindings.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useDispatch, useRegistry } from '@wordpress/data';
-import { getBlockType } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -12,50 +11,6 @@ import { useBlockEditContext } from '../components/block-edit';
 
 function isObjectEmpty( object ) {
 	return ! object || Object.keys( object ).length === 0;
-}
-
-export const BLOCK_BINDINGS_ALLOWED_BLOCKS = {
-	'core/paragraph': [ 'content' ],
-	'core/heading': [ 'content' ],
-	'core/image': [ 'id', 'url', 'title', 'alt' ],
-	'core/button': [ 'url', 'text', 'linkTarget', 'rel' ],
-};
-
-/**
- * Based on the given block name,
- * check if it is possible to bind the block.
- *
- * @param {string} blockName - The block name.
- * @return {boolean} Whether it is possible to bind the block to sources.
- */
-export function canBindBlock( blockName ) {
-	return blockName in BLOCK_BINDINGS_ALLOWED_BLOCKS;
-}
-
-/**
- * Based on the given block name and attribute name,
- * check if it is possible to bind the block attribute.
- *
- * @param {string} blockName     - The block name.
- * @param {string} attributeName - The attribute name.
- * @return {boolean} Whether it is possible to bind the block attribute.
- */
-export function canBindAttribute( blockName, attributeName ) {
-	return (
-		canBindBlock( blockName ) &&
-		BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ].includes( attributeName )
-	);
-}
-
-export function getBindableAttributes( blockName ) {
-	const blockType = getBlockType( blockName );
-	const allowedAttributes = BLOCK_BINDINGS_ALLOWED_BLOCKS[ blockName ] || [];
-	// Still comparing with the allowed blocks constant until we can automate the bindings server process.
-	return Object.keys( blockType.attributes ).filter(
-		( key ) =>
-			blockType.attributes[ key ].role === 'content' &&
-			allowedAttributes.includes( key )
-	);
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This is a first iteration of adding "role: content" as an opt-in for block bindings. I still left the `BLOCK_BINDINGS_ALLOWED_BLOCKS` variable, to ensure only blocks that are updated with the required code to process the bindings on the server are included.

## Tests

E2E tests should pass. This PR is not changing anything yet, just adding another check.