### PR TITLE
DataViews: Handle `grid` preview size based on container width

### DIFF
--- a/packages/dataviews/src/components/dataviews-context/index.ts
+++ b/packages/dataviews/src/components/dataviews-context/index.ts
@@ -28,6 +28,7 @@ type DataViewsContextType< Item > = {
 	getItemId: ( item: Item ) => string;
 	onClickItem?: ( item: Item ) => void;
 	isItemClickable: ( item: Item ) => boolean;
+	containerWidth: number;
 };
 
 const DataViewsContext = createContext< DataViewsContextType< any > >( {
@@ -45,6 +46,7 @@ const DataViewsContext = createContext< DataViewsContextType< any > >( {
 	openedFilter: null,
 	getItemId: ( item ) => item.id,
 	isItemClickable: () => true,
+	containerWidth: 0,
 } );
 
 export default DataViewsContext;

--- a/packages/dataviews/src/components/dataviews/index.tsx
+++ b/packages/dataviews/src/components/dataviews/index.tsx
@@ -8,6 +8,7 @@ import type { ReactNode } from 'react';
  */
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useMemo, useState } from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -73,6 +74,15 @@ export default function DataViews< Item >( {
 	isItemClickable = defaultIsItemClickable,
 	header,
 }: DataViewsProps< Item > ) {
+	const [ containerWidth, setContainerWidth ] = useState( 0 );
+	const containerRef = useResizeObserver(
+		( resizeObserverEntries: any ) => {
+			setContainerWidth(
+				resizeObserverEntries[ 0 ].borderBoxSize[ 0 ].inlineSize
+			);
+		},
+		{ box: 'border-box' }
+	);
 	const [ selectionState, setSelectionState ] = useState< string[] >( [] );
 	const isUncontrolled =
 		selectionProperty === undefined || onChangeSelection === undefined;
@@ -117,9 +127,10 @@ export default function DataViews< Item >( {
 				getItemId,
 				isItemClickable,
 				onClickItem,
+				containerWidth,
 			} }
 		>
-			<div className="dataviews-wrapper">
+			<div className="dataviews-wrapper" ref={ containerRef }>
 				<HStack
 					alignment="top"
 					justify="space-between"

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -3,6 +3,7 @@
 	grid-template-rows: max-content;
 	padding: 0 $grid-unit-60 $grid-unit-30;
 	transition: padding ease-out 0.1s;
+	container-type: inline-size;
 	@include reduce-motion("transition");
 
 
@@ -126,21 +127,30 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
-	grid-template-columns: repeat(1, minmax(0, 1fr));
-
-	@include break-mobile() {
+	/**
+	 * Breakpoints were adjusted from media queries breakpoints to account for
+	 * the sidebar width. This was done to match the existing styles we had.
+	 */
+	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
+	@container (max-width: 480px) {
+		grid-template-columns: repeat(1, minmax(0, 1fr));
+		padding-left: $grid-unit-30;
+		padding-right: $grid-unit-30;
+	}
+	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
+	@container (min-width: 480px) {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
-
-	@include break-xlarge() {
+	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
+	@container (min-width: 780px) {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
 	}
-
-	@include break-huge() {
+	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
+	@container (min-width: 1140px) {
 		grid-template-columns: repeat(4, minmax(0, 1fr));
 	}
-
-	@include break-xhuge() {
+	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
+	@container (min-width: 1520px) {
 		grid-template-columns: repeat(5, minmax(0, 1fr));
 	}
 }
@@ -161,13 +171,6 @@
 .dataviews-view-grid__card:focus-within .dataviews-selection-checkbox,
 .dataviews-view-grid__card.is-selected .dataviews-selection-checkbox {
 	top: $grid-unit-10;
-}
-
-@container (max-width: 430px) {
-	.dataviews-view-grid {
-		padding-left: $grid-unit-30;
-		padding-right: $grid-unit-30;
-	}
 }
 
 .dataviews-view-grid__media--clickable {

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -131,25 +131,20 @@
 	 * Breakpoints were adjusted from media queries breakpoints to account for
 	 * the sidebar width. This was done to match the existing styles we had.
 	 */
-	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
 	@container (max-width: 480px) {
 		grid-template-columns: repeat(1, minmax(0, 1fr));
 		padding-left: $grid-unit-30;
 		padding-right: $grid-unit-30;
 	}
-	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
 	@container (min-width: 480px) {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
 	}
-	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
 	@container (min-width: 780px) {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
 	}
-	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
 	@container (min-width: 1140px) {
 		grid-template-columns: repeat(4, minmax(0, 1fr));
 	}
-	/* stylelint-disable-next-line scss/at-rule-no-unknown -- '@container' not globally permitted */
 	@container (min-width: 1520px) {
 		grid-template-columns: repeat(5, minmax(0, 1fr));
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Currently in `grid` layout for DataViews we adjust the preview size based on viewport width. This is wrong and you can see that in [Storybook](https://wordpress.github.io/gutenberg/?path=/story/dataviews-dataviews--default&globals=maxWidthWrapper:wordpress-sidebar) - make sure to change to `grid` layout.

This PR handles that by using the container width, which is also passed as part of DataViews context for any consumer.

Also related to: https://github.com/WordPress/gutenberg/pull/68030, which tries DataViews inside the inserter.


## Testing Instructions
1. Compare DataViews `grid` layout (example in templates page) in various widths (by resizing the viewport).
2. The differences should be minimal(maybe just a few pixels?) if any.
3. In Storybook (`npm run storybook:dev`) and check DataViews `grid` layout in various containers
<img width="971" alt="Screenshot 2024-12-18 at 10 07 29 AM" src="https://github.com/user-attachments/assets/1a2964c8-8e95-4e36-918d-ea12680eb8c9" />


