### PR TITLE
[ New Inline Format ] Introduce Inline Time Format for improved SEO and accessibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34395,6 +34395,16 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
+		"node_modules/locutus": {
+			"version": "2.0.32",
+			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.32.tgz",
+			"integrity": "sha512-fr7OCpbE4xeefhHqfh6hM2/l9ZB3XvClHgtgFnQNImrM/nqL950o6FO98vmUH8GysfQRCcyBYtZ4C8GcY52Edw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10",
+				"yarn": ">= 1"
+			}
+		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -54764,7 +54774,8 @@
 				"@wordpress/icons": "*",
 				"@wordpress/private-apis": "*",
 				"@wordpress/rich-text": "*",
-				"@wordpress/url": "*"
+				"@wordpress/url": "*",
+				"locutus": "2.0.32"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34395,16 +34395,6 @@
 				"signal-exit": "^3.0.2"
 			}
 		},
-		"node_modules/locutus": {
-			"version": "2.0.32",
-			"resolved": "https://registry.npmjs.org/locutus/-/locutus-2.0.32.tgz",
-			"integrity": "sha512-fr7OCpbE4xeefhHqfh6hM2/l9ZB3XvClHgtgFnQNImrM/nqL950o6FO98vmUH8GysfQRCcyBYtZ4C8GcY52Edw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10",
-				"yarn": ">= 1"
-			}
-		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -54774,8 +54764,7 @@
 				"@wordpress/icons": "*",
 				"@wordpress/private-apis": "*",
 				"@wordpress/rich-text": "*",
