### PR TITLE
postcss-plugins-preset: bump autoprefixer to 10.4.20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17513,43 +17513,6 @@
 			"integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
 			"dev": true
 		},
-		"node_modules/autoprefixer": {
-			"version": "10.4.14",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.14.tgz",
-			"integrity": "sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==",
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "tidelift",
-					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
-				}
-			],
-			"dependencies": {
-				"browserslist": "^4.21.5",
-				"caniuse-lite": "^1.0.30001464",
-				"fraction.js": "^4.2.0",
-				"normalize-range": "^0.1.2",
-				"picocolors": "^1.0.0",
-				"postcss-value-parser": "^4.2.0"
-			},
-			"bin": {
-				"autoprefixer": "bin/autoprefixer"
-			},
-			"engines": {
-				"node": "^10 || ^12 || >=14"
-			},
-			"peerDependencies": {
-				"postcss": "^8.1.0"
-			}
-		},
-		"node_modules/autoprefixer/node_modules/postcss-value-parser": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
-		},
 		"node_modules/autosize": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/autosize/-/autosize-4.0.2.tgz",
@@ -25665,6 +25628,7 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
 			"integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+			"dev": true,
 			"engines": {
 				"node": "*"
 			},
@@ -51967,7 +51931,7 @@
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@wordpress/base-styles": "*",
-				"autoprefixer": "^10.2.5"
+				"autoprefixer": "^10.4.20"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -51976,6 +51940,59 @@
 			"peerDependencies": {
 				"postcss": "^8.0.0"
 			}
+		},
+		"packages/postcss-plugins-preset/node_modules/autoprefixer": {
+			"version": "10.4.20",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
+			"integrity": "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/postcss/"
+				},
+				{
+					"type": "tidelift",
+					"url": "https://tidelift.com/funding/github/npm/autoprefixer"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"dependencies": {
+				"browserslist": "^4.23.3",
+				"caniuse-lite": "^1.0.30001646",
+				"fraction.js": "^4.3.7",
+				"normalize-range": "^0.1.2",
+				"picocolors": "^1.0.1",
+				"postcss-value-parser": "^4.2.0"
+			},
+			"bin": {
+				"autoprefixer": "bin/autoprefixer"
+			},
+			"engines": {
+				"node": "^10 || ^12 || >=14"
+			},
+			"peerDependencies": {
+				"postcss": "^8.1.0"
+			}
+		},
+		"packages/postcss-plugins-preset/node_modules/fraction.js": {
+			"version": "4.3.7",
+			"resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+			"integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+			"engines": {
+				"node": "*"
+			},
+			"funding": {
+				"type": "patreon",
+				"url": "https://github.com/sponsors/rawify"
+			}
+		},
+		"packages/postcss-plugins-preset/node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
 		},
 		"packages/postcss-themes": {
 			"name": "@wordpress/postcss-themes",

--- a/packages/postcss-plugins-preset/CHANGELOG.md
+++ b/packages/postcss-plugins-preset/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Enhancements
+
+-   The bundled `autoprefixer` dependency has been updated from requiring `^10.2.5` to requiring `^10.4.20` (see [#68237](https://github.com/WordPress/gutenberg/pull/68237)).
+
 ## 5.14.0 (2024-12-11)
 
 ## 5.13.0 (2024-11-27)

--- a/packages/postcss-plugins-preset/package.json
+++ b/packages/postcss-plugins-preset/package.json
@@ -31,7 +31,7 @@
 	"main": "lib/index.js",
 	"dependencies": {
 		"@wordpress/base-styles": "*",
-		"autoprefixer": "^10.2.5"
+		"autoprefixer": "^10.4.20"
 	},
 	"peerDependencies": {
 		"postcss": "^8.0.0"


### PR DESCRIPTION
## What?
Bumps `autoprefixer` to the latest version, `v10.4.20`.

## Why?
Mainly to get a bunch of fixes and enhancements, namely the one coming from [`v10.4.19`](https://github.com/postcss/autoprefixer/releases/tag/10.4.19):

https://github.com/postcss/autoprefixer/commit/cf808243ce6eef1087ddedfd0e1bfca3af6db9c8#diff-9601a8f6c734c2001be34a2361f76946d19a39a709b5e8c624a2a5a0aade05f2R18

Alternative to #68199. Closes #68199.

## How?
We're specifically bumping the version of `autoprefixer` we require in our `postcss-plugins-preset` package. 

The only reason we were depending on an old version was old minimal dependencies in `@docusaurus/core` we use for the static docs site.

## Testing Instructions
* Test the following cases and verify there are no visual changes when comparing to trunk:
	* In Storybook, go to Button > Icon and type any text in the button (or just go to `?path=/story/components-button--icon&args=text:WordPress`)
	* In Storybook, go to Tabs > Vertical (or just go to `?path=/story/components-tabs--vertical`)
	* In the site editor, make sure you have done and saved at least a few changes to global styles. Then access global styles revisions from the Global Styles sidebar heading and compare the meta (the author info) under one or more revisions
* Smoke test local dev build `npm run dev`
* Smoke test create-block (`node packages/create-block/index.js test-plugin` for example)

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![Screenshot 2024-12-20 at 16 43 29](https://github.com/user-attachments/assets/bb5ed0c1-8aaf-4124-acc1-2a39014652ee)
