### PR TITLE
RichText: Introduce new `attributeKey` prop

### DIFF
--- a/packages/block-editor/src/components/rich-text/README.md
+++ b/packages/block-editor/src/components/rich-text/README.md
@@ -16,6 +16,10 @@ _Required._ Called when the value changes.
 
 _Optional._ If the editable field is bound to a block attribute (through the `value` and `onChange` props) then this prop should specify the attribute name. The field will use this value to set the block editor selection correctly, specifying in which attribute and at what offset does the selection start or end.
 
+### `attributeKey: String`
+
+_Optional._ If the editable field is bound to a block attribute, then this prop should specify the key of the attribute. The editable field will use the key name to supply the default handling for the `value`, `onChange` and `identifier` props, when any of these are not explicitly set.
+
 ### `tagName: String`
 
 _Default: `div`._ The [tag name](https://www.w3.org/TR/html51/syntax.html#tag-name) of the editable element.
@@ -27,7 +31,7 @@ _Optional._ Placeholder text to show when the field is empty, similar to the
 
 ### `disableLineBreaks: Boolean`
 
-_Optional._  Disables inserting line breaks on `Enter` when it is set to `true`
+_Optional._ Disables inserting line breaks on `Enter` when it is set to `true`
 
 ### `onReplace( blocks: Array ): Function`
 
@@ -113,13 +117,11 @@ registerBlockType( /* ... */, {
 } );
 ```
 
-
 ## RichTextToolbarButton
 
 Slot to extend the format toolbar. Use it in the edit function of a `registerFormatType` call to surface the format to the UI.
 
 ### Example
-
 
 ```js
 import { registerFormatType } from '@wordpress/rich-text';

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -81,6 +81,7 @@ export function RichTextWrapper(
 	{
 		children,
 		tagName = 'div',
+		attributeKey,
 		value: adjustedValue = '',
 		onChange: adjustedOnChange,
 		isSelected: originalIsSelected,
@@ -117,6 +118,7 @@ export function RichTextWrapper(
 			alternative: 'block.json support key: "splitting"',
 		} );
 	}
+	identifier = identifier || attributeKey;
 
 	const instanceId = useInstanceId( RichTextWrapper );
 	const anchorRef = useRef();

--- a/packages/block-editor/src/components/rich-text/index.js
+++ b/packages/block-editor/src/components/rich-text/index.js
@@ -587,9 +587,8 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 				return props.value || '';
 			}
 
