### PR TITLE
[Dataviews] Fix: Media item focus style is not visible on Grid.

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -33,10 +33,10 @@
 		}
 		&.is-selected .dataviews-view-grid__media::after,
 		.dataviews-view-grid__media:focus::after {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);			
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 		}
 		&.is-selected .dataviews-view-grid__media::after {
-			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);	
+			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
 		}
 		.dataviews-view-grid__media:focus::after {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -30,12 +30,14 @@
 			.dataviews-view-grid__fields .dataviews-view-grid__field .dataviews-view-grid__field-value {
 				color: $gray-900;
 			}
-
-			.dataviews-view-grid__media::after {
-				background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
-				box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
-			}
 		}
+		&.is-selected .dataviews-view-grid__media::after,
+		.dataviews-view-grid__media:focus:after {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
+			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
+		}
+
+
 	}
 
 	.dataviews-view-grid__media {

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -32,9 +32,8 @@
 			}
 		}
 		&.is-selected .dataviews-view-grid__media::after,
-		.dataviews-view-grid__media::focus::after {
-			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
-			
+		.dataviews-view-grid__media:focus::after {
+			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);			
 		}
 		&.is-selected .dataviews-view-grid__media::after {
 			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);	
@@ -42,8 +41,6 @@
 		.dataviews-view-grid__media:focus::after {
 			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
-
-
 	}
 
 	.dataviews-view-grid__media {

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -32,7 +32,7 @@
 			}
 		}
 		&.is-selected .dataviews-view-grid__media::after,
-		.dataviews-view-grid__media:focus:after {
+		.dataviews-view-grid__media::focus::after {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
 			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
 		}

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -34,7 +34,13 @@
 		&.is-selected .dataviews-view-grid__media::after,
 		.dataviews-view-grid__media::focus::after {
 			background-color: rgba(var(--wp-admin-theme-color--rgb), 0.08);
-			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);
+			
+		}
+		&.is-selected .dataviews-view-grid__media::after {
+			box-shadow: inset 0 0 0 $border-width var(--wp-admin-theme-color);	
+		}
+		.dataviews-view-grid__media:focus::after {
+			box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
 		}
 
 


### PR DESCRIPTION
Fixes an issue noticed by @oandregal at https://github.com/WordPress/gutenberg/pull/67690#issuecomment-2531029736.
Currently, the grid item media button does not communicate that the item is focused. This PR solves the issue by applying a blue border to the focused item.

## Screenshots
<img width="489" alt="Screenshot 2024-12-10 at 12 07 04" src="https://github.com/user-attachments/assets/1ad57dfe-ab32-44bd-a125-29fc3eb33369">

## Testing Instructions
Go to `wp-admin/site-editor.php?p=%2Fpage&layout=grid`.
Focus the search field tab until you focus a grid  item and verify it has a focus style.