### PR TITLE
Social Links: Fix appender size in non-iframe editor

### DIFF
--- a/packages/block-library/src/social-links/editor.scss
+++ b/packages/block-library/src/social-links/editor.scss
@@ -101,6 +101,10 @@
 .wp-block-social-links .block-list-appender {
 	position: static; // display inline.
 
+	.block-editor-inserter {
+		font-size: inherit;
+	}
+
 	.block-editor-button-block-appender {
 		height: 1.5em;
 		width: 1.5em;


### PR DESCRIPTION
Follow-up #65769

## What?

#65769 made the appender size of the Social Icons block equal to the actual icons. However, I found that this size was incorrect in the non-iframe editor and the widget editor:

![image](https://github.com/user-attachments/assets/3e502f0f-9087-4ed2-8eca-73ef6af1d613)

## Why?

The appender button is expected to be `1.5em` sized, inheriting the font size applied to the Social Icons block.

However, it is not variable-sized because [the 13px font size is always applied by the `.block-editor-inserter selector`](https://github.com/WordPress/gutenberg/blob/ca24ccecae21664f9527ae6440805c101faec0b0/packages/block-editor/src/components/inserter/style.scss#L11). Because this style comes from the block editor, it will not be loaded in the iframe editor, but non-iframe editors will be affected by this style:

![font-size-inherit](https://github.com/user-attachments/assets/7f1a4d74-4289-4a63-adaf-3971a1e36f0c)

## How?

Add `font-size: inherit` to inherit the font size of the Social Icons block.

## Testing Instructions

- Activate the classic theme and install [the Coblocks plugin](https://wordpress.org/plugins/coblocks/). This will make the post editor work as a non-iframe editor because the [`useShouldIframe()` hook conditions are met](https://github.com/WordPress/gutenberg/blob/ca24ccecae21664f9527ae6440805c101faec0b0/packages/edit-post/src/components/layout/use-should-iframe.js#L19-L34).
- Insert a Social Icons block.
- Resize it.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/9d507305-c669-403d-8751-1c6ad9984828

