### PR TITLE
Adds `the_excerpt` filter in the `core/post-excerpt` block.

### DIFF
--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -19,6 +19,7 @@ import {
 import { PanelBody, ToggleControl, RangeControl } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -150,7 +151,8 @@ export default function PostExcerptEditor( {
 	 * the raw and the rendered excerpt depending on which is being used.
 	 */
 	const rawOrRenderedExcerpt = (
-		rawExcerpt || strippedRenderedExcerpt
+		applyFilters( 'the_excerpt', undefined, rawExcerpt ) ||
+		strippedRenderedExcerpt
 	).trim();
 
 	let trimmedExcerpt = '';

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -28,13 +28,6 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	*/
 	$excerpt_length = $attributes['excerptLength'];
 
-	/**
-	 * Filters the displayed post excerpt.
-	 *
-	 * @see get_the_excerpt()
-	 *
-	 * @param string $post_excerpt The post excerpt.
-	 */
 	$excerpt        = apply_filters( 'the_excerpt', get_the_excerpt( $block->context['postId'] ) );
 	if ( isset( $excerpt_length ) ) {
 		$excerpt = wp_trim_words( $excerpt, $excerpt_length );

--- a/packages/block-library/src/post-excerpt/index.php
+++ b/packages/block-library/src/post-excerpt/index.php
@@ -27,7 +27,15 @@ function render_block_core_post_excerpt( $attributes, $content, $block ) {
 	* wp_trim_words is used instead.
 	*/
 	$excerpt_length = $attributes['excerptLength'];
-	$excerpt        = get_the_excerpt( $block->context['postId'] );
+
+	/**
+	 * Filters the displayed post excerpt.
+	 *
+	 * @see get_the_excerpt()
+	 *
+	 * @param string $post_excerpt The post excerpt.
+	 */
+	$excerpt        = apply_filters( 'the_excerpt', get_the_excerpt( $block->context['postId'] ) );
 	if ( isset( $excerpt_length ) ) {
 		$excerpt = wp_trim_words( $excerpt, $excerpt_length );
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR adds missing [`the_excerpt`](https://developer.wordpress.org/reference/hooks/the_excerpt/) filter. Allowing much more consistent usage.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The post excerpt block does not call the the_excerpt filter before rendering the block. In contrast, the post content block does call the the_content filter before rendering. (Ref. https://github.com/WordPress/gutenberg/issues/28214). In order to add consistency this filter has been added.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
This PR adds filter in frontend (`index.js`) as well as in the `edit.js` of the block.
https://github.com/CoderAbhinav/gutenberg/blob/351c8fe74313d3f2f8eabbbcca1ac91224751347/packages/block-library/src/post-excerpt/index.php#L31-L38

https://github.com/CoderAbhinav/gutenberg/blob/756b5970d155feae8a45f23fd62473dacd6a89b6/packages/block-library/src/post-excerpt/edit.js#L149-L155


The implementation is done with reference to https://developer.wordpress.org/reference/functions/the_excerpt/#source this code.

## Testing Instructions
Add a filter like this first.
```php
function my_excerpt_filter( $excerpt ) {
	return "Filtered: $excerpt";
  }
add_filter( 'the_excerpt', 'my_excerpt_filter' );
```

1. Then create a new post.
2. Add excerpt to the post.
3. Add post excerpt block in the editor. Check if the content is updated.
4. Save the post and check the frontend, for same changes.