### PR TITLE
Columns & Column: Add support for `Add Column` Button to append a column

### DIFF
--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -17,12 +17,49 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
+	ToolbarButton,
 	__experimentalUseCustomUnits as useCustomUnits,
 	PanelBody,
 	__experimentalUnitControl as UnitControl,
 } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
+
+function AddColumnButton() {
+	const { insertBlock } = useDispatch( blockEditorStore );
+	const { _getBlockRootClientId, _getBlockIndex, _getSelectedBlockClientId } =
+		useSelect( ( select ) => {
+			const {
+				getBlockRootClientId,
+				getBlockIndex,
+				getSelectedBlockClientId,
+			} = select( blockEditorStore );
+
+			return {
+				_getBlockRootClientId: getBlockRootClientId,
+				_getBlockIndex: getBlockIndex,
+				_getSelectedBlockClientId: getSelectedBlockClientId,
+			};
+		} );
+
+	const handleAddColumn = () => {
+		const selectedBlockClientId = _getSelectedBlockClientId();
+		const newColumn = createBlock( 'core/column' );
+		const rootClientId = _getBlockRootClientId( selectedBlockClientId );
+		const currentBlockIndex = _getBlockIndex( selectedBlockClientId );
+
+		insertBlock( newColumn, currentBlockIndex + 1, rootClientId, true );
+	};
+
+	return (
+		<BlockControls group="block">
+			<ToolbarButton onClick={ handleAddColumn }>
+				{ __( 'Add Column' ) }
+			</ToolbarButton>
+		</BlockControls>
+	);
+}
 
 function ColumnInspectorControls( { width, setAttributes } ) {
 	const [ availableUnits ] = useSettings( 'spacing.units' );
@@ -124,6 +161,7 @@ function ColumnEdit( {
 					setAttributes={ setAttributes }
 				/>
 			</InspectorControls>
+			<AddColumnButton />
 			<div { ...innerBlocksProps } />
 		</>
 	);

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -53,7 +53,7 @@ function AddColumnButton() {
 	};
 
 	return (
-		<BlockControls group="block">
+		<BlockControls group="other">
 			<ToolbarButton onClick={ handleAddColumn }>
 				{ __( 'Add Column' ) }
 			</ToolbarButton>

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -12,6 +12,7 @@ import {
 	PanelBody,
 	RangeControl,
 	ToggleControl,
+	ToolbarButton,
 } from '@wordpress/components';
 
 import {
@@ -43,6 +44,32 @@ import {
 const DEFAULT_BLOCK = {
 	name: 'core/column',
 };
+
+function AddColumnButton() {
+	const { insertBlock } = useDispatch( blockEditorStore );
+	const { _getSelectedBlockClientId } = useSelect( ( select ) => {
+		const { getSelectedBlockClientId } = select( blockEditorStore );
+
+		return {
+			_getSelectedBlockClientId: getSelectedBlockClientId,
+		};
+	} );
+
+	const handleAddColumn = () => {
+		const selectedBlockClientId = _getSelectedBlockClientId();
+		const newColumn = createBlock( 'core/column' );
+
+		insertBlock( newColumn, 0, selectedBlockClientId, true );
+	};
+
+	return (
+		<BlockControls group="other">
+			<ToolbarButton onClick={ handleAddColumn }>
+				{ __( 'Add Column' ) }
+			</ToolbarButton>
+		</BlockControls>
+	);
+}
 
 function ColumnInspectorControls( {
 	clientId,
@@ -243,6 +270,7 @@ function ColumnsEditContainer( { attributes, setAttributes, clientId } ) {
 					isStackedOnMobile={ isStackedOnMobile }
 				/>
 			</InspectorControls>
+			<AddColumnButton />
 			<div { ...innerBlocksProps } />
 		</>
 	);


### PR DESCRIPTION
Fixes: #67843 

## What?
This PR adds an `enhancement` to add a new column by pressing the `Add Column` button from the `Block Controls` to simplify the process of creating a new `Column`

## Why?
Introduces simplification in the process of appending a`Column`.

## How?
A `ToolbarButton` named `Add Column` is added to the `BlockControls` of both the `Column` and `Columns` Component.

## Testing Instructions
1. Insert a Columns Block.
2. Notice the new `Add Column` Button in the `BlockControls`.
3. Click on `Add Column` to add a new column.
4. Notice a similar `Add Column` button on `Column` Blocks inside `Columns`.
5. Click on `Add Column` Button of `Column` Block and observe a new `Column` added inside the same parent.

## Screencast

https://github.com/user-attachments/assets/6a084d30-652b-438c-b0f9-a4fc7d413e4d


