### PR TITLE
Site Editor: fix sidebar item animation regression

### DIFF
--- a/packages/edit-site/src/components/layout/index.js
+++ b/packages/edit-site/src/components/layout/index.js
@@ -132,7 +132,7 @@ function Layout() {
 										/>
 										<SidebarContent
 											shouldAnimate={
-												routeKey !== 'styles-view'
+												routeKey !== 'styles'
 											}
 											routeKey={ routeKey }
 										>


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes a regression caused by https://github.com/WordPress/gutenberg/pull/67057.

For top-level nav items without any child routes (styles) don't animate the sidebar.

Noticed in https://github.com/WordPress/gutenberg/pull/66851#discussion_r1877215848


## Testing Instructions

Using a block theme, head to the Site Editor "Appearance > Editor"

Click on "Styles".

The sidebar nav shouldn't animate.

### Before


https://github.com/user-attachments/assets/ed8e6090-c52d-43b3-92d4-eb427167bc51


### After 


https://github.com/user-attachments/assets/87821fd1-d186-4323-8c37-83886cbf58be

