### PR TITLE
Fix: Increase Link UI search results when directly adding a Nav Link block variation

### DIFF
--- a/packages/block-library/src/navigation-link/link-ui.js
+++ b/packages/block-library/src/navigation-link/link-ui.js
@@ -52,19 +52,19 @@ export function getSuggestionsQuery( type, kind ) {
 	switch ( type ) {
 		case 'post':
 		case 'page':
-			return { type: 'post', subtype: type };
+			return { type: 'post', subtype: type, perPage: 20 };
 		case 'category':
-			return { type: 'term', subtype: 'category' };
+			return { type: 'term', subtype: 'category', perPage: 20 };
 		case 'tag':
-			return { type: 'term', subtype: 'post_tag' };
+			return { type: 'term', subtype: 'post_tag', perPage: 20 };
 		case 'post_format':
 			return { type: 'post-format' };
 		default:
 			if ( kind === 'taxonomy' ) {
-				return { type: 'term', subtype: type };
+				return { type: 'term', subtype: type, perPage: 20 };
 			}
 			if ( kind === 'post-type' ) {
-				return { type: 'post', subtype: type };
+				return { type: 'post', subtype: type, perPage: 20 };
 			}
 			return {
 				// for custom link which has no type


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Resolves https://github.com/WordPress/gutenberg/issues/68185
Add perPage property to suggestions query.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Fix: Increase Link UI search results when directly adding a Nav Link block variation


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/719f171c-ba9b-4bda-8756-028b9663a7b0
