### PR TITLE
Revert "Replace remaining custom deep cloning with 'structuredClone'"

### DIFF
--- a/packages/block-editor/src/components/global-styles/use-global-styles-output.js
+++ b/packages/block-editor/src/components/global-styles/use-global-styles-output.js
@@ -624,7 +624,7 @@ function pickStyleKeys( treeToPickFrom ) {
 	// clone the style objects so that `getFeatureDeclarations` can remove consumed keys from it
 	const clonedEntries = pickedEntries.map( ( [ key, style ] ) => [
 		key,
-		structuredClone( style ),
+		JSON.parse( JSON.stringify( style ) ),
 	] );
 	return Object.fromEntries( clonedEntries );
 }

--- a/packages/block-editor/src/hooks/style.js
+++ b/packages/block-editor/src/hooks/style.js
@@ -245,7 +245,7 @@ export function omitStyle( style, paths, preserveReference = false ) {
 
 	let newStyle = style;
 	if ( ! preserveReference ) {
-		newStyle = structuredClone( style );
+		newStyle = JSON.parse( JSON.stringify( style ) );
 	}
 
 	if ( ! Array.isArray( paths ) ) {

--- a/test/unit/config/global-mocks.js
+++ b/test/unit/config/global-mocks.js
@@ -3,7 +3,6 @@
  */
 import { TextDecoder, TextEncoder } from 'node:util';
 import { Blob as BlobPolyfill, File as FilePolyfill } from 'node:buffer';
-import 'core-js/stable/structured-clone';
 
 jest.mock( '@wordpress/compose', () => {
 	return {
@@ -50,6 +49,3 @@ if ( ! global.TextEncoder ) {
 // Override jsdom built-ins with native node implementation.
 global.Blob = BlobPolyfill;
 global.File = FilePolyfill;
-
-// Polyfill structuredClone for jsdom.
-global.structuredClone = structuredClone;


### PR DESCRIPTION
## What?
Fixes #68046.
Reverts #67707.

The `structuredClone` API is not available in Hermes (https://github.com/facebook/hermes/issues/684). The Mobile App tests were disabled recently, so I missed this failure.

## Testing Instructions
None. CI checks should be green.
