### PR TITLE
Navigation Link UI: Remove onClose from onSelectBlock

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -78,7 +78,7 @@ export function getSuggestionsQuery( type, kind ) {
 	}
 }
 
-function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
+function LinkUIBlockInserter( { clientId, onBack } ) {
 	const { rootBlockClientId } = useSelect(
 		( select ) => {
 			const { getBlockRootClientId } = select( blockEditorStore );
@@ -140,7 +140,6 @@ function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
 				prioritizePatterns={ false }
 				selectBlockOnInsert
 				hasSearch={ false }
-				onSelect={ onSelectBlock }
 			/>
 		</div>
 	);
@@ -202,10 +201,6 @@ function UnforwardedLinkUI( props, ref ) {
 		LinkUI,
 		`link-ui-link-control__description`
 	);
-
-	// Selecting a block should close the popover and also remove the (previously) automatically inserted
-	// link block so that the newly selected block can be inserted in its place.
-	const { onClose: onSelectBlock } = props;
 
 	return (
 		<Popover
@@ -287,7 +282,6 @@ function UnforwardedLinkUI( props, ref ) {
 						setAddingBlock( false );
 						setFocusAddBlockButton( true );
 					} }
-					onSelectBlock={ onSelectBlock }
 				/>
 			) }
 		</Popover>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a bug where the `onClose` from the Navigation `LinkUi` popover was being called after the `LinkUI` was already closed.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fixes https://github.com/WordPress/gutenberg/issues/67712

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove `onSelectBlock` from the `QuickInserter` even if the `LinkUI` had already been closed. There have been updates to this flow around closing the `LinkUI` since the code was originally written, and the `onClose` should be handled by the popover already.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
Steps taken from @darnado's in https://github.com/WordPress/gutenberg/issues/67712

1. Go to Appearance → Editor in the WordPress Dashboard.
2. Open the Design section.
3. Navigate to Patterns → Header, and select any pattern containing the Navigation Core Block.
4. Select the Navigation Core Block and click the "plus" button.
5. Click "+ Add block," then select "Browse All" to open the sidebar with available blocks.
6. Click on any block in the sidebar to add it to the Navigation Core Block.
7. Check that the block is inserted and there are no errors in the console

In general, test inserting blocks from both the navigation link ui inserter and from clicking "Browse all" and inserting blocks into the navigation block.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
