### PR TITLE
Remove placeholder of default paragraph when it's the only block and canvas is zoomed out

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -21,6 +21,7 @@ import { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS } from './defaults';
 import { insertAt, moveTo } from './array';
 import { sectionRootClientIdKey } from './private-keys';
 import { unlock } from '../lock-unlock';
+import { getBlockName } from './selectors';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
 
@@ -2268,6 +2269,16 @@ function getDerivedBlockEditingModesForTree(
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
 		if ( isZoomedOut || isNavMode ) {
+			if (
+				isZoomedOut &&
+				state.blocks.order.length === 1 &&
+				getBlockName( state.blocks.order[ 0 ] ) === 'core/paragraph' &&
+				state.blocks.order[ 0 ] === clientId
+			) {
+				derivedBlockEditingModes.set( clientId, 'disabled' );
+				return;
+			}
+
 			// If the root block is the section root set its editing mode to contentOnly.
 			if ( clientId === sectionRootClientId ) {
 				derivedBlockEditingModes.set( clientId, 'contentOnly' );

--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -21,7 +21,6 @@ import { PREFERENCES_DEFAULTS, SETTINGS_DEFAULTS } from './defaults';
 import { insertAt, moveTo } from './array';
 import { sectionRootClientIdKey } from './private-keys';
 import { unlock } from '../lock-unlock';
-import { getBlockName } from './selectors';
 
 const { isContentBlock } = unlock( blocksPrivateApis );
 
@@ -2269,16 +2268,6 @@ function getDerivedBlockEditingModesForTree(
 	traverseBlockTree( state, treeClientId, ( block ) => {
 		const { clientId, name: blockName } = block;
 		if ( isZoomedOut || isNavMode ) {
-			if (
-				isZoomedOut &&
-				state.blocks.order.length === 1 &&
-				getBlockName( state.blocks.order[ 0 ] ) === 'core/paragraph' &&
-				state.blocks.order[ 0 ] === clientId
-			) {
-				derivedBlockEditingModes.set( clientId, 'disabled' );
-				return;
-			}
-
 			// If the root block is the section root set its editing mode to contentOnly.
 			if ( clientId === sectionRootClientId ) {
 				derivedBlockEditingModes.set( clientId, 'contentOnly' );

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -183,7 +183,9 @@ function ParagraphBlock( {
 				}
 				data-empty={ RichText.isEmpty( content ) }
 				placeholder={ placeholder }
-				data-custom-placeholder={ placeholder ? true : undefined }
+				data-custom-placeholder={
+					placeholder && ! isZoomOut ? true : undefined
+				}
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations
 			/>

--- a/packages/block-library/src/paragraph/edit.js
+++ b/packages/block-library/src/paragraph/edit.js
@@ -20,14 +20,16 @@ import {
 	useBlockProps,
 	useSettings,
 	useBlockEditingMode,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
+import { useSelect } from '@wordpress/data';
 import { getBlockSupport } from '@wordpress/blocks';
 import { formatLtr } from '@wordpress/icons';
-
 /**
  * Internal dependencies
  */
 import { useOnEnter } from './use-enter';
+import { unlock } from '../lock-unlock';
 
 function ParagraphRTLControl( { direction, setDirection } ) {
 	return (
@@ -109,7 +111,11 @@ function ParagraphBlock( {
 	isSelected: isSingleSelected,
 	name,
 } ) {
-	const { align, content, direction, dropCap, placeholder } = attributes;
+	const isZoomOut = useSelect( ( select ) =>
+		unlock( select( blockEditorStore ) ).isZoomOut()
+	);
+
+	const { align, content, direction, dropCap } = attributes;
 	const blockProps = useBlockProps( {
 		ref: useOnEnter( { clientId, content } ),
 		className: clsx( {
@@ -119,6 +125,12 @@ function ParagraphBlock( {
 		style: { direction },
 	} );
 	const blockEditingMode = useBlockEditingMode();
+	let { placeholder } = attributes;
+	if ( isZoomOut ) {
+		placeholder = '';
+	} else if ( ! placeholder ) {
+		placeholder = __( 'Type / to choose a block' );
+	}
 
 	return (
 		<>
@@ -170,7 +182,7 @@ function ParagraphBlock( {
 						: __( 'Block: Paragraph' )
 				}
 				data-empty={ RichText.isEmpty( content ) }
-				placeholder={ placeholder || __( 'Type / to choose a block' ) }
+				placeholder={ placeholder }
 				data-custom-placeholder={ placeholder ? true : undefined }
 				__unstableEmbedURLOnPaste
 				__unstableAllowPrefixTransformations


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Closes #65474

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

The instructions to insert blocks via the forward slash quick inserter make no sense when the canvas is zoomed out.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- I think this PR solves the issue - removing the placeholder of the paragraph block only offers a clean look in zoom out, but also avoids an empty block list which the post content also does
- the paragraph block is still selectable but only if you click around to find it. Being a "section" it will be in content only so one can type in it too. So to be clear, the functionality is still there it's just a cleaner UX.
- this PR has two commits, the earlier bd9410e3152cf9dbe6bd8f0a90ec22a508dd6c2e shows a way to disable the block when it's only one and we're in zoom out. It's quite fragile, specific, and also there can be other default blocks so not sure what to do about that, hence my preference to not do anything (disable, hide, remove) to the default block. Removing the label is enough.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- create an empty page
- click the content area
- observe there is an empty paragraph
- zoom out
- observe the text in the empty paragraph is no lonhger visible
- open the pattern inserter
- observe patterns can be dropped with the displacement animation working

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

N/A

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/e093ecdf-46c6-4fa1-baed-f694db4f0ffc


