### PR TITLE
Fixed non-existing path issue

### DIFF
--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -25,7 +25,18 @@ import { store as editSiteStore } from './store';
 import { unlock } from './lock-unlock';
 import App from './components/app';
 
-const { registerCoreBlockBindingsSources } = unlock( editorPrivateApis );
+const { registerCoreBlockBindingsSources } = unlock(editorPrivateApis);
+
+/**
+ * Checks if the given path exists.
+ *
+ * @param {string} path The path to check.
+ * @return {boolean} True if the path exists, false otherwise.
+ */
+async function checkPathExists(path) {
+	const response = await fetch(`/wp-json/wp/v2/templates${path}`);
+	return response.ok;
+}
 
 /**
  * Initializes the site editor screen.
@@ -33,35 +44,79 @@ const { registerCoreBlockBindingsSources } = unlock( editorPrivateApis );
  * @param {string} id       ID of the root element to render the screen in.
  * @param {Object} settings Editor settings.
  */
-export function initializeEditor( id, settings ) {
-	const target = document.getElementById( id );
-	const root = createRoot( target );
+export async function initializeEditor(id, settings) {
+	const target = document.getElementById(id);
+	const root = createRoot(target);
+	// Extract the 'p' parameter from the URL
+	const urlParams = new URLSearchParams(window.location.search);
+	const path = urlParams.get('p');
 
-	dispatch( blocksStore ).reapplyBlockTypeFilters();
+	// Decode the URI component for the path
+	const decodedPath = decodeURIComponent(path || '');
+
+	if (decodedPath && !(await checkPathExists(decodedPath))) {
+		// Render a "Not Found" message
+		root.render(
+			<StrictMode>
+				<div
+					style={{
+						textAlign: 'center',
+						marginTop: '50px',
+						fontSize: '24px',
+						color: '#fff',
+					}}
+				>
+					<strong>404:</strong> Template Not Found
+					<div style={{ marginTop: '20px' }}>
+						<button
+							onClick={() => {
+								// Redirect to the site editor
+								window.location.href = '/wp-admin/site-editor.php';
+							}}
+							style={{
+								padding: '10px 20px',
+								backgroundColor: '#0073aa',
+								color: 'white',
+								border: 'none',
+								borderRadius: '5px',
+								cursor: 'pointer',
+								fontSize: '16px',
+							}}
+						>
+							Go to Site Editor
+						</button>
+					</div>
+				</div>
+			</StrictMode>
+		);
+		return root;
+	}
+
+	dispatch(blocksStore).reapplyBlockTypeFilters();
 	const coreBlocks = __experimentalGetCoreBlocks().filter(
-		( { name } ) => name !== 'core/freeform'
+		({ name }) => name !== 'core/freeform'
 	);
-	registerCoreBlocks( coreBlocks );
+	registerCoreBlocks(coreBlocks);
 	registerCoreBlockBindingsSources();
-	dispatch( blocksStore ).setFreeformFallbackBlockName( 'core/html' );
-	registerLegacyWidgetBlock( { inserter: false } );
-	registerWidgetGroupBlock( { inserter: false } );
-	if ( globalThis.IS_GUTENBERG_PLUGIN ) {
-		__experimentalRegisterExperimentalCoreBlocks( {
+	dispatch(blocksStore).setFreeformFallbackBlockName('core/html');
+	registerLegacyWidgetBlock({ inserter: false });
+	registerWidgetGroupBlock({ inserter: false });
+	if (globalThis.IS_GUTENBERG_PLUGIN) {
+		__experimentalRegisterExperimentalCoreBlocks({
 			enableFSEBlocks: true,
-		} );
+		});
 	}
 
 	// We dispatch actions and update the store synchronously before rendering
 	// so that we won't trigger unnecessary re-renders with useEffect.
-	dispatch( preferencesStore ).setDefaults( 'core/edit-site', {
+	dispatch(preferencesStore).setDefaults('core/edit-site', {
 		welcomeGuide: true,
 		welcomeGuideStyles: true,
 		welcomeGuidePage: true,
 		welcomeGuideTemplate: true,
-	} );
+	});
 
-	dispatch( preferencesStore ).setDefaults( 'core', {
+	dispatch(preferencesStore).setDefaults('core', {
 		allowRightClickOverrides: true,
 		distractionFree: false,
 		editorMode: 'visual',
@@ -70,24 +125,24 @@ export function initializeEditor( id, settings ) {
 		focusMode: false,
 		inactivePanels: [],
 		keepCaretInsideBlock: false,
-		openPanels: [ 'post-status' ],
+		openPanels: ['post-status'],
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
-	} );
+	});
 
-	if ( window.__experimentalMediaProcessing ) {
-		dispatch( preferencesStore ).setDefaults( 'core/media', {
+	if (window.__experimentalMediaProcessing) {
+		dispatch(preferencesStore).setDefaults('core/media', {
 			requireApproval: true,
 			optimizeOnUpload: true,
-		} );
+		});
 	}
 
-	dispatch( editSiteStore ).updateSettings( settings );
+	dispatch(editSiteStore).updateSettings(settings);
 
 	// Prevent the default browser action for files dropped outside of dropzones.
-	window.addEventListener( 'dragover', ( e ) => e.preventDefault(), false );
-	window.addEventListener( 'drop', ( e ) => e.preventDefault(), false );
+	window.addEventListener('dragover', (e) => e.preventDefault(), false);
+	window.addEventListener('drop', (e) => e.preventDefault(), false);
 
 	root.render(
 		<StrictMode>
@@ -99,10 +154,10 @@ export function initializeEditor( id, settings ) {
 }
 
 export function reinitializeEditor() {
-	deprecated( 'wp.editSite.reinitializeEditor', {
+	deprecated('wp.editSite.reinitializeEditor', {
 		since: '6.2',
 		version: '6.3',
-	} );
+	});
 }
 
 export { default as PluginTemplateSettingPanel } from './components/plugin-template-setting-panel';


### PR DESCRIPTION
Part of  #67445 

## What?
Site Editor should display a 404 message when you navigate to a non-existing path

## Why?
Currently, the Site Editor is showing a black page with no message or content when the user miss-type the link

## How?
It will show a 404 message with a button to get back to the site editor.

## Testing Instructions
Try navigating to wp-admin/site-editor.php?p=%2Ftemplate-fdgfdgdfg

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/5ebbb68e-6819-4cde-aa5b-6c606bb2a9a3


