### PR TITLE
Tabs: use correct ariakit type for root component

### DIFF
--- a/packages/components/src/tabs/types.ts
+++ b/packages/components/src/tabs/types.ts
@@ -22,7 +22,7 @@ export type TabsProps = {
 	 * `Tabs.Tablist` component and as many instances of the `Tabs.TabPanel`
 	 * components as there are `Tabs.Tab` components.
 	 */
-	children: Ariakit.TabProps[ 'children' ];
+	children: Ariakit.TabProviderProps[ 'children' ];
 	/**
 	 * Determines if the tab should be selected when it receives focus. If set to
 	 * `false`, the tab will only be selected upon clicking, not when using arrow
@@ -33,7 +33,7 @@ export type TabsProps = {
 	 *
 	 * @see https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/
 	 */
-	selectOnMove?: Ariakit.TabStoreProps[ 'selectOnMove' ];
+	selectOnMove?: Ariakit.TabProviderProps[ 'selectOnMove' ];
 	/**
 	 * The id of the tab whose panel is currently visible.
 	 *
@@ -44,7 +44,7 @@ export type TabsProps = {
 	 * in "controlled" mode. When in "controlled" mode, the `null` value will
 	 * result in no tabs being selected, and the tablist becoming tabbable.
 	 */
-	selectedTabId?: Ariakit.TabStoreProps[ 'selectedId' ];
+	selectedTabId?: Ariakit.TabProviderProps[ 'selectedId' ];
 	/**
 	 * The id of the tab whose panel is currently visible.
 	 *
@@ -55,11 +55,11 @@ export type TabsProps = {
 	 * Note: this prop will be overridden by the `selectedTabId` prop if it is
 	 * provided (meaning the component will be used in "controlled" mode).
 	 */
-	defaultTabId?: Ariakit.TabStoreProps[ 'defaultSelectedId' ];
+	defaultTabId?: Ariakit.TabProviderProps[ 'defaultSelectedId' ];
 	/**
 	 * The function called when the `selectedTabId` changes.
 	 */
-	onSelect?: Ariakit.TabStoreProps[ 'setSelectedId' ];
+	onSelect?: Ariakit.TabProviderProps[ 'setSelectedId' ];
 	/**
 	 * The current active tab `id`. The active tab is the tab element within the
 	 * tablist widget that has DOM focus.
@@ -69,7 +69,7 @@ export type TabsProps = {
 	 *   itself will have focus and users will be able to navigate to it using
 	 *   arrow keys.activeTabId
 	 */
-	activeTabId?: Ariakit.TabStoreProps[ 'activeId' ];
+	activeTabId?: Ariakit.TabProviderProps[ 'activeId' ];
 	/**
 	 * The tab id that should be active by default when the composite widget is
 	 * rendered. If `null`, the tablist element itself will have focus
@@ -79,11 +79,11 @@ export type TabsProps = {
 	 * Note: this prop will be overridden by the `activeTabId` prop if it is
 	 * provided.
 	 */
-	defaultActiveTabId?: Ariakit.TabStoreProps[ 'defaultActiveId' ];
+	defaultActiveTabId?: Ariakit.TabProviderProps[ 'defaultActiveId' ];
 	/**
 	 * A callback that gets called when the `activeTabId` state changes.
 	 */
-	onActiveTabIdChange?: Ariakit.TabStoreProps[ 'setActiveId' ];
+	onActiveTabIdChange?: Ariakit.TabProviderProps[ 'setActiveId' ];
 	/**
 	 * Defines the orientation of the tablist and determines which arrow keys
 	 * can be used to move focus:
@@ -93,7 +93,7 @@ export type TabsProps = {
 	 *
 	 * @default "horizontal"
 	 */
-	orientation?: Ariakit.TabStoreProps[ 'orientation' ];
+	orientation?: Ariakit.TabProviderProps[ 'orientation' ];
 };
 
 export type TabListProps = {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Fix prop type definitions for the `Tabs` component by importing type defs from the correct ariakit component

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

Correctness

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

Change from `TabProps` (the single tab) to `TabProviderProps` (the tab provider)

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

- No TS errors
- Same Storybook computed prop types
- Smoke test the `Tabs` component
