### PR TITLE
Stylebook: avoid double line in subcategory titles

### DIFF
--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -239,7 +239,6 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	.edit-site-style-book__subcategory-title {
 		font-size: 16px;
 		margin-bottom: 40px;
-    	border-bottom: 1px solid #ddd;
     	padding-bottom: 8px;
 	}
 

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -223,7 +223,6 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 		border: 1px solid color-mix( in srgb, currentColor 10%, transparent );
 	}
 
-	.edit-site-style-book__subcategory-title,
 	.edit-site-style-book__example-title {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 13px;
@@ -237,10 +236,15 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	}
 
 	.edit-site-style-book__subcategory-title {
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 16px;
 		margin-bottom: 40px;
-    	border-bottom: 1px solid #ddd;
+    	border-bottom: 1px solid color-mix( in srgb, currentColor 10%, transparent );
     	padding-bottom: 8px;
+		color: color-mix( in srgb, currentColor 60%, transparent );
+		font-weight: normal;
+		line-height: normal;
+		text-align: left;
 	}
 
 	.edit-site-style-book__example-preview {

--- a/packages/edit-site/src/components/style-book/constants.ts
+++ b/packages/edit-site/src/components/style-book/constants.ts
@@ -223,6 +223,7 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 		border: 1px solid color-mix( in srgb, currentColor 10%, transparent );
 	}
 
+	.edit-site-style-book__subcategory-title,
 	.edit-site-style-book__example-title {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 13px;
@@ -236,15 +237,10 @@ export const STYLE_BOOK_IFRAME_STYLES = `
 	}
 
 	.edit-site-style-book__subcategory-title {
-		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		font-size: 16px;
 		margin-bottom: 40px;
-    	border-bottom: 1px solid color-mix( in srgb, currentColor 10%, transparent );
+    	border-bottom: 1px solid #ddd;
     	padding-bottom: 8px;
-		color: color-mix( in srgb, currentColor 60%, transparent );
-		font-weight: normal;
-		line-height: normal;
-		text-align: left;
 	}
 
 	.edit-site-style-book__example-preview {


### PR DESCRIPTION
## What?

Stylebook: avoid double lines in subcategory titles

## Why?
Fixes a visual regression presumably introduced in https://github.com/WordPress/gutenberg/pull/67546

## How?
CSS adjustments.

## Testing Instructions
Navigate to the 'theme' tab of the stylebook and observe the titles.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/9fdc66b0-c763-444d-8705-4906cb977428)|![Screenshot from 2024-12-09 13-16-10](https://github.com/user-attachments/assets/d3e992cf-189a-489a-a8ed-68f88deefb25) |



