### PR TITLE
Page List Block: Add dropdown menu props to ToolsPanel component

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -38,6 +38,7 @@ import {
 	convertDescription,
 	ConvertToLinksModal,
 } from './convert-to-links-modal';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 // We only show the edit option when page count is <= MAX_PAGE_COUNT
 // Performance of Navigation Links is not good past this value.
@@ -124,6 +125,7 @@ export default function PageListEdit( {
 	const [ isOpen, setOpen ] = useState( false );
 	const openModal = useCallback( () => setOpen( true ), [] );
 	const closeModal = () => setOpen( false );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const { records: pages, hasResolved: hasResolvedPages } = useEntityRecords(
 		'postType',
@@ -326,6 +328,7 @@ export default function PageListEdit( {
 					resetAll={ () => {
 						setAttributes( { parentPageID: 0 } );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					{ pagesTree.length > 0 && (
 						<ToolsPanelItem


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/67903

## What?
Enhances the Page List block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

## Screenshots or screencast <!-- if applicable -->



| Before | After |
|--------|-------|
| <img width="281" alt="Screenshot 2024-12-16 at 1 19 05 PM" src="https://github.com/user-attachments/assets/0c3655b3-8ffd-4690-88b5-a295c7f2a56b" />   |   <img width="562" alt="Screenshot 2024-12-16 at 1 19 34 PM" src="https://github.com/user-attachments/assets/1a88f14a-f8d6-4278-9f96-a24345e703f1" /> |


