### PR TITLE
Add Post Type Archive in Link UI and Navigation Link via Types API endpoint

### DIFF
--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -43,7 +43,7 @@ function gutenberg_register_archive_link_field() {
 		'type',
 		'archive_link',
 		array(
-			'get_callback'    => function ( $post_object ) {
+			'get_callback'    => static function ( $post_object ) {
 				return (string) get_post_type_archive_link( $post_object['slug'] )
 			},
 			'update_callback' => null,

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -43,7 +43,7 @@ function gutenberg_register_archive_link_field() {
 		'type',
 		'archive_link',
 		array(
-			'get_callback'    => function( $post_object ) {
+			'get_callback'    => function ( $post_object ) {
 				if ( isset( $post_object['has_archive'] ) && $post_object['has_archive'] ) {
 					$post_type = $post_object['slug'];
 					$archive_link = get_post_type_archive_link( $post_type );

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -44,11 +44,7 @@ function gutenberg_register_archive_link_field() {
 		'archive_link',
 		array(
 			'get_callback'    => function ( $post_object ) {
-				if ( isset( $post_object['has_archive'] ) && $post_object['has_archive'] ) {
-					$archive_link = get_post_type_archive_link( $post_object['slug'] );
-					return $archive_link ? $archive_link : '';
-				}
-				return '';
+				return (string) get_post_type_archive_link( $post_object['slug'] )
 			},
 			'update_callback' => null,
 			'schema'          => array(

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -45,8 +45,7 @@ function gutenberg_register_archive_link_field() {
 		array(
 			'get_callback'    => function ( $post_object ) {
 				if ( isset( $post_object['has_archive'] ) && $post_object['has_archive'] ) {
-					$post_type = $post_object['slug'];
-					$archive_link = get_post_type_archive_link( $post_type );
+					$archive_link = get_post_type_archive_link( $post_object['slug'] );
 					return $archive_link ? $archive_link : '';
 				}
 				return '';

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -44,7 +44,7 @@ function gutenberg_register_archive_link_field() {
 		'archive_link',
 		array(
 			'get_callback'    => static function ( $post_object ) {
-				return (string) get_post_type_archive_link( $post_object['slug'] )
+				return (string) get_post_type_archive_link( $post_object['slug'] );
 			},
 			'update_callback' => null,
 			'schema'          => array(

--- a/lib/rest-api.php
+++ b/lib/rest-api.php
@@ -36,3 +36,28 @@ function gutenberg_register_edit_site_export_controller_endpoints() {
 	$edit_site_export_controller->register_routes();
 }
 add_action( 'rest_api_init', 'gutenberg_register_edit_site_export_controller_endpoints' );
+
+
+function gutenberg_register_archive_link_field() {
+	register_rest_field(
+		'type',
+		'archive_link',
+		array(
+			'get_callback'    => function( $post_object ) {
+				if ( isset( $post_object['has_archive'] ) && $post_object['has_archive'] ) {
+					$post_type = $post_object['slug'];
+					$archive_link = get_post_type_archive_link( $post_type );
+					return $archive_link ? $archive_link : '';
+				}
+				return '';
+			},
+			'update_callback' => null,
+			'schema'          => array(
+				'description' => __( 'Link to the post type archive page', 'default' ),
+				'type'        => 'string',
+				'context'     => array( 'view', 'edit' ),
+			),
+		)
+	);
+}
+add_action( 'rest_api_init', 'gutenberg_register_archive_link_field' );

--- a/packages/block-editor/src/components/link-control/search-item.js
+++ b/packages/block-editor/src/components/link-control/search-item.js
@@ -13,6 +13,7 @@ import {
 	file,
 	home,
 	verse,
+	customPostType,
 } from '@wordpress/icons';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { safeDecodeURI, filterURLForDisplay, getPath } from '@wordpress/url';
@@ -42,18 +43,16 @@ function SearchItemIcon( { isURL, suggestion } ) {
 				icon = verse;
 			}
 		}
+	} else {
+		icon = customPostType;
 	}
 
-	if ( icon ) {
-		return (
-			<Icon
-				className="block-editor-link-control__search-item-icon"
-				icon={ icon }
-			/>
-		);
-	}
-
-	return null;
+	return (
+		<Icon
+			className="block-editor-link-control__search-item-icon"
+			icon={ icon }
+		/>
+	);
 }
 
 /**
@@ -154,6 +153,10 @@ function getVisualTypeName( suggestion ) {
 
 	if ( suggestion.isBlogHome ) {
 		return 'blog home';
+	}
+
+	if ( suggestion.kind === 'post-type-archive' ) {
+		return 'archive';
 	}
 
 	// Rename 'post_tag' to 'tag'. Ideally, the API would return the localised CPT or taxonomy label.

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -386,6 +386,7 @@ function block_core_navigation_link_filter_variations( $variations, $block_type 
  * @return array
  */
 function block_core_navigation_link_build_variations() {
+
 	$post_types = get_post_types( array( 'show_in_nav_menus' => true ), 'objects' );
 	$taxonomies = get_taxonomies( array( 'show_in_nav_menus' => true ), 'objects' );
 
@@ -406,6 +407,27 @@ function block_core_navigation_link_build_variations() {
 			} else {
 				$variations[] = $variation;
 			}
+		}
+
+		// If any of the post types have `has_archive` set to true then add a post-type-archive variation.
+		$has_archive = array_filter(
+			$post_types,
+			function ( $post_type ) {
+				return $post_type->has_archive;
+			}
+		);
+
+		if ( $has_archive ) {
+			$variation    = array(
+				'name'        => 'post-type-archive',
+				'title'       => __( 'Post Type Archive Link' ),
+				'description' => __( 'A link to a post type archive' ),
+				'attributes'  => array(
+					'type' => 'all',
+					'kind' => 'post-type-archive',
+				),
+			);
+			$variations[] = $variation;
 		}
 	}
 	if ( $taxonomies ) {

--- a/packages/block-library/src/navigation-link/index.php
+++ b/packages/block-library/src/navigation-link/index.php
@@ -410,12 +410,13 @@ function block_core_navigation_link_build_variations() {
 		}
 
 		// If any of the post types have `has_archive` set to true then add a post-type-archive variation.
-		$has_archive = array_filter(
-			$post_types,
-			function ( $post_type ) {
-				return $post_type->has_archive;
+		$has_archive = array();
+
+		foreach ( $post_types as $post_type ) {
+			if ( $post_type->has_archive ) {
+				$has_archive[] = $post_type;
 			}
-		);
+		}
 
 		if ( $has_archive ) {
 			$variation    = array(

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -63,6 +63,9 @@ export function getSuggestionsQuery( type, kind ) {
 			if ( kind === 'taxonomy' ) {
 				return { type: 'term', subtype: type };
 			}
+			if ( kind === 'post-type-archive' ) {
+				return { type: 'post-type-archive' };
+			}
 			if ( kind === 'post-type' ) {
 				return { type: 'post', subtype: type };
 			}

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -249,10 +249,7 @@ export default async function fetchLinkSuggestions(
 	if ( ! type || type === 'post-type-archive' ) {
 		queries.push(
 			apiFetch< PostTypesAPIResult[] >( {
-				path: addQueryArgs( '/wp/v2/types', {
-					page,
-					per_page: perPage,
-				} ),
+				path: addQueryArgs( '/wp/v2/types' ),
 			} )
 				.then( ( results ) => {
 					const resultValues = Object.values( results );

--- a/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
+++ b/packages/core-data/src/fetch/__experimental-fetch-link-suggestions.ts
@@ -62,6 +62,7 @@ type PostTypesAPIResult = {
 	slug: string;
 	name: string;
 	archive_link: string;
+	has_archive: boolean;
 };
 
 export type SearchResult = {
@@ -254,7 +255,7 @@ export default async function fetchLinkSuggestions(
 				.then( ( results ) => {
 					const resultValues = Object.values( results );
 					return resultValues
-						.filter( ( result ) => !! result.archive_link ) // Filter out results with falsy archive_link, including empty strings
+						.filter( ( result ) => result.has_archive ) // Filter out results with falsy archive_link, including empty strings
 						.map( ( result, index ) => {
 							return {
 								id: index + 1, // avoid results being filtered due to falsy id

--- a/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
+++ b/packages/core-data/src/fetch/test/__experimental-fetch-link-suggestions.js
@@ -86,6 +86,16 @@ jest.mock( '@wordpress/api-fetch', () =>
 							'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
 					},
 				] );
+			case '/wp/v2/search?search=&per_page=20&type=post-type-archive':
+				return Promise.resolve( [
+					{
+						id: 'books',
+						title: 'All Books',
+						url: 'http://wordpress.local/books/',
+						type: 'books-archive',
+						kind: 'post-type-archive',
+					},
+				] );
 			default:
 				return Promise.resolve( [
 					{
@@ -187,7 +197,7 @@ describe( 'fetchLinkSuggestions', () => {
 		);
 	} );
 
-	it( 'returns suggestions from post, term, post-format and media', () => {
+	it( 'returns suggestions from post, term, post-format, media and post-type-archive', () => {
 		return fetchLinkSuggestions( '', {} ).then( ( suggestions ) =>
 			expect( suggestions ).toEqual( [
 				{
@@ -231,6 +241,13 @@ describe( 'fetchLinkSuggestions', () => {
 					url: 'http://localhost:8888/wp-content/uploads/2022/03/test-pdf.pdf',
 					type: 'attachment',
 					kind: 'media',
+				},
+				{
+					id: 'books',
+					title: 'All Books',
+					url: 'http://wordpress.local/books/',
+					type: 'books-archive',
+					kind: 'post-type-archive',
 				},
 			] )
 		);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Alternative to https://github.com/WordPress/gutenberg/pull/66821.

Provides ability to link to Post Type Archives via the Link UI.

Closes https://github.com/WordPress/gutenberg/issues/31452

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Parity with Classic Menus where you could search for and add links to the Post Type Archives.

This also ensures that when visiting the Archives pages the current-menu-item class is added to the menu item.



## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Extends the existing Types REST API to include the URL for the post type archive. 
- Queries that endpoint from the link search suggestions handler on the client side.
- All result ordering is achieved via the sorting/weighting code on the client side.

**Note**: I appreciate that the extension to the Types endpoint will need to be undertaken in Core. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Please follow testing steps from https://github.com/WordPress/gutenberg/pull/66821.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
