### PR TITLE
BlockCard: Fix title alignment

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -14,9 +14,8 @@ import {
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
-import { __, _x, isRTL, sprintf } from '@wordpress/i18n';
+import { __, isRTL } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { createInterpolateElement } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -71,25 +70,10 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 			<BlockIcon icon={ icon } showColors />
 			<VStack spacing={ 1 }>
 				<h2 className="block-editor-block-card__title">
-					{ name?.length
-						? createInterpolateElement(
-								sprintf(
-									// translators:  1: Custom block name. 2: Block title.
-									_x(
-										'<span>%1$s</span> <badge>%2$s</badge>',
-										'block label'
-									),
-									name,
-									title
-								),
-								{
-									span: (
-										<span className="block-editor-block-card__name" />
-									),
-									badge: <Badge />,
-								}
-						  )
-						: title }
+					<span className="block-editor-block-card__name">
+						{ !! name?.length ? name : title }
+					</span>
+					{ !! name?.length && <Badge>{ title }</Badge> }
 				</h2>
 				{ description && (
 					<Text className="block-editor-block-card__description">

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -16,8 +16,11 @@
 		font-size: $default-font-size;
 		line-height: $default-line-height;
 		margin: 0;
-		padding: 3px 0; // This makes the title as high as the icon.
 	}
+}
+
+.block-editor-block-card__name {
+	padding: 3px 0; // This makes the title as high as the icon.
 }
 
 .block-editor-block-card .block-editor-block-icon {


### PR DESCRIPTION
See https://github.com/WordPress/gutenberg/pull/65641#issuecomment-2550984540

## What?

This PR will align the title and icon regardless of whether the block has a custom name or not.

## Why?

There is padding applied to the element that wraps both the main text and the badge, and because the badge is taller, there is a misalignment with and without the badge:

![padding](https://github.com/user-attachments/assets/6fb973a0-15be-4229-8ce4-14065b09d2bc)

## How?

- Regardless of whether a badge is present or not, always surround the main text with an element that has the `block-editor-block-card__name` CSS class.
- Apply padding to the main text only.

## Testing Instructions

### Storybook

- Run `npm run storybook:dev`
- Access http://localhost:50240/?path=/story/blockeditor-blockcard--default 

#### Before

https://github.com/user-attachments/assets/eb912994-f69a-400b-82b3-2523a169d627

#### After

https://github.com/user-attachments/assets/054e3a04-f890-4e52-8ed3-dad48a6a1e61

## Block Editor

Insert a block and give it a custom name.

![image](https://github.com/user-attachments/assets/e520abc0-9008-46f2-9a61-d3bfc7f8e437)



