### PR TITLE
Storybook: Add BlockAlignmentMatrixControl Stories and update README

### DIFF
--- a/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/README.md
@@ -64,9 +64,9 @@ Function to execute upon a user's change of the matrix state.
 
 -   **Type:** `string`
 -   **Default:** `'center'`
--   **Options:** `center`, `center center`, `center left`, `center right`, `top center`, `top left`, `top right`, `bottom center`, `bottom left`, `bottom right`
+-   **Options:** `'center'`, `'center center'`, `'center left'`, `'center right'`, `'top center'`, `'top left'`, `'top right'`, `'bottom center'`, `'bottom left'`, `'bottom right'`
 
-Describes the content alignment location.
+Content alignment location.
 
 ### `isDisabled`
 

--- a/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/README.md
@@ -64,7 +64,7 @@ Function to execute upon a user's change of the matrix state.
 
 -   **Type:** `string`
 -   **Default:** `'center'`
--   **Options:** `'center'`, `'center center'`, `'center left'`, `'center right'`, `'top center'`, `'top left'`, `'top right'`, `'bottom center'`, `'bottom left'`, `'bottom right'`
+-   **Options:** `center`, `center center`, `center left`, `center right`, `top center`, `top left`, `top right`, `bottom center`, `bottom left`, `bottom right`
 
 Describes the content alignment location.
 
@@ -73,4 +73,4 @@ Describes the content alignment location.
 -   **Type:** `boolean`
 -   **Default:** `false`
 
-Disables the control.
+Whether the control should be disabled.

