### PR TITLE
Pages: update layout-specific config when the view is updated

### DIFF
--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -141,13 +141,15 @@ function useView( postType ) {
 	// without affecting any other config.
 	const onUrlLayoutChange = useEvent( () => {
 		setView( ( prevView ) => {
-			const layoutToApply = layout ?? LAYOUT_LIST;
-			if ( layoutToApply === prevView.type ) {
+			const newType = layout ?? LAYOUT_LIST;
+			if ( newType === prevView.type ) {
 				return prevView;
 			}
+
 			return {
 				...prevView,
-				type: layout ?? LAYOUT_LIST,
+				type: newType,
+				...defaultLayouts[ newType ],
 			};
 		} );
 	} );
@@ -169,6 +171,7 @@ function useView( postType ) {
 			setView( {
 				...newView,
 				type,
+				...defaultLayouts[ type ],
 			} );
 		}
 	} );

--- a/packages/edit-site/src/components/post-list/index.js
+++ b/packages/edit-site/src/components/post-list/index.js
@@ -109,6 +109,7 @@ function useView( postType ) {
 		return {
 			...initialView,
 			type,
+			...defaultLayouts[ type ],
 		};
 	} );
 


### PR DESCRIPTION
## What?

Certain layouts may have extra information under `view.layout`. When the view config is updated externally (e.g., updated when the URL changes), we need to keep track of the layout-specific config as well.

## Why?

Otherwise, when users open a URL with a specific layout, its view config won't load.

## How?

- Consider view.layout on view initialization. 847fd3b40cf2bdade4a3e3554b64e5d741920be9
- Consider view.layout on updating it. 9554c5b5b58d3ecf6b16686f754bb12dbbdb2715

## Testing Instructions

- Add some layout-specific config to defaultLayouts. For example:

```js
[ LAYOUT_TABLE ]: {
  layout: {
    density: 'compact'
  }
},
```

- Load the URL that opens that specific layout. http://localhost:8888/wp-admin/site-editor.php?p=%2Fpage&layout=table
- Verify that the compacted density is properly activated.
