### PR TITLE
Navigation: Upsize back buttons

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 -   `BoxControl`: Add presets support ([#67688](https://github.com/WordPress/gutenberg/pull/67688)).
+-   `Navigation`: Upsize back buttons ([#68157](https://github.com/WordPress/gutenberg/pull/68157)).
 
 ### Deprecations
 

--- a/packages/components/src/navigation/back-button/index.tsx
+++ b/packages/components/src/navigation/back-button/index.tsx
@@ -49,6 +49,7 @@ function UnforwardedNavigationBackButton(
 	const icon = isRTL() ? chevronRight : chevronLeft;
 	return (
 		<MenuBackButtonUI
+			__next40pxDefaultSize
 			className={ classes }
 			href={ href }
 			variant="tertiary"

--- a/packages/components/src/navigation/item/index.tsx
+++ b/packages/components/src/navigation/item/index.tsx
@@ -79,6 +79,8 @@ export function NavigationItem( props: NavigationItemProps ) {
 		? restProps
 		: {
 				as: Button,
+				__next40pxDefaultSize:
+					'as' in restProps ? restProps.as === undefined : true,
 				href,
 				onClick: onItemClick,
 				'aria-current': isActive ? 'page' : undefined,


### PR DESCRIPTION
In preparation for #65751

## What?

Upsizes the back buttons (`NavigationBackButton`) of `Navigation`.

## Why?

So it's consistent with the new default Button sizes, and won't log deprecation warnings when we start logging them for Button.

## Testing Instructions

See Storybook for Navigation.
