### PR TITLE
Login/out Block: Add button display option

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -436,7 +436,7 @@ Show login & logout links. ([Source](https://github.com/WordPress/gutenberg/tree
 -	**Name:** core/loginout
 -	**Category:** theme
 -	**Supports:** className, color (background, gradients, link, ~~text~~), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** displayLoginAsForm, redirectToCurrent
+-	**Attributes:** displayAsButton, displayLoginAsForm, redirectToCurrent
 
 ## Media & Text
 

--- a/packages/block-library/src/loginout/block.json
+++ b/packages/block-library/src/loginout/block.json
@@ -12,6 +12,10 @@
 			"type": "boolean",
 			"default": false
 		},
+		"displayAsButton": {
+			"type": "boolean",
+			"default": false
+		},
 		"redirectToCurrent": {
 			"type": "boolean",
 			"default": true

--- a/packages/block-library/src/loginout/edit.js
+++ b/packages/block-library/src/loginout/edit.js
@@ -14,7 +14,8 @@ import { __ } from '@wordpress/i18n';
 import { useToolsPanelDropdownMenuProps } from '../utils/hooks';
 
 export default function LoginOutEdit( { attributes, setAttributes } ) {
-	const { displayLoginAsForm, redirectToCurrent } = attributes;
+	const { displayLoginAsForm, displayAsButton, redirectToCurrent } =
+		attributes;
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 
 	return (
@@ -50,6 +51,25 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 						/>
 					</ToolsPanelItem>
 					<ToolsPanelItem
+						label={ __( 'Display as button' ) }
+						isShownByDefault
+						hasValue={ () => displayAsButton }
+						onDeselect={ () =>
+							setAttributes( { displayAsButton: false } )
+						}
+					>
+						<ToggleControl
+							__nextHasNoMarginBottom
+							label={ __( 'Display as button' ) }
+							checked={ displayAsButton }
+							onChange={ () =>
+								setAttributes( {
+									displayAsButton: ! displayAsButton,
+								} )
+							}
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
 						label={ __( 'Redirect to current URL' ) }
 						isShownByDefault
 						hasValue={ () => ! redirectToCurrent }
@@ -72,10 +92,18 @@ export default function LoginOutEdit( { attributes, setAttributes } ) {
 			</InspectorControls>
 			<div
 				{ ...useBlockProps( {
-					className: 'logged-in',
+					className: `logged-in${
+						displayAsButton ? ' wp-block-button' : ''
+					}`,
 				} ) }
 			>
-				<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
+				{ displayAsButton ? (
+					<div className="wp-block-button__link wp-element-button">
+						<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
+					</div>
+				) : (
+					<a href="#login-pseudo-link">{ __( 'Log out' ) }</a>
+				) }
 			</div>
 		</>
 	);

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -25,6 +25,15 @@ function render_block_core_loginout( $attributes ) {
 		false
 	);
 
+	// If display as button is enabled, wrap the link in button classes
+    if ( ! empty( $attributes['displayAsButton'] ) ) {
+        $classes .= ' wp-block-button';
+        $contents = sprintf(
+            '<div class="wp-block-button__link wp-element-button">%s</div>',
+            $contents
+        );
+    }
+
 	// If logged-out and displayLoginAsForm is true, show the login form.
 	if ( ! is_user_logged_in() && ! empty( $attributes['displayLoginAsForm'] ) ) {
 		// Add a class.

--- a/packages/block-library/src/loginout/index.php
+++ b/packages/block-library/src/loginout/index.php
@@ -26,13 +26,13 @@ function render_block_core_loginout( $attributes ) {
 	);
 
 	// If display as button is enabled, wrap the link in button classes
-    if ( ! empty( $attributes['displayAsButton'] ) ) {
-        $classes .= ' wp-block-button';
-        $contents = sprintf(
-            '<div class="wp-block-button__link wp-element-button">%s</div>',
-            $contents
-        );
-    }
+	if ( ! empty( $attributes['displayAsButton'] ) ) {
+		$classes .= ' wp-block-button';
+		$contents = sprintf(
+			'<div class="wp-block-button__link wp-element-button">%s</div>',
+			$contents
+		);
+	}
 
 	// If logged-out and displayLoginAsForm is true, show the login form.
 	if ( ! is_user_logged_in() && ! empty( $attributes['displayLoginAsForm'] ) ) {


### PR DESCRIPTION
Fixes: #68226 

## What?
Add a button display option to the Login/out block, allowing users to style the login/logout link as a button instead of just a text link.

## Why?
The Login/out block currently only displays as a text link, which may not match the desired visual presentation in all contexts. This enhancement allows users to display the block as a button, providing better visual alignment with other button elements and improving the block's flexibility for various use cases.


## Testing Instructions
1. Create or edit a post/page
2. Insert a Login/out block
3. In the block settings sidebar, look for the "Display as a button" toggle under Settings
4. Toggle the button display on/off
5. Verify the block updates in the editor to show as a button
6. Save the post/page
7. View the post/page on the frontend
8. Verify the login/logout link appears as a button when enabled
9. Test both logged-in and logged-out states

## Screencast

https://github.com/user-attachments/assets/736f1f47-609e-4b75-87bc-ed6de576a39b


