### PR TITLE
Fix: Fix link to minimal-block example plugin code.

### DIFF
--- a/docs/getting-started/fundamentals/registration-of-a-block.md
+++ b/docs/getting-started/fundamentals/registration-of-a-block.md
@@ -42,7 +42,7 @@ function minimal_block_ca6eda___register_block() {
 add_action( 'init', 'minimal_block_ca6eda___register_block' );
 ```
 
-_See the [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/minimal-block-ca6eda) of the  [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/index.php)_
+_See the [full block example](https://github.com/WordPress/block-development-examples/tree/trunk/plugins/minimal-block-ca6eda) of the  [code above](https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/plugin.php)_
 
 ## Registering a block with JavaScript (client-side)
 


### PR DESCRIPTION
The link https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/index.php is invalid and returns a 404 the correct link should be https://github.com/WordPress/block-development-examples/blob/trunk/plugins/minimal-block-ca6eda/plugin.php. This PR fixes the issue.