### PR TITLE
Fix(embed-block): Only call `setAttributes()` when attrs change

### DIFF
--- a/packages/block-library/src/embed/edit.js
+++ b/packages/block-library/src/embed/edit.js
@@ -172,7 +172,13 @@ const EmbedEdit = ( props ) => {
 			// When obtaining an incoming preview,
 			// we set the attributes derived from the preview data.
 			const mergedAttributes = getMergedAttributes();
-			setAttributes( mergedAttributes );
+			const hasChanges = Object.keys( mergedAttributes ).some(
+				( key ) => mergedAttributes[ key ] !== attributes[ key ]
+			);
+
+			if ( hasChanges ) {
+				setAttributes( mergedAttributes );
+			}
 
 			if ( onReplace ) {
 				const upgradedBlock = createUpgradedEmbedBlock(


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/61778.

Prevents `setAttributes()` from being called whenever the block remounts and no attributes have changed.

## Why?
Due to the way `setAttributes()` [currently works](https://github.com/WordPress/gutenberg/blob/9034196c71bab20b1cc38035f40f6404fc6dfc71/packages/block-editor/src/components/block-list/block.js#L265) and how the [embed block calls setAttributes()](https://github.com/WordPress/gutenberg/blob/c01cb99445c2261d2af1238b59104334fae91714/packages/block-library/src/embed/edit.js#L175) with a new shallow copy of attributes whenever the block is remounted, the following steps result in an ugly bug:

1. Select multiple blocks that include either multiple embed blocks, or an embed block alongside an image block.
2. And then drag these blocks to a location where they get remounted, such as dragging them inside a group block or outside their parent block.

This causes the full set of attributes from the last embed block selected to be set to all the other dragged embed + image blocks, changing them all into duplicate blocks of the last embed block.

The problem is due to a combination of:

1. `setAttributes()` updates all passed attributes to all selected blocks, this was intended for mass block option editing. However, this is not always the desired behaviour.
2. Whenever the embed block is remounted, it calls `setAttributes()` using a new shallow copy of the full set of attributes.

## How?
The current `setAttributes()` implementation has desired and undesired effects, and needs to be expanded upon to address the undesired effects. That could indirectly fix this embed block remounting situation.

However, the embed block should not be trying to update its attributes upon every block remount.

This PR Prevents the embed block from calling `setAttributes()` when no attributes have been changed.

## Testing Instructions
1. Open a post or page.
2. Add an embed block and and image block.
4. Add a separate group block.
5. Select the embed and image blocks, and drag them inside the group block.

Without this PR, the image block would get turned into an embed block as its attributes are changed to be the same as the embed block attributes. Causing the image block to fail and then automatically gets converted into an embed block. 