### PR TITLE
Fix: Some 403 errors for editor roles.

### DIFF
--- a/packages/editor/src/components/post-actions/set-as-homepage.js
+++ b/packages/editor/src/components/post-actions/set-as-homepage.js
@@ -122,8 +122,13 @@ const SetAsHomepageModal = ( { items, closeModal } ) => {
 
 export const useSetAsHomepageAction = () => {
 	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
-		const siteSettings = getEntityRecord( 'root', 'site' );
+		const { getEntityRecord, canUser } = select( coreStore );
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
 		return {
 			pageOnFront: siteSettings?.page_on_front,
 			pageForPosts: siteSettings?.page_for_posts,

--- a/packages/editor/src/components/post-actions/set-as-posts-page.js
+++ b/packages/editor/src/components/post-actions/set-as-posts-page.js
@@ -118,8 +118,14 @@ const SetAsPostsPageModal = ( { items, closeModal } ) => {
 
 export const useSetAsPostsPageAction = () => {
 	const { pageOnFront, pageForPosts } = useSelect( ( select ) => {
-		const { getEntityRecord } = select( coreStore );
-		const siteSettings = getEntityRecord( 'root', 'site' );
+		const { getEntityRecord, canUser } = select( coreStore );
+		const siteSettings = canUser( 'read', {
+			kind: 'root',
+			name: 'site',
+		} )
+			? getEntityRecord( 'root', 'site' )
+			: undefined;
+
 		return {
 			pageOnFront: siteSettings?.page_on_front,
 			pageForPosts: siteSettings?.page_for_posts,


### PR DESCRIPTION
This PR fixes some 403 network errors for users with editor roles caused by the set as homepage and set as blog page actions.
cc: @Mamaduka 

## Testing Instructions
With a user with ean ditor role, create a new page and verify the number of 403 errors is lower when compared with trunk.
There is still a 403 error which will be fixed at https://github.com/WordPress/gutenberg/pull/68110/files.
