### PR TITLE
Fix Zoom Out with empty block list

### DIFF
--- a/packages/block-editor/src/components/block-list/index.js
+++ b/packages/block-editor/src/components/block-list/index.js
@@ -250,6 +250,9 @@ function Items( {
 				</AsyncModeProvider>
 			) ) }
 			{ order.length < 1 && placeholder }
+			{ isZoomOut && order.length < 1 && (
+				<ZoomOutSeparator isEmptyBlockList position="bottom" />
+			) }
 			{ shouldRenderAppender && (
 				<BlockListAppender
 					tagName={ __experimentalAppenderTagName }

--- a/packages/block-editor/src/components/block-list/zoom-out-separator.js
+++ b/packages/block-editor/src/components/block-list/zoom-out-separator.js
@@ -25,6 +25,7 @@ export function ZoomOutSeparator( {
 	clientId,
 	rootClientId = '',
 	position = 'top',
+	isEmptyBlockList,
 } ) {
 	const [ isDraggedOver, setIsDraggedOver ] = useState( false );
 	const {
@@ -59,7 +60,7 @@ export function ZoomOutSeparator( {
 
 	const isReducedMotion = useReducedMotion();
 
-	if ( ! clientId ) {
+	if ( ! clientId && ! isEmptyBlockList ) {
 		return;
 	}
 
@@ -70,7 +71,7 @@ export function ZoomOutSeparator( {
 		sectionClientIds &&
 		sectionClientIds.includes( clientId );
 
-	if ( ! isSectionBlock ) {
+	if ( ! isSectionBlock && ! isEmptyBlockList ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

WIP 

Closes https://github.com/WordPress/gutenberg/issues/67564

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
