### PR TITLE
Clean script: Use braces instead of @-pattern for glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,7 +181,7 @@
 		"postbuild:packages": " npm run --if-present --workspaces build:wp",
 		"build:plugin-zip": "bash ./bin/build-plugin-zip.sh",
 		"clean:package-types": "tsc --build --clean && rimraf --glob './packages/*/build-types'",
-		"clean:packages": "rimraf --glob './packages/*/@(build|build-module|build-wp|build-style)'",
+		"clean:packages": "rimraf --glob './packages/*/{build,build-module,build-wp,build-style}'",
 		"component-usage-stats": "node ./node_modules/react-scanner/bin/react-scanner -c ./react-scanner.config.js",
 		"dev": "cross-env NODE_ENV=development npm run build:packages && concurrently \"wp-scripts start\" \"npm run dev:packages\"",
 		"dev:packages": "cross-env NODE_ENV=development concurrently \"node ./bin/packages/watch.js\" \"tsc --build --watch\"",

--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
 		"docs:gen": "node ./docs/tool/index.js",
 		"docs:theme-ref": "node ./bin/api-docs/gen-theme-reference.mjs",
 		"env": "wp-env",
-		"fixtures:clean": "rimraf --glob 'test/integration/fixtures/blocks/*.+(json|serialized.html)'",
+		"fixtures:clean": "rimraf --glob 'test/integration/fixtures/blocks/*.{json,serialized.html}'",
 		"fixtures:generate": "cross-env GENERATE_MISSING_FIXTURES=y npm run test:unit test/integration/full-content/ && npm run format test/integration/fixtures/blocks/*.json",
 		"fixtures:regenerate": "npm-run-all fixtures:clean fixtures:generate",
 		"format": "wp-scripts format",


### PR DESCRIPTION

## What?
Try braces instead of @-pattern to fix [a windows build issue](https://github.com/WordPress/wordpress-develop/actions/runs/12277835641/job/34258166878):

```
> gutenberg@19.9.0-rc.1 clean:packages
> rimraf --glob './packages/*/@(build|build-module|build-wp|build-style)'

'build-module' is not recognized as an internal or external command,
operable program or batch file.
```

**I don't have a good setup to debug this, I have no good way of reproducing the issue or verifying the fix.**

Follow-up to https://github.com/WordPress/gutenberg/pull/67829.


## Why?

Trying to get those windows build issues addressed.

## How?

Try a different glob pattern to expand to the desired paths.

## Testing Instructions
```sh
npm run build:packages
ls packages/interactivity
```

prints

```
build
build-module
build-types
src
CHANGELOG.md
README.md
package.json
tsconfig.json
tsconfig.test.json
tsconfig.test.tsbuildinfo
tsconfig.tsbuildinfo
```


```sh
npm run clean:packages
npm run clean:package-types
ls packages/interactivity
```

prints

```
src
CHANGELOG.md
README.md
package.json
tsconfig.json
tsconfig.test.json
```