### PR TITLE
Updated @since Doc Order in Inline documentation

### DIFF
--- a/backport-changelog/6.8/8032.md
+++ b/backport-changelog/6.8/8032.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8032
+
+* https://github.com/WordPress/gutenberg/pull/68003

--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -211,9 +211,9 @@ function gutenberg_render_block_style_variation_support_styles( $parsed_block ) 
  * block attributes in the `render_block_data` filter gets applied to the
  * block's markup.
  *
- * @see gutenberg_render_block_style_variation_support_styles
- *
  * @since 6.6.0
+ *
+ * @see gutenberg_render_block_style_variation_support_styles
  *
  * @param  string $block_content Rendered block content.
  * @param  array  $block         Block object.


### PR DESCRIPTION
Need to Update  According to Php [Coding Standard](https://developer.wordpress.org/coding-standards/inline-documentation-standards/php/) in Below File

- lib/block-supports/block-style-variations.php `@since` Should add before `@see` tag