### PR TITLE
Button Block: Set proper typography for inner elements 

### DIFF
--- a/packages/block-editor/src/hooks/index.native.js
+++ b/packages/block-editor/src/hooks/index.native.js
@@ -33,3 +33,4 @@ export { getColorClassesAndStyles, useColorProps } from './use-color-props';
 export { getSpacingClassesAndStyles } from './use-spacing-props';
 export { useCachedTruthy } from './use-cached-truthy';
 export { useEditorWrapperStyles } from './use-editor-wrapper-styles';
+export { getTypographyClassesAndStyles } from './use-typography-props';

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -85,7 +85,16 @@
 			}
 		},
 		"typography": {
-			"__experimentalSkipSerialization": true,
+			"__experimentalSkipSerialization": [
+				"fontSize",
+				"lineHeight",
+				"__experimentalFontFamily",
+				"__experimentalFontWeight",
+				"__experimentalFontStyle",
+				"__experimentalTextTransform",
+				"__experimentalTextDecoration",
+				"__experimentalLetterSpacing"
+			],
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -88,12 +88,12 @@
 			"__experimentalSkipSerialization": [
 				"fontSize",
 				"lineHeight",
-				"__experimentalFontFamily",
-				"__experimentalFontWeight",
-				"__experimentalFontStyle",
-				"__experimentalTextTransform",
-				"__experimentalTextDecoration",
-				"__experimentalLetterSpacing"
+				"fontFamily",
+				"fontWeight",
+				"fontStyle",
+				"textTransform",
+				"textDecoration",
+				"letterSpacing"
 			],
 			"fontSize": true,
 			"lineHeight": true,

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -85,6 +85,7 @@
 			}
 		},
 		"typography": {
+			"__experimentalSkipSerialization": true,
 			"fontSize": true,
 			"lineHeight": true,
 			"__experimentalFontFamily": true,

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -132,7 +132,6 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-button .wp-block-button__link",
 		"interactivity": {
 			"clientNavigation": true
 		}
@@ -142,5 +141,11 @@
 		{ "name": "outline", "label": "Outline" }
 	],
 	"editorStyle": "wp-block-button-editor",
-	"style": "wp-block-button"
+	"style": "wp-block-button",
+	"selectors": {
+		"root": ".wp-block-button .wp-block-button__link",
+		"typography": {
+			"writingMode": ".wp-block-button"
+		}
+	}
 }

