### PR TITLE
Storybook: Fix a few editor styles warnings

### DIFF
--- a/storybook/stories/playground/box/index.js
+++ b/storybook/stories/playground/box/index.js
@@ -12,7 +12,7 @@ import {
 /**
  * Internal dependencies
  */
-import editorStyles from '../editor-styles';
+import { editorStyles } from '../editor-styles';
 import './style.css';
 
 export default function EditorBox() {

--- a/storybook/stories/playground/with-undo-redo/index.js
+++ b/storybook/stories/playground/with-undo-redo/index.js
@@ -15,7 +15,7 @@ import { undo as undoIcon, redo as redoIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import editorStyles from '../editor-styles';
+import { editorStyles } from '../editor-styles';
 import './style.css';
 
 export default function EditorWithUndoRedo() {

--- a/storybook/stories/playground/zoom-out/index.js
+++ b/storybook/stories/playground/zoom-out/index.js
@@ -16,7 +16,7 @@ import { parse } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import editorStyles from '../editor-styles';
+import { editorStyles } from '../editor-styles';
 // eslint-disable-next-line @wordpress/dependency-group
 import contentCss from '!!raw-loader!../../../../packages/block-editor/build-style/content.css';
 import { pattern } from './pattern';


### PR DESCRIPTION
## What?
This PR resolves three editor styles warnings in Storybook.

## Why?
Just fixing warnings.

## How?
Using the named import correctly.

## Testing Instructions
* Load Storybook
* Verify you no longer see the "editor styles" warnings from the screenshot. Warnings should be down from 6 to 3. 

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-12-20 at 16 12 07](https://github.com/user-attachments/assets/65bf4fd3-5928-46b3-9908-e6a10ad85272)

