### PR TITLE
Update template part block to behave more like pattern block

### DIFF
--- a/packages/block-editor/src/store/private-selectors.js
+++ b/packages/block-editor/src/store/private-selectors.js
@@ -505,7 +505,9 @@ export function isSectionBlock( state, clientId ) {
 	const sectionRootClientId = getSectionRootClientId( state );
 	const sectionClientIds = getBlockOrder( state, sectionRootClientId );
 	return (
-		getBlockName( state, clientId ) === 'core/block' ||
+		[ 'core/block', 'core/template-part' ].includes(
+			getBlockName( state, clientId )
+		) ||
 		getTemplateLock( state, clientId ) === 'contentOnly' ||
 		( isNavigationMode( state ) && sectionClientIds.includes( clientId ) )
 	);

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -2260,9 +2260,10 @@ function getDerivedBlockEditingModesForTree(
 	const sectionClientIds = state.blocks.order.get( sectionRootClientId );
 	const syncedPatternClientIds = Object.keys(
 		state.blocks.controlledInnerBlocks
-	).filter(
-		( clientId ) =>
-			state.blocks.byClientId?.get( clientId )?.name === 'core/block'
+	).filter( ( clientId ) =>
+		[ 'core/block', 'core/template-part' ].includes(
+			state.blocks.byClientId?.get( clientId )?.name
+		)
 	);
 
 	traverseBlockTree( state, treeClientId, ( block ) => {


### PR DESCRIPTION
## What?
Part of #65698

When editing a synced pattern, the design of the pattern is locked, and a user has to click 'Edit original' to change the design.

This PR makes template parts work the same way, and this is mostly changing the experience when editing a template where the inner blocks of template parts can be freely edited.

## Problems

From testing this change, the main issue I see is that some of the inner blocks types like Site Title, Site Logo and poss. also navigation should be editable, similar to if they had pattern overrides enabled.

I'm not sure the best way to resolve that, there's no API/mechanism for making this possible currently. 🤔 

Likely need something new here, maybe a private block supports API.

## Why?
@youknowriad suggested that it'd be good to tackle this (https://github.com/WordPress/gutenberg/pull/67372#discussion_r1881746405, https://github.com/WordPress/gutenberg/pull/67372#discussion_r1883905378)

This ties in with some separate conversations that have been ongoing:
- Merging the concepts of Sync Patterns and Template Parts - the two blocks should work the same way if they're to be unified (see more discussion in #57011)
- Global/Local editing (https://github.com/WordPress/gutenberg/issues/55025)

## How?
The implementation is very straightforward and I can follow up with some e2e tests if there's agreement on the change. A couple of place in the code are updated to:
- Make template parts use the same block editing modes as synced patterns do
- Make template parts always considered a 'section', just like synced patterns. This part won't really do anything until #67372 is merged.

## Testing Instructions
1. Open the site editor
2. Edit a template like Blog Homepage
3. Select the template part and try to edit it, note that you have to click the 'Edit' button on the block toolbar to edit the inner blocks.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2e17ab99-dbc9-4849-bbb0-c641db8730a4


