### PR TITLE
Enhance template registration e2e tests to handle welcome dialog visibility

### DIFF
--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -101,7 +101,15 @@ test.describe( 'Block template registration', () => {
 	} ) => {
 		// Create a post.
 		await admin.visitAdminPage( '/post-new.php' );
-		await page.getByLabel( 'Close', { exact: true } ).click();
+
+		// Get the dialog with aria-label "Welcome to the editor"
+		const welcomeDialog = page.getByLabel( 'Welcome to the editor' );
+
+		// if the dialog is visible within 2 seconds, click the Close button, otherwise continue
+		if ( await welcomeDialog.isVisible( { timeout: 2000 } ) ) {
+			await welcomeDialog.getByLabel( 'Close' ).click();
+		}
+
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'User-created post.' },
@@ -283,6 +291,15 @@ test.describe( 'Block template registration', () => {
 			.click();
 		await page.getByRole( 'option', { name: 'admin' } ).click();
 		await expect( page.getByText( 'Choose a pattern' ) ).toBeVisible();
+
+		// Get the dialog with aria-label "Welcome to the editor"
+		const welcomeDialog = page.getByLabel( 'Welcome to the editor' );
+
+		// if the dialog is visible within 2 seconds, click the Close button, otherwise continue
+		if ( await welcomeDialog.isVisible( { timeout: 2000 } ) ) {
+			await welcomeDialog.getByLabel( 'Close' ).click();
+		}
+
 		await page.getByLabel( 'Close', { exact: true } ).click();
 		await editor.insertBlock( {
 			name: 'core/paragraph',

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -127,7 +127,7 @@ test.describe( 'Block template registration', () => {
 		blockTemplateRegistrationUtils,
 	} ) => {
 		// Create a post.
-		await admin.visitAdminPage( '/post-new.php' );
+		await admin.createNewPost();
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'User-created post.' },

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -101,7 +101,6 @@ test.describe( 'Block template registration', () => {
 	} ) => {
 		// Create a post.
 		await admin.createNewPost();
-
 		await editor.insertBlock( {
 			name: 'core/paragraph',
 			attributes: { content: 'User-created post.' },
@@ -283,7 +282,6 @@ test.describe( 'Block template registration', () => {
 			.click();
 		await page.getByRole( 'option', { name: 'admin' } ).click();
 		await expect( page.getByText( 'Choose a pattern' ) ).toBeVisible();
-
 		await page.getByLabel( 'Close', { exact: true } ).click();
 		await editor.insertBlock( {
 			name: 'core/paragraph',

--- a/test/e2e/specs/site-editor/template-registration.spec.js
+++ b/test/e2e/specs/site-editor/template-registration.spec.js
@@ -100,15 +100,7 @@ test.describe( 'Block template registration', () => {
 		page,
 	} ) => {
 		// Create a post.
-		await admin.visitAdminPage( '/post-new.php' );
-
-		// Get the dialog with aria-label "Welcome to the editor"
-		const welcomeDialog = page.getByLabel( 'Welcome to the editor' );
-
-		// if the dialog is visible within 2 seconds, click the Close button, otherwise continue
-		if ( await welcomeDialog.isVisible( { timeout: 2000 } ) ) {
-			await welcomeDialog.getByLabel( 'Close' ).click();
-		}
+		await admin.createNewPost();
 
 		await editor.insertBlock( {
 			name: 'core/paragraph',
@@ -291,14 +283,6 @@ test.describe( 'Block template registration', () => {
 			.click();
 		await page.getByRole( 'option', { name: 'admin' } ).click();
 		await expect( page.getByText( 'Choose a pattern' ) ).toBeVisible();
-
-		// Get the dialog with aria-label "Welcome to the editor"
-		const welcomeDialog = page.getByLabel( 'Welcome to the editor' );
-
-		// if the dialog is visible within 2 seconds, click the Close button, otherwise continue
-		if ( await welcomeDialog.isVisible( { timeout: 2000 } ) ) {
-			await welcomeDialog.getByLabel( 'Close' ).click();
-		}
 
 		await page.getByLabel( 'Close', { exact: true } ).click();
 		await editor.insertBlock( {


### PR DESCRIPTION
## What?
In the e2e test for template registration, take into account that the `Welcome to the editor` dialog might be either open or closed.

## Why?
In another PR [#67289](https://github.com/WordPress/gutenberg/pull/67289) I found some e2e test failures related to this.

We should check if the `Welcome to the editor` dialog is actually open before attempting to close it.

## How?
- Remove the line that attempts to close the "Welcome to the editor" dialog in template registration e2e test. 
- Use `admin.createNewPost();` to create posts instead which internally handles closing the dialog.


## Testing Instructions
This only updates e2e tests, CI check should be sufficient

## Screenshots or screencast <!-- if applicable -->

<img width="400" alt="Screenshot 2024-12-17 at 17 13 14" src="https://github.com/user-attachments/assets/fb532f63-e34f-46be-83ef-4759d48fb9da" />

