### PR TITLE
Components: Normalize newlines in auto-generated READMEs

### DIFF
--- a/bin/api-docs/gen-components-docs/markdown/index.mjs
+++ b/bin/api-docs/gen-components-docs/markdown/index.mjs
@@ -8,6 +8,10 @@ import json2md from 'json2md';
  */
 import { generateMarkdownPropsJson } from './props.mjs';
 
+function normalizeTrailingNewline( str ) {
+	return str?.length ? str.replace( /\n*$/, '\n' ) : undefined;
+}
+
 export function generateMarkdownDocs( { typeDocs, subcomponentTypeDocs } ) {
 	const mainDocsJson = [
 		{ h1: typeDocs.displayName },
@@ -15,7 +19,7 @@ export function generateMarkdownDocs( { typeDocs, subcomponentTypeDocs } ) {
 		{
 			p: `<p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-${ typeDocs.displayName.toLowerCase() }--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>`,
 		},
-		typeDocs.description,
+		normalizeTrailingNewline( typeDocs.description ),
 		...generateMarkdownPropsJson( typeDocs.props ),
 	];
 
@@ -26,7 +30,7 @@ export function generateMarkdownDocs( { typeDocs, subcomponentTypeDocs } ) {
 					{
 						h3: subcomponentTypeDoc.displayName,
 					},
-					subcomponentTypeDoc.description,
+					normalizeTrailingNewline( subcomponentTypeDoc.description ),
 					...generateMarkdownPropsJson( subcomponentTypeDoc.props, {
 						headingLevel: 4,
 					} ),

--- a/bin/api-docs/gen-components-docs/markdown/index.mjs
+++ b/bin/api-docs/gen-components-docs/markdown/index.mjs
@@ -8,8 +8,17 @@ import json2md from 'json2md';
  */
 import { generateMarkdownPropsJson } from './props.mjs';
 
+/**
+ * If the string is contentful, ensure that it ends with a single newline.
+ * Otherwise normalize to `undefined`.
+ *
+ * @param {string} [str]
+ */
 function normalizeTrailingNewline( str ) {
-	return str?.length ? str.replace( /\n*$/, '\n' ) : undefined;
+	if ( ! str?.trim() ) {
+		return undefined;
+	}
+	return str.replace( /\n*$/, '\n' );
 }
 
 export function generateMarkdownDocs( { typeDocs, subcomponentTypeDocs } ) {

--- a/packages/components/src/alignment-matrix-control/README.md
+++ b/packages/components/src/alignment-matrix-control/README.md
@@ -21,6 +21,7 @@ const Example = () => {
 	);
 };
 ```
+
 ## Props
 
 ### `defaultValue`

--- a/packages/components/src/angle-picker-control/README.md
+++ b/packages/components/src/angle-picker-control/README.md
@@ -23,6 +23,7 @@ function Example() {
   );
 }
 ```
+
 ## Props
 
 ### `as`

--- a/packages/components/src/base-control/README.md
+++ b/packages/components/src/base-control/README.md
@@ -25,6 +25,7 @@ const MyCustomTextareaControl = ({ children, ...baseProps }) => (
 	);
 );
 ```
+
 ## Props
 
 ### `__nextHasNoMarginBottom`
@@ -113,6 +114,7 @@ const MyBaseControl = () => (
 	</BaseControl>
 );
 ```
+
 #### Props
 
 ##### `as`

--- a/packages/components/src/box-control/README.md
+++ b/packages/components/src/box-control/README.md
@@ -28,6 +28,7 @@ function Example() {
   );
 };
 ```
+
 ## Props
 
 ### `__next40pxDefaultSize`

--- a/packages/components/src/button/README.md
+++ b/packages/components/src/button/README.md
@@ -17,6 +17,7 @@ const Mybutton = () => (
   </Button>
 );
 ```
+
 ## Props
 
 ### `__next40pxDefaultSize`

--- a/packages/components/src/form-file-upload/README.md
+++ b/packages/components/src/form-file-upload/README.md
@@ -19,6 +19,7 @@ const MyFormFileUpload = () => (
   </FormFileUpload>
 );
 ```
+
 ## Props
 
 ### `__next40pxDefaultSize`

--- a/packages/components/src/gradient-picker/README.md
+++ b/packages/components/src/gradient-picker/README.md
@@ -43,6 +43,7 @@ const MyGradientPicker = () => {
   );
 };
 ```
+
 ## Props
 
 ### `__experimentalIsRenderedInSidebar`

--- a/packages/components/src/icon/README.md
+++ b/packages/components/src/icon/README.md
@@ -11,6 +11,7 @@ import { wordpress } from '@wordpress/icons';
 
 <Icon icon={ wordpress } />
 ```
+
 ## Props
 
 ### `icon`

--- a/packages/components/src/tree-select/README.md
+++ b/packages/components/src/tree-select/README.md
@@ -51,6 +51,7 @@ const MyTreeSelect = () => {
 	);
 }
 ```
+
 ## Props
 
 ### `__next40pxDefaultSize`


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Fixes a minor issue with component descriptions running into the next sections due to a missing newline.

## Why?

This missing newline isn't visible when the Markdown is rendered to HTML, but is a bit messy when reading as raw Markdown text.

## Testing Instructions

`npm run docs:components` to regenerate the README files.