### PR TITLE
Allow replace operation on empty default block in Zoom Out

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -456,7 +456,15 @@ export default function useBlockDropZone( {
 				const [ targetIndex, operation, nearestSide ] =
 					dropTargetPosition;
 
-				if ( isZoomOut() && operation !== 'insert' ) {
+				const isTargetIndexEmptyDefaultBlock =
+					operation === 'replace' &&
+					blocksData[ targetIndex ]?.isUnmodifiedDefaultBlock;
+
+				if (
+					isZoomOut() &&
+					! isTargetIndexEmptyDefaultBlock &&
+					operation !== 'insert'
+				) {
 					return;
 				}
 

--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -457,7 +457,6 @@ export default function useBlockDropZone( {
 					dropTargetPosition;
 
 				const isTargetIndexEmptyDefaultBlock =
-					operation === 'replace' &&
 					blocksData[ targetIndex ]?.isUnmodifiedDefaultBlock;
 
 				if (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Allows for drag and drop of Patterns in Zoom Out if the only block is an unmodified default block (normally `core/paragraph`).

Fixes part of https://github.com/WordPress/gutenberg/issues/67564

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently on `trunk` when editing a Page in the Site Editor you can end up with a placeholder `core/paragraph` block in witin the `core/post-content` block.

When in Zoom Out you drag and drop a Pattern onto this block there is no drop zone rendered.

This PR fixes that to show the drop zone. It also works if there is an unmodified default block _anywhere_ within the block list which can happen if you click a pattern and insert into an empty page as the default block remains.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Allows for a `replace` operation to be handled in Zoom Out but _only_ if the block being replaced is an unmodified default block (i.e. `core/paragraph`).

This in turn allows the zoom out separator to be rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Site Editor
- New Page
- Empty all content
- See that there is a default paragraph
- Open Zoom Out
- Drag and drop a Pattern and see the drop zone rendered.
- Undo (back to default para only)
- _Click_ any Pattern to insert into the Page. You should see the default paragraph remains (this is not a bug but intended functionality).
- Now attempt drag and drop of Pattern again above/below newly inserted Pattern checking that drop zones are rendered.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



https://github.com/user-attachments/assets/f0a904a8-9ab6-4234-a63d-a95bff74e460

