### PR TITLE
Login/Logout: Add dropdown menu props to ToolsPanel component

### DIFF
--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -8,9 +8,14 @@ import {
 	__experimentalToolsPanelItem as ToolsPanelItem,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function LoginOutEdit( { attributes, setAttributes } ) {
 	const { displayLoginAsForm, redirectToCurrent } = attributes;
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
 		<>
@@ -23,6 +28,7 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 							redirectToCurrent: true,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						label={ __( 'Display login as form' ) }


### PR DESCRIPTION
Follow up of: #67909

## What?
Enhances the Login/Logout block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

## Screenshots

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/9db111c3-de6d-468e-aa34-4ac0ab74150d)|![image](https://github.com/user-attachments/assets/0c8174d3-f81a-46e3-9ab7-b5b6b2a30ce9)|
