### PR TITLE
Add: Number of templates using a template part and link to see them.

### DIFF
--- a/packages/edit-site/src/components/page-templates/hooks.js
+++ b/packages/edit-site/src/components/page-templates/hooks.js
@@ -98,3 +98,31 @@ export function useAddedBy( postType, postId ) {
 		[ postType, postId ]
 	);
 }
+
+/**
+ * Returns the template part title.
+ *
+ * @param {?string} slug The template part slug.
+ * @return {?string} The template part title.
+ */
+export function useTemplatePartTitle( slug ) {
+	return useSelect(
+		( select ) => {
+			const { getEntityRecord, getCurrentTheme } = select( coreStore );
+			const theme = getCurrentTheme()?.stylesheet;
+			if ( ! theme ) {
+				return;
+			}
+			const templatePart = getEntityRecord(
+				'postType',
+				'wp_template_part',
+				`${ theme }//${ slug }`
+			);
+			if ( ! templatePart ) {
+				return;
+			}
+			return templatePart.title?.rendered;
+		},
+		[ slug ]
+	);
+}

--- a/packages/edit-site/src/components/page-templates/index.js
+++ b/packages/edit-site/src/components/page-templates/index.js
@@ -42,15 +42,20 @@ import {
 	DEFAULT_VIEW,
 	getActiveViewOverridesForTab,
 } from './view-utils';
+import { useTemplatePartTitle } from './hooks';
 
