### PR TITLE
Storybook: Fix `emotion/is-prop-valid` warning

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"@babel/runtime-corejs3": "7.25.7",
 				"@babel/traverse": "7.25.7",
 				"@emotion/babel-plugin": "11.11.0",
+				"@emotion/is-prop-valid": "1.2.2",
 				"@emotion/jest": "11.7.1",
 				"@emotion/native": "11.0.0",
 				"@geometricpanda/storybook-addon-badges": "2.0.5",
@@ -4467,6 +4468,19 @@
 			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
 			"integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
 		},
+		"node_modules/@emotion/is-prop-valid": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
+			"integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
+			"dependencies": {
+				"@emotion/memoize": "^0.8.1"
+			}
+		},
+		"node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+		},
 		"node_modules/@emotion/jest": {
 			"version": "11.7.1",
 			"resolved": "https://registry.npmjs.org/@emotion/jest/-/jest-11.7.1.tgz",
@@ -4617,19 +4631,6 @@
 					"optional": true
 				}
 			}
-		},
-		"node_modules/@emotion/styled/node_modules/@emotion/is-prop-valid": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.2.tgz",
-			"integrity": "sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==",
-			"dependencies": {
-				"@emotion/memoize": "^0.8.1"
-			}
-		},
-		"node_modules/@emotion/styled/node_modules/@emotion/memoize": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
-			"integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
 		},
 		"node_modules/@emotion/unitless": {
 			"version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"@babel/runtime-corejs3": "7.25.7",
 		"@babel/traverse": "7.25.7",
 		"@emotion/babel-plugin": "11.11.0",
+		"@emotion/is-prop-valid": "1.2.2",
 		"@emotion/jest": "11.7.1",
 		"@emotion/native": "11.0.0",
 		"@geometricpanda/storybook-addon-badges": "2.0.5",


### PR DESCRIPTION
## What?
This PR resolves the last warning we see on load in Storybook (after #68198 and #68199 tackled the other five).

## Why?
Just fixing a warning.

## How?
Adding `emotion/is-prop-valid` as a specific dev dependency because currently it's declared as an optional peer dependency:

https://github.com/motiondivision/motion/blob/6ddb3e79685653f18a863f64f76c3fb5fade1903/packages/framer-motion/package.json#L94-L102

## Testing Instructions
* Load Storybook
* Verify you no longer see the "emotion/is-prop-valid" warning from the screenshot. Warnings should be down by one.
* Verify this doesn't result in any new modules in `package-lock.json`, just shifting existing ones around.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-12-20 at 17 52 21](https://github.com/user-attachments/assets/400012bc-889e-45ad-a49e-08fb34bd774a)


