### PR TITLE
Document text update in preference modal

### DIFF
--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -128,7 +128,7 @@ function PreferencesModalContents( { extraSections = {} } ) {
 							<PreferencesModalSection
 								title={ __( 'Document settings' ) }
 								description={ __(
-									'Select what settings are shown in the document panel.'
+									'Select what settings are shown in the settings panel.'
 								) }
 							>
 								<EnablePluginDocumentSettingPanelOption.Slot />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/57252

## Why?
Modifying the text as per the scenario mentioned in the ticket.

## How?
For now, just replaced the 'document panel' to 'settings panel'.

## Testing Instructions
Go to the post editor > Options > Preferences modal dialog.
Observe the description of the 'Document settings' section.
It will show 'settings panel' instead of 'document panel'.

## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|![Screenshot](https://github.com/user-attachments/assets/344b6886-0fa7-4e3e-b25f-b5d86ae32cb3)|![Screenshot (1)](https://github.com/user-attachments/assets/f32869c9-72f1-4f1d-b175-3f33bc72d20e)|
