### PR TITLE
Query Pagination: Update 'showLabel' help text

### DIFF
--- a/packages/block-library/src/query-pagination/query-pagination-label-control.js
+++ b/packages/block-library/src/query-pagination/query-pagination-label-control.js
@@ -9,9 +9,7 @@ export function QueryPaginationLabelControl( { value, onChange } ) {
 		<ToggleControl
 			__nextHasNoMarginBottom
 			label={ __( 'Show label text' ) }
-			help={ __(
-				'Toggle off to hide the label text, e.g. "Next Page".'
-			) }
+			help={ __( 'Make label text visible to the users.' ) }
 			onChange={ onChange }
 			checked={ value === true }
 		/>

--- a/packages/block-library/src/query-pagination/query-pagination-label-control.js
+++ b/packages/block-library/src/query-pagination/query-pagination-label-control.js
@@ -9,7 +9,7 @@ export function QueryPaginationLabelControl( { value, onChange } ) {
 		<ToggleControl
 			__nextHasNoMarginBottom
 			label={ __( 'Show label text' ) }
-			help={ __( 'Make label text visible to the users.' ) }
+			help={ __( 'Make label text visible, e.g. "Next Page".' ) }
 			onChange={ onChange }
 			checked={ value === true }
 		/>


### PR DESCRIPTION
## What?
Part of #51335.

PR updates Query Pagination block's `'showLabel` attribute helps text. The project eliminates the `toggle` keyword from labels and help texts. See #66369.

I've also removed the example from a string. The results of toggling to options are visible in the Canvas.


## Testing Instructions
1. Open the Site Editor.
2. Select Query Pagination blocks.
3. Switch to the "Arrow" icon style.
4. Confirm that updated help text is displayed.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![CleanShot 2024-12-18 at 20 21 20](https://github.com/user-attachments/assets/c57a5ad8-a36c-4d34-b38f-b3c2ca667566)|![CleanShot 2024-12-18 at 20 23 20](https://github.com/user-attachments/assets/024cc7b1-4326-4999-90d0-3cb153e2c8b0)|