### PR TITLE
Update "Call to Action" to "Call to action"

### DIFF
--- a/packages/editor/src/components/editor-help/intro-to-blocks.native.js
+++ b/packages/editor/src/components/editor-help/intro-to-blocks.native.js
@@ -71,7 +71,7 @@ const IntroToBlocks = () => {
 				<HelpDetailSectionHeadingText text={ __( 'Build layouts' ) } />
 				<HelpDetailBodyText
 					text={ __(
-						'Arrange your content into columns, add Call to Action buttons, and overlay images with text.'
+						'Arrange your content into columns, add Call to action buttons, and overlay images with text.'
 					) }
 				/>
 				<HelpDetailImage


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Follow-up of https://core.trac.wordpress.org/ticket/62414

## Why?
The original issue was reported by @jasmussen [here](https://github.com/WordPress/twentytwentyfive/issues/674).

The idea is to update all the "Call to Action" strings, to "Call to action" using sentence case and not title case. This would add cohesion with the other strings we have.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Updating the remaining strings.
