### PR TITLE
Storybook: ColorPaletteControl

### DIFF
--- a/packages/block-editor/src/components/color-palette/stories/index.story.js
+++ b/packages/block-editor/src/components/color-palette/stories/index.story.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ColorPalette } from '@wordpress/block-editor';
+
+export default {
+	title: 'Components/ColorPaletteControl',
+	component: ColorPalette,
+	argTypes: {
+		onChange: { action: 'onChange' },
+	},
+};
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ color, setColor ] = useState( null );
+
+		return (
+			<div style={ { padding: '20px', background: '#f4f4f4' } }>
+				<ColorPalette
+					{ ...args }
+					value={ color }
+					onChange={ ( newColor ) => {
+						setColor( newColor );
+						onChange( newColor );
+					} }
+				/>
+				<div style={ { marginTop: '10px' } }>
+					<strong>Selected Color:</strong> { color || 'None' }
+				</div>
+			</div>
+		);
+	},
+	args: {
+		colors: [
+			{ name: 'Red', color: '#f00' },
+			{ name: 'Green', color: '#0f0' },
+			{ name: 'Blue', color: '#00f' },
+			{ name: 'Yellow', color: '#ff0' },
+		],
+		disableCustomColors: false,
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR will add stories for ColorPaletteControl components in the Storybook


## Why?
Most of Block Editor components don't have stories.
Block Editor components's Storybook should also be added and updated like the Components. 
Currently ColorPaletteControl story is not availbale.


Part of https://github.com/WordPress/gutenberg/issues/67165

## How?
Adding story for ColorPaletteControl

## Testing Instructions

1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the ColorPaletteControl stories.



## Screenshots or screencast <!-- if applicable -->
![colorpalette](https://github.com/user-attachments/assets/521427d4-874d-4420-a41f-dfbac1474e6d)


