### PR TITLE
Menu: migrate Storybook examples to CSF3

### DIFF
--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Meta, StoryObj } from '@storybook/react';
+import type { StoryObj, Meta } from '@storybook/react';
 import { css } from '@emotion/react';
 
 /**
@@ -22,7 +22,7 @@ import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
 import type { MenuProps } from '../types';
 
-const meta = {
+const meta: Meta< typeof Menu > = {
 	id: 'components-experimental-menu',
 	title: 'Components (Experimental)/Actions/Menu',
 	component: Menu,
@@ -64,126 +64,120 @@ const meta = {
 			source: { excludeDecorators: true },
 		},
 	},
-} satisfies Meta< typeof Menu >;
+};
 export default meta;
 
-type Story = StoryObj< MenuProps >;
+export const Default: StoryObj< typeof Menu > = {
+	render: ( props: MenuProps ) => (
+		<Menu { ...props }>
+			<Menu.TriggerButton
+				render={ <Button __next40pxDefaultSize variant="secondary" /> }
+			>
+				Open menu
+			</Menu.TriggerButton>
+			<Menu.Popover>
+				<Menu.Item>
+					<Menu.ItemLabel>Label</Menu.ItemLabel>
+				</Menu.Item>
+				<Menu.Item>
+					<Menu.ItemLabel>Label</Menu.ItemLabel>
+					<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
+				</Menu.Item>
+				<Menu.Item>
+					<Menu.ItemLabel>Label</Menu.ItemLabel>
+					<Menu.ItemHelpText>
+						The menu item help text is automatically truncated when
+						there are more than two lines of text
+					</Menu.ItemHelpText>
+				</Menu.Item>
+				<Menu.Item hideOnClick={ false }>
+					<Menu.ItemLabel>Label</Menu.ItemLabel>
+					<Menu.ItemHelpText>
+						This item doesn&apos;t close the menu on click
+					</Menu.ItemHelpText>
+				</Menu.Item>
+				<Menu.Item disabled>Disabled item</Menu.Item>
+				<Menu.Separator />
+				<Menu.Group>
+					<Menu.GroupLabel>Group label</Menu.GroupLabel>
+					<Menu.Item
+						prefix={ <Icon icon={ customLink } size={ 24 } /> }
+					>
+						<Menu.ItemLabel>With prefix</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu.Item suffix="⌘S">With suffix</Menu.Item>
+					<Menu.Item
+						disabled
+						prefix={
+							<Icon icon={ formatCapitalize } size={ 24 } />
+						}
+						suffix="⌥⌘T"
+					>
+						<Menu.ItemLabel>
+							Disabled with prefix and suffix
+						</Menu.ItemLabel>
+						<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
+					</Menu.Item>
+				</Menu.Group>
+			</Menu.Popover>
+		</Menu>
+	),
 
-export const Default: Story = {
-	args: {
-		children: (
-			<>
-				<Menu.TriggerButton
-					render={
-						<Button __next40pxDefaultSize variant="secondary" />
-					}
-				>
-					Open menu
-				</Menu.TriggerButton>
-				<Menu.Popover>
-					<Menu.Item>
-						<Menu.ItemLabel>Label</Menu.ItemLabel>
-					</Menu.Item>
-					<Menu.Item>
-						<Menu.ItemLabel>Label</Menu.ItemLabel>
-						<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
-					</Menu.Item>
-					<Menu.Item>
-						<Menu.ItemLabel>Label</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							The menu item help text is automatically truncated
-							when there are more than two lines of text
-						</Menu.ItemHelpText>
-					</Menu.Item>
-					<Menu.Item hideOnClick={ false }>
-						<Menu.ItemLabel>Label</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							This item doesn&apos;t close the menu on click
-						</Menu.ItemHelpText>
-					</Menu.Item>
-					<Menu.Item disabled>Disabled item</Menu.Item>
-					<Menu.Separator />
-					<Menu.Group>
-						<Menu.GroupLabel>Group label</Menu.GroupLabel>
-						<Menu.Item
-							prefix={ <Icon icon={ customLink } size={ 24 } /> }
-						>
-							<Menu.ItemLabel>With prefix</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item suffix="⌘S">With suffix</Menu.Item>
-						<Menu.Item
-							disabled
-							prefix={
-								<Icon icon={ formatCapitalize } size={ 24 } />
-							}
-							suffix="⌥⌘T"
-						>
-							<Menu.ItemLabel>
-								Disabled with prefix and suffix
-							</Menu.ItemLabel>
-							<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
-						</Menu.Item>
-					</Menu.Group>
-				</Menu.Popover>
-			</>
-		),
-	},
+	args: {},
 };
 
-export const WithSubmenu: Story = {
-	args: {
-		children: (
-			<>
-				<Menu.TriggerButton
-					render={
-						<Button __next40pxDefaultSize variant="secondary" />
-					}
-				>
-					Open menu
-				</Menu.TriggerButton>
-				<Menu.Popover>
-					<Menu.Item>Level 1 item</Menu.Item>
-					<Menu>
-						<Menu.SubmenuTriggerItem suffix="Suffix">
-							<Menu.ItemLabel>
-								Submenu trigger item with a long label
-							</Menu.ItemLabel>
-						</Menu.SubmenuTriggerItem>
-						<Menu.Popover>
-							<Menu.Item>
-								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-							</Menu.Item>
-							<Menu.Item>
-								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-							</Menu.Item>
-							<Menu>
-								<Menu.SubmenuTriggerItem>
+export const WithSubmenu: StoryObj< typeof Menu > = {
+	render: ( props: MenuProps ) => (
+		<Menu { ...props }>
+			<Menu.TriggerButton
+				render={ <Button __next40pxDefaultSize variant="secondary" /> }
+			>
+				Open menu
+			</Menu.TriggerButton>
+			<Menu.Popover>
+				<Menu.Item>Level 1 item</Menu.Item>
+				<Menu>
+					<Menu.SubmenuTriggerItem suffix="Suffix">
+						<Menu.ItemLabel>
+							Submenu trigger item with a long label
+						</Menu.ItemLabel>
+					</Menu.SubmenuTriggerItem>
+					<Menu.Popover>
+						<Menu.Item>
+							<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item>
+							<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu>
+							<Menu.SubmenuTriggerItem>
+								<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
+							</Menu.SubmenuTriggerItem>
+							<Menu.Popover>
+								<Menu.Item>
 									<Menu.ItemLabel>
-										Submenu trigger
+										Level 3 item
 									</Menu.ItemLabel>
-								</Menu.SubmenuTriggerItem>
-								<Menu.Popover>
-									<Menu.Item>
-										<Menu.ItemLabel>
-											Level 3 item
-										</Menu.ItemLabel>
-									</Menu.Item>
-									<Menu.Item>
-										<Menu.ItemLabel>
-											Level 3 item
-										</Menu.ItemLabel>
-									</Menu.Item>
-								</Menu.Popover>
-							</Menu>
-						</Menu.Popover>
-					</Menu>
-				</Menu.Popover>
-			</>
-		),
+								</Menu.Item>
+								<Menu.Item>
+									<Menu.ItemLabel>
+										Level 3 item
+									</Menu.ItemLabel>
+								</Menu.Item>
+							</Menu.Popover>
+						</Menu>
+					</Menu.Popover>
+				</Menu>
+			</Menu.Popover>
+		</Menu>
+	),
+
+	args: {
+		...Default.args,
 	},
 };
 
-export const WithCheckboxes: Story = {
+export const WithCheckboxes: StoryObj< typeof Menu > = {
 	render: function WithCheckboxes( props: MenuProps ) {
 		const [ isAChecked, setAChecked ] = useState( false );
 		const [ isBChecked, setBChecked ] = useState( true );
@@ -327,9 +321,13 @@ export const WithCheckboxes: Story = {
 			</Menu>
 		);
 	},
+
+	args: {
+		...Default.args,
+	},
 };
 
-export const WithRadios: Story = {
+export const WithRadios: StoryObj< typeof Menu > = {
 	render: function WithRadios( props: MenuProps ) {
 		const [ radioValue, setRadioValue ] = useState( 'two' );
 		const onRadioChange: React.ComponentProps<
@@ -395,6 +393,10 @@ export const WithRadios: Story = {
 			</Menu>
 		);
 	},
+
+	args: {
+		...Default.args,
+	},
 };
 
 const modalOnTopOfMenuPopover = css`
@@ -403,8 +405,7 @@ const modalOnTopOfMenuPopover = css`
 	}
 `;
 
-// For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
-export const WithModals: Story = {
+export const WithModals: StoryObj< typeof Menu > = {
 	render: function WithModals( props: MenuProps ) {
 		const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
 		const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
@@ -466,6 +467,10 @@ export const WithModals: Story = {
 			</>
 		);
 	},
+
+	args: {
+		...Default.args,
+	},
 };
 
 const ExampleSlotFill = createSlotFill( 'Example' );
@@ -516,8 +521,8 @@ const Fill = ( { children }: { children: React.ReactNode } ) => {
 	);
 };
 
-export const WithSlotFill: Story = {
-	render: ( props ) => {
+export const WithSlotFill: StoryObj< typeof Menu > = {
+	render: ( props: MenuProps ) => {
 		return (
 			<SlotFillProvider>
 				<Menu { ...props }>
@@ -556,6 +561,10 @@ export const WithSlotFill: Story = {
 			</SlotFillProvider>
 		);
 	},
+
+	args: {
+		...Default.args,
+	},
 };
 
 const toolbarVariantContextValue = {
@@ -563,8 +572,9 @@ const toolbarVariantContextValue = {
 		variant: 'toolbar',
 	},
 };
-export const ToolbarVariant: Story = {
-	render: ( props ) => (
+
+export const ToolbarVariant: StoryObj< typeof Menu > = {
+	render: ( props: MenuProps ) => (
 		// TODO: add toolbar
 		<ContextSystemProvider value={ toolbarVariantContextValue }>
 			<Menu { ...props }>
@@ -597,10 +607,14 @@ export const ToolbarVariant: Story = {
 			</Menu>
 		</ContextSystemProvider>
 	),
+
+	args: {
+		...Default.args,
+	},
 };
 
-export const InsideModal: Story = {
-	render: function InsideModal( props ) {
+export const InsideModal: StoryObj< typeof Menu > = {
+	render: function InsideModal( props: MenuProps ) {
 		const [ isModalOpen, setModalOpen ] = useState( false );
 		return (
 			<>
@@ -663,6 +677,11 @@ export const InsideModal: Story = {
 			</>
 		);
 	},
+
+	args: {
+		...Default.args,
+	},
+
 	parameters: {
 		docs: {
 			source: { type: 'code' },

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -67,7 +67,7 @@ const meta = {
 } satisfies Meta< typeof Menu >;
 export default meta;
 
-type Story = StoryObj< typeof meta >;
+type Story = StoryObj< MenuProps >;
 
 export const Default: Story = {
 	args: {

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -20,6 +20,7 @@ import Button from '../../button';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
+import type { MenuProps } from '../types';
 
 const meta = {
 	id: 'components-experimental-menu',
@@ -183,7 +184,7 @@ export const WithSubmenu: Story = {
 };
 
 export const WithCheckboxes: Story = {
-	render: function WithCheckboxes( props ) {
+	render: function WithCheckboxes( props: MenuProps ) {
 		const [ isAChecked, setAChecked ] = useState( false );
 		const [ isBChecked, setBChecked ] = useState( true );
 		const [ multipleCheckboxesValue, setMultipleCheckboxesValue ] =
@@ -329,7 +330,7 @@ export const WithCheckboxes: Story = {
 };
 
 export const WithRadios: Story = {
-	render: function WithRadios( props ) {
+	render: function WithRadios( props: MenuProps ) {
 		const [ radioValue, setRadioValue ] = useState( 'two' );
 		const onRadioChange: React.ComponentProps<
 			typeof Menu.RadioItem
@@ -404,7 +405,7 @@ const modalOnTopOfMenuPopover = css`
 
 // For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
 export const WithModals: Story = {
-	render: function WithModals( props ) {
+	render: function WithModals( props: MenuProps ) {
 		const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
 		const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
 

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import type { Meta, StoryFn } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import { css } from '@emotion/react';
 
 /**
@@ -20,9 +20,8 @@ import Button from '../../button';
 import Modal from '../../modal';
 import { createSlotFill, Provider as SlotFillProvider } from '../../slot-fill';
 import { ContextSystemProvider } from '../../context';
-import type { MenuProps } from '../types';
 
-const meta: Meta< typeof Menu > = {
+const meta = {
 	id: 'components-experimental-menu',
 	title: 'Components (Experimental)/Actions/Menu',
 	component: Menu,
@@ -64,318 +63,146 @@ const meta: Meta< typeof Menu > = {
 			source: { excludeDecorators: true },
 		},
 	},
-};
+} satisfies Meta< typeof Menu >;
 export default meta;
 
-export const Default: StoryFn< typeof Menu > = ( props: MenuProps ) => (
-	<Menu { ...props }>
-		<Menu.TriggerButton
-			render={ <Button __next40pxDefaultSize variant="secondary" /> }
-		>
-			Open menu
-		</Menu.TriggerButton>
-		<Menu.Popover>
-			<Menu.Item>
-				<Menu.ItemLabel>Label</Menu.ItemLabel>
-			</Menu.Item>
-			<Menu.Item>
-				<Menu.ItemLabel>Label</Menu.ItemLabel>
-				<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
-			</Menu.Item>
-			<Menu.Item>
-				<Menu.ItemLabel>Label</Menu.ItemLabel>
-				<Menu.ItemHelpText>
-					The menu item help text is automatically truncated when
-					there are more than two lines of text
-				</Menu.ItemHelpText>
-			</Menu.Item>
-			<Menu.Item hideOnClick={ false }>
-				<Menu.ItemLabel>Label</Menu.ItemLabel>
-				<Menu.ItemHelpText>
-					This item doesn&apos;t close the menu on click
-				</Menu.ItemHelpText>
-			</Menu.Item>
-			<Menu.Item disabled>Disabled item</Menu.Item>
-			<Menu.Separator />
-			<Menu.Group>
-				<Menu.GroupLabel>Group label</Menu.GroupLabel>
-				<Menu.Item prefix={ <Icon icon={ customLink } size={ 24 } /> }>
-					<Menu.ItemLabel>With prefix</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item suffix="⌘S">With suffix</Menu.Item>
-				<Menu.Item
-					disabled
-					prefix={ <Icon icon={ formatCapitalize } size={ 24 } /> }
-					suffix="⌥⌘T"
-				>
-					<Menu.ItemLabel>
-						Disabled with prefix and suffix
-					</Menu.ItemLabel>
-					<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
-				</Menu.Item>
-			</Menu.Group>
-		</Menu.Popover>
-	</Menu>
-);
-Default.args = {};
+type Story = StoryObj< typeof meta >;
 
-export const WithSubmenu: StoryFn< typeof Menu > = ( props: MenuProps ) => (
-	<Menu { ...props }>
-		<Menu.TriggerButton
-			render={ <Button __next40pxDefaultSize variant="secondary" /> }
-		>
-			Open menu
-		</Menu.TriggerButton>
-		<Menu.Popover>
-			<Menu.Item>Level 1 item</Menu.Item>
-			<Menu>
-				<Menu.SubmenuTriggerItem suffix="Suffix">
-					<Menu.ItemLabel>
-						Submenu trigger item with a long label
-					</Menu.ItemLabel>
-				</Menu.SubmenuTriggerItem>
+export const Default: Story = {
+	args: {
+		children: (
+			<>
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
+				>
+					Open menu
+				</Menu.TriggerButton>
 				<Menu.Popover>
 					<Menu.Item>
-						<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
 					</Menu.Item>
 					<Menu.Item>
-						<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
+						<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
 					</Menu.Item>
+					<Menu.Item>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							The menu item help text is automatically truncated
+							when there are more than two lines of text
+						</Menu.ItemHelpText>
+					</Menu.Item>
+					<Menu.Item hideOnClick={ false }>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							This item doesn&apos;t close the menu on click
+						</Menu.ItemHelpText>
+					</Menu.Item>
+					<Menu.Item disabled>Disabled item</Menu.Item>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>Group label</Menu.GroupLabel>
+						<Menu.Item
+							prefix={ <Icon icon={ customLink } size={ 24 } /> }
+						>
+							<Menu.ItemLabel>With prefix</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item suffix="⌘S">With suffix</Menu.Item>
+						<Menu.Item
+							disabled
+							prefix={
+								<Icon icon={ formatCapitalize } size={ 24 } />
+							}
+							suffix="⌥⌘T"
+						>
+							<Menu.ItemLabel>
+								Disabled with prefix and suffix
+							</Menu.ItemLabel>
+							<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
+						</Menu.Item>
+					</Menu.Group>
+				</Menu.Popover>
+			</>
+		),
+	},
+};
+
+export const WithSubmenu: Story = {
+	args: {
+		children: (
+			<>
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
+				>
+					Open menu
+				</Menu.TriggerButton>
+				<Menu.Popover>
+					<Menu.Item>Level 1 item</Menu.Item>
 					<Menu>
-						<Menu.SubmenuTriggerItem>
-							<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
+						<Menu.SubmenuTriggerItem suffix="Suffix">
+							<Menu.ItemLabel>
+								Submenu trigger item with a long label
+							</Menu.ItemLabel>
 						</Menu.SubmenuTriggerItem>
 						<Menu.Popover>
 							<Menu.Item>
-								<Menu.ItemLabel>Level 3 item</Menu.ItemLabel>
+								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
 							</Menu.Item>
 							<Menu.Item>
-								<Menu.ItemLabel>Level 3 item</Menu.ItemLabel>
+								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
 							</Menu.Item>
+							<Menu>
+								<Menu.SubmenuTriggerItem>
+									<Menu.ItemLabel>
+										Submenu trigger
+									</Menu.ItemLabel>
+								</Menu.SubmenuTriggerItem>
+								<Menu.Popover>
+									<Menu.Item>
+										<Menu.ItemLabel>
+											Level 3 item
+										</Menu.ItemLabel>
+									</Menu.Item>
+									<Menu.Item>
+										<Menu.ItemLabel>
+											Level 3 item
+										</Menu.ItemLabel>
+									</Menu.Item>
+								</Menu.Popover>
+							</Menu>
 						</Menu.Popover>
 					</Menu>
 				</Menu.Popover>
-			</Menu>
-		</Menu.Popover>
-	</Menu>
-);
-WithSubmenu.args = {
-	...Default.args,
+			</>
+		),
+	},
 };
 
-export const WithCheckboxes: StoryFn< typeof Menu > = ( props: MenuProps ) => {
-	const [ isAChecked, setAChecked ] = useState( false );
-	const [ isBChecked, setBChecked ] = useState( true );
-	const [ multipleCheckboxesValue, setMultipleCheckboxesValue ] = useState<
-		string[]
-	>( [ 'b' ] );
+export const WithCheckboxes: Story = {
+	render: function WithCheckboxes( props ) {
+		const [ isAChecked, setAChecked ] = useState( false );
+		const [ isBChecked, setBChecked ] = useState( true );
+		const [ multipleCheckboxesValue, setMultipleCheckboxesValue ] =
+			useState< string[] >( [ 'b' ] );
 
-	const onMultipleCheckboxesCheckedChange: React.ComponentProps<
-		typeof Menu.CheckboxItem
-	>[ 'onChange' ] = ( e ) => {
-		setMultipleCheckboxesValue( ( prevValues ) => {
-			if ( prevValues.includes( e.target.value ) ) {
-				return prevValues.filter( ( val ) => val !== e.target.value );
-			}
-			return [ ...prevValues, e.target.value ];
-		} );
-	};
+		const onMultipleCheckboxesCheckedChange: React.ComponentProps<
+			typeof Menu.CheckboxItem
+		>[ 'onChange' ] = ( e ) => {
+			setMultipleCheckboxesValue( ( prevValues ) => {
+				if ( prevValues.includes( e.target.value ) ) {
+					return prevValues.filter(
+						( val ) => val !== e.target.value
+					);
+				}
+				return [ ...prevValues, e.target.value ];
+			} );
+		};
 
-	return (
-		<Menu { ...props }>
-			<Menu.TriggerButton
-				render={ <Button __next40pxDefaultSize variant="secondary" /> }
-			>
-				Open menu
-			</Menu.TriggerButton>
-			<Menu.Popover>
-				<Menu.Group>
-					<Menu.GroupLabel>
-						Single selection, uncontrolled
-					</Menu.GroupLabel>
-					<Menu.CheckboxItem
-						name="checkbox-individual-uncontrolled-a"
-						value="a"
-						suffix="⌥⌘T"
-					>
-						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							Initially unchecked
-						</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-					<Menu.CheckboxItem
-						name="checkbox-individual-uncontrolled-b"
-						value="b"
-						defaultChecked
-					>
-						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-				</Menu.Group>
-				<Menu.Separator />
-				<Menu.Group>
-					<Menu.GroupLabel>
-						Single selection, controlled
-					</Menu.GroupLabel>
-					<Menu.CheckboxItem
-						name="checkbox-individual-controlled-a"
-						value="a"
-						checked={ isAChecked }
-						onChange={ ( e ) => {
-							setAChecked( e.target.checked );
-						} }
-					>
-						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							Initially unchecked
-						</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-					<Menu.CheckboxItem
-						name="checkbox-individual-controlled-b"
-						value="b"
-						checked={ isBChecked }
-						onChange={ ( e ) => setBChecked( e.target.checked ) }
-					>
-						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-				</Menu.Group>
-				<Menu.Separator />
-				<Menu.Group>
-					<Menu.GroupLabel>
-						Multiple selection, uncontrolled
-					</Menu.GroupLabel>
-					<Menu.CheckboxItem
-						name="checkbox-multiple-uncontrolled"
-						value="a"
-					>
-						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							Initially unchecked
-						</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-					<Menu.CheckboxItem
-						name="checkbox-multiple-uncontrolled"
-						value="b"
-						defaultChecked
-					>
-						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-				</Menu.Group>
-				<Menu.Separator />
-				<Menu.Group>
-					<Menu.GroupLabel>
-						Multiple selection, controlled
-					</Menu.GroupLabel>
-					<Menu.CheckboxItem
-						name="checkbox-multiple-controlled"
-						value="a"
-						checked={ multipleCheckboxesValue.includes( 'a' ) }
-						onChange={ onMultipleCheckboxesCheckedChange }
-					>
-						<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							Initially unchecked
-						</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-					<Menu.CheckboxItem
-						name="checkbox-multiple-controlled"
-						value="b"
-						checked={ multipleCheckboxesValue.includes( 'b' ) }
-						onChange={ onMultipleCheckboxesCheckedChange }
-					>
-						<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
-						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-					</Menu.CheckboxItem>
-				</Menu.Group>
-			</Menu.Popover>
-		</Menu>
-	);
-};
-WithCheckboxes.args = {
-	...Default.args,
-};
-
-export const WithRadios: StoryFn< typeof Menu > = ( props: MenuProps ) => {
-	const [ radioValue, setRadioValue ] = useState( 'two' );
-	const onRadioChange: React.ComponentProps<
-		typeof Menu.RadioItem
-	>[ 'onChange' ] = ( e ) => setRadioValue( e.target.value );
-
-	return (
-		<Menu { ...props }>
-			<Menu.TriggerButton
-				render={ <Button __next40pxDefaultSize variant="secondary" /> }
-			>
-				Open menu
-			</Menu.TriggerButton>
-			<Menu.Popover>
-				<Menu.Group>
-					<Menu.GroupLabel>Uncontrolled</Menu.GroupLabel>
-					<Menu.RadioItem name="radio-uncontrolled" value="one">
-						<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							Initially unchecked
-						</Menu.ItemHelpText>
-					</Menu.RadioItem>
-					<Menu.RadioItem
-						name="radio-uncontrolled"
-						value="two"
-						defaultChecked
-					>
-						<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
-						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-					</Menu.RadioItem>
-				</Menu.Group>
-				<Menu.Separator />
-				<Menu.Group>
-					<Menu.GroupLabel>Controlled</Menu.GroupLabel>
-					<Menu.RadioItem
-						name="radio-controlled"
-						value="one"
-						checked={ radioValue === 'one' }
-						onChange={ onRadioChange }
-					>
-						<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
-						<Menu.ItemHelpText>
-							Initially unchecked
-						</Menu.ItemHelpText>
-					</Menu.RadioItem>
-					<Menu.RadioItem
-						name="radio-controlled"
-						value="two"
-						checked={ radioValue === 'two' }
-						onChange={ onRadioChange }
-					>
-						<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
-						<Menu.ItemHelpText>Initially checked</Menu.ItemHelpText>
-					</Menu.RadioItem>
-				</Menu.Group>
-			</Menu.Popover>
-		</Menu>
-	);
-};
-WithRadios.args = {
-	...Default.args,
-};
-
-const modalOnTopOfMenuPopover = css`
-	&& {
-		z-index: 1000000;
-	}
-`;
-
-// For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
-export const WithModals: StoryFn< typeof Menu > = ( props: MenuProps ) => {
-	const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
-	const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
-
-	const cx = useCx();
-	const modalOverlayClassName = cx( modalOnTopOfMenuPopover );
-
-	return (
-		<>
+		return (
 			<Menu { ...props }>
 				<Menu.TriggerButton
 					render={
@@ -385,49 +212,259 @@ export const WithModals: StoryFn< typeof Menu > = ( props: MenuProps ) => {
 					Open menu
 				</Menu.TriggerButton>
 				<Menu.Popover>
-					<Menu.Item
-						onClick={ () => setOuterModalOpen( true ) }
-						hideOnClick={ false }
-					>
-						<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
-					</Menu.Item>
-					<Menu.Item
-						onClick={ () => setInnerModalOpen( true ) }
-						hideOnClick={ false }
-					>
-						<Menu.ItemLabel>Open inner modal</Menu.ItemLabel>
-					</Menu.Item>
-					{ isInnerModalOpen && (
-						<Modal
-							onRequestClose={ () => setInnerModalOpen( false ) }
-							overlayClassName={ modalOverlayClassName }
+					<Menu.Group>
+						<Menu.GroupLabel>
+							Single selection, uncontrolled
+						</Menu.GroupLabel>
+						<Menu.CheckboxItem
+							name="checkbox-individual-uncontrolled-a"
+							value="a"
+							suffix="⌥⌘T"
 						>
-							Modal&apos;s contents
-							<button
-								onClick={ () => setInnerModalOpen( false ) }
-							>
-								Close
-							</button>
-						</Modal>
-					) }
+							<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially unchecked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+						<Menu.CheckboxItem
+							name="checkbox-individual-uncontrolled-b"
+							value="b"
+							defaultChecked
+						>
+							<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially checked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+					</Menu.Group>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>
+							Single selection, controlled
+						</Menu.GroupLabel>
+						<Menu.CheckboxItem
+							name="checkbox-individual-controlled-a"
+							value="a"
+							checked={ isAChecked }
+							onChange={ ( e ) => {
+								setAChecked( e.target.checked );
+							} }
+						>
+							<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially unchecked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+						<Menu.CheckboxItem
+							name="checkbox-individual-controlled-b"
+							value="b"
+							checked={ isBChecked }
+							onChange={ ( e ) =>
+								setBChecked( e.target.checked )
+							}
+						>
+							<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially checked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+					</Menu.Group>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>
+							Multiple selection, uncontrolled
+						</Menu.GroupLabel>
+						<Menu.CheckboxItem
+							name="checkbox-multiple-uncontrolled"
+							value="a"
+						>
+							<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially unchecked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+						<Menu.CheckboxItem
+							name="checkbox-multiple-uncontrolled"
+							value="b"
+							defaultChecked
+						>
+							<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially checked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+					</Menu.Group>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>
+							Multiple selection, controlled
+						</Menu.GroupLabel>
+						<Menu.CheckboxItem
+							name="checkbox-multiple-controlled"
+							value="a"
+							checked={ multipleCheckboxesValue.includes( 'a' ) }
+							onChange={ onMultipleCheckboxesCheckedChange }
+						>
+							<Menu.ItemLabel>Checkbox item A</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially unchecked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+						<Menu.CheckboxItem
+							name="checkbox-multiple-controlled"
+							value="b"
+							checked={ multipleCheckboxesValue.includes( 'b' ) }
+							onChange={ onMultipleCheckboxesCheckedChange }
+						>
+							<Menu.ItemLabel>Checkbox item B</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially checked
+							</Menu.ItemHelpText>
+						</Menu.CheckboxItem>
+					</Menu.Group>
 				</Menu.Popover>
 			</Menu>
-			{ isOuterModalOpen && (
-				<Modal
-					onRequestClose={ () => setOuterModalOpen( false ) }
-					overlayClassName={ modalOverlayClassName }
-				>
-					Modal&apos;s contents
-					<button onClick={ () => setOuterModalOpen( false ) }>
-						Close
-					</button>
-				</Modal>
-			) }
-		</>
-	);
+		);
+	},
 };
-WithModals.args = {
-	...Default.args,
+
+export const WithRadios: Story = {
+	render: function WithRadios( props ) {
+		const [ radioValue, setRadioValue ] = useState( 'two' );
+		const onRadioChange: React.ComponentProps<
+			typeof Menu.RadioItem
+		>[ 'onChange' ] = ( e ) => setRadioValue( e.target.value );
+
+		return (
+			<Menu { ...props }>
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
+				>
+					Open menu
+				</Menu.TriggerButton>
+				<Menu.Popover>
+					<Menu.Group>
+						<Menu.GroupLabel>Uncontrolled</Menu.GroupLabel>
+						<Menu.RadioItem name="radio-uncontrolled" value="one">
+							<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially unchecked
+							</Menu.ItemHelpText>
+						</Menu.RadioItem>
+						<Menu.RadioItem
+							name="radio-uncontrolled"
+							value="two"
+							defaultChecked
+						>
+							<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially checked
+							</Menu.ItemHelpText>
+						</Menu.RadioItem>
+					</Menu.Group>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>Controlled</Menu.GroupLabel>
+						<Menu.RadioItem
+							name="radio-controlled"
+							value="one"
+							checked={ radioValue === 'one' }
+							onChange={ onRadioChange }
+						>
+							<Menu.ItemLabel>Radio item 1</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially unchecked
+							</Menu.ItemHelpText>
+						</Menu.RadioItem>
+						<Menu.RadioItem
+							name="radio-controlled"
+							value="two"
+							checked={ radioValue === 'two' }
+							onChange={ onRadioChange }
+						>
+							<Menu.ItemLabel>Radio item 2</Menu.ItemLabel>
+							<Menu.ItemHelpText>
+								Initially checked
+							</Menu.ItemHelpText>
+						</Menu.RadioItem>
+					</Menu.Group>
+				</Menu.Popover>
+			</Menu>
+		);
+	},
+};
+
+const modalOnTopOfMenuPopover = css`
+	&& {
+		z-index: 1000000;
+	}
+`;
+
+// For more examples with `Modal`, check https://ariakit.org/examples/menu-wordpress-modal
+export const WithModals: Story = {
+	render: function WithModals( props ) {
+		const [ isOuterModalOpen, setOuterModalOpen ] = useState( false );
+		const [ isInnerModalOpen, setInnerModalOpen ] = useState( false );
+
+		const cx = useCx();
+		const modalOverlayClassName = cx( modalOnTopOfMenuPopover );
+
+		return (
+			<>
+				<Menu { ...props }>
+					<Menu.TriggerButton
+						render={
+							<Button __next40pxDefaultSize variant="secondary" />
+						}
+					>
+						Open menu
+					</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item
+							onClick={ () => setOuterModalOpen( true ) }
+							hideOnClick={ false }
+						>
+							<Menu.ItemLabel>Open outer modal</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item
+							onClick={ () => setInnerModalOpen( true ) }
+							hideOnClick={ false }
+						>
+							<Menu.ItemLabel>Open inner modal</Menu.ItemLabel>
+						</Menu.Item>
+						{ isInnerModalOpen && (
+							<Modal
+								onRequestClose={ () =>
+									setInnerModalOpen( false )
+								}
+								overlayClassName={ modalOverlayClassName }
+							>
+								Modal&apos;s contents
+								<button
+									onClick={ () => setInnerModalOpen( false ) }
+								>
+									Close
+								</button>
+							</Modal>
+						) }
+					</Menu.Popover>
+				</Menu>
+				{ isOuterModalOpen && (
+					<Modal
+						onRequestClose={ () => setOuterModalOpen( false ) }
+						overlayClassName={ modalOverlayClassName }
+					>
+						Modal&apos;s contents
+						<button onClick={ () => setOuterModalOpen( false ) }>
+							Close
+						</button>
+					</Modal>
+				) }
+			</>
+		);
+	},
 };
 
 const ExampleSlotFill = createSlotFill( 'Example' );
@@ -478,9 +515,57 @@ const Fill = ( { children }: { children: React.ReactNode } ) => {
 	);
 };
 
-export const WithSlotFill: StoryFn< typeof Menu > = ( props: MenuProps ) => {
-	return (
-		<SlotFillProvider>
+export const WithSlotFill: Story = {
+	render: ( props ) => {
+		return (
+			<SlotFillProvider>
+				<Menu { ...props }>
+					<Menu.TriggerButton
+						render={
+							<Button __next40pxDefaultSize variant="secondary" />
+						}
+					>
+						Open menu
+					</Menu.TriggerButton>
+					<Menu.Popover>
+						<Menu.Item>
+							<Menu.ItemLabel>Item</Menu.ItemLabel>
+						</Menu.Item>
+						<Slot />
+					</Menu.Popover>
+				</Menu>
+
+				<Fill>
+					<Menu.Item>
+						<Menu.ItemLabel>Item from fill</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu>
+						<Menu.SubmenuTriggerItem>
+							<Menu.ItemLabel>Submenu from fill</Menu.ItemLabel>
+						</Menu.SubmenuTriggerItem>
+						<Menu.Popover>
+							<Menu.Item>
+								<Menu.ItemLabel>
+									Submenu item from fill
+								</Menu.ItemLabel>
+							</Menu.Item>
+						</Menu.Popover>
+					</Menu>
+				</Fill>
+			</SlotFillProvider>
+		);
+	},
+};
+
+const toolbarVariantContextValue = {
+	Menu: {
+		variant: 'toolbar',
+	},
+};
+export const ToolbarVariant: Story = {
+	render: ( props ) => (
+		// TODO: add toolbar
+		<ContextSystemProvider value={ toolbarVariantContextValue }>
 			<Menu { ...props }>
 				<Menu.TriggerButton
 					render={
@@ -491,140 +576,95 @@ export const WithSlotFill: StoryFn< typeof Menu > = ( props: MenuProps ) => {
 				</Menu.TriggerButton>
 				<Menu.Popover>
 					<Menu.Item>
-						<Menu.ItemLabel>Item</Menu.ItemLabel>
+						<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
 					</Menu.Item>
-					<Slot />
-				</Menu.Popover>
-			</Menu>
-
-			<Fill>
-				<Menu.Item>
-					<Menu.ItemLabel>Item from fill</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu>
-					<Menu.SubmenuTriggerItem>
-						<Menu.ItemLabel>Submenu from fill</Menu.ItemLabel>
-					</Menu.SubmenuTriggerItem>
-					<Menu.Popover>
-						<Menu.Item>
-							<Menu.ItemLabel>
-								Submenu item from fill
-							</Menu.ItemLabel>
-						</Menu.Item>
-					</Menu.Popover>
-				</Menu>
-			</Fill>
-		</SlotFillProvider>
-	);
-};
-WithSlotFill.args = {
-	...Default.args,
-};
-
-const toolbarVariantContextValue = {
-	Menu: {
-		variant: 'toolbar',
-	},
-};
-export const ToolbarVariant: StoryFn< typeof Menu > = ( props: MenuProps ) => (
-	// TODO: add toolbar
-	<ContextSystemProvider value={ toolbarVariantContextValue }>
-		<Menu { ...props }>
-			<Menu.TriggerButton
-				render={ <Button __next40pxDefaultSize variant="secondary" /> }
-			>
-				Open menu
-			</Menu.TriggerButton>
-			<Menu.Popover>
-				<Menu.Item>
-					<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item>
-					<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Separator />
-				<Menu>
-					<Menu.SubmenuTriggerItem>
-						<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
-					</Menu.SubmenuTriggerItem>
-					<Menu.Popover>
-						<Menu.Item>
-							<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-						</Menu.Item>
-					</Menu.Popover>
-				</Menu>
-			</Menu.Popover>
-		</Menu>
-	</ContextSystemProvider>
-);
-ToolbarVariant.args = {
-	...Default.args,
-};
-
-export const InsideModal: StoryFn< typeof Menu > = ( props: MenuProps ) => {
-	const [ isModalOpen, setModalOpen ] = useState( false );
-	return (
-		<>
-			<Button
-				onClick={ () => setModalOpen( true ) }
-				__next40pxDefaultSize
-				variant="secondary"
-			>
-				Open modal
-			</Button>
-			{ isModalOpen && (
-				<Modal
-					onRequestClose={ () => setModalOpen( false ) }
-					title="Menu inside modal"
-				>
-					<Menu { ...props }>
-						<Menu.TriggerButton
-							render={
-								<Button
-									__next40pxDefaultSize
-									variant="secondary"
-								/>
-							}
-						>
-							Open menu
-						</Menu.TriggerButton>
+					<Menu.Item>
+						<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
+					</Menu.Item>
+					<Menu.Separator />
+					<Menu>
+						<Menu.SubmenuTriggerItem>
+							<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
+						</Menu.SubmenuTriggerItem>
 						<Menu.Popover>
 							<Menu.Item>
-								<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
+								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
 							</Menu.Item>
-							<Menu.Item>
-								<Menu.ItemLabel>Level 1 item</Menu.ItemLabel>
-							</Menu.Item>
-							<Menu.Separator />
-							<Menu>
-								<Menu.SubmenuTriggerItem>
-									<Menu.ItemLabel>
-										Submenu trigger
-									</Menu.ItemLabel>
-								</Menu.SubmenuTriggerItem>
-								<Menu.Popover>
-									<Menu.Item>
-										<Menu.ItemLabel>
-											Level 2 item
-										</Menu.ItemLabel>
-									</Menu.Item>
-								</Menu.Popover>
-							</Menu>
 						</Menu.Popover>
 					</Menu>
-					<Button onClick={ () => setModalOpen( false ) }>
-						Close modal
-					</Button>
-				</Modal>
-			) }
-		</>
-	);
+				</Menu.Popover>
+			</Menu>
+		</ContextSystemProvider>
+	),
 };
-InsideModal.args = {
-	...Default.args,
-};
-InsideModal.parameters = {
-	docs: {
-		source: { type: 'code' },
+
+export const InsideModal: Story = {
+	render: function InsideModal( props ) {
+		const [ isModalOpen, setModalOpen ] = useState( false );
+		return (
+			<>
+				<Button
+					onClick={ () => setModalOpen( true ) }
+					__next40pxDefaultSize
+					variant="secondary"
+				>
+					Open modal
+				</Button>
+				{ isModalOpen && (
+					<Modal
+						onRequestClose={ () => setModalOpen( false ) }
+						title="Menu inside modal"
+					>
+						<Menu { ...props }>
+							<Menu.TriggerButton
+								render={
+									<Button
+										__next40pxDefaultSize
+										variant="secondary"
+									/>
+								}
+							>
+								Open menu
+							</Menu.TriggerButton>
+							<Menu.Popover>
+								<Menu.Item>
+									<Menu.ItemLabel>
+										Level 1 item
+									</Menu.ItemLabel>
+								</Menu.Item>
+								<Menu.Item>
+									<Menu.ItemLabel>
+										Level 1 item
+									</Menu.ItemLabel>
+								</Menu.Item>
+								<Menu.Separator />
+								<Menu>
+									<Menu.SubmenuTriggerItem>
+										<Menu.ItemLabel>
+											Submenu trigger
+										</Menu.ItemLabel>
+									</Menu.SubmenuTriggerItem>
+									<Menu.Popover>
+										<Menu.Item>
+											<Menu.ItemLabel>
+												Level 2 item
+											</Menu.ItemLabel>
+										</Menu.Item>
+									</Menu.Popover>
+								</Menu>
+							</Menu.Popover>
+						</Menu>
+						<Button onClick={ () => setModalOpen( false ) }>
+							Close modal
+						</Button>
+					</Modal>
+				) }
+			</>
+		);
+	},
+	parameters: {
+		docs: {
+			source: { type: 'code' },
+		},
 	},
 };

--- a/packages/components/src/menu/stories/index.story.tsx
+++ b/packages/components/src/menu/stories/index.story.tsx
@@ -68,112 +68,117 @@ const meta: Meta< typeof Menu > = {
 export default meta;
 
 export const Default: StoryObj< typeof Menu > = {
-	render: ( props: MenuProps ) => (
-		<Menu { ...props }>
-			<Menu.TriggerButton
-				render={ <Button __next40pxDefaultSize variant="secondary" /> }
-			>
-				Open menu
-			</Menu.TriggerButton>
-			<Menu.Popover>
-				<Menu.Item>
-					<Menu.ItemLabel>Label</Menu.ItemLabel>
-				</Menu.Item>
-				<Menu.Item>
-					<Menu.ItemLabel>Label</Menu.ItemLabel>
-					<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
-				</Menu.Item>
-				<Menu.Item>
-					<Menu.ItemLabel>Label</Menu.ItemLabel>
-					<Menu.ItemHelpText>
-						The menu item help text is automatically truncated when
-						there are more than two lines of text
-					</Menu.ItemHelpText>
-				</Menu.Item>
-				<Menu.Item hideOnClick={ false }>
-					<Menu.ItemLabel>Label</Menu.ItemLabel>
-					<Menu.ItemHelpText>
-						This item doesn&apos;t close the menu on click
-					</Menu.ItemHelpText>
-				</Menu.Item>
-				<Menu.Item disabled>Disabled item</Menu.Item>
-				<Menu.Separator />
-				<Menu.Group>
-					<Menu.GroupLabel>Group label</Menu.GroupLabel>
-					<Menu.Item
-						prefix={ <Icon icon={ customLink } size={ 24 } /> }
-					>
-						<Menu.ItemLabel>With prefix</Menu.ItemLabel>
+	args: {
+		children: (
+			<>
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
+				>
+					Open menu
+				</Menu.TriggerButton>
+				<Menu.Popover>
+					<Menu.Item>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
 					</Menu.Item>
-					<Menu.Item suffix="⌘S">With suffix</Menu.Item>
-					<Menu.Item
-						disabled
-						prefix={
-							<Icon icon={ formatCapitalize } size={ 24 } />
-						}
-						suffix="⌥⌘T"
-					>
-						<Menu.ItemLabel>
-							Disabled with prefix and suffix
-						</Menu.ItemLabel>
-						<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
+					<Menu.Item>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
+						<Menu.ItemHelpText>Help text</Menu.ItemHelpText>
 					</Menu.Item>
-				</Menu.Group>
-			</Menu.Popover>
-		</Menu>
-	),
-
-	args: {},
+					<Menu.Item>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							The menu item help text is automatically truncated
+							when there are more than two lines of text
+						</Menu.ItemHelpText>
+					</Menu.Item>
+					<Menu.Item hideOnClick={ false }>
+						<Menu.ItemLabel>Label</Menu.ItemLabel>
+						<Menu.ItemHelpText>
+							This item doesn&apos;t close the menu on click
+						</Menu.ItemHelpText>
+					</Menu.Item>
+					<Menu.Item disabled>Disabled item</Menu.Item>
+					<Menu.Separator />
+					<Menu.Group>
+						<Menu.GroupLabel>Group label</Menu.GroupLabel>
+						<Menu.Item
+							prefix={ <Icon icon={ customLink } size={ 24 } /> }
+						>
+							<Menu.ItemLabel>With prefix</Menu.ItemLabel>
+						</Menu.Item>
+						<Menu.Item suffix="⌘S">With suffix</Menu.Item>
+						<Menu.Item
+							disabled
+							prefix={
+								<Icon icon={ formatCapitalize } size={ 24 } />
+							}
+							suffix="⌥⌘T"
+						>
+							<Menu.ItemLabel>
+								Disabled with prefix and suffix
+							</Menu.ItemLabel>
+							<Menu.ItemHelpText>And help text</Menu.ItemHelpText>
+						</Menu.Item>
+					</Menu.Group>
+				</Menu.Popover>
+			</>
+		),
+	},
 };
 
 export const WithSubmenu: StoryObj< typeof Menu > = {
-	render: ( props: MenuProps ) => (
-		<Menu { ...props }>
-			<Menu.TriggerButton
-				render={ <Button __next40pxDefaultSize variant="secondary" /> }
-			>
-				Open menu
-			</Menu.TriggerButton>
-			<Menu.Popover>
-				<Menu.Item>Level 1 item</Menu.Item>
-				<Menu>
-					<Menu.SubmenuTriggerItem suffix="Suffix">
-						<Menu.ItemLabel>
-							Submenu trigger item with a long label
-						</Menu.ItemLabel>
-					</Menu.SubmenuTriggerItem>
-					<Menu.Popover>
-						<Menu.Item>
-							<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu.Item>
-							<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
-						</Menu.Item>
-						<Menu>
-							<Menu.SubmenuTriggerItem>
-								<Menu.ItemLabel>Submenu trigger</Menu.ItemLabel>
-							</Menu.SubmenuTriggerItem>
-							<Menu.Popover>
-								<Menu.Item>
-									<Menu.ItemLabel>
-										Level 3 item
-									</Menu.ItemLabel>
-								</Menu.Item>
-								<Menu.Item>
-									<Menu.ItemLabel>
-										Level 3 item
-									</Menu.ItemLabel>
-								</Menu.Item>
-							</Menu.Popover>
-						</Menu>
-					</Menu.Popover>
-				</Menu>
-			</Menu.Popover>
-		</Menu>
-	),
-
 	args: {
 		...Default.args,
+		children: (
+			<>
+				<Menu.TriggerButton
+					render={
+						<Button __next40pxDefaultSize variant="secondary" />
+					}
+				>
+					Open menu
+				</Menu.TriggerButton>
+				<Menu.Popover>
+					<Menu.Item>Level 1 item</Menu.Item>
+					<Menu>
+						<Menu.SubmenuTriggerItem suffix="Suffix">
+							<Menu.ItemLabel>
+								Submenu trigger item with a long label
+							</Menu.ItemLabel>
+						</Menu.SubmenuTriggerItem>
+						<Menu.Popover>
+							<Menu.Item>
+								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+							</Menu.Item>
+							<Menu.Item>
+								<Menu.ItemLabel>Level 2 item</Menu.ItemLabel>
+							</Menu.Item>
+							<Menu>
+								<Menu.SubmenuTriggerItem>
+									<Menu.ItemLabel>
+										Submenu trigger
+									</Menu.ItemLabel>
+								</Menu.SubmenuTriggerItem>
+								<Menu.Popover>
+									<Menu.Item>
+										<Menu.ItemLabel>
+											Level 3 item
+										</Menu.ItemLabel>
+									</Menu.Item>
+									<Menu.Item>
+										<Menu.ItemLabel>
+											Level 3 item
+										</Menu.ItemLabel>
+									</Menu.Item>
+								</Menu.Popover>
+							</Menu>
+						</Menu.Popover>
+					</Menu>
+				</Menu.Popover>
+			</>
+		),
 	},
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Migrate `Menu`'s storybook examples to [the latest story format](https://storybook.js.org/docs/api/csf)

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Keeping aligned with latest Storybook specs and features, potentially better performance

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Followed docs at https://storybook.js.org/docs/api/csf

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Build storybook locally (`npm run storybook:dev`), make sure that all `Menu` stories work as on `trunk`