### PR TITLE
env: Fix changelog entry

### DIFF
--- a/packages/env/CHANGELOG.md
+++ b/packages/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   Add support for WordPress multisite installations. Enabled via the new `multisite` environment config ([#67845](https://github.com/WordPress/gutenberg/pull/67845)).
+
 ### Internal
 
 -   Refactored the code to use new API introduced together with `@inquirer/prompts` instead of legacy `inquirer` package ([#67877](https://github.com/WordPress/gutenberg/pull/67877)).
@@ -10,8 +14,7 @@
 
 ### Enhancements
 
--   Add phpMyAdmin as an optional service. Enabled via the new `phpmyadminPort` environment config, as well as env vars `WP_ENV_PHPMYADMIN_PORT` and `WP_ENV_TESTS_PHPMYADMIN_PORT`.
--   Add support for WordPress multisite installations. Enabled via the new `multisite` environment config.
+-   Add phpMyAdmin as an optional service. Enabled via the new `phpmyadminPort` environment config, as well as env vars `WP_ENV_PHPMYADMIN_PORT` and `WP_ENV_TESTS_PHPMYADMIN_PORT` ([#67588](https://github.com/WordPress/gutenberg/pull/67588)).
 
 ### Internal
 


### PR DESCRIPTION
## What?

Multisite support was added via #67845. This PR is part of Gutenberg 20.0 and is not released yet, so it should be added to the Unreleased section. At the same time, I linked the PR link to the changelog about multisite, phpmyAdmin.

## Testing Instructions

See: https://github.com/WordPress/gutenberg/blob/d619c3667d920736ffe56c1f84209f671bcb08e8/packages/env/CHANGELOG.md