### PR TITLE
Query Page Numbers: Add dropdown menu props to ToolsPanel component 

### DIFF
--- a/packages/block-library/src/query-pagination-numbers/edit.js
+++ b/packages/block-library/src/query-pagination-numbers/edit.js
@@ -9,6 +9,11 @@ import {
 	RangeControl,
 } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 const createPaginationItem = ( content, Tag = 'a', extraClass = '' ) => (
 	<Tag key={ content } className={ `page-numbers ${ extraClass }` }>
 		{ content }
@@ -50,6 +55,7 @@ export default function QueryPaginationNumbersEdit( {
 	const paginationNumbers = previewPaginationNumbers(
 		parseInt( midSize, 10 )
 	);
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
 		<>
@@ -57,6 +63,7 @@ export default function QueryPaginationNumbersEdit( {
 				<ToolsPanel
 					label={ __( 'Settings' ) }
 					resetAll={ () => setAttributes( { midSize: 2 } ) }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						label={ __( 'Number of links' ) }


### PR DESCRIPTION
Follows up: #67958

## What?
Enhances the Query Page Numbers block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

## Screenshots or screencast <!-- if applicable -->





| Before | After |
|--------|-------|
| <img width="279" alt="Screenshot 2024-12-16 at 1 29 40 PM" src="https://github.com/user-attachments/assets/1963779f-9a2a-4ae5-b8ea-5acf3c59727a" /> | <img width="561" alt="Screenshot 2024-12-16 at 1 29 52 PM" src="https://github.com/user-attachments/assets/12875049-c782-4981-b0a1-a79722b63d15" /> |
