### PR TITLE
Interactivity API: Prevent each directive errors and allow any iterable

### DIFF
--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/render.php
@@ -260,3 +260,54 @@
 		data-wp-text="context.callbackRunCount"
 	></data>
 </div>
+
+<hr>
+
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-unset"
+>
+	<template data-wp-each="state.eachUnset"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-null"
+>
+	<template data-wp-each="state.eachNull"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-undefined"
+>
+	<template data-wp-each="state.eachUndefined"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-array"
+>
+	<template data-wp-each="state.eachArray"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-set"
+>
+	<template data-wp-each="state.eachSet"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-string"
+>
+	<template data-wp-each="state.eachString"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-generator"
+>
+	<template data-wp-each="state.eachGenerator"><p data-wp-text="context.item"></p></template>
+</div>
+<div
+	data-wp-interactive="directive-each"
+	data-testid="each-with-iterator"
+>
+	<template data-wp-each="state.eachIterator"><p data-wp-text="context.item"></p></template>
+</div>

--- a/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
+++ b/packages/e2e-tests/plugins/interactive-blocks/directive-each/view.js
@@ -13,6 +13,28 @@ const { state } = store( 'directive-each' );
 store( 'directive-each', {
 	state: {
 		letters: [ 'A', 'B', 'C' ],
+		eachUndefined: undefined,
+		eachNull: null,
+		eachArray: [ 'an', 'array' ],
+		eachSet: new Set( [ 'a', 'set' ] ),
+		eachString: 'str',
+		*eachGenerator() {
+			yield 'a';
+			yield 'generator';
+		},
+		eachIterator: {
+			[ Symbol.iterator ]() {
+				const vals = [ 'implements', 'iterator' ];
+				let i = 0;
+				return {
+					next() {
+						return i < vals.length
+							? { value: vals[ i++ ], done: false }
+							: { done: true };
+					},
+				};
+			},
+		},
 	},
 } );
 

