### PR TITLE
Plugin: Only override REST server for older WP versions

### DIFF
--- a/lib/compat/wordpress-6.7/rest-api.php
+++ b/lib/compat/wordpress-6.7/rest-api.php
@@ -124,15 +124,18 @@ function gutenberg_register_wp_rest_templates_controller_plugin_field() {
 }
 add_action( 'rest_api_init', 'gutenberg_register_wp_rest_templates_controller_plugin_field' );
 
-/**
- * Overrides the default 'WP_REST_Server' class.
- *
- * @return string The name of the custom server class.
- */
-function gutenberg_override_default_rest_server() {
-	return 'Gutenberg_REST_Server';
+// The `get_user` function was introduced in WP 6.7.
+if ( ! function_exists( 'get_user' ) ) {
+	/**
+	 * Overrides the default 'WP_REST_Server' class.
+	 *
+	 * @return string The name of the custom server class.
+	 */
+	function gutenberg_override_default_rest_server() {
+		return 'Gutenberg_REST_Server';
+	}
+	add_filter( 'wp_rest_server_class', 'gutenberg_override_default_rest_server', 1 );
 }
-add_filter( 'wp_rest_server_class', 'gutenberg_override_default_rest_server', 1 );
 
 
 /**


### PR DESCRIPTION
## What?
PR makes REST server override conditional and only applies it WP < 6.7. There's no need to override if WP already supports `targetHints`.

## How?
Uses the [`get_user` function](https://developer.wordpress.org/reference/functions/get_user/) for version check. This is more efficient than version checks.

## Testing Instructions
None. Just confirm that the logic is correct.

### Testing Instructions for Keyboard
Same.
