### PR TITLE
Editor: Remove the 'content-only' check from 'TemplatePartConverterMenuItem'

### DIFF
--- a/packages/editor/src/components/template-part-menu-items/index.js
+++ b/packages/editor/src/components/template-part-menu-items/index.js
@@ -27,24 +27,15 @@ export default function TemplatePartMenuItems() {
 }
 
 function TemplatePartConverterMenuItem( { clientIds, onClose } ) {
-	const { isContentOnly, blocks } = useSelect(
+	const { blocks } = useSelect(
 		( select ) => {
-			const { getBlocksByClientId, getBlockEditingMode } =
-				select( blockEditorStore );
+			const { getBlocksByClientId } = select( blockEditorStore );
 			return {
 				blocks: getBlocksByClientId( clientIds ),
-				isContentOnly:
-					clientIds.length === 1 &&
-					getBlockEditingMode( clientIds[ 0 ] ) === 'contentOnly',
 			};
 		},
 		[ clientIds ]
 	);
-
-	// Do not show the convert button if the block is in content-only mode.
-	if ( isContentOnly ) {
-		return null;
-	}
 
 	// Allow converting a single template part to standard blocks.
 	if ( blocks.length === 1 && blocks[ 0 ]?.name === 'core/template-part' ) {


### PR DESCRIPTION
## What?
This is a follow-up to #67749.

PR removes the unnecessary `isContentOnly` check from `TemplatePartConverterMenuItem`. The check now happens at the top level.


## Testing Instructions
1. Enable experimental Write Mode.
2. Open a template in Site Editor.
3. Select a block.
4. Confirm that the "Create template part" is displayed in block options.
5. Switch to write mode.
6. Confirm that block options no longer display the " Create template " part.

### Testing Instructions for Keyboard
Same.
