### PR TITLE
Create Block: Add multi variant

### DIFF
--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -58,6 +58,22 @@ const predefinedPluginTemplates = {
 			},
 			viewScript: 'file:./view.js',
 			example: {},
+			transformer: ( view ) => {
+				const {
+					variantVars: { isMultiVariant },
+					slug,
+					folderName,
+					plugin,
+				} = view;
+
+				return {
+					...view,
+					folderName:
+						isMultiVariant && plugin
+							? `${ folderName }/${ slug }`
+							: view.folderName,
+				};
+			},
 		},
 		variants: {
 			static: {},
@@ -65,6 +81,12 @@ const predefinedPluginTemplates = {
 				slug: 'example-dynamic',
 				title: 'Example Dynamic',
 				render: 'file:./render.php',
+			},
+			multi: {
+				customScripts: {
+					'build-blocks-manifest': 'wp-scripts build-blocks-manifest',
+					postbuild: 'npm run build-blocks-manifest',
+				},
 			},
 		},
 	},

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -53,7 +53,7 @@ function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
 		);
 	}
 	// Register the blocks.
-	$blocks = glob( __DIR__  . '/*', GLOB_ONLYDIR );
+	$blocks = glob( __DIR__  . '/build/*', GLOB_ONLYDIR );
 	foreach ( $blocks as $block ) {
 		register_block_type( $block );
 	}

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -42,6 +42,25 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
+
+	{{#isMultiVariant}}
+	// wp_register_block_metadata_collection was introduced in WP 6.7.
+	if ( function_exists( 'wp_register_block_metadata_collection' ) ) {
+		// Register the block metadata.
+		wp_register_block_metadata_collection(
+			__DIR__ . '/build',
+			__DIR__ . '/build/blocks-manifest.php'
+		);
+	}
+	// Register the blocks.
+	$blocks = glob( __DIR__  . '/*', GLOB_ONLYDIR );
+	foreach ( $blocks as $block ) {
+		register_block_type( $block );
+	}
+	{{/isMultiVariant}}
+	{{^isMultiVariant}}
+	// Register the block.
 	register_block_type( __DIR__ . '/build' );
+	{{/isMultiVariant}}
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related to https://github.com/WordPress/gutenberg/issues/25188.

This PR introduces a new `multi` variant for the create-block package that provides a starting point for building plugins that contain multiple blocks. This replaces https://github.com/WordPress/gutenberg/pull/66485

Closes https://github.com/WordPress/gutenberg/issues/66484

## Why?
Creating plugins that register multiple block is common task and this variant provides the scaffolding to do so and includes the performance tools that were released in 6.7

## Testing Instructions
1. Checkout this branch
2. Run `node packages/create-block/index.js test-plugin --variant multi`
3. Confirm that a plugin called `test-plugin` is created and that the block files are in `src/test-plugin`