### PR TITLE
Page description changes

### DIFF
--- a/packages/edit-site/src/components/site-editor-routes/pages.js
+++ b/packages/edit-site/src/components/site-editor-routes/pages.js
@@ -32,6 +32,9 @@ export const pagesRoute = {
 				title={ __( 'Pages' ) }
 				backPath="/"
 				content={ <DataViewsSidebarContent postType="page" /> }
+				description={ __(
+					'Create, edit, and manage the content and structure of individual pages on your site to customize your site layout and design.'
+				) }
 			/>
 		),
 		content: <PostList postType="page" />,


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/62101

## Why?
Pages does not have a description like the others


## How?
Added description for Pages in site editor like templates and Patterns.

## Testing Instructions

Go to WP admin dashboard.
Navigate to Appearance-> Site Editor.
Check Pages and verify description added for it.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Screenshot (3)](https://github.com/user-attachments/assets/49f47cee-cf00-461c-93c5-410c4b31f39f)|![Screenshot (2)](https://github.com/user-attachments/assets/55a3d8d9-5cd6-4995-b5cb-8770e4814216)|
