### PR TITLE
ActionItem.Slot: Render as `MenuGroup` by default

### DIFF
--- a/packages/editor/src/components/more-menu/index.js
+++ b/packages/editor/src/components/more-menu/index.js
@@ -113,7 +113,6 @@ export default function MoreMenu() {
 						<ActionItem.Slot
 							name="core/plugin-more-menu"
 							label={ __( 'Plugins' ) }
-							as={ MenuGroup }
 							fillProps={ { onClick: onClose } }
 						/>
 						<MenuGroup label={ __( 'Tools' ) }>

--- a/packages/editor/src/components/preview-dropdown/index.js
+++ b/packages/editor/src/components/preview-dropdown/index.js
@@ -190,7 +190,6 @@ export default function PreviewDropdown( { forceIsAutosaveable, disabled } ) {
 					) }
 					<ActionItem.Slot
 						name="core/plugin-preview-menu"
-						as={ MenuGroup }
 						fillProps={ { onClick: onClose } }
 					/>
 				</>

--- a/packages/interface/CHANGELOG.md
+++ b/packages/interface/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+-   `ActionItem.Slot`: Render as `MenuGroup` by default ([#67985](https://github.com/WordPress/gutenberg/pull/67985)).
+
 ## 8.3.0 (2024-12-11)
 
 ## 8.2.0 (2024-11-27)

--- a/packages/interface/src/components/action-item/README.md
+++ b/packages/interface/src/components/action-item/README.md
@@ -24,11 +24,11 @@ Property used to change the event bubbling behavior, passed to the `Slot` compon
 
 ### as
 
-The component used as the container of the fills. Defaults to the `ButtonGroup` component.
+The component used as the container of the fills. Defaults to the `MenuGroup` component.
 
 -   Type: `Component`
 -   Required: no
--   Default: `ButtonGroup`
+-   Default: `MenuGroup`
 
 ## ActionItem
 

--- a/packages/interface/src/components/action-item/index.js
+++ b/packages/interface/src/components/action-item/index.js
@@ -1,14 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { ButtonGroup, Button, Slot, Fill } from '@wordpress/components';
+import { MenuGroup, Button, Slot, Fill } from '@wordpress/components';
 import { Children } from '@wordpress/element';
 
 const noop = () => {};
 
 function ActionItemSlot( {
 	name,
-	as: Component = ButtonGroup,
+	as: Component = MenuGroup,
 	fillProps = {},
 	bubblesVirtually,
 	...props


### PR DESCRIPTION
Part of #65339

## What?

Render the `ActionItem.Slot` as a `MenuGroup` by default, instead of `ButtonGroup`.

## Why?

- We want to deprecate ButtonGroup.
- All internal usages are rendering `as={ MenuGroup }`.
- [No extenders](https://wpdirectory.net/search/01JF0K2MZQ525HCGPDK4B0P351) are actually using custom `ActionItem.Slot`s, meaning that if anyone is using `ActionItem`s for anything, it is to render into the Core action item slots (which are `MenuGroup`).
- `@wordpress/interface` is an experimental package.

I think this means that, although it is theoretically a breaking change, it should be safe in practice.

## Testing Instructions

I couldn't get a test case set up 🙁 I've tried something like this in the Storybook, and nothing is rendering, before or after this PR:

```
export const Test = {
	render: () => {
		return (
			<SlotFillProvider>
				<ActionItem.Slot name="foo/bar" />
				<ActionItem name="foo/bar">Hello</ActionItem>
			</SlotFillProvider>
		);
	},
};
```

The changes are theoretically safe and unit tests are passing, but it would be great if someone can confirm.