### PR TITLE
DataViews: Hide actions related UI in `grid` when no actions or bulk actions are passed

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -22,7 +22,10 @@ import { useInstanceId } from '@wordpress/compose';
  */
 import ItemActions from '../../components/dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
-import { useHasAPossibleBulkAction } from '../../components/dataviews-bulk-actions';
+import {
+	useHasAPossibleBulkAction,
+	useSomeItemHasAPossibleBulkAction,
+} from '../../components/dataviews-bulk-actions';
 import type {
 	Action,
 	NormalizedField,
@@ -47,6 +50,7 @@ interface GridItemProps< Item > {
 	descriptionField?: NormalizedField< Item >;
 	regularFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
+	hasBulkActions: boolean;
 }
 
 function GridItem< Item >( {
@@ -63,6 +67,7 @@ function GridItem< Item >( {
 	descriptionField,
 	regularFields,
 	badgeFields,
+	hasBulkActions,
 }: GridItemProps< Item > ) {
 	const { showTitle = true, showMedia = true, showDescription = true } = view;
 	const hasBulkAction = useHasAPossibleBulkAction( actions, item );
@@ -135,7 +140,7 @@ function GridItem< Item >( {
 					{ renderedMediaField }
 				</div>
 			) }
-			{ showMedia && renderedMediaField && (
+			{ hasBulkActions && showMedia && renderedMediaField && (
 				<DataViewsSelectionCheckbox
 					item={ item }
 					selection={ selection }
@@ -152,7 +157,9 @@ function GridItem< Item >( {
 				<div { ...clickableTitleItemProps } { ...titleA11yProps }>
 					{ renderedTitleField }
 				</div>
-				<ItemActions item={ item } actions={ actions } isCompact />
+				{ !! actions?.length && (
+					<ItemActions item={ item } actions={ actions } isCompact />
+				) }
 			</HStack>
 			<VStack spacing={ 1 }>
 				{ showDescription && descriptionField?.render && (
@@ -258,6 +265,7 @@ export default function ViewGrid< Item >( {
 	);
 	const hasData = !! data?.length;
 	const updatedPreviewSize = useUpdatedPreviewSizeOnViewportChange();
+	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const usedPreviewSize = updatedPreviewSize || view.layout?.previewSize;
 	const gridStyle = usedPreviewSize
 		? {
@@ -292,6 +300,7 @@ export default function ViewGrid< Item >( {
 								descriptionField={ descriptionField }
 								regularFields={ regularFields }
 								badgeFields={ badgeFields }
+								hasBulkActions={ hasBulkActions }
 							/>
 						);
 					} ) }


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Discovered while exploring https://github.com/WordPress/gutenberg/pull/68030.

This PR fixes two small things  in DataViews `grid` layout:
1. Do not render the multi selection `checkbox` on items, when no bulk actions exist
2. Do not render the disabled actions dropdown trigger if no actions are passed.

We have similar handling in `table` layout.

## Testing Instructions
1. Everything should work as before in existing usages of DataViews
2. You could test in trunk by removing the actions in `templates` [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/edit-site/src/components/page-templates/index.js#L203)