### PR TITLE
Site Title Block: Add dropdown menu props to ToolsPanel component

### DIFF
--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -25,6 +25,11 @@ import {
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { decodeEntities } from '@wordpress/html-entities';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 export default function SiteTitleEdit( {
 	attributes,
 	setAttributes,
@@ -47,6 +52,7 @@ export default function SiteTitleEdit( {
 		};
 	}, [] );
 	const { editEntityRecord } = useDispatch( coreStore );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	function setTitle( newTitle ) {
 		editEntityRecord( 'root', 'site', undefined, {
@@ -121,6 +127,7 @@ export default function SiteTitleEdit( {
 							linkTarget: '_self',
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => isLink !== false }


### PR DESCRIPTION
Follow up of: https://github.com/WordPress/gutenberg/pull/67898

## What?
Enhances the Site Title block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/987d6ea9-cf3e-4922-b53b-288de7a2a258)|![image](https://github.com/user-attachments/assets/96a4e319-ef5d-442f-9701-da69c06d2ea2)|