--- a/packages/interactivity/CHANGELOG.md
+++ b/packages/interactivity/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Allow more iterables to be used in each directives ([#67798](https://github.com/WordPress/gutenberg/pull/67798)).
+
+### Bug Fixes
+
+-   Fix an error when the value used in an each directive is not iterable ([#67798](https://github.com/WordPress/gutenberg/pull/67798)).
+
 ## 6.14.0 (2024-12-11)
 
 ## 6.13.0 (2024-11-27)

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -568,9 +568,15 @@ export default () => {
 			const { namespace } = entry;
 
 			const list = evaluate( entry );
+
 			const itemProp = isNonDefaultDirectiveSuffix( entry )
 				? kebabToCamelCase( entry.suffix )
 				: 'item';
+
+			if ( typeof list?.map !== 'function' ) {
+				return [];
+			}
+
 			return list.map( ( item ) => {
 				const itemContext = proxifyContext(
 					proxifyState( namespace, {} ),

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -4,7 +4,7 @@
 /**
  * External dependencies
  */
-import { h as createElement, type RefObject } from 'preact';
+import { h as createElement, type VNode, type RefObject } from 'preact';
 import { useContext, useMemo, useRef } from 'preact/hooks';
 
 /**
@@ -573,11 +573,13 @@ export default () => {
 				? kebabToCamelCase( entry.suffix )
 				: 'item';
 
-			if ( typeof list?.map !== 'function' ) {
-				return [];
+			if ( ! list || ! ( Symbol.iterator in list ) ) {
+				return;
 			}
 
-			return list.map( ( item ) => {
+			const result: VNode< any >[] = [];
+
+			for ( const item of list ) {
 				const itemContext = proxifyContext(
 					proxifyState( namespace, {} ),
 					inheritedValue.client[ namespace ]
@@ -602,12 +604,15 @@ export default () => {
 					? getEvaluate( { scope } )( eachKey[ 0 ] )
 					: item;
 
-				return createElement(
-					Provider,
-					{ value: mergedContext, key },
-					element.props.content
+				result.push(
+					createElement(
+						Provider,
+						{ value: mergedContext, key },
+						element.props.content
+					)
 				);
-			} );
+			}
+			return result;
 		},
 		{ priority: 20 }
 	);

--- a/packages/interactivity/src/directives.tsx
+++ b/packages/interactivity/src/directives.tsx
@@ -567,19 +567,19 @@ export default () => {
 			const [ entry ] = each;
 			const { namespace } = entry;
 
-			const list = evaluate( entry );
+			const iterable = evaluate( entry );
+
+			if ( typeof iterable?.[ Symbol.iterator ] !== 'function' ) {
+				return;
+			}
 
 			const itemProp = isNonDefaultDirectiveSuffix( entry )
 				? kebabToCamelCase( entry.suffix )
 				: 'item';
 
-			if ( ! list || ! ( Symbol.iterator in list ) ) {
-				return;
-			}
-
 			const result: VNode< any >[] = [];
 
-			for ( const item of list ) {
+			for ( const item of iterable ) {
 				const itemContext = proxifyContext(
 					proxifyState( namespace, {} ),
 					inheritedValue.client[ namespace ]

--- a/packages/interactivity/src/hooks.tsx
+++ b/packages/interactivity/src/hooks.tsx
@@ -77,7 +77,7 @@ interface DirectiveArgs {
 }
 
 export interface DirectiveCallback {
-	( args: DirectiveArgs ): VNode< any > | null | void;
+	( args: DirectiveArgs ): VNode< any > | VNode< any >[] | null | void;
 }
 
 interface DirectiveOptions {

--- a/test/e2e/specs/interactivity/directive-each.spec.ts
+++ b/test/e2e/specs/interactivity/directive-each.spec.ts
@@ -18,7 +18,7 @@ test.describe( 'data-wp-each', () => {
 		await utils.deleteAllPosts();
 	} );
 
-	test( 'should use `item` as the defaul item name in the context', async ( {
+	test( 'should use `item` as the default item name in the context', async ( {
 		page,
 	} ) => {
 		const elements = page.getByTestId( 'letters' ).getByTestId( 'item' );

--- a/test/e2e/specs/interactivity/directive-each.spec.ts
+++ b/test/e2e/specs/interactivity/directive-each.spec.ts
@@ -500,4 +500,37 @@ test.describe( 'data-wp-each', () => {
 		await expect( element ).toHaveText( 'beta' );
 		await expect( callbackRunCount ).toHaveText( '1' );
 	} );
+
+	for ( const testId of [
+		'each-with-unset',
+		'each-with-null',
+		'each-with-undefined',
+	] ) {
+		test( `does not error with non-iterable values: ${ testId }`, async ( {
+			page,
+		} ) => {
+			await expect( page.getByTestId( testId ) ).toBeEmpty();
+		} );
+	}
+
+	for ( const [ testId, values ] of [
+		[ 'each-with-array', [ 'an', 'array' ] ],
+		[ 'each-with-set', [ 'a', 'set' ] ],
+		[ 'each-with-string', [ 's', 't', 'r' ] ],
+		[ 'each-with-generator', [ 'a', 'generator' ] ],
+
+		// TODO: Is there a problem with proxies here?
+		// [ 'each-with-iterator', [ 'implements', 'iterator' ] ],
+	] as const ) {
+		test( `support different each iterable values: ${ testId }`, async ( {
+			page,
+		} ) => {
+			const element = page.getByTestId( testId );
+			for ( const value of values ) {
+				await expect(
+					element.getByText( value, { exact: true } )
+				).toBeVisible();
+			}
+		} );
+	}
 } );


### PR DESCRIPTION
## What?

If an each directive does has a value without properties or without a callable `.map` method, it causes an error.

Fixes https://github.com/WordPress/gutenberg/issues/67174.


## Why?

The API can be more robust in handling data problems like this. It's likely the each should render nothing if instead of `[]` the value is `null` or some other non-iterable.

Take and example like this:

```php
<?php
wp_interactivity_state(
	'example',
	array(
		'maybeIterable' => null,
	)
);
?>
<div data-wp-interactive="example" data-wp-init="updateValue">
	<template data-wp-each="state.maybeIterable">
		<p data-wp-text="context.item"></p>
	</template>
</div>
```
```js
import * as iAPI from '@wordpress/interactivity';
const { state } = iAPI.store('example', {
	updateValue() {
		console.log('initializing (array)…');
		state.maybeIterable = [1, 2, 3];
		let i = 0;
		setTimeout(() => {
			console.log('updating (set)…');
			state.maybeIterable = new Set(['x', 'y', 'z']);
		}, 2_000 * ++i);
		setTimeout(() => {
			console.log('updating (string)…');
			state.maybeIterable = 'abc';
		}, 2_000 * ++i);
		setTimeout(() => {
			console.log('updating (generator)…');
			state.maybeIterable = function* () {
				yield 'this';
				yield 'is';
				yield 'cool';
			};
		}, 2_000 * ++i);
		setTimeout(() => {
			console.log('deleting property…');
			delete state.maybeIterable;
		}, 2_000 * ++i);
		setTimeout(() => {
			console.log('updating (non-iterable)…');
			state.maybeIterable = 42;
		}, 2_000 * ++i);
		setTimeout(() => {
			console.log('updating (undefined)…');
			state.maybeIterable = undefined;
		}, 2_000 * ++i);
		setTimeout(() => {
			console.log('updating (Uint8Array)…');
			state.maybeIterable = new Uint8Array([0xf, 0xe, 0xd]);
		}, 2_000 * ++i);
	},
});
```

This has many opportunities for runtime errors, starting with the `null` initial value.

## How?

Check whether a property is iterable and iterate instead of calling its `.map` method.

## Testing Instructions

The snippets above can be used.

Needs unit tests.



## Screenshots or screencast

https://github.com/user-attachments/assets/34ccbd6e-ff0f-4d43-a4ab-afc3aeb99784


