### PR TITLE
Query Pagination: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -20,6 +20,7 @@ import { useEffect } from '@wordpress/element';
  */
 import { QueryPaginationArrowControls } from './query-pagination-arrow-controls';
 import { QueryPaginationLabelControl } from './query-pagination-label-control';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const TEMPLATE = [
 	[ 'core/query-pagination-previous' ],
@@ -59,6 +60,7 @@ export default function QueryPaginationEdit( {
 			setAttributes( { showLabel: true } );
 		}
 	}, [ paginationArrow, setAttributes, showLabel ] );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	return (
 		<>
 			{ hasNextPreviousBlocks && (
@@ -71,6 +73,7 @@ export default function QueryPaginationEdit( {
 								showLabel: true,
 							} );
 						} }
+						dropdownMenuProps={ dropdownMenuProps }
 					>
 						<ToolsPanelItem
 							hasValue={ () => paginationArrow !== 'none' }

--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -9,7 +9,10 @@ import {
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { PanelBody } from '@wordpress/components';
+import {
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 
 /**
@@ -60,22 +63,48 @@ export default function QueryPaginationEdit( {
 		<>
 			{ hasNextPreviousBlocks && (
 				<InspectorControls>
-					<PanelBody title={ __( 'Settings' ) }>
-						<QueryPaginationArrowControls
-							value={ paginationArrow }
-							onChange={ ( value ) => {
-								setAttributes( { paginationArrow: value } );
-							} }
-						/>
-						{ paginationArrow !== 'none' && (
-							<QueryPaginationLabelControl
-								value={ showLabel }
+					<ToolsPanel
+						label={ __( 'Settings' ) }
+						resetAll={ () => {
+							setAttributes( {
+								paginationArrow: 'none',
+								showLabel: true,
+							} );
+						} }
+					>
+						<ToolsPanelItem
+							hasValue={ () => paginationArrow !== 'none' }
+							label={ __( 'Pagination arrow' ) }
+							onDeselect={ () =>
+								setAttributes( { paginationArrow: 'none' } )
+							}
+							isShownByDefault
+						>
+							<QueryPaginationArrowControls
+								value={ paginationArrow }
 								onChange={ ( value ) => {
-									setAttributes( { showLabel: value } );
+									setAttributes( { paginationArrow: value } );
 								} }
 							/>
+						</ToolsPanelItem>
+						{ paginationArrow !== 'none' && (
+							<ToolsPanelItem
+								hasValue={ () => ! showLabel }
+								label={ __( 'Show text' ) }
+								onDeselect={ () =>
+									setAttributes( { showLabel: true } )
+								}
+								isShownByDefault
+							>
+								<QueryPaginationLabelControl
+									value={ showLabel }
+									onChange={ ( value ) => {
+										setAttributes( { showLabel: value } );
+									} }
+								/>
+							</ToolsPanelItem>
 						) }
-					</PanelBody>
+					</ToolsPanel>
 				</InspectorControls>
 			) }
 			<nav { ...innerBlocksProps } />


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/67813

## What?
Refactored Query Pagination Block code to include ToolsPanel instead of PanelBody.

## Screenshots

| Before | After ||
|-|:-:|-|
| |  | Settings Expanded |
|![Before - PanelBody interface](https://github.com/user-attachments/assets/8978cde8-1a32-42da-9548-ca2f33638a6b)|![After - ToolsPanel interface 2](https://github.com/user-attachments/assets/7a52ceca-55e6-4fb9-a53e-c8ad945b00d0)|![After - ToolsPanel interface 1](https://github.com/user-attachments/assets/0136d205-101a-4ed6-afd1-04a70ba9477d)|


