### PR TITLE
Storybook: Adds story for block preview.

### DIFF
--- a/packages/block-editor/src/components/block-preview/stories/index.story.js
+++ b/packages/block-editor/src/components/block-preview/stories/index.story.js
@@ -1,0 +1,101 @@
+/**
+ * WordPress dependencies
+ */
+import { createBlock } from '@wordpress/blocks';
+import { registerCoreBlocks } from '@wordpress/block-library';
+
+/**
+ * Internal dependencies
+ */
+import BlockPreview from '../index';
+
+// Register core blocks to be used in the preview.
+registerCoreBlocks();
+
+// Sample blocks for the story.
+const sampleBlocks = [
+	createBlock( 'core/heading', {
+		content: 'This is a heading block.',
+		level: 2,
+	} ),
+	createBlock( 'core/paragraph', { content: 'This is a paragraph block.' } ),
+];
+
+const meta = {
+	title: 'BlockEditor/BlockPreview',
+	component: BlockPreview,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `BlockPreview` component renders a preview of blocks in an isolated editor environment.',
+			},
+		},
+	},
+	argTypes: {
+		blocks: {
+			description: 'Block instance(s) to render in the preview.',
+			control: 'object',
+			table: {
+				type: {
+					summary: 'Array|Object',
+				},
+			},
+		},
+		viewportWidth: {
+			description: 'Width of the preview container in pixels.',
+			control: 'number',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+			defaultValue: 1200,
+		},
+		minHeight: {
+			description: 'Minimum height of the preview iframe in pixels.',
+			control: 'number',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		additionalStyles: {
+			description:
+				'Additional styles to apply to the preview iframe as an array of CSS rules.',
+			control: 'object',
+			table: {
+				type: {
+					summary: 'Array',
+				},
+			},
+			defaultValue: [],
+		},
+	},
+};
+export default meta;
+
+export const Default = {
+	render: function Template( args ) {
+		return <BlockPreview { ...args } />;
+	},
+	args: {
+		blocks: sampleBlocks,
+		viewportWidth: 1200,
+		minHeight: 100,
+		additionalStyles: [],
+	},
+};
+
+export const CustomStyles = {
+	render: function Template( args ) {
+		return <BlockPreview { ...args } />;
+	},
+	args: {
+		blocks: sampleBlocks,
+		viewportWidth: 1200,
+		minHeight: 100,
+		additionalStyles: [ { css: `body { color: #ff0000; }` } ],
+	},
+};

--- a/packages/block-editor/src/components/block-preview/stories/index.story.js
+++ b/packages/block-editor/src/components/block-preview/stories/index.story.js
@@ -7,7 +7,8 @@ import { registerCoreBlocks } from '@wordpress/block-library';
 /**
  * Internal dependencies
  */
-import BlockPreview from '../index';
+import BlockPreview from '..';
+import { BlockEditorProvider } from '../../provider';
 
 // Register core blocks to be used in the preview.
 registerCoreBlocks();
@@ -63,7 +64,7 @@ const meta = {
 		},
 		additionalStyles: {
 			description:
-				'Additional styles to apply to the preview iframe as an array of CSS rules.',
+				'Additional styles to apply to the preview iframe as an array of CSS rules. Each object should contain a `css` attribute.',
 			control: 'object',
 			table: {
 				type: {
@@ -78,7 +79,11 @@ export default meta;
 
 export const Default = {
 	render: function Template( args ) {
-		return <BlockPreview { ...args } />;
+		return (
+			<BlockEditorProvider settings={ { styles: [] } }>
+				<BlockPreview { ...args } />
+			</BlockEditorProvider>
+		);
 	},
 	args: {
 		blocks: sampleBlocks,
@@ -90,12 +95,16 @@ export const Default = {
 
 export const CustomStyles = {
 	render: function Template( args ) {
-		return <BlockPreview { ...args } />;
+		return (
+			<BlockEditorProvider settings={ { styles: [] } }>
+				<BlockPreview { ...args } />
+			</BlockEditorProvider>
+		);
 	},
 	args: {
 		blocks: sampleBlocks,
 		viewportWidth: 1200,
 		minHeight: 100,
-		additionalStyles: [ { css: `body { color: #ff0000; }` } ],
+		additionalStyles: [ { css: `p { color: #ff0000; }` } ],
 	},
 };


### PR DESCRIPTION
## What?
This PR adds story for `block-preview` component.

## Why?
Part of: #67165

## Testing Instructions

1. Start Storybook by running npm run storybook:dev
2. Open Storybook at http://localhost:50240/
3. Test the story for `BlockPreview`


## Screenshots or screencast 
![image](https://github.com/user-attachments/assets/41d659b4-ea16-4810-9f86-d5d8eb2c7987)



