### PR TITLE
Enhancement: Add descriptive name for docker container images

### DIFF
--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -74,17 +74,18 @@ module.exports = async function loadConfig(
 		md5( configFilePath )
 	);
 
-	// If cache doesn't exist, create with new name
+	// Descriptive cache directory name
 	const directory = path.dirname( configFilePath ).replace( /^.*[\\/]/, '' );
+	const verboseCacheDirectoryPath = path.resolve(
+		await getCacheDirectory(),
+		'wp-env-' + directory + '-' + md5( configFilePath )
+	);
+
+	// If cache doesn't exist, create with new name
 	const cacheDirectoryPath = await fs
 		.access( md5CacheDirectoryPath )
 		.then( () => md5CacheDirectoryPath )
-		.catch( async () => {
-			return path.resolve(
-				await getCacheDirectory(),
-				'wp-env-' + directory + '-' + md5( configFilePath )
-			);
-		} );
+		.catch( () => verboseCacheDirectoryPath );
 
 	// Parse any configuration we found in the given directory.
 	// This comes merged and prepared for internal consumption.

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -68,22 +68,21 @@ module.exports = async function loadConfig(
 		}
 	}
 
-	// Traditional cache directory name
-	const md5CacheDirectoryPath = path.resolve(
+	// Legacy cache directory name
+	const legacyCacheDirectoryPath = path.resolve(
 		await getCacheDirectory(),
 		md5( configFilePath )
 	);
 
-	// Descriptive cache directory name
-	const directory = path.basename( path.dirname( configFilePath ) );
+	// Descriptive cache directory name. Format: wp-env-<project-dir>[-<variant>]-<short-hash>
 	const descriptiveCacheDirectoryPath = path.resolve(
 		await getCacheDirectory(),
-		'wp-env-' + directory + '-' + md5( configFilePath )
+		buildDescriptiveCacheDirectoryName( configFilePath )
 	);
 
 	// If cache doesn't exist, create with new name
-	const cacheDirectoryPath = existsSync( md5CacheDirectoryPath )
-		? md5CacheDirectoryPath
+	const cacheDirectoryPath = existsSync( legacyCacheDirectoryPath )
+		? legacyCacheDirectoryPath
 		: descriptiveCacheDirectoryPath;
 
 	// Parse any configuration we found in the given directory.
@@ -136,6 +135,53 @@ module.exports = async function loadConfig(
 		env: config.env,
 	};
 };
