### PR TITLE
DataViews: Fix hidden List layout actions dropdown

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/list/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/list/style.scss
@@ -12,6 +12,7 @@ ul.dataviews-view-list {
 		.dataviews-view-list__item-wrapper {
 			position: relative;
 			padding: $grid-unit-20 $grid-unit-30;
+			box-sizing: border-box;
 		}
 
 		.dataviews-view-list__item-actions {


### PR DESCRIPTION
closes #66814 

## What?

When using the DataViews list layout in outside WordPress, the actions dropdown can be hidden if your app doesn't have a global box-sizing CSS rule. 

This issue can be reproduced in storybook where the "actions" dropdown is hidden in list view.

## Testing Instructions

1- Run storybook `npm run dev`
2- Switch to "list" layout
3- Check that the actions dropdown is visible properly.