### PR TITLE
Pages: remove unnecessary padding for items

### DIFF
--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -212,7 +212,7 @@ export default function CustomDataViewsList( { type, activeView, isCustom } ) {
 			<div className="edit-site-sidebar-navigation-screen-dataviews__group-header">
 				<Heading level={ 2 }>{ __( 'Custom Views' ) }</Heading>
 			</div>
-			<ItemGroup>
+			<ItemGroup className="edit-site-sidebar-navigation-screen-dataviews__custom-items">
 				{ customDataViews.map( ( customViewRecord ) => {
 					return (
 						<CustomDataViewItem

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -14,7 +14,6 @@
 
 .edit-site-sidebar-dataviews-dataview-item {
 	border-radius: $radius-small;
-	padding-right: $grid-unit-10;
 
 	.edit-site-sidebar-dataviews-dataview-item__dropdown-menu {
 		min-width: initial;

--- a/packages/edit-site/src/components/sidebar-dataviews/style.scss
+++ b/packages/edit-site/src/components/sidebar-dataviews/style.scss
@@ -12,6 +12,10 @@
 	margin-right: -$grid-unit-20;
 }
 
+.edit-site-sidebar-navigation-screen-dataviews__custom-items .edit-site-sidebar-dataviews-dataview-item {
+	padding-right: $grid-unit-10;
+}
+
 .edit-site-sidebar-dataviews-dataview-item {
 	border-radius: $radius-small;
 


### PR DESCRIPTION
## What?

Note how the outer focus ring doesn't wrap the whole item:

| Before | After |
| --- | --- |
| <img width="294" alt="Screenshot 2024-12-13 at 13 08 02" src="https://github.com/user-attachments/assets/b9deec79-d991-486d-9bd0-35797450be79" /> | <img width="294" alt="Screenshot 2024-12-13 at 13 02 37" src="https://github.com/user-attachments/assets/fa48b5a4-6297-423d-816b-1321baa64e5a" /> |

## Why?

In any other site editor screen, the focus style for the list item takes the whole item.

## How?

Remove unnecessary padding rule.

## Testing Instructions

Go to the Pages screen in the site editor and focus one of the items with the keyboard. Verify the outer ring wraps the whole item.