### PR TITLE
Add CSS classname to fix the negative margins not appearing in the Navigation Screen

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -19,7 +19,7 @@ import { store as editSiteStore } from '../../store';
 
 export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 	return (
-		<ItemGroup>
+		<ItemGroup className="edit-site-sidebar-navigation-screen-main">
 			{ isBlockBasedTheme && (
 				<>
 					<SidebarNavigationItem


### PR DESCRIPTION
Issue: #67369

Related PR: #67575 

Related comment: [comment](https://github.com/WordPress/gutenberg/pull/67575#issuecomment-2535240008)
## What?
Due to regression introduced by https://github.com/WordPress/gutenberg/pull/66851. The CSS classname `edit-site-sidebar-navigation-screen-main` was removed from the `<ItemGroup>`, this caused negative margins not to be applied

## Why?
To apply negative margins.