### PR TITLE
Styles: Use `justify-content: flex-start` instead of `start`

### DIFF
--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -337,7 +337,7 @@
 		}
 
 		&.has-text {
-			justify-content: start;
+			justify-content: flex-start;
 			padding-right: $grid-unit-15;
 			padding-left: $grid-unit-10;
 			gap: $grid-unit-05;

--- a/packages/components/src/tabs/styles.ts
+++ b/packages/components/src/tabs/styles.ts
@@ -240,7 +240,7 @@ export const TabChildren = styled.span`
 		justify-content: center;
 	}
 	[aria-orientation='vertical'] & {
-		justify-content: start;
+		justify-content: flex-start;
 	}
 `;
 

--- a/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
+++ b/packages/edit-site/src/components/global-styles/screen-revisions/style.scss
@@ -121,7 +121,7 @@
 
 .edit-site-global-styles-screen-revisions__meta {
 	display: flex;
-	justify-content: start;
+	justify-content: flex-start;
 	width: 100%;
 	align-items: flex-start;
 	text-align: left;


### PR DESCRIPTION
## What?
This PR resolves two warnings in Storybook.

Don't merge just yet: #68237 might be a better alternative. 

## Why?
Just fixing warnings.

## How?
Using `justify-content: flex-start` instead of `justify-content: start`.

## Testing Instructions
* In Storybook, verify the warnings from the screenshot are gone.
* Test the following cases and verify there are no visual changes when comparing to trunk:
	* In Storybook, go to Button > Icon and type any text in the button (or just go to `?path=/story/components-button--icon&args=text:WordPress`)
	* In Storybook, go to Tabs > Vertical (or just go to `?path=/story/components-tabs--vertical`)
	* In the site editor, make sure you have done and saved at least a few changes to global styles. Then access global styles revisions from the Global Styles sidebar heading and compare the meta (the author info) under one or more revisions

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-12-20 at 16 43 29](https://github.com/user-attachments/assets/bb5ed0c1-8aaf-4124-acc1-2a39014652ee)


