### PR TITLE
Fix: Post title caret position issue

### DIFF
--- a/packages/editor/src/components/post-title/index.js
+++ b/packages/editor/src/components/post-title/index.js
@@ -99,10 +99,6 @@ const PostTitle = forwardRef( ( _, forwardedRef ) => {
 		__unstableDisableFormats: false,
 	} );
 
-	useEffect( () => {}, [ history ] );
-
-	useEffect( () => {}, [ selection, currentHistoryIndex ] );
-
 	useEffect( () => {
 		if ( editorAction !== 'undo' && editorAction !== 'redo' ) {
 			updateHistory( selection.start );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
See: #64724 
## Why?

Previously we were not maintaining any caret position history stacks so predicting caret positions on undo/redo was not possible .

## How?

- Used a history array which records the caret positions on different onChange events .
- Captured different key strokes to listen to undo and redo events . 

## Testing Instructions

### Testing Instructions for Keyboard

- Add a new post or page.
- Select the Title block and enter a title.
- Paste additional text into the end of the field.
- Undo the paste with Cmd+z/Ctrl+z (using the editor toolbar Undo button changes focus from the field, so is n/a).
- Observe the location of the caret after undo ( | caret is moved to start of the deleted text).
- Without clicking or repositioning the caret, re-paste into the field with Cmd+v/Ctrl+v.
- Observe where the pasted text is inserted ( | text is inserted at end of field with updated caret position ).

## Screenshots or screencast <!-- if applicable -->

## Before

https://github.com/user-attachments/assets/1a517d1f-2c14-4cf1-99e7-1e241b168fb1

## After

https://github.com/user-attachments/assets/337cf0c4-27e0-4f08-ab7e-93bbda3e3d50
