### PR TITLE
Fixed Input Unit Block: Unit jumps to px when set to 0

### DIFF
--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -10,7 +10,6 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
-	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
@@ -183,11 +182,6 @@ function FlexControls( {
 					size="__unstable-large"
 					units={ units }
 					onChange={ ( value ) => {
-						if ( value === '' ) {
-							const [ , currentUnit ] =
-								parseQuantityAndUnitFromRawValue( flexSize );
-							value = `0${ currentUnit || 'px' }`;
-						}
 						onChange( {
 							selfStretch,
 							flexSize: value,

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -10,6 +10,7 @@ import {
 	__experimentalVStack as VStack,
 	__experimentalToolsPanelItem as ToolsPanelItem,
 	__experimentalUseCustomUnits as useCustomUnits,
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	Flex,
 	FlexItem,
 } from '@wordpress/components';
@@ -182,6 +183,11 @@ function FlexControls( {
 					size="__unstable-large"
 					units={ units }
 					onChange={ ( value ) => {
+						if ( value === '' ) {
+							const [ , currentUnit ] =
+								parseQuantityAndUnitFromRawValue( flexSize );
+							value = `0${ currentUnit || 'px' }`;
+						}
 						onChange( {
 							selfStretch,
 							flexSize: value,

--- a/packages/block-editor/src/components/child-layout-control/index.js
+++ b/packages/block-editor/src/components/child-layout-control/index.js
@@ -187,6 +187,7 @@ function FlexControls( {
 							flexSize: value,
 						} );
 					} }
+					shouldPreserveUnit
 					value={ flexSize }
 					label={ flexResetLabel }
 					hideLabelFromVision

--- a/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js
@@ -234,6 +234,7 @@ export default function SpacingInputControl( {
 						hideLabelFromVision
 						className="spacing-sizes-control__custom-value-input"
 						size="__unstable-large"
+						shouldPreserveUnit
 						onDragStart={ () => {
 							if ( value?.charAt( 0 ) === '-' ) {
 								setMinValue( 0 );

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -139,7 +139,13 @@ function UnforwardedUnitControl(
 		) {
 			// Add a check if we should preserve the unit when the quantity is empty.
 			if ( shouldPreserveUnit ) {
-				onChangeProp?.( `0${ unit }`, changeProps );
+				const newValue = getValidParsedQuantityAndUnit(
+					0,
+					units,
+					parsedQuantity,
+					unit
+				).join( '' );
+				onChangeProp?.( newValue, changeProps );
 				return;
 			}
 

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -136,7 +136,7 @@ function UnforwardedUnitControl(
 			typeof nextQuantityValue === 'undefined' ||
 			nextQuantityValue === null
 		) {
-			onChangeProp?.( '', changeProps );
+			onChangeProp?.( `0${ unit }`, changeProps );
 			return;
 		}
 

--- a/packages/components/src/unit-control/index.tsx
+++ b/packages/components/src/unit-control/index.tsx
@@ -57,6 +57,7 @@ function UnforwardedUnitControl(
 		value: valueProp,
 		onFocus: onFocusProp,
 		__shouldNotWarnDeprecated36pxSize,
+		shouldPreserveUnit = false,
 		...props
 	} = useDeprecated36pxDefaultSizeProp( unitControlProps );
 
@@ -136,7 +137,13 @@ function UnforwardedUnitControl(
 			typeof nextQuantityValue === 'undefined' ||
 			nextQuantityValue === null
 		) {
-			onChangeProp?.( `0${ unit }`, changeProps );
+			// Add a check if we should preserve the unit when the quantity is empty.
+			if ( shouldPreserveUnit ) {
+				onChangeProp?.( `0${ unit }`, changeProps );
+				return;
+			}
+
+			onChangeProp?.( '', changeProps );
 			return;
 		}
 

--- a/packages/components/src/unit-control/types.ts
+++ b/packages/components/src/unit-control/types.ts
@@ -114,4 +114,10 @@ export type UnitControlProps = Pick< InputControlProps, 'size' > &
 		 * @ignore
 		 */
 		__shouldNotWarnDeprecated36pxSize?: boolean;
+		/**
+		 * Whether to preserve the unit when the value is empty.
+		 *
+		 * @default false
+		 */
+		shouldPreserveUnit?: boolean;
 	};


### PR DESCRIPTION
fixes #51616 

## What?
This PR fixes the issue where the unit in the spacer and dimension controls resets to px when the input value is cleared.

## Why?
When removing the value from input fields like spacer height or padding in the dimensions control, the unit automatically resets to px. This behavior causes unexpected results and reduces user control over custom styles. Fixing this improves usability and ensures a consistent editing experience.

## How?
The fix was applied in packages/components/src/unit-control/index.tsx, where the unit was being dropped when the input value was cleared. The implementation now ensures that when the value is empty, it defaults to 0 with the current unit preserved, preventing the reset to px.

## Testing Instructions

1. Open the WordPress editor (post or page).
2. Add a Spacer block inside a stack.
3. Change its unit to vh.
4. Clear the height value to input a new value.
5. Ensure the unit stays as vh and does not revert to px.

### Additional Test:

1. Go to Global Styles settings.
2. Select the Button block.
3. Adjust padding values and clear the input fields.
4. Ensure the unit remains consistent and doesn’t default to px.

## Screencast

https://github.com/user-attachments/assets/6ce01b9f-534c-467d-96c6-833e99bb8fc1


