### PR TITLE
Archive: Add dropdown menu props to ToolsPanel component 

### DIFF
--- a/packages/block-library/src/archives/edit.js
+++ b/packages/block-library/src/archives/edit.js
@@ -12,8 +12,15 @@ import { __ } from '@wordpress/i18n';
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import ServerSideRender from '@wordpress/server-side-render';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 export default function ArchivesEdit( { attributes, setAttributes } ) {
 	const { showLabel, showPostCounts, displayAsDropdown, type } = attributes;
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
 		<>
@@ -28,6 +35,7 @@ export default function ArchivesEdit( { attributes, setAttributes } ) {
 							type: 'monthly',
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						label={ __( 'Display as dropdown' ) }


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/67841
## What?
Enhances the Archives block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.


## Screenshots or screencast



| Before | After |
|--------|-------|
| <img width="284" alt="Before Image" src="https://github.com/user-attachments/assets/a50322f9-320e-428c-ae6d-d4dff4b9fe2c" /> | <img width="570" alt="After Image" src="https://github.com/user-attachments/assets/41f125d9-7176-42ba-9444-8bfe0c929694" /> |