+
+/**
+ * Derives the descriptive cache directory name for a given config file path.
+ *
+ * Format: `wp-env-<project-dir>[-<variant>]-<short-hash>`.
+ *
+ * @param {string} configFilePath Absolute path to the resolved config file.
+ *
+ * @return {string} The directory name to use as the cache directory.
+ */
+function buildDescriptiveCacheDirectoryName( configFilePath ) {
+	const projectDirectory = path.basename( path.dirname( configFilePath ) );
+	const variant = getConfigVariant( configFilePath );
+	const shortHash = md5( configFilePath ).slice( 0, 8 );
+
+	const segments = [ 'wp-env', projectDirectory ];
+	if ( variant ) {
+		segments.push( variant );
+	}
+	segments.push( shortHash );
+
+	return segments.join( '-' );
+}
+
+/**
+ * Extracts a variant label from a config file name.
+ *
+ * Example: `.wp-env.test.json`   -> 'test'
+ *
+ * @param {string} configFilePath Absolute path to the resolved config file.
+ *
+ * @return {string} The sanitized variant, or '' if none could be derived.
+ */
+function getConfigVariant( configFilePath ) {
+	const basename = path.basename( configFilePath, '.json' );
+
+	let variant;
+	if ( basename === '.wp-env' ) {
+		variant = '';
+	} else if ( basename.startsWith( '.wp-env.' ) ) {
+		variant = basename.slice( '.wp-env.'.length );
+	} else {
+		variant = basename;
+	}
+
+	return variant.replace( /[^a-zA-Z0-9._]+/g, '-' ).replace( /^-+|-+$/g, '' );
+}
 
 /**
  * Checks to see whether or not there is any configuration present in the directory.

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -68,9 +68,10 @@ module.exports = async function loadConfig(
 		}
 	}
 
+	const directory = path.dirname( configFilePath ).replace( /^.*[\\/]/, '' );
 	const cacheDirectoryPath = path.resolve(
 		await getCacheDirectory(),
-		md5( configFilePath )
+		'wp-env-' + directory + '-' + md5( configFilePath )
 	);
 
 	// Parse any configuration we found in the given directory.

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -68,11 +68,23 @@ module.exports = async function loadConfig(
 		}
 	}
 
-	const directory = path.dirname( configFilePath ).replace( /^.*[\\/]/, '' );
-	const cacheDirectoryPath = path.resolve(
+	// Traditional cache directory name
+	const md5CacheDirectoryPath = path.resolve(
 		await getCacheDirectory(),
-		'wp-env-' + directory + '-' + md5( configFilePath )
+		md5( configFilePath )
 	);
+
+	// If cache doesn't exist, create with new name
+	const directory = path.dirname( configFilePath ).replace( /^.*[\\/]/, '' );
+	const cacheDirectoryPath = await fs
+		.access( md5CacheDirectoryPath )
+		.then( () => md5CacheDirectoryPath )
+		.catch( async () => {
+			return path.resolve(
+				await getCacheDirectory(),
+				'wp-env-' + directory + '-' + md5( configFilePath )
+			);
+		} );
 
 	// Parse any configuration we found in the given directory.
 	// This comes merged and prepared for internal consumption.

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -3,7 +3,7 @@
  * External dependencies
  */
 const path = require( 'path' );
