### PR TITLE
DataViews: Don't render actions dropdown when all eligible ones are `primary`

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -145,13 +145,6 @@ export function ActionsMenuGroup< Item >( {
 	);
 }
 
-function hasOnlyOneActionAndIsPrimary< Item >(
-	primaryActions: Action< Item >[],
-	actions: Action< Item >[]
-) {
-	return primaryActions.length === 1 && actions.length === 1;
-}
-
 export default function ItemActions< Item >( {
 	item,
 	actions,
@@ -184,7 +177,8 @@ export default function ItemActions< Item >( {
 		);
 	}
 
-	if ( hasOnlyOneActionAndIsPrimary( primaryActions, actions ) ) {
+	// If all actions are primary, there is no need to render the dropdown.
+	if ( primaryActions.length === eligibleActions.length ) {
 		return (
 			<PrimaryActions
 				item={ item }


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Related: https://github.com/WordPress/gutenberg/issues/66811 and https://github.com/WordPress/gutenberg/pull/67020

There can be cases where the eligible actions are all primary ones. In that case there is no need to render the dropdown with the actions as it will only contain the primary ones. This is used in `table` layout for now.

## Testing Instructions
1. In storybook or a component that uses DataViews pass two primary actions only and choose the `table` layout.
2. The dropdown should not be rendered.
3. Everything else should work as before.
