### PR TITLE
Fix global styles updating in style book.

### DIFF
--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -50,6 +50,7 @@ import { getExamples } from './examples';
 import { store as siteEditorStore } from '../../store';
 import { useSection } from '../sidebar-global-styles-wrapper';
 import { STYLE_BOOK_COLOR_GROUPS } from '../style-book/constants';
+import { GlobalStylesRenderer } from '../global-styles-renderer';
 
 const {
 	ExperimentalBlockEditorProvider,
@@ -432,6 +433,7 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 		<div className="edit-site-style-book">
 			{ resizeObserver }
 			<BlockEditorProvider settings={ settings }>
+				<GlobalStylesRenderer disableRootPadding />
 				<StyleBookBody
 					examples={ examplesForSinglePageUse }
 					settings={ settings }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes a regression introduced in the style book by  #67811, where changing styles in the global styles UI doesn't update the style book styles.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With a block theme enabled, navigate to "Styles" in the site editor.
2. Click "Style book" in the content area to show the style book.
3. Change some styles in global styles (e.g. global background color), and check that they update correctly in the style book.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
