### PR TITLE
Updated Small typo in unbrotli.js file

### DIFF
--- a/packages/edit-site/lib/unbrotli.js
+++ b/packages/edit-site/lib/unbrotli.js
@@ -180,7 +180,7 @@ module.exports = BrotliBitReader;
      CONTEXT_SIGNED: second-order context model tuned for signed integers.
 
    The context id for the UTF8 context model is calculated as follows. If p1
-   and p2 are the previous two bytes, we calcualte the context as
+   and p2 are the previous two bytes, we calculate the context as
 
      context = kContextLookup[p1] | kContextLookup[p2 + 256].
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Updated Small typo in packages/edit-site/lib/unbrotli.js file. There is a word `calcualte` it should be `calculate`


## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->

1. Open packages/edit-site/lib/unbrotli.js file
2. Go to Line Number 183
3. See the typo