### PR TITLE
[mini] in-between indicator: make symmetric

### DIFF
--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -112,12 +112,16 @@ function BlockPopoverInbetween( {
 				} else if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;
-					width = previousRect ? previousRect.width : nextRect.width;
+					width = previousRect
+						? ( previousRect.width + nextRect.width ) / 2
+						: nextRect.width;
 					height =
 						nextRect && previousRect
 							? nextRect.top - previousRect.bottom
 							: 0;
-					left = previousRect ? previousRect.left : nextRect.left;
+					left = previousRect
+						? ( previousRect.left + nextRect.left ) / 2
+						: nextRect.left;
 				} else {
 					top = previousRect ? previousRect.top : nextRect.top;
 					height = previousRect

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -101,16 +101,18 @@ function BlockPopoverInbetween( {
 				} else if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;
-					width = previousRect
-						? ( previousRect.width + nextRect.width ) / 2
-						: nextRect.width;
+					width =
+						nextRect && previousRect
+							? ( previousRect.width + nextRect.width ) / 2
+							: ( previousRect || nextRect ).width;
 					height =
 						nextRect && previousRect
 							? nextRect.top - previousRect.bottom
 							: 0;
-					left = previousRect
-						? ( previousRect.left + nextRect.left ) / 2
-						: nextRect.left;
+					left =
+						nextRect && previousRect
+							? ( previousRect.left + nextRect.left ) / 2
+							: ( previousRect || nextRect ).left;
 				} else {
 					top = previousRect ? previousRect.top : nextRect.top;
 					height = previousRect

--- a/packages/block-editor/src/components/block-popover/inbetween.js
+++ b/packages/block-editor/src/components/block-popover/inbetween.js
@@ -101,12 +101,16 @@ function BlockPopoverInbetween( {
 				} else if ( isVertical ) {
 					// vertical
 					top = previousRect ? previousRect.bottom : nextRect.top;
-					width = previousRect ? previousRect.width : nextRect.width;
+					width = previousRect
+						? ( previousRect.width + nextRect.width ) / 2
+						: nextRect.width;
 					height =
 						nextRect && previousRect
 							? nextRect.top - previousRect.bottom
 							: 0;
-					left = previousRect ? previousRect.left : nextRect.left;
+					left = previousRect
+						? ( previousRect.left + nextRect.left ) / 2
+						: nextRect.left;
 				} else {
 					top = previousRect ? previousRect.top : nextRect.top;
 					height = previousRect


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Still not 100% ideal, but I believe much better than before. In trunk, we will always look at the previous block to determine the width of the indicator. It's much better to take the average width of the previous and next block so that:

* The indicator does not turn out super big or super small.
* The indicator is the same size before and after the block.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Hover between blocks such as the separator and full width image.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<img width="1464" alt="Screenshot 2024-12-18 at 15 04 21" src="https://github.com/user-attachments/assets/426b8c46-60ea-45f2-bbe1-8e6b899824f6" />|<img width="1464" alt="Screenshot 2024-12-18 at 14 54 34" src="https://github.com/user-attachments/assets/ecfc64f9-b030-4a3c-a4d1-f6da2f28bbb2" />|
|<img width="1464" alt="Screenshot 2024-12-18 at 15 04 35" src="https://github.com/user-attachments/assets/5dfa1156-fd41-442d-9e2d-ef1b71f9278b" />|<img width="1464" alt="Screenshot 2024-12-18 at 15 02 07" src="https://github.com/user-attachments/assets/26ccb87f-6ac2-4ccf-8a92-ae0317274c49" />|
