### PR TITLE
Background supports: add default controls supports

### DIFF
--- a/packages/block-editor/src/hooks/background.js
+++ b/packages/block-editor/src/hooks/background.js
@@ -177,6 +177,11 @@ export function BackgroundImagePanel( {
 		},
 	};
 
+	const defaultControls = getBlockSupport( name, [
+		BACKGROUND_SUPPORT_KEY,
+		'defaultControls',
+	] );
+
 	return (
 		<StylesBackgroundPanel
 			inheritedValue={ inheritedValue }
@@ -185,6 +190,7 @@ export function BackgroundImagePanel( {
 			defaultValues={ BACKGROUND_BLOCK_DEFAULT_VALUES }
 			settings={ updatedSettings }
 			onChange={ onChange }
+			defaultControls={ defaultControls }
 			value={ style }
 		/>
 	);


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Part of https://github.com/WordPress/gutenberg/issues/54336

## What?

It was an oversight not to check block settings for background image default controls. 

There is only "one" control officially, but at least this change allows blocks to control it pulling it in line with other blocks.

This PR passes the support settings to the component in the block style hook.

Thanks to @aaronrobertshaw for spotting it.

## Why?

Blocks that support background images such as the [Group block](https://github.com/WordPress/gutenberg/blob/1418afc9b662b8bdb5d35a7bdb6d9ba9b28b69bb/packages/block-library/src/group/block.json) have explicitly opted into the background image default control:

```json
			"__experimentalDefaultControls": {
				"backgroundImage": true
			}
```

But that value has not effect when, in fact, the same settings are [hardcoded in the component](https://github.com/WordPress/gutenberg/blob/8daade531adbe542ea098b6eb904faf73b0a0434/packages/block-editor/src/components/global-styles/background-panel.js#L17-L17).

The consequence is that setting the control to `false` does nothing.

It was considered to remove the redundant `__experimentalDefaultControls` settings from the block.json files for Group, Post Content, Verse et. al. 

However I think we could leave them in as an explicit flag if the component's default ever updates.

There are still a few outstanding inconsistencies with background image supports, most of which have been noted in https://github.com/WordPress/gutenberg/issues/54336


## Testing Instructions
Insert a Group block, select it and check the styles in the block settings panel.
The background image control should be visible by default.
Now set the defaultControl to `false`:

```json
diff --git a/packages/block-library/src/group/block.json b/packages/block-library/src/group/block.json
index 3c7d8d3ce1..d7180ebf66 100644
--- a/packages/block-library/src/group/block.json
+++ b/packages/block-library/src/group/block.json
@@ -32,7 +32,7 @@
 			"backgroundImage": true,
 			"backgroundSize": true,
 			"__experimentalDefaultControls": {
-				"backgroundImage": true
+				"backgroundImage": false
 			}
 		},
 		"color": {
```
The background image control should not be visible by default.

## Screenshots or screencast <!-- if applicable -->



|Before|After|
|-|-|
|<img width="269" alt="Screenshot 2024-12-18 at 6 41 27 pm" src="https://github.com/user-attachments/assets/acc2922f-f5ab-495e-8796-d6ee155ad417" />|<img width="284" alt="Screenshot 2024-12-18 at 6 41 10 pm" src="https://github.com/user-attachments/assets/869ddcfc-2022-407e-ae52-72bcb88a0ef8" />|



