### PR TITLE
Edit post: fix meta box pane’s pointer capture

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -318,7 +318,9 @@ function MetaBoxesMain() {
 			// the event to end the drag is captured by the target (resize handle)
 			// whether or not it’s under the pointer.
 			onPointerDown: ( { pointerId, target } ) => {
-				target.setPointerCapture( pointerId );
+				if ( separatorRef.current.parentElement.contains( target ) ) {
+					target.setPointerCapture( pointerId );
+				}
 			},
 			onResizeStart: ( event, direction, elementRef ) => {
 				if ( isAutoHeight ) {


### PR DESCRIPTION
## What?
Fixes a bug of interference with interactivity of elements within the meta box pane.

## Why?
It’s a bug. Fixes #67316

## How?
Adds a conditional so that the pointer is captured only for targets within the meta box pane’s drag handle.

## Testing Instructions
1. Using Firefox
2. Load the Post editor with "Custom fields" set to show
3. In the meta box pane, resize the "Value" text area for "Add New Custom Field:"
4. Confirm it works as expected.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
