### PR TITLE
FontFamilyControl: Deprecate 36px default size

### DIFF
--- a/packages/block-editor/src/components/font-family/README.md
+++ b/packages/block-editor/src/components/font-family/README.md
@@ -29,6 +29,7 @@ const MyFontFamilyControl = () => {
 				setFontFamily( newFontFamily );
 			} }
 			__nextHasNoMarginBottom
+			__next40pxDefaultSize
 		/>
 	);
 };

--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -58,6 +58,20 @@ export default function FontFamilyControl( {
 		);
 	}
 
+	if (
+		! __next40pxDefaultSize &&
+		( props.size === undefined || props.size === 'default' )
+	) {
+		deprecated(
+			`36px default size for wp.blockEditor.__experimentalFontFamilyControl`,
+			{
+				since: '6.8',
+				version: '7.1',
+				hint: 'Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.',
+			}
+		);
+	}
+
 	return (
 		<CustomSelectControl
 			__next40pxDefaultSize={ __next40pxDefaultSize }

--- a/packages/block-editor/src/components/font-family/stories/index.story.js
+++ b/packages/block-editor/src/components/font-family/stories/index.story.js
@@ -50,5 +50,6 @@ export const Default = {
 			},
 		],
 		__nextHasNoMarginBottom: true,
+		__next40pxDefaultSize: true,
 	},
 };


### PR DESCRIPTION
Part of #65751

## What?

Deprecates the 36px default size on `FontFamilyControl`.

## Testing Instructions

A props combination like this in the component Storybook should not log a warning:

```js
Default.args = {
	__next40pxDefaultSize: false,
	size: '__unstable-large',
};
```

But unless there is a non-`'default'` `size` prop, it should log a warning when `__next40pxDefaultSize` is falsey.