### PR TITLE
[Dataviews] Fix: Space does not triggers the media button on grid view.

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
+++ b/packages/dataviews/src/dataviews-layouts/utils/get-clickable-item-props.ts
@@ -25,7 +25,11 @@ export default function getClickableItemProps< Item >( {
 			onClickItem( item );
 		},
 		onKeyDown: ( event: React.KeyboardEvent ) => {
-			if ( event.key === 'Enter' || event.key === '' ) {
+			if (
+				event.key === 'Enter' ||
+				event.key === '' ||
+				event.key === ' '
+			) {
 				// Prevents onChangeSelection from triggering.
 				event.stopPropagation();
 				onClickItem( item );


### PR DESCRIPTION
Fixes an issue reported by @oandregal at https://github.com/WordPress/gutenberg/pull/67690#issuecomment-2531038703. Currently while pressing space on the media button in the grid view the button is not triggered as expected. This PR fixes the issue.

## Testing Instructions
Goto http://localhost:7888/site-wp-dev/wp-admin/site-editor.php?p=%2Fpage&layout=grid
Focus the search field tab until you focus a grid item press space and verify the button is triggered as expected.
