### PR TITLE
FontAppearanceControl: Deprecate 36px default size

### DIFF
--- a/packages/block-editor/src/components/font-appearance-control/index.js
+++ b/packages/block-editor/src/components/font-appearance-control/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { CustomSelectControl } from '@wordpress/components';
+import deprecated from '@wordpress/deprecated';
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -146,6 +147,20 @@ export default function FontAppearanceControl( props ) {
 			currentSelection.name
 		);
 	};
+
+	if (
+		! __next40pxDefaultSize &&
+		( otherProps.size === undefined || otherProps.size === 'default' )
+	) {
+		deprecated(
+			`36px default size for wp.blockEditor.__experimentalFontAppearanceControl`,
+			{
+				since: '6.8',
+				version: '7.1',
+				hint: 'Set the `__next40pxDefaultSize` prop to true to start opting into the new default size, which will become the default in a future version.',
+			}
+		);
+	}
 
 	return (
 		hasStylesOrWeights && (


### PR DESCRIPTION
Part of #65751

## What?

Deprecates the 36px default size on `FontAppearanceControl`.

## Testing Instructions

Add a Paragraph block in the block editor and add an Appearance control from the Typography section in the block inspector.

(You might see a `useSelect` warning in the console, but that is being [addressed](https://github.com/WordPress/gutenberg/pull/67743/files#r1878398085).)

Changing the props on here should log a warning (e.g. removing the `size` prop):

https://github.com/WordPress/gutenberg/blob/8a10c7512a275f15201b389c3b9391652808f383/packages/block-editor/src/components/global-styles/typography-panel.js#L454-L464