### PR TITLE
REST API: Simplify 'default_rendering_mode' field registration for post types

### DIFF
--- a/backport-changelog/6.8/7129.md
+++ b/backport-changelog/6.8/7129.md
@@ -2,3 +2,4 @@ https://github.com/WordPress/wordpress-develop/pull/7129
 
 * https://github.com/WordPress/gutenberg/pull/62304
 * https://github.com/WordPress/gutenberg/pull/67879
+* https://github.com/WordPress/gutenberg/pull/67867

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-post-types-controller-6-8.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-post-types-controller-6-8.php
@@ -13,29 +13,33 @@
  * @return void
  */
 function gutenberg_editor_rendering_mode_field() {
-	register_rest_field( 'type', 'default_rendering_mode', array(
-		'get_callback' => static function( $object ) {
-			$post_type_object = get_post_type_object( $object['slug'] );
+	register_rest_field(
+		'type',
+		'default_rendering_mode',
+		array(
+			'get_callback' => static function ( $object ) {
+				$post_type_object = get_post_type_object( $object['slug'] );
 
-			// Property will only exist if the post type supports the block editor.
-			if ( ! $post_type_object || ! isset( $post_type_object->default_rendering_mode ) ) {
-				return '';
-			}
+				// Property will only exist if the post type supports the block editor.
+				if ( ! $post_type_object || ! isset( $post_type_object->default_rendering_mode ) ) {
+					return 'post-only';
+				}
 
-			// Validate the filtered rendering mode.
-			if ( ! in_array( $post_type_object->default_rendering_mode, gutenberg_post_type_rendering_modes(), true ) ) {
-				return 'post-only';
-			}
+				// Validate the filtered rendering mode.
+				if ( ! in_array( $post_type_object->default_rendering_mode, gutenberg_post_type_rendering_modes(), true ) ) {
+					return 'post-only';
+				}
 
-			return $post_type_object->default_rendering_mode;
-		},
-		'schema' => array(
-			'description' => __( 'The rendering mode for the editor.', 'gutenberg' ),
-			'type'        => 'string',
-			'enum'        => array( 'post-only', 'template-locked' ),
-			'context'     => array( 'edit' ),
-			'readonly'    => true,
-		),
-	) );
+				return $post_type_object->default_rendering_mode;
+			},
+			'schema'       => array(
+				'description' => __( 'The rendering mode for the editor.', 'gutenberg' ),
+				'type'        => 'string',
+				'enum'        => array( 'post-only', 'template-locked' ),
+				'context'     => array( 'edit' ),
+				'readonly'    => true,
+			),
+		)
+	);
 }
 add_action( 'rest_api_init', 'gutenberg_editor_rendering_mode_field' );

--- a/lib/compat/wordpress-6.8/class-gutenberg-rest-post-types-controller-6-8.php
+++ b/lib/compat/wordpress-6.8/class-gutenberg-rest-post-types-controller-6-8.php
@@ -6,56 +6,36 @@
  */
 
 /**
- * Gutenberg_REST_Post_Types_Controller_6_8 class
+ * Register a REST field for the default rendering mode of a post type.
  *
- * Add Block Editor default rendering mode to the post type response
- * to allow enabling/disabling at the post type level.
+ * Note: Logic will become part of the `prepare_item_for_response` method when backporting to the core.
+ *
+ * @return void
  */
