### PR TITLE
Fix: Extra Space Between Caption and Embedded Content in Embed Block 

### DIFF
--- a/packages/block-library/src/embed/style.scss
+++ b/packages/block-library/src/embed/style.scss
@@ -86,4 +86,12 @@
 	.wp-embed-aspect-1-2 .wp-block-embed__wrapper::before {
 		padding-top: 200%; // 2 / 1 * 100
 	}
+
+	.wp-embed-aspect-5-3 .wp-block-embed__wrapper::before {
+		padding-top: 60%; // 3 / 5 * 100
+	}
+
+	.wp-embed-aspect-5-2 .wp-block-embed__wrapper::before {
+		padding-top: 40%; // 2 / 5 * 100
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR is intended to solve issue for spacing between the caption and spotify embed

## Why?
Resolves https://github.com/WordPress/gutenberg/issues/67859

## How?
The PR adds two new variations to Embed Block specifically for Spotify Embeds 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Log in to the WordPress dashboard and navigate to a post or page editor.
Add an Embed block (e.g., Spotify or Twitter).
Paste a valid URL to embed the content.
Add a caption below the embed by clicking the “Add caption” option.
Observe the extra space between the caption and the embedded content.
Now add the `.wp-embed-aspect-5-3` or `.wp-embed-aspect-5-2` in the Additional CSS section to fix the issue  

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/a86032ad-2122-4f07-a824-eb109fc5d010



