### PR TITLE
Post Comments Count: Add Border Support

### DIFF
--- a/packages/block-library/src/post-comments-count/block.json
+++ b/packages/block-library/src/post-comments-count/block.json
@@ -39,8 +39,15 @@
 				"fontSize": true
 			}
 		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
+		},
 		"interactivity": {
 			"clientNavigation": true
 		}
-	}
+	},
+	"style": "wp-block-post-comments-count"
 }

--- a/packages/block-library/src/post-comments-count/style.scss
+++ b/packages/block-library/src/post-comments-count/style.scss
@@ -1,0 +1,4 @@
+.wp-block-post-comments-count {
+	// This block has customizable padding, border-box makes that more predictable.
+		box-sizing: border-box;
+}

--- a/packages/block-library/src/post-comments-count/style.scss
+++ b/packages/block-library/src/post-comments-count/style.scss
@@ -1,4 +1,4 @@
 .wp-block-post-comments-count {
 	// This block has customizable padding, border-box makes that more predictable.
-		box-sizing: border-box;
+	box-sizing: border-box;
 }

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -36,6 +36,7 @@
 @import "./post-author/style.scss";
 @import "./post-author-biography/style.scss";
 @import "./post-comments-form/style.scss";
+@import "./post-comments-count/style.scss";
 @import "./post-content/style.scss";
 @import "./post-date/style.scss";
 @import "./post-excerpt/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border support to the `Post Comment Count` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Comment Count` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Post Comment Count` block's border is Configurable via Global Styles.
- Edit Single Post Template &  Add `Post Comment Count` block and Apply the border Styles.
- Verify that `Post Comment Count` block styles take precedence over global Styles.
- Verify that `Post Comment Count` block borders  display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2af809d8-9b07-4d7a-aee0-bdf687e84850

