### PR TITLE
Storybook: Fix warnings in Layout document

### DIFF
--- a/storybook/stories/foundations/layout.mdx
+++ b/storybook/stories/foundations/layout.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs/blocks';
+import { Meta } from '@storybook/blocks';
 import areas from './static/areas.svg';
 import pageLayoutExample1 from './static/page-layout-example-1.svg';
 import pageLayoutExample2 from './static/page-layout-example-2.svg';
@@ -27,32 +27,34 @@ At the highest level admin pages are comprised of _areas_, that can be arranged 
 Areas can be combined in different ways depending on the use case. Here are some examples.
 
 <table>
-	<tr>
-		<td style={{verticalAlign: 'top', width: '50%'}}>
-			#### Sidebar, Content Frame and Preview Frame
-			<img src={ pageLayoutExample1 } alt="Diagram illustrating an example of the 'Sidebar, Content Frame and Preview Frame' arrangement" width="100%" />
+	<tbody>
+		<tr>
+			<td style={{verticalAlign: 'top', width: '50%'}}>
+				#### Sidebar, Content Frame and Preview Frame
+				<img src={ pageLayoutExample1 } alt="Diagram illustrating an example of the 'Sidebar, Content Frame and Preview Frame' arrangement" width="100%" />
 
-			A demonstration of this arrangement can be found in the Styles section of the Site Editor, and in the Pages and Templates sections when List layout is selected.
-		</td>
-		<td style={{verticalAlign: 'top', width: '50%'}}>
-			#### Sidebar and Preview Frame
-			<img src={ pageLayoutExample2 } alt="Diagram illustrating an example of the 'Sidebar and Preview Frame' arrangement" width="100%" />
+				A demonstration of this arrangement can be found in the Styles section of the Site Editor, and in the Pages and Templates sections when List layout is selected.
+			</td>
+			<td style={{verticalAlign: 'top', width: '50%'}}>
+				#### Sidebar and Preview Frame
+				<img src={ pageLayoutExample2 } alt="Diagram illustrating an example of the 'Sidebar and Preview Frame' arrangement" width="100%" />
 
-			A demonstration of this arrangement can be found in the Design section.
-		</td>
-	</tr>
-	<tr>
-		<td style={{verticalAlign: 'top', width: '50%'}}>
-			#### Sidebar and Content Frame
-			<img src={ pageLayoutExample3 } alt="Diagram illustrating an example of the 'Sidebar and Content Frame' arrangement" width="100%" />
+				A demonstration of this arrangement can be found in the Design section.
+			</td>
+		</tr>
+		<tr>
+			<td style={{verticalAlign: 'top', width: '50%'}}>
+				#### Sidebar and Content Frame
+				<img src={ pageLayoutExample3 } alt="Diagram illustrating an example of the 'Sidebar and Content Frame' arrangement" width="100%" />
 
-			A demonstration of this arrangement can be found in the Patterns and Templates sections of the Site Editor, or in the Pages section when Table or Grid layout are selected.
-		</td>
-		<td style={{verticalAlign: 'top', width: '50%'}}>
-			#### Sidebar and multiple Content Frames
-			<img src={ pageLayoutExample4 } alt="Diagram illustrating an example of the 'Sidebar and multiple Content Frames' arrangement" width="100%" />
+				A demonstration of this arrangement can be found in the Patterns and Templates sections of the Site Editor, or in the Pages section when Table or Grid layout are selected.
+			</td>
+			<td style={{verticalAlign: 'top', width: '50%'}}>
+				#### Sidebar and multiple Content Frames
+				<img src={ pageLayoutExample4 } alt="Diagram illustrating an example of the 'Sidebar and multiple Content Frames' arrangement" width="100%" />
 
-			Multiple content frames can be utilised as required.
-		</td>
-	</tr>
+				Multiple content frames can be utilised as required.
+			</td>
+		</tr>
+	</tbody>
 </table>


### PR DESCRIPTION
## What?
Fixing a warning and an error in the `Foundations: Layout` document in Storybook.

## Why?
To keeping code high quality and prevent unnecessary warnings and errors.

Found while working on #67863.

## How?
We're importing from `@storybook/blocks` and adding a `tbody` wrapper. 

## Testing Instructions
* Open http://localhost:50240/?path=/docs/foundations-layout--page
* Verify you no longer see the warning and the error from the screenshot.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2024-12-12 at 11 44 43](https://github.com/user-attachments/assets/f3ae801b-ba4b-4dc3-90df-4cefb1151cf6)
