### PR TITLE
More Block: Refactor settings panel to use ToolsPanel 

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+	ToggleControl,
+} from '@wordpress/components';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
@@ -40,17 +44,34 @@ export default function MoreEdit( {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __(
-							'Hide the excerpt on the full content page'
-						) }
-						checked={ !! noTeaser }
-						onChange={ toggleHideExcerpt }
-						help={ getHideExcerptHelp }
-					/>
-				</PanelBody>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							noTeaser: false,
+							customText: DEFAULT_TEXT,
+						} );
+					} }
+				>
+					<ToolsPanelItem
+						label={ __( 'Hide excerpt' ) }
+						isShownByDefault
+						hasValue={ () => noTeaser }
+						onDeselect={ () =>
+							setAttributes( { noTeaser: false } )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Hide the excerpt on the full content page'
+							) }
+							checked={ !! noTeaser }
+							onChange={ toggleHideExcerpt }
+							help={ getHideExcerptHelp }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
 				<input

--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -49,7 +49,6 @@ export default function MoreEdit( {
 					resetAll={ () => {
 						setAttributes( {
 							noTeaser: false,
-							customText: DEFAULT_TEXT,
 						} );
 					} }
 				>


### PR DESCRIPTION
Part of: #67813 
Fixes: #67926

## What?
Refactored More Block code to include ToolsPanel instead of PanelBody.

## Screenshots

<table>
  <tr>
  <td colspan="1" width="33%"><b>Trunk</b></td>
  <td colspan="2" width="66%"><b>In this PR</b></td>
  </tr>
  <tr>
    <td width="33%">
<img width="281" alt="image" src="https://github.com/user-attachments/assets/176ac9ff-c203-4877-ac07-2a9ac38acdd3" />
      </td>
    <td width="33%">
      <img width="280" alt="Screenshot 2024-12-13 at 10 39 48 AM" src="https://github.com/user-attachments/assets/7f0ecee5-bf88-4556-9d6d-6dae75c1e614" />
    </td>
    <td width="33%">
      <img width="282" alt="Screenshot 2024-12-13 at 10 40 00 AM" src="https://github.com/user-attachments/assets/da237b06-b493-49c5-9df0-2a41cc1f60b6" />
    </td>
  </tr>
</table>







