### PR TITLE
Fix: Inserter category tabs: avoid unnecessary aria-label

### DIFF
--- a/packages/block-editor/src/components/inserter/category-tabs/index.js
+++ b/packages/block-editor/src/components/inserter/category-tabs/index.js
@@ -64,7 +64,6 @@ function CategoryTabs( {
 					<Tabs.Tab
 						key={ category.name }
 						tabId={ category.name }
-						aria-label={ category.label }
 						aria-current={
 							category === selectedCategory ? 'true' : undefined
 						}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR removes the unnecessary aria-label which is part of <Tabs.Tab> component 

## Why?
Fixes https://github.com/WordPress/gutenberg/issues/68138

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
`aria-label={ category.label }` is now not part of <Tabs.Tab> to avoid confusion to screen readers as we already have content present inside <Tabs.Tab>
