### PR TITLE
Add README for WritingModeControl component

### DIFF
--- a/packages/block-editor/src/components/writing-mode-control/README.md
+++ b/packages/block-editor/src/components/writing-mode-control/README.md
@@ -1,0 +1,53 @@
+# WritingModeControl
+
+WritingModeControl is a React component that renders a UI that allows users to select text orientation (writing mode).
+The component provides a toggle group interface that allows users to switch between horizontal and vertical text orientations, with automatic RTL (Right-to-Left) support.
+
+## Usage
+
+```jsx
+import { WritingModeControl } from '@wordpress/block-editor';
+import { useState } from '@wordpress/element';
+
+const MyWritingModeControl = () => {
+    const [ writingMode, setWritingMode ] = useState();
+
+    return (
+        <WritingModeControl
+            value={ writingMode }
+            onChange={ ( newWritingMode ) => {
+                setWritingMode( newWritingMode );
+            } }
+        />
+    );
+};
+```
+
+## Props
+
+The component accepts the following props:
+
+### onChange
+
+A function that handles change in the writing mode selection.
+
+- Type: `function`
+- Required: Yes
+
+### value
+
+The current writing mode value. Can be one of:
+- `'horizontal-tb'` - Horizontal top-to-bottom text
+- `'vertical-rl'` - Vertical right-to-left text (for LTR languages)
+- `'vertical-lr'` - Vertical left-to-right text (for RTL languages)
+
+- Type: `string`
+- Required: No
+- Default: `undefined`
+
+### className
+
+Additional class name to add to the control.
+
+- Type: `string`
+- Required: No

--- a/packages/block-editor/src/components/writing-mode-control/README.md
+++ b/packages/block-editor/src/components/writing-mode-control/README.md
@@ -3,6 +3,8 @@
 WritingModeControl is a React component that renders a UI that allows users to select text orientation (writing mode).
 The component provides a toggle group interface that allows users to switch between horizontal and vertical text orientations, with automatic RTL (Right-to-Left) support.
 
+![WritingModeControl component preview](https://github.com/user-attachments/assets/69dc0560-bcdb-47af-9219-214ff359676f)
+
 ## Usage
 
 ```jsx
@@ -36,14 +38,19 @@ A function that handles change in the writing mode selection.
 
 ### value
 
-The current writing mode value. Can be one of:
-- `'horizontal-tb'` - Horizontal top-to-bottom text
-- `'vertical-rl'` - Vertical right-to-left text (for LTR languages)
-- `'vertical-lr'` - Vertical left-to-right text (for RTL languages)
+The current writing mode value.
 
 - Type: `string`
 - Required: No
 - Default: `undefined`
+
+The writing mode values follow this schema:
+
+| Value | Description |
+| ----- | ----------- |
+| horizontal-tb | Horizontal top-to-bottom text |
+| vertical-rl | Vertical right-to-left text (for LTR languages) |
+| vertical-lr | Vertical left-to-right text (for RTL languages) |
 
 ### className
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/22891

## What?
This PR adds a README for the `WritingModeControl` component.

