### PR TITLE
Resolved an issue where the "Set Featured Image" option in the Image block could be misinterpreted.

### DIFF
--- a/packages/block-library/src/image/image.js
+++ b/packages/block-library/src/image/image.js
@@ -1126,7 +1126,7 @@ export default function Image( {
 				id &&
 				clientId === selectedClientIds[ 0 ] && (
 					<MenuItem onClick={ setPostFeatureImage }>
-						{ __( 'Set featured image' ) }
+						{ __( 'Set as featured image' ) }
 					</MenuItem>
 				)
 			}


### PR DESCRIPTION
Fixes : #67761

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Updated the "Set Featured Image" label to "Set as Featured Image" in the Image block for improved clarity and consistency.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
"featured image" alone can be misinterpreted

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
I have updated the "Set Featured Image" label to "Set as Featured Image"

## Screenshots or screencast <!-- if applicable -->
<img width="1438" alt="Screenshot 2024-12-10 at 11 33 15 AM" src="https://github.com/user-attachments/assets/32a74f9b-e666-4ca3-b247-0bba384d003a">

