### PR TITLE
Updating Navigation descriptions

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -467,7 +467,7 @@ Content before this block will be shown in the excerpt on your archives page. ([
 
 ## Navigation
 
-A collection of blocks that allow visitors to get around your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation))
+A collection of blocks that help visitors navigate through your site. ([Source](https://github.com/WordPress/gutenberg/tree/trunk/packages/block-library/src/navigation))
 
 -	**Name:** core/navigation
 -	**Category:** theme

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -17,7 +17,7 @@
 		"core/loginout",
 		"core/buttons"
 	],
-	"description": "A collection of blocks that allow visitors to get around your site.",
+	"description": "A collection of blocks that help visitors navigate through your site.",
 	"keywords": [ "menu", "navigation", "links" ],
 	"textdomain": "default",
 	"attributes": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/58357

## Why?
Clarity for Navigation related descriptions in block and site editor section.

## How?
Updated descriptions in navigation block and site editor section.

## Testing Instructions

- Go to WP admin dashboard.
- Navigate to Appearance->Editor
- Click on Navigation, check the description.
- Open any page/post edit view.
- Add Navigation block and check & verify the block description.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![Screenshot (4)](https://github.com/user-attachments/assets/e9310f17-eec0-4d4f-8f93-c504fc3ac419)![Screenshot (5)](https://github.com/user-attachments/assets/15709ae6-8d35-4b9b-a987-c7ac70376669)|![Screenshot (6)](https://github.com/user-attachments/assets/ccef9732-0159-4089-ac71-81a2781fc614)![Screenshot (7)](https://github.com/user-attachments/assets/44b4e62d-6060-47fa-b0c0-d83e68852b9d)|
