### PR TITLE
Try: add content flag to blocks with no content attributes

### DIFF
--- a/packages/block-editor/src/store/selectors.js
+++ b/packages/block-editor/src/store/selectors.js
@@ -9,6 +9,7 @@ import {
 	getPossibleBlockTransformations,
 	switchToBlockType,
 	store as blocksStore,
+	privateApis,
 } from '@wordpress/blocks';
 import { Platform } from '@wordpress/element';
 import { applyFilters } from '@wordpress/hooks';
@@ -59,6 +60,7 @@ import {
 const MILLISECONDS_PER_HOUR = 3600 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 3600 * 1000;
 const MILLISECONDS_PER_WEEK = 7 * 24 * 3600 * 1000;
+const { blockMetadataDisplayKey } = unlock( privateApis );
 
 /**
  * Shared reference to an empty array for cases where it is important to avoid
@@ -1668,6 +1670,14 @@ const canInsertBlockTypeUnmemoized = (
 		blockName = blockType.name;
 	} else {
 		blockType = getBlockType( blockName );
+	}
+
+	/*
+	 * Properties of certain blocks such as the Query block should be editable and insertable in write mode.
+	 * These blocks, however, don't always have attributes with content roles.
+	 */
+	if ( blockType.supports?.[ blockMetadataDisplayKey ]?.role === 'content' ) {
+		return true;
 	}
 
 	const isLocked = !! getTemplateLock( state, rootClientId );

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -77,7 +77,10 @@ export default function addDisplayKeyToBlockMetadata(
 	}
 	return {
 		...blockSettings,
-		[ blockMetadataDisplayKey ]: { role: 'content' },
+		supports: {
+			...blockSettings.supports,
+			[ blockMetadataDisplayKey ]: { role: 'content' },
+		},
 	};
 }
 

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { loop as icon } from '@wordpress/icons';
+import { privateApis } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -12,6 +14,7 @@ import edit from './edit';
 import save from './save';
 import variations from './variations';
 import deprecated from './deprecated';
+import { unlock } from '../lock-unlock';
 
 const { name } = metadata;
 export { metadata, name };
@@ -64,4 +67,30 @@ export const settings = {
 	deprecated,
 };
 
-export const init = () => initBlock( { name, metadata, settings } );
+const { blockMetadataDisplayKey } = unlock( privateApis );
+export default function addDisplayKeyToBlockMetadata(
+	blockSettings,
+	blockName
+) {
+	if ( blockName !== 'core/query' ) {
+		return blockSettings;
+	}
+	return {
+		...blockSettings,
+		donkey: true,
+		[ blockMetadataDisplayKey ]: { role: 'content' },
+	};
+}
+
+export const init = () => {
+	addFilter(
+		'blocks.registerBlockType',
+		'core/query',
+		addDisplayKeyToBlockMetadata
+	);
+	return initBlock( {
+		name,
+		metadata,
+		settings,
+	} );
+};

--- a/packages/block-library/src/query/index.js
+++ b/packages/block-library/src/query/index.js
@@ -77,7 +77,6 @@ export default function addDisplayKeyToBlockMetadata(
 	}
 	return {
 		...blockSettings,
-		donkey: true,
 		[ blockMetadataDisplayKey ]: { role: 'content' },
 	};
 }

--- a/packages/blocks/src/api/index.js
+++ b/packages/blocks/src/api/index.js
@@ -3,6 +3,7 @@
  */
 import { lock } from '../lock-unlock';
 import { isContentBlock } from './utils';
+import { blockMetadataDisplayKey } from './private-keys';
 
 // The blocktype is the most important concept within the block API. It defines
 // all aspects of the block configuration and its interfaces, including `edit`
@@ -176,5 +177,6 @@ export {
 	__EXPERIMENTAL_PATHS_WITH_OVERRIDE,
 } from './constants';
 
+// Private APIs.
 export const privateApis = {};
-lock( privateApis, { isContentBlock } );
+lock( privateApis, { isContentBlock, blockMetadataDisplayKey } );

--- a/packages/blocks/src/api/private-keys.js
+++ b/packages/blocks/src/api/private-keys.js
@@ -1,0 +1,1 @@
+export const blockMetadataDisplayKey = Symbol( 'blockMetadataDisplay' );

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -11,6 +11,7 @@ import warning from '@wordpress/warning';
 import i18nBlockSchema from './i18n-block.json';
 import { store as blocksStore } from '../store';
 import { unlock } from '../lock-unlock';
