### PR TITLE
Fix uploading background images in stylebook view.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51237,6 +51237,7 @@
 				"@wordpress/icons": "*",
 				"@wordpress/keyboard-shortcuts": "*",
 				"@wordpress/keycodes": "*",
+				"@wordpress/media-utils": "5.14.0",
 				"@wordpress/notices": "*",
 				"@wordpress/patterns": "*",
 				"@wordpress/plugins": "*",

--- a/packages/edit-site/package.json
+++ b/packages/edit-site/package.json
@@ -56,6 +56,7 @@
 		"@wordpress/icons": "*",
 		"@wordpress/keyboard-shortcuts": "*",
 		"@wordpress/keycodes": "*",
+		"@wordpress/media-utils": "5.14.0",
 		"@wordpress/notices": "*",
 		"@wordpress/patterns": "*",
 		"@wordpress/plugins": "*",

--- a/packages/edit-site/src/components/style-book/index.js
+++ b/packages/edit-site/src/components/style-book/index.js
@@ -35,6 +35,8 @@ import {
 	useEffect,
 } from '@wordpress/element';
 import { ENTER, SPACE } from '@wordpress/keycodes';
+import { uploadMedia } from '@wordpress/media-utils';
+import { store as coreStore } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
@@ -361,10 +363,22 @@ export const StyleBookPreview = ( { userConfig = {}, isStatic = false } ) => {
 		[]
 	);
 
+	const canUserUploadMedia = useSelect(
+		( select ) =>
+			select( coreStore ).canUser( 'create', {
+				kind: 'root',
+				name: 'media',
+			} ),
+		[]
+	);
+
 	// Update block editor settings because useMultipleOriginColorsAndGradients fetch colours from there.
 	useEffect( () => {
-		dispatch( blockEditorStore ).updateSettings( siteEditorSettings );
-	}, [ siteEditorSettings ] );
+		dispatch( blockEditorStore ).updateSettings( {
+			...siteEditorSettings,
+			mediaUpload: canUserUploadMedia ? uploadMedia : undefined,
+		} );
+	}, [ siteEditorSettings, canUserUploadMedia ] );
 
 	const [ section, onChangeSection ] = useSection();
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fixes [this issue](https://github.com/WordPress/gutenberg/pull/67811#issuecomment-2552831827).

Because there's no editor rendered in the style book view, the block editor settings aren't updated with the media upload function, even if user has the required permissions.

As a side note, and something to potentially address as a follow up, should we really require upload permissions to access the media library? As it stands without upload the whole dropdown is inaccessible:

<img width="347" alt="Screenshot 2024-12-20 at 12 15 52 pm" src="https://github.com/user-attachments/assets/eee4e3bc-ac7c-44b8-82b1-64302b379ea6" />

I'm guessing that if you have access to the site editor you probably also have upload permissions, but maybe worth thinking about.


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

1. With a block theme enabled, open the "Styles" section in the site editor.
2. Click on "Style book" to switch to the style book view and reload the page.
3. Navigate to the "Background" section and click on "Add background image".
4. Dropdown should open as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
