### PR TITLE
Navigation: Prepare for hard deprecation

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -13,6 +13,7 @@
 -   `InputControl`: Deprecate 36px default size ([#66897](https://github.com/WordPress/gutenberg/pull/66897)).
 -   `RadioGroup`: Log deprecation warning ([#68067](https://github.com/WordPress/gutenberg/pull/68067)).
 -   Soft deprecate `ButtonGroup` component. Use `ToggleGroupControl` instead ([#65429](https://github.com/WordPress/gutenberg/pull/65429)).
+-   `Navigation`: Log deprecation warning for removal in WP 7.1. Use `Navigator` instead ([#68158](https://github.com/WordPress/gutenberg/pull/68158)).
 
 ### Bug Fixes
 

--- a/packages/components/src/navigation/index.tsx
+++ b/packages/components/src/navigation/index.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 /**
  * WordPress dependencies
  */
+import deprecated from '@wordpress/deprecated';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { isRTL } from '@wordpress/i18n';
 
@@ -78,6 +79,12 @@ export function Navigation( {
 	const [ slideOrigin, setSlideOrigin ] = useState< 'left' | 'right' >();
 	const navigationTree = useCreateNavigationTree();
 	const defaultSlideOrigin = isRTL() ? 'right' : 'left';
+
+	deprecated( 'wp.components.Navigation (and all subcomponents)', {
+		since: '6.8',
+		version: '7.1',
+		alternative: 'wp.components.Navigator',
+	} );
 
 	const setActiveMenu: NavigationContextType[ 'setActiveMenu' ] = (
 		menuId,

--- a/packages/components/src/navigation/test/index.tsx
+++ b/packages/components/src/navigation/test/index.tsx
@@ -176,6 +176,10 @@ describe( 'Navigation', () => {
 
 		const menuItems = screen.getAllByRole( 'listitem' );
 
+		expect( console ).toHaveWarnedWith(
+			'wp.components.Navigation (and all subcomponents) is deprecated since version 6.8 and will be removed in version 7.1. Please use wp.components.Navigator instead.'
+		);
+
 		expect( menuItems ).toHaveLength( 4 );
 		expect( menuItems[ 0 ] ).toHaveTextContent( 'Item 1' );
 		expect( menuItems[ 1 ] ).toHaveTextContent( 'Item 2' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Starts logging a deprecation warning for `Navigation`, with an explicit end version.

## Why?

After passive deprecating (#61099) this component, we have had to do maintenance work on it many times. Given the [low usage](https://wpdirectory.net/search/01JFGKB7PQQNK63ATYAQS7SNFQ), I think it would be beneficial to eventually hard remove this code from the codebase.

## Testing Instructions

✅ Deprecation warning should be logged in the Storybook.
✅ Unit tests should pass.

## ✍️ Dev Note

The `Navigation` component (and all its subcomponents) are deprecated, planned for hard removal in WordPress 7.1. Use the [`Navigator`](https://wordpress.github.io/gutenberg/?path=/docs/components-radiocontrol--docs) component instead.