### PR TITLE
Storybook: Add stories for the ContrastChecker component

### DIFF
--- a/packages/block-editor/src/components/contrast-checker/stories/index.story.js
+++ b/packages/block-editor/src/components/contrast-checker/stories/index.story.js
@@ -1,0 +1,111 @@
+/**
+ * Internal dependencies
+ */
+import ContrastChecker from '../';
+
+const meta = {
+	title: 'BlockEditor/ContrastChecker',
+	component: ContrastChecker,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Determines if contrast for text styles is sufficient (WCAG 2.0 AA) when used with a given background color.',
+			},
+		},
+	},
+	argTypes: {
+		backgroundColor: {
+			control: 'color',
+			description:
+				'The background color to check the contrast of text against.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		fallbackBackgroundColor: {
+			control: 'color',
+			description:
+				'A fallback background color value, in case `backgroundColor` is not available.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		textColor: {
+			control: 'color',
+			description:
+				'The text color to check the contrast of the background against.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		fallbackTextColor: {
+			control: 'color',
+			description:
+				'A fallback text color value, in case `textColor` is not available.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		fontSize: {
+			control: 'number',
+			description:
+				'The font-size (as a `px` value) of the text to check the contrast against.',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		isLargeText: {
+			control: 'boolean',
+			description:
+				'Whether the text is large (approximately `24px` or higher).',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		linkColor: {
+			control: 'color',
+			description: 'The link color to check the contrast against.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		fallbackLinkColor: {
+			control: 'color',
+			description: 'Fallback link color if linkColor is not available.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		enableAlphaChecker: {
+			control: 'boolean',
+			description: 'Whether to enable checking for transparent colors.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {};

--- a/packages/block-editor/src/components/contrast-checker/stories/index.story.js
+++ b/packages/block-editor/src/components/contrast-checker/stories/index.story.js
@@ -101,6 +101,7 @@ const meta = {
 				type: {
 					summary: 'boolean',
 				},
+				defaultValue: { summary: false },
 			},
 		},
 	},
@@ -108,4 +109,9 @@ const meta = {
 
 export default meta;
 
-export const Default = {};
+export const Default = {
+	args: {
+		backgroundColor: '#ffffff',
+		textColor: '#ffffff',
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?

This PR adds the Storybook stories for the ContrastChecker component in the block editor. It includes comprehensive stories demonstrating different text alignment states.



## Testing Instructions

- Start Storybook by running `npm run storybook:dev`
- Open Storybook at http://localhost:50240/
- Navigate to "BlockEditor/ContrastChecker" in the Storybook sidebar
- Test the stories


## Screencast


https://github.com/user-attachments/assets/5a554311-f9ba-4585-8d96-f3a282aed024


