### PR TITLE
Post Title: Transform added for paragraph and heading

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -19,8 +19,9 @@ import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-
+import { useSelect, select } from '@wordpress/data';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { store as editorStore } from '@wordpress/editor';
 export default function PostTitleEdit( {
 	attributes: { level, levelOptions, textAlign, isLink, rel, linkTarget },
 	setAttributes,
@@ -30,6 +31,7 @@ export default function PostTitleEdit( {
 	const TagName = level === 0 ? 'p' : `h${ level }`;
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const userCanEdit = useSelect(
+		// eslint-disable-next-line no-shadow
 		( select ) => {
 			/**
 			 * useCanEditEntity may trigger an OPTIONS request to the REST API
@@ -180,3 +182,43 @@ export default function PostTitleEdit( {
 		</>
 	);
 }
+export const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/heading', 'core/paragraph' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/post-title', {
+					textAlign: attributes.align || undefined, // Map alignment if available
+				} ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( { textAlign } ) => {
+				const postTitle =
+					select( editorStore ).getEditedPostAttribute( 'title' ) ||
+					__( 'Add a title…' );
+				return createBlock( 'core/heading', {
+					content: postTitle,
+					align: textAlign,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( { textAlign } ) => {
+				const postTitle =
+					select( editorStore ).getEditedPostAttribute( 'title' ) ||
+					__( 'Add a title…' );
+				return createBlock( 'core/paragraph', {
+					content: postTitle,
+					align: textAlign,
+				} );
+			},
+		},
+	],
+};

--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -19,9 +19,7 @@ import { ToggleControl, TextControl, PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useEntityProp, store as coreStore } from '@wordpress/core-data';
-import { useSelect, select } from '@wordpress/data';
-// eslint-disable-next-line import/no-extraneous-dependencies
-import { store as editorStore } from '@wordpress/editor';
+import { useSelect } from '@wordpress/data';
 export default function PostTitleEdit( {
 	attributes: { level, levelOptions, textAlign, isLink, rel, linkTarget },
 	setAttributes,
@@ -182,43 +180,3 @@ export default function PostTitleEdit( {
 		</>
 	);
 }
-export const transforms = {
-	from: [
-		{
-			type: 'block',
-			blocks: [ 'core/heading', 'core/paragraph' ],
-			transform: ( attributes ) =>
-				createBlock( 'core/post-title', {
-					textAlign: attributes.align || undefined, // Map alignment if available
-				} ),
-		},
-	],
-	to: [
-		{
-			type: 'block',
-			blocks: [ 'core/heading' ],
-			transform: ( { textAlign } ) => {
-				const postTitle =
-					select( editorStore ).getEditedPostAttribute( 'title' ) ||
-					__( 'Add a title…' );
-				return createBlock( 'core/heading', {
-					content: postTitle,
-					align: textAlign,
-				} );
-			},
-		},
-		{
-			type: 'block',
-			blocks: [ 'core/paragraph' ],
-			transform: ( { textAlign } ) => {
-				const postTitle =
-					select( editorStore ).getEditedPostAttribute( 'title' ) ||
-					__( 'Add a title…' );
-				return createBlock( 'core/paragraph', {
-					content: postTitle,
-					align: textAlign,
-				} );
-			},
-		},
-	],
-};

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -8,7 +8,7 @@ import { title as icon } from '@wordpress/icons';
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import edit from './edit';
+import edit, { transforms } from './edit';
 import deprecated from './deprecated';
 
 const { name } = metadata;
@@ -18,6 +18,7 @@ export const settings = {
 	icon,
 	edit,
 	deprecated,
+	transforms,
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-title/index.js
+++ b/packages/block-library/src/post-title/index.js
@@ -8,8 +8,9 @@ import { title as icon } from '@wordpress/icons';
  */
 import initBlock from '../utils/init-block';
 import metadata from './block.json';
-import edit, { transforms } from './edit';
+import edit from './edit';
 import deprecated from './deprecated';
+import transforms from './transforms';
 
 const { name } = metadata;
 export { metadata, name };

--- a/packages/block-library/src/post-title/transforms.js
+++ b/packages/block-library/src/post-title/transforms.js
@@ -1,0 +1,49 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { createBlock } from '@wordpress/blocks';
+import { select } from '@wordpress/data';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { store as editorStore } from '@wordpress/editor';
+export const transforms = {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'core/heading', 'core/paragraph' ],
+			transform: ( attributes ) =>
+				createBlock( 'core/post-title', {
+					textAlign: attributes.align || undefined, // Map alignment if available
+				} ),
+		},
+	],
+	to: [
+		{
+			type: 'block',
+			blocks: [ 'core/heading' ],
+			transform: ( { textAlign } ) => {
+				const postTitle =
+					select( editorStore ).getEditedPostAttribute( 'title' ) ||
+					__( 'Add a title…' );
+				return createBlock( 'core/heading', {
+					content: postTitle,
+					align: textAlign,
+				} );
+			},
+		},
+		{
+			type: 'block',
+			blocks: [ 'core/paragraph' ],
+			transform: ( { textAlign } ) => {
+				const postTitle =
+					select( editorStore ).getEditedPostAttribute( 'title' ) ||
+					__( 'Add a title…' );
+				return createBlock( 'core/paragraph', {
+					content: postTitle,
+					align: textAlign,
+				} );
+			},
+		},
+	],
+};
+export default transforms;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/52203

## Why?
Currently Title block has no transform option for paragraph and heading.

## How?
Added paragraph and heading transform to title block.

## Testing Instructions

1. Go to WP admin dashboard.
2. Edit/create any post/page.
3. Create a Title Block
4. Try to transform it to a heading/paragraph block.



## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/07ab5c2e-df28-4f96-a7b9-028d5ed54386


