### PR TITLE
Badge component: Fix Storybook url link

### DIFF
--- a/bin/api-docs/gen-components-docs/markdown/props.mjs
+++ b/bin/api-docs/gen-components-docs/markdown/props.mjs
@@ -48,4 +48,3 @@ export function generateMarkdownPropsJson( props, { headingLevel = 2 } = {} ) {
 
 	return [ { [ `h${ headingLevel }` ]: 'Props' }, ...propsJson ];
 }
-

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,6 +26,10 @@
 
 -   `SlotFill`: rewrite the non-portal version to use `observableMap` ([#67400](https://github.com/WordPress/gutenberg/pull/67400)).
 
+### Documentation
+
+-   `Badge`: Fix Storybook url link ([#68077](https://github.com/WordPress/gutenberg/pull/68077)).
+
 ## 29.0.0 (2024-12-11)
 
 ### Breaking Changes

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -26,10 +26,6 @@
 
 -   `SlotFill`: rewrite the non-portal version to use `observableMap` ([#67400](https://github.com/WordPress/gutenberg/pull/67400)).
 
-### Documentation
-
--   `Badge`: Fix Storybook url link ([#68077](https://github.com/WordPress/gutenberg/pull/68077)).
-
 ## 29.0.0 (2024-12-11)
 
 ### Breaking Changes

--- a/packages/components/src/badge/stories/index.story.tsx
+++ b/packages/components/src/badge/stories/index.story.tsx
@@ -11,6 +11,7 @@ import Badge from '..';
 const meta = {
 	component: Badge,
 	title: 'Components/Containers/Badge',
+	id: 'components-badge',
 	tags: [ 'status-private' ],
 } satisfies Meta< typeof Badge >;
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fix an issue where the Storybook link in the `Badge` component README was not linking to an actual story:

https://github.com/user-attachments/assets/106a18ae-e6c1-4904-ad4f-3ac7d38ee694

## Why?

This is because the URL rules are different when automatically generating a README and when using Storybook.

## How?

By adding an `id` field to the storybook meta,  change the story URL of the `Badge` component as follows:

- From: https://wordpress.github.io/gutenberg/?path=/docs/components-containers-badge--docs
- To: https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard

- Run `npm run storybook:dev`
- The story URL for the `Badge` component should be `http://localhost:50240/?path=/docs/components-badge--docs`.