-const fs = require( 'fs' ).promises;
+const { existsSync, promises: fsPromises } = require( 'fs' );
 
 /**
  * Internal dependencies
@@ -82,10 +82,9 @@ module.exports = async function loadConfig(
 	);
 
 	// If cache doesn't exist, create with new name
-	const cacheDirectoryPath = await fs
-		.access( md5CacheDirectoryPath )
-		.then( () => md5CacheDirectoryPath )
-		.catch( () => verboseCacheDirectoryPath );
+	const cacheDirectoryPath = existsSync( md5CacheDirectoryPath )
+		? md5CacheDirectoryPath
+		: verboseCacheDirectoryPath;
 
 	// Parse any configuration we found in the given directory.
 	// This comes merged and prepared for internal consumption.
@@ -148,7 +147,7 @@ module.exports = async function loadConfig(
 async function hasLocalConfig( configFilePaths ) {
 	for ( const filePath of configFilePaths ) {
 		try {
-			await fs.stat( filePath );
+			await fsPromises.stat( filePath );
 			return true;
 		} catch {}
 	}

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -76,7 +76,7 @@ module.exports = async function loadConfig(
 
 	// Descriptive cache directory name
 	const directory = path.dirname( configFilePath ).replace( /^.*[\\/]/, '' );
-	const verboseCacheDirectoryPath = path.resolve(
+	const descriptiveCacheDirectoryPath = path.resolve(
 		await getCacheDirectory(),
 		'wp-env-' + directory + '-' + md5( configFilePath )
 	);
@@ -84,7 +84,7 @@ module.exports = async function loadConfig(
 	// If cache doesn't exist, create with new name
 	const cacheDirectoryPath = existsSync( md5CacheDirectoryPath )
 		? md5CacheDirectoryPath
-		: verboseCacheDirectoryPath;
+		: descriptiveCacheDirectoryPath;
 
 	// Parse any configuration we found in the given directory.
 	// This comes merged and prepared for internal consumption.

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -75,7 +75,7 @@ module.exports = async function loadConfig(
 	);
 
 	// Descriptive cache directory name
-	const directory = path.dirname( configFilePath ).replace( /^.*[\\/]/, '' );
+	const directory = path.basename( path.dirname( configFilePath ) );
 	const descriptiveCacheDirectoryPath = path.resolve(
 		await getCacheDirectory(),
 		'wp-env-' + directory + '-' + md5( configFilePath )

--- a/packages/env/lib/config/load-config.js
+++ b/packages/env/lib/config/load-config.js
@@ -60,7 +60,7 @@ module.exports = async function loadConfig(
 	// If a custom config path was provided, verify the file exists.
 	if ( customConfigPath ) {
 		try {
-			await fs.stat( configFilePath );
+			await fsPromises.stat( configFilePath );
 		} catch {
 			throw new ValidationError(
 				`Config file not found: ${ configFilePath }`

--- a/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
@@ -5,7 +5,7 @@ exports[`Config Integration should load local and override configuration files 1
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c56/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -22,10 +22,10 @@ exports[`Config Integration should load local and override configuration files 1
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -54,10 +54,10 @@ exports[`Config Integration should load local and override configuration files 1
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -81,7 +81,7 @@ exports[`Config Integration should load local and override configuration files 1
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c56",
 }
 `;
 
@@ -90,7 +90,7 @@ exports[`Config Integration should load local configuration file 1`] = `
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c56/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -107,10 +107,10 @@ exports[`Config Integration should load local configuration file 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -139,10 +139,10 @@ exports[`Config Integration should load local configuration file 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -166,7 +166,7 @@ exports[`Config Integration should load local configuration file 1`] = `
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c56",
 }
 `;
 
@@ -175,7 +175,7 @@ exports[`Config Integration should use default configuration 1`] = `
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c56/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -192,10 +192,10 @@ exports[`Config Integration should use default configuration 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "100.0.0",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -224,10 +224,10 @@ exports[`Config Integration should use default configuration 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "100.0.0",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -251,7 +251,7 @@ exports[`Config Integration should use default configuration 1`] = `
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c56",
 }
 `;
 
@@ -260,7 +260,7 @@ exports[`Config Integration should use environment variables over local and over
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c56/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -277,10 +277,10 @@ exports[`Config Integration should use environment variables over local and over
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -310,10 +310,10 @@ exports[`Config Integration should use environment variables over local and over
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c56/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c56/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -338,6 +338,6 @@ exports[`Config Integration should use environment variables over local and over
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c56",
 }
 `;

--- a/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
+++ b/packages/env/lib/config/test/__snapshots__/config-integration.js.snap
@@ -5,7 +5,7 @@ exports[`Config Integration should load local and override configuration files 1
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -22,10 +22,10 @@ exports[`Config Integration should load local and override configuration files 1
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -54,10 +54,10 @@ exports[`Config Integration should load local and override configuration files 1
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -81,7 +81,7 @@ exports[`Config Integration should load local and override configuration files 1
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
 }
 `;
 
@@ -90,7 +90,7 @@ exports[`Config Integration should load local configuration file 1`] = `
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -107,10 +107,10 @@ exports[`Config Integration should load local configuration file 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -139,10 +139,10 @@ exports[`Config Integration should load local configuration file 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -166,7 +166,7 @@ exports[`Config Integration should load local configuration file 1`] = `
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
 }
 `;
 
@@ -175,7 +175,7 @@ exports[`Config Integration should use default configuration 1`] = `
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -192,10 +192,10 @@ exports[`Config Integration should use default configuration 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "100.0.0",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -224,10 +224,10 @@ exports[`Config Integration should use default configuration 1`] = `
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "100.0.0",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -251,7 +251,7 @@ exports[`Config Integration should use default configuration 1`] = `
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
 }
 `;
 
@@ -260,7 +260,7 @@ exports[`Config Integration should use environment variables over local and over
   "configDirectoryPath": "/test/gutenberg",
   "customConfigPath": null,
   "detectedLocalConfig": true,
-  "dockerComposeConfigPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
+  "dockerComposeConfigPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/docker-compose.yml",
   "env": {
     "development": {
       "config": {
@@ -277,10 +277,10 @@ exports[`Config Integration should use environment variables over local and over
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -310,10 +310,10 @@ exports[`Config Integration should use environment variables over local and over
       },
       "coreSource": {
         "basename": "WordPress",
-        "clonePath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
-        "path": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "clonePath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
+        "path": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/WordPress",
         "ref": "trunk",
-        "testsPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
+        "testsPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338/tests-WordPress",
         "type": "git",
         "url": "https://github.com/WordPress/WordPress.git",
       },
@@ -338,6 +338,6 @@ exports[`Config Integration should use environment variables over local and over
   },
   "name": "gutenberg",
   "testsEnvironment": true,
-  "workDirectoryPath": "/cache/5fea4c5689ef6cc4a4e6eaaa39323338",
+  "workDirectoryPath": "/cache/wp-env-gutenberg-5fea4c5689ef6cc4a4e6eaaa39323338",
 }
 `;

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -17,6 +17,7 @@ jest.mock( 'fs', () => ( {
 		stat: jest.fn().mockResolvedValue( true ),
 		mkdir: jest.fn(),
 		writeFile: jest.fn(),
+		access: jest.fn().mockRejectedValue( { code: 'ENOENT' } ),
 	},
 } ) );
 

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -17,8 +17,8 @@ jest.mock( 'fs', () => ( {
 		stat: jest.fn().mockResolvedValue( true ),
 		mkdir: jest.fn(),
 		writeFile: jest.fn(),
-		access: jest.fn().mockRejectedValue( { code: 'ENOENT' } ),
 	},
+	existsSync: jest.fn().mockReturnValue( false ),
 } ) );
 
 // This mocks a small response with a format matching the stable-check API.

--- a/packages/env/lib/config/test/config-integration.js
+++ b/packages/env/lib/config/test/config-integration.js
@@ -4,12 +4,14 @@
  * External dependencies
  */
 const { readFile } = require( 'fs' ).promises;
