### PR TITLE
Inserter: Add loading state and refactor pattern

### DIFF
--- a/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-explorer/index.js
@@ -17,7 +17,8 @@ function PatternsExplorer( { initialCategory, rootClientId } ) {
 	const [ selectedCategory, setSelectedCategory ] =
 		useState( initialCategory );
 
-	const patternCategories = usePatternCategories( rootClientId );
+	const { categories: patternCategories } =
+		usePatternCategories( rootClientId );
 
 	return (
 		<div className="block-editor-block-patterns-explorer">

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/index.js
@@ -3,7 +3,7 @@
  */
 import { useState } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -25,9 +25,17 @@ function BlockPatternsTab( {
 } ) {
 	const [ showPatternsExplorer, setShowPatternsExplorer ] = useState( false );
 
-	const categories = usePatternCategories( rootClientId );
+	const { categories, isLoading } = usePatternCategories( rootClientId );
 
 	const isMobile = useViewportMatch( 'medium', '<' );
+
+	if ( isLoading ) {
+		return (
+			<div className="block-editor-inserter__block-patterns-tabs-container-spinner">
+				<Spinner />
+			</div>
+		);
+	}
 
 	if ( ! categories.length ) {
 		return <InserterNoResults />;

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/pattern-category-previews.js
@@ -51,7 +51,7 @@ export function PatternCategoryPreviews( {
 	const [ patternSyncFilter, setPatternSyncFilter ] = useState( 'all' );
 	const [ patternSourceFilter, setPatternSourceFilter ] = useState( 'all' );
 
-	const availableCategories = usePatternCategories(
+	const { categories: availableCategories } = usePatternCategories(
 		rootClientId,
 		patternSourceFilter
 	);

--- a/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
+++ b/packages/block-editor/src/components/inserter/block-patterns-tab/use-pattern-categories.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useMemo } from '@wordpress/element';
+import { useMemo, useState, useEffect } from '@wordpress/element';
 import { _x, _n, sprintf } from '@wordpress/i18n';
 
 import { speak } from '@wordpress/a11y';
@@ -29,10 +29,17 @@ function hasRegisteredCategory( pattern, allCategories ) {
 }
 
 export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
+	const [ isLoading, setIsLoading ] = useState( true );
 	const [ patterns, allCategories ] = usePatternsState(
 		undefined,
 		rootClientId
 	);
+
+	useEffect( () => {
+		if ( patterns.length && allCategories.length ) {
+			setIsLoading( false );
+		}
+	}, [ patterns, allCategories ] );
 
 	const filteredPatterns = useMemo(
 		() =>
@@ -47,6 +54,10 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 
 	// Remove any empty categories.
 	const populatedCategories = useMemo( () => {
+		if ( isLoading ) {
+			return [];
+		}
+
 		const categories = allCategories
 			.filter( ( category ) =>
 				filteredPatterns.some( ( pattern ) =>
@@ -100,7 +111,7 @@ export function usePatternCategories( rootClientId, sourceFilter = 'all' ) {
 			)
 		);
 		return categories;
-	}, [ allCategories, filteredPatterns ] );
+	}, [ allCategories, filteredPatterns, isLoading ] );
 
-	return populatedCategories;
+	return { categories: populatedCategories, isLoading };
 }

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -648,3 +648,10 @@ $block-inserter-tabs-height: 44px;
 .block-editor-tabbed-sidebar__tabpanel .block-editor-inserter__help-text {
 	padding: 0 $grid-unit-30 $grid-unit-20;
 }
+
+.block-editor-inserter__block-patterns-tabs-container-spinner {
+	height: 100%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}


### PR DESCRIPTION
Closes: #68232
## What?
This PR improves the user experience in the block inserter by introducing a proper loading state for pattern categories. Instead of displaying “No results found” during loading, a spinner is now shown to indicate that the categories are being fetched.

## Why?
Previously, the interface displayed “No results found” while pattern categories were still loading, which could confuse users. Adding a spinner provides clearer feedback and enhances the user experience.


## How?
1.	Refactored usePatternCategories to return an object with categories and isLoading.
2.	Updated BlockPatternsTab to show a spinner while categories are being fetched instead of displaying “No results found.”
3.	Refactored PatternsExplorer and PatternCategoryPreviews to destructure categories from the hook’s response.
4.	Added styles to center the spinner in the block patterns tab during loading.

## Testing Instructions
1. Refactored usePatternCategories to return an object with categories and isLoading.
2.	Updated BlockPatternsTab to show a spinner while categories are being fetched instead of displaying “No results found.”
3.	Refactored PatternsExplorer and PatternCategoryPreviews to destructure categories from the hook’s response.

## Screenshots or screencast <!-- if applicable -->
### Before:

https://github.com/user-attachments/assets/d0de8f79-285e-4746-bd6b-01a15221f7e4


### After:

https://github.com/user-attachments/assets/2a098246-54a8-4b4b-a9f8-3f4b2b6f02c4

