### PR TITLE
Fix: Editing "Page" is broken for low capability users.

### DIFF
--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -171,8 +171,7 @@ export const getHomePage = createRegistrySelector( ( select ) =>
 			canUser( state, 'read', {
 				kind: 'root',
 				name: 'site',
-			} ),
-			getEntityRecord( state, 'root', 'site' ),
+			} ) && getEntityRecord( state, 'root', 'site' ),
 			getDefaultTemplateId( state, {
 				slug: 'front-page',
 			} ),

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -180,6 +180,13 @@ export const getHomePage = createRegistrySelector( ( select ) =>
 );
 
 export const getPostsPageId = createRegistrySelector( ( select ) => () => {
+	const canReadSiteData = select( STORE_NAME ).canUser( 'read', {
+		kind: 'root',
+		name: 'site',
+	} );
+	if ( ! canReadSiteData ) {
+		return null;
+	}
 	const siteData = select( STORE_NAME ).getEntityRecord( 'root', 'site' ) as
 		| SiteData
 		| undefined;

--- a/packages/core-data/src/private-selectors.ts
+++ b/packages/core-data/src/private-selectors.ts
@@ -6,7 +6,12 @@ import { createSelector, createRegistrySelector } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getDefaultTemplateId, getEntityRecord, type State } from './selectors';
+import {
+	canUser,
+	getDefaultTemplateId,
+	getEntityRecord,
+	type State,
+} from './selectors';
 import { STORE_NAME } from './name';
 import { unlock } from './lock-unlock';
 
@@ -134,6 +139,13 @@ interface SiteData {
 export const getHomePage = createRegistrySelector( ( select ) =>
 	createSelector(
 		() => {
+			const canReadSiteData = select( STORE_NAME ).canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} );
+			if ( ! canReadSiteData ) {
+				return null;
+			}
 			const siteData = select( STORE_NAME ).getEntityRecord(
 				'root',
 				'site'
@@ -156,6 +168,10 @@ export const getHomePage = createRegistrySelector( ( select ) =>
 			return { postType: 'wp_template', postId: frontPageTemplateId };
 		},
 		( state ) => [
+			canUser( state, 'read', {
+				kind: 'root',
+				name: 'site',
+			} ),
 			getEntityRecord( state, 'root', 'site' ),
 			getDefaultTemplateId( state, {
 				slug: 'front-page',

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -402,6 +402,10 @@ function Layout( {
 				kind: 'postType',
 				name: 'wp_template',
 			} );
+			const canDiscoverTemplate = canUser( 'read', {
+				kind: 'root',
+				name: 'site',
+			} );
 			const { isZoomOut } = unlock( select( blockEditorStore ) );
 			const { getEditorMode, getRenderingMode } = select( editorStore );
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
@@ -428,6 +432,7 @@ function Layout( {
 					supportsTemplateMode &&
 					isViewable &&
 					canViewTemplate &&
+					canDiscoverTemplate &&
 					! isEditingTemplate
 						? getTemplateId( currentPostType, currentPostId )
 						: null,

--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -402,10 +402,6 @@ function Layout( {
 				kind: 'postType',
 				name: 'wp_template',
 			} );
-			const canDiscoverTemplate = canUser( 'read', {
-				kind: 'root',
-				name: 'site',
-			} );
 			const { isZoomOut } = unlock( select( blockEditorStore ) );
 			const { getEditorMode, getRenderingMode } = select( editorStore );
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
@@ -432,7 +428,6 @@ function Layout( {
 					supportsTemplateMode &&
 					isViewable &&
 					canViewTemplate &&
-					canDiscoverTemplate &&
 					! isEditingTemplate
 						? getTemplateId( currentPostType, currentPostId )
 						: null,

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -163,6 +163,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 		BlockEditorProviderComponent = ExperimentalBlockEditorProvider,
 		__unstableTemplate: template,
 	} ) => {
+		const hasTemplate = !! template;
 		const {
 			editorSettings,
 			selection,
@@ -193,11 +194,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					hasLoadedPostObject: _hasLoadedPostObject,
 					editorSettings: getEditorSettings(),
 					isReady: __unstableIsEditorReady(),
-					mode: template ? getRenderingMode() : 'post-only',
-					defaultMode:
-						template && postTypeObject?.default_rendering_mode
-							? postTypeObject?.default_rendering_mode
-							: 'post-only',
+					mode: getRenderingMode(),
+					defaultMode: postTypeObject?.default_rendering_mode,
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'
@@ -205,7 +203,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							: null,
 				};
 			},
-			[ template, post.type ]
+			[ post.type ]
 		);
 
 		const shouldRenderTemplate = !! template && mode !== 'post-only';
@@ -325,13 +323,18 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Sets the right rendering mode when loading the editor.
 		useEffect( () => {
-			setRenderingMode( defaultMode );
-		}, [ defaultMode, setRenderingMode ] );
+			setRenderingMode( hasTemplate ? defaultMode : 'post-only' );
+		}, [ hasTemplate, defaultMode, setRenderingMode ] );
 
 		useHideBlocksFromInserter( post.type, mode );
 
 		// Register the editor commands.
 		useCommands();
+
+		console.log( {
+			notRender: ! isReady || ! mode || ! hasLoadedPostObject,
+			settings: ! settings.isPreviewMode,
+		} );
 
 		if ( ! isReady || ! mode || ! hasLoadedPostObject ) {
 			return null;

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -193,9 +193,11 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					hasLoadedPostObject: _hasLoadedPostObject,
 					editorSettings: getEditorSettings(),
 					isReady: __unstableIsEditorReady(),
-					mode: getRenderingMode(),
+					mode: template ? getRenderingMode() : 'post-only',
 					defaultMode:
-						postTypeObject?.default_rendering_mode ?? 'post-only',
+						template && postTypeObject?.default_rendering_mode
+							? postTypeObject?.default_rendering_mode
+							: 'post-only',
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'
@@ -203,7 +205,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							: null,
 				};
 			},
-			[ post.type ]
+			[ template, post.type ]
 		);
 
 		const shouldRenderTemplate = !! template && mode !== 'post-only';

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -196,7 +196,9 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					isReady: __unstableIsEditorReady(),
 					mode: getRenderingMode(),
 					defaultMode:
-						postTypeObject?.default_rendering_mode ?? 'post-only',
+						hasTemplate && postTypeObject?.default_rendering_mode
+							? postTypeObject?.default_rendering_mode
+							: 'post-only',
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'
@@ -204,7 +206,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 							: null,
 				};
 			},
-			[ post.type ]
+			[ post.type, hasTemplate ]
 		);
 
 		const shouldRenderTemplate = !! template && mode !== 'post-only';
@@ -324,8 +326,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Sets the right rendering mode when loading the editor.
 		useEffect( () => {
-			setRenderingMode( hasTemplate ? defaultMode : 'post-only' );
-		}, [ hasTemplate, defaultMode, setRenderingMode ] );
+			setRenderingMode( defaultMode );
+		}, [ defaultMode, setRenderingMode ] );
 
 		useHideBlocksFromInserter( post.type, mode );
 

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -195,7 +195,8 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					editorSettings: getEditorSettings(),
 					isReady: __unstableIsEditorReady(),
 					mode: getRenderingMode(),
-					defaultMode: postTypeObject?.default_rendering_mode,
+					defaultMode:
+						postTypeObject?.default_rendering_mode ?? 'post-only',
 					selection: getEditorSelection(),
 					postTypeEntities:
 						post.type === 'wp_template'
@@ -330,11 +331,6 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 
 		// Register the editor commands.
 		useCommands();
-
-		console.log( {
-			notRender: ! isReady || ! mode || ! hasLoadedPostObject,
-			settings: ! settings.isPreviewMode,
-		} );
 
 		if ( ! isReady || ! mode || ! hasLoadedPostObject ) {
 			return null;


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/68053

The issue arises because, despite checking that the user does not have permission to read templates and passing an undefined template, we were still passing the template-lock mode. Without a valid template, this mode does not function correctly. So to fix the problem when there is no template we use the post only mode.

This change addresses the issue and is necessary; however, the pull request is still in progress. There is a minor bug where the page start pattern modal briefly closes and reopens during loading. I am currently looking for a suitable solution that is not a hacky fix, for the close and reopen.


## Testing Instructions
With the 2024 theme and an editor user verify you can create and edit pages and they load in the normal post view.
Verify that the template view is loaded for admins.