+const { existsSync } = require( 'fs' );
 
 /**
  * Internal dependencies
  */
 const loadConfig = require( '../load-config' );
 const detectDirectoryType = require( '../detect-directory-type' );
+const md5 = require( '../../md5' );
 
 jest.mock( 'fs', () => ( {
 	promises: {
@@ -200,5 +202,87 @@ describe( 'Config Integration', () => {
 			'test'
 		);
 		expect( config ).toMatchSnapshot();
+	} );
+
+	describe( 'cache directory naming', () => {
+		beforeEach( () => {
+			readFile.mockImplementation( async () => {
+				throw { code: 'ENOENT' };
+			} );
+			existsSync.mockReturnValue( false );
+		} );
+
+		it( 'uses the descriptive `wp-env-<dir>-<8charHash>` format by default', async () => {
+			const config = await loadConfig( '/test/gutenberg' );
+
+			const expectedHash = md5( '/test/gutenberg/.wp-env.json' ).slice(
+				0,
+				8
+			);
+			expect( config.workDirectoryPath ).toEqual(
+				`/cache/wp-env-gutenberg-${ expectedHash }`
+			);
+			// The short hash is exactly 8 hex chars.
+			expect( expectedHash ).toMatch( /^[0-9a-f]{8}$/ );
+		} );
+
+		it( 'produces distinct cache dirs for the same config filename in different directories', async () => {
+			const configA = await loadConfig( '/work/alice/myproject' );
+			const configB = await loadConfig( '/work/bob/myproject' );
+
+			expect( configA.workDirectoryPath ).toMatch(
+				/^\/cache\/wp-env-myproject-[0-9a-f]{8}$/
+			);
+			expect( configB.workDirectoryPath ).toMatch(
+				/^\/cache\/wp-env-myproject-[0-9a-f]{8}$/
+			);
+			expect( configA.workDirectoryPath ).not.toEqual(
+				configB.workDirectoryPath
+			);
+		} );
+
+		it( 'extracts a variant from `.wp-env.<variant>.json` custom config', async () => {
+			const config = await loadConfig(
+				'/test/gutenberg',
+				'/test/gutenberg/.wp-env.test.json'
+			);
+
+			const expectedHash = md5(
+				'/test/gutenberg/.wp-env.test.json'
+			).slice( 0, 8 );
+			expect( config.workDirectoryPath ).toEqual(
+				`/cache/wp-env-gutenberg-test-${ expectedHash }`
+			);
+		} );
+
+		it( 'derives a variant from an arbitrarily-named custom config file', async () => {
+			const config = await loadConfig(
+				'/test/gutenberg',
+				'/some/configs/staging.json'
+			);
+
+			const expectedHash = md5( '/some/configs/staging.json' ).slice(
+				0,
+				8
+			);
+			// The project-dir segment comes from the config file's parent directory
+			expect( config.workDirectoryPath ).toEqual(
+				`/cache/wp-env-configs-staging-${ expectedHash }`
+			);
+		} );
+
+		it( 'keeps using the legacy pure-md5 cache directory when it already exists', async () => {
+			const configFilePath = '/test/gutenberg/.wp-env.json';
+			const legacyPath = `/cache/${ md5( configFilePath ) }`;
+
+			// the legacy md5 directory is present on disk.
+			existsSync.mockImplementation(
+				( candidate ) => candidate === legacyPath
+			);
+
+			const config = await loadConfig( '/test/gutenberg' );
+
+			expect( config.workDirectoryPath ).toEqual( legacyPath );
+		} );
 	} );
 } );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Resolves https://github.com/WordPress/gutenberg/issues/64153

## What?
The docker container image names are indistinguishable. See screenshots shared in https://github.com/WordPress/gutenberg/issues/64153

Container, image, and cache-directory names generated by wp-env are an indistinguishable wall of md5 hashes. This PR replaces them with readable, directory-aware names while preserving every existing environment on disk.

## Why?
It would enhance the clarity and usability of directory names generated by wp-env. Using more descriptive names based on the project folder and file would make it easier to identify directories. Container names remain unique while reducing clutter in file explorers or Docker, making management more efficient. This solution would simplify troubleshooting and improve workflow for developers.

## How?
Instead of directly using MD5 of the directory name

https://github.com/WordPress/gutenberg/blob/f9b966b290b7ed3445b2269b3062ea1264202972/packages/env/lib/config/load-config.js#L45-L48

As suggested use a prefix. Prepend it with `wp-env-<project-dir>[-<variant>]-<short-hash>`

## Backwards compatibility
Upgrading wp-env must not orphan a running environment. If the legacy pure-md5 cache directory already exists for a given config file, wp-env keeps using it; the new descriptive name only takes effect for fresh environments.

## Adopting the new names on an existing environment
Run `wp-env destroy` followed by `wp-env start`. (destroy will delete all resources, please test this in a new env, not an old one whose data you wanna preserve)

## Testing Instructions
1. Check out this branch, `npm run build`.
2. From any project folder with a `.wp-env.json`, run `npm run wp-env start`.
3. Confirm `ls ~/.wp-env/` shows `wp-env-<folder>-<8hex>/`.
4. Confirm `docker ps` shows readable container names.
5. Parallel-env test: in the same folder, run `npx wp-env start --config .wp-env.test.json`, container names should include `-test-`.
6. Parent/child test: `.wp-env.json` in a subdirectory of another project with `.wp-env.json` should produce a distinct cache dir.

## Screenshots
|Before|After|
|-|-|
|<img width="1002" alt="Screenshot 2024-12-11 at 6 03 27 PM" src="https://github.com/user-attachments/assets/032e8bb0-c361-433e-9eec-9a2ff30f8350">|<img width="1002" alt="Screenshot 2024-12-11 at 6 04 34 PM" src="https://github.com/user-attachments/assets/45d56c3c-f4a9-41e5-a54d-05f0f0b41ca8">|
