### PR TITLE
Enhance: Improve pagination logic in core/query-pagination-previous block

### DIFF
--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Server-side rendering of the `core/query-pagination-previous` block.
  *
@@ -45,18 +44,13 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 		$content = get_previous_posts_link( $label );
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-	} elseif ( 1 < $page ) {
+	} else {
+		$block_query     = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+		$block_max_pages = $block_query->max_num_pages;
+		$total           = ! $max_page || $max_page > $block_max_pages ? $block_max_pages : $max_page;
+		wp_reset_postdata();
 
-		$total_pages = $max_page;
-		if ( ! isset( $block->context['query']['inherit'] ) || ! $block->context['query']['inherit'] ) {
-			$block_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
-			$total_pages = $block_query->max_num_pages;
-			wp_reset_postdata();
-		}
-
-		$total = ! $max_page || $max_page > $total_pages ? $total_pages : $max_page;
-
-		if ( $page <= $total ) {
+		if ( 1 < $page && $page <= $total ) {
 			$content = sprintf(
 				'<a href="%1$s" %2$s>%3$s</a>',
 				esc_url( add_query_arg( $page_key, $page - 1 ) ),

--- a/packages/block-library/src/query-pagination-previous/index.php
+++ b/packages/block-library/src/query-pagination-previous/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Server-side rendering of the `core/query-pagination-previous` block.
  *
@@ -19,14 +20,14 @@
 function render_block_core_query_pagination_previous( $attributes, $content, $block ) {
 	$page_key            = isset( $block->context['queryId'] ) ? 'query-' . $block->context['queryId'] . '-page' : 'query-page';
 	$enhanced_pagination = isset( $block->context['enhancedPagination'] ) && $block->context['enhancedPagination'];
+	$max_page            = isset( $block->context['query']['pages'] ) ? (int) $block->context['query']['pages'] : 0;
 	$page                = empty( $_GET[ $page_key ] ) ? 1 : (int) $_GET[ $page_key ];
-
-	$wrapper_attributes = get_block_wrapper_attributes();
-	$show_label         = isset( $block->context['showLabel'] ) ? (bool) $block->context['showLabel'] : true;
-	$default_label      = __( 'Previous Page' );
-	$label_text         = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
-	$label              = $show_label ? $label_text : '';
-	$pagination_arrow   = get_query_pagination_arrow( $block, false );
+	$wrapper_attributes  = get_block_wrapper_attributes();
+	$show_label          = isset( $block->context['showLabel'] ) ? (bool) $block->context['showLabel'] : true;
+	$default_label       = __( 'Previous Page' );
+	$label_text          = isset( $attributes['label'] ) && ! empty( $attributes['label'] ) ? esc_html( $attributes['label'] ) : $default_label;
+	$label               = $show_label ? $label_text : '';
+	$pagination_arrow    = get_query_pagination_arrow( $block, false );
 	if ( ! $label ) {
 		$wrapper_attributes .= ' aria-label="' . $label_text . '"';
 	}
@@ -44,13 +45,25 @@ function render_block_core_query_pagination_previous( $attributes, $content, $bl
 		add_filter( 'previous_posts_link_attributes', $filter_link_attributes );
 		$content = get_previous_posts_link( $label );
 		remove_filter( 'previous_posts_link_attributes', $filter_link_attributes );
-	} elseif ( 1 !== $page ) {
-		$content = sprintf(
-			'<a href="%1$s" %2$s>%3$s</a>',
-			esc_url( add_query_arg( $page_key, $page - 1 ) ),
-			$wrapper_attributes,
-			$label
-		);
+	} elseif ( 1 < $page ) {
+
+		$total_pages = $max_page;
+		if ( ! isset( $block->context['query']['inherit'] ) || ! $block->context['query']['inherit'] ) {
+			$block_query = new WP_Query( build_query_vars_from_query_block( $block, $page ) );
+			$total_pages = $block_query->max_num_pages;
+			wp_reset_postdata();
+		}
+
+		$total = ! $max_page || $max_page > $total_pages ? $total_pages : $max_page;
+
+		if ( $page <= $total ) {
+			$content = sprintf(
+				'<a href="%1$s" %2$s>%3$s</a>',
+				esc_url( add_query_arg( $page_key, $page - 1 ) ),
+				$wrapper_attributes,
+				$label
+			);
+		}
 	}
 
 	if ( $enhanced_pagination && isset( $content ) ) {


### PR DESCRIPTION
Fixes: #67748 

## What?
The **Query Pagination Previous** block is displayed even when a user navigates beyond the range of available query results. Since no results are shown in such cases, displaying this block is unnecessary and can be confusing. This PR addresses the issue by ensuring the **Query Pagination Previous** block is hidden when the query has no results, improving user experience and interface clarity.

## How?
The logic has been updated to render the block only when the page number is greater than 1 and less than or equal to the total number of pages, ensuring accurate and appropriate visibility.

## Testing Instructions
1. Add a query loop block.
2. Make sure to add Query Pagination block which contains Query Pagination Previous Block as well.
3. Enter a page range that lies outside the query range.
4. Observe that the block **Query Pagination Previous** is not rendered.

## Screencast

https://github.com/user-attachments/assets/2cf3cc25-215f-4eb6-877d-ac2f6086f7f5

## Screenshots

**Before:**
![Screenshot 2024-12-10 at 11 42 10 AM](https://github.com/user-attachments/assets/38549725-eaa4-40f1-a7b9-528842446cc7)


**After:**
![Screenshot 2024-12-10 at 11 41 08 AM](https://github.com/user-attachments/assets/a339cab2-9a8c-4e00-bd2a-f1bb1ed3b2c4)



