### PR TITLE
Make sure the sidebar navigation item focus style is fully visible.

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -20,6 +20,11 @@
 		color: $white;
 	}
 
+	// Make sure the focus style is drawn on top of the current item background.
+	&:focus-visible {
+		transform: translateZ(0);
+	}
+
 	.edit-site-sidebar-navigation-item__drilldown-indicator {
 		fill: $gray-600;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/67816

## What?
<!-- In a few words, what is the PR actually doing? -->
The focus style of the sidebar navigation items is partially hidden behind the background of the active item.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Focus style should be fully visible.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Promotes the focused items to a higher z-stack.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the testing instructions from the issue https://github.com/WordPress/gutenberg/issues/67816
- Observe the focus style is now fully visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/f9bf048f-ab91-4130-a784-c78b6d423dff)|![after](https://github.com/user-attachments/assets/0c6ebc5b-4f38-498d-9cb5-f1d92ef8acf9)|
