### PR TITLE
Fix: DataForm: datetime field update not reflected immediately in render component 

### DIFF
--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -137,6 +137,18 @@ export function TimePicker( {
 		onChange?.( format( newDate, TIMEZONELESS_FORMAT ) );
 	};
 
+	const handleInputChange = (
+		event: React.FormEvent< HTMLInputElement >,
+		method: 'date' | 'year'
+	) => {
+		const newValue = ( event as React.ChangeEvent< HTMLInputElement > )
+			.target.value;
+		const changeCallback = buildNumberControlChangeCallback(
+			method === 'year' ? 'year' : 'date'
+		);
+		changeCallback( newValue, { event } );
+	};
+
 	const dayField = (
 		<DayInput
 			key="day"
@@ -154,6 +166,7 @@ export function TimePicker( {
 			isDragEnabled={ false }
 			isShiftStepEnabled={ false }
 			onChange={ buildNumberControlChangeCallback( 'date' ) }
+			onInput={ ( e ) => handleInputChange( e, 'date' ) }
 		/>
 	);
 
@@ -194,6 +207,7 @@ export function TimePicker( {
 			isShiftStepEnabled={ false }
 			onChange={ buildNumberControlChangeCallback( 'year' ) }
 			__unstableStateReducer={ buildPadInputStateReducer( 4 ) }
+			onInput={ ( e ) => handleInputChange( e, 'year' ) }
 		/>
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR fixes `datetime` field update not reflected immediately in render component when working with input 

## Why?
Issue Reported:
- https://github.com/WordPress/gutenberg/issues/68148

## How?

This PR adds a new function `handleInputChange` which handles the input changes and calls  `buildNumberControlChangeCallback()` with year or date depending on the input field

## Testing Instructions

- Ensure that add Quick Edit experiment is enabled
- Visit wp-admin/site-editor.php?p=%2Fpage&layout=table&quickEdit=true
- Select a page
- Edit the date.
- Change the day via character keys.
- See that the preview isn't updated.
- Change the day via navigation keys.
- See that the preview is updated.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a2d3a5a6-94c4-4c9f-91e8-5bc234da7011


