### PR TITLE
Storybook: Add story for the Warning component 

### DIFF
--- a/packages/block-editor/src/components/warning/stories/index.story.js
+++ b/packages/block-editor/src/components/warning/stories/index.story.js
@@ -1,0 +1,67 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Warning from '../';
+
+const meta = {
+	title: 'BlockEditor/Warning',
+	component: Warning,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Displays a warning message with optional action buttons and secondary actions dropdown.',
+			},
+		},
+	},
+	argTypes: {
+		children: {
+			control: 'text',
+			description:
+				'Intended to represent the block to which the warning pertains. See screenshots above.',
+			table: {
+				type: { summary: 'string|element' },
+			},
+		},
+		className: {
+			control: 'text',
+			description: 'Classes to pass to element.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		actions: {
+			control: 'object',
+			description:
+				'An array of elements to be rendered as action buttons in the warning element.',
+			table: {
+				type: { summary: 'Element[]' },
+			},
+		},
+		secondaryActions: {
+			control: 'object',
+			description:
+				'An array of { title, onClick } to be rendered as options in a dropdown of secondary actions.',
+			table: {
+				type: { summary: '{ title: string, onClick: Function }[]' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		children: __( 'This block ran into an issue.' ),
+	},
+	render: function Template( props ) {
+		return <Warning { ...props } />;
+	},
+};

--- a/packages/block-editor/src/components/warning/stories/index.story.js
+++ b/packages/block-editor/src/components/warning/stories/index.story.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -24,7 +25,7 @@ const meta = {
 		children: {
 			control: 'text',
 			description:
-				'Intended to represent the block to which the warning pertains. See screenshots above.',
+				'Intended to represent the block to which the warning pertains.',
 			table: {
 				type: { summary: 'string|element' },
 			},
@@ -61,7 +62,25 @@ export const Default = {
 	args: {
 		children: __( 'This block ran into an issue.' ),
 	},
-	render: function Template( props ) {
-		return <Warning { ...props } />;
+};
+
+export const WithActions = {
+	args: {
+		...Default.args,
+		actions: [
+			<Button key="fix-issue" __next40pxDefaultSize variant="primary">
+				{ __( 'Fix issue' ) }
+			</Button>,
+		],
+	},
+};
+
+export const WithSecondaryActions = {
+	args: {
+		...Default.args,
+		secondaryActions: [
+			{ title: __( 'Get help' ) },
+			{ title: __( 'Remove block' ) },
+		],
 	},
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds the Storybook stories for the Warning component in the block editor.

## Testing Instructions

1. Start Storybook by running npm run storybook:dev
2. Open Storybook at http://localhost:50240/
3. Navigate to "BlockEditor/Warning" in the Storybook sidebar
4. Test the story

## Screenshots or screencast 

https://github.com/user-attachments/assets/91800b37-50b3-42e7-a4b8-264c10a2fc92



