### PR TITLE
Tabs: add docs about not recommending usage with links

### DIFF
--- a/packages/components/src/tabs/README.md
+++ b/packages/components/src/tabs/README.md
@@ -95,6 +95,12 @@ const MyControlledTabs = () => (
 	);
 ```
 
+#### Using `Tabs` with links
+
+The semantics implemented by the `Tabs` component don't align well with the semantics needed by a list of links. Furthermore, end users usually expect every link to be tabbable, while `Tabs.Tablist` is a [composite](https://w3c.github.io/aria/#composite) widget acting as a single tab stop.
+
+For these reasons, even if the `Tabs` component is fully extensible, we don't recommend using `Tabs` with links, and we don't currently provide any related Storybook example.
+
 ### Components and Sub-components
 
 Tabs is comprised of four individual components:


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Following the conversation in #67699, this PR introduces a section in the `Tabs` component's README about discouraging the usage of the component with links.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

See https://github.com/WordPress/gutenberg/pull/67699#discussion_r1873703258

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Added a section to the README

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Read the added docs