### PR TITLE
Fix don't show inserter in Zoom Out dropzone when the text is visible

### DIFF
--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -20,6 +20,8 @@ function ZoomOutModeInserters() {
 		setInserterIsOpened,
 		sectionRootClientId,
 		selectedBlockClientId,
+		blockInsertionPoint,
+		insertionPointVisible,
 	} = useSelect( ( select ) => {
 		const {
 			getSettings,
@@ -27,6 +29,8 @@ function ZoomOutModeInserters() {
 			getSelectionStart,
 			getSelectedBlockClientId,
 			getSectionRootClientId,
+			getBlockInsertionPoint,
+			isBlockInsertionPointVisible,
 		} = unlock( select( blockEditorStore ) );
 
 		const root = getSectionRootClientId();
@@ -38,6 +42,8 @@ function ZoomOutModeInserters() {
 			setInserterIsOpened:
 				getSettings().__experimentalSetIsInserterOpened,
 			selectedBlockClientId: getSelectedBlockClientId(),
+			blockInsertionPoint: getBlockInsertionPoint(),
+			insertionPointVisible: isBlockInsertionPointVisible(),
 		};
 	}, [] );
 
@@ -62,7 +68,19 @@ function ZoomOutModeInserters() {
 	const index = blockOrder.findIndex(
 		( clientId ) => selectedBlockClientId === clientId
 	);
-	const nextClientId = blockOrder[ index + 1 ];
+
+	const insertionIndex = index + 1;
+
+	const nextClientId = blockOrder[ insertionIndex ];
+
+	// if the block insertion point is visible, and the insertion
+	// indicies match then we don't need to render the inserter.
+	if (
+		insertionPointVisible &&
+		blockInsertionPoint?.index === insertionIndex
+	) {
+		return null;
+	}
 
 	return (
 		<BlockPopoverInbetween
@@ -73,11 +91,11 @@ function ZoomOutModeInserters() {
 				onClick={ () => {
 					setInserterIsOpened( {
 						rootClientId: sectionRootClientId,
-						insertionIndex: index + 1,
+						insertionIndex,
 						tab: 'patterns',
 						category: 'all',
 					} );
-					showInsertionPoint( sectionRootClientId, index + 1, {
+					showInsertionPoint( sectionRootClientId, insertionIndex, {
 						operation: 'insert',
 					} );
 				} }

--- a/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
+++ b/packages/block-editor/src/components/block-tools/zoom-out-mode-inserters.js
@@ -73,7 +73,7 @@ function ZoomOutModeInserters() {
 
 	const nextClientId = blockOrder[ insertionIndex ];
 
-	// if the block insertion point is visible, and the insertion
+	// If the block insertion point is visible, and the insertion
 	// indicies match then we don't need to render the inserter.
 	if (
 		insertionPointVisible &&


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Hides the inserter `+` when the zoom out dropzone is rendered

Closes https://github.com/WordPress/gutenberg/issues/67568

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because otherwise - as per the Issue - we get the inserter rendered on top of the drop zone text in Zoom Out.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Conditionally displayed the inserter only when the current insertion index doesn't match the targetted insertion index for the inserter being rendered.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Site Editor
- Add Patterns
- Zoom Out
- Select a section
- Click on the `+` inserter
- See that the dropzone appears 
- See the inserter doesn't render
- Click another section and its inserter `+`
- Check that works too
- Generally try and break it - use 0 blocks, try Pages, Templates...etc

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->




https://github.com/user-attachments/assets/6057b4fb-4938-46cb-9bb2-9ef1ac745e50

