### PR TITLE
StyleBook: Make available in all classic themes

### DIFF
--- a/lib/compat/wordpress-6.8/site-editor.php
+++ b/lib/compat/wordpress-6.8/site-editor.php
@@ -130,7 +130,7 @@ add_filter( 'wp_die_handler', 'gutenberg_styles_wp_die_handler' );
  * @global array $submenu
  */
 function gutenberg_add_styles_submenu_item() {
-	if ( ! wp_is_block_theme() && ( current_theme_supports( 'editor-styles' ) || wp_theme_has_theme_json() ) ) {
+	if ( ! wp_is_block_theme() ) {
 		global $submenu;
 
 		$styles_menu_item = array(


### PR DESCRIPTION
Follow-up #66851
See this discussion: https://github.com/WordPress/gutenberg/pull/66851#discussion_r1872695946

## What?

This PR enables the stylebook regardless of whether a classic theme has theme.json or supports editor styles.

## Why?

I've noticed that editor-related styles can be added via code like this for example, which is not related to whether you have a theme.json or not, and whether it supports editor styles or not:

```php
function test_enqueue_block_editor_assets() {
	wp_enqueue_style(
		'emptyhybrid-test',
		get_theme_file_uri( '/style.css' ),
	);
}
add_action( 'enqueue_block_assets', 'test_enqueue_block_editor_assets' );

// This hook really shouldn't be used for block-related styles, but there may still be themes that use it this way.
function test_enqueue_block_editor_assets() {
	wp_enqueue_style(
		'emptyhybrid-test',
		get_theme_file_uri( '/style.css' ),
	);
}
add_action( 'enqueue_block_editor_assets', 'test_enqueue_block_editor_assets' );
```

It probably makes more sense to cover all the possibilities and make it available to all classic themes, rather than adding complex conditional statements.

## Testing Instructions

- Access `http://localhost:8889/wp-admin/`.
- Activate the Emptyhybrid theme.
- Make sure Appearance > Design is available.