### PR TITLE
Link UI: Introduce margin to fix obscuring the `+` button while editing `navigation sub-menus`

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -213,6 +213,7 @@ function UnforwardedLinkUI( props, ref ) {
 			placement="bottom"
 			onClose={ props.onClose }
 			anchor={ props.anchor }
+			className="link-ui-popover"
 			shift
 		>
 			{ ! addingBlock && (

--- a/packages/block-library/src/navigation-link/style.scss
+++ b/packages/block-library/src/navigation-link/style.scss
@@ -28,3 +28,7 @@
 	margin-left: $grid-unit-10;
 	text-transform: uppercase;
 }
+
+.link-ui-popover {
+	margin-top: $default-block-margin;
+}


### PR DESCRIPTION
Fixes: #68182 

## What, Why & How?
Currently, when editing navigation links, the link UI popover can obscure the "+" button, making it difficult for users to add new items. This PR adds a top margin to the popover to ensure better visibility and accessibility of the add button.

- Add top margin to Navigation Link block popover
- Use existing block margin variable for consistency
- Improve UX for navigation menu editing

## Testing Instructions
1. Create a `navigation block`
2. Try adding `sub-menu items` to `menu items`
3. Notice, the `+` button now does not overlap with the `Popover`

## Screenshots

| Before | After |
|---------|--------|
| ![Before - Link UI Popover obscuring + button](https://github.com/user-attachments/assets/83651337-e367-4e0b-9a69-76be3d97dee2) | ![After - Link UI Popover with proper spacing](https://github.com/user-attachments/assets/782127b7-a3aa-4e40-adf1-89b62baa8817) |
