### PR TITLE
Storybook: Add JustifyContentControl story

### DIFF
--- a/packages/block-editor/src/components/justify-content-control/stories/index.story.js
+++ b/packages/block-editor/src/components/justify-content-control/stories/index.story.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { JustifyContentControl, JustifyToolbar } from '../';
+
+const meta = {
+	title: 'BlockEditor/JustifyContentControl',
+	component: JustifyContentControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Control component for setting justify content alignment.',
+			},
+		},
+	},
+	argTypes: {
+		allowedControls: {
+			control: { type: null },
+			table: {
+				type: { summary: 'string[]' },
+				defaultValue: {
+					summary: "[ 'left', 'center', 'right', 'space-between' ]",
+				},
+			},
+			description: 'An array of strings for what controls to show.',
+		},
+		isCollapsed: {
+			control: { type: null },
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'true' },
+			},
+			description: 'Whether the control should be collapsed.',
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+			},
+			description: 'Function called when the alignment changes.',
+		},
+		value: {
+			control: { type: null },
+			table: {
+				type: { summary: 'string' },
+			},
+			description: 'Current value of the alignment setting.',
+		},
+		popoverProps: {
+			control: { type: null },
+			table: {
+				type: { summary: 'object' },
+			},
+			description: 'Props to pass to the popover component.',
+		},
+		isToolbar: {
+			control: { type: null },
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+			description: 'Whether to render as a toolbar control.',
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( 'left' );
+
+		return (
+			<JustifyContentControl
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				value={ value }
+			/>
+		);
+	},
+};
+
+export const Toolbar = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( 'left' );
+
+		return (
+			<JustifyToolbar
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				value={ value }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add stories for JustifyContentControl component in the Storybook.

## Testing Instructions
1. Run npm run storybook:dev
2. Open the storybook on http://localhost:50240/
3. Check the JustifyContentControl stories.

## Screenshots or screencast

![image](https://github.com/user-attachments/assets/7cdf1f92-c2c4-457a-94cd-3d69aa6b211b)


