### PR TITLE
Updated no result text for consistency

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -166,7 +166,7 @@ export function PatternCategoryPreviews( {
 						variant="muted"
 						className="block-editor-inserter__patterns-category-no-results"
 					>
-						{ __( 'No results found' ) }
+						{ __( 'No results found.' ) }
 					</Text>
 				) }
 			</VStack>

--- a/packages/block-editor/src/components/url-input/index.js
+++ b/packages/block-editor/src/components/url-input/index.js
@@ -208,7 +208,7 @@ class URLInput extends Component {
 					);
 				} else {
 					this.props.debouncedSpeak(
-						__( 'No results.' ),
+						__( 'No results found.' ),
 						'assertive'
 					);
 				}

--- a/packages/components/src/autocomplete/autocompleter-ui.tsx
+++ b/packages/components/src/autocomplete/autocompleter-ui.tsx
@@ -159,7 +159,7 @@ export function getAutoCompleterUI( autocompleter: WPCompleter ) {
 					);
 				}
 			} else {
-				debouncedSpeak( __( 'No results.' ), 'assertive' );
+				debouncedSpeak( __( 'No results found.' ), 'assertive' );
 			}
 		}
 

--- a/packages/components/src/combobox-control/index.tsx
+++ b/packages/components/src/combobox-control/index.tsx
@@ -309,7 +309,7 @@ function ComboboxControl( props: ComboboxControlProps ) {
 						),
 						matchingSuggestions.length
 				  )
-				: __( 'No results.' );
+				: __( 'No results found.' );
 
 			speak( message, 'polite' );
 		}

--- a/packages/components/src/form-token-field/index.tsx
+++ b/packages/components/src/form-token-field/index.tsx
@@ -595,7 +595,7 @@ export function FormTokenField( props: FormTokenFieldProps ) {
 						),
 						matchingSuggestions.length
 				  )
-				: __( 'No results.' );
+				: __( 'No results found.' );
 
 			debouncedSpeak( message, 'assertive' );
 		}

--- a/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/search-widget.tsx
@@ -312,7 +312,7 @@ function ComboboxList( { view, filter, onChangeView }: SearchWidgetProps ) {
 						</Ariakit.ComboboxItem>
 					);
 				} ) }
-				{ ! matches.length && <p>{ __( 'No results found' ) }</p> }
+				{ ! matches.length && <p>{ __( 'No results found.' ) }</p> }
 			</Ariakit.ComboboxList>
 		</Ariakit.ComboboxProvider>
 	);

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -286,7 +286,9 @@ export default function ViewGrid< Item >( {
 						'dataviews-no-results': ! isLoading,
 					} ) }
 				>
-					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
+					<p>
+						{ isLoading ? <Spinner /> : __( 'No results found.' ) }
+					</p>
 				</div>
 			) }
 		</>

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -475,7 +475,9 @@ export default function ViewList< Item >( props: ViewListProps< Item > ) {
 				} ) }
 			>
 				{ ! hasData && (
-					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
+					<p>
+						{ isLoading ? <Spinner /> : __( 'No results found.' ) }
+					</p>
 				) }
 			</div>
 		);

--- a/packages/dataviews/src/dataviews-layouts/table/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/table/index.tsx
@@ -400,7 +400,9 @@ function ViewTable< Item >( {
 				id={ tableNoticeId }
 			>
 				{ ! hasData && (
-					<p>{ isLoading ? <Spinner /> : __( 'No results' ) }</p>
+					<p>
+						{ isLoading ? <Spinner /> : __( 'No results found.' ) }
+					</p>
 				) }
 			</div>
 		</>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/67728

## Why?
'No result' text is inconsistent across the editor.

## How?
Updating 'No result' text to 'No results found' in all places in order to keep the consistency.

Updated the following occurrence to `__( 'No results found.' )
`

4 occurrences of
__( 'No results.' )
with a trailing period.

3 occurrences of
__( 'No results' )
with no trailing period

2 occurrences of
__( 'No results found' )
with no trailing period.





