### PR TITLE
Block popover: fix scrolling over

### DIFF
--- a/packages/block-editor/src/components/block-popover/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-popover/use-popover-scroll.js
@@ -2,24 +2,35 @@
  * WordPress dependencies
  */
 import { useRefEffect } from '@wordpress/compose';
+import { getScrollContainer } from '@wordpress/dom';
+
+const scrollContainerCache = new WeakMap();
 
 /**
  * Allow scrolling "through" popovers over the canvas. This is only called for
  * as long as the pointer is over a popover. Do not use React events because it
  * will bubble through portals.
  *
- * @param {Object} scrollableRef
+ * @param {Object} contentRef
  */
-function usePopoverScroll( scrollableRef ) {
+function usePopoverScroll( contentRef ) {
 	return useRefEffect(
 		( node ) => {
-			if ( ! scrollableRef ) {
+			// Do not guard for an undefined scrollableRef because it
+			// scrollableRef is required and it would be a bug.
+			if ( ! contentRef.current ) {
 				return;
 			}
 
 			function onWheel( event ) {
 				const { deltaX, deltaY } = event;
-				scrollableRef.current.scrollBy( deltaX, deltaY );
+				const contentEl = contentRef.current;
+				let scrollContainer = scrollContainerCache.get( contentEl );
+				if ( ! scrollContainer ) {
+					scrollContainer = getScrollContainer( contentEl );
+					scrollContainerCache.set( contentEl, scrollContainer );
+				}
+				scrollContainer.scrollBy( deltaX, deltaY );
 			}
 			// Tell the browser that we do not call event.preventDefault
 			// See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#improving_scrolling_performance_with_passive_listeners
@@ -29,7 +40,7 @@ function usePopoverScroll( scrollableRef ) {
 				node.removeEventListener( 'wheel', onWheel, options );
 			};
 		},
-		[ scrollableRef ]
+		[ contentRef ]
 	);
 }
 

--- a/packages/block-editor/src/components/block-popover/use-popover-scroll.js
+++ b/packages/block-editor/src/components/block-popover/use-popover-scroll.js
@@ -16,12 +16,6 @@ const scrollContainerCache = new WeakMap();
 function usePopoverScroll( contentRef ) {
 	return useRefEffect(
 		( node ) => {
-			// Do not guard for an undefined scrollableRef because it
-			// scrollableRef is required and it would be a bug.
-			if ( ! contentRef.current ) {
-				return;
-			}
-
 			function onWheel( event ) {
 				const { deltaX, deltaY } = event;
 				const contentEl = contentRef.current;

--- a/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
+++ b/packages/block-editor/src/components/block-tools/block-toolbar-popover.js
@@ -11,7 +11,7 @@ import { useShortcut } from '@wordpress/keyboard-shortcuts';
 /**
  * Internal dependencies
  */
-import BlockPopover from '../block-popover';
+import { PrivateBlockPopover } from '../block-popover';
 import useBlockToolbarPopoverProps from './use-block-toolbar-popover-props';
 import useSelectedBlockToolProps from './use-selected-block-tool-props';
 import { store as blockEditorStore } from '../../store';
@@ -58,7 +58,7 @@ export default function BlockToolbarPopover( {
 
 	return (
 		! isTyping && (
-			<BlockPopover
+			<PrivateBlockPopover
 				clientId={ clientIdToPositionOver }
 				bottomClientId={ lastClientId }
 				className={ clsx( 'block-editor-block-list__block-popover', {
@@ -66,6 +66,7 @@ export default function BlockToolbarPopover( {
 				} ) }
 				resize={ false }
 				{ ...popoverProps }
+				__unstableContentRef={ __unstableContentRef }
 			>
 				<PrivateBlockToolbar
 					// If the toolbar is being shown because of being forced
@@ -79,7 +80,7 @@ export default function BlockToolbarPopover( {
 					} }
 					variant="toolbar"
 				/>
-			</BlockPopover>
+			</PrivateBlockPopover>
 		)
 	);
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/63260.

Scrolling the content when the pointer is over the block popover stopped working.

It seems to be caused by:
1. #61529 (ref no longer passed)
2. The body may not always be the scrollable element.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Hover over the block toolbar and scroll.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
