### PR TITLE
Inserter: Should receive focus on open

### DIFF
--- a/packages/block-editor/src/components/inserter/menu.js
+++ b/packages/block-editor/src/components/inserter/menu.js
@@ -82,6 +82,8 @@ function InserterMenu(
 		if ( isZoomOutMode ) {
 			return 'patterns';
 		}
+
+		return 'blocks';
 	}
 	const [ selectedTab, setSelectedTab ] = useState( getInitialTab() );
 

--- a/test/e2e/specs/site-editor/site-editor-inserter.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-inserter.spec.js
@@ -28,32 +28,51 @@ test.describe( 'Site Editor Inserter', () => {
 		},
 	} );
 
-	// eslint-disable-next-line playwright/expect-expect
 	test( 'inserter toggle button should toggle global inserter', async ( {
 		InserterUtils,
-	} ) => {
-		await InserterUtils.openBlockLibrary();
-		await InserterUtils.closeBlockLibrary();
-	} );
-
-	// A test for https://github.com/WordPress/gutenberg/issues/43090.
-	test( 'should close the inserter when clicking on the toggle button', async ( {
+		page,
 		editor,
-		InserterUtils,
 	} ) => {
-		const beforeBlocks = await editor.getBlocks();
-
 		await InserterUtils.openBlockLibrary();
-		await InserterUtils.expectActiveTab( 'Blocks' );
-		await InserterUtils.blockLibrary
-			.getByRole( 'option', { name: 'Buttons' } )
-			.click();
-
-		await expect
-			.poll( editor.getBlocks )
-			.toMatchObject( [ ...beforeBlocks, { name: 'core/buttons' } ] );
-
 		await InserterUtils.closeBlockLibrary();
+
+		await test.step( 'should open the inserter via enter keypress on toggle button', async () => {
+			await InserterUtils.inserterButton.focus();
+			await page.keyboard.press( 'Enter' );
+			await expect( InserterUtils.blockLibrary ).toBeVisible();
+		} );
+
+		await test.step( 'should set focus to the blocks tab when opening the inserter', async () => {
+			await expect(
+				InserterUtils.getBlockLibraryTab( 'Blocks' )
+			).toBeFocused();
+		} );
+
+		await test.step( 'should close the inserter via escape keypress', async () => {
+			await page.keyboard.press( 'Escape' );
+			await expect( InserterUtils.blockLibrary ).toBeHidden();
+		} );
+
+		await test.step( 'should focus inserter toggle button after closing the inserter via escape keypress', async () => {
+			await expect( InserterUtils.inserterButton ).toBeFocused();
+		} );
+
+		// A test for https://github.com/WordPress/gutenberg/issues/43090.
+		await test.step( 'should close the inserter when clicking on the toggle button', async () => {
+			const beforeBlocks = await editor.getBlocks();
+
+			await InserterUtils.openBlockLibrary();
+			await InserterUtils.expectActiveTab( 'Blocks' );
+			await InserterUtils.blockLibrary
+				.getByRole( 'option', { name: 'Buttons' } )
+				.click();
+
+			await expect
+				.poll( editor.getBlocks )
+				.toMatchObject( [ ...beforeBlocks, { name: 'core/buttons' } ] );
+
+			await InserterUtils.closeBlockLibrary();
+		} );
 	} );
 
 	test.describe( 'Inserter Zoom Level UX', () => {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
See https://github.com/WordPress/gutenberg/issues/67755
## What?
<!-- In a few words, what is the PR actually doing? -->
We were relying on the tabs component to set an initial tab for us, and then focusing it afterwards. It seems like something has changed within the tabs component's behavior where the selected tab is getting set too late, and our auto-focus check has already completed. Passing which tab we want selected fixes it.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Consistent behavior and readability. Since we will always have an initial tab selected, it's easier to understand the code if there's always a default tab set instead of having the tabs component guess which one for us. 

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Sets an initial tab to be focused if none is manually passed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Click the inserter toggle button
- There should be no visible focus outline
- Press the right arrow key
- Focus should be on the pattern tab

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
- Move focus to the inserter toggle button
- Press enter
- The blocks tab should be focused with a visible outline

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
