### PR TITLE
Grid Visualizer: Improve observation logic

### DIFF
--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -62,6 +62,17 @@ const GridVisualizerGrid = forwardRef(
 				observer.observe( element );
 				observers.push( observer );
 			}
+
+			const mutationObserver = new window.MutationObserver( () => {
+				setGridInfo( getGridInfo( gridElement ) );
+			} );
+			mutationObserver.observe( gridElement, {
+				attributeFilter: [ 'style' ],
+				childList: true,
+				subtree: true,
+			} );
+			observers.push( mutationObserver );
+
 			return () => {
 				for ( const observer of observers ) {
 					observer.disconnect();

--- a/packages/block-editor/src/components/grid/grid-visualizer.js
+++ b/packages/block-editor/src/components/grid/grid-visualizer.js
@@ -67,7 +67,7 @@ const GridVisualizerGrid = forwardRef(
 				setGridInfo( getGridInfo( gridElement ) );
 			} );
 			mutationObserver.observe( gridElement, {
-				attributeFilter: [ 'style' ],
+				attributeFilter: [ 'style', 'class' ],
 				childList: true,
 				subtree: true,
 			} );

--- a/packages/block-editor/src/components/grid/utils.js
+++ b/packages/block-editor/src/components/grid/utils.js
@@ -160,6 +160,21 @@ export function getGridInfo( gridElement ) {
 		gridElement,
 		'grid-template-rows'
 	);
+	const borderTopWidth = getComputedCSS( gridElement, 'border-top-width' );
+	const borderRightWidth = getComputedCSS(
+		gridElement,
+		'border-right-width'
+	);
+	const borderBottomWidth = getComputedCSS(
+		gridElement,
+		'border-bottom-width'
+	);
+	const borderLeftWidth = getComputedCSS( gridElement, 'border-left-width' );
+	const paddingTop = getComputedCSS( gridElement, 'padding-top' );
+	const paddingRight = getComputedCSS( gridElement, 'padding-right' );
+	const paddingBottom = getComputedCSS( gridElement, 'padding-bottom' );
+	const paddingLeft = getComputedCSS( gridElement, 'padding-left' );
+
 	const numColumns = gridTemplateColumns.split( ' ' ).length;
 	const numRows = gridTemplateRows.split( ' ' ).length;
 	const numItems = numColumns * numRows;
@@ -172,7 +187,10 @@ export function getGridInfo( gridElement ) {
 			gridTemplateColumns,
 			gridTemplateRows,
 			gap: getComputedCSS( gridElement, 'gap' ),
-			padding: getComputedCSS( gridElement, 'padding' ),
+			paddingTop: `calc(${ paddingTop } + ${ borderTopWidth })`,
+			paddingRight: `calc(${ paddingRight } + ${ borderRightWidth })`,
+			paddingBottom: `calc(${ paddingBottom } + ${ borderBottomWidth })`,
+			paddingLeft: `calc(${ paddingLeft } + ${ borderLeftWidth })`,
 		},
 	};
 }


### PR DESCRIPTION
Fix the issue found in this comment: https://github.com/WordPress/gutenberg/pull/64425#pullrequestreview-2519538374

## What?

This PR makes the grid visualizer's frames match their actual child elements more accurately.

## Why?

This component is used to draw the frames for the blocks inside it when the block is a grid layout type. This frame is re-rendered when the grid block or its children change size. However, when padding or borders are applied to a grid block, this frame may not match the actual child blocks:

![image](https://github.com/user-attachments/assets/ace788f7-87b0-4cea-a6cd-50181516989d)

## How?

To resolve this mismatch, I made two changes:

- On the grid element itself, add a `MutationObserber` to monitor changes to style attributes, so that the frame is re-rendered when, for example, the vertical padding changes.
- In the `getGridInfo()` function, include the border width for padding calculations.

## Testing Instructions

- Insert a Grid block.
- Change the styles for padding, margin, gap, border, etc.
- The child elements and visualizer positions should match perfectly.
- This logic should also work correctly when the grid block has no "box-sizing: border-box" style applied. Remove [this style](https://github.com/WordPress/gutenberg/blob/212144c8dd868e8f0faab851aadb0aa06a38de3b/packages/block-library/src/group/style.scss#L3) and test again.
- It should work correctly when applied via global styles, not just on the block instance.
  - **Note:** However, only the vertical padding does not sync immediately in the global styles, probably because neither the `ResizeObserver` nor the `MutationObserber` can detect the change. If you have an approach to solve this, please let me know.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/4b6cfb5e-7228-40f2-9aaf-f3d677885d73


