### PR TITLE
Enabled List View for Patterns

### DIFF
--- a/packages/edit-site/src/components/page-patterns/index.js
+++ b/packages/edit-site/src/components/page-patterns/index.js
@@ -18,6 +18,7 @@ import Page from '../page';
 import {
 	LAYOUT_GRID,
 	LAYOUT_TABLE,
+	LAYOUT_LIST,
 	PATTERN_TYPES,
 	TEMPLATE_PART_POST_TYPE,
 	PATTERN_DEFAULT_CATEGORY,
@@ -51,6 +52,15 @@ const defaultLayouts = {
 	[ LAYOUT_GRID ]: {
 		layout: {
 			badgeFields: [ 'sync-status' ],
+		},
+	},
+	[ LAYOUT_LIST ]: {
+		layout: {
+			styles: {
+				author: {
+					width: '1%',
+				},
+			},
 		},
 	},
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Enhancement for the scenario mentioned in this ticket.
Fixes  https://github.com/WordPress/gutenberg/issues/63306 
## Why?
In the layout options, list view is not available for patterns

## How?
Enabled List View for Patterns in the site editor settings page.

## Testing Instructions

1. Login WP dashboard.
2. Go to Appearance -> Editor.
3. Navigate to Patterns.
4. Like the Pages section, Patterns layout section has list view enabled now.


## Screenshots or screencast <!-- if applicable -->

Before:

![patternbefore](https://github.com/user-attachments/assets/7f5a4e14-c5cd-49d9-a6f4-671a6019158b)
After:

![patternlist](https://github.com/user-attachments/assets/fae6ce34-6bff-4d99-af4f-595bd1c71fef)
