### PR TITLE
Fix reference to `wp-env start` in docs

### DIFF
--- a/docs/getting-started/devenv/get-started-with-wp-env.md
+++ b/docs/getting-started/devenv/get-started-with-wp-env.md
@@ -47,7 +47,7 @@ wp-env start
 Once the script completes, you can access the local environment at: <code>http://localhost:8888</code>. Log into the WordPress dashboard using username `admin` and password `password`.
 
 <div class="callout callout-tip">
-    Some projects, like Gutenberg, include their own specific <code>wp-env</code> configurations, and the documentation might prompt you to run <code>npm run start wp-env</code> instead.
+    Some projects, like Gutenberg, include their own specific <code>wp-env</code> configurations, and the documentation might prompt you to run <code>npm run wp-env start</code> instead.
 </div>
 
 For more information on controlling the Docker environment, see the [@wordpress/env package](/packages/env/README.md) readme.


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixing the reference to start `wp-env` in the docs.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Because it was the other way around (`npm run start wp-env` instead of `npm run wp-env start`)

