### PR TITLE
Storybook: Add Story for FontSizePicker

### DIFF
--- a/packages/block-editor/src/components/font-sizes/stories/index.story.js
+++ b/packages/block-editor/src/components/font-sizes/stories/index.story.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import FontSizePicker from '../font-size-picker.js';
+
+const meta = {
+	title: 'BlockEditor/FontSizePicker',
+	component: FontSizePicker,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders a user interface that allows the user to select predefined (common) font sizes.',
+			},
+		},
+	},
+	argTypes: {
+		fallbackFontSize: {
+			control: { type: null },
+			description:
+				'Starting position for the font size picker slider, if active.',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			table: {
+				type: { summary: 'function' },
+			},
+			description: 'Function executed when the font size changes.',
+		},
+		value: {
+			control: { type: 'number' },
+			description: 'The current font size value.',
+			table: {
+				type: {
+					summary: 'number',
+				},
+			},
+		},
+		withSlider: {
+			control: { type: null },
+			description:
+				'To control the UI to contain a slider or a numeric text input field.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
+
+		return (
+			<FontSizePicker
+				{ ...args }
+				value={ value }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/67165 

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR will add story for `font-sizes` component in the Storybook.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run npm run storybook:dev
2. Open the storybook on [localhost](http://localhost:50240/)
3. Check the `FontSizePicker` story.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1440" alt="Screenshot 2024-12-20 at 2 51 55 PM" src="https://github.com/user-attachments/assets/767ebcd9-4084-4fd0-b1a0-85a824ca335d" />


