### PR TITLE
CustomSelectControl: Refactor to use Ariakit store state for current value

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -46,7 +46,7 @@
 
 -   `ResizableBox`: Make drag handles focusable ([#67305](https://github.com/WordPress/gutenberg/pull/67305)).
 -   `CustomSelectControl`: Update correctly when `showSelectedHint` is enabled ([#67733](https://github.com/WordPress/gutenberg/pull/67733)).
--   `CustomSelectControl`: use `useStoreState` to get `currentValue` for optimistic updates ([#67815](https://github.com/WordPress/gutenberg/pull/67815))
+-   `CustomSelectControl`: Use `useStoreState` to get `currentValue` and avoid stale values ([#67815](https://github.com/WordPress/gutenberg/pull/67815)).
 
 ## 28.13.0 (2024-11-27)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 -   `ResizableBox`: Make drag handles focusable ([#67305](https://github.com/WordPress/gutenberg/pull/67305)).
 -   `CustomSelectControl`: Update correctly when `showSelectedHint` is enabled ([#67733](https://github.com/WordPress/gutenberg/pull/67733)).
+-   `CustomSelectControl`: use `useStoreState` to get `currentValue` for optimistic updates ([#67815](https://github.com/WordPress/gutenberg/pull/67815))
 
 ## 28.13.0 (2024-11-27)
 

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -116,6 +116,8 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		defaultValue: options[ 0 ]?.name,
 	} );
 
+	const { value: currentValue } = Ariakit.useStoreState( store );
+
 	const children = options
 		.map( applyOptionDeprecations )
 		.map( ( { name, key, hint, style, className } ) => {
@@ -149,8 +151,6 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			);
 		} );
 
-	const { value: currentValue } = store.getState();
-
 	const renderSelectedValueHint = () => {
 		const selectedOptionHint = options
 			?.map( applyOptionDeprecations )
@@ -158,7 +158,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 
 		return (
 			<Styled.SelectedExperimentalHintWrapper>
-				{ store.getState().value }
+				{ currentValue }
 				{ selectedOptionHint && (
 					<Styled.SelectedExperimentalHintItem
 						// Keeping the classname for legacy reasons

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -116,8 +116,6 @@ function CustomSelectControl< T extends CustomSelectOption >(
 		defaultValue: options[ 0 ]?.name,
 	} );
 
-	const { value: currentValue } = Ariakit.useStoreState( store );
-
 	const children = options
 		.map( applyOptionDeprecations )
 		.map( ( { name, key, hint, style, className } ) => {
@@ -151,10 +149,12 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			);
 		} );
 
+	const { value: currentValue } = Ariakit.useStoreState( store );
+
 	const renderSelectedValueHint = () => {
 		const selectedOptionHint = options
 			?.map( applyOptionDeprecations )
-			?.find( ( { name } ) => store.getState().value === name )?.hint;
+			?.find( ( { name } ) => currentValue === name )?.hint;
 
 		return (
 			<Styled.SelectedExperimentalHintWrapper>

--- a/packages/components/src/custom-select-control/index.tsx
+++ b/packages/components/src/custom-select-control/index.tsx
@@ -149,7 +149,7 @@ function CustomSelectControl< T extends CustomSelectOption >(
 			);
 		} );
 
-	const { value: currentValue } = Ariakit.useStoreState( store );
+	const currentValue = Ariakit.useStoreState( store, 'value' );
 
 	const renderSelectedValueHint = () => {
 		const selectedOptionHint = options


### PR DESCRIPTION
Fixes: #67759 

## What?  
This PR fixes a bug where the Button component's description fails to update correctly when uncontrolled.

## How?  
The implementation replaces `store.getState()` with `Ariakit.useStoreState(store)` to accurately retrieve the current value, ensuring the description updates as expected.

## Testing Instructions
1. Add the below code snippet to the storybook.
```js
export const Uncontrolled = {
	args: {
		...Default.args,
	},
};
```
2. In DevTools, checkout out the accessibility panel for the main combobox button. The button description will now update after changing the selected options.

## Screencast

### Before:

https://github.com/user-attachments/assets/89980a97-6762-4efd-bb74-22d46fd1dcf4


### After:

![Custom Select Control After](https://github.com/user-attachments/assets/1aa60325-a69e-410f-a6d7-a6a8d33a2c2d)



