### PR TITLE
CI: Improve backport-changelog PR regex

### DIFF
--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -34,7 +34,7 @@ jobs:
 
                   # Find any changelog file that contains the Gutenberg PR link
                   gutenberg_pr_url="https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}"
-                  changelog_file=$(grep -rl "[-*] ${gutenberg_pr_url}" "${changelog_folder}" | head -n 1)
+                  changelog_file=$(grep -Erl "^[-*]\s+${gutenberg_pr_url}$" "${changelog_folder}" | head -n 1)
 
                   # Confirm that there is an entry containing the Gutenberg PR link
                   if [[ -z "${changelog_file}" ]]; then

--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -34,7 +34,7 @@ jobs:
 
                   # Find any changelog file that contains the Gutenberg PR link
                   gutenberg_pr_url="https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}"
-                  changelog_file=$(grep -Erl "[*-] +${gutenberg_pr_url}$" "${changelog_folder}" | head -n 1)
+                  changelog_file=$(grep -Erl "[-*] +${gutenberg_pr_url}$" "${changelog_folder}" | head -n 1)
 
                   # Confirm that there is an entry containing the Gutenberg PR link
                   if [[ -z "${changelog_file}" ]]; then

--- a/.github/workflows/check-backport-changelog.yml
+++ b/.github/workflows/check-backport-changelog.yml
@@ -34,7 +34,7 @@ jobs:
 
                   # Find any changelog file that contains the Gutenberg PR link
                   gutenberg_pr_url="https://github\.com/WordPress/gutenberg/pull/${PR_NUMBER}"
-                  changelog_file=$(grep -Erl "^[-*]\s+${gutenberg_pr_url}$" "${changelog_folder}" | head -n 1)
+                  changelog_file=$(grep -Erl "[*-] +${gutenberg_pr_url}$" "${changelog_folder}" | head -n 1)
 
                   # Confirm that there is an entry containing the Gutenberg PR link
                   if [[ -z "${changelog_file}" ]]; then


### PR DESCRIPTION
## What?

The backport-changelog CI script searches for matching markdown files in the backport-changelog directory.

This relies on a regular expression matching some specific markdown syntax, specifically a list item with a given text. There are different ways of writing the same list that are identically in rendered markdown, this PR changes the regex to be more resilient to possible differences in the specific markdown used to obtain the same file result.

[Markdown lists are interesting.](https://spec.commonmark.org/0.31.2/#lists)

Part of https://github.com/WordPress/gutenberg/pull/66235, where markdown autoformatting is applied.

### Done

- Allow one or more spaces after the list item mark (`- ` and `-   ` are both allowed).
- Anchor the regex to the end of the string. This prevents non-matching PR numbers from match (e.g. PR 6300 would match when searching for 63002).


### Not done
- It could also be anchored to the start of the string, but that may not be strictly correct (some number of spaces are allowed before the list item mark) so I avoided it here.
- `+` is also a valid list item mark according to commonmark, but my experience is that it's an unusual choice in practice and I did not add it here. It was not necessary for #66235.




## Why?

Autoformatting in #66235 changes these markdown files in a consistent way that should have no semantic impact. Update our tooling appropriately.

## How?

By adjusting the regex.

## Testing Instructions

Try the different regexes on this PR, they should behave the same. If you try them on #66235, this regex should work while the previous one would not.

```sh
## Original regex !!! This would fail on #66235
grep -Erl "[-*] https://github.com/WordPress/gutenberg/pull/66302" backport-changelog
# backport-changelog/6.8/7604.md

## Updated regex
grep -Erl "[-*] +https://github.com/WordPress/gutenberg/pull/66302$" backport-changelog
# backport-changelog/6.8/7604.md
```