### PR TITLE
Image: Avoid link class loss when pasting for raw transformation

### DIFF
--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -59,6 +59,7 @@ const schema = ( { phrasingContentSchema } ) => ( {
 			...imageSchema,
 			a: {
 				attributes: [ 'href', 'rel', 'target' ],
+				classes: [ /[\w-]*/ ],
 				children: imageSchema,
 			},
 			figcaption: {


### PR DESCRIPTION
## What?
Fixes #11995.

PR updates the Image block's raw transformation schema to support link classes. This prevents content loss when pasting an image.

Users can edit these classes using Link UI. See #7771.

## Testing Instructions
1. Create a post or page.
2. Add an empty paragraph.
3. Paste test image content.

<details><summary>Test image HTML</summary>
<p>

```html
<figure class="wp-block-image size-large"><a class="test-link hey --what" href="https://bbc.com"><img src="https://s.w.org/patterns/files/2021/06/image-from-rawpixel-id-539759-jpeg-1-1024x1024.jpg" alt="Vintage Cupid Illustration" class="wp-image-179"/></a></figure>
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2024-12-10 at 22 15 04](https://github.com/user-attachments/assets/e1dfb9e6-6db9-4961-a71e-20373f7d8833)