-			const blockBindingsSourceName =
-				blockBindings?.[ props.attributeKey ]?.source;
-			if ( ! blockBindingsSourceName ) {
+			const blockBinding = blockBindings?.[ props.attributeKey ];
+			if ( ! blockBinding?.source ) {
 				const blockAttributes = select(
 					blockEditorStore
 				).getBlockAttributes( context.clientId );
@@ -598,7 +597,7 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 
 			const blockBindingsSource = unlock(
 				select( blocksStore )
-			).getBlockBindingsSource( blockBindingsSourceName );
+			).getBlockBindingsSource( blockBinding.source );
 
 			const bindingsContext = {};
 			for ( const [ key, value ] of Object.entries( blockContext ) ) {
@@ -609,7 +608,9 @@ const PublicForwardedRichTextContainer = forwardRef( ( props, ref ) => {
 
 			return (
 				blockBindingsSource?.getValues( {
-					bindings: blockBindings,
+					bindings: {
+						[ props.attributeKey ]: { args: blockBinding.args },
+					},
 					context: bindingsContext,
 					clientId: context.clientId,
 					select,

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -274,9 +274,9 @@ function ButtonEdit( props ) {
 			>
 				<RichText
 					ref={ mergedRef }
+					attributeKey="text"
 					aria-label={ __( 'Button text' ) }
 					placeholder={ placeholder || __( 'Add text…' ) }
-					value={ text }
 					onChange={ ( value ) =>
 						setAttributes( {
 							text: removeAnchorTag( value ),
@@ -304,7 +304,6 @@ function ButtonEdit( props ) {
 					} }
 					onReplace={ onReplace }
 					onMerge={ mergeBlocks }
-					identifier="text"
 				/>
 			</div>
 			<BlockControls group="block">

--- a/packages/block-library/src/button/edit.native.js
+++ b/packages/block-library/src/button/edit.native.js
@@ -241,11 +241,6 @@ function ButtonEdit( props ) {
 		);
 	}
 
-	function onChangeText( value ) {
-		const { setAttributes } = props;
-		setAttributes( { text: value } );
-	}
-
 	function onChangeBorderRadius( newRadius ) {
 		const { setAttributes, attributes } = props;
 		const { style } = attributes;
@@ -495,15 +490,13 @@ function ButtonEdit( props ) {
 				) }
 				<RichText
 					ref={ onSetRef }
+					attributeKey="text"
 					placeholder={ placeholderText }
-					value={ text }
-					onChange={ onChangeText }
 					style={ textStyles }
 					textAlign={ align }
 					placeholderTextColor={
 						style?.color || styles.placeholderTextColor.color
 					}
-					identifier="text"
 					tagName="p"
 					minWidth={ minWidth } // The minimum Button size.
 					maxWidth={ isFixedWidth ? minWidth : maxWidth } // The width of the screen.

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -6,8 +6,6 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 export default function CodeEdit( {
-	attributes,
-	setAttributes,
 	onRemove,
 	insertBlocksAfter,
 	mergeBlocks,
@@ -17,9 +15,7 @@ export default function CodeEdit( {
 		<pre { ...blockProps }>
 			<RichText
 				tagName="code"
-				identifier="content"
-				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
+				attributeKey="content"
 				onRemove={ onRemove }
 				onMerge={ mergeBlocks }
 				placeholder={ __( 'Write code…' ) }

--- a/packages/block-library/src/code/edit.native.js
+++ b/packages/block-library/src/code/edit.native.js
@@ -21,14 +21,7 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import styles from './theme.scss';
 
 export function CodeEdit( props ) {
-	const {
-		attributes,
-		setAttributes,
-		onRemove,
-		style,
-		insertBlocksAfter,
-		mergeBlocks,
-	} = props;
+	const { onRemove, style, insertBlocksAfter, mergeBlocks } = props;
 	const codeStyle = {
 		...usePreferredColorSchemeStyle(
 			styles.blockCode,
@@ -47,11 +40,9 @@ export function CodeEdit( props ) {
 		<View style={ codeStyle }>
 			<RichText
 				tagName="pre"
-				value={ attributes.content }
-				identifier="content"
+				attributeKey="content"
 				style={ textStyle }
 				underlineColorAndroid="transparent"
-				onChange={ ( content ) => setAttributes( { content } ) }
 				onMerge={ mergeBlocks }
 				onRemove={ onRemove }
 				placeholder={ __( 'Write code…' ) }

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -26,7 +26,7 @@ const TEMPLATE = [
 ];
 
 function DetailsEdit( { attributes, setAttributes, clientId } ) {
-	const { showContent, summary } = attributes;
+	const { showContent } = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
@@ -87,15 +87,11 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 			>
 				<summary onClick={ ( event ) => event.preventDefault() }>
 					<RichText
-						identifier="summary"
+						attributeKey="summary"
 						aria-label={ __( 'Write summary' ) }
 						placeholder={ __( 'Write summary…' ) }
 						allowedFormats={ [] }
 						withoutInteractiveFormatting
-						value={ summary }
-						onChange={ ( newSummary ) =>
-							setAttributes( { summary: newSummary } )
-						}
 					/>
 				</summary>
 				{ innerBlocksProps.children }

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -64,7 +64,6 @@ function ClipboardToolbarButton( { text, disabled } ) {
 function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 	const {
 		id,
-		fileName,
 		href,
 		textLinkHref,
 		textLinkTarget,
@@ -289,9 +288,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 				) }
 				<div className="wp-block-file__content-wrapper">
 					<RichText
-						identifier="fileName"
 						tagName="a"
-						value={ fileName }
+						attributeKey="fileName"
 						placeholder={ __( 'Write file name…' ) }
 						withoutInteractiveFormatting
 						onChange={ ( text ) =>
@@ -305,8 +303,8 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						<div className="wp-block-file__button-richtext-wrapper">
 							{ /* Using RichText here instead of PlainText so that it can be styled like a button. */ }
 							<RichText
-								identifier="downloadButtonText"
 								tagName="div" // Must be block-level or else cursor disappears.
+								attributeKey="downloadButtonText"
 								aria-label={ __( 'Download button text' ) }
 								className={ clsx(
 									'wp-block-file__button',
@@ -314,7 +312,6 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 										'button'
 									)
 								) }
-								value={ downloadButtonText }
 								withoutInteractiveFormatting
 								placeholder={ __( 'Add text…' ) }
 								onChange={ ( text ) =>

--- a/packages/block-library/src/heading/edit.js
+++ b/packages/block-library/src/heading/edit.js
@@ -110,9 +110,8 @@ function HeadingEdit( {
 				</BlockControls>
 			) }
 			<RichText
-				identifier="content"
 				tagName={ tagName }
-				value={ content }
+				attributeKey="content"
 				onChange={ onContentChange }
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }

--- a/packages/block-library/src/heading/edit.native.js
+++ b/packages/block-library/src/heading/edit.native.js
@@ -105,9 +105,8 @@ function HeadingEdit( {
 				/>
 			</BlockControls>
 			<RichText
-				identifier="content"
 				tagName={ tagName }
-				value={ content }
+				attributeKey="content"
 				onChange={ onContentChange }
 				onMerge={ mergeBlocks }
 				onSplit={ ( value, isOriginal ) => {

--- a/packages/block-library/src/home-link/edit.js
+++ b/packages/block-library/src/home-link/edit.js
@@ -13,7 +13,7 @@ import { store as coreStore } from '@wordpress/core-data';
 
 const preventDefault = ( event ) => event.preventDefault();
 
-export default function HomeEdit( { attributes, setAttributes, context } ) {
+export default function HomeEdit( { attributes, context } ) {
 	const homeUrl = useSelect( ( select ) => {
 		// Site index.
 		return select( coreStore ).getEntityRecord( 'root', '__unstableBase' )
@@ -42,12 +42,9 @@ export default function HomeEdit( { attributes, setAttributes, context } ) {
 				onClick={ preventDefault }
 			>
 				<RichText
-					identifier="label"
+					attributeKey="label"
 					className="wp-block-home-link__label"
 					value={ attributes.label ?? __( 'Home' ) }
-					onChange={ ( labelValue ) => {
-						setAttributes( { label: labelValue } );
-					} }
 					aria-label={ __( 'Home link text' ) }
 					placeholder={ __( 'Add home link' ) }
 					withoutInteractiveFormatting

--- a/packages/block-library/src/list-item/edit.js
+++ b/packages/block-library/src/list-item/edit.js
@@ -68,12 +68,7 @@ export function IndentUI( { clientId } ) {
 	);
 }
 
-export default function ListItemEdit( {
-	attributes,
-	setAttributes,
-	clientId,
-	mergeBlocks,
-} ) {
+export default function ListItemEdit( { attributes, clientId, mergeBlocks } ) {
 	const { placeholder, content } = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
@@ -88,12 +83,8 @@ export default function ListItemEdit( {
 			<li { ...innerBlocksProps }>
 				<RichText
 					ref={ useMergeRefs( [ useEnterRef, useSpaceRef ] ) }
-					identifier="content"
 					tagName="div"
-					onChange={ ( nextContent ) =>
-						setAttributes( { content: nextContent } )
-					}
-					value={ content }
+					attributeKey="content"
 					aria-label={ __( 'List text' ) }
 					placeholder={ placeholder || __( 'List' ) }
 					onMerge={ onMerge }

--- a/packages/block-library/src/list-item/edit.native.js
+++ b/packages/block-library/src/list-item/edit.native.js
@@ -30,7 +30,6 @@ const OPACITY = '9e';
 
 export default function ListItemEdit( {
 	attributes,
-	setAttributes,
 	clientId,
 	style,
 	mergeBlocks,
@@ -148,12 +147,8 @@ export default function ListItemEdit( {
 				>
 					<RichText
 						__unstableUseSplitSelection
-						identifier="content"
 						tagName="p"
-						onChange={ ( nextContent ) =>
-							setAttributes( { content: nextContent } )
-						}
-						value={ content }
+						attributeKey="content"
 						placeholder={ placeholder || __( 'List' ) }
 						placeholderTextColor={
 							defaultPlaceholderTextColorWithOpacity

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -505,14 +505,8 @@ export default function NavigationLinkEdit( {
 									<>
 										<RichText
 											ref={ ref }
-											identifier="label"
+											attributeKey="label"
 											className="wp-block-navigation-item__label"
-											value={ label }
-											onChange={ ( labelValue ) =>
-												setAttributes( {
-													label: labelValue,
-												} )
-											}
 											onMerge={ mergeBlocks }
 											onReplace={ onReplace }
 											__unstableOnSplitAtEnd={ () =>

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -503,12 +503,8 @@ export default function NavigationSubmenuEdit( {
 					{ /* eslint-enable */ }
 					<RichText
 						ref={ ref }
-						identifier="label"
+						attributeKey="label"
 						className="wp-block-navigation-item__label"
-						value={ label }
-						onChange={ ( labelValue ) =>
-							setAttributes( { label: labelValue } )
-						}
 						onMerge={ mergeBlocks }
 						onReplace={ onReplace }
 						aria-label={ __( 'Navigation link text' ) }

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -152,13 +152,9 @@ function ParagraphBlock( {
 				/>
 			) }
 			<RichText
-				identifier="content"
 				tagName="p"
+				attributeKey="content"
 				{ ...blockProps }
-				value={ content }
-				onChange={ ( newContent ) =>
-					setAttributes( { content: newContent } )
-				}
 				onMerge={ mergeBlocks }
 				onReplace={ onReplace }
 				onRemove={ onRemove }

--- a/packages/block-library/src/paragraph/edit.native.js
+++ b/packages/block-library/src/paragraph/edit.native.js
@@ -29,7 +29,7 @@ function ParagraphBlock( {
 		return !! select( blockEditorStore ).getSettings().isRTL;
 	}, [] );
 
-	const { align, content, placeholder } = attributes;
+	const { align, placeholder } = attributes;
 
 	const styles = {
 		...( style?.baseColors && {
@@ -62,16 +62,10 @@ function ParagraphBlock( {
 				/>
 			</BlockControls>
 			<RichText
-				identifier="content"
 				tagName="p"
-				value={ content }
+				attributeKey="content"
 				deleteEnter
 				style={ styles }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						content: nextContent,
-					} );
-				} }
 				onSplit={ ( value, isOriginal ) => {
 					let newAttributes;
 

--- a/packages/block-library/src/post-author/edit.js
+++ b/packages/block-library/src/post-author/edit.js
@@ -206,14 +206,10 @@ function PostAuthorEdit( {
 				<div className="wp-block-post-author__content">
 					{ ( ! RichText.isEmpty( byline ) || isSelected ) && (
 						<RichText
-							identifier="byline"
+							attributeKey="byline"
 							className="wp-block-post-author__byline"
 							aria-label={ __( 'Post author byline text' ) }
 							placeholder={ __( 'Write byline…' ) }
-							value={ byline }
-							onChange={ ( value ) =>
-								setAttributes( { byline: value } )
-							}
 						/>
 					) }
 					<p className="wp-block-post-author__name">

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -33,7 +33,7 @@ import { useCanEditEntity } from '../utils/hooks';
 const ELLIPSIS = '…';
 
 export default function PostExcerptEditor( {
-	attributes: { textAlign, moreText, showMoreOnNewLine, excerptLength },
+	attributes: { textAlign, showMoreOnNewLine, excerptLength },
 	setAttributes,
 	isSelected,
 	context: { postId, postType, queryId },
@@ -134,15 +134,11 @@ export default function PostExcerptEditor( {
 	}
 	const readMoreLink = (
 		<RichText
-			identifier="moreText"
-			className="wp-block-post-excerpt__more-link"
 			tagName="a"
+			attributeKey="moreText"
+			className="wp-block-post-excerpt__more-link"
 			aria-label={ __( '“Read more” link text' ) }
 			placeholder={ __( 'Add "read more" link text' ) }
-			value={ moreText }
-			onChange={ ( newMoreText ) =>
-				setAttributes( { moreText: newMoreText } )
-			}
 			withoutInteractiveFormatting
 		/>
 	);

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -26,15 +26,7 @@ import { store as coreStore } from '@wordpress/core-data';
 
 export default function PostNavigationLinkEdit( {
 	context: { postType },
-	attributes: {
-		type,
-		label,
-		showTitle,
-		textAlign,
-		linkLabel,
-		arrow,
-		taxonomy,
-	},
+	attributes: { type, showTitle, textAlign, linkLabel, arrow, taxonomy },
 	setAttributes,
 } ) {
 	const isNext = type === 'next';
@@ -194,14 +186,10 @@ export default function PostNavigationLinkEdit( {
 				) }
 				<RichText
 					tagName="a"
-					identifier="label"
+					attributeKey="label"
 					aria-label={ ariaLabel }
 					placeholder={ placeholder }
-					value={ label }
 					allowedFormats={ [ 'core/bold', 'core/italic' ] }
-					onChange={ ( newLabel ) =>
-						setAttributes( { label: newLabel } )
-					}
 				/>
 				{ showTitle && (
 					<a

--- a/packages/block-library/src/post-terms/edit.js
+++ b/packages/block-library/src/post-terms/edit.js
@@ -98,15 +98,11 @@ export default function PostTermsEdit( {
 				{ isLoading && hasPost && <Spinner /> }
 				{ ! isLoading && ( isSelected || prefix ) && (
 					<RichText
-						identifier="prefix"
+						attributeKey="prefix"
 						allowedFormats={ ALLOWED_FORMATS }
 						className="wp-block-post-terms__prefix"
 						aria-label={ __( 'Prefix' ) }
 						placeholder={ __( 'Prefix' ) + ' ' }
-						value={ prefix }
-						onChange={ ( value ) =>
-							setAttributes( { prefix: value } )
-						}
 						tagName="span"
 					/>
 				) }
@@ -142,15 +138,11 @@ export default function PostTermsEdit( {
 						__( 'Term items not found.' ) ) }
 				{ ! isLoading && ( isSelected || suffix ) && (
 					<RichText
-						identifier="suffix"
+						attributeKey="suffix"
 						allowedFormats={ ALLOWED_FORMATS }
 						className="wp-block-post-terms__suffix"
 						aria-label={ __( 'Suffix' ) }
 						placeholder={ ' ' + __( 'Suffix' ) }
-						value={ suffix }
-						onChange={ ( value ) =>
-							setAttributes( { suffix: value } )
-						}
 						tagName="span"
 						__unstableOnSplitAtEnd={ () =>
 							insertBlocksAfter(

--- a/packages/block-library/src/preformatted/edit.js
+++ b/packages/block-library/src/preformatted/edit.js
@@ -6,27 +6,18 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 
 export default function PreformattedEdit( {
-	attributes,
 	mergeBlocks,
-	setAttributes,
 	onRemove,
 	insertBlocksAfter,
 	style,
 } ) {
-	const { content } = attributes;
 	const blockProps = useBlockProps( { style } );
 
 	return (
 		<RichText
 			tagName="pre"
-			identifier="content"
+			attributeKey="content"
 			preserveWhiteSpace
-			value={ content }
-			onChange={ ( nextContent ) => {
-				setAttributes( {
-					content: nextContent,
-				} );
-			} }
 			onRemove={ onRemove }
 			aria-label={ __( 'Preformatted text' ) }
 			placeholder={ __( 'Write preformatted text…' ) }

--- a/packages/block-library/src/pullquote/edit.js
+++ b/packages/block-library/src/pullquote/edit.js
@@ -30,7 +30,7 @@ function PullQuoteEdit( {
 	isSelected,
 	insertBlocksAfter,
 } ) {
-	const { textAlign, citation, value } = attributes;
+	const { textAlign, citation } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -51,14 +51,8 @@ function PullQuoteEdit( {
 			<Figure { ...blockProps }>
 				<BlockQuote>
 					<RichText
-						identifier="value"
+						attributeKey="value"
 						tagName="p"
-						value={ value }
-						onChange={ ( nextValue ) =>
-							setAttributes( {
-								value: nextValue,
-							} )
-						}
 						aria-label={ __( 'Pullquote text' ) }
 						placeholder={
 							// translators: placeholder text used for the quote
@@ -68,19 +62,13 @@ function PullQuoteEdit( {
 					/>
 					{ shouldShowCitation && (
 						<RichText
-							identifier="citation"
 							tagName={ isWebPlatform ? 'cite' : undefined }
+							attributeKey="citation"
 							style={ { display: 'block' } }
-							value={ citation }
 							aria-label={ __( 'Pullquote citation text' ) }
 							placeholder={
 								// translators: placeholder text used for the citation
 								__( 'Add citation' )
-							}
-							onChange={ ( nextCitation ) =>
-								setAttributes( {
-									citation: nextCitation,
-								} )
 							}
 							className="wp-block-pullquote__citation"
 							__unstableMobileNoFocusOnMount

--- a/packages/block-library/src/pullquote/edit.native.js
+++ b/packages/block-library/src/pullquote/edit.native.js
@@ -60,7 +60,7 @@ const getBorderColor = ( props ) => {
 
 function PullQuoteEdit( props ) {
 	const { attributes, setAttributes, isSelected, insertBlocksAfter } = props;
-	const { textAlign, citation, value } = attributes;
+	const { textAlign, citation } = attributes;
 
 	const blockProps = useBlockProps( {
 		backgroundColor: getBackgroundColor( props ),
@@ -82,13 +82,7 @@ function PullQuoteEdit( props ) {
 			<Figure { ...blockProps }>
 				<BlockQuote textColor={ getTextColor( props ) }>
 					<RichText
-						identifier="value"
-						value={ value }
-						onChange={ ( nextValue ) =>
-							setAttributes( {
-								value: nextValue,
-							} )
-						}
+						attributeKey="value"
 						aria-label={ __( 'Pullquote text' ) }
 						placeholder={
 							// translators: placeholder text used for the quote
@@ -98,17 +92,11 @@ function PullQuoteEdit( props ) {
 					/>
 					{ shouldShowCitation && (
 						<RichText
-							identifier="citation"
-							value={ citation }
+							attributeKey="citation"
 							aria-label={ __( 'Pullquote citation text' ) }
 							placeholder={
 								// translators: placeholder text used for the citation
 								__( 'Add citation' )
-							}
-							onChange={ ( nextCitation ) =>
-								setAttributes( {
-									citation: nextCitation,
-								} )
 							}
 							__unstableMobileNoFocusOnMount
 							textAlign={ textAlign ?? 'center' }

--- a/packages/block-library/src/read-more/edit.js
+++ b/packages/block-library/src/read-more/edit.js
@@ -11,7 +11,7 @@ import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
 export default function ReadMore( {
-	attributes: { content, linkTarget },
+	attributes: { linkTarget },
 	setAttributes,
 	insertBlocksAfter,
 } ) {
@@ -33,14 +33,10 @@ export default function ReadMore( {
 				</PanelBody>
 			</InspectorControls>
 			<RichText
-				identifier="content"
 				tagName="a"
+				attributeKey="content"
 				aria-label={ __( '“Read more” link text' ) }
 				placeholder={ __( 'Read more' ) }
-				value={ content }
-				onChange={ ( newValue ) =>
-					setAttributes( { content: newValue } )
-				}
 				__unstableOnSplitAtEnd={ () =>
 					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
 				}

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -69,7 +69,6 @@ export default function SearchEdit( {
 	clientId,
 } ) {
 	const {
-		label,
 		showLabel,
 		placeholder,
 		width,
@@ -354,16 +353,12 @@ export default function SearchEdit( {
 
 				{ ! buttonUseIcon && (
 					<RichText
-						identifier="buttonText"
+						attributeKey="buttonText"
 						className={ buttonClasses }
 						style={ buttonStyles }
 						aria-label={ __( 'Button text' ) }
 						placeholder={ __( 'Add button text…' ) }
 						withoutInteractiveFormatting
-						value={ buttonText }
-						onChange={ ( html ) =>
-							setAttributes( { buttonText: html } )
-						}
 						onClick={ handleButtonClick }
 					/>
 				) }
@@ -555,13 +550,11 @@ export default function SearchEdit( {
 
 			{ showLabel && (
 				<RichText
-					identifier="label"
+					attributeKey="label"
 					className={ labelClassnames }
 					aria-label={ __( 'Label text' ) }
 					placeholder={ __( 'Add label…' ) }
 					withoutInteractiveFormatting
-					value={ label }
-					onChange={ ( html ) => setAttributes( { label: html } ) }
 					style={ typographyProps.style }
 				/>
 			) }

--- a/packages/block-library/src/search/edit.native.js
+++ b/packages/block-library/src/search/edit.native.js
@@ -395,15 +395,11 @@ export default function SearchEdit( {
 					>
 						<RichText
 							className="wp-block-search__button"
-							identifier="buttonText"
+							attributeKey="buttonText"
 							tagName="p"
 							style={ richTextButtonStyle }
 							placeholder={ buttonPlaceholderText }
-							value={ buttonText }
 							withoutInteractiveFormatting
-							onChange={ ( html ) =>
-								setAttributes( { buttonText: html } )
-							}
 							minWidth={ MIN_BUTTON_WIDTH }
 							maxWidth={ blockWidth - MARGINS }
 							textAlign="center"
@@ -449,15 +445,11 @@ export default function SearchEdit( {
 				>
 					<RichText
 						className="wp-block-search__label"
-						identifier="label"
+						attributeKey="label"
 						tagName="p"
 						style={ styles.richTextLabel }
 						placeholder={ __( 'Add label…' ) }
 						withoutInteractiveFormatting
-						value={ label }
-						onChange={ ( html ) =>
-							setAttributes( { label: html } )
-						}
 						isSelected={ isLabelSelected }
 						__unstableMobileNoFocusOnMount={ ! isSelected }
 						unstableOnFocus={ () => {

--- a/packages/block-library/src/utils/caption.js
+++ b/packages/block-library/src/utils/caption.js
@@ -94,7 +94,7 @@ export function Caption( {
 			{ showCaption &&
 				( ! RichText.isEmpty( caption ) || isSelected ) && (
 					<RichText
-						identifier={ attributeKey }
+						attributeKey={ attributeKey }
 						tagName={ tagName }
 						className={ clsx(
 							className,
@@ -105,10 +105,6 @@ export function Caption( {
 						ref={ ref }
 						aria-label={ label }
 						placeholder={ placeholder }
-						value={ caption }
-						onChange={ ( value ) =>
-							setAttributes( { [ attributeKey ]: value } )
-						}
 						inlineToolbar
 						__unstableOnSplitAtEnd={ () =>
 							insertBlocksAfter(

--- a/packages/block-library/src/verse/edit.js
+++ b/packages/block-library/src/verse/edit.js
@@ -23,7 +23,7 @@ export default function VerseEdit( {
 	insertBlocksAfter,
 	style,
 } ) {
-	const { textAlign, content } = attributes;
+	const { textAlign } = attributes;
 	const blockProps = useBlockProps( {
 		className: clsx( {
 			[ `has-text-align-${ textAlign }` ]: textAlign,
@@ -43,14 +43,8 @@ export default function VerseEdit( {
 			</BlockControls>
 			<RichText
 				tagName="pre"
-				identifier="content"
+				attributeKey="content"
 				preserveWhiteSpace
-				value={ content }
-				onChange={ ( nextContent ) => {
-					setAttributes( {
-						content: nextContent,
-					} );
-				} }
 				aria-label={ __( 'Verse text' ) }
 				placeholder={ __( 'Write verse…' ) }
 				onRemove={ onRemove }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/issues/58233



## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

TODO:
- [x] Refactor all core blocks
- [x] Implement the default `onChange` handler when the `attributeKey` prop set
- [x] Implement the default `value` when the `attributeKey` prop set
- [x] Integrate Block Bindings source get and update value when an attribute is connected

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
