### PR TITLE
CI: Skip native jobs

### DIFF
--- a/.github/workflows/rnmobile-android-runner.yml
+++ b/.github/workflows/rnmobile-android-runner.yml
@@ -14,8 +14,9 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
-        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        runs-on: macos-13
+        if: false
+        #if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 native-test-name: [gutenberg-editor-rendering]

--- a/.github/workflows/rnmobile-ios-runner.yml
+++ b/.github/workflows/rnmobile-ios-runner.yml
@@ -14,8 +14,9 @@ concurrency:
 
 jobs:
     test:
-        runs-on: macos-12
-        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
+        runs-on: macos-13
+        if: false
+        #if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
         strategy:
             matrix:
                 xcode: ['14.2']


### PR DESCRIPTION
The real fix for these failures is being iterated on here #67595 
That said in the meantime, this PR just skips these jobs to avoid the noise on all the PRs