### PR TITLE
Term List Block: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -26,6 +26,11 @@ import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 export default function CategoriesEdit( {
 	attributes: {
 		displayAsDropdown,
@@ -181,6 +186,7 @@ export default function CategoriesEdit( {
 	const blockProps = useBlockProps( {
 		className: classes,
 	} );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
 		<TagName { ...blockProps }>
@@ -197,6 +203,7 @@ export default function CategoriesEdit( {
 							showLabel: true,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					{ Array.isArray( taxonomies ) && (
 						<ToolsPanelItem

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -7,12 +7,13 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	PanelBody,
 	Placeholder,
 	SelectControl,
 	Spinner,
 	ToggleControl,
 	VisuallyHidden,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import {
@@ -184,68 +185,153 @@ export default function CategoriesEdit( {
 	return (
 		<TagName { ...blockProps }>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( {
+							displayAsDropdown: false,
+							showHierarchy: false,
+							showPostCounts: false,
+							showOnlyTopLevel: false,
+							showEmpty: false,
+							showLabel: true,
+						} );
+					} }
+				>
 					{ Array.isArray( taxonomies ) && (
-						<SelectControl
-							__nextHasNoMarginBottom
-							__next40pxDefaultSize
+						<ToolsPanelItem
+							hasValue={ () => {
+								return taxonomySlug !== 'category'
+									? taxonomySlug !== 'post_tag'
+									: taxonomySlug !== 'category';
+							} }
 							label={ __( 'Taxonomy' ) }
-							options={ taxonomies.map( ( t ) => ( {
-								label: t.name,
-								value: t.slug,
-							} ) ) }
-							value={ taxonomySlug }
-							onChange={ ( selectedTaxonomy ) =>
-								setAttributes( {
-									taxonomy: selectedTaxonomy,
-								} )
-							}
-						/>
+							onDeselect={ () => {
+								const defaultTaxonomy =
+									taxonomySlug !== 'category'
+										? 'post_tag'
+										: 'category';
+								setAttributes( { taxonomy: defaultTaxonomy } );
+							} }
+							isShownByDefault
+						>
+							<SelectControl
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
+								label={ __( 'Taxonomy' ) }
+								options={ taxonomies.map( ( t ) => ( {
+									label: t.name,
+									value: t.slug,
+								} ) ) }
+								value={ taxonomySlug }
+								onChange={ ( selectedTaxonomy ) =>
+									setAttributes( {
+										taxonomy: selectedTaxonomy,
+									} )
+								}
+							/>
+						</ToolsPanelItem>
 					) }
-					<ToggleControl
-						__nextHasNoMarginBottom
+					<ToolsPanelItem
+						hasValue={ () => displayAsDropdown !== false }
 						label={ __( 'Display as dropdown' ) }
-						checked={ displayAsDropdown }
-						onChange={ toggleAttribute( 'displayAsDropdown' ) }
-					/>
+						onDeselect={ () =>
+							setAttributes( { displayAsDropdown: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display as dropdown' ) }
+							checked={ displayAsDropdown }
+							onChange={ toggleAttribute( 'displayAsDropdown' ) }
+						/>
+					</ToolsPanelItem>
 					{ displayAsDropdown && (
-						<ToggleControl
-							__nextHasNoMarginBottom
-							className="wp-block-categories__indentation"
+						<ToolsPanelItem
+							hasValue={ () => showLabel !== true }
 							label={ __( 'Show label' ) }
-							checked={ showLabel }
-							onChange={ toggleAttribute( 'showLabel' ) }
-						/>
+							onDeselect={ () =>
+								setAttributes( { showLabel: true } )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								className="wp-block-categories__indentation"
+								label={ __( 'Show label' ) }
+								checked={ showLabel }
+								onChange={ toggleAttribute( 'showLabel' ) }
+							/>
+						</ToolsPanelItem>
 					) }
-					<ToggleControl
-						__nextHasNoMarginBottom
+					<ToolsPanelItem
+						hasValue={ () => showPostCounts !== false }
 						label={ __( 'Show post counts' ) }
-						checked={ showPostCounts }
-						onChange={ toggleAttribute( 'showPostCounts' ) }
-					/>
+						onDeselect={ () =>
+							setAttributes( { showPostCounts: false } )
+						}
+						isShownByDefault
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Show post counts' ) }
+							checked={ showPostCounts }
+							onChange={ toggleAttribute( 'showPostCounts' ) }
+						/>
+					</ToolsPanelItem>
 					{ isHierarchicalTaxonomy && (
-						<ToggleControl
-							__nextHasNoMarginBottom
+						<ToolsPanelItem
+							hasValue={ () => showOnlyTopLevel !== false }
 							label={ __( 'Show only top level terms' ) }
-							checked={ showOnlyTopLevel }
-							onChange={ toggleAttribute( 'showOnlyTopLevel' ) }
-						/>
+							onDeselect={ () =>
+								setAttributes( { showOnlyTopLevel: false } )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show only top level terms' ) }
+								checked={ showOnlyTopLevel }
+								onChange={ toggleAttribute(
+									'showOnlyTopLevel'
+								) }
+							/>
+						</ToolsPanelItem>
 					) }
-					<ToggleControl
-						__nextHasNoMarginBottom
+					<ToolsPanelItem
+						hasValue={ () => showEmpty !== false }
 						label={ __( 'Show empty terms' ) }
-						checked={ showEmpty }
-						onChange={ toggleAttribute( 'showEmpty' ) }
-					/>
-					{ isHierarchicalTaxonomy && ! showOnlyTopLevel && (
+						onDeselect={ () =>
+							setAttributes( { showEmpty: false } )
+						}
+						isShownByDefault
+					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={ __( 'Show hierarchy' ) }
-							checked={ showHierarchy }
-							onChange={ toggleAttribute( 'showHierarchy' ) }
+							label={ __( 'Show empty terms' ) }
+							checked={ showEmpty }
+							onChange={ toggleAttribute( 'showEmpty' ) }
 						/>
+					</ToolsPanelItem>
+					{ isHierarchicalTaxonomy && ! showOnlyTopLevel && (
+						<ToolsPanelItem
+							hasValue={ () => showHierarchy !== false }
+							label={ __( 'Show hierarchy' ) }
+							onDeselect={ () =>
+								setAttributes( { showHierarchy: false } )
+							}
+							isShownByDefault
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __( 'Show hierarchy' ) }
+								checked={ showHierarchy }
+								onChange={ toggleAttribute( 'showHierarchy' ) }
+							/>
+						</ToolsPanelItem>
 					) }
-				</PanelBody>
+				</ToolsPanel>
 			</InspectorControls>
 			{ isResolving && (
 				<Placeholder icon={ pin } label={ __( 'Terms' ) }>

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -195,6 +195,7 @@ export default function CategoriesEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
+							taxonomy: 'category',
 							displayAsDropdown: false,
 							showHierarchy: false,
 							showPostCounts: false,
@@ -208,17 +209,11 @@ export default function CategoriesEdit( {
 					{ Array.isArray( taxonomies ) && (
 						<ToolsPanelItem
 							hasValue={ () => {
-								return taxonomySlug !== 'category'
-									? taxonomySlug !== 'post_tag'
-									: taxonomySlug !== 'category';
+								return taxonomySlug !== 'category';
 							} }
 							label={ __( 'Taxonomy' ) }
 							onDeselect={ () => {
-								const defaultTaxonomy =
-									taxonomySlug !== 'category'
-										? 'post_tag'
-										: 'category';
-								setAttributes( { taxonomy: defaultTaxonomy } );
+								setAttributes( { taxonomy: 'category' } );
 							} }
 							isShownByDefault
 						>
@@ -240,7 +235,7 @@ export default function CategoriesEdit( {
 						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem
-						hasValue={ () => displayAsDropdown !== false }
+						hasValue={ () => !! displayAsDropdown }
 						label={ __( 'Display as dropdown' ) }
 						onDeselect={ () =>
 							setAttributes( { displayAsDropdown: false } )
@@ -256,7 +251,7 @@ export default function CategoriesEdit( {
 					</ToolsPanelItem>
 					{ displayAsDropdown && (
 						<ToolsPanelItem
-							hasValue={ () => showLabel !== true }
+							hasValue={ () => ! showLabel }
 							label={ __( 'Show label' ) }
 							onDeselect={ () =>
 								setAttributes( { showLabel: true } )
@@ -273,7 +268,7 @@ export default function CategoriesEdit( {
 						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem
-						hasValue={ () => showPostCounts !== false }
+						hasValue={ () => !! showPostCounts }
 						label={ __( 'Show post counts' ) }
 						onDeselect={ () =>
 							setAttributes( { showPostCounts: false } )
@@ -289,7 +284,7 @@ export default function CategoriesEdit( {
 					</ToolsPanelItem>
 					{ isHierarchicalTaxonomy && (
 						<ToolsPanelItem
-							hasValue={ () => showOnlyTopLevel !== false }
+							hasValue={ () => !! showOnlyTopLevel }
 							label={ __( 'Show only top level terms' ) }
 							onDeselect={ () =>
 								setAttributes( { showOnlyTopLevel: false } )
@@ -307,7 +302,7 @@ export default function CategoriesEdit( {
 						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem
-						hasValue={ () => showEmpty !== false }
+						hasValue={ () => !! showEmpty }
 						label={ __( 'Show empty terms' ) }
 						onDeselect={ () =>
 							setAttributes( { showEmpty: false } )
@@ -323,7 +318,7 @@ export default function CategoriesEdit( {
 					</ToolsPanelItem>
 					{ isHierarchicalTaxonomy && ! showOnlyTopLevel && (
 						<ToolsPanelItem
-							hasValue={ () => showHierarchy !== false }
+							hasValue={ () => !! showHierarchy }
 							label={ __( 'Show hierarchy' ) }
 							onDeselect={ () =>
 								setAttributes( { showHierarchy: false } )


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/67813

## What?
Refactored Term List Block code to include ToolsPanel instead of PanelBody.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/7a631962-414d-475d-a029-e4a2080ecbd2)|![image](https://github.com/user-attachments/assets/4eecfc2d-4f78-484a-beea-833521584e2e)|
