### PR TITLE
Columns: Replace some store selectors with 'getBlockOrder'

### DIFF
--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -52,19 +52,15 @@ function ColumnInspectorControls( {
 } ) {
 	const { count, canInsertColumnBlock, minCount } = useSelect(
 		( select ) => {
-			const {
-				canInsertBlockType,
-				canRemoveBlock,
-				getBlocks,
-				getBlockCount,
-			} = select( blockEditorStore );
-			const innerBlocks = getBlocks( clientId );
+			const { canInsertBlockType, canRemoveBlock, getBlockOrder } =
+				select( blockEditorStore );
+			const blockOrder = getBlockOrder( clientId );
 
 			// Get the indexes of columns for which removal is prevented.
 			// The highest index will be used to determine the minimum column count.
-			const preventRemovalBlockIndexes = innerBlocks.reduce(
-				( acc, block, index ) => {
-					if ( ! canRemoveBlock( block.clientId ) ) {
+			const preventRemovalBlockIndexes = blockOrder.reduce(
+				( acc, blockId, index ) => {
+					if ( ! canRemoveBlock( blockId ) ) {
 						acc.push( index );
 					}
 					return acc;
@@ -73,7 +69,7 @@ function ColumnInspectorControls( {
 			);
 
 			return {
-				count: getBlockCount( clientId ),
+				count: blockOrder.length,
 				canInsertColumnBlock: canInsertBlockType(
 					'core/column',
 					clientId


### PR DESCRIPTION
## What?
A micro-optimization for Columns block selectors. PR replaces `getBlocks` and `getBlockCount` with `getBlockOrder` selector. It returns all the data blocks needed to derive states.

## Testing Instructions
None. E2E tests cover this logic. See `prevent the removal of locked column block from the column count change UI` e2e test.

### Testing Instructions for Keyboard
Same.
