### PR TITLE
Remove fallback select previous link, as it should not be necessary

### DIFF
--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -598,9 +598,6 @@ export default function NavigationLinkEdit( {
 								} else if ( ref.current ) {
 									// select the ref when adding a new link
 									ref.current.focus();
-								} else {
-									// Fallback
-									selectPreviousBlock( clientId, true );
 								}
 							} }
 							anchor={ popoverAnchor }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/68035

## What?
<!-- In a few words, what is the PR actually doing? -->
Removes a fallback for auto-focusing the previously selected block when closing the link ui popover.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
It was causing focus to be reset to the previous block when closing the link ui, even if focus was intentionally moved elsewhere.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Remove the fallback for selectPreviousBlock.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
