### PR TITLE
DOM: Support class wildcard matcher in 'cleanNodeList'

### DIFF
--- a/packages/block-library/src/image/transforms.js
+++ b/packages/block-library/src/image/transforms.js
@@ -59,7 +59,7 @@ const schema = ( { phrasingContentSchema } ) => ( {
 			...imageSchema,
 			a: {
 				attributes: [ 'href', 'rel', 'target' ],
-				classes: [ /[\w-]*/ ],
+				classes: [ '*' ],
 				children: imageSchema,
 			},
 			figcaption: {

--- a/packages/dom/src/dom/clean-node-list.js
+++ b/packages/dom/src/dom/clean-node-list.js
@@ -76,7 +76,10 @@ export default function cleanNodeList( nodeList, doc, schema, inline ) {
 						// TODO: Explore patching this in jsdom-jscore.
 						if ( node.classList && node.classList.length ) {
 							const mattchers = classes.map( ( item ) => {
-								if ( typeof item === 'string' ) {
+								if ( item === '*' ) {
+									// Keep all classes.
+									return () => true;
+								} else if ( typeof item === 'string' ) {
 									return (
 										/** @type {string} */ className
 									) => className === item;


### PR DESCRIPTION
## What?
Build on top of #67803.

This PR updates the `cleanNodeList` method and allows element classes to accept a wildcard (`*`).

## Why?
Makes it easier to retain all classes for an element.

## Testing Instructions
1. Create a post or page.
2. Add an empty paragraph.
3. Paste test image content.

<details><summary>Test image HTML</summary>
<p>

```html
<figure class="wp-block-image size-large"><a class="test-link hey --what" href="https://bbc.com"><img src="https://s.w.org/patterns/files/2021/06/image-from-rawpixel-id-539759-jpeg-1-1024x1024.jpg" alt="Vintage Cupid Illustration" class="wp-image-179"/></a></figure>
``` 

</p>
</details> 

### Testing Instructions for Keyboard
Same.

## Screenshot
![CleanShot 2024-12-10 at 22 15 04](https://github.com/user-attachments/assets/e1dfb9e6-6db9-4961-a71e-20373f7d8833)