### PR TITLE
Add README for TextAlignmentControl component

### DIFF
--- a/packages/block-editor/src/components/text-alignment-control/README.md
+++ b/packages/block-editor/src/components/text-alignment-control/README.md
@@ -1,12 +1,10 @@
 # TextAlignmentControl
 
-The `TextAlignmentControl` component is responsible for rendering a control element that allows users to select and apply text alignment options to blocks or elements in the Gutenberg editor. It provides an intuitive interface for aligning text with options such as `left`, `center`, `right`, and `justify`.
+The `TextAlignmentControl` component is responsible for rendering a control element that allows users to select and apply text alignment options to blocks or elements in the Gutenberg editor. It provides an intuitive interface for aligning text with options such as `left`, `center` and `right`.
 
-## Development guidelines
+## Usage
 
-### Usage
-
-Renders the Text Alignment Component with `left`, `center`, `right`, and `justify` alignment options.
+Renders the Text Alignment Component with `left`, `center` and `right` alignment options.
 
 ```jsx
 import { TextAlignmentControl } from '@wordpress/block-editor';
@@ -21,13 +19,13 @@ const MyTextAlignmentControlComponent = () => (
 );
 ```
 
-### Props
+## Props
 
 ### `value`
 
 -   **Type:** `String`
 -   **Default:** `left`
--   **Options:** `left`, `center`, `right`, `justify`
+-   **Options:** `left`, `center`, `right`
 
 The current value of the text alignment setting. You may only choose from the `Options` listed above.
 
@@ -35,7 +33,7 @@ The current value of the text alignment setting. You may only choose from the `O
 
 -   **Type:** `Function`
 
-A callback function invoked when the text alignment value is changed via an interaction with any of the options. The function is called with the new alignment value (`left`, `center`, `right`, `justify`) as the only argument.
+A callback function invoked when the text alignment value is changed via an interaction with any of the options. The function is called with the new alignment value (`left`, `center`, `right`) as the only argument.
 
 ### `className`
 

--- a/packages/block-editor/src/components/text-alignment-control/README.md
+++ b/packages/block-editor/src/components/text-alignment-control/README.md
@@ -24,8 +24,8 @@ const MyTextAlignmentControlComponent = () => (
 ### `value`
 
 -   **Type:** `String`
--   **Default:** `left`
--   **Options:** `left`, `center`, `right`
+-   **Default:** `undefined`
+-   **Options:** `left`, `center`, `right`, `justify`
 
 The current value of the text alignment setting. You may only choose from the `Options` listed above.
 

--- a/packages/block-editor/src/components/text-alignment-control/README.md
+++ b/packages/block-editor/src/components/text-alignment-control/README.md
@@ -1,0 +1,51 @@
+# TextAlignmentControl
+
+The `TextAlignmentControl` component is responsible for rendering a control element that allows users to select and apply text alignment options to blocks or elements in the Gutenberg editor. It provides an intuitive interface for aligning text with options such as `left`, `center`, `right`, and `justify`.
+
+## Development guidelines
+
+### Usage
+
+Renders the Text Alignment Component with `left`, `center`, `right`, and `justify` alignment options.
+
+```jsx
+import { TextAlignmentControl } from '@wordpress/block-editor';
+
+const MyTextAlignmentControlComponent = () => (
+	<TextAlignmentControl
+		value={ textAlign }
+		onChange={ ( value ) => {
+			setAttributes( { textAlign: value } );
+		} }
+	/>
+);
+```
+
+### Props
+
+### `value`
+
+-   **Type:** `String`
+-   **Default:** `left`
+-   **Options:** `left`, `center`, `right`, `justify`
+
+The current value of the text alignment setting. You may only choose from the `Options` listed above.
+
+### `onChange`
+
+-   **Type:** `Function`
+
+A callback function invoked when the text alignment value is changed via an interaction with any of the options. The function is called with the new alignment value (`left`, `center`, `right`, `justify`) as the only argument.
+
+### `className`
+
+-   **Type:** `String`
+
+Class name to add to the control for custom styling.
+
+### `options`
+
+-   **Type:** `Array`
+-   **Default:** [`left`, `center`, `right`]
+
+An array that determines which alignment options will be available in the control. You can pass an array of alignment values to customize the options.


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/22891
Follow up: https://github.com/WordPress/gutenberg/pull/67371

## What?
This PR adds a README for the TextAlignmentControl component.

