### PR TITLE
[ Navigation block ] Remove unnecessary white spaces.

### DIFF
--- a/packages/block-library/src/navigation/edit/responsive-wrapper.js
+++ b/packages/block-library/src/navigation/edit/responsive-wrapper.js
@@ -49,7 +49,7 @@ export default function ResponsiveWrapper( {
 			'is-menu-open': isOpen,
 			'hidden-by-default': isHiddenByDefault,
 		}
-	);
+	).trim();
 
 	const styles = {
 		color: ! overlayTextColor?.slug && overlayTextColor?.color,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Remove unnecessary white spaces from navigation block's class.

## Why?

The navigation block's class name contains unnecessary spaces.

![スクリーンショット 2024-12-15 15 21 00](https://github.com/user-attachments/assets/a2065193-4ca7-4d76-9e4b-79645473e65c)

## How?

Delete space ( add .trim(); )

## Testing Instructions

1. npm run build
2. Please check HTML of the navigation block

## Screenshots or screencast <!-- if applicable -->

After
![スクリーンショット 2024-12-15 15 39 21](https://github.com/user-attachments/assets/9faf72f6-f31a-4847-9fd7-8cb2d4d4630f)

