### PR TITLE
Update active menu item appearance

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-item/style.scss
+++ b/packages/edit-site/src/components/sidebar-navigation-item/style.scss
@@ -18,6 +18,7 @@
 	&[aria-current="true"] {
 		background: $gray-800;
 		color: $white;
+		font-weight: $font-weight-medium;
 	}
 
 	// Make sure the focus style is drawn on top of the current item background.


### PR DESCRIPTION
## What?
Update the active menu item appearance in all data views, based on https://github.com/WordPress/gutenberg/pull/67318.

## Why?
https://github.com/WordPress/gutenberg/pull/67318 updated the appearance of active menu items. Changes included updating the background color and the font-weight. While the background color was successfully applied across, it appears the font-weight change was missed in the Template and Pattern management views on account of them using a slightly different component.

## Testing Instructions
1. Open the site editor
2. Check that the active menu items are consistent across all pages

|Before|After|
|-|-|
| <img width="297" alt="Screenshot 2024-12-19 at 14 59 22" src="https://github.com/user-attachments/assets/1ff926ee-99c9-4f83-ab4e-e4cfe507667b" /> | <img width="298" alt="Screenshot 2024-12-19 at 14 59 11" src="https://github.com/user-attachments/assets/e99af6e8-8d78-4be3-b6f3-f7acbda17e35" /> |
