### PR TITLE
Dataviews: refactor filters UI

### DIFF
--- a/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
@@ -26,6 +26,8 @@ interface AddFilterProps {
 	view: View;
 	onChangeView: ( view: View ) => void;
 	setOpenedFilter: ( filter: string | null ) => void;
+	addFilterOpen: boolean;
+	setAddFilterOpen: ( open: boolean ) => void;
 }
 
 export function AddFilterMenu( {
@@ -34,6 +36,8 @@ export function AddFilterMenu( {
 	onChangeView,
 	setOpenedFilter,
 	trigger,
+	addFilterOpen,
+	setAddFilterOpen,
 }: AddFilterProps & {
 	trigger: React.ReactNode;
 } ) {
@@ -42,6 +46,8 @@ export function AddFilterMenu( {
 		<Menu
 			trigger={ trigger }
 			defaultOpen={ inactiveFilters.length === filters.length }
+			open={ addFilterOpen }
+			onOpenChange={ setAddFilterOpen }
 		>
 			{ inactiveFilters.map( ( filter ) => {
 				return (
@@ -72,7 +78,7 @@ export function AddFilterMenu( {
 }
 
 function AddFilter(
-	{ filters, view, onChangeView, setOpenedFilter }: AddFilterProps,
+	{ filters, ...rest }: AddFilterProps,
 	ref: Ref< HTMLButtonElement >
 ) {
 	if ( ! filters.length || filters.every( ( { isPrimary } ) => isPrimary ) ) {
@@ -93,7 +99,7 @@ function AddFilter(
 					{ __( 'Add filter' ) }
 				</Button>
 			}
-			{ ...{ filters, view, onChangeView, setOpenedFilter } }
+			{ ...{ filters, ...rest } }
 		/>
 	);
 }

--- a/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/add-filter.tsx
@@ -39,7 +39,10 @@ export function AddFilterMenu( {
 } ) {
 	const inactiveFilters = filters.filter( ( filter ) => ! filter.isVisible );
 	return (
-		<Menu trigger={ trigger }>
+		<Menu
+			trigger={ trigger }
+			defaultOpen={ inactiveFilters.length === filters.length }
+		>
 			{ inactiveFilters.map( ( filter ) => {
 				return (
 					<Menu.Item

--- a/packages/dataviews/src/components/dataviews-filters/index.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/index.tsx
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState, useRef, useMemo } from '@wordpress/element';
+import { useState, useRef, useMemo, useEffect } from '@wordpress/element';
 import { __experimentalHStack as HStack, Button } from '@wordpress/components';
 import { funnel } from '@wordpress/icons';
 import { _x } from '@wordpress/i18n';
@@ -61,6 +61,55 @@ export function useFilters( fields: NormalizedField< any >[], view: View ) {
 		} );
 		return filters;
 	}, [ fields, view ] );
+}
+
+function Add( {
+	filters,
+	view,
+	onChangeView,
+	buttonRef,
+	isShowingFilter,
+	setIsShowingFilter,
+	addFilterRef,
+	setOpenedFilter,
+}: {
+	filters: NormalizedFilter[];
+	view: View;
+	onChangeView: ( view: View ) => void;
+	buttonRef: React.RefObject< HTMLButtonElement >;
+	isShowingFilter: boolean;
+	setIsShowingFilter: ( isShowingFilter: boolean ) => void;
+	addFilterRef: React.RefObject< HTMLButtonElement >;
+	setOpenedFilter: ( filter: string | null ) => void;
+} ) {
+	const [ addFilterOpen, setAddFilterOpen ] = useState< boolean >(
+		! view.filters?.length
+	);
+
+	useEffect( () => {
+		if ( isShowingFilter && ! view.filters?.length && ! addFilterOpen ) {
+			setIsShowingFilter( false );
+			buttonRef.current?.focus();
+		}
+	}, [
+		view.filters,
+		addFilterOpen,
+		isShowingFilter,
+		buttonRef,
+		setIsShowingFilter,
+	] );
+
+	return (
+		<AddFilter
+			filters={ filters }
+			view={ view }
+			onChangeView={ onChangeView }
+			ref={ addFilterRef }
+			setOpenedFilter={ setOpenedFilter }
+			addFilterOpen={ addFilterOpen }
+			setAddFilterOpen={ setAddFilterOpen }
+		/>
+	);
 }
 
 export default function useDataViewsFilters( {
@@ -132,21 +181,20 @@ export default function useDataViewsFilters( {
 						/>
 					);
 				} ) }
-			<AddFilter
+			<Add
 				filters={ filters }
 				view={ view }
 				onChangeView={ onChangeView }
-				ref={ addFilterRef }
+				addFilterRef={ addFilterRef }
 				setOpenedFilter={ setOpenedFilter }
+				buttonRef={ buttonRef }
+				isShowingFilter={ isShowingFilter }
+				setIsShowingFilter={ setIsShowingFilter }
 			/>
 			<ResetFilters
 				filters={ filters }
 				view={ view }
 				onChangeView={ onChangeView }
-				onClick={ () => {
-					setIsShowingFilter( false );
-					buttonRef.current?.focus();
-				} }
 			/>
 		</HStack>
 	);

--- a/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
@@ -13,14 +13,12 @@ interface ResetFilterProps {
 	filters: NormalizedFilter[];
 	view: View;
 	onChangeView: ( view: View ) => void;
-	onClick: () => void;
 }
 
 export default function ResetFilter( {
 	filters,
 	view,
 	onChangeView,
-	onClick,
 }: ResetFilterProps ) {
 	const isPrimary = ( field: string ) =>
 		filters.some(
@@ -46,7 +44,6 @@ export default function ResetFilter( {
 					search: '',
 					filters: [],
 				} );
-				onClick();
 			} }
 		>
 			{ __( 'Reset' ) }

--- a/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
+++ b/packages/dataviews/src/components/dataviews-filters/reset-filters.tsx
@@ -13,12 +13,14 @@ interface ResetFilterProps {
 	filters: NormalizedFilter[];
 	view: View;
 	onChangeView: ( view: View ) => void;
+	onClick: () => void;
 }
 
 export default function ResetFilter( {
 	filters,
 	view,
 	onChangeView,
+	onClick,
 }: ResetFilterProps ) {
 	const isPrimary = ( field: string ) =>
 		filters.some(
@@ -44,6 +46,7 @@ export default function ResetFilter( {
 					search: '',
 					filters: [],
 				} );
+				onClick();
 			} }
 		>
 			{ __( 'Reset' ) }

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -13,11 +13,7 @@ import { useMemo, useState } from '@wordpress/element';
  * Internal dependencies
  */
 import DataViewsContext from '../dataviews-context';
-import {
-	default as DataViewsFilters,
-	useFilters,
-	FiltersToggle,
-} from '../dataviews-filters';
+import { default as useDataViewsFilters } from '../dataviews-filters';
 import DataViewsLayout from '../dataviews-layout';
 import DataViewsFooter from '../dataviews-footer';
 import DataViewsSearch from '../dataviews-search';
@@ -95,10 +91,13 @@ export default function DataViews< Item >( {
 		);
 	}, [ selection, data, getItemId ] );
 
-	const filters = useFilters( _fields, view );
-	const [ isShowingFilter, setIsShowingFilter ] = useState< boolean >( () =>
-		( filters || [] ).some( ( filter ) => filter.isPrimary )
-	);
+	const { toggle, area } = useDataViewsFilters( {
+		view,
+		fields: _fields,
+		onChangeView,
+		openedFilter,
+		setOpenedFilter,
+	} );
 
 	return (
 		<DataViewsContext.Provider
@@ -132,14 +131,7 @@ export default function DataViews< Item >( {
 						className="dataviews__search"
 					>
 						{ search && <DataViewsSearch label={ searchLabel } /> }
-						<FiltersToggle
-							filters={ filters }
-							view={ view }
-							onChangeView={ onChangeView }
-							setOpenedFilter={ setOpenedFilter }
-							setIsShowingFilter={ setIsShowingFilter }
-							isShowingFilter={ isShowingFilter }
-						/>
+						{ toggle }
 					</HStack>
 					<HStack
 						spacing={ 1 }
@@ -152,7 +144,7 @@ export default function DataViews< Item >( {
 						{ header }
 					</HStack>
 				</HStack>
-				{ isShowingFilter && <DataViewsFilters /> }
+				{ area }
 				<DataViewsLayout />
 				<DataViewsFooter />
 			</div>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Simplifies the filters UI and fixes focus return. It does this by removing the double meaning of the main toggle. Instead it always opens the filters area. If there's no active filters, the menu will be opened.

Maybe there's some rough edges to polish.

Additionally I put it all together in a single hook that absorbs the shared state and refs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Simpler works better.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