-const { usePostActions, usePostFields, templateTitleField } =
-	unlock( editorPrivateApis );
+const {
+	usePostActions,
+	usePostFields,
+	templateTitleField,
+	useTemplatesFilteredByTemplatePart,
+} = unlock( editorPrivateApis );
 const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { useEntityRecordsWithPermissions } = unlock( corePrivateApis );
 
 export default function PageTemplates() {
 	const { path, query } = useLocation();
-	const { activeView = 'active', postId } = query;
+	const { activeView = 'active', postId, usingTemplatePart } = query;
 	const [ selection, setSelection ] = useState( [ postId ] );
 	const [ selectedRegisteredTemplate, setSelectedRegisteredTemplate ] =
 		useState( false );
@@ -143,7 +148,7 @@ export default function PageTemplates() {
 		isLoadingData = isLoadingStaticData;
 	}
 
-	const records = useMemo( () => {
+	const unfilteredRecords = useMemo( () => {
 		function isCustom( record ) {
 			// For registered templates, the is_custom field is defined.
 			return (
@@ -183,6 +188,13 @@ export default function PageTemplates() {
 		staticRecords,
 		activeView,
 	] );
+
+	const records = useTemplatesFilteredByTemplatePart(
+		usingTemplatePart,
+		unfilteredRecords
+	);
+
+	const templatePartTitle = useTemplatePartTitle( usingTemplatePart );
 
 	const users = useSelect(
 		( select ) => {
@@ -321,12 +333,21 @@ export default function PageTemplates() {
 		( action ) => action.id === 'duplicate-post'
 	);
 
+	let title = __( 'Templates' );
+	if ( usingTemplatePart && templatePartTitle ) {
+		title = sprintf(
+			/* translators: %s: template part title */
+			__( 'Templates using %s template part.' ),
+			templatePartTitle
+		);
+	}
+
 	return (
 		<Page
 			className="edit-site-page-templates"
-			title={ __( 'Templates' ) }
+			title={ title }
 			headingLevel={ 2 }
-			actions={ <AddNewTemplate /> }
+			actions={ usingTemplatePart ? undefined : <AddNewTemplate /> }
 		>
 			<DataViews
 				key={ activeView }

--- a/packages/editor/src/components/post-last-edited-panel/style.scss
+++ b/packages/editor/src/components/post-last-edited-panel/style.scss
@@ -1,4 +1,5 @@
-.editor-post-last-edited-panel {
+.editor-post-last-edited-panel,
+.editor-post-used-by-panel {
 	color: $gray-700;
 	& .components-text {
 		color: inherit;

--- a/packages/editor/src/components/post-last-edited-panel/style.scss
+++ b/packages/editor/src/components/post-last-edited-panel/style.scss
@@ -1,6 +1,7 @@
 @use "@wordpress/base-styles/colors" as *;
 
-.editor-post-last-edited-panel {
+.editor-post-last-edited-panel,
+.editor-post-used-by-panel {
 	color: $gray-700;
 	& .components-text {
 		color: inherit;

--- a/packages/editor/src/components/post-used-by-panel/index.js
+++ b/packages/editor/src/components/post-used-by-panel/index.js
@@ -1,0 +1,82 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	__experimentalText as Text,
+	ExternalLink,
+} from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { useEntityRecords } from '@wordpress/core-data';
+import { _n, sprintf } from '@wordpress/i18n';
+import { createInterpolateElement } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Internal dependencies
+ */
+import { store as editorStore } from '../../store';
+import {
+	TEMPLATE_PART_POST_TYPE,
+	TEMPLATE_POST_TYPE,
+} from '../../store/constants';
+import useTemplatesFilteredByTemplatePart from '../../utils/use-templates-filtered-by-template-part';
+
+function PostUsedByTemplatePartPanel( { templatePartSlug } ) {
+	const { records: templates } = useEntityRecords(
+		'postType',
+		TEMPLATE_POST_TYPE,
+		{
+			per_page: -1,
+		}
+	);
+	const filteredTemplates = useTemplatesFilteredByTemplatePart(
+		templatePartSlug,
+		templates
+	);
+	if ( ! filteredTemplates?.length ) {
+		return null;
+	}
+	return (
+		<Text>
+			{ createInterpolateElement(
+				sprintf(
+					/* translators: 1: number of templates. */
+					_n(
+						'Used by <Link>%1$s template</Link>.',
+						'Used by <Link>%1$s templates</Link>.',
+						filteredTemplates.length
+					),
+					filteredTemplates.length
+				),
+				{
+					Link: (
+						<ExternalLink
+							href={ addQueryArgs( 'site-editor.php', {
+								p: '/template',
+								usingTemplatePart: templatePartSlug,
+							} ) }
+						/>
+					),
+				}
+			) }
+		</Text>
+	);
+}
+
+export default function PostUsedByPanel() {
+	const { postType, slug } = useSelect( ( select ) => {
+		select( editorStore ).getCurrentPostType();
+		return {
+			postType: select( editorStore ).getCurrentPostType(),
+			slug: select( editorStore ).getCurrentPostAttribute( 'slug' ),
+		};
+	}, [] );
+	if ( postType !== TEMPLATE_PART_POST_TYPE ) {
+		return null;
+	}
+	return (
+		<div className="editor-post-used-by-panel">
+			<PostUsedByTemplatePartPanel templatePartSlug={ slug } />
+		</div>
+	);
+}

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -29,6 +29,7 @@ import SiteDiscussion from '../site-discussion';
 import { store as editorStore } from '../../store';
 import { PrivatePostLastRevision } from '../post-last-revision';
 import PostTrash from '../post-trash';
+import PostUsedByPanel from '../post-used-by-panel';
 
 /**
  * Module Constants
@@ -70,6 +71,7 @@ export default function PostSummary( { onActionPerformed } ) {
 							<VStack spacing={ 1 }>
 								<PostContentInformation />
 								<PostLastEditedPanel />
+								<PostUsedByPanel />
 							</VStack>
 							{ ! isRemovedPostStatusPanel && (
 								<VStack spacing={ 4 }>

--- a/packages/editor/src/components/sidebar/post-summary.js
+++ b/packages/editor/src/components/sidebar/post-summary.js
@@ -30,6 +30,7 @@ import SiteDiscussion from '../site-discussion';
 import { store as editorStore } from '../../store';
 import { PrivatePostLastRevision } from '../post-last-revision';
 import PostTrash from '../post-trash';
+import PostUsedByPanel from '../post-used-by-panel';
 
 /**
  * Module Constants
@@ -84,6 +85,7 @@ function ClassicPostSummary( { onActionPerformed } ) {
 							<VStack spacing={ 1 }>
 								<PostContentInformation />
 								<PostLastEditedPanel />
+								<PostUsedByPanel />
 							</VStack>
 							{ ! isRemovedPostStatusPanel && (
 								<VStack spacing={ 4 }>

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -26,6 +26,7 @@ import {
 import { CreateTemplatePartModal } from '@wordpress/fields';
 import { registerCoreBlockBindingsSources } from './bindings/api';
 import { getTemplateInfo } from './utils/get-template-info';
+import useTemplatesFilteredByTemplatePart from './utils/use-templates-filtered-by-template-part';
 
 const { store: interfaceStore, ...remainingInterfaceApis } = interfaceApis;
 
@@ -51,4 +52,5 @@ lock( privateApis, {
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	interfaceStore,
 	...remainingInterfaceApis,
+	useTemplatesFilteredByTemplatePart,
 } );

--- a/packages/editor/src/private-apis.js
+++ b/packages/editor/src/private-apis.js
@@ -30,6 +30,7 @@ import { StyleBookPreview } from './components/style-book';
 import { useGlobalStyles, useStyle } from './components/global-styles/hooks';
 import { GlobalStylesActionMenu } from './components/global-styles/menu';
 import UploadProgressSnackbar from './components/upload-progress-snackbar';
+import useTemplatesFilteredByTemplatePart from './utils/use-templates-filtered-by-template-part';
 
 const { store: interfaceStore, ...remainingInterfaceApis } = interfaceApis;
 
@@ -61,4 +62,5 @@ lock( privateApis, {
 	// This is a temporary private API while we're updating the site editor to use EditorProvider.
 	interfaceStore,
 	...remainingInterfaceApis,
+	useTemplatesFilteredByTemplatePart,
 } );

--- a/packages/editor/src/utils/use-templates-filtered-by-template-part.js
+++ b/packages/editor/src/utils/use-templates-filtered-by-template-part.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+import { parse } from '@wordpress/blocks';
+
+function findBlock( blocks, isMatch ) {
+	if ( ! Array.isArray( blocks ) ) {
+		return;
+	}
+	for ( const block of blocks ) {
+		if ( isMatch( block ) ) {
+			return block;
+		}
+		const childResult = findBlock( block.innerBlocks, isMatch );
+		if ( childResult ) {
+			return childResult;
+		}
+	}
+}
+
+export default function useTemplatesFilteredByTemplatePart(
+	templatePartSlug,
+	templates
+) {
+	const [ result, setResult ] = useState( [] );
+	// We are using a timeout and an effect just to make sure
+	// the parsing of templates is done asynchronously and does not blocks
+	// the rendering of the page.
+	useEffect( () => {
+		if ( ! templatePartSlug || ! templates ) {
+			return;
+		}
+		const timeoutId = setTimeout( () => {
+			setResult(
+				templates.filter( ( template ) => {
+					if ( template?.content?.raw ) {
+						const blocks = parse( template.content.raw );
+						return !! findBlock( blocks, ( block ) => {
+							return (
+								block.name === 'core/template-part' &&
+								block.attributes.slug === templatePartSlug
+							);
+						} );
+					}
+					return false;
+				} )
+			);
+		}, 0 );
+		return () => {
+			if ( timeoutId ) {
+				clearTimeout( timeoutId );
+			}
+		};
+	} );
+	if ( ! templatePartSlug || ! templates ) {
+		return templates;
+	}
+	return result;
+}


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/60205.

This is the first PR on the tracking of global element usage.
When a template part is open on the editor it shows the number of templates using that template part.
It also includes a link to a view listing the templates using that template part.

Some notes:


## Computation of templates using a template part in the client.

The computation of templates using a template part is performed on the client side. I considered extending the API to handle this on the backend, but for templates, that would introduce unnecessary complexity. 

The templates endpoint, by default, passes all templates to the client, uses a default per_page setting of -1. Since we are already requesting all the templates in multiple instances, we may as well compute the subset of templates using a template part on the client side.
This computation is done asynchronously to make sure it does not block the render in any way.

## The filtering of templates for the ones that use a template part does not rely on dataviews.

Currently, the filters offered by Dataviews do not allow us to filter a template based on the usage of a specific template part. The existing filters only support selecting items whose field has a specific value or does not have a specific value. Unfortunately, the filter we need—"Template uses template part x"—is not applicable, as we don’t even have a field for template parts.

Dataviews filters need to be expanded to accommodate cases where matching depends on a custom condition. This is illustrated in the mockup below:
![image](https://github.com/user-attachments/assets/ac35b029-0e5b-47f9-b5f6-dca6c7f138f4).

A possible solution could be to implement a field "template parts used". Specifying the set of template parts used in a template, and then have filters that support fields with multiple values ( we will also need that for tags for example).

At present, I filter the set of templates before passing them to Dataviews if the `usingTemplatePart=` parameter is included. While this solution is not ideal, I think, it is acceptable until Dataviews provides filters we can use for this scenario. 

cc: @ntsekouras, @oandregal — let me know if there is a way to accomplish this using Dataviews that I may have overlooked.




## Testing Instructions
Open a template part on the editor for example the sidebar.
Verify the editor shows on the inspector how many templates are using that template part.
Click on the link and verify the list of links using the template part is shown.

## Screenshots or screencast <!-- if applicable -->
<img width="392" alt="Screenshot 2024-12-20 at 19 19 31" src="https://github.com/user-attachments/assets/0e400030-9f44-4dd3-9d8b-5bd23ef71d2f" />
<img width="1817" alt="Screenshot 2024-12-20 at 19 38 04" src="https://github.com/user-attachments/assets/16a9ef08-238b-4cee-9ce6-be42e1ef6ea3" />
>

