### PR TITLE
Remove isPressEnterToChange from TimePicker

### DIFF
--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -188,7 +188,6 @@ export function TimePicker( {
 			max={ 9999 }
 			required
 			spinControls="none"
-			isPressEnterToChange
 			isDragEnabled={ false }
 			isShiftStepEnabled={ false }
 			onChange={ buildNumberControlChangeCallback( 'year' ) }

--- a/packages/components/src/date-time/time/index.tsx
+++ b/packages/components/src/date-time/time/index.tsx
@@ -150,7 +150,6 @@ export function TimePicker( {
 			max={ 31 }
 			required
 			spinControls="none"
-			isPressEnterToChange
 			isDragEnabled={ false }
 			isShiftStepEnabled={ false }
 			onChange={ buildNumberControlChangeCallback( 'date' ) }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR removes the isPressEnterToChange from Day and Year component of TimePicker
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As in the #68148 issue the datetime is only getting updated when we change via navigation buttons or by clicking outside of the input of day and year.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
By removing isPressEnterToChange property from DayInput and YearInput component.


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/38f84789-4598-40a7-be8b-6460cfc5f2c5




<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Issue URL - https://github.com/WordPress/gutenberg/issues/68148