### PR TITLE
Improve the EntitiesSavedStates modal dialog design and labeling

### DIFF
--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -144,10 +144,7 @@ export default function SavePanel() {
 			<Modal
 				className="edit-site-save-panel__modal"
 				onRequestClose={ onClose }
-				__experimentalHideHeader
-				contentLabel={ __(
-					'Save site, content, and template changes'
-				) }
+				title={ __( 'Review changes' ) }
 			>
 				<_EntitiesSavedStates onClose={ onClose } isWithinModalDialog />
 			</Modal>

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -31,7 +31,11 @@ const { EntitiesSavedStatesExtensible, NavigableRegion } =
 	unlock( privateApis );
 const { useLocation } = unlock( routerPrivateApis );
 
-const EntitiesSavedStatesForPreview = ( { onClose, renderDialog } ) => {
+const EntitiesSavedStatesForPreview = ( {
+	onClose,
+	renderDialog,
+	isWithinModalDialog,
+} ) => {
 	const isDirtyProps = useEntitiesSavedStatesIsDirty();
 	let activateSaveLabel;
 	if ( isDirtyProps.isDirty ) {
@@ -76,22 +80,32 @@ const EntitiesSavedStatesForPreview = ( { onClose, renderDialog } ) => {
 				saveEnabled: true,
 				saveLabel: activateSaveLabel,
 				renderDialog,
+				isWithinModalDialog,
 			} }
 		/>
 	);
 };
 
-const _EntitiesSavedStates = ( { onClose, renderDialog } ) => {
+const _EntitiesSavedStates = ( {
+	onClose,
+	renderDialog,
+	isWithinModalDialog,
+} ) => {
 	if ( isPreviewingTheme() ) {
 		return (
 			<EntitiesSavedStatesForPreview
 				onClose={ onClose }
 				renderDialog={ renderDialog }
+				isWithinModalDialog={ isWithinModalDialog }
 			/>
 		);
 	}
 	return (
-		<EntitiesSavedStates close={ onClose } renderDialog={ renderDialog } />
+		<EntitiesSavedStates
+			close={ onClose }
+			renderDialog={ renderDialog }
+			isWithinModalDialog={ isWithinModalDialog }
+		/>
 	);
 };
 
@@ -135,7 +149,7 @@ export default function SavePanel() {
 					'Save site, content, and template changes'
 				) }
 			>
-				<_EntitiesSavedStates onClose={ onClose } />
+				<_EntitiesSavedStates onClose={ onClose } isWithinModalDialog />
 			</Modal>
 		) : null;
 	}

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -34,7 +34,7 @@ const { useLocation } = unlock( routerPrivateApis );
 const EntitiesSavedStatesForPreview = ( {
 	onClose,
 	renderDialog,
-	isWithinModalDialog,
+	variant,
 } ) => {
 	const isDirtyProps = useEntitiesSavedStatesIsDirty();
 	let activateSaveLabel;
@@ -80,23 +80,19 @@ const EntitiesSavedStatesForPreview = ( {
 				saveEnabled: true,
 				saveLabel: activateSaveLabel,
 				renderDialog,
-				isWithinModalDialog,
+				variant,
 			} }
 		/>
 	);
 };
 
