### PR TITLE
Storybook: PublicPublishDateTimePicker

### DIFF
--- a/packages/block-editor/src/components/publish-date-time-picker/stories/index.story.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/stories/index.story.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import PublicPublishDateTimePicker from '../';
+
+export default {
+	title: 'BlockEditor/PublicPublishDateTimePicker',
+	component: PublicPublishDateTimePicker,
+	argTypes: {
+		onChange: { action: 'onChange' },
+		onClose: { action: 'onClose' },
+	},
+};
+
+const Template = ( args ) => {
+	const [ currentDate, setCurrentDate ] = useState(
+		args.currentDate || null
+	);
+
+	return (
+		<PublicPublishDateTimePicker
+			{ ...args }
+			currentDate={ currentDate }
+			onChange={ ( date ) => {
+				setCurrentDate( date );
+				args.onChange( date );
+			} }
+		/>
+	);
+};
+
+export const Default = Template.bind( {} );
+Default.args = {
+	currentDate: new Date().toISOString(),
+	showPopoverHeaderActions: true,
+};

--- a/packages/block-editor/src/components/publish-date-time-picker/stories/index.story.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/stories/index.story.js
@@ -9,7 +9,7 @@ import { useState } from '@wordpress/element';
 import PublicPublishDateTimePicker from '../';
 
 export default {
-	title: 'BlockEditor/PublicPublishDateTimePicker',
+	title: 'Components/PublicPublishDateTimePicker',
 	component: PublicPublishDateTimePicker,
 	argTypes: {
 		onChange: { action: 'onChange' },
@@ -17,25 +17,25 @@ export default {
 	},
 };
 
-const Template = ( args ) => {
-	const [ currentDate, setCurrentDate ] = useState(
-		args.currentDate || null
-	);
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ currentDate, setCurrentDate ] = useState(
+			args.currentDate || null
+		);
 
-	return (
-		<PublicPublishDateTimePicker
-			{ ...args }
-			currentDate={ currentDate }
-			onChange={ ( date ) => {
-				setCurrentDate( date );
-				args.onChange( date );
-			} }
-		/>
-	);
-};
-
-export const Default = Template.bind( {} );
-Default.args = {
-	currentDate: new Date().toISOString(),
-	showPopoverHeaderActions: true,
+		return (
+			<PublicPublishDateTimePicker
+				{ ...args }
+				currentDate={ currentDate }
+				onChange={ ( date ) => {
+					setCurrentDate( date );
+					onChange( date );
+				} }
+			/>
+		);
+	},
+	args: {
+		currentDate: new Date().toISOString(),
+		showPopoverHeaderActions: true,
+	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR will add stories for PublicPublishDateTimePicker components in the Storybook
Part of https://github.com/WordPress/gutenberg/issues/67165


## Why?
Most of Block Editor components don't have stories.
Block Editor components's Storybook should also be added and updated like the Components. Currently PublicPublishDateTimePicker story is not availbale.


Part of https://github.com/WordPress/gutenberg/issues/67165

## How?
Adding story for PublicPublishDateTimePicker

## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the PublicPublishDateTimePicker stories.



## Screenshots or screencast <!-- if applicable -->
![storybook](https://github.com/user-attachments/assets/8693bb0d-c7a1-42cd-81c2-3cd4b83950cb)


