### PR TITLE
Layout: Add vertical alignment controls to FlexLayout component

### DIFF
--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -10,6 +10,11 @@ import {
 	justifyStretch,
 	arrowRight,
 	arrowDown,
+	justifyBottom,
+	justifyCenterVertical,
+	justifyTop,
+	justifySpaceBetweenVertical,
+	justifyStretchVertical,
 } from '@wordpress/icons';
 import {
 	ToggleControl,
@@ -66,8 +71,11 @@ export default {
 		onChange,
 		layoutBlockSupport = {},
 	} ) {
-		const { allowOrientation = true, allowJustification = true } =
-			layoutBlockSupport;
+		const {
+			allowOrientation = true,
+			allowJustification = true,
+			allowVerticalAlignment = true,
+		} = layoutBlockSupport;
 		return (
 			<>
 				<Flex>
@@ -82,6 +90,16 @@ export default {
 					{ allowOrientation && (
 						<FlexItem>
 							<OrientationControl
+								layout={ layout }
+								onChange={ onChange }
+							/>
+						</FlexItem>
+					) }
+				</Flex>
+				<Flex>
+					{ allowVerticalAlignment && (
+						<FlexItem>
+							<FlexLayoutVerticalAlignmentControl
 								layout={ layout }
 								onChange={ onChange }
 							/>
@@ -117,6 +135,7 @@ export default {
 					<FlexLayoutVerticalAlignmentControl
 						layout={ layout }
 						onChange={ onChange }
+						isToolbar
 					/>
 				) }
 			</BlockControls>
@@ -196,7 +215,11 @@ export default {
 	},
 };
 
-function FlexLayoutVerticalAlignmentControl( { layout, onChange } ) {
+function FlexLayoutVerticalAlignmentControl( {
+	layout,
+	onChange,
+	isToolbar = false,
+} ) {
 	const { orientation = 'horizontal' } = layout;
 
 	const defaultVerticalAlignment =
@@ -213,16 +236,72 @@ function FlexLayoutVerticalAlignmentControl( { layout, onChange } ) {
 		} );
 	};
 
+	if ( isToolbar ) {
+		return (
+			<BlockVerticalAlignmentControl
+				onChange={ onVerticalAlignmentChange }
+				value={ verticalAlignment }
+				controls={
+					orientation === 'horizontal'
+						? [ 'top', 'center', 'bottom', 'stretch' ]
+						: [ 'top', 'center', 'bottom', 'space-between' ]
+				}
+			/>
+		);
+	}
+
+	const alignmentOptions = [
+		{
+			value: 'top',
+			icon: justifyTop,
+			label: __( 'Align items top' ),
+		},
+		{
+			value: 'center',
+			icon: justifyCenterVertical,
+			label: __( 'Align items middle' ),
+		},
+		{
+			value: 'bottom',
+			icon: justifyBottom,
+			label: __( 'Align items bottom' ),
+		},
+	];
+
+	if ( orientation === 'horizontal' ) {
+		alignmentOptions.push( {
+			value: 'stretch',
+			icon: justifyStretchVertical,
+			label: __( 'Stretch items' ),
+		} );
+	} else {
+		alignmentOptions.push( {
+			value: 'space-between',
+			icon: justifySpaceBetweenVertical,
+			label: __( 'Space between items' ),
+		} );
+	}
+
 	return (
-		<BlockVerticalAlignmentControl
-			onChange={ onVerticalAlignmentChange }
+		<ToggleGroupControl
+			__next40pxDefaultSize
+			__nextHasNoMarginBottom
+			label={ __( 'Alignment' ) }
 			value={ verticalAlignment }
-			controls={
-				orientation === 'horizontal'
-					? [ 'top', 'center', 'bottom', 'stretch' ]
-					: [ 'top', 'center', 'bottom', 'space-between' ]
-			}
-		/>
+			onChange={ onVerticalAlignmentChange }
+			className="block-editor-hooks__flex-layout-justification-controls"
+		>
+			{ alignmentOptions.map( ( { value, icon, label } ) => {
+				return (
+					<ToggleGroupControlOptionIcon
+						key={ value }
+						value={ value }
+						icon={ icon }
+						label={ label }
+					/>
+				);
+			} ) }
+		</ToggleGroupControl>
 	);
 }
 

--- a/packages/block-editor/src/layouts/flex.js
+++ b/packages/block-editor/src/layouts/flex.js
@@ -96,16 +96,16 @@ export default {
 						</FlexItem>
 					) }
 				</Flex>
-				<Flex>
-					{ allowVerticalAlignment && (
+				{ allowVerticalAlignment && (
+					<Flex>
 						<FlexItem>
 							<FlexLayoutVerticalAlignmentControl
 								layout={ layout }
 								onChange={ onChange }
 							/>
 						</FlexItem>
-					) }
-				</Flex>
+					</Flex>
+				) }
 				<FlexWrapControl layout={ layout } onChange={ onChange } />
 			</>
 		);


### PR DESCRIPTION
Fixes: #68101 

## What?
This PR adds support for `Alignment Options` in the `Layout Inspector Panel`.  

## Why?
Previously, users would see the `Justification Options` both in the toolbar and in the Inspector Panel, however, the `Alignment Options` were only visible in the `Toolbar`. This PR bridges this gap by introducing `Alignment Options` in the `Inspector Panel`.

## How?
The Layout Panel for `Rows` and `Stacks` for which the issue is about, is governed by `flex.js`. Updating this file to add support for `Alignment Options` similar to what was done for `Justification Options` did the job.

## Testing Instructions
1. Add a `row` or `stack` block.
2. Notice, `alignment` can now be changed from both the `toolbar` as well as the `inspector panel`.

## Screenshots

|Before|After|
|-|-|
|<img width="273" alt="before_alignment" src="https://github.com/user-attachments/assets/31ed458a-46ef-4905-811b-d941646ffaa4" />|![Screenshot 2024-12-19 at 10 25 18 AM](https://github.com/user-attachments/assets/16baef94-ed4f-4702-9b35-09f5b1b0e6b2)|


## Screencast

https://github.com/user-attachments/assets/724986f2-09c1-42d2-aa58-60d23baff7e0

