### PR TITLE
Add story for HeightControl

### DIFF
--- a/packages/block-editor/src/components/height-control/stories/index.story.js
+++ b/packages/block-editor/src/components/height-control/stories/index.story.js
@@ -8,14 +8,63 @@ import { useState } from '@wordpress/element';
  */
 import HeightControl from '../';
 
-export default {
-	component: HeightControl,
+/**
+ * The `HeightControl` component renders a height control component.
+ */
+const meta = {
 	title: 'BlockEditor/HeightControl',
+	component: HeightControl,
+	argTypes: {
+		value: {
+			control: false,
+			defaultValue: '100px',
+			description:
+				'The current height value. It can be a string including a unit (e.g., `100px`), or a number.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: false,
+			description:
+				'A callback function invoked when the height value is changed. Called with the new height value as the only argument.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		label: {
+			control: 'text',
+			defaultValue: 'Height',
+			description: 'A label for the height control.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+	},
 };
 
-const Template = ( props ) => {
-	const [ value, setValue ] = useState();
-	return <HeightControl onChange={ setValue } value={ value } { ...props } />;
-};
+export default meta;
 
-export const Default = Template.bind( {} );
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( args.value );
+
+		return (
+			<HeightControl
+				{ ...args }
+				onChange={ ( newValue ) => {
+					onChange( newValue );
+					setValue( newValue );
+				} }
+				value={ value }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
## What?
Add story for HeightControl

## Why?
Part of https://github.com/WordPress/gutenberg/issues/67165

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the HeadingLevelDropdown stories.