### PR TITLE
Page List Block: Fix critical error when converting to link

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -362,6 +362,7 @@ export default function PageListEdit( {
 						<ToolsPanelItem
 							label={ __( 'Edit Menu' ) }
 							isShownByDefault
+							hasValue={ () => false }
 						>
 							<div>
 								<p>{ convertDescription }</p>


### PR DESCRIPTION
Temporary fix for https://github.com/WordPress/gutenberg/issues/67932#issuecomment-2544544964

## What?

To prevent a critical error, add a `hasValue` prop to the `ToolsPanelItem` component that always returns `false`.

## Why?

In the case that this PR is trying to fix, only the "Edit" button is rendered, and it has no value. So, while ideally the `hasValue` prop itself wouldn't be necessary, this prop is required and will throw a critical error if it's missing.

## How?

Add a `hasValue` prop that always returns `false` to prevent a critical error. Ideally, I think the `ToolsPanelItem` should be modified to correctly handle items that have no value (See [this comment](https://github.com/WordPress/gutenberg/issues/67813#issuecomment-2544734526)).

If this PR approach is not ideal, we may need to revert #67903 for now.

## Testing Instructions

- Select the Navigation block.
- Select the Page List block within that block.
- Ensure that the "Edit" button appears in the block sidebar.

## Screenshot

![edit-menu](https://github.com/user-attachments/assets/f4892910-acc6-4a6a-8afb-391f18feb3a3)