### PR TITLE
[Docs] Fix: Two broken links to the packages reference API and to blocks docs

### DIFF
--- a/docs/getting-started/fundamentals/javascript-in-the-block-editor.md
+++ b/docs/getting-started/fundamentals/javascript-in-the-block-editor.md
@@ -38,9 +38,9 @@ The `wp-scripts` package also facilitates the use of JavaScript modules, allowin
 
 Integrating JavaScript into your WordPress projects without a build process can be the most straightforward approach in specific scenarios. This is particularly true for projects that don't leverage JSX or other advanced JavaScript features requiring compilation.
 
-When you opt out of a build process, you interact directly with WordPress's [JavaScript APIs](/docs/reference-guides/packages/) through the global `wp` object. This means that all the methods and packages provided by WordPress are readily available, but with one caveat: you must manually manage script dependencies. This is done by adding [the handle](/docs/contributors/code/scripts.md) of each corresponding package to the dependency array of your enqueued JavaScript file.
+When you opt out of a build process, you interact directly with WordPress's [JavaScript APIs](/docs/reference-guides/packages.md) through the global `wp` object. This means that all the methods and packages provided by WordPress are readily available, but with one caveat: you must manually manage script dependencies. This is done by adding [the handle](/docs/contributors/code/scripts.md) of each corresponding package to the dependency array of your enqueued JavaScript file.
 
-For example, suppose you're creating a script that registers a new block [variation](/docs/reference-guides/block-api/block-variations.md) using the `registerBlockVariation` function from the [`blocks`](/docs/reference-guides/packages/packages-blocks.md) package. You must include `wp-blocks` in your script's dependency array. This guarantees that the `wp.blocks.registerBlockVariation` method is available and defined by the time your script executes.
+For example, suppose you're creating a script that registers a new block [variation](/docs/reference-guides/block-api/block-variations.md) using the `registerBlockVariation` function from the [`blocks`](/packages/blocks/README.md) package. You must include `wp-blocks` in your script's dependency array. This guarantees that the `wp.blocks.registerBlockVariation` method is available and defined by the time your script executes.
 
 In the following example, the `wp-blocks` dependency is defined when enqueuing the `variations.js` file.
 


### PR DESCRIPTION
The links /docs/reference-guides/packages/ and /docs/reference-guides/packages/packages-blocks.md don't link to any valid destination. This PR fixes both links to point to the correct destinations.


## Testing Instructions
Using GitHub UI I went to https://github.com/WordPress/gutenberg/blob/40e003d85a06b44037beecb8b5bd7aa253fe7e67/docs/getting-started/fundamentals/javascript-in-the-block-editor.md and verified both links https://github.com/WordPress/gutenberg/blob/40e003d85a06b44037beecb8b5bd7aa253fe7e67/docs/reference-guides/packages.md and https://github.com/WordPress/gutenberg/blob/40e003d85a06b44037beecb8b5bd7aa253fe7e67/packages/blocks/README.md work while on https://github.com/WordPress/gutenberg/blob/9437f7e73f9c6c9f831f2a26a555dfa8fddb3d61/docs/getting-started/fundamentals/javascript-in-the-block-editor.md (current trunk commit) https://github.com/WordPress/gutenberg/blob/9437f7e73f9c6c9f831f2a26a555dfa8fddb3d61/docs/reference-guides/packages and https://github.com/WordPress/gutenberg/blob/9437f7e73f9c6c9f831f2a26a555dfa8fddb3d61/docs/reference-guides/packages/packages-blocks.md don't work.