### PR TITLE
Add /assets folder to build-plugin-zip

### DIFF
--- a/bin/build-plugin-zip.sh
+++ b/bin/build-plugin-zip.sh
@@ -88,6 +88,7 @@ zip --recurse-paths --no-dir-entries \
 	post-content.php \
 	build \
 	build-module \
+	assets \
 	readme.txt \
 	changelog.txt \
 	README.md


### PR DESCRIPTION
## What?
Fixes #67835  and helps implementing a Playground preview for the Gutenberg plugin in the WordPress plugin repository, that was added in a previous PR #67742 

## Why?
The plugin repository needs the /assets/blueprints/folder in the plugin.zip

## How?
added a line to the directories to be bundled. 

## Testing Instructions
Download the plugin.zip from the branch and see if the assets folder is included.
