### PR TITLE
Do not control Nav Link item focus when focus within sidebar control

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -158,8 +158,14 @@ function getMissingText( type ) {
  * packages/block-library/src/navigation-submenu/edit.js
  * Consider reuseing this components for both blocks.
  */
-function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
+function Controls( { attributes, setAttributes, setIsFocused } ) {
 	const { label, url, description, title, rel } = attributes;
+
+	const focusProps = {
+		onFocus: () => setIsFocused( true ),
+		onBlur: () => setIsFocused( false ),
+	};
+
 	return (
 		<PanelBody title={ __( 'Settings' ) }>
 			<TextControl
@@ -171,8 +177,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				} }
 				label={ __( 'Text' ) }
 				autoComplete="off"
-				onFocus={ () => setIsLabelFieldFocused( true ) }
-				onBlur={ () => setIsLabelFieldFocused( false ) }
+				{ ...focusProps }
 			/>
 			<TextControl
 				__nextHasNoMarginBottom
@@ -187,6 +192,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				} }
 				label={ __( 'Link' ) }
 				autoComplete="off"
+				{ ...focusProps }
 			/>
 			<TextareaControl
 				__nextHasNoMarginBottom
@@ -198,6 +204,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				help={ __(
 					'The description will be displayed in the menu if the current theme supports it.'
 				) }
+				{ ...focusProps }
 			/>
 			<TextControl
 				__nextHasNoMarginBottom
@@ -211,6 +218,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				help={ __(
 					'Additional information to help clarify the purpose of the link.'
 				) }
+				{ ...focusProps }
 			/>
 			<TextControl
 				__nextHasNoMarginBottom
@@ -224,6 +232,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 				help={ __(
 					'The relationship of the linked URL as space-separated link types.'
 				) }
+				{ ...focusProps }
 			/>
 		</PanelBody>
 	);
@@ -266,7 +275,8 @@ export default function NavigationLinkEdit( {
 
 	// Change the label using inspector causes rich text to change focus on firefox.
 	// This is a workaround to keep the focus on the label field when label filed is focused we don't render the rich text.
-	const [ isLabelFieldFocused, setIsLabelFieldFocused ] = useState( false );
+	const [ isControlFieldFocused, setIsControlFieldFocused ] =
+		useState( false );
 
 	const {
 		isAtMaxNesting,
@@ -484,7 +494,7 @@ export default function NavigationLinkEdit( {
 				<Controls
 					attributes={ attributes }
 					setAttributes={ setAttributes }
-					setIsLabelFieldFocused={ setIsLabelFieldFocused }
+					setIsFocused={ setIsControlFieldFocused }
 				/>
 			</InspectorControls>
 			<div { ...blockProps }>
@@ -501,7 +511,7 @@ export default function NavigationLinkEdit( {
 						<>
 							{ ! isInvalid &&
 								! isDraft &&
-								! isLabelFieldFocused && (
+								! isControlFieldFocused && (
 									<>
 										<RichText
 											ref={ ref }
@@ -537,7 +547,7 @@ export default function NavigationLinkEdit( {
 								) }
 							{ ( isInvalid ||
 								isDraft ||
-								isLabelFieldFocused ) && (
+								isControlFieldFocused ) && (
 								<div className="wp-block-navigation-link__placeholder-text wp-block-navigation-link__label">
 									<Tooltip text={ tooltipText }>
 										<span
@@ -592,6 +602,12 @@ export default function NavigationLinkEdit( {
 								}
 
 								setIsLinkOpen( false );
+
+								// If a control is focused allow it to retain focus.
+								if ( isControlFieldFocused ) {
+									return;
+								}
+
 								if ( openedBy ) {
 									openedBy.focus();
 									setOpenedBy( null );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Avoids controlling the focus when closing the Link UI _if_ the current focus is within a sidebar control.

Fixes https://github.com/WordPress/gutenberg/issues/68035

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Currently on trunk when creating a new Link and then focusing on one of the inspector control sidebar fields focus is "stolen". See the Issue where this is detailed.

This is caused by:

- a code conditional which will fallback to selecting the previous block - I have asked whether @jeryj has some context on this.
- the RichText in the Nav Link block canvas stealing focus

Both Issues overlay and are related.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

This PR patches the current problem by extending the state which tracks whether the label field has focus to include _all_ of the inspector control fields. This allows us to disable the `RichText` from rendering and stealing focus if a sidebar field is focused by the user.

This PR also adds a conditional which exits early from any focus management logic if the focus is currently within any of the sidebar fields.

I will say that it seems extreme that we need to control the `RichText` in this manner. Moreover, I'd love to understand more about why the fallback to select the previous block is necessary.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- Nav block
- Open inspector controls
- Create a new link to `/` in the canvas.
- Focus on any of the sidebar fields.
- See that focus remains in that field and you can type.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/ae9c20f9-1cf0-4597-b98f-7d094ad1ac1e


