### PR TITLE
Try: Return error when session is missing for REST nonce refresh

### DIFF
--- a/lib/compat/wordpress-6.8/ajax-actions.php
+++ b/lib/compat/wordpress-6.8/ajax-actions.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Temporary compatibility shims for Core Ajax handlers.
+ *
+ * @package gutenberg
+ */
+
+/**
+ * Handles renewing the REST API nonce via AJAX.
+ *
+ * @since 5.3.0
+ * @since 6.8.0 Returns error when session token is missing.
+ */
+function gutenberg_ajax_rest_nonce() {
+	$token = wp_get_session_token();
+	if ( empty( $token ) ) {
+		wp_send_json_error( null, rest_authorization_required_code() );
+	}
+
+	exit( wp_create_nonce( 'wp_rest' ) );
+}
+add_action( 'wp_ajax_rest-nonce', 'gutenberg_ajax_rest_nonce', 0 );

--- a/lib/compat/wordpress-6.8/ajax-actions.php
+++ b/lib/compat/wordpress-6.8/ajax-actions.php
@@ -9,15 +9,14 @@
  * Handles renewing the REST API nonce via AJAX.
  *
  * @since 5.3.0
- * @since 6.8.0 Returns an error if a renewed nonce isn't valid.
+ * @since 6.8.0 Returns error when session token is missing.
  */
 function gutenberg_ajax_rest_nonce() {
-	$nonce  = wp_create_nonce( 'wp_rest' );
-	$result = wp_verify_nonce( $nonce, 'wp_rest' );
-	if ( ! $result ) {
+	$token = wp_get_session_token();
+	if ( empty( $token ) ) {
 		wp_send_json_error( null, rest_authorization_required_code() );
 	}
 
-	exit( $result );
+	exit( wp_create_nonce( 'wp_rest' ) );
 }
 add_action( 'wp_ajax_rest-nonce', 'gutenberg_ajax_rest_nonce', 0 );

--- a/lib/compat/wordpress-6.8/ajax-actions.php
+++ b/lib/compat/wordpress-6.8/ajax-actions.php
@@ -9,14 +9,15 @@
  * Handles renewing the REST API nonce via AJAX.
  *
  * @since 5.3.0
- * @since 6.8.0 Returns error when session token is missing.
+ * @since 6.8.0 Returns an error if a renewed nonce isn't valid.
  */
 function gutenberg_ajax_rest_nonce() {
-	$token = wp_get_session_token();
-	if ( empty( $token ) ) {
+	$nonce  = wp_create_nonce( 'wp_rest' );
+	$result = wp_verify_nonce( $nonce, 'wp_rest' );
+	if ( ! $result ) {
 		wp_send_json_error( null, rest_authorization_required_code() );
 	}
 
-	exit( wp_create_nonce( 'wp_rest' ) );
+	exit( $result );
 }
 add_action( 'wp_ajax_rest-nonce', 'gutenberg_ajax_rest_nonce', 0 );

--- a/lib/load.php
+++ b/lib/load.php
@@ -95,6 +95,7 @@ require __DIR__ . '/compat/wordpress-6.7/compat.php';
 require __DIR__ . '/compat/wordpress-6.7/post-formats.php';
 
 // WordPress 6.8 compat.
+require __DIR__ . '/compat/wordpress-6.8/ajax-actions.php';
 require __DIR__ . '/compat/wordpress-6.8/preload.php';
 require __DIR__ . '/compat/wordpress-6.8/blocks.php';
 require __DIR__ . '/compat/wordpress-6.8/functions.php';


### PR DESCRIPTION
## What?
Fixes #36118.
Fixes #42400.

This PR updates the `apiFetch` nonce endpoint to return an error when the session token is missing. It also avoids infinite loops when apiFetch tries to refresh the nonces.

## Why?
The endpoint always refreshes to nonce even when the session has expired. The `wp_create_nonce` doesn't do any validation and always returns a token value.

## Testing Instructions
1. Open a post or page.
2. Add an Image block.
3. Select an image.
4. Temporarily renames `wordpress_logged_in_*` cookie via DevTools.
5. Refresh the editor and observer Networks tab.
6. Confirm that the browser doesn't make infinite requests.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-12-11 at 11 19 50](https://github.com/user-attachments/assets/faef1040-7fb6-4cd1-a18f-079fbe1f36f5)
