### PR TITLE
Add Tools Panel dropdown menu props to More block

### DIFF
--- a/packages/block-library/src/more/edit.js
+++ b/packages/block-library/src/more/edit.js
@@ -10,6 +10,10 @@ import {
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { ENTER } from '@wordpress/keycodes';
 import { getDefaultBlockName, createBlock } from '@wordpress/blocks';
+/**
+ * Internal dependencies
+ */
+import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 const DEFAULT_TEXT = __( 'Read more' );
 
@@ -41,6 +45,8 @@ export default function MoreEdit( {
 		width: `${ ( customText ? customText : DEFAULT_TEXT ).length + 1.2 }em`,
 	};
 
+	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
+
 	return (
 		<>
 			<InspectorControls>
@@ -51,6 +57,7 @@ export default function MoreEdit( {
 							noTeaser: false,
 						} );
 					} }
+					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
 						label={ __( 'Hide excerpt' ) }


### PR DESCRIPTION
Part of: #68019

## What?
Enhances the More block's ToolsPanel by adding support for dropdown menu functionality through the useToolsPanelDropdownMenuProps hook.

## Screenshots 

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/9f47100c-5325-4065-9864-3d24a05d26e3)|![image](https://github.com/user-attachments/assets/45d98c98-b855-4980-90e1-596d4254e6ed)|
