### PR TITLE
.wp-env.json schema: Add `testsPort` field

### DIFF
--- a/schemas/json/wp-env.json
+++ b/schemas/json/wp-env.json
@@ -49,7 +49,7 @@
 					"default": []
 				},
 				"port": {
-					"description": "The primary port number to use for the installation. You'll access the instance through the port: 'http://localhost:8888'.",
+					"description": "The primary port number to use for the installation. You'll access the instance through the port: http://localhost:8888",
 					"type": "integer",
 					"default": 8888
 				},
@@ -114,6 +114,11 @@
 						}
 					},
 					"default": {}
+				},
+				"testsPort": {
+					"description": "The port number for the test site. You'll access the instance through the port: http://localhost:8889",
+					"type": "integer",
+					"default": 8889
 				}
 			}
 		},
@@ -125,7 +130,7 @@
 						"$ref": "#/definitions/wpEnvPropertyNames"
 					},
 					{
-						"enum": [ "$schema", "env" ]
+						"enum": [ "$schema", "env", "testsPort" ]
 					}
 				]
 			}


### PR DESCRIPTION
## What?

I noticed that in the `.wp-env.json` schema, even though `testsPort` is available at the root level, the code editor still throws a warning:

![image](https://github.com/user-attachments/assets/71d2a09b-02b1-40de-8908-e0ff4ff44218)

## Testing Instructions

Update wp-env.json as follows:

```json
{
	"$schema": "./schemas/json/wp-env.json",
	"core": "WordPress/WordPress",
	"plugins": [ "." ],
	"port": 8888,
	"testsPort": 8889,
	"env": {
		"development": {
			"port": 8888,
			"testsPort": 8889
		},
		"tests": {
			"port": 8888,
			"testsPort": 8889
		}
	}
}
```

Update your wp-env.json as follows.

- `testsPort` should not give you a warning.
- However, `env.{instance}.testsPort` should give you a warning since it's a disallowed field.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/54e074e3-3ad5-4c93-a843-ed4796254213)
