### PR TITLE
Pullquote: Adding missing alignment style

### DIFF
--- a/packages/block-library/src/pullquote/style.scss
+++ b/packages/block-library/src/pullquote/style.scss
@@ -46,6 +46,10 @@
 .wp-block-pullquote.has-text-align-right blockquote {
 	text-align: right;
 }
+// Ensure that we are reasonably specific to override theme defaults.
+.wp-block-pullquote.has-text-align-center blockquote {
+	text-align: center;
+}
 
 // .is-style-solid-color is deprecated.
 // This selector has not been scoped with `:root :where`, as global styles


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/53879

## Why?
The styles for the pullquote block do not explicitly define what happens with .has-text-align-center.

## How?
Added style for has-text-align-center class in style.css

## Testing Instructions

- Override default style for textAlign of the pullquote with CSS or theme.json.
- Select the "Center" text align option


