### PR TITLE
core-data: remove dependency on block-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53415,7 +53415,6 @@
 			"dependencies": {
 				"@babel/runtime": "7.25.7",
 				"@wordpress/api-fetch": "*",
-				"@wordpress/block-editor": "*",
 				"@wordpress/blocks": "*",
 				"@wordpress/compose": "*",
 				"@wordpress/data": "*",

--- a/packages/block-editor/src/components/inner-blocks/index.js
+++ b/packages/block-editor/src/components/inner-blocks/index.js
@@ -13,6 +13,7 @@ import {
 	getBlockSupport,
 	store as blocksStore,
 	__unstableGetInnerBlocksProps as getInnerBlocksProps,
+	InnerBlocksContent,
 } from '@wordpress/blocks';
 
 /**
@@ -309,7 +310,7 @@ useInnerBlocksProps.save = getInnerBlocksProps;
 ForwardedInnerBlocks.DefaultBlockAppender = DefaultBlockAppender;
 ForwardedInnerBlocks.ButtonBlockAppender = ButtonBlockAppender;
 
-ForwardedInnerBlocks.Content = () => useInnerBlocksProps.save().children;
+ForwardedInnerBlocks.Content = InnerBlocksContent;
 
 /**
  * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/inner-blocks/README.md

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -20,7 +20,11 @@ import {
 	removeFormat,
 } from '@wordpress/rich-text';
 import { Popover } from '@wordpress/components';
-import { getBlockBindingsSource } from '@wordpress/blocks';
+import {
+	getBlockBindingsSource,
+	RichTextContent,
+	valueToHTMLString,
+} from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -37,7 +41,6 @@ import { useFormatTypes } from './use-format-types';
 import { useEventListeners } from './event-listeners';
 import FormatEdit from './format-edit';
 import { getAllowedFormats } from './utils';
-import { Content, valueToHTMLString } from './content';
 import { withDeprecations } from './with-deprecations';
 import { canBindBlock } from '../../utils/block-bindings';
 import BlockContext from '../block-context';
@@ -504,7 +507,7 @@ export const PrivateRichText = withDeprecations(
 	forwardRef( RichTextWrapper )
 );
 
-PrivateRichText.Content = Content;
+PrivateRichText.Content = RichTextContent;
 PrivateRichText.isEmpty = ( value ) => {
 	return ! value || value.length === 0;
 };
@@ -562,7 +565,7 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 	return <PrivateRichText ref={ ref } { ...props } readOnly={ false } />;
 } );
 
-PublicForwardedRichTextContainer.Content = Content;
+PublicForwardedRichTextContainer.Content = RichTextContent;
 PublicForwardedRichTextContainer.isEmpty = ( value ) => {
 	return ! value || value.length === 0;
 };

--- a/packages/block-editor/src/components/rich-text/index.native.js
+++ b/packages/block-editor/src/components/rich-text/index.native.js
@@ -14,6 +14,7 @@ import {
 	getBlockTransforms,
 	findTransform,
 	isUnmodifiedDefaultBlock,
+	RichTextContent,
 } from '@wordpress/blocks';
 import { useInstanceId, useMergeRefs } from '@wordpress/compose';
 import {
@@ -42,7 +43,6 @@ import {
 	createLinkInParagraph,
 } from './utils';
 import EmbedHandlerPicker from './embed-handler-picker';
-import { Content } from './content';
 import RichText from './native';
 import { withDeprecations } from './with-deprecations';
 import { findSelection } from './event-listeners/input-rules';
@@ -679,7 +679,7 @@ export const PrivateRichText = withDeprecations(
 	forwardRef( RichTextWrapper )
 );
 
-PrivateRichText.Content = Content;
+PrivateRichText.Content = RichTextContent;
 
 PrivateRichText.isEmpty = ( value ) => {
 	return ! value || value.length === 0;

--- a/packages/block-editor/src/private-apis.js
+++ b/packages/block-editor/src/private-apis.js
@@ -4,7 +4,6 @@
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
 import { lock } from './lock-unlock';
-import { getRichTextValues } from './components/rich-text/get-rich-text-values';
 import ResizableBoxPopover from './components/resizable-box-popover';
 import { default as PrivateQuickInserter } from './components/inserter/quick-inserter';
 import {
@@ -59,7 +58,6 @@ lock( privateApis, {
 	ExperimentalBlockCanvas,
 	ExperimentalBlockEditorProvider,
 	getDuotoneFilter,
-	getRichTextValues,
 	PrivateQuickInserter,
 	extractWords,
 	getNormalizedSearchTerms,

--- a/packages/block-editor/src/private-apis.native.js
+++ b/packages/block-editor/src/private-apis.native.js
@@ -3,7 +3,6 @@
  */
 import * as globalStyles from './components/global-styles';
 import { ExperimentalBlockEditorProvider } from './components/provider';
-import { getRichTextValues } from './components/rich-text/get-rich-text-values';
 import { lock } from './lock-unlock';
 import { PrivateRichText } from './components/rich-text/';
 
@@ -14,6 +13,5 @@ export const privateApis = {};
 lock( privateApis, {
 	...globalStyles,
 	ExperimentalBlockEditorProvider,
-	getRichTextValues,
 	PrivateRichText,
 } );

--- a/packages/blocks/README.md
+++ b/packages/blocks/README.md
@@ -291,6 +291,10 @@ _Returns_
 
 -   `Array`: Block types that the blocks argument can be transformed to.
 
+### getRichTextValues
+
+Undocumented declaration.
+
 ### getSaveContent
 
 Given a block type containing a save render implementation and attributes, returns the static markup to be saved.
@@ -364,6 +368,10 @@ _Parameters_
 _Returns_
 
 -   `boolean`: True if a block contains at least one child blocks with inserter support and false otherwise.
+
+### InnerBlocksContent
+
+Undocumented declaration.
 
 ### isReusableBlock
 
@@ -680,6 +688,10 @@ _Parameters_
 
 -   _blockName_ `string`: Name of the block (example: “core/columns”).
 -   _variation_ `WPBlockVariation`: Object describing a block variation.
+
+### RichTextContent
+
+Undocumented declaration.
 
 ### serialize
 
@@ -1003,6 +1015,10 @@ _Parameters_
 _Returns_
 
 -   `[boolean,Array<LoggerItem>]`: validation results.
+
+### valueToHTMLString
+
+Undocumented declaration.
 
 ### withBlockContentContext
 

--- a/packages/blocks/src/api/content.js
+++ b/packages/blocks/src/api/content.js
@@ -2,27 +2,38 @@
  * WordPress dependencies
  */
 import { RawHTML } from '@wordpress/element';
-import { children as childrenSource } from '@wordpress/blocks';
 import deprecated from '@wordpress/deprecated';
 
 /**
  * Internal dependencies
  */
-import RichText from './';
+import childrenSource from './children';
+import { getInnerBlocksProps } from './serializer';
 
-/**
- * Internal dependencies
- */
-import { getMultilineTag } from './utils';
+export function InnerBlocksContent() {
+	return getInnerBlocksProps().children;
+}
+
+function isEmpty( value ) {
+	return ! value || value.length === 0;
+}
+
+function getMultilineTag( multiline ) {
+	if ( multiline !== true && multiline !== 'p' && multiline !== 'li' ) {
+		return undefined;
+	}
+
+	return multiline === true ? 'p' : multiline;
+}
 
 export function valueToHTMLString( value, multiline ) {
-	if ( RichText.isEmpty( value ) ) {
+	if ( isEmpty( value ) ) {
 		const multilineTag = getMultilineTag( multiline );
 		return multilineTag ? `<${ multilineTag }></${ multilineTag }>` : '';
 	}
 
 	if ( Array.isArray( value ) ) {
-		deprecated( 'wp.blockEditor.RichText value prop as children type', {
+		deprecated( 'wp.blocks.RichTextContent value prop as children type', {
 			since: '6.1',
 			version: '6.3',
 			alternative: 'value prop as string',
@@ -42,7 +53,7 @@ export function valueToHTMLString( value, multiline ) {
 	return value.toHTMLString();
 }
 
-export function Content( {
+export function RichTextContent( {
 	value,
 	tagName: Tag,
 	multiline,

--- a/packages/blocks/src/api/get-rich-text-values.js
+++ b/packages/blocks/src/api/get-rich-text-values.js
@@ -2,17 +2,13 @@
  * WordPress dependencies
  */
 import { RawHTML, StrictMode, Fragment } from '@wordpress/element';
-import {
-	getSaveElement,
-	__unstableGetBlockProps as getBlockProps,
-} from '@wordpress/blocks';
 import { RichTextData } from '@wordpress/rich-text';
 
 /**
  * Internal dependencies
  */
-import InnerBlocks from '../inner-blocks';
-import { Content } from './content';
+import { getSaveElement, getBlockProps } from './serializer';
+import { InnerBlocksContent, RichTextContent } from './content';
 
 /*
  * This function is similar to `@wordpress/element`'s `renderToString` function,
@@ -42,9 +38,9 @@ function addValuesForElement( element, values, innerBlocks ) {
 			return addValuesForElements( props.children, values, innerBlocks );
 		case RawHTML:
 			return;
-		case InnerBlocks.Content:
+		case InnerBlocksContent:
 			return addValuesForBlocks( values, innerBlocks );
-		case Content:
+		case RichTextContent:
 			values.push( props.value );
 			return;
 	}
@@ -85,7 +81,7 @@ function addValuesForBlocks( values, blocks ) {
 			// Instead of letting save elements use `useInnerBlocksProps.save`,
 			// force them to use InnerBlocks.Content instead so we can intercept
 			// a single component.
-			<InnerBlocks.Content />
+			<InnerBlocksContent />
 		);
 		addValuesForElement( saveElement, values, innerBlocks );
 	}

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -175,6 +175,12 @@ export {
 	__EXPERIMENTAL_ELEMENTS,
 	__EXPERIMENTAL_PATHS_WITH_OVERRIDE,
 } from './constants';
+export {
+	RichTextContent,
+	InnerBlocksContent,
+	valueToHTMLString,
+} from './content';
+export { getRichTextValues } from './get-rich-text-values';
 
 export const privateApis = {};
 lock( privateApis, { isContentBlock } );

--- a/packages/core-data/package.json
+++ b/packages/core-data/package.json
@@ -34,7 +34,6 @@
 	"dependencies": {
 		"@babel/runtime": "7.25.7",
 		"@wordpress/api-fetch": "*",
-		"@wordpress/block-editor": "*",
 		"@wordpress/blocks": "*",
 		"@wordpress/compose": "*",
 		"@wordpress/data": "*",

--- a/packages/core-data/src/footnotes/get-rich-text-values-cached.js
+++ b/packages/core-data/src/footnotes/get-rich-text-values-cached.js
@@ -1,35 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { privateApis as blockEditorPrivateApis } from '@wordpress/block-editor';
-
-/**
- * Internal dependencies
- */
-import { unlock } from '../lock-unlock';
-
-// TODO: The following line should have been:
-//
-//   const unlockedApis = unlock( blockEditorPrivateApis );
-//
-// But there are hidden circular dependencies in RNMobile code, specifically in
-// certain native components in the `components` package that depend on
-// `block-editor`. What follows is a workaround that defers the `unlock` call
-// to prevent native code from failing.
-//
-// Fix once https://github.com/WordPress/gutenberg/issues/52692 is closed.
-let unlockedApis;
+import { getRichTextValues } from '@wordpress/blocks';
 
 const cache = new WeakMap();
 
 export default function getRichTextValuesCached( block ) {
-	if ( ! unlockedApis ) {
-		unlockedApis = unlock( blockEditorPrivateApis );
-	}
-
-	if ( ! cache.has( block ) ) {
-		const values = unlockedApis.getRichTextValues( [ block ] );
+	let values = cache.get( block );
+	if ( ! values ) {
+		values = getRichTextValues( [ block ] );
 		cache.set( block, values );
 	}
-	return cache.get( block );
+	return values;
 }


### PR DESCRIPTION
This PR removes the `block-editor` dependency from the `core-data` package, by implementing the `getBlockFootnotesOrder` function only using the `element`, `blocks` and `rich-text` packages. It implements the plan I laid out in https://github.com/WordPress/gutenberg/pull/67687#discussion_r1877774399. Fixes #64604.

I'm removing the `getRichTextValues` private export from `block-editor` and adding four new exports to `blocks`:
- `getRichTextValues`: traverses a tree of parsed blocks and extracts all `RichTextData` values from them. It uses the "serializer" code from `blocks`, `RichTextData.fromHTMLString` constructor from `rich-text`, and it also needs to know the identity of the `InnerBlocks.Content` and `RichText.Content` function components so that it can recognize them in the JSX markup returned by block `save()` functions.
- `InnerBlocksContent`: a simple component intended to be interpreted only by the block serializer. Used in `save()` functions to render inner blocks.
- `RichTextContent`: another component used by `save()` functions to render rich-text attributes. A thin wrapper around `valueToHTMLString`, serializing `RichTextData` values into HTML strings.
- `valueToHTMLString`: a think wrapper around `RichTextData.toHTMLString`, with some extra code that handles deprecated stuff (`value` as array, `multiline` prop). This should probably be in `rich-text` instead of `blocks`. Or maybe we could remove it completely and call `value.toHTMLString` directly?

Open questions are:
- all four exports are currently public. Which of them should be private?
- should `valueToHTMLString` be moved to `rich-text`? Or can we remove it completely? It's used by `RichText.Content` when serializing (saving) blocks and also by `block-editor` `RichText` component in preview mode (see also #60544).