### PR TITLE
Archives Block: Refactor setting panel

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -2,10 +2,11 @@
  * WordPress dependencies
  */
 import {
-	PanelBody,
 	ToggleControl,
 	SelectControl,
 	Disabled,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
@@ -17,55 +18,104 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<ToggleControl
-						__nextHasNoMarginBottom
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							displayAsDropdown: false,
+							showLabel: false,
+							showPostCounts: false,
+							type: 'monthly',
+						} );
+					} }
+				>
+					<ToolsPanelItem
 						label={ __( 'Display as dropdown' ) }
-						checked={ displayAsDropdown }
-						onChange={ () =>
-							setAttributes( {
-								displayAsDropdown: ! displayAsDropdown,
-							} )
+						isShownByDefault
+						hasValue={ () => displayAsDropdown }
+						onDeselect={ () =>
+							setAttributes( { displayAsDropdown: false } )
 						}
-					/>
-					{ displayAsDropdown && (
+					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show label' ) }
-							checked={ showLabel }
+							label={ __( 'Display as dropdown' ) }
+							checked={ displayAsDropdown }
 							onChange={ () =>
 								setAttributes( {
-									showLabel: ! showLabel,
+									displayAsDropdown: ! displayAsDropdown,
 								} )
 							}
 						/>
+					</ToolsPanelItem>
+
+					{ displayAsDropdown && (
+						<ToolsPanelItem
+							label={ __( 'Show label' ) }
+							isShownByDefault
+							hasValue={ () => showLabel }
+							onDeselect={ () =>
+								setAttributes( { showLabel: false } )
+							}
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show label' ) }
+								checked={ showLabel }
+								onChange={ () =>
+									setAttributes( {
+										showLabel: ! showLabel,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
 					) }
-					<ToggleControl
-						__nextHasNoMarginBottom
+
+					<ToolsPanelItem
 						label={ __( 'Show post counts' ) }
-						checked={ showPostCounts }
-						onChange={ () =>
-							setAttributes( {
-								showPostCounts: ! showPostCounts,
-							} )
+						isShownByDefault
+						hasValue={ () => showPostCounts }
+						onDeselect={ () =>
+							setAttributes( { showPostCounts: false } )
 						}
-					/>
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show post counts' ) }
+							checked={ showPostCounts }
+							onChange={ () =>
+								setAttributes( {
+									showPostCounts: ! showPostCounts,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+
+					<ToolsPanelItem
 						label={ __( 'Group by' ) }
-						options={ [
-							{ label: __( 'Year' ), value: 'yearly' },
-							{ label: __( 'Month' ), value: 'monthly' },
-							{ label: __( 'Week' ), value: 'weekly' },
-							{ label: __( 'Day' ), value: 'daily' },
-						] }
-						value={ type }
-						onChange={ ( value ) =>
-							setAttributes( { type: value } )
+						isShownByDefault
+						hasValue={ () => !! type }
+						onDeselect={ () =>
+							setAttributes( { type: 'monthly' } )
 						}
-					/>
-				</PanelBody>
+					>
+						<SelectControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Group by' ) }
+							options={ [
+								{ label: __( 'Year' ), value: 'yearly' },
+								{ label: __( 'Month' ), value: 'monthly' },
+								{ label: __( 'Week' ), value: 'weekly' },
+								{ label: __( 'Day' ), value: 'daily' },
+							] }
+							value={ type }
+							onChange={ ( value ) =>
+								setAttributes( { type: value } )
+							}
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
 				<Disabled>


### PR DESCRIPTION
Part of: #67813 

## What?
Refactored the code to include ToolsPanel instead of PanelBody.

## Screenshots

<table>
  <tr>
  <td colspan="1" width="33%"><b>Trunk</b></td>
  <td colspan="2" width="66%"><b>In this PR</b></td>
  </tr>
  <tr>
    <td width="33%">
      <img width="100%" alt="Screenshot 2024-12-11 at 9 39 30 PM" src="https://github.com/user-attachments/assets/31e36a96-3b83-4908-aff2-969e3b972be3" />
      </td>
    <td width="33%">
      <img width="100%" alt="Screenshot 2024-12-11 at 9 38 15 PM" src="https://github.com/user-attachments/assets/5eea62f8-4794-4bbc-8f65-ceea3f8d3c00" />
    </td>
    <td width="33%">
      <img width="100%" alt="Screenshot 2024-12-11 at 9 37 48 PM" src="https://github.com/user-attachments/assets/a167d3ef-ad39-4255-a54b-ea359459414a" />
    </td>
  </tr>
</table>




 


