### PR TITLE
Remove unnecessary CSS order property for the contrast checker in the Color hook

### DIFF
--- a/packages/block-editor/src/hooks/color.scss
+++ b/packages/block-editor/src/hooks/color.scss
@@ -1,12 +1,5 @@
 .color-block-support-panel {
 	.block-editor-contrast-checker {
-		/**
-		 * Contrast checkers are forced to the bottom of the panel so all
-		 * injected color controls can appear as a single item group without
-		 * the contrast checkers suddenly appearing between items.
-		 */
-		/* stylelint-disable-next-line property-disallowed-list -- This should be removed when https://github.com/WordPress/gutenberg/issues/58936 is fixed. */
-		order: 9999;
 		grid-column: span 2;
 		margin-top: $grid-unit-20;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/58936

## What?
<!-- In a few words, what is the PR actually doing? -->
Part of ongoing effort to remove any `order` CSS property from the codebase.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `order` CSS property must not be used to alter the visual order in s way that affects meaning and interaction.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Removes the `order` property.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- Repeat the instructions from the issue https://github.com/WordPress/gutenberg/issues/58936
- Observe there are no visual changes.
- Check any usage of the ContrastChecker, and make sure there are no slot / fill implementations where additional controls may be added between the color settings and the ContrastChecker.
- To my understanding, the `Navigation` and `Social Links` blocks use `ContrastChecker` directly rather than `BlockColorContrastChecker` so they aren't affected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
