### PR TITLE
Widget Editor: Don't close the inserter when focusing outside it

### DIFF
--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -2,10 +2,7 @@
  * WordPress dependencies
  */
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
-import {
-	useViewportMatch,
-	__experimentalUseDialog as useDialog,
-} from '@wordpress/compose';
+import { useViewportMatch } from '@wordpress/compose';
 import { useCallback, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 
@@ -25,19 +22,10 @@ export default function InserterSidebar() {
 		return setIsInserterOpened( false );
 	}, [ setIsInserterOpened ] );
 
-	const [ inserterDialogRef, inserterDialogProps ] = useDialog( {
-		onClose: closeInserter,
-		focusOnMount: true,
-	} );
-
 	const libraryRef = useRef();
 
 	return (
-		<div
-			ref={ inserterDialogRef }
-			{ ...inserterDialogProps }
-			className="edit-widgets-layout__inserter-panel"
-		>
+		<div className="edit-widgets-layout__inserter-panel">
 			<div className="edit-widgets-layout__inserter-panel-content">
 				<Library
 					showInserterHelpPanel


### PR DESCRIPTION
## What?

Fixes #67809

In the widget editor, if you click "Browse all" after clicking the button inserter, the main inserter doesn't open. To solve this issue, we will not close the main inserter even if the focus is outside of it.

> [!NOTE]
> > In the widget editor, if you click "Browse all" after clicking the button inserter, the main inserter doesn't open.
>
> This problem has been fixed by https://github.com/WordPress/gutenberg/pull/68060. As a result, this PR only fixes the second problem described below.

## Why?

I identified this issue as being caused by #64877. The most likely cause is as follows, but note that there are two issues intertwined:

- Click "Browse All" from the button inserter. This will cause the main inserter to open.
- Normally, the first tab in the main inserter should be focused, but [this statement](https://github.com/WordPress/gutenberg/blob/dfa7a41e0d7bee9eb853a75336dd9dcf10bc3adc/packages/block-editor/src/components/button-block-appender/index.js#L37) will cause the button inserter to be focused again. This is not the expected behavior, so this is the **first** problem.
- The main inserter in the widget editor uses the `useDialog` hook. Since the button inserter is focused again, it is determined that "the outside is focused" and the main inserter that is about to be opened is immediately closed. This behavior is inconsistent with other editors, which is the **second** problem.

## How?

This PR removes the `useDialog` hook to **only solve the second issue**, meaning that the main inserter will not be closed when focus is gained outside of it, which makes it consistent with the behavior of other editors.

Related PR: https://github.com/WordPress/gutenberg/pull/61004/

## Testing Instructions

- Enable Twenty Twenty-One.
- Go to Appearance> Widgets.
- Open the main inserter.
- Click anywhere on the editor canvas.
  - trunk: The main inserter should close.
  - This PR: The main inserter should not close.
- Open the main inserter again.
- Click the button appender inside the Footer widget.
- **The main inserter should close.** However, this behaviour is intentional as other editors have the same behaviour.

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/6a0f1f4e-b7ee-4085-ab56-2355230ea042

### After

https://github.com/user-attachments/assets/5c10b17a-17cb-458a-a249-b3a2f1ac470e