### PR TITLE
DateFormatPicker: fix styles & spacing

### DIFF
--- a/packages/block-editor/src/components/date-format-picker/index.js
+++ b/packages/block-editor/src/components/date-format-picker/index.js
@@ -40,7 +40,11 @@ export default function DateFormatPicker( {
 	onChange,
 } ) {
 	return (
-		<fieldset className="block-editor-date-format-picker">
+		<VStack
+			as="fieldset"
+			spacing={ 4 }
+			className="block-editor-date-format-picker"
+		>
 			<VisuallyHidden as="legend">{ __( 'Date format' ) }</VisuallyHidden>
 			<ToggleControl
 				__nextHasNoMarginBottom
@@ -57,7 +61,7 @@ export default function DateFormatPicker( {
 			{ format && (
 				<NonDefaultControls format={ format } onChange={ onChange } />
 			) }
-		</fieldset>
+		</VStack>
 	);
 }
 

--- a/packages/block-editor/src/components/date-format-picker/style.scss
+++ b/packages/block-editor/src/components/date-format-picker/style.scss
@@ -1,5 +1,7 @@
 .block-editor-date-format-picker {
-	margin-bottom: $grid-unit-20;
+	margin: 0 0 $grid-unit-20;
+	padding: 0;
+	border: none;
 }
 
 .block-editor-date-format-picker__custom-format-select-control__custom-option {


### PR DESCRIPTION
Fixes #67917
Related to #67290

## What?

This PR resolves two issues in the `DateFormatPicker` component:

- Browser default styles (border, margin, padding) are applied to the `fieldset` element when no reset style from WordPress exists
- No space between two controls

As a result, the issue reported in https://github.com/WordPress/gutenberg/issues/67917#issuecomment-2544506759 will be fixed.

## Why?

I discovered this issue while looking into #67290 and #67906.

When this component is displayed inside a WordPress page, it has no border, padding or margin due to [the reset styles in WordPress core](https://github.com/t-hamano/wordpress-develop/blob/a27e6a8ecd5279a45e47ef88d048643740d07b5a/src/wp-admin/css/common.css#L2617-L2621).

Additionally, #67906 caused this setting to be refactored to use a `ToolsPanelItem`, which negates the bottom margin expected by the inspector control:

![margin](https://github.com/user-attachments/assets/8c27a56a-959c-441f-9860-28eae9ae5978)

This component may be used outside of WordPress, for example in the developer's own block editor, so we need to ensure that it displays with the correct layout wherever it is displayed.

## How?

- Add reset styles to the `fieldset` element
- Add spacing with the `VStack` component

## Testing Instructions

### Storybook

- Run `npm run storybook:dev`
- Access http://localhost:50240/?path=/story/blockeditor-dateformatpicker--default

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/d0aaf339-fc67-4112-b40d-177ec93e9db0) | ![image](https://github.com/user-attachments/assets/e48e7ef8-910f-4ed7-a150-cb3249cac791) |

### Date Block

- Insert a Date block
- Uncheck the "Default format" setting

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/1e541459-f8a5-4b46-93d7-ca87bff1b6d5) | ![image](https://github.com/user-attachments/assets/5a7ec261-8a00-4399-ac15-6816eac8568d) |