### PR TITLE
Badge: Support text truncation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 -   Add new `Badge` component ([#66555](https://github.com/WordPress/gutenberg/pull/66555)).
 -   `Menu`: refactor to more granular sub-components ([#67422](https://github.com/WordPress/gutenberg/pull/67422)).
+-   `Badge`: Support text truncation ([#68107](https://github.com/WordPress/gutenberg/pull/68107)).
 
 ### Internal
 

--- a/packages/components/src/badge/index.tsx
+++ b/packages/components/src/badge/index.tsx
@@ -56,9 +56,10 @@ function Badge( {
 					icon={ contextBasedIcon() }
 					size={ 16 }
 					fill="currentColor"
+					className="components-badge__icon"
 				/>
 			) }
-			{ children }
+			<span className="components-badge__content">{ children }</span>
 		</span>
 	);
 }

--- a/packages/components/src/badge/styles.scss
+++ b/packages/components/src/badge/styles.scss
@@ -13,10 +13,8 @@ $badge-colors: (
 	border-radius: $radius-small;
 	font-size: $font-size-small;
 	font-weight: 400;
-	flex-shrink: 0;
 	line-height: $font-line-height-small;
-	width: fit-content;
-	display: flex;
+	display: inline-flex;
 	align-items: center;
 	gap: 2px;
 
@@ -35,4 +33,14 @@ $badge-colors: (
 			--base-color: #{$color};
 		}
 	}
+}
+
+.components-badge__icon {
+	flex-shrink: 0;
+}
+
+.components-badge__content {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }

--- a/packages/components/src/badge/styles.scss
+++ b/packages/components/src/badge/styles.scss
@@ -6,10 +6,13 @@ $badge-colors: (
 );
 
 .components-badge {
+	@include reset;
+
 	background-color: color-mix(in srgb, $white 90%, var(--base-color));
 	color: color-mix(in srgb, $black 50%, var(--base-color));
 	padding: 0 $grid-unit-10;
 	min-height: $grid-unit-30;
+	max-width: 100%;
 	border-radius: $radius-small;
 	font-size: $font-size-small;
 	font-weight: 400;

--- a/packages/components/src/badge/test/index.tsx
+++ b/packages/components/src/badge/test/index.tsx
@@ -6,12 +6,17 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import Badge from '..';
+import _Badge from '..';
+
+const testid = 'my-badge';
+const Badge = ( props: React.ComponentProps< typeof _Badge > ) => (
+	<_Badge data-testid={ testid } { ...props } />
+);
 
 describe( 'Badge', () => {
 	it( 'should render correctly with default props', () => {
 		render( <Badge>Code is Poetry</Badge> );
-		const badge = screen.getByText( 'Code is Poetry' );
+		const badge = screen.getByTestId( testid );
 		expect( badge ).toBeInTheDocument();
 		expect( badge.tagName ).toBe( 'SPAN' );
 		expect( badge ).toHaveClass( 'components-badge' );
@@ -19,14 +24,14 @@ describe( 'Badge', () => {
 
 	it( 'should render as per its intent and contain an icon', () => {
 		render( <Badge intent="error">Code is Poetry</Badge> );
-		const badge = screen.getByText( 'Code is Poetry' );
+		const badge = screen.getByTestId( testid );
 		expect( badge ).toHaveClass( 'components-badge', 'is-error' );
 		expect( badge ).toHaveClass( 'has-icon' );
 	} );
 
 	it( 'should combine custom className with default class', () => {
 		render( <Badge className="custom-class">Code is Poetry</Badge> );
-		const badge = screen.getByText( 'Code is Poetry' );
+		const badge = screen.getByTestId( testid );
 		expect( badge ).toHaveClass( 'components-badge' );
 		expect( badge ).toHaveClass( 'custom-class' );
 	} );


### PR DESCRIPTION
Closes #68091

## What?

Add text truncation support to `Badge`.

## Testing Instructions

In the Storybook for Badge, use Dev Tools to add a width restriction to `.components-badge`, for example `width: 80px`. Alternatively, add a width restriction to a parent conatiner.

## Screenshots or screencast <!-- if applicable -->

<img width="126" alt="Truncated Badge" src="https://github.com/user-attachments/assets/a0f4936b-8171-4df6-ad94-7c216f517f10" />