### PR TITLE
List View: fix appender size

### DIFF
--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -561,7 +561,7 @@ svg {
 
 	// TODO: Consider passing size="small" to the Inserter toggle instead.
 	// Special dimensions for this button.
-	&.block-editor-inserter__toggle {
+	&.has-icon.is-next-40px-default-size {
 		min-width: $button-size-small;
 	}
 

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -553,12 +553,17 @@ svg {
 }
 
 .list-view-appender .block-editor-inserter__toggle {
-	background-color: #1e1e1e;
-	color: #fff;
-	margin: $grid-unit-10 0 0 24px;
-	height: 24px;
-	min-width: 24px;
+	background-color: $gray-900;
+	color: $white;
+	margin: $grid-unit-10 0 0 $grid-unit-30;
+	height: $button-size-small;
 	padding: 0;
+
+	// TODO: Consider passing size="small" to the Inserter toggle instead.
+	// Special dimensions for this button.
+	&.block-editor-inserter__toggle {
+		min-width: $button-size-small;
+	}
 
 	&:hover,
 	&:focus {


### PR DESCRIPTION
Related to #68155

## What?

The list view appender is expected to be 24px in size, but due to the low specificity of the CSS selector it appears to have changed to 40px wide:

![list-view-appender](https://github.com/user-attachments/assets/e55b9dd8-44ef-41e4-a4a1-f858f4cfa633)

## How?

As [this comment says](https://github.com/WordPress/gutenberg/pull/68155#discussion_r1893319848), ideally we should consider using `size="small"` prop instead of custom CSS, but for now I increased the specificity of the CSS selector and overridden it with a 24px size.

I've also replaced some hard-coded values ​​with SCSS variables.

## Testing Instructions

Open the Navigation block's sidebar to see the size of the appender.

Note: As far as I know, the Navigation block's sidebar is the only place where the appender is displayed in the list view.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![image](https://github.com/user-attachments/assets/f570a241-a92c-4122-b15c-9db512c3d69f) | ![image](https://github.com/user-attachments/assets/2fbebdb0-71cc-42ec-b01e-ccdcf58c6d48) |
