### PR TITLE
pagination: scroll to top

### DIFF
--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -94,11 +94,16 @@ function DataViewsPagination() {
 				</HStack>
 				<HStack expanded={ false } spacing={ 1 }>
 					<Button
-						onClick={ () =>
-							onChangeView( {
-								...view,
-								page: currentPage - 1,
-							} )
+						onClick={ () =>{
+								onChangeView( {
+									...view,
+									page: currentPage - 1,
+								} );
+								const scrollContainer = document.querySelector('.dataviews-wrapper');
+								if (scrollContainer) {
+									scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+								}
+							}
 						}
 						disabled={ currentPage === 1 }
 						accessibleWhenDisabled
@@ -109,8 +114,13 @@ function DataViewsPagination() {
 						tooltipPosition="top"
 					/>
 					<Button
-						onClick={ () =>
-							onChangeView( { ...view, page: currentPage + 1 } )
+						onClick={ () => {
+								onChangeView( { ...view, page: currentPage + 1 } );
+								const scrollContainer = document.querySelector('.dataviews-wrapper');
+								if (scrollContainer) {
+									scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
+								}
+							}
 						}
 						disabled={ currentPage >= totalPages }
 						accessibleWhenDisabled

--- a/packages/dataviews/src/components/dataviews-pagination/index.tsx
+++ b/packages/dataviews/src/components/dataviews-pagination/index.tsx
@@ -94,17 +94,20 @@ function DataViewsPagination() {
 				</HStack>
 				<HStack expanded={ false } spacing={ 1 }>
 					<Button
-						onClick={ () =>{
-								onChangeView( {
-									...view,
-									page: currentPage - 1,
+						onClick={ () => {
+							onChangeView( {
+								...view,
+								page: currentPage - 1,
+							} );
+							const scrollContainer =
+								document.querySelector( '.dataviews-wrapper' );
+							if ( scrollContainer ) {
+								scrollContainer.scrollTo( {
+									top: 0,
+									behavior: 'smooth',
 								} );
-								const scrollContainer = document.querySelector('.dataviews-wrapper');
-								if (scrollContainer) {
-									scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
-								}
 							}
-						}
+						} }
 						disabled={ currentPage === 1 }
 						accessibleWhenDisabled
 						label={ __( 'Previous page' ) }
@@ -115,13 +118,16 @@ function DataViewsPagination() {
 					/>
 					<Button
 						onClick={ () => {
-								onChangeView( { ...view, page: currentPage + 1 } );
-								const scrollContainer = document.querySelector('.dataviews-wrapper');
-								if (scrollContainer) {
-									scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
-								}
+							onChangeView( { ...view, page: currentPage + 1 } );
+							const scrollContainer =
+								document.querySelector( '.dataviews-wrapper' );
+							if ( scrollContainer ) {
+								scrollContainer.scrollTo( {
+									top: 0,
+									behavior: 'smooth',
+								} );
 							}
-						}
+						} }
 						disabled={ currentPage >= totalPages }
 						accessibleWhenDisabled
 						label={ __( 'Next page' ) }


### PR DESCRIPTION
Fixes #62540 

## Testing Instructions

1. Open the site editor
2. Click on patterns and scroll down to view the last row
3. Now click on the next icon ">>".
4. Make sure it will scroll to the first row of the next page instead of the last row.