### PR TITLE
Shadows: Always show reset button if hover is not supported

### DIFF
--- a/packages/edit-site/src/components/global-styles/style.scss
+++ b/packages/edit-site/src/components/global-styles/style.scss
@@ -169,10 +169,18 @@
 	top: $grid-unit;
 	opacity: 0;
 
+	&.edit-site-global-styles__shadow-editor__remove-button {
+		border: none;
+	}
+
 	.edit-site-global-styles__shadow-editor__dropdown-toggle:hover + &,
 	&:focus,
 	&:hover {
-		border: none;
+		opacity: 1;
+	}
+
+	@media (hover: none) {
+		// Show reset button on devices that do not support hover.
 		opacity: 1;
 	}
 }


### PR DESCRIPTION
Follow-up #67705

## What? Why?  How?

#67705 made the reset button in the shadow panel visible only on hover. However, I found that it was not possible to remove the shadow on devices that don't support hover. Therefore, I made the reset button visible on all devices that don't support hover.

## Testing Instructions

- Site Editor > Global Styles > Shadows > Add shadow preset > Add  multiple shadow value
- Desktop layout: The reset button is only visible on hover.
- Mobile Device (Can be simulated using browser developer tools): The reset button is always visible.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/d5160736-7e63-4de6-9315-130d508852db) | ![image](https://github.com/user-attachments/assets/b04daf67-2b9f-4585-8ddf-e1407000ef0d) |
