### PR TITLE
Fix style book background color.

### DIFF
--- a/packages/edit-site/src/components/editor-canvas-container/style.scss
+++ b/packages/edit-site/src/components/editor-canvas-container/style.scss
@@ -1,6 +1,10 @@
 .edit-site-editor-canvas-container {
 	height: 100%;
 
+	// This is the gray background color that's applied behind "isolation mode".
+	// The color normally comes from .editor-visual-editor, but that class is missing here.
+	background-color: $gray-300;
+
 	// Controls height of editor and editor canvas container (style book, global styles revisions previews etc.)
 	iframe {
 		display: block;


### PR DESCRIPTION
## What?

The Style Book in the site editor is missing a gray background:

![before](https://github.com/user-attachments/assets/3ff3d57d-f28d-4357-8aad-7e7cf483b8fb)

This gray background is present in focus mode as well:

![tps](https://github.com/user-attachments/assets/f65c2b31-5e00-474b-ba1d-49297ff65ceb)

This PR fixes it:

![after](https://github.com/user-attachments/assets/e8a992a4-616d-479f-a706-1bd939c30768)

## Why?

The gray background used to be there. It comes from `editor-visual-editor`, perhaps that class was refactored away from this context.

## How?

This PR simply adds the color to the appropriate container class.

## Testing Instructions

Go to the site editor, edit view, global styles, and toggle the style book, observe the gray background behind the resize handles.