### PR TITLE
Storybook: Add TabbedSidebar stories and improve docs

### DIFF
--- a/packages/block-editor/src/components/tabbed-sidebar/README.md
+++ b/packages/block-editor/src/components/tabbed-sidebar/README.md
@@ -74,6 +74,7 @@ The ID of the currently selected tab.
 -   **Default:** `undefined`
 
 Array of tab objects. Each tab should have:
+
 - `name` (string): Unique identifier for the tab
 - `title` (string): Display title for the tab
 - `panel` (React.Node): Content to display in the tab panel

--- a/packages/block-editor/src/components/tabbed-sidebar/README.md
+++ b/packages/block-editor/src/components/tabbed-sidebar/README.md
@@ -1,21 +1,19 @@
-# Tabbed Panel
+# TabbedSidebar
 
-The `TabbedPanel` component is used to create the secondary panels in the editor.
+The `TabbedSidebar` component is used to create secondary panels in the editor with tabbed navigation.
 
 ## Development guidelines
 
-This acts as a wrapper for the `Tabs` component, but adding conventions that can be shared between all secondary panels, for example:
+This acts as a wrapper for the `Tabs` component, adding conventions that can be shared between all secondary panels, including:
 
 -   A close button
 -   Tabs that fill the panel
--   Custom scollbars
+-   Custom scrollbars
 
 ### Usage
 
