### PR TITLE
Use Badge component in dataview grids.

### DIFF
--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -13,6 +13,7 @@ import {
 	Spinner,
 	Flex,
 	FlexItem,
+	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useInstanceId } from '@wordpress/compose';
@@ -20,6 +21,7 @@ import { useInstanceId } from '@wordpress/compose';
 /**
  * Internal dependencies
  */
+import { unlock } from '../../lock-unlock';
 import ItemActions from '../../components/dataviews-item-actions';
 import DataViewsSelectionCheckbox from '../../components/dataviews-selection-checkbox';
 import {
@@ -35,6 +37,7 @@ import type {
 import type { SetSelection } from '../../private-types';
 import getClickableItemProps from '../utils/get-clickable-item-props';
 import { useUpdatedPreviewSizeOnViewportChange } from './preview-size-picker';
+const { Badge } = unlock( componentsPrivateApis );
 
 interface GridItemProps< Item > {
 	view: ViewGridType;
@@ -175,12 +178,12 @@ function GridItem< Item >( {
 					>
 						{ badgeFields.map( ( field ) => {
 							return (
-								<FlexItem
+								<Badge
 									key={ field.id }
 									className="dataviews-view-grid__field-value"
 								>
 									<field.render item={ item } />
-								</FlexItem>
+								</Badge>
 							);
 						} ) }
 					</HStack>

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -111,17 +111,6 @@
 		&:not(:empty) {
 			padding-bottom: $grid-unit-15;
 		}
-
-		.dataviews-view-grid__field-value {
-			width: fit-content;
-			background: $gray-100;
-			padding: 0 $grid-unit-10;
-			min-height: $grid-unit-30;
-			border-radius: $radius-small;
-			display: flex;
-			align-items: center;
-			font-size: 12px;
-		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Partial to https://github.com/WordPress/gutenberg/issues/68020

Use the new `Badge` component in the dataview's grid.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

To improve consistency and sustainability.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Using the new component and removing redundant styles. We're keeping the `dataviews-view-grid__field-value` class in the badge so that we don't have to refactor the way the "synced" badge styles work.

## Testing Instructions

1. Open the site editor.
2. Go to the Patterns screen.
3. Confirm that the "Synced" badge is using the new component.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/d0c47091-d674-4182-8f9d-f12b9b4e60b7



