### PR TITLE
Feature: Keep track of loading state of query loop block

### DIFF
--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -35,6 +35,14 @@ function render_block_core_query( $attributes, $content, $block ) {
 				'data-wp-context',
 				wp_json_encode(
 					array(
+						/**
+						 * Checks whether the current navigation was originated from this Query block.
+						 *
+						 * Usage:
+						 *   ```js
+						 *   const { isCurrentNavigationOrigin } = getContext( 'core/query' );
+						 *   ```
+						 */
 						'isCurrentNavigationOrigin' => false,
 					)
 				)

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -35,7 +35,6 @@ function render_block_core_query( $attributes, $content, $block ) {
 				'data-wp-context',
 				wp_json_encode(
 					[
-						'routerRegion'              => 'query-' . $attributes['queryId'],
 						'isCurrentNavigationOrigin' => false,
 					]
 				)

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -34,9 +34,9 @@ function render_block_core_query( $attributes, $content, $block ) {
 			$p->set_attribute(
 				'data-wp-context',
 				wp_json_encode(
-					[
+					array(
 						'isCurrentNavigationOrigin' => false,
-					]
+					)
 				)
 			);
 			$p->set_attribute( 'data-wp-key', $attributes['queryId'] );

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -35,13 +35,13 @@ function render_block_core_query( $attributes, $content, $block ) {
 				'data-wp-context',
 				wp_json_encode(
 					[
-						'routerRegion' => 'query-' . $attributes['queryId'],
-						'isLoading'    => false,
+						'routerRegion'              => 'query-' . $attributes['queryId'],
+						'isCurrentNavigationOrigin' => false,
 					]
 				)
 			);
 			$p->set_attribute( 'data-wp-key', $attributes['queryId'] );
-			$p->set_attribute( 'data-wp-class--is-loading', 'context.isLoading' );
+			$p->set_attribute( 'data-wp-class--is-current-navigation-origin', 'context.isCurrentNavigationOrigin' );
 			$content = $p->get_updated_html();
 		}
 	}

--- a/packages/block-library/src/query/index.php
+++ b/packages/block-library/src/query/index.php
@@ -31,8 +31,17 @@ function render_block_core_query( $attributes, $content, $block ) {
 			// Add the necessary directives.
 			$p->set_attribute( 'data-wp-interactive', 'core/query' );
 			$p->set_attribute( 'data-wp-router-region', 'query-' . $attributes['queryId'] );
-			$p->set_attribute( 'data-wp-context', '{}' );
+			$p->set_attribute(
+				'data-wp-context',
+				wp_json_encode(
+					[
+						'routerRegion' => 'query-' . $attributes['queryId'],
+						'isLoading'    => false,
+					]
+				)
+			);
 			$p->set_attribute( 'data-wp-key', $attributes['queryId'] );
+			$p->set_attribute( 'data-wp-class--is-loading', 'context.isLoading' );
 			$content = $p->get_updated_html();
 		}
 	}

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -35,9 +35,9 @@ store(
 					const { actions } = yield import(
 						'@wordpress/interactivity-router'
 					);
-					ctx.isLoading = true;
+					ctx.isCurrentNavigationOrigin = true;
 					yield actions.navigate( ref.href );
-					ctx.isLoading = false;
+					ctx.isCurrentNavigationOrigin = false;
 					ctx.url = ref.href;
 
 					// Focus the first anchor of the Query block.

--- a/packages/block-library/src/query/view.js
+++ b/packages/block-library/src/query/view.js
@@ -35,7 +35,9 @@ store(
 					const { actions } = yield import(
 						'@wordpress/interactivity-router'
 					);
+					ctx.isLoading = true;
 					yield actions.navigate( ref.href );
+					ctx.isLoading = false;
 					ctx.url = ref.href;
 
 					// Focus the first anchor of the Query block.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Keep track of the `loading` state of the Query Loop router region.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This was discussed a bit in slack: https://wordpress.slack.com/archives/C071CRKGKUP/p1733744467794479

It allows us to do more in terms of loading indicators when any interactive blocks nested inside the query trigger a navigation.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The query loop already proxies the `actions.navigaite` function from the `core/router` store trough it's own custom `navigate` action. So we can use that to manually keep track of the loading state for the query that can be accessed by any child blocks nested within the query. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. Add a query loop with pagination 
2. Ensure the "Reload page" option in the advanced settings is unchecked 
3. Throttle your browser to a really slow network connection
4. See that a `is-current-navigation-origin` class gets added to the query loop block when new results are fetched.
