### PR TITLE
Button Block: Refactor setting panel

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -18,10 +18,11 @@ import { useEffect, useState, useRef, useMemo } from '@wordpress/element';
 import {
 	Button,
 	ButtonGroup,
-	PanelBody,
 	TextControl,
 	ToolbarButton,
 	Popover,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import {
 	AlignmentControl,
@@ -123,26 +124,39 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 	}
 
 	return (
-		<PanelBody title={ __( 'Settings' ) }>
-			<ButtonGroup aria-label={ __( 'Button width' ) }>
-				{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
-					return (
-						<Button
-							key={ widthValue }
-							size="small"
-							variant={
-								widthValue === selectedWidth
-									? 'primary'
-									: undefined
-							}
-							onClick={ () => handleChange( widthValue ) }
-						>
-							{ widthValue }%
-						</Button>
-					);
-				} ) }
-			</ButtonGroup>
-		</PanelBody>
+		<ToolsPanel
+			label={ __( 'Settings' ) }
+			resetAll={ () => {
+				handleChange( undefined );
+			} }
+		>
+			<ToolsPanelItem
+				label={ __( 'Button width' ) }
+				__nextHasNoMarginBottom
+				isShownByDefault
+				hasValue={ () => !! selectedWidth }
+				onDeselect={ () => handleChange( undefined ) }
+			>
+				<ButtonGroup aria-label={ __( 'Button width' ) }>
+					{ [ 25, 50, 75, 100 ].map( ( widthValue ) => {
+						return (
+							<Button
+								key={ widthValue }
+								size="small"
+								variant={
+									widthValue === selectedWidth
+										? 'primary'
+										: undefined
+								}
+								onClick={ () => handleChange( widthValue ) }
+							>
+								{ widthValue }%
+							</Button>
+						);
+					} ) }
+				</ButtonGroup>
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 }
 


### PR DESCRIPTION
part of #67813

## Before
|![image](https://github.com/user-attachments/assets/7c0d707f-f4e0-413f-854e-e7b9714b2231)

## After
|![image](https://github.com/user-attachments/assets/e0f48073-283c-4f3e-8f95-80fe4f6c0f1a)

![image](https://github.com/user-attachments/assets/60fe9529-14d3-460d-bdcd-2ceced9c37fb)
