### PR TITLE
BoxControl: Better minimum value support

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   `SelectControl`: Deprecate 36px default size ([#66898](https://github.com/WordPress/gutenberg/pull/66898)).
 -   `InputControl`: Deprecate 36px default size ([#66897](https://github.com/WordPress/gutenberg/pull/66897)).
 
+### Bug Fixes
+
+-   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
+
 ## 29.0.0 (2024-12-11)
 
 ### Breaking Changes

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -78,6 +78,7 @@ export default function BoxInputControl( {
 	setSelectedUnits,
 	sides,
 	side,
+	min = 0,
 	...props
 }: BoxControlInputControlProps ) {
 	const defaultValuesToModify = getSidesToModify( side, sides );
@@ -154,6 +155,7 @@ export default function BoxInputControl( {
 			<Tooltip placement="top-end" text={ LABELS[ side ] }>
 				<StyledUnitControl
 					{ ...props }
+					min={ min }
 					__shouldNotWarnDeprecated36pxSize
 					__next40pxDefaultSize={ __next40pxDefaultSize }
 					className="component-box-control__unit-control"
@@ -184,7 +186,7 @@ export default function BoxInputControl( {
 							: undefined
 					);
 				} }
-				min={ 0 }
+				min={ isFinite( min ) ? min : 0 }
 				max={ CUSTOM_VALUE_SETTINGS[ computedUnit ?? 'px' ]?.max ?? 10 }
 				step={
 					CUSTOM_VALUE_SETTINGS[ computedUnit ?? 'px' ]?.step ?? 0.1


### PR DESCRIPTION
Related #67625

## What?

In some BoxControl components, (like for margin) we want to allow negative margins. This is done by passing `min: -Infinity` to the component. This is already partially supported and used but I've found that the "RangeControl" doesn't work in an optimal way: You can actually set any number in the Range control even if it's inferior to min
 
This is a tiny PR that just passes the minimum number down to the RangeControl when it's provided and different than an infinite value. It's not perfect but it's slightly better than what's in trunk. 

## Testing Instructions

 - Run storybook locally `npm run storybook:dev`
 - Define `inputProps` as something like `{ min: 10 }` for the default BoxControl component story.
 - Notice that the minimum is respected in both ways of changing the value.