### PR TITLE
Navigation Submenu Block: Add dropdown menu props to ToolsPanel component

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -44,6 +44,7 @@ import {
 	getColors,
 	getNavigationChildBlockProps,
 } from '../navigation/edit/utils';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ALLOWED_BLOCKS = [
 	'core/navigation-link',
@@ -153,6 +154,7 @@ export default function NavigationSubmenuEdit( {
 	const isDraggingWithin = useIsDraggingWithin( listItemRef );
 	const itemLabelPlaceholder = __( 'Add text…' );
 	const ref = useRef();
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	const {
 		parentCount,
@@ -394,6 +396,7 @@ export default function NavigationSubmenuEdit( {
 							rel: '',
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						label={ __( 'Text' ) }


### PR DESCRIPTION
Follows up: #67969

## What?
Enhances the Navigation Submenu block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

| Before | After |
|--------|-------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/942b7258-cbac-4419-8eac-880752c49f7e" />  | <img width="556" alt="Screenshot 2024-12-16 at 2 13 11 PM" src="https://github.com/user-attachments/assets/e8a20724-0db4-4be9-bf0c-e0a56e05edcc" /> |