### PR TITLE
CSP: Refactor accessibility scripts to use Object.assign for style attributes

### DIFF
--- a/packages/a11y/src/script/add-container.js
+++ b/packages/a11y/src/script/add-container.js
@@ -10,20 +10,19 @@ export default function addContainer( ariaLive = 'polite' ) {
 	container.id = `a11y-speak-${ ariaLive }`;
 	container.className = 'a11y-speak-region';
 
-	container.setAttribute(
-		'style',
-		'position: absolute;' +
-			'margin: -1px;' +
-			'padding: 0;' +
-			'height: 1px;' +
-			'width: 1px;' +
-			'overflow: hidden;' +
-			'clip: rect(1px, 1px, 1px, 1px);' +
-			'-webkit-clip-path: inset(50%);' +
-			'clip-path: inset(50%);' +
-			'border: 0;' +
-			'word-wrap: normal !important;'
-	);
+	Object.assign( container.style, {
+		position: 'absolute',
+		margin: '-1px',
+		padding: '0',
+		height: '1px',
+		width: '1px',
+		overflow: 'hidden',
+		clip: 'rect(1px, 1px, 1px, 1px)',
+		webkitClipPath: 'inset(50%)',
+		clipPath: 'inset(50%)',
+		border: '0',
+		wordWrap: 'normal',
+	} );
 	container.setAttribute( 'aria-live', ariaLive );
 	container.setAttribute( 'aria-relevant', 'additions text' );
 	container.setAttribute( 'aria-atomic', 'true' );

--- a/packages/a11y/src/script/add-intro-text.ts
+++ b/packages/a11y/src/script/add-intro-text.ts
@@ -18,20 +18,19 @@ export default function addIntroText() {
 	introText.className = 'a11y-speak-intro-text';
 	introText.textContent = __( 'Notifications' );
 
-	introText.setAttribute(
-		'style',
-		'position: absolute;' +
-			'margin: -1px;' +
-			'padding: 0;' +
-			'height: 1px;' +
-			'width: 1px;' +
-			'overflow: hidden;' +
-			'clip: rect(1px, 1px, 1px, 1px);' +
-			'-webkit-clip-path: inset(50%);' +
-			'clip-path: inset(50%);' +
-			'border: 0;' +
-			'word-wrap: normal !important;'
-	);
+	Object.assign( introText.style, {
+		position: 'absolute',
+		margin: '-1px',
+		padding: '0',
+		height: '1px',
+		width: '1px',
+		overflow: 'hidden',
+		clip: 'rect(1px, 1px, 1px, 1px)',
+		webkitClipPath: 'inset(50%)',
+		clipPath: 'inset(50%)',
+		border: '0',
+		wordWrap: 'normal',
+	} );
 	introText.setAttribute( 'hidden', 'hidden' );
 
 	const { body } = document;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Refactor: Use Object.assign to set inline style

More info:
https://github.com/WordPress/gutenberg/issues/68021

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This change will not be blocked by a CSP without unsafe-inline.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
The implementation replaces the existing `setAttribute` call with `Object.assign`, applying individual style properties to the element's `style` object.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Install Wordpress and activate the Twenty Nineteen theme
2. Add the following code to the functions.php file of the Twenty Nineteen theme:

```
// Enqueue the wp-a11y script plus internal script that uses a wp-a11y function that sets inline styles
function enqueue_wp_a11y_script() {

	wp_enqueue_script('wp-a11y');

	$internal_script = "
        document.addEventListener('DOMContentLoaded', function() {
            if (typeof wp !== 'undefined' && wp.a11y && wp.a11y.speak) {
                wp.a11y.speak( 'The message you want to send to the ARIA live region', 'assertive' );
            }
        });
    ";
	wp_add_inline_script('wp-a11y', $internal_script);
}
add_action('wp_enqueue_scripts', 'enqueue_wp_a11y_script');

// Add CSP without unsafe-inline
// To reduce CSP violations/noise: Added nonces to internal script and style tags/directives, allow data: in font-src and https://secure.gravatar.com as img-src
function add_csp_without_unsafe_inline() {
	ob_start( function ( $output ) {
		static $nonce = null;

		if ( $nonce === null ) {
			$nonce = bin2hex( openssl_random_pseudo_bytes( 32 ) );
		}

		$output = preg_replace_callback( '#<script.*?\>#', function ( $matches ) use ( $nonce ) {
			return str_replace( '<script', "<script nonce='{$nonce}'", $matches[0] );
		}, $output );

		$output = preg_replace_callback( '#<style.*?\>#', function ( $matches ) use ( $nonce ) {
			return str_replace( '<style', "<style nonce='{$nonce}'", $matches[0] );
		}, $output );

		header( "Content-Security-Policy: default-src 'self'; script-src 'self' 'nonce-{$nonce}'; style-src 'self' 'nonce-{$nonce}'; font-src 'self' data:; img-src 'self' https://secure.gravatar.com" );

		return $output;
	} );
}
add_action( 'template_redirect', 'add_csp_without_unsafe_inline');
```

3. Open the website in a browser and check the console for CSP violations in wp-a11y script
4. Activate the Gutenberg plugin with this commit and confirm that the wp-a11y script is still enqueued but no longer triggers CSP violations

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->
-
## Screenshots or screencast <!-- if applicable -->
-