### PR TITLE
Create Block: Optimize the default template for multiple blocks case

### DIFF
--- a/bin/test-create-block.sh
+++ b/bin/test-create-block.sh
@@ -56,7 +56,7 @@ if [ "$expected" -ne "$actual" ]; then
     exit 1
 fi
 expected=7
-actual=$( find src -maxdepth 1 -type f | wc -l )
+actual=$( find src -maxdepth 2 -type f | wc -l )
 if [ "$expected" -ne "$actual" ]; then
 	error "Expected $expected files in the \`src\` directory, but found $actual."
     exit 1
@@ -70,7 +70,7 @@ status "Building block..."
 
 status "Verifying build..."
 expected=9
-actual=$( find build -maxdepth 1 -type f | wc -l )
+actual=$( find build -maxdepth 2 -type f | wc -l )
 if [ "$expected" -ne "$actual" ]; then
 	error "Expected $expected files in the \`build\` directory, but found $actual."
     exit 1

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Enhancement
 
 -   Add support for custom `textdomain` property for the scaffolded block ([#57197](https://github.com/WordPress/gutenberg/pull/57197)).
--   Update the default template to scaffold a block in its subfolder to make it easier to update to multiple blocks in a single plugin.
+-   Update the default template to scaffold a block in its subfolder to make it easier to update to multiple blocks in a single plugin ([#68175](https://github.com/WordPress/gutenberg/pull/68175)).
 
 ### Internal
 

--- a/packages/create-block/CHANGELOG.md
+++ b/packages/create-block/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancement
 
 -   Add support for custom `textdomain` property for the scaffolded block ([#57197](https://github.com/WordPress/gutenberg/pull/57197)).
+-   Update the default template to scaffold a block in its subfolder to make it easier to update to multiple blocks in a single plugin.
 
 ### Internal
 

--- a/packages/create-block/lib/scaffold.js
+++ b/packages/create-block/lib/scaffold.js
@@ -58,13 +58,12 @@ module.exports = async (
 	}
 ) => {
 	slug = slug.toLowerCase();
-	namespace = namespace.toLowerCase();
 	const rootDirectory = join( process.cwd(), targetDir || slug );
 	const transformedValues = transformer( {
 		$schema,
 		apiVersion,
 		plugin,
-		namespace,
+		namespace: namespace.toLowerCase(),
 		slug,
 		title,
 		description,
@@ -84,7 +83,7 @@ module.exports = async (
 		npmDependencies,
 		npmDevDependencies,
 		customScripts,
-		folderName,
+		folderName: folderName.replace( /\$slug/g, slug ),
 		editorScript,
 		editorStyle,
 		style,

--- a/packages/create-block/lib/templates.js
+++ b/packages/create-block/lib/templates.js
@@ -59,6 +59,7 @@ const predefinedPluginTemplates = {
 			},
 			viewScript: 'file:./view.js',
 			example: {},
+			folderName: './src/$slug',
 		},
 		variants: {
 			static: {},

--- a/packages/create-block/lib/templates/plugin/$slug.php.mustache
+++ b/packages/create-block/lib/templates/plugin/$slug.php.mustache
@@ -42,6 +42,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @see https://developer.wordpress.org/reference/functions/register_block_type/
  */
 function {{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init() {
-	register_block_type( __DIR__ . '/build' );
+	register_block_type( __DIR__ . '/build/{{slug}}' );
 }
 add_action( 'init', '{{namespaceSnakeCase}}_{{slugSnakeCase}}_block_init' );


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Related to https://github.com/WordPress/gutenberg/issues/25188.

@ryanwelcher explores a variant of the template that automatically supports multiple blocks in the single plugin:
- https://github.com/WordPress/gutenberg/pull/67886

Here, I propose updating the default template to scaffold a block in its subfolder named after the block's slug to make it easier to update to multiple blocks in a single plugin.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

When a developer needs to add more than one block in a WordPress plugin scaffolder by `npx @wordpress/create-block` they often need to move the first block to a subfolder and update the path in PHP file accordingly.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

The default path to the block can be extended to contain the block's slug as the folder name.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

Run `npm run test:create-block` and make sure the tests pass.

Scaffold a block and inspect the project:
```sh
npx wp-create-block test-block
```

<img width="352" alt="Screenshot 2024-12-20 at 11 25 02" src="https://github.com/user-attachments/assets/80827e7a-fed5-4dcf-985e-93bb6e8dc1aa" />

Ensure that the block still works as before in the block editor.