-const _EntitiesSavedStates = ( {
-	onClose,
-	renderDialog,
-	isWithinModalDialog,
-} ) => {
+const _EntitiesSavedStates = ( { onClose, renderDialog, variant } ) => {
 	if ( isPreviewingTheme() ) {
 		return (
 			<EntitiesSavedStatesForPreview
 				onClose={ onClose }
 				renderDialog={ renderDialog }
-				isWithinModalDialog={ isWithinModalDialog }
+				variant={ variant }
 			/>
 		);
 	}
@@ -104,7 +100,7 @@ const _EntitiesSavedStates = ( {
 		<EntitiesSavedStates
 			close={ onClose }
 			renderDialog={ renderDialog }
-			isWithinModalDialog={ isWithinModalDialog }
+			variant={ variant }
 		/>
 	);
 };
@@ -147,7 +143,7 @@ export default function SavePanel() {
 				title={ __( 'Review changes' ) }
 				size="small"
 			>
-				<_EntitiesSavedStates onClose={ onClose } isWithinModalDialog />
+				<_EntitiesSavedStates onClose={ onClose } variant="inline" />
 			</Modal>
 		) : null;
 	}

--- a/packages/edit-site/src/components/save-panel/index.js
+++ b/packages/edit-site/src/components/save-panel/index.js
@@ -145,6 +145,7 @@ export default function SavePanel() {
 				className="edit-site-save-panel__modal"
 				onRequestClose={ onClose }
 				title={ __( 'Review changes' ) }
+				size="small"
 			>
 				<_EntitiesSavedStates onClose={ onClose } isWithinModalDialog />
 			</Modal>

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -402,6 +402,7 @@ _Parameters_
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
 -   _props.renderDialog_ `boolean`: Whether to render the component with modal dialog behavior.
+-   _props.isWithinModalDialog_ `boolean`: Whether this component is rendered within a Modal component.
 
 _Returns_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -402,7 +402,7 @@ _Parameters_
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
 -   _props.renderDialog_ `boolean`: Whether to render the component with modal dialog behavior.
--   _props.isWithinModalDialog_ `boolean`: Whether this component is rendered within a Modal component.
+-   _props.variant_ `boolean`: Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
 
 _Returns_
 

--- a/packages/editor/README.md
+++ b/packages/editor/README.md
@@ -402,7 +402,7 @@ _Parameters_
 -   _props_ `Object`: The component props.
 -   _props.close_ `Function`: The function to close the dialog.
 -   _props.renderDialog_ `boolean`: Whether to render the component with modal dialog behavior.
--   _props.variant_ `boolean`: Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
+-   _props.variant_ `string`: Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
 
 _Returns_
 

--- a/packages/editor/src/components/entities-saved-states/entity-record-item.js
+++ b/packages/editor/src/components/entities-saved-states/entity-record-item.js
@@ -64,6 +64,7 @@ export default function EntityRecordItem( { record, checked, onChange } ) {
 					}
 					checked={ checked }
 					onChange={ onChange }
+					className="entities-saved-states__change-control"
 				/>
 			</PanelRow>
 			{ hasPostMetaChanges && (

--- a/packages/editor/src/components/entities-saved-states/entity-type-list.js
+++ b/packages/editor/src/components/entities-saved-states/entity-type-list.js
@@ -94,7 +94,11 @@ export default function EntityTypeList( {
 	}
 
 	return (
-		<PanelBody title={ entityLabel } initialOpen>
+		<PanelBody
+			title={ entityLabel }
+			initialOpen
+			className="entities-saved-states__panel-body"
+		>
 			<EntityDescription record={ firstRecord } count={ count } />
 			{ list.map( ( record ) => {
 				return (

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -122,10 +122,13 @@ export function EntitiesSavedStatesExtensible( {
 	const [ saveDialogRef, saveDialogProps ] = useDialog( {
 		onClose: () => dismissPanel(),
 	} );
-	const dialogLabel = useInstanceId( EntitiesSavedStatesExtensible, 'label' );
-	const dialogDescription = useInstanceId(
+	const dialogLabelId = useInstanceId(
 		EntitiesSavedStatesExtensible,
-		'description'
+		'entities-saved-states__panel-label'
+	);
+	const dialogDescriptionId = useInstanceId(
+		EntitiesSavedStatesExtensible,
+		'entities-saved-states__panel-description'
 	);
 
 	const selectItemsToSaveDescription = !! dirtyEntityRecords.length
@@ -174,8 +177,8 @@ export function EntitiesSavedStatesExtensible( {
 				'is-within-modal-dialog': isWithinModalDialog,
 			} ) }
 			role={ renderDialog ? 'dialog' : undefined }
-			aria-labelledby={ renderDialog ? dialogLabel : undefined }
-			aria-describedby={ renderDialog ? dialogDescription : undefined }
+			aria-labelledby={ renderDialog ? dialogLabelId : undefined }
+			aria-describedby={ renderDialog ? dialogDescriptionId : undefined }
 		>
 			{ ! isWithinModalDialog && (
 				<Flex className="entities-saved-states__panel-header" gap={ 2 }>
@@ -184,34 +187,33 @@ export function EntitiesSavedStatesExtensible( {
 			) }
 
 			<div className="entities-saved-states__text-prompt">
-				<div
-					className="entities-saved-states__text-prompt--header-wrapper"
-					id={ renderDialog ? dialogLabel : undefined }
-				>
-					<strong className="entities-saved-states__text-prompt--header">
+				<div className="entities-saved-states__text-prompt--header-wrapper">
+					<strong
+						id={ renderDialog ? dialogLabelId : undefined }
+						className="entities-saved-states__text-prompt--header"
+					>
 						{ __( 'Are you ready to save?' ) }
 					</strong>
-					{ additionalPrompt }
 				</div>
-				<p
-					id={ renderDialog ? dialogDescription : undefined }
-					className="entities-saved-states__text-prompt--changes-count"
-				>
-					{ isDirty
-						? createInterpolateElement(
-								sprintf(
-									/* translators: %d: number of site changes waiting to be saved. */
-									_n(
-										'There is <strong>%d site change</strong> waiting to be saved.',
-										'There are <strong>%d site changes</strong> waiting to be saved.',
+				<div id={ renderDialog ? dialogDescriptionId : undefined }>
+					{ additionalPrompt }
+					<p className="entities-saved-states__text-prompt--changes-count">
+						{ isDirty
+							? createInterpolateElement(
+									sprintf(
+										/* translators: %d: number of site changes waiting to be saved. */
+										_n(
+											'There is <strong>%d site change</strong> waiting to be saved.',
+											'There are <strong>%d site changes</strong> waiting to be saved.',
+											dirtyEntityRecords.length
+										),
 										dirtyEntityRecords.length
 									),
-									dirtyEntityRecords.length
-								),
-								{ strong: <strong /> }
-						  )
-						: selectItemsToSaveDescription }
-				</p>
+									{ strong: <strong /> }
+							  )
+							: selectItemsToSaveDescription }
+					</p>
+				</div>
 			</div>
 
 			{ sortedPartitionedSavables.map( ( list ) => {

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -37,7 +37,7 @@ function identity( values ) {
  * @param {Object}   props              The component props.
  * @param {Function} props.close        The function to close the dialog.
  * @param {boolean}  props.renderDialog Whether to render the component with modal dialog behavior.
- * @param {boolean}  props.variant      Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
+ * @param {string}   props.variant      Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
  *
  * @return {React.ReactNode} The rendered component.
  */
@@ -71,7 +71,7 @@ export default function EntitiesSavedStates( {
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
  * @param {Array}    props.unselectedEntities    Array of unselected entities.
- * @param {boolean}  props.variant               Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
+ * @param {string}   props.variant               Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
  *
  * @return {React.ReactNode} The rendered component.
  */

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -160,7 +160,6 @@ export function EntitiesSavedStatesExtensible( {
 					} )
 				}
 				className="editor-entities-saved-states__save-button"
-				expanded={ isWithinModalDialog ? false : true }
 			>
 				{ saveLabel }
 			</FlexItem>
@@ -190,11 +189,14 @@ export function EntitiesSavedStatesExtensible( {
 					id={ renderDialog ? dialogLabel : undefined }
 				>
 					<strong className="entities-saved-states__text-prompt--header">
-						{ __( 'xxAre you ready to save?' ) }
+						{ __( 'Are you ready to save?' ) }
 					</strong>
 					{ additionalPrompt }
 				</div>
-				<p id={ renderDialog ? dialogDescription : undefined }>
+				<p
+					id={ renderDialog ? dialogDescription : undefined }
+					className="entities-saved-states__text-prompt--changes-count"
+				>
 					{ isDirty
 						? createInterpolateElement(
 								sprintf(
@@ -224,7 +226,11 @@ export function EntitiesSavedStatesExtensible( {
 			} ) }
 
 			{ isWithinModalDialog && (
-				<Flex direction="row" justify="flex-end">
+				<Flex
+					direction="row"
+					justify="flex-end"
+					className="entities-saved-states__panel-footer"
+				>
 					{ actionButtons }
 				</Flex>
 			) }

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -34,24 +34,24 @@ function identity( values ) {
 /**
  * Renders the component for managing saved states of entities.
  *
- * @param {Object}   props                     The component props.
- * @param {Function} props.close               The function to close the dialog.
- * @param {boolean}  props.renderDialog        Whether to render the component with modal dialog behavior.
- * @param {boolean}  props.isWithinModalDialog Whether this component is rendered within a Modal component.
+ * @param {Object}   props              The component props.
+ * @param {Function} props.close        The function to close the dialog.
+ * @param {boolean}  props.renderDialog Whether to render the component with modal dialog behavior.
+ * @param {boolean}  props.variant      Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
  *
  * @return {React.ReactNode} The rendered component.
  */
 export default function EntitiesSavedStates( {
 	close,
 	renderDialog,
-	isWithinModalDialog,
+	variant,
 } ) {
 	const isDirtyProps = useIsDirty();
 	return (
 		<EntitiesSavedStatesExtensible
 			close={ close }
 			renderDialog={ renderDialog }
-			isWithinModalDialog={ isWithinModalDialog }
+			variant={ variant }
 			{ ...isDirtyProps }
 		/>
 	);
@@ -71,7 +71,7 @@ export default function EntitiesSavedStates( {
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
  * @param {Array}    props.unselectedEntities    Array of unselected entities.
- * @param {boolean}  props.isWithinModalDialog   Whether this component is rendered within a Modal component.
+ * @param {boolean}  props.variant               Changes the layout of the component. When an `inline` value is provided, the action buttons are rendered at the end of the component instead of at the start.
  *
  * @return {React.ReactNode} The rendered component.
  */
@@ -86,7 +86,7 @@ export function EntitiesSavedStatesExtensible( {
 	isDirty,
 	setUnselectedEntities,
 	unselectedEntities,
-	isWithinModalDialog,
+	variant = 'default',
 } ) {
 	const saveButtonRef = useRef();
 	const { saveDirtyEntities } = unlock( useDispatch( editorStore ) );
@@ -138,20 +138,20 @@ export function EntitiesSavedStatesExtensible( {
 	const actionButtons = (
 		<>
 			<FlexItem
-				isBlock={ isWithinModalDialog ? false : true }
+				isBlock={ variant === 'inline' ? false : true }
 				as={ Button }
-				variant={ isWithinModalDialog ? 'tertiary' : 'secondary' }
-				size={ isWithinModalDialog ? undefined : 'compact' }
+				variant={ variant === 'inline' ? 'tertiary' : 'secondary' }
+				size={ variant === 'inline' ? undefined : 'compact' }
 				onClick={ dismissPanel }
 			>
 				{ __( 'Cancel' ) }
 			</FlexItem>
 			<FlexItem
-				isBlock={ isWithinModalDialog ? false : true }
+				isBlock={ variant === 'inline' ? false : true }
 				as={ Button }
 				ref={ saveButtonRef }
 				variant="primary"
-				size={ isWithinModalDialog ? undefined : 'compact' }
+				size={ variant === 'inline' ? undefined : 'compact' }
 				disabled={ ! saveEnabled }
 				accessibleWhenDisabled
 				onClick={ () =>
@@ -174,13 +174,13 @@ export function EntitiesSavedStatesExtensible( {
 			ref={ renderDialog ? saveDialogRef : undefined }
 			{ ...( renderDialog && saveDialogProps ) }
 			className={ clsx( 'entities-saved-states__panel', {
-				'is-within-modal-dialog': isWithinModalDialog,
+				'is-within-modal-dialog': variant === 'inline',
 			} ) }
 			role={ renderDialog ? 'dialog' : undefined }
 			aria-labelledby={ renderDialog ? dialogLabelId : undefined }
 			aria-describedby={ renderDialog ? dialogDescriptionId : undefined }
 		>
-			{ ! isWithinModalDialog && (
+			{ variant === 'default' && (
 				<Flex className="entities-saved-states__panel-header" gap={ 2 }>
 					{ actionButtons }
 				</Flex>
@@ -227,7 +227,7 @@ export function EntitiesSavedStatesExtensible( {
 				);
 			} ) }
 
-			{ isWithinModalDialog && (
+			{ variant === 'inline' && (
 				<Flex
 					direction="row"
 					justify="flex-end"

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -135,23 +135,25 @@ export function EntitiesSavedStatesExtensible( {
 		? __( 'Select the items you want to save.' )
 		: undefined;
 
+	const isInline = variant === 'inline';
+
 	const actionButtons = (
 		<>
 			<FlexItem
-				isBlock={ variant === 'inline' ? false : true }
+				isBlock={ isInline ? false : true }
 				as={ Button }
-				variant={ variant === 'inline' ? 'tertiary' : 'secondary' }
-				size={ variant === 'inline' ? undefined : 'compact' }
+				variant={ isInline ? 'tertiary' : 'secondary' }
+				size={ isInline ? undefined : 'compact' }
 				onClick={ dismissPanel }
 			>
 				{ __( 'Cancel' ) }
 			</FlexItem>
 			<FlexItem
-				isBlock={ variant === 'inline' ? false : true }
+				isBlock={ isInline ? false : true }
 				as={ Button }
 				ref={ saveButtonRef }
 				variant="primary"
-				size={ variant === 'inline' ? undefined : 'compact' }
+				size={ isInline ? undefined : 'compact' }
 				disabled={ ! saveEnabled }
 				accessibleWhenDisabled
 				onClick={ () =>
@@ -174,13 +176,13 @@ export function EntitiesSavedStatesExtensible( {
 			ref={ renderDialog ? saveDialogRef : undefined }
 			{ ...( renderDialog && saveDialogProps ) }
 			className={ clsx( 'entities-saved-states__panel', {
-				'is-within-modal-dialog': variant === 'inline',
+				'is-inline': isInline,
 			} ) }
 			role={ renderDialog ? 'dialog' : undefined }
 			aria-labelledby={ renderDialog ? dialogLabelId : undefined }
 			aria-describedby={ renderDialog ? dialogDescriptionId : undefined }
 		>
-			{ variant === 'default' && (
+			{ ! isInline && (
 				<Flex className="entities-saved-states__panel-header" gap={ 2 }>
 					{ actionButtons }
 				</Flex>
@@ -227,7 +229,7 @@ export function EntitiesSavedStatesExtensible( {
 				);
 			} ) }
 
-			{ variant === 'inline' && (
+			{ isInline && (
 				<Flex
 					direction="row"
 					justify="flex-end"

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { Button, Flex, FlexItem } from '@wordpress/components';
@@ -29,18 +34,24 @@ function identity( values ) {
 /**
  * Renders the component for managing saved states of entities.
  *
- * @param {Object}   props              The component props.
- * @param {Function} props.close        The function to close the dialog.
- * @param {boolean}  props.renderDialog Whether to render the component with modal dialog behavior.
+ * @param {Object}   props                     The component props.
+ * @param {Function} props.close               The function to close the dialog.
+ * @param {boolean}  props.renderDialog        Whether to render the component with modal dialog behavior.
+ * @param {boolean}  props.isWithinModalDialog Whether this component is rendered within a Modal component.
  *
  * @return {React.ReactNode} The rendered component.
  */
-export default function EntitiesSavedStates( { close, renderDialog } ) {
+export default function EntitiesSavedStates( {
+	close,
+	renderDialog,
+	isWithinModalDialog,
+} ) {
 	const isDirtyProps = useIsDirty();
 	return (
 		<EntitiesSavedStatesExtensible
 			close={ close }
 			renderDialog={ renderDialog }
+			isWithinModalDialog={ isWithinModalDialog }
 			{ ...isDirtyProps }
 		/>
 	);
@@ -60,6 +71,7 @@ export default function EntitiesSavedStates( { close, renderDialog } ) {
  * @param {boolean}  props.isDirty               Flag indicating if there are dirty entities.
  * @param {Function} props.setUnselectedEntities Function to set unselected entities.
  * @param {Array}    props.unselectedEntities    Array of unselected entities.
+ * @param {boolean}  props.isWithinModalDialog   Whether this component is rendered within a Modal component.
  *
  * @return {React.ReactNode} The rendered component.
  */
@@ -74,6 +86,7 @@ export function EntitiesSavedStatesExtensible( {
 	isDirty,
 	setUnselectedEntities,
 	unselectedEntities,
+	isWithinModalDialog,
 } ) {
 	const saveButtonRef = useRef();
 	const { saveDirtyEntities } = unlock( useDispatch( editorStore ) );
@@ -119,46 +132,57 @@ export function EntitiesSavedStatesExtensible( {
 		? __( 'Select the items you want to save.' )
 		: undefined;
 
+	const actionButtons = (
+		<>
+			<FlexItem
+				isBlock={ isWithinModalDialog ? false : true }
+				as={ Button }
+				variant={ isWithinModalDialog ? 'tertiary' : 'secondary' }
+				size={ isWithinModalDialog ? undefined : 'compact' }
+				onClick={ dismissPanel }
+			>
+				{ __( 'Cancel' ) }
+			</FlexItem>
+			<FlexItem
+				isBlock={ isWithinModalDialog ? false : true }
+				as={ Button }
+				ref={ saveButtonRef }
+				variant="primary"
+				size={ isWithinModalDialog ? undefined : 'compact' }
+				disabled={ ! saveEnabled }
+				accessibleWhenDisabled
+				onClick={ () =>
+					saveDirtyEntities( {
+						onSave,
+						dirtyEntityRecords,
+						entitiesToSkip: unselectedEntities,
+						close,
+					} )
+				}
+				className="editor-entities-saved-states__save-button"
+				expanded={ isWithinModalDialog ? false : true }
+			>
+				{ saveLabel }
+			</FlexItem>
+		</>
+	);
+
 	return (
 		<div
 			ref={ renderDialog ? saveDialogRef : undefined }
 			{ ...( renderDialog && saveDialogProps ) }
-			className="entities-saved-states__panel"
+			className={ clsx( 'entities-saved-states__panel', {
+				'is-within-modal-dialog': isWithinModalDialog,
+			} ) }
 			role={ renderDialog ? 'dialog' : undefined }
 			aria-labelledby={ renderDialog ? dialogLabel : undefined }
 			aria-describedby={ renderDialog ? dialogDescription : undefined }
 		>
-			<Flex className="entities-saved-states__panel-header" gap={ 2 }>
-				<FlexItem
-					isBlock
-					as={ Button }
-					variant="secondary"
-					size="compact"
-					onClick={ dismissPanel }
-				>
-					{ __( 'Cancel' ) }
-				</FlexItem>
-				<FlexItem
-					isBlock
-					as={ Button }
-					ref={ saveButtonRef }
-					variant="primary"
-					size="compact"
-					disabled={ ! saveEnabled }
-					accessibleWhenDisabled
-					onClick={ () =>
-						saveDirtyEntities( {
-							onSave,
-							dirtyEntityRecords,
-							entitiesToSkip: unselectedEntities,
-							close,
-						} )
-					}
-					className="editor-entities-saved-states__save-button"
-				>
-					{ saveLabel }
-				</FlexItem>
-			</Flex>
+			{ ! isWithinModalDialog && (
+				<Flex className="entities-saved-states__panel-header" gap={ 2 }>
+					{ actionButtons }
+				</Flex>
+			) }
 
 			<div className="entities-saved-states__text-prompt">
 				<div
@@ -166,7 +190,7 @@ export function EntitiesSavedStatesExtensible( {
 					id={ renderDialog ? dialogLabel : undefined }
 				>
 					<strong className="entities-saved-states__text-prompt--header">
-						{ __( 'Are you ready to save?' ) }
+						{ __( 'xxAre you ready to save?' ) }
 					</strong>
 					{ additionalPrompt }
 				</div>
@@ -198,6 +222,12 @@ export function EntitiesSavedStatesExtensible( {
 					/>
 				);
 			} ) }
+
+			{ isWithinModalDialog && (
+				<Flex direction="row" justify="flex-end">
+					{ actionButtons }
+				</Flex>
+			) }
 		</div>
 	);
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -16,6 +16,42 @@
 	}
 }
 
+.entities-saved-states__panel.is-within-modal-dialog {
+	.entities-saved-states__text-prompt {
+		padding: 0;
+	}
+
+	.entities-saved-states__panel-body {
+		padding-left: 0;
+		padding-right: 0;
+		border: 0;
+
+		> h2 {
+			margin-left: -1 * $grid-unit-20;
+			margin-right: -1 * $grid-unit-20;
+			margin-bottom: 0;
+
+			button {
+				font-size: $font-size-x-small;
+				text-transform: uppercase;
+			}
+		}
+	}
+
+	.entities-saved-states__text-prompt--header-wrapper {
+		display: none;
+	}
+
+	.entities-saved-states__text-prompt--changes-count {
+		margin-top: 0;
+		margin-bottom: $grid-unit-30;
+	}
+
+	.entities-saved-states__panel-footer {
+		margin-top: $grid-unit-20;
+	}
+}
+
 .entities-saved-states__description-heading {
 	font-size: $default-font-size;
 }

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -44,7 +44,7 @@
 
 	.entities-saved-states__text-prompt--changes-count {
 		margin-top: 0;
-		margin-bottom: $grid-unit-30;
+		margin-bottom: $grid-unit-10;
 	}
 
 	.entities-saved-states__panel-footer {

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -52,13 +52,8 @@
 	}
 }
 
-.entities-saved-states__description-heading {
-	font-size: $default-font-size;
-}
-
 .entities-saved-states__changes {
-	color: $gray-700;
-	font-size: $helptext-font-size;
+	font-size: $default-font-size;
 	margin: $grid-unit-05 $grid-unit-20 0 $grid-unit-30;
 	list-style: disc;
 

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -59,7 +59,7 @@
 .entities-saved-states__changes {
 	color: $gray-700;
 	font-size: $helptext-font-size;
-	margin: $grid-unit-10 $grid-unit-20 0 $grid-unit-20;
+	margin: $grid-unit-05 $grid-unit-20 0 $grid-unit-30;
 	list-style: disc;
 
 	li {

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -16,7 +16,7 @@
 	}
 }
 
-.entities-saved-states__panel.is-within-modal-dialog {
+.entities-saved-states__panel.is-inline {
 	.entities-saved-states__text-prompt {
 		padding: 0;
 	}

--- a/packages/editor/src/components/entities-saved-states/style.scss
+++ b/packages/editor/src/components/entities-saved-states/style.scss
@@ -52,6 +52,10 @@
 	}
 }
 
+.entities-saved-states__change-control {
+	flex: 1;
+}
+
 .entities-saved-states__changes {
 	font-size: $default-font-size;
 	margin: $grid-unit-05 $grid-unit-20 0 $grid-unit-30;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/49832 
Fixes https://github.com/WordPress/gutenberg/issues/67354

Note: if this gets merged, please add props to @dhruvang21 for the alternative PR https://github.com/WordPress/gutenberg/pull/67473

## What?
<!-- In a few words, what is the PR actually doing? -->
The modal dialog to save entities reuses the `EntitiesSavedStates` component 'as is'. This isn't ideal in terms oc content order, styling, and accessibility because modal dialogs expecte their content in a more meaningful order, with a visible title, specific styling and appropriate labeling and description.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- The styling and user experience for modal dialogs should be consistent.
- Labeling and description of modal dialogs should be meaningful.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds a `isWithinModalDialog` prop to `EntitiesSavedStates` and its variant to distinguish when this component is used within a modal dialog.
- Based on that, rearranges the order of the content and provides a visible title + close button for the modal dialog usage.
- Refines the styling to be as close as possible to the one provided in https://github.com/WordPress/gutenberg/issues/49832 withi minimal changes.
- Fixes the accessible name (via aria-labelledby) and accessible description (via aria-describedby) of the component when used with a modal behavior in the save panel on the right, as described in https://github.com/WordPress/gutenberg/issues/67354

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Go to the Site editor.
- Make a change to a template and to some global style e.g. a simple color change.
- Click 'Save' at the top right of the screen.
- Observe the save panel is unchanged.
- Observe this panel, which uses a modal behavior anda  role=dialog has:
  - An aria-labelledby attribute that points to the visible title.
  - An aria-describedby attribute that points to the visible description after the title.
- Click 'Open Navigation' at the top left of the screen.
- Click the 'Review changes' button at the bottom of the navigation panel.
- Observe the modal dialog:
  - has a visible title
  - has a close button
  - The Cancel and Save buttons are not at the bottom of the modal dialog, right aligned.
  - The styling of the content is close to the design provided in https://github.com/WordPress/gutenberg/issues/49832
- Go to the WP admin > Appearance > any non-active block theme > Live Preview
- Click the activate button at the bottom of the navigation panel.
- Observe the modal dialog styling and content order is consistent with the previous modal dialog.
- Edit the theme preview and make some simple change e.g. a global styles color change.
- Click 'Activate {theme name} & Save' at the top right of the screen.
- Observe the panel that opens has an additional 'prompt' text e.g. `Saving your changes will change your active theme from Twenty Twenty-Four to Twenty Twenty-Five.`
- Observe this text is part of the accessible description of the panel references by an aria-describedby attribute, together with the following text e.g. `There are 2 site changes waiting to be saved.`
- Observe the panel element with role=dialog has an aria-labelledby attribute that points to the text `Are you ready to save?`

Screenshot to illustrate the labeling / description:

![Screenshot 2024-12-10 at 12 39 51](https://github.com/user-attachments/assets/49a202ee-cf4b-4829-8644-8e91391f1811)


### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Current|Site editor|Theme preview|
|-|-|-|
|![current](https://github.com/user-attachments/assets/39778e75-f62b-477a-aa3b-b2d0414c9127)|![site save](https://github.com/user-attachments/assets/15a5269e-f075-4a89-82dd-cc5cba3e6a23)|![theme preview](https://github.com/user-attachments/assets/171b6358-0e10-4a4b-81d6-eb7fa971c6d7)|

