### PR TITLE
Page List block: Don't wrap Edit button with ToolsPanelItem component

### DIFF
--- a/packages/block-library/src/page-list/edit.js
+++ b/packages/block-library/src/page-list/edit.js
@@ -359,24 +359,18 @@ export default function PageListEdit( {
 					) }
 
 					{ allowConvertToLinks && (
-						<ToolsPanelItem
-							label={ __( 'Edit Menu' ) }
-							isShownByDefault
-							hasValue={ () => false }
-						>
-							<div>
-								<p>{ convertDescription }</p>
-								<Button
-									__next40pxDefaultSize
-									variant="primary"
-									accessibleWhenDisabled
-									disabled={ ! hasResolvedPages }
-									onClick={ convertToNavigationLinks }
-								>
-									{ __( 'Edit' ) }
-								</Button>
-							</div>
-						</ToolsPanelItem>
+						<div style={ { gridColumn: '1 / -1' } }>
+							<p>{ convertDescription }</p>
+							<Button
+								__next40pxDefaultSize
+								variant="primary"
+								accessibleWhenDisabled
+								disabled={ ! hasResolvedPages }
+								onClick={ convertToNavigationLinks }
+							>
+								{ __( 'Edit' ) }
+							</Button>
+						</div>
 					) }
 				</ToolsPanel>
 			</InspectorControls>


### PR DESCRIPTION
Closes #67932
See https://github.com/WordPress/gutenberg/issues/67813#issuecomment-2550739237

## What?

The Edit button in the Page List block does not have any value, so it does not need to be wrapped in a `ToolsPanelItem` component.

## Testing Instructions

- Open the site editor and select the Page List block in the Navigation block.
- Open the block sidebar.
- In the Settings options menu, there should only be a "Parent Page" options button.
- Make sure the Edit button works.

## Screenshots or screencast <!-- if applicable -->

![image](https://github.com/user-attachments/assets/1df2a3be-8d2f-43fa-a6e8-8955a031d344)
