### PR TITLE
Read More: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/read-more/edit.js
+++ b/packages/block-library/src/read-more/edit.js
@@ -6,7 +6,11 @@ import {
 	RichText,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { ToggleControl, PanelBody } from '@wordpress/components';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -19,18 +23,30 @@ export default function ReadMore( {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<ToggleControl
-						__nextHasNoMarginBottom
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => setAttributes( { linkTarget: '_self' } ) }
+				>
+					<ToolsPanelItem
 						label={ __( 'Open in new tab' ) }
-						onChange={ ( value ) =>
-							setAttributes( {
-								linkTarget: value ? '_blank' : '_self',
-							} )
+						isShownByDefault
+						hasValue={ () => linkTarget !== '_self' }
+						onDeselect={ () =>
+							setAttributes( { linkTarget: '_self' } )
 						}
-						checked={ linkTarget === '_blank' }
-					/>
-				</PanelBody>
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Open in new tab' ) }
+							onChange={ ( value ) =>
+								setAttributes( {
+									linkTarget: value ? '_blank' : '_self',
+								} )
+							}
+							checked={ linkTarget === '_blank' }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<RichText
 				identifier="content"

--- a/packages/block-library/src/read-more/edit.js
+++ b/packages/block-library/src/read-more/edit.js
@@ -14,18 +14,26 @@ import {
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 export default function ReadMore( {
 	attributes: { content, linkTarget },
 	setAttributes,
 	insertBlocksAfter,
 } ) {
 	const blockProps = useBlockProps();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	return (
 		<>
 			<InspectorControls>
 				<ToolsPanel
 					label={ __( 'Settings' ) }
 					resetAll={ () => setAttributes( { linkTarget: '_self' } ) }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						label={ __( 'Open in new tab' ) }


### PR DESCRIPTION
Issue: #67944
Part of #67813

## What?
Update the Read More block to use the ToolsPanel and ToolsPanelItem components for settings management.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/bb111d74-e817-4749-b1d4-ecd2d6a7ffe1)|![image](https://github.com/user-attachments/assets/d4d2c59e-dcbb-43c0-b395-0657a87b02cd)|