### PR TITLE
Plugin: Fix eligibility check for post types' default rendering mode

### DIFF
--- a/backport-changelog/6.8/7129.md
+++ b/backport-changelog/6.8/7129.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7129
 
 * https://github.com/WordPress/gutenberg/pull/62304
+* https://github.com/WordPress/gutenberg/pull/67879

--- a/lib/compat/wordpress-6.8/post.php
+++ b/lib/compat/wordpress-6.8/post.php
@@ -32,15 +32,18 @@ function gutenberg_post_type_rendering_modes() {
  * @return array Updated array of post type arguments.
  */
 function gutenberg_post_type_default_rendering_mode( $args, $post_type ) {
-	$rendering_mode  = 'page' === $post_type ? 'template-locked' : 'post-only';
-	$rendering_modes = gutenberg_post_type_rendering_modes();
+	if ( ! wp_is_block_theme() || ! current_theme_supports( 'block-templates' ) ) {
+		return $args;
+	}
 
 	// Make sure the post type supports the block editor.
 	if (
-		wp_is_block_theme() &&
 		( isset( $args['show_in_rest'] ) && $args['show_in_rest'] ) &&
 		( ! empty( $args['supports'] ) && in_array( 'editor', $args['supports'], true ) )
 	) {
+		$rendering_mode  = 'page' === $post_type ? 'template-locked' : 'post-only';
+		$rendering_modes = gutenberg_post_type_rendering_modes();
+
 		// Validate the supplied rendering mode.
 		if (
 			isset( $args['default_rendering_mode'] ) &&


### PR DESCRIPTION
## What?
Fixes #67875.

PR fixes checks for adding a new `default_rendering_mode` to the post-type object, ensuring that the current theme supports `block-template`.

## Testing Instructions
1. Disabled `block-template` support for block theme.
2. Open a page.
3. Confirm that its content is correctly rendered.

### Snippet

```php
add_action( 'after_setup_theme', function() {
	remove_theme_support( 'block-templates' );
} );
```

### Testing Instructions for Keyboard
Same.
