### PR TITLE
Fail gracefully when block in `createBlock` function is not registered

### DIFF
--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -599,20 +599,11 @@ export function switchToBlockType( blocks, name ) {
  *
  * @return {Object} block.
  */
-export const getBlockFromExample = ( name, example ) => {
-	try {
-		return createBlock(
-			name,
-			example.attributes,
-			( example.innerBlocks ?? [] ).map( ( innerBlock ) =>
-				getBlockFromExample( innerBlock.name, innerBlock )
-			)
-		);
-	} catch {
-		return createBlock( 'core/missing', {
-			originalName: name,
-			originalContent: '',
-			originalUndelimitedContent: '',
-		} );
-	}
-};
+export const getBlockFromExample = ( name, example ) =>
+	createBlock(
+		name,
+		example.attributes,
+		( example.innerBlocks ?? [] ).map( ( innerBlock ) =>
+			getBlockFromExample( innerBlock.name, innerBlock )
+		)
+	);

--- a/packages/blocks/src/api/factory.js
+++ b/packages/blocks/src/api/factory.js
@@ -17,6 +17,7 @@ import {
 	getGroupingBlockName,
 } from './registration';
 import {
+	isBlockRegistered,
 	normalizeBlockType,
 	__experimentalSanitizeBlockAttributes,
 } from './utils';
@@ -31,6 +32,14 @@ import {
  * @return {Object} Block object.
  */
 export function createBlock( name, attributes = {}, innerBlocks = [] ) {
+	if ( ! isBlockRegistered( name ) ) {
+		return createBlock( 'core/missing', {
+			originalName: name,
+			originalContent: '',
+			originalUndelimitedContent: '',
+		} );
+	}
+
 	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
 		name,
 		attributes
@@ -94,15 +103,22 @@ export function __experimentalCloneSanitizedBlock(
 	mergeAttributes = {},
 	newInnerBlocks
 ) {
+	const { name } = block;
+
+	if ( ! isBlockRegistered( name ) ) {
+		return createBlock( 'core/missing', {
+			originalName: name,
+			originalContent: '',
+			originalUndelimitedContent: '',
+		} );
+	}
+
 	const clientId = uuid();
 
-	const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-		block.name,
-		{
-			...block.attributes,
-			...mergeAttributes,
-		}
-	);
+	const sanitizedAttributes = __experimentalSanitizeBlockAttributes( name, {
+		...block.attributes,
+		...mergeAttributes,
+	} );
 
 	return {
 		...block,

--- a/packages/blocks/src/api/templates.js
+++ b/packages/blocks/src/api/templates.js
@@ -109,22 +109,11 @@ export function synchronizeBlocksWithTemplate( blocks = [], template ) {
 				attributes
 			);
 
-			let [ blockName, blockAttributes ] =
+			const [ blockName, blockAttributes ] =
 				convertLegacyBlockNameAndAttributes(
 					name,
 					normalizedAttributes
 				);
-
-			// If a Block is undefined at this point, use the core/missing block as
-			// a placeholder for a better user experience.
-			if ( undefined === getBlockType( blockName ) ) {
-				blockAttributes = {
-					originalName: name,
-					originalContent: '',
-					originalUndelimitedContent: '',
-				};
-				blockName = 'core/missing';
-			}
 
 			return createBlock(
 				blockName,

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -218,9 +218,7 @@ describe( 'isBlockRegistered', () => {
 	it( 'returns true if the block is registered', () => {
 		registerBlockType( 'core/test-block', { title: 'Test block' } );
 		expect( isBlockRegistered( 'core/test-block' ) ).toBe( true );
-		getBlockTypes().forEach( ( block ) => {
-			unregisterBlockType( block.name );
-		} );
+		unregisterBlockType( 'core/test-block' );
 	} );
 
 	it( 'returns false if the block is not registered', () => {

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -12,6 +12,7 @@ import {
 	isUnmodifiedDefaultBlock,
 	getAccessibleBlockLabel,
 	getBlockLabel,
+	isBlockRegistered,
 	__experimentalSanitizeBlockAttributes,
 	getBlockAttributesNamesByRole,
 	isContentBlock,
@@ -213,6 +214,22 @@ describe( 'getAccessibleBlockLabel', () => {
 	} );
 } );
 
+describe( 'isBlockRegistered', () => {
+	it( 'returns true if the block is registered', () => {
+		registerBlockType( 'core/test-block', {} );
+		expect( isBlockRegistered( 'core/test-block' ) ).toBe( true );
+		getBlockTypes().forEach( ( block ) => {
+			unregisterBlockType( block.name );
+		} );
+	} );
+
+	it( 'returns false if the block is not registered', () => {
+		expect( isBlockRegistered( 'core/not-registered-test-block' ) ).toBe(
+			false
+		);
+	} );
+} );
+
 describe( 'sanitizeBlockAttributes', () => {
 	afterEach( () => {
 		getBlockTypes().forEach( ( block ) => {
@@ -243,15 +260,18 @@ describe( 'sanitizeBlockAttributes', () => {
 		} );
 	} );
 
-	it( 'throws error if the block is not registered', () => {
-		expect( () => {
-			__experimentalSanitizeBlockAttributes(
-				'core/not-registered-test-block',
-				{}
-			);
-		} ).toThrowErrorMatchingInlineSnapshot(
-			`"Block type 'core/not-registered-test-block' is not registered."`
+	it( 'logs warning and returns empty object if the block is not registered', () => {
+		const consoleSpy = jest.spyOn( console, 'warn' );
+		const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
+			'core/not-registered-test-block',
+			{}
 		);
+
+		expect( sanitizedAttributes ).toBe( {} );
+		expect( consoleSpy ).toHaveBeenCalledWith(
+			"Block type 'core/not-registered-test-block' is not registered."
+		);
+		consoleSpy.mockRestore();
 	} );
 
 	it( 'handles undefined values and default values', () => {

--- a/packages/blocks/src/api/test/utils.js
+++ b/packages/blocks/src/api/test/utils.js
@@ -216,7 +216,7 @@ describe( 'getAccessibleBlockLabel', () => {
 
 describe( 'isBlockRegistered', () => {
 	it( 'returns true if the block is registered', () => {
-		registerBlockType( 'core/test-block', {} );
+		registerBlockType( 'core/test-block', { title: 'Test block' } );
 		expect( isBlockRegistered( 'core/test-block' ) ).toBe( true );
 		getBlockTypes().forEach( ( block ) => {
 			unregisterBlockType( block.name );
@@ -260,18 +260,15 @@ describe( 'sanitizeBlockAttributes', () => {
 		} );
 	} );
 
-	it( 'logs warning and returns empty object if the block is not registered', () => {
-		const consoleSpy = jest.spyOn( console, 'warn' );
-		const sanitizedAttributes = __experimentalSanitizeBlockAttributes(
-			'core/not-registered-test-block',
-			{}
+	it( 'throws error if the block is not registered', () => {
+		expect( () => {
+			__experimentalSanitizeBlockAttributes(
+				'core/not-registered-test-block',
+				{}
+			);
+		} ).toThrowErrorMatchingInlineSnapshot(
+			`"Block type 'core/not-registered-test-block' is not registered."`
 		);
-
-		expect( sanitizedAttributes ).toBe( {} );
-		expect( consoleSpy ).toHaveBeenCalledWith(
-			"Block type 'core/not-registered-test-block' is not registered."
-		);
-		consoleSpy.mockRestore();
 	} );
 
 	it( 'handles undefined values and default values', () => {

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -268,6 +268,17 @@ export function getDefault( attributeSchema ) {
 }
 
 /**
+ * Check if a block is registered.
+ *
+ * @param {string} name The block's name.
+ *
+ * @return {boolean} Whether the block is registered.
+ */
+export function isBlockRegistered( name ) {
+	return getBlockType( name ) !== undefined;
+}
+
+/**
  * Ensure attributes contains only values defined by block type, and merge
  * default values for missing attributes.
  *
@@ -281,7 +292,7 @@ export function __experimentalSanitizeBlockAttributes( name, attributes ) {
 
 	if ( undefined === blockType ) {
 		warning( `Block type '${ name }' is not registered.` );
-		return false;
+		return {};
 	}
 
 	return Object.entries( blockType.attributes ).reduce(

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -13,6 +13,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { RichTextData } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
+import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -279,7 +280,8 @@ export function __experimentalSanitizeBlockAttributes( name, attributes ) {
 	const blockType = getBlockType( name );
 
 	if ( undefined === blockType ) {
-		throw new Error( `Block type '${ name }' is not registered.` );
+		warning( `Block type '${ name }' is not registered.` );
+		return false;
 	}
 
 	return Object.entries( blockType.attributes ).reduce(

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -13,7 +13,6 @@ import { __, sprintf } from '@wordpress/i18n';
 import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 import { RichTextData } from '@wordpress/rich-text';
 import deprecated from '@wordpress/deprecated';
-import warning from '@wordpress/warning';
 
 /**
  * Internal dependencies
@@ -291,8 +290,7 @@ export function __experimentalSanitizeBlockAttributes( name, attributes ) {
 	const blockType = getBlockType( name );
 
 	if ( undefined === blockType ) {
-		warning( `Block type '${ name }' is not registered.` );
-		return {};
+		throw new Error( `Block type '${ name }' is not registered.` );
 	}
 
 	return Object.entries( blockType.attributes ).reduce(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

In this PR I'm checking if block is registered before sanitizing its attributes. If it doesn't exist, return `core/missing` to gracefully handle the situation.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

This is to preserve editor or inserter crash if `createBlock` or `createBlocksFromInnerBlocksTemplate` uses a block that is unregistered for any reason (e.g. due some custom logic in plugins).

**Example scenario:**
1. Block variation is build based on `createBlocksFromInnerBlocksTemplate` and depends on `core/post-title`
2. If for any reason `core/post-title` is unregistered (for example other plugin provides "updated" version of Post Title block)
3. When inserting the variation, the editor will crash.
4. If variation is exposed in the inserter (`scope: [ 'inserter' ]`) it's enough it will appear in results to cause a crash. It will be "rendered" for preview purpose.

To prevent both cases, the `core/missing` block should be rendered, rather than throwing error, to gracefully handle this situation.

> [!NOTE]  
> I'm well aware this scenario is against Gutenberg's principles and there should not be the case in which core blocks are unregistered. But at the same time it may happen and `unregisterBlockType` function is there so any plugin can use it. This PR's purpose is not to encourage that but to gracefully fail instead of crashing editor which prevents further usage of blocks.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Verify if block is registered and return `core/missing` if not.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Create new post
2. Open browser's console and unregister `core/post-title` by pasting `wp.blocks.unregisterBlockType('core/post-title')
` (this is to imitate some other plugin does that)
3. Insert Query Loop block
4. Choose some variation with title
5. **Expected:** Make sure the Editor doesn't crash, there's no error in console and the `core/missing` is rendered instead of Post Title mentioning its name.

<img width="762" alt="image" src="https://github.com/user-attachments/assets/0c87b4e4-f9ab-4fdc-856a-cad27c653391" />

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![crash-before](https://github.com/user-attachments/assets/f86d88ab-ffd3-4292-846a-95bb32f14d38) | ![crash-after](https://github.com/user-attachments/assets/d0170baf-b682-4241-a2f4-7ff6208d121c) |
