### PR TITLE
Query Page Numbers Block: Refactor settings panel to use ToolsPanel

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/edit.js
+++ b/packages/block-library/src/query-pagination-numbers/edit.js
@@ -4,8 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import {
-	ToolsPanel,
-	ToolsPanelItem,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 	RangeControl,
 } from '@wordpress/components';
 

--- a/packages/block-library/src/query-pagination-numbers/edit.js
+++ b/packages/block-library/src/query-pagination-numbers/edit.js
@@ -3,7 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { PanelBody, RangeControl } from '@wordpress/components';
+import {
+	ToolsPanel,
+	ToolsPanelItem,
+	RangeControl,
+} from '@wordpress/components';
 
 const createPaginationItem = ( content, Tag = 'a', extraClass = '' ) => (
 	<Tag key={ content } className={ `page-numbers ${ extraClass }` }>
@@ -46,28 +50,39 @@ export default function QueryPaginationNumbersEdit( {
 	const paginationNumbers = previewPaginationNumbers(
 		parseInt( midSize, 10 )
 	);
+
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody title={ __( 'Settings' ) }>
-					<RangeControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => setAttributes( { midSize: 2 } ) }
+				>
+					<ToolsPanelItem
 						label={ __( 'Number of links' ) }
-						help={ __(
-							'Specify how many links can appear before and after the current page number. Links to the first, current and last page are always visible.'
-						) }
-						value={ midSize }
-						onChange={ ( value ) => {
-							setAttributes( {
-								midSize: parseInt( value, 10 ),
-							} );
-						} }
-						min={ 0 }
-						max={ 5 }
-						withInputField={ false }
-					/>
-				</PanelBody>
+						hasValue={ () => midSize !== undefined }
+						onDeselect={ () => setAttributes( { midSize: 2 } ) }
+						isShownByDefault
+					>
+						<RangeControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={ __( 'Number of links' ) }
+							help={ __(
+								'Specify how many links can appear before and after the current page number. Links to the first, current and last page are always visible.'
+							) }
+							value={ midSize }
+							onChange={ ( value ) => {
+								setAttributes( {
+									midSize: parseInt( value, 10 ),
+								} );
+							} }
+							min={ 0 }
+							max={ 5 }
+							withInputField={ false }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>{ paginationNumbers }</div>
 		</>


### PR DESCRIPTION
Part of: #67813 
Fixes: #67946
## What?
Refactored Query Page Numbers Block code to include ToolsPanel instead of PanelBody.

## Screenshots


<table>
  <tr>
  <td colspan="1" width="33%"><b>Trunk</b></td>
  <td colspan="2" width="66%"><b>In this PR</b></td>
  </tr>
  <tr>
    <td width="33%">
<img width="282" alt="image" src="https://github.com/user-attachments/assets/8a0ead64-a8c3-4f6d-acfa-0175e5607a17" />
      </td>
    <td width="33%">
<img width="281" alt="Screenshot 2024-12-13 at 3 30 58 PM" src="https://github.com/user-attachments/assets/ed189566-8b7d-4df0-9617-8f12c9a661f0" />
    </td>
    <td width="33%">
<img width="281" alt="Screenshot 2024-12-13 at 3 30 49 PM" src="https://github.com/user-attachments/assets/2b9dde79-99bc-446d-8ebb-ef20e52a8120" />
    </td>
  </tr>
</table>

