### PR TITLE
Updated 'Set featured image'  text in dropdown

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1126,7 +1126,7 @@ export default function Image( {
 				id &&
 				clientId === selectedClientIds[ 0 ] && (
 					<MenuItem onClick={ setPostFeatureImage }>
-						{ __( 'Set featured image' ) }
+						{ __( 'Set as featured image' ) }
 					</MenuItem>
 				)
 			}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fix mentioned in https://github.com/WordPress/gutenberg/issues/67761

## Why?
As per the ticket, current text can be misinterpreted that you will be guided to an interface to select a featured image which has already available in side panel.

## How?
Update the text in the dropdown menu to 'Set as featured image',

## Testing Instructions

- Go to WP page/post edit screen.
- Add a new image block.
- Upload a new image
- Open the options dropdown menu.
- Now the text updated to 'Set as featured image'.


## Screenshots or screencast <!-- if applicable -->


Before:
![featuredbefore](https://github.com/user-attachments/assets/5bf82922-93a8-4e2b-b9dd-83e472b24025)
After:
![featuredafter](https://github.com/user-attachments/assets/075239b4-9c19-4b6c-b132-a6939d8bc0b5)