-class Gutenberg_REST_Post_Types_Controller_6_8 extends WP_REST_Post_Types_Controller {
-	/**
-	 * Add Block Editor default rendering mode setting to the response.
-	 *
-	 * @param  WP_Post_Type    $item    Post type object.
-	 * @param  WP_REST_Request $request Request object.
-	 * @return WP_REST_Response Response object.
-	 */
-	public function prepare_item_for_response( $item, $request ) {
-		$response = parent::prepare_item_for_response( $item, $request );
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+function gutenberg_editor_rendering_mode_field() {
+	register_rest_field( 'type', 'default_rendering_mode', array(
+		'get_callback' => static function( $object ) {
+			$post_type_object = get_post_type_object( $object['slug'] );
 
-		// Property will only exist if the post type supports the block editor.
-		if ( 'edit' === $context && property_exists( $item, 'default_rendering_mode' ) ) {
-			/**
-			 * Filters the block editor rendering mode for a post type.
-			 *
-			 * @since 6.8.0
-			 * @param string       $default_rendering_mode Default rendering mode for the post type.
-			 * @param WP_Post_Type $post_type              Post type name.
-			 * @return string Default rendering mode for the post type.
-			 */
-			$rendering_mode = apply_filters( 'post_type_default_rendering_mode', $item->default_rendering_mode, $item );
-
-			/**
-			 * Filters the block editor rendering mode for a specific post type.
-			 * Applied after the generic `post_type_default_rendering_mode` filter.
-			 *
-			 * The dynamic portion of the hook name, `$item->name`, refers to the post type slug.
-			 *
-			 * @since 6.8.0
-			 * @param string       $default_rendering_mode Default rendering mode for the post type.
-			 * @param WP_Post_Type $post_type              Post type object.
-			 * @return string Default rendering mode for the post type.
-			 */
-			$rendering_mode = apply_filters( "post_type_{$item->name}_default_rendering_mode", $rendering_mode, $item );
-
-			// Validate the filtered rendering mode.
-			if ( ! in_array( $rendering_mode, gutenberg_post_type_rendering_modes(), true ) ) {
-				$rendering_mode = 'post-only';
+			// Property will only exist if the post type supports the block editor.
+			if ( ! $post_type_object || ! isset( $post_type_object->default_rendering_mode ) ) {
+				return '';
 			}
 
-			$response->data['default_rendering_mode'] = $rendering_mode;
-		}
+			// Validate the filtered rendering mode.
+			if ( ! in_array( $post_type_object->default_rendering_mode, gutenberg_post_type_rendering_modes(), true ) ) {
+				return 'post-only';
+			}
 
-		return rest_ensure_response( $response );
-	}
+			return $post_type_object->default_rendering_mode;
+		},
+		'schema' => array(
+			'description' => __( 'The rendering mode for the editor.', 'gutenberg' ),
+			'type'        => 'string',
+			'enum'        => array( 'post-only', 'template-locked' ),
+			'context'     => array( 'edit' ),
+			'readonly'    => true,
+		),
+	) );
 }
+add_action( 'rest_api_init', 'gutenberg_editor_rendering_mode_field' );

--- a/lib/compat/wordpress-6.8/rest-api.php
+++ b/lib/compat/wordpress-6.8/rest-api.php
@@ -10,17 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	die( 'Silence is golden.' );
 }
 
-if ( ! function_exists( 'gutenberg_add_post_type_rendering_mode' ) ) {
-	/**
-	 * Add Block Editor default rendering mode to the post type response.
-	 */
-	function gutenberg_add_post_type_rendering_mode() {
-		$controller = new Gutenberg_REST_Post_Types_Controller_6_8();
-		$controller->register_routes();
-	}
-}
-add_action( 'rest_api_init', 'gutenberg_add_post_type_rendering_mode' );
-
 // When querying terms for a given taxonomy in the REST API, respect the default
 // query arguments set for that taxonomy upon registration.
 function gutenberg_respect_taxonomy_default_args_in_rest_api( $args ) {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -179,15 +179,17 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					getRenderingMode,
 					__unstableIsEditorReady,
 				} = select( editorStore );
-				const { getEntitiesConfig } = select( coreStore );
+				const {
+					getEntitiesConfig,
+					getPostType,
+					hasFinishedResolution,
+				} = select( coreStore );
 
-				const postTypeObject = select( coreStore ).getPostType(
-					post.type
+				const postTypeObject = getPostType( post.type );
+				const _hasLoadedPostObject = hasFinishedResolution(
+					'getPostType',
+					[ post.type ]
 				);
-
-				const _hasLoadedPostObject = select(
-					coreStore
-				).hasFinishedResolution( 'getPostType', [ post.type ] );
 
 				return {
 					hasLoadedPostObject: _hasLoadedPostObject,
@@ -195,7 +197,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					isReady: __unstableIsEditorReady(),
 					mode: getRenderingMode(),
 					defaultMode:
-						postTypeObject?.default_rendering_mode ?? 'post-only',
+						postTypeObject?.default_rendering_mode || 'post-only',
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'


### PR DESCRIPTION
## What?
A follow-up to #62304.

Simplifies the registration of the `default_rendering_mode` post-type REST property by adding it via `register_rest_field` instead of a controller override. It also adds a schema for the new property.

I've removed the new filters introduced in the original PR. Why:

* Response properties rarely have separate filters.
* They only allowed filtering `default_rendering_mode` for REST API responses. This could cause some unexpected results.
* Consumers can easily override the value using the existing `register_post_type_args` or `rest_prepare_post_type` filters.

In the future, we could provide API like [`add_post_type_support`](https://developer.wordpress.org/reference/functions/add_post_type_support/), but first, let's see how these configurations mature.

cc @TylerB24890

## Testing Instructions
1. Open a page.
2. Confirm that it's rendered in `template-locked` mode.

### Testing Instructions for Keyboard
Same.