### PR TITLE
Get active element within the iframe when restoring focus

### DIFF
--- a/packages/block-editor/src/components/button-block-appender/index.js
+++ b/packages/block-editor/src/components/button-block-appender/index.js
@@ -7,7 +7,7 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { forwardRef, useRef } from '@wordpress/element';
+import { forwardRef } from '@wordpress/element';
 import { _x, sprintf } from '@wordpress/i18n';
 import { Icon, plus } from '@wordpress/icons';
 import deprecated from '@wordpress/deprecated';
@@ -16,15 +16,11 @@ import deprecated from '@wordpress/deprecated';
  * Internal dependencies
  */
 import Inserter from '../inserter';
-import { useMergeRefs } from '@wordpress/compose';
 
 function ButtonBlockAppender(
 	{ rootClientId, className, onFocus, tabIndex, onSelect },
 	ref
 ) {
-	const inserterButtonRef = useRef();
-
-	const mergedInserterButtonRef = useMergeRefs( [ inserterButtonRef, ref ] );
 	return (
 		<Inserter
 			position="bottom center"
@@ -34,7 +30,6 @@ function ButtonBlockAppender(
 				if ( onSelect && typeof onSelect === 'function' ) {
 					onSelect( ...args );
 				}
-				inserterButtonRef.current?.focus();
 			} }
 			renderToggle={ ( {
 				onToggle,
@@ -61,7 +56,7 @@ function ButtonBlockAppender(
 				return (
 					<Button
 						__next40pxDefaultSize
-						ref={ mergedInserterButtonRef }
+						ref={ ref }
 						onFocus={ onFocus }
 						tabIndex={ tabIndex }
 						className={ clsx(

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -48,7 +48,21 @@ function useFocusReturn( onFocusReturn ) {
 				return;
 			}
 
-			focusedBeforeMount.current = node.ownerDocument.activeElement;
+			/** @type {any} */
+			const activeElement = node.ownerDocument.activeElement;
+
+			// If the activeElement is an iframe, we need to get the active element within the iframe.
+			// Otherwise, focus from items within the iframed canvas will get sent to the iframe itself,
+			// not the active element within the iframe.
+			if (
+				activeElement?.tagName === 'IFRAME' &&
+				activeElement.contentDocument?.activeElement
+			) {
+				focusedBeforeMount.current =
+					activeElement.contentDocument.activeElement;
+			} else {
+				focusedBeforeMount.current = activeElement;
+			}
 		} else if ( focusedBeforeMount.current ) {
 			const isFocused = ref.current?.contains(
 				ref.current?.ownerDocument.activeElement

--- a/packages/compose/src/hooks/use-focus-return/index.js
+++ b/packages/compose/src/hooks/use-focus-return/index.js
@@ -48,21 +48,13 @@ function useFocusReturn( onFocusReturn ) {
 				return;
 			}
 
-			/** @type {any} */
-			const activeElement = node.ownerDocument.activeElement;
+			const activeDocument =
+				node.ownerDocument.activeElement instanceof
+				window.HTMLIFrameElement
+					? node.ownerDocument.activeElement.contentDocument
+					: node.ownerDocument;
 
-			// If the activeElement is an iframe, we need to get the active element within the iframe.
-			// Otherwise, focus from items within the iframed canvas will get sent to the iframe itself,
-			// not the active element within the iframe.
-			if (
-				activeElement?.tagName === 'IFRAME' &&
-				activeElement.contentDocument?.activeElement
-			) {
-				focusedBeforeMount.current =
-					activeElement.contentDocument.activeElement;
-			} else {
-				focusedBeforeMount.current = activeElement;
-			}
+			focusedBeforeMount.current = activeDocument?.activeElement ?? null;
 		} else if ( focusedBeforeMount.current ) {
 			const isFocused = ref.current?.contains(
 				ref.current?.ownerDocument.activeElement


### PR DESCRIPTION
Fixes https://github.com/WordPress/gutenberg/issues/67809

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
`useFocusReturn` doesn't work for items within the editor canvas iframe. Focus is sent to the `iframe` canvas instead of the active element within it. This PR allows for focus to get restored to the active element within the canvas.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
This root focus loss issue has caused a lot of fragile hotfixes. After this is merged, we can remove them. Here's a list of ones I know about:
- [Selecting the previous navigation link block when there is nothing to focus](https://github.com/WordPress/gutenberg/blob/trunk/packages/block-library/src/navigation-link/edit.js#L572-L614). This one may be trickier to address though, as the appender may disappear due to the whole "adding a temporary block and removing it" situation of the navigation block.
- [Always restoring focus when the block list appender quick inserter is closed or block selected](https://github.com/WordPress/gutenberg/pull/64877/files#diff-4cdcf916fb8cf5f88b98cd9e95ab532d90369cd768334f7896720a2b85c018bbR37)
- The above causes this issue: [Block inserter does not work on widgets screen](https://github.com/WordPress/gutenberg/issues/67809#top)
- In progress (hopefully will be fixed by removing the code that is itself a hotfix, rather than adding yet another hotfix on top of it): [Do not control Nav Link item focus when focus within sidebar control](https://github.com/WordPress/gutenberg/pull/68044#top)
- Probably others.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

<!-- In a few words, what is the PR actually doing? -->
The `useFocusReturn` hook stores the `activeElement` as `focusedBeforeMount.current`, and then when popover/modal/etc closes, it returns focus to the `focusedBeforeMount.current`. 

This works well unless the `activeElement` is _within_ an `iframe` (like the editor canvas). If the element is within an `iframe` , then the `focusedBeforeMount.current` is set as the iframe itself, not the `activeElement` within the `iframe`.

This PR checks to see if the `activeElement` is an `iframe` and if the `iframe` has an `activeElement` itself. If so, it sets the `activeElement` within the `iframe` as the `focusedBeforeMount.current`.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- On the iframed block editor
- Add a group block
- Click the appender
- Press Escape
- Focus should be on the appender again
- Press Enter to open the inserter again
- Repeat test with the social icon block appender

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
