### PR TITLE
Fix re-renders caused by `getEntityRecordsPermissions` after #67667

### DIFF
--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -57,7 +57,12 @@ export const getBlockPatternsForPostType = createRegistrySelector(
  */
 export const getEntityRecordsPermissions = createRegistrySelector( ( select ) =>
 	createSelector(
-		( state: State, kind: string, name: string, ids: string[] ) => {
+		(
+			state: State,
+			kind: string,
+			name: string,
+			ids: string | string[]
+		) => {
 			const normalizedIds = Array.isArray( ids ) ? ids : [ ids ];
 			return normalizedIds.map( ( id ) => ( {
 				delete: select( STORE_NAME ).canUser( 'delete', {

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -97,7 +97,7 @@ export function getEntityRecordPermissions(
 	name: string,
 	id: string
 ) {
-	return getEntityRecordsPermissions( state, kind, name, [ id ] )[ 0 ];
+	return getEntityRecordsPermissions( state, kind, name, id )[ 0 ];
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Address the regression mentioned in https://github.com/WordPress/gutenberg/pull/67667#discussion_r1876415219

## Why?
Passing an array of string of ids when not needed caused a slight performance issue due to re-renders.

## How?
By updating the signature of `getEntityRecordsPermissions` to allow array of strings

## Testing Instructions

- Just verify that CI is happy.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
