### PR TITLE
Block Editor: Revert 'Warning' component autofocus

### DIFF
--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -13,11 +13,7 @@ import { moreVertical } from '@wordpress/icons';
 function Warning( { className, actions, children, secondaryActions } ) {
 	return (
 		<div style={ { display: 'contents', all: 'initial' } }>
-			<div
-				className={ clsx( className, 'block-editor-warning' ) }
-				tabIndex="0"
-				role="alert"
-			>
+			<div className={ clsx( className, 'block-editor-warning' ) }>
 				<div className="block-editor-warning__contents">
 					<p className="block-editor-warning__message">
 						{ children }

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -9,21 +9,13 @@ import clsx from 'clsx';
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
-import { useEffect, useRef } from '@wordpress/element';
 
 function Warning( { className, actions, children, secondaryActions } ) {
-	const alertRef = useRef();
-
-	useEffect( () => {
-		alertRef.current?.focus();
-	}, [] );
-
 	return (
 		<div style={ { display: 'contents', all: 'initial' } }>
 			<div
 				className={ clsx( className, 'block-editor-warning' ) }
 				tabIndex="0"
-				ref={ alertRef }
 				role="alert"
 			>
 				<div className="block-editor-warning__contents">

--- a/packages/block-editor/src/components/warning/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/warning/test/__snapshots__/index.js.snap
@@ -7,8 +7,6 @@ exports[`Warning should match snapshot 1`] = `
   >
     <div
       class="block-editor-warning"
-      role="alert"
-      tabindex="0"
     >
       <div
         class="block-editor-warning__contents"


### PR DESCRIPTION
## What?
Reverts `Warning` component autofocus logic introduced in #67433.

## Why?
See recent discussions in https://github.com/WordPress/gutenberg/pull/67433#issuecomment-2553175068.

## Testing Instructions
None. Confirm that changes are fully reverted.
