### PR TITLE
Storybook: Add more `max-width` containers

### DIFF
--- a/storybook/decorators/with-max-width-wrapper.js
+++ b/storybook/decorators/with-max-width-wrapper.js
@@ -23,7 +23,7 @@ export const WithMaxWidthWrapper = ( Story, context ) => {
 	 * such as being located within the WordPress editor sidebars.
 	 */
 	const maxWidth = context.globals.maxWidthWrapper;
-	if ( ! context.globals.maxWidthWrapper ) {
+	if ( ! maxWidth ) {
 		return <Story { ...context } />;
 	}
 	return (

--- a/storybook/decorators/with-max-width-wrapper.js
+++ b/storybook/decorators/with-max-width-wrapper.js
@@ -3,6 +3,13 @@
  */
 import styled from '@emotion/styled';
 
+const maxWidthWrapperMap = {
+	none: 0,
+	'wordpress-sidebar': 248,
+	'large-container': 960,
+	'small-container': 600,
+};
+
 const Indicator = styled.div`
 	display: flex;
 	justify-content: center;
@@ -22,7 +29,7 @@ export const WithMaxWidthWrapper = ( Story, context ) => {
 	 * This can be used to simulate real world constraints on components
 	 * such as being located within the WordPress editor sidebars.
 	 */
-	const maxWidth = context.globals.maxWidthWrapper;
+	const maxWidth = maxWidthWrapperMap[ context.globals.maxWidthWrapper ];
 	if ( ! maxWidth ) {
 		return <Story { ...context } />;
 	}

--- a/storybook/decorators/with-max-width-wrapper.js
+++ b/storybook/decorators/with-max-width-wrapper.js
@@ -3,16 +3,6 @@
  */
 import styled from '@emotion/styled';
 
-/**
- * A Storybook decorator to wrap a story in a div applying a max width and
- * padding. This can be used to simulate real world constraints on components
- * such as being located within the WordPress editor sidebars.
- */
-
-const Wrapper = styled.div`
-	max-width: 248px;
-`;
-
 const Indicator = styled.div`
 	display: flex;
 	justify-content: center;
@@ -27,14 +17,19 @@ const Indicator = styled.div`
 `;
 
 export const WithMaxWidthWrapper = ( Story, context ) => {
-	if ( context.globals.maxWidthWrapper === 'none' ) {
+	/**
+	 * A Storybook decorator to wrap a story in a div applying a max width.
+	 * This can be used to simulate real world constraints on components
+	 * such as being located within the WordPress editor sidebars.
+	 */
+	const maxWidth = context.globals.maxWidthWrapper;
+	if ( ! context.globals.maxWidthWrapper ) {
 		return <Story { ...context } />;
 	}
-
 	return (
-		<Wrapper>
+		<div style={ { maxWidth } }>
 			<Story { ...context } />
-			<Indicator>Max-Width Wrapper - 248px</Indicator>
-		</Wrapper>
+			<Indicator>{ `Max-Width Wrapper - ${ maxWidth }px` }</Indicator>
+		</div>
 	);
 };

--- a/storybook/decorators/with-max-width-wrapper.js
+++ b/storybook/decorators/with-max-width-wrapper.js
@@ -6,8 +6,8 @@ import styled from '@emotion/styled';
 const maxWidthWrapperMap = {
 	none: 0,
 	'wordpress-sidebar': 248,
-	'large-container': 960,
 	'small-container': 600,
+	'large-container': 960,
 };
 
 const Indicator = styled.div`

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -84,10 +84,10 @@ export const globalTypes = {
 		toolbar: {
 			icon: 'outline',
 			items: [
-				{ value: 0, title: 'None' },
-				{ value: 248, title: 'WP Sidebar' },
-				{ value: 960, title: 'Large container' },
-				{ value: 600, title: 'Small container' },
+				{ value: 'none', title: 'None' },
+				{ value: 'wordpress-sidebar', title: 'WP Sidebar' },
+				{ value: 'large-container', title: 'Large container' },
+				{ value: 'small-container', title: 'Small container' },
 			],
 		},
 	},

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -84,8 +84,10 @@ export const globalTypes = {
 		toolbar: {
 			icon: 'outline',
 			items: [
-				{ value: 'none', title: 'None' },
-				{ value: 'wordpress-sidebar', title: 'WP Sidebar' },
+				{ value: 0, title: 'None' },
+				{ value: 248, title: 'WP Sidebar' },
+				{ value: 960, title: 'Large container' },
+				{ value: 600, title: 'Small container' },
 			],
 		},
 	},

--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -86,8 +86,8 @@ export const globalTypes = {
 			items: [
 				{ value: 'none', title: 'None' },
 				{ value: 'wordpress-sidebar', title: 'WP Sidebar' },
-				{ value: 'large-container', title: 'Large container' },
 				{ value: 'small-container', title: 'Small container' },
+				{ value: 'large-container', title: 'Large container' },
 			],
 		},
 	},


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR adds some more `max-width` containers in Storybook as it's valuable to have them for many components. An example is DataViews and this code was extracted by: https://github.com/WordPress/gutenberg/pull/68078.
<img width="971" alt="Screenshot 2024-12-18 at 10 07 29 AM" src="https://github.com/user-attachments/assets/9ec1a4dc-d5c6-49df-984c-8592d1f1e111" />
