### PR TITLE
Customizer Widgets: Fix inserter button size and animation

### DIFF
--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -33,16 +33,25 @@
 		border-radius: $radius-small;
 		color: $white;
 		padding: 0;
-		min-width: $grid-unit-30;
-		height: $grid-unit-30;
+		min-width: $grid-unit-40;
+		height: $grid-unit-40;
 		margin: $grid-unit-15 0 $grid-unit-15 auto;
 
 		&::before {
 			content: none;
 		}
 
+		svg {
+			transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
+			@include reduce-motion("transition");
+		}
+
 		&.is-pressed {
 			background: $gray-900;
+
+			svg {
+				transform: rotate(45deg);
+			}
 		}
 	}
 


### PR DESCRIPTION
Related to #67440

## What?

In the Customizer widget, do two things:

- Change the button to 32px square
- Add an animation when the inserter is opened

## Why?

The inserter button was previously 24px in size:

![image](https://github.com/user-attachments/assets/8ad46c4a-85e5-4e68-a308-c2840847d5ec)

Due to the influence of #67440, it seems that only the button width has changed from 24px to 32px.

## How?

We could have changed it back to its original 24px size, but since the visual size of all the other buttons in this toolbar is 32px, I've changed the inserter button to be 32px square as well.

As for animations, the same styles are applied as in the Editor and Widget Editor:

https://github.com/WordPress/gutenberg/blob/b1d943f027532a9e83b2739930d218c67f7f930d/packages/editor/src/components/document-tools/style.scss#L18-L25

## Testing Instructions

- Activate Twenty Twenty-One
- Appearance > Customize > Widgets

## Screenshots or screencast <!-- if applicable -->

| State | Before | After |
|--------|--------|--------|
| Default | ![image](https://github.com/user-attachments/assets/77703030-3147-4596-bb17-eceeb9a4859b)  | ![image](https://github.com/user-attachments/assets/107c62c2-90b7-4846-a734-270ce8ad8716) |
| Inserter Opened | ![image](https://github.com/user-attachments/assets/9495525e-47f4-46bb-91d1-75671a8a93ae) | ![image](https://github.com/user-attachments/assets/6cff1f53-4b2c-46a4-a150-cec31e2b7a62) |