### PR TITLE
Block Editor: Fix Iframe error for links without 'href'

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -192,7 +192,7 @@ function Iframe( {
 					// Appending a hash to the current URL will not reload the
 					// page. This is useful for e.g. footnotes.
 					const href = event.target.getAttribute( 'href' );
-					if ( href.startsWith( '#' ) ) {
+					if ( href?.startsWith( '#' ) ) {
 						iFrameDocument.defaultView.location.hash =
 							href.slice( 1 );
 					}


### PR DESCRIPTION
## What?
This is a follow-up to #66751.

PR fixes an error when the Iframe component tries to intercept URLs with no `href` attribute.

## Why?
The `getAttrobute` resolves to `null` when a link has no `href` attribute.

## Testing Instructions
1. Open the Site Editor.
2. Open a template with Query and Query Pagination block.
3. Try clicking on links in the Query Pagination block.
4. No errors should be logged in the DevTools console.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-12-16 at 15 51 24](https://github.com/user-attachments/assets/1cddf179-43f4-4ad1-9389-09ed3b1daf01)
