### PR TITLE
Replace PanelBody with ToolsPanel in columns block

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -9,9 +9,10 @@ import clsx from 'clsx';
 import { __ } from '@wordpress/i18n';
 import {
 	Notice,
-	PanelBody,
 	RangeControl,
 	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 
 import {
@@ -149,9 +150,22 @@ function ColumnInspectorControls( {
 	}
 
 	return (
-		<PanelBody title={ __( 'Settings' ) }>
+		<ToolsPanel
+			label={ __( 'Settings' ) }
+			resetAll={ () => {
+				updateColumns( count, minCount );
+				setAttributes( {
+					isStackedOnMobile: true,
+				} );
+			} }
+		>
 			{ canInsertColumnBlock && (
-				<>
+				<ToolsPanelItem
+					label={ __( 'Columns' ) }
+					isShownByDefault
+					hasValue={ () => count }
+					onDeselect={ () => updateColumns( count, minCount ) }
+				>
 					<RangeControl
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
@@ -170,19 +184,30 @@ function ColumnInspectorControls( {
 							) }
 						</Notice>
 					) }
-				</>
+				</ToolsPanelItem>
 			) }
-			<ToggleControl
-				__nextHasNoMarginBottom
+			<ToolsPanelItem
 				label={ __( 'Stack on mobile' ) }
-				checked={ isStackedOnMobile }
-				onChange={ () =>
+				isShownByDefault
+				hasValue={ () => isStackedOnMobile !== true }
+				onDeselect={ () =>
 					setAttributes( {
-						isStackedOnMobile: ! isStackedOnMobile,
+						isStackedOnMobile: true,
 					} )
 				}
-			/>
-		</PanelBody>
+			>
+				<ToggleControl
+					__nextHasNoMarginBottom
+					label={ __( 'Stack on mobile' ) }
+					checked={ isStackedOnMobile }
+					onChange={ () =>
+						setAttributes( {
+							isStackedOnMobile: ! isStackedOnMobile,
+						} )
+					}
+				/>
+			</ToolsPanelItem>
+		</ToolsPanel>
 	);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This Update is related to: https://github.com/WordPress/gutenberg/issues/67813
Update columns block with ToolsPanel and ToolsPanelItem instead of PanelBody

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



|Before|After|
|-|-|
|<img width="282" alt="Screenshot 2024-12-13 at 11 52 06 AM" src="https://github.com/user-attachments/assets/8eb48269-e299-464c-8b1e-2185f5a61fc9" />|<img width="241" alt="Screenshot 2024-12-13 at 11 53 07 AM" src="https://github.com/user-attachments/assets/48c8adda-bd4a-452f-85bc-7a9b73b91f64" /><img width="284" alt="Screenshot 2024-12-13 at 11 53 00 AM" src="https://github.com/user-attachments/assets/ecc5cbcc-4392-4614-b130-dfe81ac1b88e" />|