### PR TITLE
RadioGroup: Log deprecation warning

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `TreeSelect`: Deprecate 36px default size ([#67855](https://github.com/WordPress/gutenberg/pull/67855)).
 -   `SelectControl`: Deprecate 36px default size ([#66898](https://github.com/WordPress/gutenberg/pull/66898)).
 -   `InputControl`: Deprecate 36px default size ([#66897](https://github.com/WordPress/gutenberg/pull/66897)).
+-   `RadioGroup`: Log deprecation warning ([#68067](https://github.com/WordPress/gutenberg/pull/68067)).
 
 ### Bug Fixes
 

--- a/packages/components/src/button-group/index.tsx
+++ b/packages/components/src/button-group/index.tsx
@@ -20,13 +20,15 @@ function UnforwardedButtonGroup(
 	props: WordPressComponentProps< ButtonGroupProps, 'div', false >,
 	ref: ForwardedRef< HTMLDivElement >
 ) {
-	const { className, ...restProps } = props;
+	const { className, __shouldNotWarnDeprecated, ...restProps } = props;
 	const classes = clsx( 'components-button-group', className );
 
-	deprecated( 'wp.components.ButtonGroup', {
-		since: '6.8',
-		alternative: 'wp.components.ToggleGroupControl',
-	} );
+	if ( ! __shouldNotWarnDeprecated ) {
+		deprecated( 'wp.components.ButtonGroup', {
+			since: '6.8',
+			alternative: 'wp.components.__experimentalToggleGroupControl',
+		} );
+	}
 
 	return (
 		<div ref={ ref } role="group" className={ classes } { ...restProps } />

--- a/packages/components/src/button-group/types.ts
+++ b/packages/components/src/button-group/types.ts
@@ -8,4 +8,11 @@ export type ButtonGroupProps = {
 	 * The children elements.
 	 */
 	children: ReactNode;
+	/**
+	 * Do not throw a warning for component deprecation.
+	 * For internal components of other components that already throw the warning.
+	 *
+	 * @ignore
+	 */
+	__shouldNotWarnDeprecated?: boolean;
 };

--- a/packages/components/src/radio-group/index.tsx
+++ b/packages/components/src/radio-group/index.tsx
@@ -57,7 +57,11 @@ function UnforwardedRadioGroup(
 		<RadioGroupContext.Provider value={ contextValue }>
 			<Ariakit.RadioGroup
 				store={ radioStore }
-				render={ <ButtonGroup>{ children }</ButtonGroup> }
+				render={
+					<ButtonGroup __shouldNotWarnDeprecated>
+						{ children }
+					</ButtonGroup>
+				}
 				aria-label={ label }
 				ref={ ref }
 				{ ...props }

--- a/packages/components/src/radio-group/index.tsx
+++ b/packages/components/src/radio-group/index.tsx
@@ -6,6 +6,7 @@ import * as Ariakit from '@ariakit/react';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { useMemo, forwardRef } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
@@ -45,6 +46,12 @@ function UnforwardedRadioGroup(
 		} ),
 		[ radioStore, disabled ]
 	);
+
+	deprecated( 'wp.components.__experimentalRadioGroup', {
+		alternative:
+			'wp.components.RadioControl or wp.components.__experimentalToggleGroupControl',
+		since: '6.8',
+	} );
 
 	return (
 		<RadioGroupContext.Provider value={ contextValue }>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Soft deprecates (#61099) the RadioGroup component.

## Why?
All remaining instances of RadioGroup in the app have been removed as of #67702.

## How?
This was already passive deprecated, so just escalating the deprecation so it notifies consumers through a console warning and Dev Note.

## Testing Instructions
Go to the Storybook for RadioGroup and check that the deprecation warning is being logged in dev tools.

## ✍️ Dev Note

The `RadioGroup` component has been deprecated. To be consistent with the current WordPress design system, use [`RadioControl`](https://wordpress.github.io/gutenberg/?path=/docs/components-radiocontrol--docs) or [`ToggleGroupControl`](https://wordpress.github.io/gutenberg/?path=/docs/components-experimental-togglegroupcontrol--docs) instead.