### PR TITLE
Image Block: Change how the Image's overlay styles are applied

### DIFF
--- a/packages/block-library/src/image/index.php
+++ b/packages/block-library/src/image/index.php
@@ -290,6 +290,7 @@ function block_core_image_print_lightbox_overlay() {
 			data-wp-on-async--click="actions.hideLightbox"
 			data-wp-on-async-window--resize="callbacks.setOverlayStyles"
 			data-wp-on-async-window--scroll="actions.handleScroll"
+			data-wp-bind--style="state.overlayStyles"
 			tabindex="-1"
 			>
 				<button type="button" aria-label="$close_button_label" style="fill: $close_button_color" class="close-button">
@@ -306,7 +307,6 @@ function block_core_image_print_lightbox_overlay() {
 					</figure>
 				</div>
 				<div class="scrim" style="background-color: $background_color" aria-hidden="true"></div>
-				<style data-wp-text="state.overlayStyles"></style>
 		</div>
 HTML;
 }

--- a/packages/block-library/src/image/view.js
+++ b/packages/block-library/src/image/view.js
@@ -341,7 +341,6 @@ const { state, actions, callbacks } = store(
 				// adding 1 pixel to the container width and height solves the problem,
 				// though this can be removed if the issue is fixed in the future.
 				state.overlayStyles = `
-				:root {
 					--wp--lightbox-initial-top-position: ${ screenPosY }px;
 					--wp--lightbox-initial-left-position: ${ screenPosX }px;
 					--wp--lightbox-container-width: ${ containerWidth + 1 }px;
@@ -352,8 +351,7 @@ const { state, actions, callbacks } = store(
 					--wp--lightbox-scrollbar-width: ${
 						window.innerWidth - document.documentElement.clientWidth
 					}px;
-				}
-			`;
+				`;
 			},
 			setButtonStyles() {
 				const { imageId } = getContext();


### PR DESCRIPTION
## What?

Moves the CSS variable definition required for the Image's overlay from a `<style>` tag with `data-wp-text` to a `data-wp-bind--style` directive.

## Why?

This prevents a bad usage of `<style>` tags that should not be placed outside the `<head>` element.

![Screenshot 2024-12-10 at 12 39 32](https://github.com/user-attachments/assets/c023734e-419a-4b1d-9c3c-6c71773809bd)

## Testing Instructions

1. Insert different images in a post.
2. Enable the Lightbox feature for all of them.
3. Visit the post.
4. Ensure the lightbox animation is correctly displayed.