--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -14,6 +14,8 @@ import {
 	__experimentalGetBorderClassesAndStyles as getBorderClassesAndStyles,
 	__experimentalGetColorClassesAndStyles as getColorClassesAndStyles,
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
+	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
+	__experimentalGetElementClassName,
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 
@@ -129,6 +131,188 @@ const blockAttributes = {
 		type: 'string',
 		source: 'html',
 		selector: 'a',
+	},
+};
+
+const v12 = {
+	attributes: {
+		tagName: {
+			type: 'string',
+			enum: [ 'a', 'button' ],
+			default: 'a',
+		},
+		type: {
+			type: 'string',
+			default: 'button',
+		},
+		textAlign: {
+			type: 'string',
+		},
+		url: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'a',
+			attribute: 'href',
+		},
+		title: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'a',
+			attribute: 'title',
+		},
+		text: {
+			type: 'string',
+			source: 'html',
+			selector: 'a',
+		},
+		linkTarget: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'a',
+			attribute: 'target',
+		},
+		rel: {
+			type: 'string',
+			source: 'attribute',
+			selector: 'a',
+			attribute: 'rel',
+		},
+		placeholder: {
+			type: 'string',
+		},
+		backgroundColor: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+		gradient: {
+			type: 'string',
+		},
+		width: {
+			type: 'number',
+		},
+	},
+	supports: {
+		anchor: true,
+		align: true,
+		alignWide: false,
+		color: {
+			__experimentalSkipSerialization: true,
+			gradients: true,
+			__experimentalDefaultControls: {
+				background: true,
+				text: true,
+			},
+		},
+		typography: {
+			fontSize: true,
+			lineHeight: true,
+			__experimentalFontFamily: true,
+			__experimentalFontWeight: true,
+			__experimentalFontStyle: true,
+			__experimentalTextTransform: true,
+			__experimentalTextDecoration: true,
+			__experimentalLetterSpacing: true,
+			__experimentalWritingMode: true,
+			__experimentalDefaultControls: {
+				fontSize: true,
+			},
+		},
+		reusable: false,
+		shadow: {
+			__experimentalSkipSerialization: true,
+		},
+		spacing: {
+			__experimentalSkipSerialization: true,
+			padding: [ 'horizontal', 'vertical' ],
+			__experimentalDefaultControls: {
+				padding: true,
+			},
+		},
+		__experimentalBorder: {
+			color: true,
+			radius: true,
+			style: true,
+			width: true,
+			__experimentalSkipSerialization: true,
+			__experimentalDefaultControls: {
+				color: true,
+				radius: true,
+				style: true,
+				width: true,
+			},
+		},
+		__experimentalSelector: '.wp-block-button__link',
+		interactivity: {
+			clientNavigation: true,
+		},
+	},
+	save( { attributes, className } ) {
+		const {
+			tagName,
+			type,
+			textAlign,
+			fontSize,
+			linkTarget,
+			rel,
+			style,
+			text,
+			title,
+			url,
+			width,
+		} = attributes;
+
+		const TagName = tagName || 'a';
+		const isButtonTag = 'button' === TagName;
+		const buttonType = type || 'button';
+		const borderProps = getBorderClassesAndStyles( attributes );
+		const colorProps = getColorClassesAndStyles( attributes );
+		const spacingProps = getSpacingClassesAndStyles( attributes );
+		const shadowProps = getShadowClassesAndStyles( attributes );
+		const buttonClasses = clsx(
+			'wp-block-button__link',
+			colorProps.className,
+			borderProps.className,
+			{
+				[ `has-text-align-${ textAlign }` ]: textAlign,
+				// For backwards compatibility add style that isn't provided via
+				// block support.
+				'no-border-radius': style?.border?.radius === 0,
+			},
+			__experimentalGetElementClassName( 'button' )
+		);
+		const buttonStyle = {
+			...borderProps.style,
+			...colorProps.style,
+			...spacingProps.style,
+			...shadowProps.style,
+		};
+
+		// The use of a `title` attribute here is soft-deprecated, but still applied
+		// if it had already been assigned, for the sake of backward-compatibility.
+		// A title will no longer be assigned for new or updated button block links.
+
+		const wrapperClasses = clsx( className, {
+			[ `has-custom-width wp-block-button__width-${ width }` ]: width,
+			[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
+		} );
+
+		return (
+			<div { ...useBlockProps.save( { className: wrapperClasses } ) }>
+				<RichText.Content
+					tagName={ TagName }
+					type={ isButtonTag ? buttonType : null }
+					className={ buttonClasses }
+					href={ isButtonTag ? null : url }
+					title={ title }
+					style={ buttonStyle }
+					value={ text }
+					target={ isButtonTag ? null : linkTarget }
+					rel={ isButtonTag ? null : rel }
+				/>
+			</div>
+		);
 	},
 };
 
