### PR TITLE
More Block: Migrate to Toolspanel

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -2,7 +2,11 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ToggleControl } from '@wordpress/components';
+import {
+	ToggleControl,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
+} from '@wordpress/components';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
@@ -40,17 +44,31 @@ export default function MoreEdit( {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __(
-							'Hide the excerpt on the full content page'
-						) }
-						checked={ !! noTeaser }
-						onChange={ toggleHideExcerpt }
-						help={ getHideExcerptHelp }
-					/>
-				</PanelBody>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					resetAll={ () => {
+						setAttributes( { noTeaser: false } );
+					} }
+				>
+					<ToolsPanelItem
+						isShownByDefault
+						label={ __( 'Hide the excerpt' ) }
+						onDeselect={ () => {
+							setAttributes( { noTeaser: false } );
+						} }
+						hasValue={ () => !! noTeaser }
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __(
+								'Hide the excerpt on the full content page'
+							) }
+							checked={ !! noTeaser }
+							onChange={ toggleHideExcerpt }
+							help={ getHideExcerptHelp }
+						/>
+					</ToolsPanelItem>
+				</ToolsPanel>
 			</InspectorControls>
 			<div { ...useBlockProps() }>
 				<input


### PR DESCRIPTION
resolves #67926
Part of #67813
 
## Considerations

I have added resetAll and label to ensure that design stays consistent with other components, It changes original view by a little.

## Before

![image](https://github.com/user-attachments/assets/d183b4b4-dc44-4496-9930-eca184b1f413)

## After
![image](https://github.com/user-attachments/assets/e5cd13ed-bac0-49b7-9ae2-535d0ca594ad)
![image](https://github.com/user-attachments/assets/397dc339-32eb-48ee-98d5-7ada26f8c593)
