### PR TITLE
Move linkUI to own custom appender in navigation block

### DIFF
--- a/packages/block-editor/src/components/block-list-appender/index.js
+++ b/packages/block-editor/src/components/block-list-appender/index.js
@@ -94,7 +94,7 @@ export default function BlockListAppender( {
 			data-block
 		>
 			{ CustomAppender ? (
-				<CustomAppender />
+				<CustomAppender rootClientId={ rootClientId } />
 			) : (
 				<DefaultAppender rootClientId={ rootClientId } />
 			) }

--- a/packages/block-library/src/navigation-link/appender.js
+++ b/packages/block-library/src/navigation-link/appender.js
@@ -56,6 +56,7 @@ export default function NavigationLinkAppender( { rootClientId } ) {
 						setIsLinkOpen( false );
 					} }
 					onChange={ ( updatedValue ) => {
+						setIsLinkOpen( false );
 						updateAttributes( updatedValue, createNewLink );
 					} }
 					anchor={ popoverAnchor }

--- a/packages/block-library/src/navigation-link/appender.js
+++ b/packages/block-library/src/navigation-link/appender.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { useDispatch } from '@wordpress/data';
+import { useState, useRef } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+import { Icon, plus } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import { LinkUI } from './link-ui';
+import { updateAttributes } from './update-attributes';
+
+export default function NavigationLinkAppender( { rootClientId } ) {
+	const { insertBlock } = useDispatch( blockEditorStore );
+	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const linkUIref = useRef();
+
+	const createNewLink = ( attributes ) => {
+		const block = createBlock( 'core/navigation-link', attributes );
+
+		insertBlock( block, undefined, rootClientId );
+	};
+
+	return (
+		<>
+			<Button
+				__next40pxDefaultSize
+				ref={ setPopoverAnchor }
+				className="block-editor-button-block-appender"
+				onClick={ () => setIsLinkOpen( ( state ) => ! state ) }
+				aria-haspopup
+				aria-expanded={ isLinkOpen }
+				label="Add block"
+				showTooltip
+			>
+				<Icon icon={ plus } />
+			</Button>
+			{ isLinkOpen && (
+				<LinkUI
+					ref={ linkUIref }
+					clientId={ rootClientId }
+					link={ {
+						url: undefined,
+						label: undefined,
+						id: undefined,
+						kind: undefined,
+						type: undefined,
+						opensInNewTab: false,
+					} }
+					onClose={ () => {
+						setIsLinkOpen( false );
+					} }
+					onChange={ ( updatedValue ) => {
+						updateAttributes( updatedValue, createNewLink );
+					} }
+					anchor={ popoverAnchor }
+				/>
+			) }
+		</>
+	);
+}

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -250,6 +250,9 @@ export default function NavigationLinkEdit( {
 	} = useDispatch( blockEditorStore );
 	// Have the link editing ui open on mount if the block was just added.
 	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected );
+	// If the link ui was opened because it was just added, we need to return focus to the block instead of
+	// the appender when it is closed.
+	const focusBlockOnLinkCloseRef = useRef( isLinkOpen );
 	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -589,7 +592,19 @@ export default function NavigationLinkEdit( {
 									return;
 								}
 
+								// If the link ui was opened due to the block being added,
+								// we need to return focus to the block instead of the appender.
+								if (
+									focusBlockOnLinkCloseRef.current &&
+									linkUIref.current.contains(
+										window.document.activeElement
+									)
+								) {
+									ref.current.focus();
+								}
+
 								setIsLinkOpen( false );
+								focusBlockOnLinkCloseRef.current = false;
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ removeLink }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -248,8 +248,8 @@ export default function NavigationLinkEdit( {
 		selectBlock,
 		selectPreviousBlock,
 	} = useDispatch( blockEditorStore );
-	// Have the link editing ui open on mount when lacking a url and selected.
-	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected && ! url );
+	// Have the link editing ui open on mount if the block was just added.
+	const [ isLinkOpen, setIsLinkOpen ] = useState( isSelected );
 	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
@@ -298,6 +298,7 @@ export default function NavigationLinkEdit( {
 		},
 		[ clientId, maxNestingLevel ]
 	);
+
 	const { getBlocks } = useSelect( blockEditorStore );
 
 	/**

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -12,7 +12,6 @@ import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	LinkControl,
 	privateApis as blockEditorPrivateApis,
-	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	createInterpolateElement,
@@ -27,7 +26,7 @@ import {
 	useResourcePermissions,
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 
@@ -79,25 +78,6 @@ export function getSuggestionsQuery( type, kind ) {
 }
 
 function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
-	const { navigationBlockId } = useSelect(
-		( select ) => {
-			const { getBlockRootClientId, getBlockName } =
-				select( blockEditorStore );
-
-			const rootClientId = getBlockRootClientId( clientId );
-
-			// We need the core/navigation block to be the ID that gets passed to the as the rootClientId
-			// so the right block results show up in the quick inserter.
-			return {
-				navigationBlockId:
-					getBlockName( rootClientId ) === 'core/navigation'
-						? rootClientId
-						: clientId,
-			};
-		},
-		[ clientId ]
-	);
-
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	const dialogTitleId = useInstanceId(
@@ -142,9 +122,8 @@ function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
 			</Button>
 
 			<QuickInserter
-				rootClientId={ navigationBlockId }
-				clientId={ clientId }
-				isAppender={ false }
+				rootClientId={ clientId }
+				isAppender
 				prioritizePatterns={ false }
 				selectBlockOnInsert
 				hasSearch={ false }

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -11,7 +11,6 @@ import {
 import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	LinkControl,
-	store as blockEditorStore,
 	privateApis as blockEditorPrivateApis,
 } from '@wordpress/block-editor';
 import {
@@ -27,7 +26,7 @@ import {
 	useResourcePermissions,
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 
@@ -79,17 +78,6 @@ export function getSuggestionsQuery( type, kind ) {
 }
 
 function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
-	const { rootBlockClientId } = useSelect(
-		( select ) => {
-			const { getBlockRootClientId } = select( blockEditorStore );
-
-			return {
-				rootBlockClientId: getBlockRootClientId( clientId ),
-			};
-		},
-		[ clientId ]
-	);
-
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	const dialogTitleId = useInstanceId(
@@ -134,8 +122,7 @@ function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
 			</Button>
 
 			<QuickInserter
-				rootClientId={ rootBlockClientId }
-				clientId={ clientId }
+				rootClientId={ clientId }
 				isAppender={ false }
 				prioritizePatterns={ false }
 				selectBlockOnInsert

--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -12,6 +12,7 @@ import { __, sprintf, isRTL } from '@wordpress/i18n';
 import {
 	LinkControl,
 	privateApis as blockEditorPrivateApis,
+	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import {
 	createInterpolateElement,
@@ -26,7 +27,7 @@ import {
 	useResourcePermissions,
 } from '@wordpress/core-data';
 import { decodeEntities } from '@wordpress/html-entities';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { chevronLeftSmall, chevronRightSmall, plus } from '@wordpress/icons';
 import { useInstanceId, useFocusOnMount } from '@wordpress/compose';
 
@@ -78,6 +79,25 @@ export function getSuggestionsQuery( type, kind ) {
 }
 
 function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
+	const { navigationBlockId } = useSelect(
+		( select ) => {
+			const { getBlockRootClientId, getBlockName } =
+				select( blockEditorStore );
+
+			const rootClientId = getBlockRootClientId( clientId );
+
+			// We need the core/navigation block to be the ID that gets passed to the as the rootClientId
+			// so the right block results show up in the quick inserter.
+			return {
+				navigationBlockId:
+					getBlockName( rootClientId ) === 'core/navigation'
+						? rootClientId
+						: clientId,
+			};
+		},
+		[ clientId ]
+	);
+
 	const focusOnMountRef = useFocusOnMount( 'firstElement' );
 
 	const dialogTitleId = useInstanceId(
@@ -122,7 +142,8 @@ function LinkUIBlockInserter( { clientId, onBack, onSelectBlock } ) {
 			</Button>
 
 			<QuickInserter
-				rootClientId={ clientId }
+				rootClientId={ navigationBlockId }
+				clientId={ clientId }
 				isAppender={ false }
 				prioritizePatterns={ false }
 				selectBlockOnInsert

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -19,7 +19,6 @@ import { displayShortcut, isKeyboardEvent } from '@wordpress/keycodes';
 import { __ } from '@wordpress/i18n';
 import {
 	BlockControls,
-	InnerBlocks,
 	useInnerBlocksProps,
 	InspectorControls,
 	RichText,
@@ -39,6 +38,7 @@ import { useMergeRefs, usePrevious } from '@wordpress/compose';
  */
 import { ItemSubmenuIcon } from './icons';
 import { LinkUI } from '../navigation-link/link-ui';
+import NavigationLinkAppender from '../navigation-link/appender';
 import { updateAttributes } from '../navigation-link/update-attributes';
 import {
 	getColors,
@@ -330,7 +330,7 @@ export default function NavigationSubmenuEdit( {
 				! selectedBlockHasChildren ) ||
 			// Show the appender while dragging to allow inserting element between item and the appender.
 			hasChildren
-				? InnerBlocks.ButtonBlockAppender
+				? NavigationLinkAppender
 				: false,
 	} );
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -138,14 +138,9 @@ export default function NavigationSubmenuEdit( {
 
 	const { showSubmenuIcon, maxNestingLevel, openSubmenusOnClick } = context;
 
-	const {
-		__unstableMarkNextChangeAsNotPersistent,
-		replaceBlock,
-		selectBlock,
-	} = useDispatch( blockEditorStore );
+	const { __unstableMarkNextChangeAsNotPersistent, replaceBlock } =
+		useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
-	// Store what element opened the popover, so we know where to return focus to (toolbar button vs navigation link text)
-	const [ openedBy, setOpenedBy ] = useState( null );
 	// Use internal state instead of a ref to make sure that the component
 	// re-renders when the popover's anchor updates.
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
@@ -277,7 +272,6 @@ export default function NavigationSubmenuEdit( {
 			// If we don't stop propogation, this event bubbles up to the parent submenu item
 			event.stopPropagation();
 			setIsLinkOpen( true );
-			setOpenedBy( ref.current );
 		}
 	}
 
@@ -364,9 +358,8 @@ export default function NavigationSubmenuEdit( {
 							icon={ linkIcon }
 							title={ __( 'Link' ) }
 							shortcut={ displayShortcut.primary( 'k' ) }
-							onClick={ ( event ) => {
+							onClick={ () => {
 								setIsLinkOpen( true );
-								setOpenedBy( event.currentTarget );
 							} }
 						/>
 					) }
@@ -517,7 +510,6 @@ export default function NavigationSubmenuEdit( {
 						onClick={ () => {
 							if ( ! openSubmenusOnClick && ! url ) {
 								setIsLinkOpen( true );
-								setOpenedBy( ref.current );
 							}
 						} }
 					/>
@@ -532,12 +524,6 @@ export default function NavigationSubmenuEdit( {
 							link={ attributes }
 							onClose={ () => {
 								setIsLinkOpen( false );
-								if ( openedBy ) {
-									openedBy.focus();
-									setOpenedBy( null );
-								} else {
-									selectBlock( clientId );
-								}
 							} }
 							anchor={ popoverAnchor }
 							onRemove={ () => {

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -6,69 +6,15 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useDispatch, useSelect } from '@wordpress/data';
-import { useMemo, useState, useRef } from '@wordpress/element';
-import { Icon, plus } from '@wordpress/icons';
-import { Button } from '@wordpress/components';
-import { createBlock } from '@wordpress/blocks';
+import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+
 /**
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
 import { PRIORITIZED_INSERTER_BLOCKS } from '../constants';
-import { LinkUI } from '../../navigation-link/link-ui';
-import { updateAttributes } from '../../navigation-link/update-attributes';
-
-function NavigationLinkAppender( { rootClientId } ) {
-	const { insertBlock } = useDispatch( blockEditorStore );
-	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
-	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
-	const linkUIref = useRef();
-
-	const createNewLink = ( attributes ) => {
-		const block = createBlock( 'core/navigation-link', attributes );
-
-		insertBlock( block, undefined, rootClientId );
-	};
-
-	return (
-		<>
-			<Button
-				__next40pxDefaultSize
-				ref={ setPopoverAnchor }
-				className="block-editor-button-block-appender"
-				onClick={ () => setIsLinkOpen( ( state ) => ! state ) }
-				aria-haspopup
-				aria-expanded={ isLinkOpen }
-				label="Add block"
-				showTooltip
-			>
-				<Icon icon={ plus } />
-			</Button>
-			{ isLinkOpen && (
-				<LinkUI
-					ref={ linkUIref }
-					clientId={ rootClientId }
-					link={ {
-						url: undefined,
-						label: undefined,
-						id: undefined,
-						kind: undefined,
-						type: undefined,
-						opensInNewTab: false,
-					} }
-					onClose={ () => {
-						setIsLinkOpen( false );
-					} }
-					onChange={ ( updatedValue ) => {
-						updateAttributes( updatedValue, createNewLink );
-					} }
-					anchor={ popoverAnchor }
-				/>
-			) }
-		</>
-	);
-}
+import NavigationLinkAppender from '../../navigation-link/appender';
 
 export default function NavigationInnerBlocks( {
 	clientId,

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -4,17 +4,59 @@
 import { useEntityBlockEditor } from '@wordpress/core-data';
 import {
 	useInnerBlocksProps,
-	InnerBlocks,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
-import { useMemo } from '@wordpress/element';
-
+import { useMemo, useState, useRef } from '@wordpress/element';
+import { Icon, plus } from '@wordpress/icons';
+import { Button } from '@wordpress/components';
 /**
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
-import { DEFAULT_BLOCK, PRIORITIZED_INSERTER_BLOCKS } from '../constants';
+import { PRIORITIZED_INSERTER_BLOCKS } from '../constants';
+import { LinkUI } from '../../navigation-link/link-ui';
+
+function AddLinkAppender( { rootClientId } ) {
+	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
+	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
+	const linkUIref = useRef();
+
+	return (
+		<>
+			<Button
+				__next40pxDefaultSize
+				ref={ setPopoverAnchor }
+				className="block-editor-button-block-appender"
+				onClick={ () => setIsLinkOpen( ( state ) => ! state ) }
+				aria-haspopup
+				aria-expanded={ isLinkOpen }
+				label="Add block"
+				showTooltip
+			>
+				<Icon icon={ plus } />
+			</Button>
+			{ isLinkOpen && (
+				<LinkUI
+					ref={ linkUIref }
+					clientId={ rootClientId }
+					link={ {
+						url: undefined,
+						label: undefined,
+						id: undefined,
+						kind: undefined,
+						type: undefined,
+						opensInNewTab: false,
+					} }
+					onClose={ () => {
+						setIsLinkOpen( false );
+					} }
+					anchor={ popoverAnchor }
+				/>
+			) }
+		</>
+	);
+}
 
 export default function NavigationInnerBlocks( {
 	clientId,
@@ -82,7 +124,6 @@ export default function NavigationInnerBlocks( {
 			onInput,
 			onChange,
 			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
-			defaultBlock: DEFAULT_BLOCK,
 			directInsert: true,
 			orientation,
 			templateLock,
@@ -98,7 +139,7 @@ export default function NavigationInnerBlocks( {
 					! selectedBlockHasChildren ) ||
 				// Show the appender while dragging to allow inserting element between item and the appender.
 				parentOrChildHasSelection
-					? InnerBlocks.ButtonBlockAppender
+					? AddLinkAppender
 					: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,
@@ -106,5 +147,9 @@ export default function NavigationInnerBlocks( {
 		}
 	);
 
-	return <div { ...innerBlocksProps } />;
+	return (
+		<>
+			<div { ...innerBlocksProps } />
+		</>
+	);
 }

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -6,21 +6,30 @@ import {
 	useInnerBlocksProps,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useMemo, useState, useRef } from '@wordpress/element';
 import { Icon, plus } from '@wordpress/icons';
 import { Button } from '@wordpress/components';
+import { createBlock } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
 import PlaceholderPreview from './placeholder/placeholder-preview';
 import { PRIORITIZED_INSERTER_BLOCKS } from '../constants';
 import { LinkUI } from '../../navigation-link/link-ui';
+import { updateAttributes } from '../../navigation-link/update-attributes';
 
-function AddLinkAppender( { rootClientId } ) {
+function NavigationLinkAppender( { rootClientId } ) {
+	const { insertBlock } = useDispatch( blockEditorStore );
 	const [ isLinkOpen, setIsLinkOpen ] = useState( false );
 	const [ popoverAnchor, setPopoverAnchor ] = useState( null );
 	const linkUIref = useRef();
+
+	const createNewLink = ( attributes ) => {
+		const block = createBlock( 'core/navigation-link', attributes );
+
+		insertBlock( block, undefined, rootClientId );
+	};
 
 	return (
 		<>
@@ -50,6 +59,9 @@ function AddLinkAppender( { rootClientId } ) {
 					} }
 					onClose={ () => {
 						setIsLinkOpen( false );
+					} }
+					onChange={ ( updatedValue ) => {
+						updateAttributes( updatedValue, createNewLink );
 					} }
 					anchor={ popoverAnchor }
 				/>
@@ -139,7 +151,7 @@ export default function NavigationInnerBlocks( {
 					! selectedBlockHasChildren ) ||
 				// Show the appender while dragging to allow inserting element between item and the appender.
 				parentOrChildHasSelection
-					? AddLinkAppender
+					? NavigationLinkAppender
 					: false,
 			placeholder: showPlaceholder ? placeholder : undefined,
 			__experimentalCaptureToolbars: true,

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -338,190 +338,183 @@ test.describe( 'Navigation block', () => {
 		// Wait until the nav block inserter is visible before we continue. Otherwise the navigation block may not have finished being created.
 		await expect( navBlockInserter ).toBeVisible();
 
-		/**
-		 * Test: We don't lose focus when using the navigation link appender
-		 */
-		await pageUtils.pressKeys( 'ArrowDown' );
-		await navigation.useBlockInserter();
-		await navigation.addLinkClose();
-		/**
-		 * TODO: This is not desired behavior. Ideally the
-		 * Appender should be focused again since it opened
-		 * the link control.
-		 * IMPORTANT: This check is not to enforce this behavior,
-		 * but to make sure focus is kept nearby until we are able
-		 * to send focus to the appender.
-		 */
-		await expect( navBlock ).toBeFocused();
+		await test.step( 'should not lose focus when using the navigation link appender', async () => {
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await navigation.useBlockInserter();
+			await navigation.addLinkClose();
+			/**
+			 * TODO: This is not desired behavior. Ideally the
+			 * Appender should be focused again since it opened
+			 * the link control.
+			 * IMPORTANT: This check is not to enforce this behavior,
+			 * but to make sure focus is kept nearby until we are able
+			 * to send focus to the appender.
+			 */
+			await expect( navBlock ).toBeFocused();
+		} );
 
-		/**
-		 * Test: Creating a link sends focus to the newly created navigation link item
-		 */
-		await pageUtils.pressKeys( 'ArrowDown' );
+		await test.step( 'should send focus to the newly created navigation link item when creating a link', async () => {
+			await pageUtils.pressKeys( 'ArrowDown' );
 
-		await navigation.useBlockInserter();
-		await navigation.addPage( 'Cat' );
-		/**
-		 * Test: We can open and close the preview with the keyboard and escape
-		 *       buttons from a top-level nav item using both the shortcut and toolbar
-		 */
-		await navigation.useLinkShortcut();
-		await navigation.previewIsOpenAndCloses();
-		await navigation.checkLabelFocus( 'Cat' );
+			await navigation.useBlockInserter();
+			await navigation.addPage( 'Cat' );
+		} );
 
-		await navigation.canUseToolbarLink();
+		await test.step( 'should open and close the preview with the keyboard and escape buttons from a top-level nav item using the shortcut', async () => {
+			await navigation.useLinkShortcut();
+			await navigation.previewIsOpenAndCloses();
+			await navigation.checkLabelFocus( 'Cat' );
+		} );
 
-		/**
-		 * Test: Creating a link from a url-string (https://www.example.com) returns
-		 *       focus to the newly created link with the text selected
-		 */
-		// Move focus to the Add Block Appender.
-		await page.keyboard.press( 'Escape' );
-		await pageUtils.pressKeys( 'ArrowDown' );
-		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+		await test.step( 'should open and close the preview with the keyboard and escape buttons from a top-level nav item using the toolbar button', async () => {
+			await navigation.canUseToolbarLink();
+		} );
 
-		await navigation.useBlockInserter();
-		await navigation.addCustomURL( 'https://example.com' );
-		await navigation.expectToHaveTextSelected( 'example.com' );
+		await test.step( 'should send focus to the newly created navigation link item with text selected when creating a link from a url-like label', async () => {
+			await page.keyboard.press( 'Escape' );
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 
-		/**
-		 * Test: We can open and close the preview with the keyboard and escape
-		 *       buttons from a top-level nav link with a url-like label using
-		 *       both the shortcut and toolbar
-		 */
-		await pageUtils.pressKeys( 'ArrowLeft' );
-		await navigation.useLinkShortcut();
-		await navigation.previewIsOpenAndCloses();
-		await navigation.checkLabelFocus( 'example.com' );
+			await navigation.useBlockInserter();
+			await navigation.addCustomURL( 'https://example.com' );
+			await navigation.expectToHaveTextSelected( 'example.com' );
+		} );
 
-		await navigation.canUseToolbarLink();
+		await test.step( 'should open and close the preview with the keyboard and escape buttons from a top-level nav item with a url-like label using the shortcut', async () => {
+			await pageUtils.pressKeys( 'ArrowLeft' );
+			await navigation.useLinkShortcut();
+			await navigation.previewIsOpenAndCloses();
+			await navigation.checkLabelFocus( 'example.com' );
+		} );
 
-		/**
-		 * Test: Can add submenu item using the keyboard
-		 */
-		navigation.useToolbarButton( 'Add submenu' );
+		await test.step( 'should open and close the preview with the keyboard and escape buttons from a top-level nav item with a url-like label using the toolbar button', async () => {
+			await navigation.canUseToolbarLink();
+		} );
 
-		// Expect the submenu Add link to be present
-		await expect(
-			editor.canvas.locator( 'a' ).filter( { hasText: 'Add link' } )
-		).toBeVisible();
+		await test.step( 'should be able to add submenu item using the keyboard', async () => {
+			navigation.useToolbarButton( 'Add submenu' );
 
-		await pageUtils.pressKeys( 'ArrowDown' );
-		// There is a bug that won't allow us to press Enter to add the link: https://github.com/WordPress/gutenberg/issues/60051
-		// TODO: Use Enter after that bug is resolved
-		await navigation.useLinkShortcut();
+			// Expect the submenu Add link to be present
+			await expect(
+				editor.canvas.locator( 'a' ).filter( { hasText: 'Add link' } )
+			).toBeVisible();
 
-		await navigation.addPage( 'Dog' );
+			await pageUtils.pressKeys( 'ArrowDown' );
+			// There is a bug that won't allow us to press Enter to add the link: https://github.com/WordPress/gutenberg/issues/60051
+			// TODO: Use Enter after that bug is resolved
+			await navigation.useLinkShortcut();
 
-		/**
-		 * Test: We can open and close the preview with the keyboard and escape
-		 *       buttons from a submenu nav item using both the shortcut and toolbar
-		 */
-		await navigation.useLinkShortcut();
-		await navigation.previewIsOpenAndCloses();
-		await navigation.checkLabelFocus( 'Dog' );
+			await navigation.addPage( 'Dog' );
+		} );
 
-		await navigation.canUseToolbarLink();
+		await test.step( 'should open and close the preview with the keyboard and escape buttons from a submenu nav item using the shortcut', async () => {
+			await navigation.useLinkShortcut();
+			await navigation.previewIsOpenAndCloses();
+			await navigation.checkLabelFocus( 'Dog' );
+		} );
 
-		// Return to nav label from toolbar
-		await page.keyboard.press( 'Escape' );
+		await test.step( 'should open and close the preview with the keyboard and escape buttons from a submenu nav item using the toolbar button', async () => {
+			await navigation.canUseToolbarLink();
 
-		// We should be at the first position on the label
-		await navigation.checkLabelFocus( 'Dog' );
+			// Return to nav label from toolbar
+			await page.keyboard.press( 'Escape' );
 
-		/**
-		 * Test: We don't lose focus when closing the submenu appender
-		 */
+			// We should be at the first position on the label
+			await navigation.checkLabelFocus( 'Dog' );
+		} );
 
-		// Move focus to the submenu navigation appender
-		await page.keyboard.press( 'End' );
-		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-		await navigation.useBlockInserter();
-		await navigation.addLinkClose();
-		/**
-		 * TODO: This is not desired behavior. Ideally the
-		 * Appender should be focused again since it opened
-		 * the link control.
-		 * IMPORTANT: This check is not to enforce this behavior,
-		 * but to make sure focus is kept nearby until we are able
-		 * to send focus to the appender. It is falling back to the previous sibling.
-		 */
-		await navigation.checkLabelFocus( 'Dog' );
+		await test.step( 'should not lose focus when closing the submenu appender', async () => {
+			// Move focus to the submenu navigation appender
+			await page.keyboard.press( 'End' );
+			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+			await navigation.useBlockInserter();
+			await navigation.addLinkClose();
+			/**
+			 * TODO: This is not desired behavior. Ideally the
+			 * Appender should be focused again since it opened
+			 * the link control.
+			 * IMPORTANT: This check is not to enforce this behavior,
+			 * but to make sure focus is kept nearby until we are able
+			 * to send focus to the appender. It is falling back to the previous sibling.
+			 */
+			await navigation.checkLabelFocus( 'Dog' );
+		} );
 
-		/**
-		 * Test: Use the submenu nav item appender to add a custom link
-		 */
-		await page.keyboard.press( 'End' );
-		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-		await navigation.useBlockInserter();
-		await navigation.addCustomURL( 'https://wordpress.org' );
-		await navigation.expectToHaveTextSelected( 'wordpress.org' );
+		await test.step( 'should be able to add a custom link to a submenu nav item using the nav item appender', async () => {
+			await page.keyboard.press( 'End' );
+			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+			await navigation.useBlockInserter();
+			await navigation.addCustomURL( 'https://wordpress.org' );
+			await navigation.expectToHaveTextSelected( 'wordpress.org' );
+		} );
 
-		/**
-		 * Test: We can open and close the preview with the keyboard and escape
-		 *       both the shortcut and toolbar
-		 */
-		await pageUtils.pressKeys( 'ArrowLeft' );
-		await navigation.useLinkShortcut();
-		await navigation.previewIsOpenAndCloses();
-		await navigation.checkLabelFocus( 'wordpress.org' );
-		await navigation.canUseToolbarLink();
+		await test.step( 'should close the preview with escape key from the shortcut', async () => {
+			await pageUtils.pressKeys( 'ArrowLeft' );
+			await navigation.useLinkShortcut();
+			await navigation.previewIsOpenAndCloses();
+			await navigation.checkLabelFocus( 'wordpress.org' );
+		} );
 
-		/**
-		 * Test: We can open and close the preview from a submenu navigation block (the top-level parent of a submenu)
-		 * using both the shortcut and toolbar
-		 */
-		// Exit the toolbar
-		await page.keyboard.press( 'Escape' );
-		// Move to the submenu item
-		await pageUtils.pressKeys( 'ArrowUp', { times: 4 } );
-		await page.keyboard.press( 'Home' );
+		await test.step( 'should close the preview with escape key from the toolbar button', async () => {
+			await navigation.canUseToolbarLink();
+		} );
+		await test.step( 'should open and close open and close the preview from a submenu navigation block (the top-level parent of a submenu) using the shortcut', async () => {
+			// Exit the toolbar
+			await page.keyboard.press( 'Escape' );
+			// Move to the submenu item
+			await pageUtils.pressKeys( 'ArrowUp', { times: 4 } );
+			await page.keyboard.press( 'Home' );
 
-		// Check we're on our submenu link
-		await navigation.checkLabelFocus( 'example.com' );
-		// Test the shortcut
-		await navigation.useLinkShortcut();
-		await navigation.previewIsOpenAndCloses();
-		await navigation.checkLabelFocus( 'example.com' );
-		// Test the toolbar
-		await navigation.canUseToolbarLink();
-		await page.keyboard.press( 'Escape' );
-		await navigation.checkLabelFocus( 'example.com' );
+			// Check we're on our submenu link
+			await navigation.checkLabelFocus( 'example.com' );
+			// Test the shortcut
+			await navigation.useLinkShortcut();
+			await navigation.previewIsOpenAndCloses();
+			await navigation.checkLabelFocus( 'example.com' );
+		} );
+
+		await test.step( 'should open and close open and close the preview from a submenu navigation block (the top-level parent of a submenu) using the toolbar button', async () => {
+			await navigation.canUseToolbarLink();
+			await page.keyboard.press( 'Escape' );
+			await navigation.checkLabelFocus( 'example.com' );
+		} );
 
 		/**
 		 * Deleting returns items focus to its sibling
 		 */
-		await pageUtils.pressKeys( 'ArrowDown', { times: 4 } );
-		await navigation.checkLabelFocus( 'wordpress.org' );
-		// Delete the nav link
-		await pageUtils.pressKeys( 'access+z' );
-		// Focus moved to sibling
-		await navigation.checkLabelFocus( 'Dog' );
-		// Add a link back so we can delete the first submenu link and see if focus returns to the parent submenu item
-		await page.keyboard.press( 'End' );
-		await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
-		await navigation.useBlockInserter();
-		await navigation.addCustomURL( 'https://wordpress.org' );
-		await navigation.expectToHaveTextSelected( 'wordpress.org' );
+		await test.step( 'should return focus to sibling when deleting an item', async () => {
+			await pageUtils.pressKeys( 'ArrowDown', { times: 4 } );
+			await navigation.checkLabelFocus( 'wordpress.org' );
+			// Delete the nav link
+			await pageUtils.pressKeys( 'access+z' );
+			// Focus moved to sibling
+			await navigation.checkLabelFocus( 'Dog' );
+			// Add a link back so we can delete the first submenu link and see if focus returns to the parent submenu item
+			await page.keyboard.press( 'End' );
+			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
+			await navigation.useBlockInserter();
+			await navigation.addCustomURL( 'https://wordpress.org' );
+			await navigation.expectToHaveTextSelected( 'wordpress.org' );
 
-		await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
-		await navigation.checkLabelFocus( 'Dog' );
-		// Delete the nav link
-		await pageUtils.pressKeys( 'access+z' );
-		await pageUtils.pressKeys( 'ArrowDown' );
-		// Focus moved to parent submenu item
-		await navigation.checkLabelFocus( 'example.com' );
-		// Deleting this should move focus to the sibling item
-		await pageUtils.pressKeys( 'access+z' );
-		await navigation.checkLabelFocus( 'Cat' );
-		// Deleting with no more siblings should focus the navigation block again
-		await pageUtils.pressKeys( 'access+z' );
-		await expect( navBlock ).toBeFocused();
-		// Wait until the nav block inserter is visible before we continue.
-		await expect( navBlockInserter ).toBeVisible();
-		// Now the appender should be visible and reachable with an arrow down
-		await pageUtils.pressKeys( 'ArrowDown' );
-		await expect( navBlockInserter ).toBeFocused();
+			await pageUtils.pressKeys( 'ArrowUp', { times: 2 } );
+			await navigation.checkLabelFocus( 'Dog' );
+			// Delete the nav link
+			await pageUtils.pressKeys( 'access+z' );
+			await pageUtils.pressKeys( 'ArrowDown' );
+			// Focus moved to parent submenu item
+			await navigation.checkLabelFocus( 'example.com' );
+			// Deleting this should move focus to the sibling item
+			await pageUtils.pressKeys( 'access+z' );
+			await navigation.checkLabelFocus( 'Cat' );
+			// Deleting with no more siblings should focus the navigation block again
+			await pageUtils.pressKeys( 'access+z' );
+			await expect( navBlock ).toBeFocused();
+			// Wait until the nav block inserter is visible before we continue.
+			await expect( navBlockInserter ).toBeVisible();
+			// Now the appender should be visible and reachable with an arrow down
+			await pageUtils.pressKeys( 'ArrowDown' );
+			await expect( navBlockInserter ).toBeFocused();
+		} );
 	} );
 
 	test( 'Adding new links to a navigation block with existing inner blocks triggers creation of a single Navigation Menu', async ( {

--- a/test/e2e/specs/editor/blocks/navigation.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation.spec.js
@@ -342,20 +342,10 @@ test.describe( 'Navigation block', () => {
 			await pageUtils.pressKeys( 'ArrowDown' );
 			await navigation.useBlockInserter();
 			await navigation.addLinkClose();
-			/**
-			 * TODO: This is not desired behavior. Ideally the
-			 * Appender should be focused again since it opened
-			 * the link control.
-			 * IMPORTANT: This check is not to enforce this behavior,
-			 * but to make sure focus is kept nearby until we are able
-			 * to send focus to the appender.
-			 */
-			await expect( navBlock ).toBeFocused();
+			await expect( navigation.getNavBlockInserter() ).toBeFocused();
 		} );
 
 		await test.step( 'should send focus to the newly created navigation link item when creating a link', async () => {
-			await pageUtils.pressKeys( 'ArrowDown' );
-
 			await navigation.useBlockInserter();
 			await navigation.addPage( 'Cat' );
 		} );
@@ -429,20 +419,10 @@ test.describe( 'Navigation block', () => {
 			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 			await navigation.useBlockInserter();
 			await navigation.addLinkClose();
-			/**
-			 * TODO: This is not desired behavior. Ideally the
-			 * Appender should be focused again since it opened
-			 * the link control.
-			 * IMPORTANT: This check is not to enforce this behavior,
-			 * but to make sure focus is kept nearby until we are able
-			 * to send focus to the appender. It is falling back to the previous sibling.
-			 */
-			await navigation.checkLabelFocus( 'Dog' );
+			await expect( navigation.getNavBlockInserter() ).toBeFocused();
 		} );
 
 		await test.step( 'should be able to add a custom link to a submenu nav item using the nav item appender', async () => {
-			await page.keyboard.press( 'End' );
-			await pageUtils.pressKeys( 'ArrowRight', { times: 2 } );
 			await navigation.useBlockInserter();
 			await navigation.addCustomURL( 'https://wordpress.org' );
 			await navigation.expectToHaveTextSelected( 'wordpress.org' );

--- a/test/e2e/specs/editor/blocks/search.spec.js
+++ b/test/e2e/specs/editor/blocks/search.spec.js
@@ -44,7 +44,10 @@ test.describe( 'Search', () => {
 		} );
 		await navBlockInserter.click();
 
-		await page.getByRole( 'button', { name: 'Add block' } ).click();
+		// Move to and activate the "Add Block" button.
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Tab' );
+		await page.keyboard.press( 'Enter' );
 
 		// Click on the Search block option.
 		await page.getByRole( 'option', { name: 'Search' } ).click();


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
When you click the Navigation Block appender, it automatically inserts a link. If you cancel the action (escape or close the modal without selecting a block), the automatically added link is removed and focus gets lost or yanked to the previous block. It's also jarring to click the appender, and then have a new thing inserted and also open a modal.

So, rather than insert something automatically and then replace it (especially in the add block flow), this uses the LinkUI as the appender. It saves a bit of code and the UX feels much cleaner. Also, there have been a lot of bugs due to the previous flow.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Code quality, UX, and save ourselves the headaches of trying to manually manage when to insert and remove.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Create a new component, `NavigationLinkAppender` and use it to wrap the `<LinkUI/>` for inserting links. Then, use this on both the Navigation Block and Submenu blocks.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Especially test the keyboard flow. Add links and press Escape from the modal. You'll quickly see why this PR makes the keyboard implementation a lot better. Focus gets moved back to the appender instead of to the previous block.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

**Before**

https://github.com/user-attachments/assets/25b7681f-bb2a-40bf-b502-4d5b135c69e6

**After**

https://github.com/user-attachments/assets/e5ed30fc-4e26-4094-b66d-1e5d3022f68e




