### PR TITLE
Add dropdown menu props to ToolsPanel component

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -9,6 +9,7 @@ import clsx from 'clsx';
 import { NEW_TAB_TARGET, NOFOLLOW_REL } from './constants';
 import { getUpdatedLinkAttributes } from './get-updated-link-attributes';
 import removeAnchorTag from '../utils/remove-anchor-tag';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 /**
  * WordPress dependencies
@@ -115,10 +116,13 @@ function useEnter( props ) {
 }
 
 function WidthPanel( { selectedWidth, setAttributes } ) {
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
 			resetAll={ () => setAttributes( { width: undefined } ) }
+			dropdownMenuProps={ dropdownMenuProps }
 		>
 			<ToolsPanelItem
 				label={ __( 'Button width' ) }

--- a/packages/block-library/src/column/edit.js
+++ b/packages/block-library/src/column/edit.js
@@ -25,17 +25,24 @@ import {
 import { useSelect, useDispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 function ColumnInspectorControls( { width, setAttributes } ) {
 	const [ availableUnits ] = useSettings( 'spacing.units' );
 	const units = useCustomUnits( {
 		availableUnits: availableUnits || [ '%', 'px', 'em', 'rem', 'vw' ],
 	} );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
 			resetAll={ () => {
 				setAttributes( { width: undefined } );
 			} }
+			dropdownMenuProps={ dropdownMenuProps }
 		>
 			<ToolsPanelItem
 				hasValue={ () => width !== undefined }

--- a/packages/block-library/src/columns/edit.js
+++ b/packages/block-library/src/columns/edit.js
@@ -40,6 +40,7 @@ import {
 	getRedistributedColumnWidths,
 	toWidthPrecision,
 } from './utils';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const DEFAULT_BLOCK = {
 	name: 'core/column',
@@ -145,6 +146,8 @@ function ColumnInspectorControls( {
 		replaceInnerBlocks( clientId, innerBlocks );
 	}
 
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	return (
 		<ToolsPanel
 			label={ __( 'Settings' ) }
@@ -154,6 +157,7 @@ function ColumnInspectorControls( {
 					isStackedOnMobile: true,
 				} );
 			} }
+			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ canInsertColumnBlock && (
 				<ToolsPanelItem

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -16,6 +16,11 @@ import {
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 const TEMPLATE = [
 	[
 		'core/paragraph',
@@ -32,6 +37,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 		template: TEMPLATE,
 		__experimentalCaptureToolbars: true,
 	} );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	// Check if either the block or the inner blocks are selected.
 	const hasSelection = useSelect(
@@ -57,6 +63,7 @@ function DetailsEdit( { attributes, setAttributes, clientId } ) {
 							showContent: false,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						isShownByDefault

--- a/packages/block-library/src/post-excerpt/edit.js
+++ b/packages/block-library/src/post-excerpt/edit.js
@@ -28,7 +28,10 @@ import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { useCanEditEntity } from '../utils/hooks';
+import {
+	useCanEditEntity,
+	useToolsPanelDropdownMenuProps,
+} from '../utils/hooks';
 
 const ELLIPSIS = '…';
 
@@ -45,6 +48,8 @@ export default function PostExcerptEditor( {
 		setExcerpt,
 		{ rendered: renderedExcerpt, protected: isProtected } = {},
 	] = useEntityProp( 'postType', postType, 'excerpt', postId );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	/**
 	 * Check if the post type supports excerpts.
@@ -232,6 +237,7 @@ export default function PostExcerptEditor( {
 							excerptLength: 55,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => showMoreOnNewLine !== true }

--- a/packages/block-library/src/social-link/edit.js
+++ b/packages/block-library/src/social-link/edit.js
@@ -36,6 +36,7 @@ import { keyboardReturn } from '@wordpress/icons';
  * Internal dependencies
  */
 import { getIconBySite, getNameBySite } from './social-list';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const SocialLinkURLPopover = ( {
 	url,
@@ -109,6 +110,7 @@ const SocialLinkEdit = ( {
 	clientId,
 } ) => {
 	const { url, service, label = '', rel } = attributes;
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const {
 		showLabels,
 		iconColor,
@@ -200,6 +202,7 @@ const SocialLinkEdit = ( {
 					resetAll={ () => {
 						setAttributes( { label: undefined } );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						isShownByDefault

--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -31,6 +31,11 @@ import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
 import { useSelect } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
 const sizeOptions = [
 	{ name: __( 'Small' ), value: 'has-small-icon-size' },
 	{ name: __( 'Normal' ), value: 'has-normal-icon-size' },
@@ -68,6 +73,8 @@ export function SocialLinksEdit( props ) {
 	const hasAnySelected = isSelected || hasSelectedChild;
 
 	const logosOnly = attributes.className?.includes( 'is-style-logos-only' );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	// Remove icon background color when logos only style is selected or
 	// restore it when any other style is selected.
@@ -207,6 +214,7 @@ export function SocialLinksEdit( props ) {
 							showLabels: false,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						isShownByDefault

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -57,6 +57,7 @@ import {
 	isEmptyTableSection,
 } from './state';
 import { Caption } from '../utils/caption';
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const ALIGNMENT_CONTROLS = [
 	{
@@ -108,6 +109,8 @@ function TableEdit( {
 
 	const tableRef = useRef();
 	const [ hasTableCreated, setHasTableCreated ] = useState( false );
+
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	/**
 	 * Updates the initial column count used for table creation.
@@ -483,6 +486,7 @@ function TableEdit( {
 							foot: [],
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						hasValue={ () => hasFixedLayout !== true }

--- a/packages/block-library/src/tag-cloud/edit.js
+++ b/packages/block-library/src/tag-cloud/edit.js
@@ -25,6 +25,11 @@ import ServerSideRender from '@wordpress/server-side-render';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
+
+/**
  * Minimum number of tags a user can show using this block.
  *
  * @type {number}
@@ -51,6 +56,7 @@ function TagCloudEdit( { attributes, setAttributes } ) {
 	} = attributes;
 
 	const [ availableUnits ] = useSettings( 'spacing.units' );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	// The `pt` unit is used as the default value and is therefore
 	// always considered an available unit.
@@ -129,6 +135,7 @@ function TagCloudEdit( { attributes, setAttributes } ) {
 						largestFontSize: '22pt',
 					} );
 				} }
+				dropdownMenuProps={ dropdownMenuProps }
 			>
 				<ToolsPanelItem
 					hasValue={ () => taxonomy !== 'post_tag' }


### PR DESCRIPTION
## What?
Enhances the block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

## Progress
1. Button : In this PR
2. Table : In this PR
3. Columns : In this PR
4. Column : In this PR
5. Archives : https://github.com/WordPress/gutenberg/pull/68010
6. Date : https://github.com/WordPress/gutenberg/pull/68018
7. Tag Cloud : In this PR
8. Site Title : https://github.com/WordPress/gutenberg/pull/68017
9. Excerpt : In this PR
10. Social Icon : In this PR
11. Details : In this PR
12. Social icons : In this PR
13. Query Page Numbers 
14. Navigation Submenu : https://github.com/WordPress/gutenberg/pull/68015
15. Page List : https://github.com/WordPress/gutenberg/pull/68012
16. Featured image: https://github.com/WordPress/gutenberg/pull/67456
17. Login/Logout : https://github.com/WordPress/gutenberg/pull/68009
18. Gallery : Not merged
19. Archive Title : Not merged
20. Search Block : Not merged
21. Latest Posts : Not merged
22. More : https://github.com/WordPress/gutenberg/pull/68039
23. Navigation item : Not merged
24. Next Post : Not merged
25. Author : Not merged 
26. Spacer : Not merged 
27. Table of Contents : Not merged 
28. Term List : Not merged 
29. Latest Comments : Not merged 
30. Site Logo (Media) : Not merged 
31. Avatar : Not merged 
32. Author Name : Not merged 
33. Read More : Not merged 
34. Query Pagination : https://github.com/WordPress/gutenberg/pull/67914
35. Query Loop: Not merged 
36. Navigation (Display): Not merged 

## Screenshots or screencast 

### Button

| Before | After |
|--------|-------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/7a2874db-e6fa-45e7-9026-a89afd95109a" />  | <img width="556" alt="Screenshot 2024-12-16 at 2 13 11 PM" src="https://github.com/user-attachments/assets/d21113b8-70d5-452c-9147-4f738e69f0ac" /> |

### Table

| Before | After |
|--------|-------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/91ff7227-c7c2-4fd7-8a36-3fbc1fa40574" /> | <img width="556" alt="image" src="https://github.com/user-attachments/assets/37030364-6718-4b33-a86e-6b89c7e11f6b" /> |

### Columns

| Before | After |
|--------|-------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/0143b118-5d2d-4ac8-a5f4-45b81cc92246" /> | <img width="556" alt="image" src="https://github.com/user-attachments/assets/2df38859-b98d-4cab-927c-81fd5669c6a1" /> |

### Column

| Before | After |
|--------|-------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/d0212141-4273-4820-8254-55723cf16bb0" /> | <img width="556" alt="image" src="https://github.com/user-attachments/assets/65bc0e95-da67-4053-8818-a4b09c0739d1" /> |

### Tag Cloud

| Before | After |
|--------|-------|
| <img width="280" alt="image" src="https://github.com/user-attachments/assets/c96e9db7-76d9-4a13-afbd-7af4552b7a4d" />  | <img width="556" alt="image" src="https://github.com/user-attachments/assets/589d1a27-44e2-4bbd-856a-dc8922ab0d01" /> |


### Excerpt

| Before | After |
|--------|-------|
| <img width="279" alt="image" src="https://github.com/user-attachments/assets/599d28a8-3aaf-4901-b7f1-04464be01a74" />  | <img width="556" alt="image" src="https://github.com/user-attachments/assets/575d16d7-4e72-4b06-8949-398ad85e85c0" /> |



### Social Icon

| Before | After |
|--------|-------|
| <img width="281" alt="image" src="https://github.com/user-attachments/assets/52255e1d-660a-4f9a-a339-52971a8a8772" />| <img width="539" alt="image" src="https://github.com/user-attachments/assets/bbbd46b6-8bd9-46df-96c7-661871ca846f" /> |


### Details

| Before | After |
|--------|-------|
| <img width="282" alt="image" src="https://github.com/user-attachments/assets/23e05f9a-ee2b-4a9c-98d1-8c409dc0f19e" />| <img width="545" alt="image" src="https://github.com/user-attachments/assets/0bb41a55-9509-4a48-826e-ec708e336af4" /> |


### Social Icons

| Before | After |
|--------|-------|
| <img width="279" alt="image" src="https://github.com/user-attachments/assets/e12087e9-e582-4141-8c42-5567ad432397" />| <img width="542" alt="image" src="https://github.com/user-attachments/assets/ab84a282-654a-4793-9ec6-7e34d11795d3" /> |