-Renders a block alignment toolbar with alignments options.
-
 ```jsx
-import { TabbedSidebar } from '@wordpress/components';
+import { TabbedSidebar } from '@wordpress/block-editor';
 
 const MyTabbedSidebar = () => (
 	<TabbedSidebar
@@ -23,7 +21,7 @@ const MyTabbedSidebar = () => (
 			{
 				name: 'slug-1',
 				title: _x( 'Title 1', 'context' ),
-				panel: <PanelContents>,
+				panel: <PanelContents />,
 				panelRef: useRef('an-optional-ref'),
 			},
 			{
@@ -35,6 +33,8 @@ const MyTabbedSidebar = () => (
 		onClose={ onClickCloseButton }
 		onSelect={ onSelectTab }
 		defaultTabId="slug-1"
+		selectedTab="slug-1"
+		closeButtonLabel="Close sidebar"
 		ref={ tabsRef }
 	/>
 );
@@ -47,30 +47,40 @@ const MyTabbedSidebar = () => (
 -   **Type:** `String`
 -   **Default:** `undefined`
 
-This is passed to the `Tabs` component so it can handle the tab to select by default when it component renders.
+The ID of the tab to be selected by default when the component renders.
 
 ### `onClose`
 
 -   **Type:** `Function`
 
-The function that is called when the close button is clicked.
+Function called when the close button is clicked.
 
 ### `onSelect`
 
 -   **Type:** `Function`
 
-This is passed to the `Tabs` component - it will be called when a tab has been selected. It is passed the selected tab's ID as an argument.
+Function called when a tab is selected. Receives the selected tab's ID as an argument.
 
 ### `selectedTab`
 
 -   **Type:** `String`
 -   **Default:** `undefined`
 
-This is passed to the `Tabs` component - it will display this tab as selected.
+The ID of the currently selected tab.
 
 ### `tabs`
 
 -   **Type:** `Array`
 -   **Default:** `undefined`
 
-An array of tabs which will be rendered as `TabList` and `TabPanel` components.
+Array of tab objects. Each tab should have:
+- `name` (string): Unique identifier for the tab
+- `title` (string): Display title for the tab
+- `panel` (React.Node): Content to display in the tab panel
+- `panelRef` (React.Ref, optional): Reference to the tab panel element
+
+#### `closeButtonLabel`
+
+-   **Type:** `String`
+
+Accessibility label for the close button.

--- a/packages/block-editor/src/components/tabbed-sidebar/index.js
+++ b/packages/block-editor/src/components/tabbed-sidebar/index.js
@@ -15,6 +15,44 @@ import { unlock } from '../../lock-unlock';
 
 const { Tabs } = unlock( componentsPrivateApis );
 
+/**
+ * A component that creates a tabbed sidebar with a close button.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/tabbed-sidebar/README.md
+ *
+ * @example
+ * ```jsx
+ * function MyTabbedSidebar() {
+ *   return (
+ *     <TabbedSidebar
+ *       tabs={ [
+ *         {
+ *           name: 'tab1',
+ *           title: 'Settings',
+ *           panel: <PanelContents />,
+ *         }
+ *       ] }
+ *       onClose={ () => {} }
+ *       onSelect={ () => {} }
+ *       defaultTabId="tab1"
+ *       selectedTab="tab1"
+ *       closeButtonLabel="Close sidebar"
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @param {Object}   props                  Component props.
+ * @param {string}   [props.defaultTabId]   The ID of the tab to be selected by default when the component renders.
+ * @param {Function} props.onClose          Function called when the close button is clicked.
+ * @param {Function} props.onSelect         Function called when a tab is selected. Receives the selected tab's ID as an argument.
+ * @param {string}   props.selectedTab      The ID of the currently selected tab.
+ * @param {Array}    props.tabs             Array of tab objects. Each tab should have: name (string), title (string),
+ *                                          panel (React.Node), and optionally panelRef (React.Ref).
+ * @param {string}   props.closeButtonLabel Accessibility label for the close button.
+ * @param {Object}   ref                    Forward ref to the tabs list element.
+ * @return {Element} The tabbed sidebar component.
+ */
 function TabbedSidebar(
 	{ defaultTabId, onClose, onSelect, selectedTab, tabs, closeButtonLabel },
 	ref

--- a/packages/block-editor/src/components/tabbed-sidebar/stories/index.story.js
+++ b/packages/block-editor/src/components/tabbed-sidebar/stories/index.story.js
@@ -55,7 +55,7 @@ const meta = {
 			description: 'The ID of the currently selected tab.',
 		},
 		tabs: {
-			control: { type: null },
+			control: { type: 'array' },
 			table: {
 				type: { summary: 'array' },
 			},
@@ -63,7 +63,7 @@ const meta = {
 				'Array of tab objects. Each tab should have: name (string), title (string), panel (React.Node), and optionally panelRef (React.Ref).',
 		},
 		closeButtonLabel: {
-			control: { type: null },
+			control: { type: 'text' },
 			table: {
 				type: { summary: 'string' },
 			},

--- a/packages/block-editor/src/components/tabbed-sidebar/stories/index.story.js
+++ b/packages/block-editor/src/components/tabbed-sidebar/stories/index.story.js
@@ -11,6 +11,7 @@ import TabbedSidebar from '../';
 const meta = {
 	title: 'BlockEditor/TabbedSidebar',
 	component: TabbedSidebar,
+	tags: [ 'status-private' ],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },
@@ -80,18 +81,24 @@ const DEMO_TABS = [
 ];
 
 export const Default = {
-	render: function Template( args ) {
-		const [ selectedTab, setSelectedTab ] = useState( 'tab1' );
+	render: function Template( { onSelect, onClose, ...args } ) {
+		const [ selectedTab, setSelectedTab ] = useState();
 
 		return (
 			<TabbedSidebar
 				{ ...args }
-				tabs={ DEMO_TABS }
 				selectedTab={ selectedTab }
-				defaultTabId="tab1"
-				onSelect={ setSelectedTab }
-				closeButtonLabel="Close sidebar"
+				onSelect={ ( ...changeArgs ) => {
+					onSelect( ...changeArgs );
+					setSelectedTab( ...changeArgs );
+				} }
+				onClose={ onClose }
 			/>
 		);
+	},
+	args: {
+		tabs: DEMO_TABS,
+		defaultTabId: 'tab1',
+		closeButtonLabel: 'Close Sidebar',
 	},
 };

--- a/packages/block-editor/src/components/tabbed-sidebar/stories/index.story.js
+++ b/packages/block-editor/src/components/tabbed-sidebar/stories/index.story.js
@@ -1,0 +1,97 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import TabbedSidebar from '../';
+
+const meta = {
+	title: 'BlockEditor/TabbedSidebar',
+	component: TabbedSidebar,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'A component that creates a tabbed sidebar with a close button.',
+			},
+		},
+	},
+	argTypes: {
+		defaultTabId: {
+			control: { type: null },
+			table: {
+				type: { summary: 'string' },
+			},
+			description:
+				'The ID of the tab to be selected by default when the component renders.',
+		},
+		onClose: {
+			action: 'onClose',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+			},
+			description: 'Function called when the close button is clicked.',
+		},
+		onSelect: {
+			action: 'onSelect',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+			},
+			description:
+				"Function called when a tab is selected. Receives the selected tab's ID as an argument.",
+		},
+		selectedTab: {
+			control: { type: null },
+			table: {
+				type: { summary: 'string' },
+			},
+			description: 'The ID of the currently selected tab.',
+		},
+		tabs: {
+			control: { type: null },
+			table: {
+				type: { summary: 'array' },
+			},
+			description:
+				'Array of tab objects. Each tab should have: name (string), title (string), panel (React.Node), and optionally panelRef (React.Ref).',
+		},
+		closeButtonLabel: {
+			control: { type: null },
+			table: {
+				type: { summary: 'string' },
+			},
+			description: 'Accessibility label for the close button.',
+		},
+	},
+};
+
+export default meta;
+
+const DEMO_TABS = [
+	{ name: 'tab1', title: 'Settings' },
+	{ name: 'tab2', title: 'Styles' },
+	{ name: 'tab3', title: 'Advanced' },
+];
+
+export const Default = {
+	render: function Template( args ) {
+		const [ selectedTab, setSelectedTab ] = useState( 'tab1' );
+
+		return (
+			<TabbedSidebar
+				{ ...args }
+				tabs={ DEMO_TABS }
+				selectedTab={ selectedTab }
+				defaultTabId="tab1"
+				onSelect={ setSelectedTab }
+				closeButtonLabel="Close sidebar"
+			/>
+		);
+	},
+};


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for TabbedSidebar component in the Storybook.

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the TabbedSidebar stories.

## Screenshots or screencast
![image](https://github.com/user-attachments/assets/eae5f709-d0ac-4484-b30f-226d6dbcd1e6)

