### PR TITLE
Stylebook: add the Appearance -> Design submenu through `admin_menu` action

### DIFF
--- a/backport-changelog/6.8/7865.md
+++ b/backport-changelog/6.8/7865.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/7865
 
 * https://github.com/WordPress/gutenberg/pull/66851
+* https://github.com/WordPress/gutenberg/pull/68174

--- a/lib/compat/wordpress-6.8/site-editor.php
+++ b/lib/compat/wordpress-6.8/site-editor.php
@@ -145,4 +145,4 @@ function gutenberg_add_styles_submenu_item() {
 		}
 	}
 }
-add_action( 'admin_init', 'gutenberg_add_styles_submenu_item' );
+add_action( 'admin_menu', 'gutenberg_add_styles_submenu_item' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

This PR is an improvement to https://github.com/WordPress/gutenberg/pull/66851.

Some plugins are triggering the `admin_menu` action directly to populate the admin menus of a site. Here, I am proposing that we add the Appearance -> Design submenu via that action instead of `admin_init`.

## Testing Instructions

1. Activate a Classic theme.
2. Verify that you still see the Appearance -> Design submenu:

<img width="173" alt="image" src="https://github.com/user-attachments/assets/45630236-3bab-465d-8224-958c01d61dbe" />

