### PR TITLE
Query Pagination: Fix 'undo'  trap

### DIFF
--- a/packages/block-library/src/query-pagination/edit.js
+++ b/packages/block-library/src/query-pagination/edit.js
@@ -8,7 +8,7 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import {
 	__experimentalToolsPanel as ToolsPanel,
 	__experimentalToolsPanelItem as ToolsPanelItem,
@@ -50,17 +50,27 @@ export default function QueryPaginationEdit( {
 		},
 		[ clientId ]
 	);
+	const { __unstableMarkNextChangeAsNotPersistent } =
+		useDispatch( blockEditorStore );
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 	} );
+
 	// Always show label text if paginationArrow is set to 'none'.
 	useEffect( () => {
 		if ( paginationArrow === 'none' && ! showLabel ) {
+			__unstableMarkNextChangeAsNotPersistent();
 			setAttributes( { showLabel: true } );
 		}
-	}, [ paginationArrow, setAttributes, showLabel ] );
-	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+	}, [
+		paginationArrow,
+		setAttributes,
+		showLabel,
+		__unstableMarkNextChangeAsNotPersistent,
+	] );
+
 	return (
 		<>
 			{ hasNextPreviousBlocks && (


### PR DESCRIPTION
## What?
This is a follow-up to #50779.
See: #8119.

PR fixes the "undo trap" for Query Pagination blocks triggered by specific settings update flows.

## Why?
Attribute updates via side effects shouldn't create "undo" levels.

## How?
Marks attribute update inside the side-effect as non-persistent.

## Testing Instructions
1. Open the Site Editor.
2. Select Query Pagination blocks.
3. Change "Arrow" settings to "Arrow" or "Chevron."
4. Toggle off "Show label text".
5. Switch to "Arrow" to "None"
6. Try undoing the changes.
7. You should be able to undo changes fully.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/f7ca0be3-1b97-4f03-a6c7-e71d787765a1

