### PR TITLE
Improve logic to show entities saved panel description.

### DIFF
--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -115,7 +115,7 @@ export function EntitiesSavedStatesExtensible( {
 		'description'
 	);
 
-	const selectItemsToSaveDescription = dirtyEntityRecords.length
+	const selectItemsToSaveDescription = !! dirtyEntityRecords.length
 		? __( 'Select the items you want to save.' )
 		: undefined;
 

--- a/packages/editor/src/components/entities-saved-states/index.js
+++ b/packages/editor/src/components/entities-saved-states/index.js
@@ -115,6 +115,10 @@ export function EntitiesSavedStatesExtensible( {
 		'description'
 	);
 
+	const selectItemsToSaveDescription = dirtyEntityRecords.length
+		? __( 'Select the items you want to save.' )
+		: undefined;
+
 	return (
 		<div
 			ref={ renderDialog ? saveDialogRef : undefined }
@@ -180,7 +184,7 @@ export function EntitiesSavedStatesExtensible( {
 								),
 								{ strong: <strong /> }
 						  )
-						: __( 'Select the items you want to save.' ) }
+						: selectItemsToSaveDescription }
 				</p>
 			</div>
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/67963

## What?
<!-- In a few words, what is the PR actually doing? -->
The Theme Preview save panel shows a description `Select the items you want to save.` even when there are no change items to save.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The message is confusing and the logic to show it should be improved.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Shows the message only when there are actual dirty entities records to save.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the steps from the issue https://github.com/WordPress/gutenberg/issues/67963
- Observe the description message is shown only when appropriate.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
