### PR TITLE
Update the title, description, and order of Experiments page

### DIFF
--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -42,136 +42,52 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg_display_experiment_section',
 		'gutenberg-experiments'
 	);
-
-	add_settings_field(
-		'gutenberg-sync-collaboration',
-		__( 'Live Collaboration and offline persistence', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable the live collaboration and offline persistence between peers', 'gutenberg' ),
-			'id'    => 'gutenberg-sync-collaboration',
-		)
-	);
-
-	add_settings_field(
-		'gutenberg-custom-dataviews',
-		__( 'Custom dataviews', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test the custom dataviews in the pages page.', 'gutenberg' ),
-			'id'    => 'gutenberg-custom-dataviews',
-		)
-	);
-
-	add_settings_field(
-		'gutenberg-color-randomizer',
-		__( 'Color randomizer', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Test the Global Styles color randomizer; a utility that lets you mix the current color palette pseudo-randomly.', 'gutenberg' ),
-			'id'    => 'gutenberg-color-randomizer',
-		)
-	);
-
+	
 	add_settings_field(
 		'gutenberg-block-experiments',
-		__( 'Experimental blocks', 'gutenberg' ),
+		__( 'Blocks: add experimental blocks', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enable experimental blocks.<p class="description">(Warning: these blocks may have significant changes during development that cause validation errors and display issues.)</p>', 'gutenberg' ),
+			'label' => __( 'Enables experimental blocks on a rolling basis as they are developed.<p class="description">(Warning: these blocks may have significant changes during development that cause validation errors and display issues.)</p>', 'gutenberg' ),
 			'id'    => 'gutenberg-block-experiments',
 		)
 	);
 
 	add_settings_field(
 		'gutenberg-form-blocks',
-		__( 'Form and input blocks', 'gutenberg' ),
+		__( 'Blocks: add Form and input blocks', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Test new blocks to allow building forms (Warning: The new feature is not ready. You may experience UX issues that are being addressed)', 'gutenberg' ),
+			'label' => __( 'Enables new blocks to allow building forms. You are likely to experience UX issues that are being addressed.', 'gutenberg' ),
 			'id'    => 'gutenberg-form-blocks',
 		)
 	);
 
 	add_settings_field(
 		'gutenberg-grid-interactivity',
-		__( 'Grid interactivity', 'gutenberg' ),
+		__( 'Blocks: add Grid interactivity', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Test enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),
+			'label' => __( 'Enables enhancements to the Grid block that let you move and resize items in the editor canvas.', 'gutenberg' ),
 			'id'    => 'gutenberg-grid-interactivity',
 		)
 	);
 
 	add_settings_field(
 		'gutenberg-no-tinymce',
-		__( 'Disable TinyMCE and Classic block', 'gutenberg' ),
+		__( 'Blocks: disable TinyMCE and Classic block', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Disable TinyMCE and Classic block', 'gutenberg' ),
+			'label' => __( 'Disables the TinyMCE and Classic block', 'gutenberg' ),
 			'id'    => 'gutenberg-no-tinymce',
-		)
-	);
-
-	add_settings_field(
-		'gutenberg-full-page-client-side-navigation',
-		__( 'Enable full page client-side navigation', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable full page client-side navigation using the Interactivity API', 'gutenberg' ),
-			'id'    => 'gutenberg-full-page-client-side-navigation',
-		)
-	);
-
-	add_settings_field(
-		'gutenberg-new-posts-dashboard',
-		__( 'Redesigned posts dashboard', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable a redesigned posts dashboard.', 'gutenberg' ),
-			'id'    => 'gutenberg-new-posts-dashboard',
-		)
-	);
-
-	add_settings_field(
-		'gutenberg-quick-edit-dataviews',
-		__( 'Quick Edit in DataViews', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Allow access to a quick edit panel in the pages data views.', 'gutenberg' ),
-			'id'    => 'gutenberg-quick-edit-dataviews',
-		)
-	);
-
-	add_settings_field(
-		'gutenberg-block-comment',
-		__( 'Block Comments', 'gutenberg' ),
-		'gutenberg_display_experiment_field',
-		'gutenberg-experiments',
-		'gutenberg_experiments_section',
-		array(
-			'label' => __( 'Enable multi-user commenting on blocks', 'gutenberg' ),
-			'id'    => 'gutenberg-block-comment',
 		)
 	);
 
