### PR TITLE
Storybook: Make prop sort order consistent

### DIFF
--- a/storybook/preview.js
+++ b/storybook/preview.js
@@ -108,6 +108,9 @@ export const parameters = {
 		sort: 'requiredFirst',
 	},
 	docs: {
+		controls: {
+			sort: 'requiredFirst',
+		},
 		// Flips the order of the description and the primary component story
 		// so the component is always visible before the fold.
 		page: () => (


### PR DESCRIPTION
Discovered in #68099

## What?

Ensures consistent sorting order of the props tables in Storybook docs view and story view.

## Why?

The sorting order of the props table in Docs view and Story view can be different.

For example, see in `DropdownMenu`:

- The main props table in [Docs view](https://wordpress.github.io/gutenberg/?path=/docs/components-dropdownmenu--docs)
- The Controls panel in [Story view](https://wordpress.github.io/gutenberg/?path=/story/components-dropdownmenu--default)

## How?

There is actually a separate config for the Docs view 😳

## Testing Instructions

See Storybook docs and story views for a component like DropdownMenu.
