### PR TITLE
Zoom Out: Don't prevent the inserted block from being focussed

### DIFF
--- a/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
+++ b/packages/block-editor/src/components/block-list/use-block-props/use-focus-first-element.js
@@ -29,17 +29,13 @@ import { unlock } from '../../../lock-unlock';
  */
 export function useFocusFirstElement( { clientId, initialPosition } ) {
 	const ref = useRef();
-	const { isBlockSelected, isMultiSelecting, isZoomOut } = unlock(
+	const { isBlockSelected, isMultiSelecting } = unlock(
 		useSelect( blockEditorStore )
 	);
 
 	useEffect( () => {
 		// Check if the block is still selected at the time this effect runs.
-		if (
-			! isBlockSelected( clientId ) ||
-			isMultiSelecting() ||
-			isZoomOut()
-		) {
+		if ( ! isBlockSelected( clientId ) || isMultiSelecting() ) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Alternative fix for https://github.com/WordPress/gutenberg/issues/68145

We already have a fix here: https://github.com/WordPress/gutenberg/pull/68153/. However this approach adds more code. 

Instead this PR tries to remove the code that causes the issue. There are still some outstanding questions:

1. Do we want users to be able to edit paragraph blocks when zoomed out?
2. What was the purpose of this code? - what bugs are caused by removing it?

## Testing Instructions
1. Create a new page
2. Zoom in and add some content
3. Zoom out, leaving your cursor in the paragraph block
4. Add more content and press enter
5. Notice that focus is now moved to the new paragraph block