### PR TITLE
Refactor "Settings" panel of Next Post block to use ToolsPanel instead of PanelBody

### DIFF
--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -95,23 +95,25 @@ export default function PostNavigationLinkEdit( {
 	return (
 		<>
 			<InspectorControls>
-				<ToolsPanel label={__('Settings')}>
+				<ToolsPanel label={ __( 'Settings' ) }>
 					<ToolsPanelItem
-						hasValue={() => !!showTitle}
-						label={__('Display the title as a link')}
-						onDeselect={() => setAttributes({ showTitle: false })}
+						hasValue={ () => !! showTitle }
+						label={ __( 'Display the title as a link' ) }
+						onDeselect={ () =>
+							setAttributes( { showTitle: false } )
+						}
 					>
 						<ToggleControl
 							__nextHasNoMarginBottom
-							label={__('Display the title as a link')}
-							help={__(
+							label={ __( 'Display the title as a link' ) }
+							help={ __(
 								'If you have entered a custom label, it will be prepended before the title.'
-							)}
-							checked={!!showTitle}
-							onChange={() =>
-								setAttributes({
-									showTitle: !showTitle,
-								})
+							) }
+							checked={ !! showTitle }
+							onChange={ () =>
+								setAttributes( {
+									showTitle: ! showTitle,
+								} )
 							}
 						/>
 					</ToolsPanelItem>
@@ -131,49 +133,47 @@ export default function PostNavigationLinkEdit( {
 						/>
 					) }
 					<ToolsPanelItem
-						hasValue={() => !!arrow}
-						label={__('Arrow')}
-						onDeselect={() => setAttributes({ arrow: 'none' })}
+						hasValue={ () => !! arrow }
+						label={ __( 'Arrow' ) }
+						onDeselect={ () => setAttributes( { arrow: 'none' } ) }
 					>
 						<ToggleGroupControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
-							label={__('Arrow')}
-							value={arrow}
-							onChange={(value) => {
-								setAttributes({ arrow: value });
-							}}
-							help={__(
+							label={ __( 'Arrow' ) }
+							value={ arrow }
+							onChange={ ( value ) => {
+								setAttributes( { arrow: value } );
+							} }
+							help={ __(
 								'A decorative arrow for the next and previous link.'
-							)}
+							) }
 							isBlock
 						>
 							<ToggleGroupControlOption
 								value="none"
-								label={_x(
+								label={ _x(
 									'None',
 									'Arrow option for Next/Previous link'
-								)}
+								) }
 							/>
 							<ToggleGroupControlOption
 								value="arrow"
-								label={_x(
+								label={ _x(
 									'Arrow',
 									'Arrow option for Next/Previous link'
-								)}
+								) }
 							/>
 							<ToggleGroupControlOption
 								value="chevron"
-								label={_x(
+								label={ _x(
 									'Chevron',
 									'Arrow option for Next/Previous link'
-								)}
+								) }
 							/>
 						</ToggleGroupControl>
 					</ToolsPanelItem>
 				</ToolsPanel>
-				
-				
 			</InspectorControls>
 			<InspectorControls group="advanced">
 				<SelectControl

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -127,6 +127,7 @@ export default function PostNavigationLinkEdit( {
 									linkLabel: ! linkLabel,
 								} )
 							}
+							isShownByDefault
 						/>
 					) }
 					<ToolsPanelItem

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -11,7 +11,8 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 	ToggleControl,
 	SelectControl,
-	PanelBody,
+	__experimentalToolsPanel as ToolsPanel,
+	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import {
 	InspectorControls,
@@ -94,20 +95,26 @@ export default function PostNavigationLinkEdit( {
 	return (
 		<>
 			<InspectorControls>
-				<PanelBody>
-					<ToggleControl
-						__nextHasNoMarginBottom
-						label={ __( 'Display the title as a link' ) }
-						help={ __(
-							'If you have entered a custom label, it will be prepended before the title.'
-						) }
-						checked={ !! showTitle }
-						onChange={ () =>
-							setAttributes( {
-								showTitle: ! showTitle,
-							} )
-						}
-					/>
+				<ToolsPanel label={__('Settings')}>
+					<ToolsPanelItem
+						hasValue={() => !!showTitle}
+						label={__('Display the title as a link')}
+						onDeselect={() => setAttributes({ showTitle: false })}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={__('Display the title as a link')}
+							help={__(
+								'If you have entered a custom label, it will be prepended before the title.'
+							)}
+							checked={!!showTitle}
+							onChange={() =>
+								setAttributes({
+									showTitle: !showTitle,
+								})
+							}
+						/>
+					</ToolsPanelItem>
 					{ showTitle && (
 						<ToggleControl
 							__nextHasNoMarginBottom
@@ -122,42 +129,50 @@ export default function PostNavigationLinkEdit( {
 							}
 						/>
 					) }
-					<ToggleGroupControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Arrow' ) }
-						value={ arrow }
-						onChange={ ( value ) => {
-							setAttributes( { arrow: value } );
-						} }
-						help={ __(
-							'A decorative arrow for the next and previous link.'
-						) }
-						isBlock
+					<ToolsPanelItem
+						hasValue={() => !!arrow}
+						label={__('Arrow')}
+						onDeselect={() => setAttributes({ arrow: 'none' })}
 					>
-						<ToggleGroupControlOption
-							value="none"
-							label={ _x(
-								'None',
-								'Arrow option for Next/Previous link'
-							) }
-						/>
-						<ToggleGroupControlOption
-							value="arrow"
-							label={ _x(
-								'Arrow',
-								'Arrow option for Next/Previous link'
-							) }
-						/>
-						<ToggleGroupControlOption
-							value="chevron"
-							label={ _x(
-								'Chevron',
-								'Arrow option for Next/Previous link'
-							) }
-						/>
-					</ToggleGroupControl>
-				</PanelBody>
+						<ToggleGroupControl
+							__next40pxDefaultSize
+							__nextHasNoMarginBottom
+							label={__('Arrow')}
+							value={arrow}
+							onChange={(value) => {
+								setAttributes({ arrow: value });
+							}}
+							help={__(
+								'A decorative arrow for the next and previous link.'
+							)}
+							isBlock
+						>
+							<ToggleGroupControlOption
+								value="none"
+								label={_x(
+									'None',
+									'Arrow option for Next/Previous link'
+								)}
+							/>
+							<ToggleGroupControlOption
+								value="arrow"
+								label={_x(
+									'Arrow',
+									'Arrow option for Next/Previous link'
+								)}
+							/>
+							<ToggleGroupControlOption
+								value="chevron"
+								label={_x(
+									'Chevron',
+									'Arrow option for Next/Previous link'
+								)}
+							/>
+						</ToggleGroupControl>
+					</ToolsPanelItem>
+				</ToolsPanel>
+				
+				
 			</InspectorControls>
 			<InspectorControls group="advanced">
 				<SelectControl

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -128,19 +128,27 @@ export default function PostNavigationLinkEdit( {
 						/>
 					</ToolsPanelItem>
 					{ showTitle && (
-						<ToggleControl
-							__nextHasNoMarginBottom
-							label={ __(
-								'Include the label as part of the link'
-							) }
-							checked={ !! linkLabel }
-							onChange={ () =>
-								setAttributes( {
-									linkLabel: ! linkLabel,
-								} )
-							}
-							isShownByDefault
-						/>
+						<ToolsPanelItem
+							hasValue={ () => !! linkLabel }
+							label={ __( 'Include the label as part of the link' ) }
+							onDeselect={ () => setAttributes( { linkLabel: false } ) }
+						>
+							
+								<ToggleControl
+									__nextHasNoMarginBottom
+									label={ __(
+										'Include the label as part of the link'
+									) }
+									checked={ !! linkLabel }
+									onChange={ () =>
+										setAttributes( {
+											linkLabel: ! linkLabel,
+										} )
+									}
+									isShownByDefault
+								/>
+							
+						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem
 						hasValue={ () => !! arrow }

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -25,6 +25,11 @@ import { __, _x } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 export default function PostNavigationLinkEdit( {
 	context: { postType },
 	attributes: {
@@ -48,6 +53,7 @@ export default function PostNavigationLinkEdit( {
 	};
 
 	const displayArrow = arrowMap[ arrow ];
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	if ( showTitle ) {
 		placeholder = isNext
@@ -95,13 +101,17 @@ export default function PostNavigationLinkEdit( {
 	return (
 		<>
 			<InspectorControls>
-				<ToolsPanel label={ __( 'Settings' ) }>
+				<ToolsPanel
+					label={ __( 'Settings' ) }
+					dropdownMenuProps={ dropdownMenuProps }
+				>
 					<ToolsPanelItem
 						hasValue={ () => !! showTitle }
 						label={ __( 'Display the title as a link' ) }
 						onDeselect={ () =>
 							setAttributes( { showTitle: false } )
 						}
+						isShownByDefault
 					>
 						<ToggleControl
 							__nextHasNoMarginBottom
@@ -136,6 +146,7 @@ export default function PostNavigationLinkEdit( {
 						hasValue={ () => !! arrow }
 						label={ __( 'Arrow' ) }
 						onDeselect={ () => setAttributes( { arrow: 'none' } ) }
+						isShownByDefault
 					>
 						<ToggleGroupControl
 							__next40pxDefaultSize

--- a/packages/block-library/src/post-navigation-link/edit.js
+++ b/packages/block-library/src/post-navigation-link/edit.js
@@ -130,28 +130,30 @@ export default function PostNavigationLinkEdit( {
 					{ showTitle && (
 						<ToolsPanelItem
 							hasValue={ () => !! linkLabel }
-							label={ __( 'Include the label as part of the link' ) }
-							onDeselect={ () => setAttributes( { linkLabel: false } ) }
+							label={ __(
+								'Include the label as part of the link'
+							) }
+							onDeselect={ () =>
+								setAttributes( { linkLabel: false } )
+							}
+							isShownByDefault
 						>
-							
-								<ToggleControl
-									__nextHasNoMarginBottom
-									label={ __(
-										'Include the label as part of the link'
-									) }
-									checked={ !! linkLabel }
-									onChange={ () =>
-										setAttributes( {
-											linkLabel: ! linkLabel,
-										} )
-									}
-									isShownByDefault
-								/>
-							
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __(
+									'Include the label as part of the link'
+								) }
+								checked={ !! linkLabel }
+								onChange={ () =>
+									setAttributes( {
+										linkLabel: ! linkLabel,
+									} )
+								}
+							/>
 						</ToolsPanelItem>
 					) }
 					<ToolsPanelItem
-						hasValue={ () => !! arrow }
+						hasValue={ () => arrow !== 'none' }
 						label={ __( 'Arrow' ) }
 						onDeselect={ () => setAttributes( { arrow: 'none' } ) }
 						isShownByDefault


### PR DESCRIPTION
Part of #67813 
Fixes #67943 

## Testing Instructions

- Add Next post block
- Open the settings panel

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|<img width="280" alt="before-next-post" src="https://github.com/user-attachments/assets/6e7d44fa-4eb6-4b3b-8e6a-22322a2af810" />|<img width="280" alt="after-next-post" src="https://github.com/user-attachments/assets/6d7b7f2c-f2c6-455e-891d-6664fffc8445" />|

