### PR TITLE
Synced Patterns: Apply Block Hooks

### DIFF
--- a/backport-changelog/6.8/8015.md
+++ b/backport-changelog/6.8/8015.md
@@ -1,0 +1,3 @@
+https://github.com/WordPress/wordpress-develop/pull/8015
+
+* https://github.com/WordPress/gutenberg/pull/68058

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -170,7 +170,7 @@ add_filter( 'the_content', 'gutenberg_apply_block_hooks_to_post_content', 8 );
  * @return WP_REST_Response The response object.
  */
 function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
-	if ( empty( $response->data['content']['raw'] ) || empty( $response->data['content']['rendered'] ) ) {
+	if ( empty( $response->data['content']['raw'] ) ) {
 		return $response;
 	}
 
@@ -207,6 +207,11 @@ function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
 	$content = remove_serialized_parent_block( $content );
 
 	$response->data['content']['raw'] = $content;
+
+	// If the rendered content was previously empty, we leave it like that.
+	if ( empty( $response->data['content']['rendered'] ) ) {
+		return $response;
+	}
 
 	// No need to inject hooked blocks twice.
 	$priority = has_filter( 'the_content', 'apply_block_hooks_to_content' );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -280,6 +280,8 @@ function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
 
 	if ( 'wp_navigation' === $post->post_type ) {
 		$wrapper_block_type = 'core/navigation';
+	} elseif ( 'wp_block' === $post->post_type ) {
+		$wrapper_block_type = 'core/block';
 	} else {
 		$wrapper_block_type = 'core/post-content';
 	}
@@ -319,3 +321,4 @@ function gutenberg_update_ignored_hooked_blocks_postmeta( $post ) {
 }
 add_filter( 'rest_pre_insert_page', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
 add_filter( 'rest_pre_insert_post', 'gutenberg_update_ignored_hooked_blocks_postmeta' );
+add_filter( 'rest_pre_insert_wp_block', 'gutenberg_update_ignored_hooked_blocks_postmeta' );

--- a/lib/compat/wordpress-6.8/blocks.php
+++ b/lib/compat/wordpress-6.8/blocks.php
@@ -185,6 +185,8 @@ function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
 
 	if ( 'wp_navigation' === $post->post_type ) {
 		$wrapper_block_type = 'core/navigation';
+	} elseif ( 'wp_block' === $post->post_type ) {
+		$wrapper_block_type = 'core/block';
 	} else {
 		$wrapper_block_type = 'core/post-content';
 	}
@@ -224,6 +226,7 @@ function gutenberg_insert_hooked_blocks_into_rest_response( $response, $post ) {
 }
 add_filter( 'rest_prepare_page', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 add_filter( 'rest_prepare_post', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
+add_filter( 'rest_prepare_wp_block', 'gutenberg_insert_hooked_blocks_into_rest_response', 10, 2 );
 
 /**
  * Updates the wp_postmeta with the list of ignored hooked blocks

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -87,6 +87,7 @@ function render_block_core_block( $attributes ) {
 		add_filter( 'render_block_context', $filter_block_context, 1 );
 	}
 
+	$content = apply_block_hooks_to_content( $content, $reusable_block );
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );
 

--- a/packages/block-library/src/block/index.php
+++ b/packages/block-library/src/block/index.php
@@ -87,7 +87,26 @@ function render_block_core_block( $attributes ) {
 		add_filter( 'render_block_context', $filter_block_context, 1 );
 	}
 
+	$ignored_hooked_blocks = get_post_meta( $attributes['ref'], '_wp_ignored_hooked_blocks', true );
+	if ( ! empty( $ignored_hooked_blocks ) ) {
+		$ignored_hooked_blocks  = json_decode( $ignored_hooked_blocks, true );
+		$attributes['metadata'] = array(
+			'ignoredHookedBlocks' => $ignored_hooked_blocks,
+		);
+	}
+
+	// Wrap in "Block" block so the Block Hooks algorithm can insert blocks
+	// that are hooked as first or last child of `core/block`.
+	$content = get_comment_delimited_block_content(
+		'core/block',
+		$attributes,
+		$content
+	);
+	// Apply Block Hooks.
 	$content = apply_block_hooks_to_content( $content, $reusable_block );
+	// Remove block wrapper.
+	$content = remove_serialized_parent_block( $content );
+
 	$content = do_blocks( $content );
 	unset( $seen_refs[ $attributes['ref'] ] );
 


### PR DESCRIPTION
## What?
Apply Block Hooks to synced patterns (i.e. `core/block`).

Follow-up to https://github.com/WordPress/gutenberg/pull/67272 and https://github.com/WordPress/wordpress-develop/pull/7898. See https://github.com/WordPress/wordpress-develop/pull/7898#discussion_r1867077508 for more context.

## Why?
For consistency with post content, to which Block Hooks are now also applied.

## How?
By applying the same technique as to other post types, e.g. `post` or `wp_navigation`. See #67272 for a recent example.

## Follow-up

In a follow-up PR, I'll add a filter for the post type/block type mappings, so that they can be customized and used for CPTs.

## Testing Instructions
Start by installing the following plugin, but **do not activate it yet**:

<details>
<summary>Plugin code</summary>

```php
<?php
/**
 * Plugin Name:       Insert Separator blocks Before Headings.
 * Description:       Block Hooks demo plugin that inserts Separator blocks before Heading blocks.
 * Version:           0.1.0
 * Requires at least: 6.7
 */

defined( 'ABSPATH' ) || exit;

function insert_separators_before_headings( $hooked_blocks, $position, $anchor_block, $context ) {
	if ( ! $context instanceof WP_Post ) {
		return $hooked_blocks;
	}

	if (
		( $anchor_block === 'core/heading' && $position === 'before' ) ||
		( $anchor_block === 'core/block' && $position === 'last_child' )
	) {
		$hooked_blocks[] = 'core/separator';
	}

	return $hooked_blocks;
}
add_filter( 'hooked_block_types', 'insert_separators_before_headings', 10, 4 );

function set_separator_block_inner_html( $hooked_block, $hooked_block_type, $relative_position, $anchor_block ) {
	if (
		( $anchor_block['blockName'] === 'core/heading' && 'before' === $relative_position ) ||
		( $anchor_block['blockName'] === 'core/block' && 'last_child' === $relative_position )
	) {
        $hooked_block['innerContent'] = array( '<hr class="wp-block-separator has-alpha-channel-opacity"/>' );
	}

	return $hooked_block;
}
add_filter( 'hooked_block_core/separator', 'set_separator_block_inner_html', 10, 4 );
```
</details>

- Create a new post that contains one heading and one paragraph of text.
- Select those two blocks. From the block toolbar's three-horizontal-dots menu, select "Create Pattern".
- Give the pattern a name you'll easily remember. Keep the "Synced" toggle on.
- Save that post, and view it on the frontend. Keep it open in a tab.
- Activate the plugin.
- Go back to the tab with the post (on the frontend). Reload.
- Verify that before the heading, a separator (i.e. a horizontal line) has been inserted.
- Also verify that another separator has been inserted as the synced pattern's last child block (i.e. after the paragraph block).
- Open the post in the editor, and verify that the separators are also present there.
- Click on the synced pattern, and from its block toolbar, select "Edit original".
- Modify the separators -- e.g. move one around and remove the other. Save the synced pattern.
- Reload the post on the frontend again. Verify that the changes you made in the editor are respected.

## Screenshots or screencast

![block-hooks-with-synced-patterns](https://github.com/user-attachments/assets/9dfec9c4-3016-4e02-b760-8e4842d81413)
