### PR TITLE
RangeControl: animate thumb and track only when using marks

### DIFF
--- a/packages/components/src/range-control/styles/range-control-styles.ts
+++ b/packages/components/src/range-control/styles/range-control-styles.ts
@@ -130,8 +130,10 @@ export const Track = styled.span`
 	margin-top: ${ ( rangeHeightValue - railHeight ) / 2 }px;
 	top: 0;
 
-	@media not ( prefers-reduced-motion ) {
-		transition: width ease 0.1s;
+	.is-marked & {
+		@media not ( prefers-reduced-motion ) {
+			transition: width ease 0.1s;
+		}
 	}
 
 	${ trackBackgroundColor };
@@ -203,8 +205,10 @@ export const ThumbWrapper = styled.span`
 	border-radius: ${ CONFIG.radiusRound };
 	z-index: 3;
 
-	@media not ( prefers-reduced-motion ) {
-		transition: left ease 0.1s;
+	.is-marked & {
+		@media not ( prefers-reduced-motion ) {
+			transition: left ease 0.1s;
+		}
 	}
 
 	${ thumbColor };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/pull/67611/files#r1880356463

Tweaks the animation applied to the thumb and track elements of `RangeControl`, so that the animations only apply when the component is showing "marks"

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The animation can introduce a subtle delay that can make the experience of dragging the thumb feel slow and unresponsive.

This PR tries to achieve a good compromise by keeping the animation enabled when the component shows marks, since the experience of dragging the thumb is "stepped" and the animation doesn't really introduce a delay.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

CSS changes

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Drag the thumb on a `RangeControl` that doesn't show marks — the thumb and the slider should update instantly following the cursor (ie. no animation)
- Add `marks` to the `RangeControl` — the thumb and track should animate, like they already do on `trunk`

The difference is subtle. Artificially slowing down the transition duration could help debug the changes.