### PR TITLE
Adding command for Manage template

### DIFF
--- a/packages/core-commands/src/site-editor-navigation-commands.js
+++ b/packages/core-commands/src/site-editor-navigation-commands.js
@@ -406,6 +406,54 @@ const getSiteEditorBasicNavigationCommands = () =>
 			isLoading: false,
 		};
 	};
+const useManageTemplateCommand = () => {
+	const history = useHistory();
+	const isSiteEditor = getPath( window.location.href )?.includes(
+		'site-editor.php'
+	);
+	const { isBlockBasedTheme, canCreateTemplate } = useSelect(
+		( select ) => ( {
+			isBlockBasedTheme:
+				select( coreStore ).getCurrentTheme()?.is_block_theme,
+			canCreateTemplate: select( coreStore ).canUser( 'create', {
+				kind: 'postType',
+				name: 'wp_template',
+			} ),
+		} ),
+		[]
+	);
+
+	const commands = useMemo( () => {
+		if ( ! canCreateTemplate || ! isBlockBasedTheme ) {
+			return [];
+		}
+
+		return [
+			{
+				name: 'core/edit-site/open-templates',
+				label: __( 'Manage Templates' ),
+				icon: layout,
+				callback: ( { close } ) => {
+					const args = {
+						postType: 'wp_template',
+					};
+					const targetUrl = addQueryArgs( 'site-editor.php', args );
+					if ( isSiteEditor ) {
+						history.navigate( '/template' );
+					} else {
+						document.location = targetUrl;
+					}
+					close();
+				},
+			},
+		];
+	}, [ canCreateTemplate, isBlockBasedTheme, history, isSiteEditor ] );
+
+	return {
+		commands,
+		isLoading: false,
+	};
+};
 
 export function useSiteEditorNavigationCommands() {
 	useCommandLoader( {
@@ -428,5 +476,11 @@ export function useSiteEditorNavigationCommands() {
 		name: 'core/edit-site/basic-navigation',
 		hook: getSiteEditorBasicNavigationCommands(),
 		context: 'site-editor',
+	} );
+	useCommandLoader( {
+		name: 'core/edit-site/open-templates',
+		/* eslint-disable-next-line react-compiler/react-compiler */
+		hook: useManageTemplateCommand,
+		context: 'entity-edit',
 	} );
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/63385

## Why?
Currently` Manage Template` command is not available.


## How?
Added command for manage templates from command box.


## Testing Instructions

- Go to site editor in the WordPress admin.
- Navigate to templates.
- Choose any template to edit.
- Click on the template title,  then `Manage template` command will be available in command palette.
- Select the command and confirm it is properly navigating to template list.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/28ca0636-1f50-48a5-a78b-694f31ec76ff


