### PR TITLE
Site Editor: Make save keyboard shortcut work consistently

### DIFF
--- a/packages/edit-site/src/components/editor/index.js
+++ b/packages/edit-site/src/components/editor/index.js
@@ -250,7 +250,6 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 	};
 
 	const { saveDirtyEntities } = unlock( useDispatch( editorStore ) );
-	const { setIsSaveViewOpened } = useDispatch( editSiteStore );
 	const { dirtyEntityRecords } = useEntitiesSavedStatesIsDirty();
 	const { registerShortcut } = useDispatch( keyboardShortcutsStore );
 
@@ -273,12 +272,9 @@ export default function EditSiteEditor( { isPostsList = false } ) {
 			return;
 		}
 
-		// If only one entity is dirty, save directly
-		if ( dirtyEntityRecords.length === 1 ) {
+		if ( canvas === 'edit' ) {
+			// Save dirty entities when the user presses the save shortcut.
 			saveDirtyEntities( { dirtyEntityRecords } );
-		} else {
-			// If multiple entities are dirty, open the save panel
-			setIsSaveViewOpened( true );
 		}
 	} );
 


### PR DESCRIPTION
Fixes: #68025 

## What?
Makes the CMD+S/CTRL+S keyboard shortcut work consistently in the Site Editor's edit mode by enabling direct saving of changes.

## Why?
Currently, the save keyboard shortcut behavior is inconsistent in the Site Editor. When editing styles or making other changes, pressing CMD+S/CTRL+S doesn't consistently save changes.
This change makes the save shortcut behave more predictably by directly saving changes in edit mode, similar to how it works in the Post Editor.



## Testing Instructions
1. Open the Site Editor
2. Switch to edit mode
3. Make changes to styles (e.g., change background color in Styles panel)
4. Press CMD+S (Mac) or CTRL+S (Windows/Linux)
5. Verify changes are saved directly



## Screencast

https://github.com/user-attachments/assets/84a43610-c237-4481-922c-94c4442a4409


