### PR TITLE
Add duotone and dimensions to the block level for translation

### DIFF
--- a/backport-changelog/6.8/8031.md
+++ b/backport-changelog/6.8/8031.md
@@ -1,3 +1,4 @@
 https://github.com/WordPress/wordpress-develop/pull/8031
 
 * https://github.com/WordPress/gutenberg/pull/66675
+* https://github.com/WordPress/gutenberg/pull/68243

--- a/lib/theme-i18n.json
+++ b/lib/theme-i18n.json
@@ -76,6 +76,18 @@
 						{
 							"name": "Gradient name"
 						}
+					],
+					"duotone": [
+						{
+							"name": "Duotone name"
+						}
+					]
+				},
+				"dimensions": {
+					"aspectRatios": [
+						{
+							"name": "Aspect ratio name"
+						}
 					]
 				},
 				"spacing": {


### PR DESCRIPTION
Follow-up to https://github.com/WordPress/gutenberg/pull/66675
Core backport at https://github.com/WordPress/wordpress-develop/pull/8031/files

## What?

Make duotone and aspect ratios translatable to the block level ([details](https://github.com/WordPress/wordpress-develop/pull/8031/files#r1895617293)).

## Why?

Without this, the strings are not translatable.

## How?

Adds duotone & aspect ratios under `settings/blocks/*`, so strings defined at these places are extracted for translation.

## Testing Instructions

None. This will be picked by the wp-cli/i18n-command when merged in wordpress-develop.