### PR TITLE
Create Block: Skip init for `block.json` when no templates provided for block

### DIFF
--- a/packages/create-block/lib/init-block.js
+++ b/packages/create-block/lib/init-block.js
@@ -79,17 +79,22 @@ async function initBlockJSON( {
 }
 
 module.exports = async function ( outputTemplates, view ) {
-	await Promise.all(
-		Object.keys( outputTemplates ).map( async ( outputFile ) => {
-			await writeOutputTemplate(
-				outputTemplates[ outputFile ],
-				join(
-					view.plugin ? view.folderName : '',
-					outputFile.replace( /\$slug/g, view.slug )
-				),
-				view
-			);
-		} )
+	const results = await Promise.all(
+		Object.keys( outputTemplates ).map(
+			async ( outputFile ) =>
+				await writeOutputTemplate(
+					outputTemplates[ outputFile ],
+					join(
+						view.plugin ? view.folderName : '',
+						outputFile.replace( /\$slug/g, view.slug )
+					),
+					view
+				)
+		)
 	);
+	if ( ! results.includes( true ) ) {
+		return;
+	}
+
 	await initBlockJSON( view );
 };

--- a/packages/create-block/lib/output.js
+++ b/packages/create-block/lib/output.js
@@ -10,19 +10,19 @@ const writeOutputAsset = async ( inputFile, outputFile, view ) => {
 	const outputFilePath = join( view.rootDirectory, 'assets', outputFile );
 	await makeDir( dirname( outputFilePath ) );
 	writeFile( outputFilePath, inputFile );
+	return true;
 };
 
 const writeOutputTemplate = async ( inputFile, outputFile, view ) => {
 	// If the rendered template is empty, don't write it. This is how we can conditionally add template files.
 	const renderedFile = render( inputFile, view );
-	if ( renderedFile.trim().length ) {
-		const outputFilePath = join( view.rootDirectory, outputFile );
-		await makeDir( dirname( outputFilePath ) );
-		writeFile(
-			outputFilePath.replace( /\$slug/g, view.slug ),
-			renderedFile
-		);
+	if ( ! renderedFile.trim().length ) {
+		return false;
 	}
+	const outputFilePath = join( view.rootDirectory, outputFile );
+	await makeDir( dirname( outputFilePath ) );
+	writeFile( outputFilePath.replace( /\$slug/g, view.slug ), renderedFile );
+	return true;
 };
 
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

At the moment, `block.json` is always scaffolded when using Create Block. It happens even when there are no templates provided for the block. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

It's a stretch usage for the `@wordpress/create-block`, but as preparation to making it a more general purpose tool it seems a good direction to skip scaffolding `block.json` when the project's goal is to provide the baseline for the WordPress plugin.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
