### PR TITLE
Inserter: Use 40px default size for toggle button

### DIFF
--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -78,6 +78,7 @@
 		color: $white;
 		padding: 0;
 
+		// TODO: Consider passing size="small" to the Inserter toggle instead.
 		// Special dimensions for this button.
 		min-width: $button-size-small;
 		height: $button-size-small;

--- a/packages/block-editor/src/components/default-block-appender/content.scss
+++ b/packages/block-editor/src/components/default-block-appender/content.scss
@@ -42,6 +42,7 @@
 		color: $white;
 		padding: 0;
 
+		// TODO: Consider passing size="small" to the Inserter toggle instead.
 		// Special dimensions for this button.
 		min-width: $button-size-small;
 		height: $button-size-small;

--- a/packages/block-editor/src/components/inserter/index.js
+++ b/packages/block-editor/src/components/inserter/index.js
@@ -60,6 +60,7 @@ const defaultRenderToggle = ( {
 
 	return (
 		<Wrapper
+			__next40pxDefaultSize={ toggleProps.as ? undefined : true }
 			icon={ plus }
 			label={ label }
 			tooltipPosition="bottom"


### PR DESCRIPTION
In preparation for #65751

## What?

Ensures/verifies that the `Inserter` toggle buttons won't break when the default Button size becomes 40px. 

## Testing Instructions

Smoke test some Inserter usages in the app. There should be no visual changes.

## Screenshots or screencast <!-- if applicable -->

The black plus button is the Inserter toggle button.

<img width="416" alt="Button block Inserter" src="https://github.com/user-attachments/assets/6f55f5df-8473-4fc1-a31b-80deca73a969" />

<img width="417" alt="Block Inserter" src="https://github.com/user-attachments/assets/82e1eb89-4f1e-4ce1-b703-ade735e678af" />

<img width="553" alt="Inserter in Cover block" src="https://github.com/user-attachments/assets/d50b798a-8cf4-4755-8557-9103c3018354" />