@@ -182,19 +98,103 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enable client-side media processing.', 'gutenberg' ),
+			'label' => __( 'Enables client-side media processing to leverage the browser's capabilities to handle tasks like image resizing and compression.', 'gutenberg' ),
 			'id'    => 'gutenberg-media-processing',
+		)
+	);
+
+ 	add_settings_field(
+		'gutenberg-block-comment',
+		__( 'Collaboration: add block level comments', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables multi-user block level commenting.', 'gutenberg' ),
+			'id'    => 'gutenberg-block-comment',
+		)
+	);
+
+	add_settings_field(
+		'gutenberg-sync-collaboration',
+		__( 'Collaboration: add real time editing', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables live collaboration and offline persistence between peers.', 'gutenberg' ),
+			'id'    => 'gutenberg-sync-collaboration',
+		)
+	);
+
+ 	add_settings_field(
+		'gutenberg-color-randomizer',
+		__( 'Color randomizer', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables the Global Styles color randomizer in the Site Editor; a utility that lets you mix the current color palette pseudo-randomly.', 'gutenberg' ),
+			'id'    => 'gutenberg-color-randomizer',
+		)
+	);
+
+	add_settings_field(
+		'gutenberg-custom-dataviews',
+		__( 'Data Views: add Custom Views', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables the ability to add, edit, and save custom views when in the Site Editor.', 'gutenberg' ),
+			'id'    => 'gutenberg-custom-dataviews',
+		)
+	);
+
+ 	add_settings_field(
+		'gutenberg-new-posts-dashboard',
+		__( 'Data Views: enable for Posts', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables a redesigned posts dashboard accessible through a submenu item in the Gutenberg plugin.', 'gutenberg' ),
+			'id'    => 'gutenberg-new-posts-dashboard',
+		)
+	);
+
+	add_settings_field(
+		'gutenberg-quick-edit-dataviews',
+		__( 'Data Views: add Quick Edit', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables access to a Quick Edit panel in the Site Editor Pages experience.', 'gutenberg' ),
+			'id'    => 'gutenberg-quick-edit-dataviews',
+		)
+	);
+
+	add_settings_field(
+		'gutenberg-full-page-client-side-navigation',
+		__( 'iAPI: full page client side navigation', 'gutenberg' ),
+		'gutenberg_display_experiment_field',
+		'gutenberg-experiments',
+		'gutenberg_experiments_section',
+		array(
+			'label' => __( 'Enables full-page client-side navigation with the Interactivity API, updating HTML while preserving application state.', 'gutenberg' ),
+			'id'    => 'gutenberg-full-page-client-side-navigation',
 		)
 	);
 
 	add_settings_field(
 		'gutenberg-editor-write-mode',
-		__( 'Editor write mode', 'gutenberg' ),
+		__( 'Simplified site editing', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enable write mode in editor.', 'gutenberg' ),
+			'label' => __( 'Enables Write mode in the Site Editor for a simplified editing experience.', 'gutenberg' ),
 			'id'    => 'gutenberg-editor-write-mode',
 		)
 	);

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -98,7 +98,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg-experiments',
 		'gutenberg_experiments_section',
 		array(
-			'label' => __( 'Enables client-side media processing to leverage the browser's capabilities to handle tasks like image resizing and compression.', 'gutenberg' ),
+			'label' => __( 'Enables client-side media processing to leverage the browser\'s capabilities to handle tasks like image resizing and compression.', 'gutenberg' ),
 			'id'    => 'gutenberg-media-processing',
 		)
 	);

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -42,7 +42,7 @@ function gutenberg_initialize_experiments_settings() {
 		'gutenberg_display_experiment_section',
 		'gutenberg-experiments'
 	);
-	
+
 	add_settings_field(
 		'gutenberg-block-experiments',
 		__( 'Blocks: add experimental blocks', 'gutenberg' ),
@@ -103,7 +103,7 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
- 	add_settings_field(
+	add_settings_field(
 		'gutenberg-block-comment',
 		__( 'Collaboration: add block level comments', 'gutenberg' ),
 		'gutenberg_display_experiment_field',
@@ -151,7 +151,7 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
- 	add_settings_field(
+	add_settings_field(
 		'gutenberg-new-posts-dashboard',
 		__( 'Data Views: enable for Posts', 'gutenberg' ),
 		'gutenberg_display_experiment_field',

--- a/lib/experiments-page.php
+++ b/lib/experiments-page.php
@@ -127,7 +127,7 @@ function gutenberg_initialize_experiments_settings() {
 		)
 	);
 
- 	add_settings_field(
+	add_settings_field(
 		'gutenberg-color-randomizer',
 		__( 'Color randomizer', 'gutenberg' ),
 		'gutenberg_display_experiment_field',


### PR DESCRIPTION
We've been overdue for a clean up of the Experiments page. This PR gets that started and covers a few text changes.

## What?

Updates to the Gutenberg > Experiments page.

## Why?

The current experiments were each written individually, without a lot of points of connection even if multiple experiments touch on the same area of work, like data views. My hope is that by adding clarity, we can encourage more folks to safely explore experiments.

## How?

- Groupings like Blocks, Data Views, and Collaboration to better understand experiments and how they connect.
- Periods at the end of each sentence for descriptions (details matter!).
- Shared language across each description with “enables” and “disables” language for clarity.
- Clearer and more robust descriptions and titles. 
- Organized in alphabetical order to make it easier to skim.
- Adds clarity around Site Editor specific experiments in the descriptions.

## Screenshots or screencast <!-- if applicable -->

**Before:**

![Screenshot 2024-12-09 at 3 54 15 PM](https://github.com/user-attachments/assets/795afbda-9476-4899-9a70-59d64635fa54)

https://github.com/user-attachments/assets/74f4865d-d916-48a8-8712-d1bb4a927cd5

**After:**

![Screenshot 2024-12-09 at 3 49 23 PM](https://github.com/user-attachments/assets/31284b73-bde9-4c49-b8bb-e1be99c9bd8b)

https://github.com/user-attachments/assets/226f54ae-19ac-4539-a040-9f7f22b2a088




