### PR TITLE
Media & Text: Correctly reset the 'useFeaturedImage' attribute

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -76,6 +76,7 @@ function attributesFromMedia( {
 				mediaLink: undefined,
 				href: undefined,
 				focalPoint: undefined,
+				useFeaturedImage: false,
 			} );
 			return;
 		}
@@ -128,6 +129,7 @@ function attributesFromMedia( {
 			mediaLink: media.link || undefined,
 			href: newHref,
 			focalPoint: undefined,
+			useFeaturedImage: false,
 		} );
 	};
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/68246.

This PR will fix the issue where the useFeaturedImage flag is not reset when other media is selected in the Media Text block.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- This issue was causing featured image and other selected media displayed on the frontend

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- This PR will reset useFeaturedImage to false once any other media is selected

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Add media text block select the useFeaturedImage
2. Check the frontend
3. Select other media for the media text block and check the frontend it shouldn't show double media

## Screenshots or screencast <!-- if applicable -->