--- a/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/README.md
@@ -41,13 +41,36 @@ const controls = (
       />
     </BlockControls>
   </>
-}
+);
 ```
 
 ### Props
 
-| Name       | Type       | Default                   | Description                                                                                                                              |
-| ---------- | ---------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `label`    | `string`   | `Change matrix alignment` | concise description of tool's functionality.                                                                                             |
-| `onChange` | `function` | `noop`                    | the function to execute upon a user's change of the matrix state                                                                         |
-| `value`    | `string`   | `center`                  | describes the content alignment location and can be `top`, `right`, `bottom`, `left`, `topRight`, `bottomRight`, `bottomLeft`, `topLeft` |
+### `label`
+
+-   **Type:** `string`
+-   **Default:** `'Change matrix alignment'`
+
+Label for the control.
+
+### `onChange`
+
+-   **Type:** `Function`
+-   **Default:** `noop`
+
+Function to execute upon a user's change of the matrix state.
+
+### `value`
+
+-   **Type:** `string`
+-   **Default:** `'center'`
+-   **Options:** `'center'`, `'center center'`, `'center left'`, `'center right'`, `'top center'`, `'top left'`, `'top right'`, `'bottom center'`, `'bottom left'`, `'bottom right'`
+
+Describes the content alignment location.
+
+### `isDisabled`
+
+-   **Type:** `boolean`
+-   **Default:** `false`
+
+Disables the control.

--- a/packages/block-editor/src/components/block-alignment-matrix-control/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/index.js
@@ -36,9 +36,11 @@ const noop = () => {};
  * @param {Object}   props            Component props.
  * @param {string}   props.label      Label for the control. Defaults to 'Change matrix alignment'.
  * @param {Function} props.onChange   Function to execute upon change of matrix state.
- * @param {string}   props.value      Content alignment location. One of: 'center', 'center center', 'center left', 'center right', 'top center', 'top left', 'top right', 'bottom center', 'bottom left', 'bottom right'.
+ * @param {string}   props.value      Content alignment location. One of: 'center', 'center center',
+ *                                    'center left', 'center right', 'top center', 'top left',
+ *                                    'top right', 'bottom center', 'bottom left', 'bottom right'.
  * @param {boolean}  props.isDisabled Whether the control should be disabled.
- * @return {Element}                    The BlockAlignmentMatrixControl component.
+ * @return {Element}				  The BlockAlignmentMatrixControl component.
  */
 function BlockAlignmentMatrixControl( props ) {
 	const {

--- a/packages/block-editor/src/components/block-alignment-matrix-control/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/index.js
@@ -11,6 +11,35 @@ import {
 
 const noop = () => {};
 
+/**
+ * The alignment matrix control allows users to quickly adjust inner block alignment.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-alignment-matrix-control/README.md
+ *
+ * @example
+ * ```jsx
+ * function Example() {
+ *   return (
+ *     <BlockControls>
+ *       <BlockAlignmentMatrixControl
+ *         label={ __( 'Change content position' ) }
+ *         value="center"
+ *         onChange={ ( nextPosition ) =>
+ *           setAttributes( { contentPosition: nextPosition } )
+ *         }
+ *       />
+ *     </BlockControls>
+ *   );
+ * }
+ * ```
+ *
+ * @param {Object}   props            Component props.
+ * @param {string}   props.label      Label for the control. Defaults to 'Change matrix alignment'.
+ * @param {Function} props.onChange   Function to execute upon change of matrix state.
+ * @param {string}   props.value      Content alignment location. One of: 'center', 'center center', 'center left', 'center right', 'top center', 'top left', 'top right', 'bottom center', 'bottom left', 'bottom right'.
+ * @param {boolean}  props.isDisabled Whether the control should be disabled.
+ * @return {Element}                    The BlockAlignmentMatrixControl component.
+ */
 function BlockAlignmentMatrixControl( props ) {
 	const {
 		label = __( 'Change matrix alignment' ),

--- a/packages/block-editor/src/components/block-alignment-matrix-control/index.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/index.js
@@ -40,7 +40,7 @@ const noop = () => {};
  *                                    'center left', 'center right', 'top center', 'top left',
  *                                    'top right', 'bottom center', 'bottom left', 'bottom right'.
  * @param {boolean}  props.isDisabled Whether the control should be disabled.
- * @return {Element}				  The BlockAlignmentMatrixControl component.
+ * @return {Element} The BlockAlignmentMatrixControl component.
  */
 function BlockAlignmentMatrixControl( props ) {
 	const {

--- a/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
@@ -45,7 +45,7 @@ const meta = {
 				type: { summary: 'boolean' },
 				defaultValue: { summary: 'false' },
 			},
-			description: 'Disables the control.',
+			description: 'Whether the control should be disabled.',
 		},
 		value: {
 			control: { type: null },
@@ -53,7 +53,7 @@ const meta = {
 				type: { summary: 'string' },
 				defaultValue: { summary: 'center' },
 			},
-			description: 'Value of the control.',
+			description: 'Content alignment location.',
 		},
 	},
 };

--- a/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import BlockAlignmentMatrixControl from '../';
+
+const meta = {
+	title: 'BlockEditor/BlockAlignmentMatrixControl',
+	component: BlockAlignmentMatrixControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders a control for selecting block alignment using a matrix of alignment options.',
+			},
+		},
+	},
+	argTypes: {
+		label: {
+			control: 'text',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'Change matrix alignment' },
+			},
+			description: 'Label for the control.',
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: '() => {}' },
+			},
+			description:
+				"Function to execute upon a user's change of the matrix state.",
+		},
+		isDisabled: {
+			control: 'boolean',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+			description: 'Disables the control.',
+		},
+		value: {
+			control: { type: null },
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'center' },
+			},
+			description: 'Value of the control.',
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
+
+		return (
+			<BlockAlignmentMatrixControl
+				{ ...args }
+				value={ value }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+			/>
+		);
+	},
+};

--- a/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-alignment-matrix-control/stories/index.story.js
@@ -25,7 +25,7 @@ const meta = {
 			control: 'text',
 			table: {
 				type: { summary: 'string' },
-				defaultValue: { summary: 'Change matrix alignment' },
+				defaultValue: { summary: "'Change matrix alignment'" },
 			},
 			description: 'Label for the control.',
 		},
@@ -51,7 +51,7 @@ const meta = {
 			control: { type: null },
 			table: {
 				type: { summary: 'string' },
-				defaultValue: { summary: 'center' },
+				defaultValue: { summary: "'center'" },
 			},
 			description: 'Content alignment location.',
 		},


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for BlockAlignmentMatrixControl component in the Storybook.

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the BlockAlignmentMatrixControl stories.

## Screenshots or screencast
![image](https://github.com/user-attachments/assets/cd97b870-4be5-4e9e-a86a-6cbb97714aab)





