### PR TITLE
DataViews: Add `grid` keyboard navigation

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -65,7 +65,7 @@ export function useHasAPossibleBulkAction< Item >(
 	item: Item
 ) {
 	return useMemo( () => {
-		return actions.some( ( action ) => {
+		return actions?.some( ( action ) => {
 			return (
 				action.supportsBulk &&
 				( ! action.isEligible || action.isEligible( item ) )

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -7,7 +7,6 @@ import clsx from 'clsx';
  * WordPress dependencies
  */
 import {
-	__experimentalGrid as Grid,
 	__experimentalHStack as HStack,
 	__experimentalVStack as VStack,
 	Spinner,
@@ -57,7 +56,7 @@ interface GridItemProps< Item > {
 	hasBulkActions: boolean;
 }
 
-function chunk( array: any, size: any ) {
+function chunk( array: any, size: number ) {
 	const chunks = [];
 	for ( let i = 0, j = array.length; i < j; i += size ) {
 		chunks.push( array.slice( i, i + size ) );
@@ -129,7 +128,6 @@ function GridItem< Item >( {
 		<VStack
 			spacing={ 0 }
 			key={ id }
-			role="gridcell"
 			className={ clsx( 'dataviews-view-grid__card', {
 				'is-selected': hasBulkAction && isSelected,
 			} ) }
@@ -294,59 +292,54 @@ export default function ViewGrid< Item >( {
 							<Composite.Row
 								key={ i }
 								role="row"
-								className="dataviews-view-grid__row"
+								render={
+									<div
+										className="dataviews-view-grid__row"
+										style={ {
+											gridTemplateColumns: `repeat( ${ previewSize }, minmax(0, 1fr) )`,
+										} }
+									/>
+								}
 							>
-								<Grid
-									templateColumns={ `repeat( ${ previewSize }, minmax(0, 1fr) )` }
-									gap={ 8 }
-								>
-									{ row.map( ( item: any ) => (
-										<Composite.Item
-											key={ getItemId( item ) }
-											render={
-												<div
-													id={ getItemId( item ) }
-													className="dataviews-view-grid__row__gridcell"
-												>
-													<GridItem
-														view={ view }
-														selection={ selection }
-														onChangeSelection={
-															onChangeSelection
-														}
-														onClickItem={
-															onClickItem
-														}
-														isItemClickable={
-															isItemClickable
-														}
-														getItemId={ getItemId }
-														item={ item }
-														actions={ actions }
-														mediaField={
-															mediaField
-														}
-														titleField={
-															titleField
-														}
-														descriptionField={
-															descriptionField
-														}
-														regularFields={
-															regularFields
-														}
-														badgeFields={
-															badgeFields
-														}
-														hasBulkActions={
-															hasBulkActions
-														}
-													/>
-												</div>
-											}
-										/>
-									) ) }
-								</Grid>
+								{ row.map( ( item: any ) => (
+									<Composite.Item
+										key={ getItemId( item ) }
+										render={
+											<div
+												id={ getItemId( item ) }
+												className="dataviews-view-grid__row__gridcell"
+												role="gridcell"
+											>
+												<GridItem
+													view={ view }
+													selection={ selection }
+													onChangeSelection={
+														onChangeSelection
+													}
+													onClickItem={ onClickItem }
+													isItemClickable={
+														isItemClickable
+													}
+													getItemId={ getItemId }
+													item={ item }
+													actions={ actions }
+													mediaField={ mediaField }
+													titleField={ titleField }
+													descriptionField={
+														descriptionField
+													}
+													regularFields={
+														regularFields
+													}
+													badgeFields={ badgeFields }
+													hasBulkActions={
+														hasBulkActions
+													}
+												/>
+											</div>
+										}
+									/>
+								) ) }
 							</Composite.Row>
 						) ) }
 					</VStack>

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -297,7 +297,10 @@ export default function ViewGrid< Item >( {
 								role="row"
 								className="dataviews-view-grid__row"
 							>
-								<Grid columns={ usedPreviewSize } gap={ 8 }>
+								<Grid
+									templateColumns={ `repeat( ${ usedPreviewSize }, minmax(0, 1fr) )` }
+									gap={ 8 }
+								>
 									{ row.map( ( item: any ) => (
 										<Composite.Item
 											key={ getItemId( item ) }

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -37,7 +37,7 @@ import type {
 } from '../../types';
 import type { SetSelection } from '../../private-types';
 import getClickableItemProps from '../utils/get-clickable-item-props';
-import { useUpdatedPreviewSizeOnViewportChange } from './preview-size-picker';
+import { usePreviewSize } from './preview-size-picker';
 const { Badge } = unlock( componentsPrivateApis );
 
 interface GridItemProps< Item > {
@@ -277,9 +277,8 @@ export default function ViewGrid< Item >( {
 		{ regularFields: [], badgeFields: [] }
 	);
 	const hasData = !! data?.length;
-	const updatedPreviewSize = useUpdatedPreviewSizeOnViewportChange();
+	const previewSize = usePreviewSize();
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
-	const usedPreviewSize = updatedPreviewSize || view.layout?.previewSize;
 	return (
 		<>
 			{ hasData && (
@@ -291,14 +290,14 @@ export default function ViewGrid< Item >( {
 					aria-busy={ isLoading }
 				>
 					<VStack spacing={ 8 }>
-						{ chunk( data, usedPreviewSize ).map( ( row, i ) => (
+						{ chunk( data, previewSize ).map( ( row, i ) => (
 							<Composite.Row
 								key={ i }
 								role="row"
 								className="dataviews-view-grid__row"
 							>
 								<Grid
-									templateColumns={ `repeat( ${ usedPreviewSize }, minmax(0, 1fr) )` }
+									templateColumns={ `repeat( ${ previewSize }, minmax(0, 1fr) )` }
 									gap={ 8 }
 								>
 									{ row.map( ( item: any ) => (

--- a/packages/dataviews/src/dataviews-layouts/grid/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/index.tsx
@@ -13,6 +13,7 @@ import {
 	Spinner,
 	Flex,
 	FlexItem,
+	Composite,
 	privateApis as componentsPrivateApis,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
@@ -54,6 +55,14 @@ interface GridItemProps< Item > {
 	regularFields: NormalizedField< Item >[];
 	badgeFields: NormalizedField< Item >[];
 	hasBulkActions: boolean;
+}
+
+function chunk( array: any, size: any ) {
+	const chunks = [];
+	for ( let i = 0, j = array.length; i < j; i += size ) {
+		chunks.push( array.slice( i, i + size ) );
+	}
+	return chunks;
 }
 
 function GridItem< Item >( {
@@ -120,6 +129,7 @@ function GridItem< Item >( {
 		<VStack
 			spacing={ 0 }
 			key={ id }
+			role="gridcell"
 			className={ clsx( 'dataviews-view-grid__card', {
 				'is-selected': hasBulkAction && isSelected,
 			} ) }
@@ -270,44 +280,75 @@ export default function ViewGrid< Item >( {
 	const updatedPreviewSize = useUpdatedPreviewSizeOnViewportChange();
 	const hasBulkActions = useSomeItemHasAPossibleBulkAction( actions, data );
 	const usedPreviewSize = updatedPreviewSize || view.layout?.previewSize;
-	const gridStyle = usedPreviewSize
-		? {
-				gridTemplateColumns: `repeat(${ usedPreviewSize }, minmax(0, 1fr))`,
-		  }
-		: {};
 	return (
 		<>
 			{ hasData && (
-				<Grid
-					gap={ 8 }
-					columns={ 2 }
-					alignment="top"
+				<Composite
+					role="grid"
 					className="dataviews-view-grid"
-					style={ gridStyle }
+					focusLoop
+					focusWrap
 					aria-busy={ isLoading }
 				>
-					{ data.map( ( item ) => {
-						return (
-							<GridItem
-								key={ getItemId( item ) }
-								view={ view }
-								selection={ selection }
-								onChangeSelection={ onChangeSelection }
-								onClickItem={ onClickItem }
-								isItemClickable={ isItemClickable }
-								getItemId={ getItemId }
-								item={ item }
-								actions={ actions }
-								mediaField={ mediaField }
-								titleField={ titleField }
-								descriptionField={ descriptionField }
-								regularFields={ regularFields }
-								badgeFields={ badgeFields }
-								hasBulkActions={ hasBulkActions }
-							/>
-						);
-					} ) }
-				</Grid>
+					<VStack spacing={ 8 }>
+						{ chunk( data, usedPreviewSize ).map( ( row, i ) => (
+							<Composite.Row
+								key={ i }
+								role="row"
+								className="dataviews-view-grid__row"
+							>
+								<Grid columns={ usedPreviewSize } gap={ 8 }>
+									{ row.map( ( item: any ) => (
+										<Composite.Item
+											key={ getItemId( item ) }
+											render={
+												<div
+													id={ getItemId( item ) }
+													className="dataviews-view-grid__row__gridcell"
+												>
+													<GridItem
+														view={ view }
+														selection={ selection }
+														onChangeSelection={
+															onChangeSelection
+														}
+														onClickItem={
+															onClickItem
+														}
+														isItemClickable={
+															isItemClickable
+														}
+														getItemId={ getItemId }
+														item={ item }
+														actions={ actions }
+														mediaField={
+															mediaField
+														}
+														titleField={
+															titleField
+														}
+														descriptionField={
+															descriptionField
+														}
+														regularFields={
+															regularFields
+														}
+														badgeFields={
+															badgeFields
+														}
+														hasBulkActions={
+															hasBulkActions
+														}
+													/>
+												</div>
+											}
+										/>
+									) ) }
+								</Grid>
+							</Composite.Row>
+						) ) }
+					</VStack>
+				</Composite>
 			) }
 			{ ! hasData && (
 				<div

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -43,7 +43,7 @@ function useViewPortBreakpoint() {
 	return 'mobile';
 }
 
-export function useUpdatedPreviewSizeOnViewportChange() {
+export function usePreviewSize() {
 	const view = useContext( DataViewsContext ).view as ViewGrid;
 	const viewport = useViewPortBreakpoint();
 	return useMemo( () => {
@@ -53,15 +53,14 @@ export function useUpdatedPreviewSizeOnViewportChange() {
 			const breakValueProp = viewport === 'mobile' ? 'min' : 'default';
 			return viewportBreaks[ viewport ][ breakValueProp ];
 		}
-		let newPreviewSize;
 		const breakValues = viewportBreaks[ viewport ];
 		if ( previewSize < breakValues.min ) {
-			newPreviewSize = breakValues.min;
+			return breakValues.min;
 		}
 		if ( previewSize > breakValues.max ) {
-			newPreviewSize = breakValues.max;
+			return breakValues.max;
 		}
-		return newPreviewSize;
+		return previewSize;
 	}, [ viewport, view ] );
 }
 

--- a/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
+++ b/packages/dataviews/src/dataviews-layouts/grid/preview-size-picker.tsx
@@ -48,10 +48,12 @@ export function useUpdatedPreviewSizeOnViewportChange() {
 	const viewport = useViewPortBreakpoint();
 	return useMemo( () => {
 		const previewSize = view.layout?.previewSize;
-		let newPreviewSize;
 		if ( ! previewSize ) {
-			return;
+			// For mobile, we want the `min` value as the default.
+			const breakValueProp = viewport === 'mobile' ? 'min' : 'default';
+			return viewportBreaks[ viewport ][ breakValueProp ];
 		}
+		let newPreviewSize;
 		const breakValues = viewportBreaks[ viewport ];
 		if ( previewSize < breakValues.min ) {
 			newPreviewSize = breakValues.min;

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -1,6 +1,8 @@
 .dataviews-view-grid {
+	display: flex;
+	align-items: flex-start;
+	justify-content: center;
 	margin-bottom: auto;
-	grid-template-rows: max-content;
 	padding: 0 $grid-unit-60 $grid-unit-30;
 	transition: padding ease-out 0.1s;
 	container-type: inline-size;
@@ -116,26 +118,9 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
-	/**
-	 * Breakpoints were adjusted from media queries breakpoints to account for
-	 * the sidebar width. This was done to match the existing styles we had.
-	 */
 	@container (max-width: 480px) {
-		grid-template-columns: repeat(1, minmax(0, 1fr));
 		padding-left: $grid-unit-30;
 		padding-right: $grid-unit-30;
-	}
-	@container (min-width: 480px) {
-		grid-template-columns: repeat(2, minmax(0, 1fr));
-	}
-	@container (min-width: 780px) {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-	}
-	@container (min-width: 1140px) {
-		grid-template-columns: repeat(4, minmax(0, 1fr));
-	}
-	@container (min-width: 1520px) {
-		grid-template-columns: repeat(5, minmax(0, 1fr));
 	}
 }
 
@@ -159,4 +144,24 @@
 
 .dataviews-view-grid__media--clickable {
 	cursor: pointer;
+}
+
+
+.dataviews-view-grid__row {
+	.dataviews-view-grid__row__gridcell {
+		outline: 0;
+		outline-style: solid;
+		// outline-offset: calc(-1 * var(--wp-admin-border-width-focus));
+		border-radius: $grid-unit-10;
+
+		&[data-focus-visible] {
+			outline-color: var(--wp-admin-theme-color);
+			outline-width: var(--wp-admin-border-width-focus);
+		}
+
+		&:hover {
+			outline-color: rgba($black, 0.3);
+			outline-width: var(--wp-admin-border-width-focus);
+		}
+	}
 }

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -145,6 +145,9 @@
 
 
 .dataviews-view-grid__row {
+	display: grid;
+	gap: $grid-unit-40;
+
 	.dataviews-view-grid__row__gridcell {
 		outline: 0;
 		outline-style: solid;

--- a/packages/dataviews/src/dataviews-layouts/grid/style.scss
+++ b/packages/dataviews/src/dataviews-layouts/grid/style.scss
@@ -1,7 +1,4 @@
 .dataviews-view-grid {
-	display: flex;
-	align-items: flex-start;
-	justify-content: center;
 	margin-bottom: auto;
 	padding: 0 $grid-unit-60 $grid-unit-30;
 	transition: padding ease-out 0.1s;
@@ -118,7 +115,7 @@
 }
 
 .dataviews-view-grid.dataviews-view-grid {
-	@container (max-width: 480px) {
+	@container (max-width: 430px) {
 		padding-left: $grid-unit-30;
 		padding-right: $grid-unit-30;
 	}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves: https://github.com/WordPress/gutenberg/issues/59188

This PR aims to add proper keyboard navigation in `grid` layout for DataViews.


### Tasks
- [ ] Polish some styles. For example the `outline` and how it plays with the `preview field` outline or when there is a selected item (also has outline).
- [ ] get a11y feedback for anything missing like roles etc..



## Testing Instructions
1. Everything should work as before, regarding the number of columns for items (preview size). That entails when we loading the page (default columns) and resizing either we have selected a different `preview size` (from view options) or not. This is important as the default styles are always applied through `JS` now. This is needed because we have to split programmatically `rows`.
2. Keyboard navigation should work properly by selecting different items and we can navigate inside each item by pressing `tab`.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/ddfea677-c045-460c-ba52-872e2b94fb72