@@ -399,6 +583,7 @@ const v10 = {
 };
 
 const deprecated = [
+	v12,
 	v11,
 	v10,
 	{

--- a/packages/block-library/src/button/deprecated.js
+++ b/packages/block-library/src/button/deprecated.js
@@ -157,25 +157,29 @@ const v12 = {
 		title: {
 			type: 'string',
 			source: 'attribute',
-			selector: 'a',
+			selector: 'a,button',
 			attribute: 'title',
+			role: 'content',
 		},
 		text: {
-			type: 'string',
-			source: 'html',
-			selector: 'a',
+			type: 'rich-text',
+			source: 'rich-text',
+			selector: 'a,button',
+			role: 'content',
 		},
 		linkTarget: {
 			type: 'string',
 			source: 'attribute',
 			selector: 'a',
 			attribute: 'target',
+			role: 'content',
 		},
 		rel: {
 			type: 'string',
 			source: 'attribute',
 			selector: 'a',
 			attribute: 'rel',
+			role: 'content',
 		},
 		placeholder: {
 			type: 'string',

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -318,6 +318,7 @@ function ButtonEdit( props ) {
 						...spacingProps.style,
 						...shadowProps.style,
 						...typographyProps.style,
+						writingMode: undefined,
 					} }
 					onReplace={ onReplace }
 					onMerge={ mergeBlocks }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -38,6 +38,8 @@ import {
 	__experimentalGetElementClassName,
 	store as blockEditorStore,
 	useBlockEditingMode,
+	getTypographyClassesAndStyles as useTypographyProps,
+	useSettings,
 } from '@wordpress/block-editor';
 import { displayShortcut, isKeyboardEvent, ENTER } from '@wordpress/keycodes';
 import { link, linkOff } from '@wordpress/icons';
@@ -262,6 +264,19 @@ function ButtonEdit( props ) {
 		[ context, isSelected, metadata?.bindings?.url ]
 	);
 
+	const [ fluidTypographySettings, layout ] = useSettings(
+		'typography.fluid',
+		'layout'
+	);
+	const typographyProps = useTypographyProps( attributes, {
+		typography: {
+			fluid: fluidTypographySettings,
+		},
+		layout: {
+			wideSize: layout?.wideSize,
+		},
+	} );
+
 	return (
 		<>
 			<div
@@ -288,6 +303,7 @@ function ButtonEdit( props ) {
 						'wp-block-button__link',
 						colorProps.className,
 						borderProps.className,
+						typographyProps.className,
 						{
 							[ `has-text-align-${ textAlign }` ]: textAlign,
 							// For backwards compatibility add style that isn't
@@ -301,6 +317,7 @@ function ButtonEdit( props ) {
 						...colorProps.style,
 						...spacingProps.style,
 						...shadowProps.style,
+						...typographyProps.style,
 					} }
 					onReplace={ onReplace }
 					onMerge={ mergeBlocks }

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -284,7 +284,6 @@ function ButtonEdit( props ) {
 				className={ clsx( blockProps.className, {
 					[ `has-custom-width wp-block-button__width-${ width }` ]:
 						width,
-					[ `has-custom-font-size` ]: blockProps.style.fontSize,
 				} ) }
 			>
 				<RichText
@@ -309,6 +308,8 @@ function ButtonEdit( props ) {
 							// For backwards compatibility add style that isn't
 							// provided via block support.
 							'no-border-radius': style?.border?.radius === 0,
+							[ `has-custom-font-size` ]:
+								blockProps.style.fontSize,
 						},
 						__experimentalGetElementClassName( 'button' )
 					) }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -59,6 +59,7 @@ export default function save( { attributes, className } ) {
 		...spacingProps.style,
 		...shadowProps.style,
 		...typographyProps.style,
+		writingMode: undefined,
 	};
 
 	// The use of a `title` attribute here is soft-deprecated, but still applied

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -50,6 +50,7 @@ export default function save( { attributes, className } ) {
 			// For backwards compatibility add style that isn't provided via
 			// block support.
 			'no-border-radius': style?.border?.radius === 0,
+			[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
 		},
 		__experimentalGetElementClassName( 'button' )
 	);
@@ -68,7 +69,6 @@ export default function save( { attributes, className } ) {
 
 	const wrapperClasses = clsx( className, {
 		[ `has-custom-width wp-block-button__width-${ width }` ]: width,
-		[ `has-custom-font-size` ]: fontSize || style?.typography?.fontSize,
 	} );
 
 	return (

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -14,6 +14,7 @@ import {
 	__experimentalGetSpacingClassesAndStyles as getSpacingClassesAndStyles,
 	__experimentalGetShadowClassesAndStyles as getShadowClassesAndStyles,
 	__experimentalGetElementClassName,
+	getTypographyClassesAndStyles,
 } from '@wordpress/block-editor';
 
 export default function save( { attributes, className } ) {
@@ -38,10 +39,12 @@ export default function save( { attributes, className } ) {
 	const colorProps = getColorClassesAndStyles( attributes );
 	const spacingProps = getSpacingClassesAndStyles( attributes );
 	const shadowProps = getShadowClassesAndStyles( attributes );
+	const typographyProps = getTypographyClassesAndStyles( attributes );
 	const buttonClasses = clsx(
 		'wp-block-button__link',
 		colorProps.className,
 		borderProps.className,
+		typographyProps.className,
 		{
 			[ `has-text-align-${ textAlign }` ]: textAlign,
 			// For backwards compatibility add style that isn't provided via
@@ -55,6 +58,7 @@ export default function save( { attributes, className } ) {
 		...colorProps.style,
 		...spacingProps.style,
 		...shadowProps.style,
+		...typographyProps.style,
 	};
 
 	// The use of a `title` attribute here is soft-deprecated, but still applied

--- a/test/integration/fixtures/blocks/core__button__deprecated-v10.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v10.serialized.html
@@ -1,3 +1,3 @@
 <!-- wp:button {"fontFamily":"cambria-georgia"} -->
-<div class="wp-block-button has-cambria-georgia-font-family"><a class="wp-block-button__link wp-element-button">My button</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link has-cambria-georgia-font-family wp-element-button">My button</a></div>
 <!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.html
@@ -1,5 +1,4 @@
-<!-- wp:buttons {"align":"wide","layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons alignwide"><!-- wp:button {"fontSize":"xx-large"} -->
+<!-- wp:button {"fontSize":"xx-large"} -->
 <div class="wp-block-button has-custom-font-size has-xx-large-font-size"><a class="wp-block-button__link wp-element-button">My button 1</a></div>
 <!-- /wp:button -->
 
@@ -13,5 +12,4 @@
 
 <!-- wp:button {"tagName":"button","style":{"typography":{"letterSpacing":"39px"}}} -->
 <div class="wp-block-button" style="letter-spacing:39px"><button type="button" class="wp-block-button__link wp-element-button">My button 4</button></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons -->
+<!-- /wp:button -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.html
@@ -1,0 +1,17 @@
+<!-- wp:buttons {"align":"wide","layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons alignwide"><!-- wp:button {"fontSize":"xx-large"} -->
+<div class="wp-block-button has-custom-font-size has-xx-large-font-size"><a class="wp-block-button__link wp-element-button">My button 1</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"typography":{"fontStyle":"normal","fontWeight":"800"}}} -->
+<div class="wp-block-button" style="font-style:normal;font-weight:800"><a class="wp-block-button__link wp-element-button">My button 2</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"typography":{"letterSpacing":"39px"}}} -->
+<div class="wp-block-button" style="letter-spacing:39px"><a class="wp-block-button__link wp-element-button">My button 3</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"tagName":"button","style":{"typography":{"letterSpacing":"39px"}}} -->
+<div class="wp-block-button" style="letter-spacing:39px"><button type="button" class="wp-block-button__link wp-element-button">My button 4</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.json
@@ -1,72 +1,59 @@
 [
 	{
-		"name": "core/buttons",
+		"name": "core/button",
 		"isValid": true,
 		"attributes": {
-			"align": "wide",
-			"layout": {
-				"type": "flex",
-				"justifyContent": "center"
+			"tagName": "a",
+			"type": "button",
+			"text": "My button 1",
+			"fontSize": "xx-large"
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "My button 2",
+			"style": {
+				"typography": {
+					"fontStyle": "normal",
+					"fontWeight": "800"
+				}
 			}
 		},
-		"innerBlocks": [
-			{
-				"name": "core/button",
-				"isValid": true,
-				"attributes": {
-					"tagName": "a",
-					"type": "button",
-					"text": "My button 1",
-					"fontSize": "xx-large"
-				},
-				"innerBlocks": []
-			},
-			{
-				"name": "core/button",
-				"isValid": true,
-				"attributes": {
-					"tagName": "a",
-					"type": "button",
-					"text": "My button 2",
-					"style": {
-						"typography": {
-							"fontStyle": "normal",
-							"fontWeight": "800"
-						}
-					}
-				},
-				"innerBlocks": []
-			},
-			{
-				"name": "core/button",
-				"isValid": true,
-				"attributes": {
-					"tagName": "a",
-					"type": "button",
-					"text": "My button 3",
-					"style": {
-						"typography": {
-							"letterSpacing": "39px"
-						}
-					}
-				},
-				"innerBlocks": []
-			},
-			{
-				"name": "core/button",
-				"isValid": false,
-				"attributes": {
-					"tagName": "button",
-					"type": "button",
-					"text": "My button 4",
-					"style": {
-						"typography": {
-							"letterSpacing": "39px"
-						}
-					}
-				},
-				"innerBlocks": []
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "a",
+			"type": "button",
+			"text": "My button 3",
+			"style": {
+				"typography": {
+					"letterSpacing": "39px"
+				}
 			}
-		]
+		},
+		"innerBlocks": []
+	},
+	{
+		"name": "core/button",
+		"isValid": true,
+		"attributes": {
+			"tagName": "button",
+			"type": "button",
+			"text": "My button 4",
+			"style": {
+				"typography": {
+					"letterSpacing": "39px"
+				}
+			}
+		},
+		"innerBlocks": []
 	}
 ]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.json
@@ -1,0 +1,72 @@
+[
+	{
+		"name": "core/buttons",
+		"isValid": true,
+		"attributes": {
+			"align": "wide",
+			"layout": {
+				"type": "flex",
+				"justifyContent": "center"
+			}
+		},
+		"innerBlocks": [
+			{
+				"name": "core/button",
+				"isValid": true,
+				"attributes": {
+					"tagName": "a",
+					"type": "button",
+					"text": "My button 1",
+					"fontSize": "xx-large"
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/button",
+				"isValid": true,
+				"attributes": {
+					"tagName": "a",
+					"type": "button",
+					"text": "My button 2",
+					"style": {
+						"typography": {
+							"fontStyle": "normal",
+							"fontWeight": "800"
+						}
+					}
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/button",
+				"isValid": true,
+				"attributes": {
+					"tagName": "a",
+					"type": "button",
+					"text": "My button 3",
+					"style": {
+						"typography": {
+							"letterSpacing": "39px"
+						}
+					}
+				},
+				"innerBlocks": []
+			},
+			{
+				"name": "core/button",
+				"isValid": false,
+				"attributes": {
+					"tagName": "button",
+					"type": "button",
+					"text": "My button 4",
+					"style": {
+						"typography": {
+							"letterSpacing": "39px"
+						}
+					}
+				},
+				"innerBlocks": []
+			}
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.parsed.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.parsed.json
@@ -1,84 +1,81 @@
 [
 	{
-		"blockName": "core/buttons",
+		"blockName": "core/button",
 		"attrs": {
-			"align": "wide",
-			"layout": {
-				"type": "flex",
-				"justifyContent": "center"
+			"fontSize": "xx-large"
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button has-custom-font-size has-xx-large-font-size\"><a class=\"wp-block-button__link wp-element-button\">My button 1</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button has-custom-font-size has-xx-large-font-size\"><a class=\"wp-block-button__link wp-element-button\">My button 1</a></div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"style": {
+				"typography": {
+					"fontStyle": "normal",
+					"fontWeight": "800"
+				}
 			}
 		},
-		"innerBlocks": [
-			{
-				"blockName": "core/button",
-				"attrs": {
-					"fontSize": "xx-large"
-				},
-				"innerBlocks": [],
-				"innerHTML": "\n<div class=\"wp-block-button has-custom-font-size has-xx-large-font-size\"><a class=\"wp-block-button__link wp-element-button\">My button 1</a></div>\n",
-				"innerContent": [
-					"\n<div class=\"wp-block-button has-custom-font-size has-xx-large-font-size\"><a class=\"wp-block-button__link wp-element-button\">My button 1</a></div>\n"
-				]
-			},
-			{
-				"blockName": "core/button",
-				"attrs": {
-					"style": {
-						"typography": {
-							"fontStyle": "normal",
-							"fontWeight": "800"
-						}
-					}
-				},
-				"innerBlocks": [],
-				"innerHTML": "\n<div class=\"wp-block-button\" style=\"font-style:normal;font-weight:800\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n",
-				"innerContent": [
-					"\n<div class=\"wp-block-button\" style=\"font-style:normal;font-weight:800\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n"
-				]
-			},
-			{
-				"blockName": "core/button",
-				"attrs": {
-					"style": {
-						"typography": {
-							"letterSpacing": "39px"
-						}
-					}
-				},
-				"innerBlocks": [],
-				"innerHTML": "\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n",
-				"innerContent": [
-					"\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n"
-				]
-			},
-			{
-				"blockName": "core/button",
-				"attrs": {
-					"tagName": "button",
-					"style": {
-						"typography": {
-							"letterSpacing": "39px"
-						}
-					}
-				},
-				"innerBlocks": [],
-				"innerHTML": "\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n",
-				"innerContent": [
-					"\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n"
-				]
-			}
-		],
-		"innerHTML": "\n<div class=\"wp-block-buttons alignwide\">\n\n\n\n\n\n</div>\n",
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button\" style=\"font-style:normal;font-weight:800\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n",
 		"innerContent": [
-			"\n<div class=\"wp-block-buttons alignwide\">",
-			null,
-			"\n\n",
-			null,
-			"\n\n",
-			null,
-			"\n\n",
-			null,
-			"</div>\n"
+			"\n<div class=\"wp-block-button\" style=\"font-style:normal;font-weight:800\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"style": {
+				"typography": {
+					"letterSpacing": "39px"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n"
+		]
+	},
+	{
+		"blockName": null,
+		"attrs": {},
+		"innerBlocks": [],
+		"innerHTML": "\n\n",
+		"innerContent": [ "\n\n" ]
+	},
+	{
+		"blockName": "core/button",
+		"attrs": {
+			"tagName": "button",
+			"style": {
+				"typography": {
+					"letterSpacing": "39px"
+				}
+			}
+		},
+		"innerBlocks": [],
+		"innerHTML": "\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n"
 		]
 	}
 ]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.parsed.json
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.parsed.json
@@ -1,0 +1,84 @@
+[
+	{
+		"blockName": "core/buttons",
+		"attrs": {
+			"align": "wide",
+			"layout": {
+				"type": "flex",
+				"justifyContent": "center"
+			}
+		},
+		"innerBlocks": [
+			{
+				"blockName": "core/button",
+				"attrs": {
+					"fontSize": "xx-large"
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n<div class=\"wp-block-button has-custom-font-size has-xx-large-font-size\"><a class=\"wp-block-button__link wp-element-button\">My button 1</a></div>\n",
+				"innerContent": [
+					"\n<div class=\"wp-block-button has-custom-font-size has-xx-large-font-size\"><a class=\"wp-block-button__link wp-element-button\">My button 1</a></div>\n"
+				]
+			},
+			{
+				"blockName": "core/button",
+				"attrs": {
+					"style": {
+						"typography": {
+							"fontStyle": "normal",
+							"fontWeight": "800"
+						}
+					}
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n<div class=\"wp-block-button\" style=\"font-style:normal;font-weight:800\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n",
+				"innerContent": [
+					"\n<div class=\"wp-block-button\" style=\"font-style:normal;font-weight:800\"><a class=\"wp-block-button__link wp-element-button\">My button 2</a></div>\n"
+				]
+			},
+			{
+				"blockName": "core/button",
+				"attrs": {
+					"style": {
+						"typography": {
+							"letterSpacing": "39px"
+						}
+					}
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n",
+				"innerContent": [
+					"\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><a class=\"wp-block-button__link wp-element-button\">My button 3</a></div>\n"
+				]
+			},
+			{
+				"blockName": "core/button",
+				"attrs": {
+					"tagName": "button",
+					"style": {
+						"typography": {
+							"letterSpacing": "39px"
+						}
+					}
+				},
+				"innerBlocks": [],
+				"innerHTML": "\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n",
+				"innerContent": [
+					"\n<div class=\"wp-block-button\" style=\"letter-spacing:39px\"><button type=\"button\" class=\"wp-block-button__link wp-element-button\">My button 4</button></div>\n"
+				]
+			}
+		],
+		"innerHTML": "\n<div class=\"wp-block-buttons alignwide\">\n\n\n\n\n\n</div>\n",
+		"innerContent": [
+			"\n<div class=\"wp-block-buttons alignwide\">",
+			null,
+			"\n\n",
+			null,
+			"\n\n",
+			null,
+			"\n\n",
+			null,
+			"</div>\n"
+		]
+	}
+]

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.serialized.html
@@ -1,0 +1,17 @@
+<!-- wp:buttons {"align":"wide","layout":{"type":"flex","justifyContent":"center"}} -->
+<div class="wp-block-buttons alignwide"><!-- wp:button {"fontSize":"xx-large"} -->
+<div class="wp-block-button has-custom-font-size"><a class="wp-block-button__link has-xx-large-font-size wp-element-button">My button 1</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"typography":{"fontStyle":"normal","fontWeight":"800"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" style="font-style:normal;font-weight:800">My button 2</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"style":{"typography":{"letterSpacing":"39px"}}} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" style="letter-spacing:39px">My button 3</a></div>
+<!-- /wp:button -->
+
+<!-- wp:button {"tagName":"button","style":{"typography":{"letterSpacing":"39px"}}} -->
+<div class="wp-block-button" style="letter-spacing:39px"><button type="button" class="wp-block-button__link wp-element-button">My button 4</button></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.serialized.html
@@ -1,5 +1,5 @@
 <!-- wp:button {"fontSize":"xx-large"} -->
-<div class="wp-block-button has-custom-font-size"><a class="wp-block-button__link has-xx-large-font-size wp-element-button">My button 1</a></div>
+<div class="wp-block-button"><a class="wp-block-button__link has-xx-large-font-size has-custom-font-size wp-element-button">My button 1</a></div>
 <!-- /wp:button -->
 
 <!-- wp:button {"style":{"typography":{"fontStyle":"normal","fontWeight":"800"}}} -->

--- a/test/integration/fixtures/blocks/core__button__deprecated-v12.serialized.html
+++ b/test/integration/fixtures/blocks/core__button__deprecated-v12.serialized.html
@@ -1,5 +1,4 @@
-<!-- wp:buttons {"align":"wide","layout":{"type":"flex","justifyContent":"center"}} -->
-<div class="wp-block-buttons alignwide"><!-- wp:button {"fontSize":"xx-large"} -->
+<!-- wp:button {"fontSize":"xx-large"} -->
 <div class="wp-block-button has-custom-font-size"><a class="wp-block-button__link has-xx-large-font-size wp-element-button">My button 1</a></div>
 <!-- /wp:button -->
 
@@ -12,6 +11,5 @@
 <!-- /wp:button -->
 
 <!-- wp:button {"tagName":"button","style":{"typography":{"letterSpacing":"39px"}}} -->
-<div class="wp-block-button" style="letter-spacing:39px"><button type="button" class="wp-block-button__link wp-element-button">My button 4</button></div>
-<!-- /wp:button --></div>
-<!-- /wp:buttons -->
+<div class="wp-block-button"><button type="button" class="wp-block-button__link wp-element-button" style="letter-spacing:39px">My button 4</button></div>
+<!-- /wp:button -->


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
The current typography does not work correctly with the given button styles. This fix forces inner elements to inherit the styles.

<!-- In a few words, what is the PR actually doing? -->
Fixes #64662
related #64869

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Set Twenty Twenty-Four theme
2. Place Button block
3. Set the Appearance to Bold, etc.
You can see that the Appearance has changed on either the editor screen or the front screen.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
