### PR TITLE
Assets: Add README.md about syncing

### DIFF
--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -5,7 +5,8 @@ on:
         branches:
             - trunk
         paths:
-            - assets/**
+            - 'assets/**'
+            - '!assets/README.md'
 
 jobs:
     sync-assets:

--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -38,7 +38,6 @@ jobs:
             - name: Copy files from git checkout to svn working copy
               run: |
                   cp -R git/assets/* assets
-                  rm assets/README.md
 
             - name: Commit the updated assets
               working-directory: ./assets

--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -5,7 +5,7 @@ on:
         branches:
             - trunk
         paths:
-            - 'assets/**'
+            - assets/**
 
 jobs:
     sync-assets:

--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -36,7 +36,9 @@ jobs:
                   path: git
 
             - name: Copy files from git checkout to svn working copy
-              run: cp -R git/assets/* assets
+              run: |
+                  cp -R git/assets/* assets
+                  rm assets/README.md
 
             - name: Commit the updated assets
               working-directory: ./assets

--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -6,7 +6,6 @@ on:
             - trunk
         paths:
             - 'assets/**'
-            - '!assets/README.md'
 
 jobs:
     sync-assets:

--- a/.github/workflows/sync-assets-to-plugin-repo.yml
+++ b/.github/workflows/sync-assets-to-plugin-repo.yml
@@ -35,8 +35,7 @@ jobs:
                   path: git
 
             - name: Copy files from git checkout to svn working copy
-              run: |
-                  cp -R git/assets/* assets
+              run: cp -R git/assets/* assets
 
             - name: Commit the updated assets
               working-directory: ./assets

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,7 +1,7 @@
 ## Gutenberg Plugin Assets
 
-This directory is managed via the [`assets/` directory in the Gutenberg repository on GitHub](https://github.com/WordPress/gutenberg/tree/trunk/assets). **Changes committed directly to the plugin repository on WordPress.org will be overwritten.**
+The contents of this directory are synced from the [`assets/` directory in the Gutenberg repository on GitHub](https://github.com/WordPress/gutenberg/tree/trunk/assets) to the [`assets/` directory of the Gutenberg WordPress.org plugin repository](https://plugins.trac.wordpress.org/browser/gutenberg/assets). **Any changes committed directly to the plugin repository on WordPress.org will be overwritten.**
 
-The contents of this directory are synced with the [`assets/` directory of the Gutenberg WordPress.org plugin repository](https://plugins.trac.wordpress.org/browser/gutenberg/assets). This is done by a [GitHub Actions workflow](https://github.com/WordPress/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) that is triggered whenever a file in this directory is changed.
+The sync is performed by a [GitHub Actions workflow](https://github.com/WordPress/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) that is triggered whenever a file in this directory is changed.
 
 Since that workflow requires access to WP.org plugin repository credentials, it needs to be approved manually by a member of the Gutenberg Core team. If you don't have the necessary permissions, please ask someone in [#core-editor](https://wordpress.slack.com/archives/C02QB2JS7).

--- a/assets/README.md
+++ b/assets/README.md
@@ -2,4 +2,4 @@
 
 The contents of this directory are synced to the [`assets/` directory of the Gutenberg plugin](https://plugins.trac.wordpress.org/browser/gutenberg/assets) in the WordPress.org plugin repository. This is done by a [GitHub Actions workflow](https://github.com/WordPress/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) that is triggered whenever a file in this directory is changed (with the exception of this README, which is excluded from the sync).
 
-Since that workflow requires access to WP.org plugin repository credentials, it needs to be approved manually by a member of the Gutenberg Core team. If you don't have the necessary permissions, please ask someone in #core-editor.
+Since that workflow requires access to WP.org plugin repository credentials, it needs to be approved manually by a member of the Gutenberg Core team. If you don't have the necessary permissions, please ask someone in [#core-editor](https://wordpress.slack.com/archives/C02QB2JS7).

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,5 +1,7 @@
 ## Gutenberg Plugin Assets
 
-The contents of this directory are synced to the [`assets/` directory of the Gutenberg plugin](https://plugins.trac.wordpress.org/browser/gutenberg/assets) in the WordPress.org plugin repository. This is done by a [GitHub Actions workflow](https://github.com/WordPress/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) that is triggered whenever a file in this directory is changed (with the exception of this README, which is excluded from the sync).
+This directory is managed via the [`assets/` directory in the Gutenberg repository on GitHub](https://github.com/WordPress/gutenberg/tree/trunk/assets). **Changes committed directly to the plugin repository on WordPress.org will be overwritten.**
+
+The contents of this directory are synced with the [`assets/` directory of the Gutenberg WordPress.org plugin repository](https://plugins.trac.wordpress.org/browser/gutenberg/assets). This is done by a [GitHub Actions workflow](https://github.com/WordPress/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) that is triggered whenever a file in this directory is changed.
 
 Since that workflow requires access to WP.org plugin repository credentials, it needs to be approved manually by a member of the Gutenberg Core team. If you don't have the necessary permissions, please ask someone in [#core-editor](https://wordpress.slack.com/archives/C02QB2JS7).

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,5 @@
+## Gutenberg Plugin Assets
+
+The contents of this directory are synced to the [`assets/` directory of the Gutenberg plugin](https://plugins.trac.wordpress.org/browser/gutenberg/assets) in the WordPress.org plugin repository. This is done by a [GitHub Actions workflow](https://github.com/WordPress/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) that is triggered whenever a file in this directory is changed (with the exception of this README, which is excluded from the sync).
+
+Since that workflow requires access to WP.org plugin repository credentials, it needs to be approved manually by a member of the Gutenberg Core team. If you don't have the necessary permissions, please ask someone in #core-editor.


### PR DESCRIPTION
## What?
Add a README.md to the `assets/` directory, to document how it is synced to the plugin repository.

Follow-up to https://github.com/WordPress/gutenberg/pull/68052. See https://github.com/WordPress/gutenberg/pull/68052#issuecomment-2553153336.

## Why?
It's not that obvious.

## How?
Add that README, plus the required provisions to exclude it from being synced to the plugin repo itself.

## Testing Instructions
I've pushed this branch to my personal fork's `trunk/`. The README is found [here](https://github.com/ockham/gutenberg/blob/d3422390d23cf88da5f933749f970609cfab9c61/assets/README.md); note that [the workflow indeed hasn't been triggered](https://github.com/ockham/gutenberg/actions/workflows/sync-assets-to-plugin-repo.yml) by it.