-				"@wordpress/url": "*",
-				"locutus": "2.0.32"
+				"@wordpress/url": "*"
 			},
 			"engines": {
 				"node": ">=18.12.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54758,6 +54758,7 @@
 				"@wordpress/components": "*",
 				"@wordpress/compose": "*",
 				"@wordpress/data": "*",
+				"@wordpress/date": "*",
 				"@wordpress/element": "*",
 				"@wordpress/html-entities": "*",
 				"@wordpress/i18n": "*",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -39,7 +39,8 @@
 		"@wordpress/icons": "*",
 		"@wordpress/private-apis": "*",
 		"@wordpress/rich-text": "*",
-		"@wordpress/url": "*"
+		"@wordpress/url": "*",
+		"locutus": "2.0.32"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -33,14 +33,14 @@
 		"@wordpress/components": "*",
 		"@wordpress/compose": "*",
 		"@wordpress/data": "*",
+		"@wordpress/date": "*",
 		"@wordpress/element": "*",
 		"@wordpress/html-entities": "*",
 		"@wordpress/i18n": "*",
 		"@wordpress/icons": "*",
 		"@wordpress/private-apis": "*",
 		"@wordpress/rich-text": "*",
-		"@wordpress/url": "*",
-		"locutus": "2.0.32"
+		"@wordpress/url": "*"
 	},
 	"peerDependencies": {
 		"react": "^18.0.0",

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -39,6 +39,7 @@
 		"@wordpress/icons": "*",
 		"@wordpress/private-apis": "*",
 		"@wordpress/rich-text": "*",
+		"@wordpress/url": "*",
 		"locutus": "2.0.32"
 	},
 	"peerDependencies": {

--- a/packages/format-library/package.json
+++ b/packages/format-library/package.json
@@ -39,7 +39,6 @@
 		"@wordpress/icons": "*",
 		"@wordpress/private-apis": "*",
 		"@wordpress/rich-text": "*",
-		"@wordpress/url": "*",
 		"locutus": "2.0.32"
 	},
 	"peerDependencies": {

--- a/packages/format-library/src/default-formats.js
+++ b/packages/format-library/src/default-formats.js
@@ -9,6 +9,7 @@ import { link } from './link';
 import { strikethrough } from './strikethrough';
 import { underline } from './underline';
 import { textColor } from './text-color';
+import { time } from './time';
 import { subscript } from './subscript';
 import { superscript } from './superscript';
 import { keyboard } from './keyboard';
@@ -25,6 +26,7 @@ export default [
 	strikethrough,
 	underline,
 	textColor,
+	time,
 	subscript,
 	superscript,
 	keyboard,

--- a/packages/format-library/src/style.scss
+++ b/packages/format-library/src/style.scss
@@ -2,3 +2,4 @@
 @import "./link/style.scss";
 @import "./text-color/style.scss";
 @import "./language/style.scss";
+@import "./time/style.scss";

--- a/packages/format-library/src/time/index.js
+++ b/packages/format-library/src/time/index.js
@@ -8,10 +8,7 @@ import { gmdate, strtotime } from 'locutus/php/datetime';
  */
 import { __ } from '@wordpress/i18n';
 import { toggleFormat } from '@wordpress/rich-text';
-import {
-	RichTextToolbarButton,
-	RichTextShortcut,
-} from '@wordpress/block-editor';
+import { RichTextToolbarButton } from '@wordpress/block-editor';
 import { postDate as icon } from '@wordpress/icons';
 
 const name = 'core/time';
@@ -61,7 +58,6 @@ export const time = {
 
 			// Format the datetime attributes using gmdate
 			const datetime = gmdate( 'c', timestamp ); // ISO 8601 format
-			const datetimeISO = gmdate( 'Ymd\\THi', timestamp ); // Compact ISO format
 
 			// Apply the format with parsed datetime attributes
 			onChange(
@@ -69,8 +65,6 @@ export const time = {
 					type: name,
 					attributes: {
 						datetime,
-						'data-iso': datetimeISO,
-						style: 'text-decoration: underline; text-decoration-style: dotted',
 					},
 				} )
 			);
@@ -80,11 +74,6 @@ export const time = {
 
 		return (
 			<>
-				<RichTextShortcut
-					type="access"
-					character="d"
-					onUse={ onClick }
-				/>
 				<RichTextToolbarButton
 					icon={ icon }
 					title={ title }

--- a/packages/format-library/src/time/index.js
+++ b/packages/format-library/src/time/index.js
@@ -1,0 +1,98 @@
+/**
+ * External dependencies
+ */
+import { gmdate, strtotime } from 'locutus/php/datetime';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { toggleFormat } from '@wordpress/rich-text';
+import {
+	RichTextToolbarButton,
+	RichTextShortcut,
+} from '@wordpress/block-editor';
+import { postDate as icon } from '@wordpress/icons';
+
+const name = 'core/time';
+const title = __( 'Time' );
+
+export const time = {
+	name,
+	title,
+	tagName: 'time',
+	className: null,
+	attributes: {
+		datetime: 'datetime',
+	},
+	edit( { isActive, value, onChange, onFocus } ) {
+		function onClick() {
+			const dateDescription = value.text
+				.slice( value.start, value.end )
+				.trim();
+
+			// Exit early if no selection or format is already active
+			if ( ! dateDescription || isActive ) {
+				onChange(
+					toggleFormat( value, {
+						type: name,
+					} )
+				);
+				return;
+			}
+
+			// Clean up the date string
+			const dateCleaned = dateDescription
+				.replace( 'at ', '' ) // Remove "at"
+				.replace( 'UTC', 'GMT' ); // Replace "UTC" with "GMT"
+
+			// Parse the date string using strtotime
+			const timestamp = strtotime( dateCleaned );
+
+			// If parsing fails, toggle format without enhancement
+			if ( ! timestamp ) {
+				onChange(
+					toggleFormat( value, {
+						type: name,
+					} )
+				);
+				return;
+			}
+
+			// Format the datetime attributes using gmdate
+			const datetime = gmdate( 'c', timestamp ); // ISO 8601 format
+			const datetimeISO = gmdate( 'Ymd\\THi', timestamp ); // Compact ISO format
+
+			// Apply the format with parsed datetime attributes
+			onChange(
+				toggleFormat( value, {
+					type: name,
+					attributes: {
+						datetime,
+						'data-iso': datetimeISO,
+						style: 'text-decoration: underline; text-decoration-style: dotted',
+					},
+				} )
+			);
+
+			onFocus();
+		}
+
+		return (
+			<>
+				<RichTextShortcut
+					type="access"
+					character="d"
+					onUse={ onClick }
+				/>
+				<RichTextToolbarButton
+					icon={ icon }
+					title={ title }
+					onClick={ onClick }
+					isActive={ isActive }
+					role="menuitemcheckbox"
+				/>
+			</>
+		);
+	},
+};

--- a/packages/format-library/src/time/index.js
+++ b/packages/format-library/src/time/index.js
@@ -1,15 +1,18 @@
 /**
- * External dependencies
- */
-import { gmdate, strtotime } from 'locutus/php/datetime';
-
-/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { toggleFormat } from '@wordpress/rich-text';
+import {
+	DateTimePicker,
+	Popover,
+	Button,
+	__experimentalHStack as HStack,
+} from '@wordpress/components';
 import { RichTextToolbarButton } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+import { removeFormat, applyFormat, useAnchor } from '@wordpress/rich-text';
 import { postDate as icon } from '@wordpress/icons';
+import { dateI18n, getSettings } from '@wordpress/date';
 
 const name = 'core/time';
 const title = __( 'Time' );
@@ -19,69 +22,95 @@ export const time = {
 	title,
 	tagName: 'time',
 	className: null,
+	edit: Edit,
 	attributes: {
 		datetime: 'datetime',
 	},
-	edit( { isActive, value, onChange, onFocus } ) {
-		function onClick() {
-			const dateDescription = value.text
-				.slice( value.start, value.end )
-				.trim();
-
-			// Exit early if no selection or format is already active
-			if ( ! dateDescription || isActive ) {
-				onChange(
-					toggleFormat( value, {
-						type: name,
-					} )
-				);
-				return;
-			}
-
-			// Clean up the date string
-			const dateCleaned = dateDescription
-				.replace( 'at ', '' ) // Remove "at"
-				.replace( 'UTC', 'GMT' ); // Replace "UTC" with "GMT"
-
-			// Parse the date string using strtotime
-			const timestamp = strtotime( dateCleaned );
-
-			// If parsing fails, toggle format without enhancement
-			if ( ! timestamp ) {
-				onChange(
-					toggleFormat( value, {
-						type: name,
-					} )
-				);
-				return;
-			}
-
-			// Format the datetime attributes using gmdate
-			const datetime = gmdate( 'c', timestamp ); // ISO 8601 format
-
-			// Apply the format with parsed datetime attributes
-			onChange(
-				toggleFormat( value, {
-					type: name,
-					attributes: {
-						datetime,
-					},
-				} )
-			);
-
-			onFocus();
-		}
-
-		return (
-			<>
-				<RichTextToolbarButton
-					icon={ icon }
-					title={ title }
-					onClick={ onClick }
-					isActive={ isActive }
-					role="menuitemcheckbox"
-				/>
-			</>
-		);
-	},
 };
+
+function Edit( { isActive, value, onChange, contentRef } ) {
+	const [ date, setDate ] = useState( new Date() );
+	const [ isPopoverVisible, setIsPopoverVisible ] = useState( false );
+	const togglePopover = () => setIsPopoverVisible( ( state ) => ! state );
+	const dateTimeSettings = getSettings();
+
+	const applyDate = () => {
+		const formattedDate = dateI18n( 'c', date );
+		const attributes = {
+			datetime: formattedDate,
+		};
+		onChange(
+			applyFormat( value, {
+				type: name,
+				attributes,
+			} )
+		);
+		setIsPopoverVisible( false );
+	};
+
+	return (
+		<>
+			<RichTextToolbarButton
+				icon={ icon }
+				label={ title }
+				title={ title }
+				onClick={ () => {
+					if ( isActive ) {
+						onChange( removeFormat( value, name ) );
+					} else {
+						togglePopover();
+					}
+				} }
+				isActive={ isActive }
+				role="menuitemcheckbox"
+			/>
+			{ isPopoverVisible && (
+				<InlineDateUI
+					contentRef={ contentRef }
+					onClose={ togglePopover }
+					onApply={ applyDate }
+					date={ date }
+					onChangeDate={ setDate }
+					dateTimeSettings={ dateTimeSettings }
+				/>
+			) }
+		</>
+	);
+}
+
+function InlineDateUI( {
+	contentRef,
+	onClose,
+	onApply,
+	date,
+	onChangeDate,
+	dateTimeSettings,
+} ) {
+	const popoverAnchor = useAnchor( {
+		editableContentElement: contentRef.current,
+		settings: time,
+	} );
+
+	return (
+		<Popover
+			className="block-editor-format-toolbar__date-popover"
+			anchor={ popoverAnchor }
+			onClose={ onClose }
+		>
+			<DateTimePicker
+				is12Hour={ dateTimeSettings.formats.time }
+				currentDate={ date }
+				onChange={ onChangeDate }
+				startOfWeek={ dateTimeSettings.l10n.startOfWeek }
+			/>
+			<HStack alignment="right">
+				<Button
+					__next40pxDefaultSize
+					variant="primary"
+					text={ __( 'Apply' ) }
+					onClick={ onApply }
+				/>
+			</HStack>
+		</Popover>
+	);
+}

--- a/packages/format-library/src/time/style.scss
+++ b/packages/format-library/src/time/style.scss
@@ -1,0 +1,6 @@
+.block-editor-format-toolbar__date-popover {
+	.components-popover__content {
+		width: auto;
+		padding: 1rem;
+	}
+}


### PR DESCRIPTION
Partial Fix for : #54488

## What?
This PR introduces a Time Inline Format to display time or date information with machine-readable formatting using the `<time>` element.

## Why?
The `<time>` element with the `datetime` attribute improves machine-readability, providing better SEO and more accurate metadata for search engines.
While similar functionality exists in core blocks like Post Date or Latest Comments, these options are tied to specific content. This new feature allows inline time representation without creating additional content types.

## How?

- Enables inline application of `<time>` formatting within text, like in a Paragraph block.
- Cleans & adds the selected value in the `datetime` attribute.

## Testing Instructions

1. Add text in a Paragraph block.
2. Apply the Time Inline Format to a portion of the text and configure the datetime attribute.
3. Verify the inline time is applied with accurate attributes.
4. Confirm output improves metadata and accessibility in SEO-related tools.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ab952a1b-4d40-41ca-a8d7-2878e1c154c9

