### PR TITLE
DropZone: Make the drop zone in Storybook the same size as the item

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,7 +30,6 @@
 -   `SlotFill`: rewrite the non-portal version to use `observableMap` ([#67400](https://github.com/WordPress/gutenberg/pull/67400)).
 -   `DatePicker`: Prepare day buttons for 40px default size ([#68156](https://github.com/WordPress/gutenberg/pull/68156)).
 -   `SlotFill`: register slots in a layout effect ([#68176](https://github.com/WordPress/gutenberg/pull/68176)).
--   `DropZone`: Make the drop zone in Storybook the same size as the item ([#68231](https://github.com/WordPress/gutenberg/pull/68231)).
 
 ## 29.0.0 (2024-12-11)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -30,6 +30,7 @@
 -   `SlotFill`: rewrite the non-portal version to use `observableMap` ([#67400](https://github.com/WordPress/gutenberg/pull/67400)).
 -   `DatePicker`: Prepare day buttons for 40px default size ([#68156](https://github.com/WordPress/gutenberg/pull/68156)).
 -   `SlotFill`: register slots in a layout effect ([#68176](https://github.com/WordPress/gutenberg/pull/68176)).
+-   `DropZone`: Make the drop zone in Storybook the same size as the item ([#68231](https://github.com/WordPress/gutenberg/pull/68231)).
 
 ## 29.0.0 (2024-12-11)
 

--- a/packages/components/src/drop-zone/stories/index.story.tsx
+++ b/packages/components/src/drop-zone/stories/index.story.tsx
@@ -21,7 +21,13 @@ export default meta;
 
 const Template: StoryFn< typeof DropZone > = ( props ) => {
 	return (
-		<div style={ { background: 'lightgray', padding: 16 } }>
+		<div
+			style={ {
+				background: 'lightgray',
+				padding: 32,
+				position: 'relative',
+			} }
+		>
 			Drop something here
 			<DropZone { ...props } />
 		</div>


### PR DESCRIPTION
## What?

By adding `position:relative` to the parent element, make the size of the drop zone component match the size of the item.

At the same time, increase the padding a bit because it was a bit cramped when we were about to drop it.

## Testing Instructions

Access http://localhost:50240/?path=/story/components-dropzone--default

## Screenshots or screencast <!-- if applicable -->

### Before

https://github.com/user-attachments/assets/4a340b20-26c6-44bd-ba07-b0fc591d7329

### After

https://github.com/user-attachments/assets/50e61712-5849-43f7-ad37-0cfe2e511981