+import { blockMetadataDisplayKey } from './private-keys';
 
 /**
  * An icon type definition. One of a Dashicon slug, an element,
@@ -172,12 +173,15 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
 		'variations',
 		'blockHooks',
 		'allowedBlocks',
+		blockMetadataDisplayKey,
 	];
 
 	const settings = Object.fromEntries(
-		Object.entries( metadata ).filter( ( [ key ] ) =>
-			allowedFields.includes( key )
-		)
+		Reflect.ownKeys( metadata )
+			.map( ( key ) => [ key, metadata[ key ] ] )
+			.filter( ( [ key ] ) =>
+				allowedFields.some( ( field ) => field === key )
+			)
 	);
 
 	if ( textdomain ) {

--- a/packages/blocks/src/api/registration.js
+++ b/packages/blocks/src/api/registration.js
@@ -177,11 +177,9 @@ function getBlockSettingsFromMetadata( { textdomain, ...metadata } ) {
 	];
 
 	const settings = Object.fromEntries(
-		Reflect.ownKeys( metadata )
-			.map( ( key ) => [ key, metadata[ key ] ] )
-			.filter( ( [ key ] ) =>
-				allowedFields.some( ( field ) => field === key )
-			)
+		Object.entries( metadata ).filter( ( [ key ] ) =>
+			allowedFields.includes( key )
+		)
 	);
 
 	if ( textdomain ) {

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -374,7 +374,7 @@ export const __experimentalGetBlockAttributesNamesByRole = ( ...args ) => {
 export function isContentBlock( name ) {
 	const blockType = getBlockType( name );
 
-	if ( blockType?.[ blockMetadataDisplayKey ]?.role === 'content' ) {
+	if ( blockType.supports?.[ blockMetadataDisplayKey ]?.role === 'content' ) {
 		return true;
 	}
 

--- a/packages/blocks/src/api/utils.js
+++ b/packages/blocks/src/api/utils.js
@@ -19,6 +19,7 @@ import deprecated from '@wordpress/deprecated';
  */
 import { BLOCK_ICON_DEFAULT } from './constants';
 import { getBlockType, getDefaultBlockName } from './registration';
+import { blockMetadataDisplayKey } from './private-keys';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
@@ -371,7 +372,13 @@ export const __experimentalGetBlockAttributesNamesByRole = ( ...args ) => {
 };
 
 export function isContentBlock( name ) {
-	const attributes = getBlockType( name )?.attributes;
+	const blockType = getBlockType( name );
+
+	if ( blockType?.[ blockMetadataDisplayKey ]?.role === 'content' ) {
+		return true;
+	}
+
+	const attributes = blockType?.attributes;
 
 	return !! Object.keys( attributes )?.some( ( attributeKey ) => {
 		const attribute = attributes[ attributeKey ];

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -95,14 +95,17 @@ function bootstrappedBlockTypes( state = {}, action ) {
 				}
 			} else {
 				newDefinition = Object.fromEntries(
-					Object.entries( blockType )
+					Reflect.ownKeys( blockType )
 						.filter(
-							( [ , value ] ) =>
-								value !== null && value !== undefined
+							( key ) =>
+								blockType[ key ] !== null &&
+								blockType[ key ] !== undefined
 						)
-						.map( ( [ key, value ] ) => [
-							camelCase( key ),
-							value,
+						.map( ( key ) => [
+							typeof key === 'symbol'
+								? key
+								: camelCase( key.toString() ),
+							blockType[ key ],
 						] )
 				);
 				newDefinition.name = name;

--- a/packages/blocks/src/store/reducer.js
+++ b/packages/blocks/src/store/reducer.js
@@ -95,17 +95,14 @@ function bootstrappedBlockTypes( state = {}, action ) {
 				}
 			} else {
 				newDefinition = Object.fromEntries(
-					Reflect.ownKeys( blockType )
+					Object.entries( blockType )
 						.filter(
-							( key ) =>
-								blockType[ key ] !== null &&
-								blockType[ key ] !== undefined
+							( [ , value ] ) =>
+								value !== null && value !== undefined
 						)
-						.map( ( key ) => [
-							typeof key === 'symbol'
-								? key
-								: camelCase( key.toString() ),
-							blockType[ key ],
+						.map( ( [ key, value ] ) => [
+							camelCase( key ),
+							value,
 						] )
 				);
 				newDefinition.name = name;


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This is an experiment only. Do not commit. It's for discussion and exploration only.

Testing a private block setting to flag to the block editor environment that the block should be treated, and display, as a content block for the purposes of write mode.

## Why?
Properties of certain blocks such as the Query block should be editable in write mode. These blocks, however, don't always have attributes with content roles.

A content flag ensures these blocks will always be treated as containing "content" despite their attributes.


https://github.com/user-attachments/assets/a15c6a5f-1c02-4b26-a3f1-55c545429e26



## How?

Via the `blocks.registerBlockType` filter, adding a private Symbol to a block settings.

The side-effect is that iterating over these settings during registration and in the reducer needs to ensure Symbols are not filtered out.


## Testing Instructions

I've conducted very limited testing.

I created a template with two Query blocks: one at the root level, and another nested in a Group block.

When switching to Write mode, the Query blocks should selectable and feature in the list view.


