### PR TITLE
Pullquote: Alignment matching with toolbar icon

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -1,5 +1,5 @@
 .wp-block-pullquote {
-	text-align: center; // Default text-alignment where the `textAlign` attribute value isn't specified.
+	text-align: left; // Default text-alignment where the `textAlign` attribute value isn't specified.
 	overflow-wrap: break-word; // Break long strings of text without spaces so they don't overflow the block.
 	box-sizing: border-box;
 	margin: 0 0 1em 0;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/68117

## Why?
The initial alignment of the Pull Quote block does not correspond to the selected alignment indicated by the toolbar icon.

## How?
Alignment fixed in style.css by updating text-align value.

## Testing Instructions

- Open the WordPress Site Editor or a post editor in Gutenberg.
- Add a new Pull Quote block to the page or post.
- Check the default alignment of the block in the editor. 
- Now it is left aligned in editor and also in toolbar.



## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|![Screenshot (3)](https://github.com/user-attachments/assets/762aafda-e402-490b-b528-79b4e216f14c)|![Screenshot (2)](https://github.com/user-attachments/assets/dd2d1b4a-29c2-47c9-b2f3-373f8c86e0ff)|
