### PR TITLE
Widget Editor: Focus toggle button when the global inserter is closed

### DIFF
--- a/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
+++ b/packages/edit-widgets/src/components/secondary-sidebar/inserter-sidebar.js
@@ -4,28 +4,51 @@
 import { __experimentalLibrary as Library } from '@wordpress/block-editor';
 import { useViewportMatch } from '@wordpress/compose';
 import { useCallback, useRef } from '@wordpress/element';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { ESCAPE } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import useWidgetLibraryInsertionPoint from '../../hooks/use-widget-library-insertion-point';
 import { store as editWidgetsStore } from '../../store';
+import { unlock } from '../../lock-unlock';
 
 export default function InserterSidebar() {
 	const isMobileViewport = useViewportMatch( 'medium', '<' );
 	const { rootClientId, insertionIndex } = useWidgetLibraryInsertionPoint();
 
+	const inserterSidebarToggleRef = useSelect( ( select ) => {
+		return unlock(
+			select( editWidgetsStore )
+		).getInserterSidebarToggleRef();
+	}, [] );
+
 	const { setIsInserterOpened } = useDispatch( editWidgetsStore );
 
 	const closeInserter = useCallback( () => {
-		return setIsInserterOpened( false );
-	}, [ setIsInserterOpened ] );
+		setIsInserterOpened( false );
+		inserterSidebarToggleRef.current?.focus();
+	}, [ setIsInserterOpened, inserterSidebarToggleRef ] );
+
+	const closeOnEscape = useCallback(
+		( event ) => {
+			if ( event.keyCode === ESCAPE && ! event.defaultPrevented ) {
+				event.preventDefault();
+				closeInserter();
+			}
+		},
+		[ closeInserter ]
+	);
 
 	const libraryRef = useRef();
 
 	return (
-		<div className="edit-widgets-layout__inserter-panel">
+		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
+		<div
+			className="edit-widgets-layout__inserter-panel"
+			onKeyDown={ closeOnEscape }
+		>
 			<div className="edit-widgets-layout__inserter-panel-content">
 				<Library
 					showInserterHelpPanel

--- a/test/e2e/specs/widgets/editing-widgets.spec.js
+++ b/test/e2e/specs/widgets/editing-widgets.spec.js
@@ -116,6 +116,7 @@ test.describe( 'Widgets screen', () => {
 			secondWidgetArea.getByRole( 'document', {
 				name: /^Empty block/,
 			} );
+
 		await addedParagraphBlockInSecondWidgetArea.focus();
 		await page.keyboard.type( 'Third Paragraph' );
 
@@ -143,6 +144,25 @@ test.describe( 'Widgets screen', () => {
 				},
 			],
 		} );
+	} );
+
+	test( 'Should focus the global inserter toggle when the global inserter is closed', async ( {
+		page,
+	} ) => {
+		const blockInserterToggle = page
+			.getByRole( 'toolbar', { name: 'Document tools' } )
+			.getByRole( 'button', { name: 'Block Inserter', exact: true } );
+		await blockInserterToggle.click();
+		await page
+			.getByRole( 'button', { name: 'Close Block Inserter' } )
+			.click();
+
+		await expect( blockInserterToggle ).toBeFocused();
+
+		await blockInserterToggle.click();
+		await page.keyboard.press( 'Escape' );
+
+		await expect( blockInserterToggle ).toBeFocused();
 	} );
 
 	test( 'Should insert content using the inline inserter', async ( {


### PR DESCRIPTION
## What?

To prevent focus loss in the widget editor, the inserter toggle gets focus when the following actions are performed:

- The "Close Block Inserter" button is clicked
- Escape key is pressed

## Why?

a11y. [Similar implementations](https://github.com/WordPress/gutenberg/blob/ca24ccecae21664f9527ae6440805c101faec0b0/packages/editor/src/components/inserter-sidebar/index.js#L66-L80) exist in the `editor` package, but the widget editor is implemented differently and must be implemented separately.

## Testing Instructions

- Activate Twenty Twenty-One.
- Open the widget editor.
- Click the global inserter.
  - Press the Escape key.
  - Click the "Close Block Inserter" button.
- The global inserter toggle button should be focused.


### Testing Instructions for Keyboard

You should be able to do the same thing using just the keyboard.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/671b8d6b-6595-4528-ba68-fb348ce100ff

