### PR TITLE
Block supports: show selected item in font family select control

### DIFF
--- a/packages/block-editor/src/components/font-family/index.js
+++ b/packages/block-editor/src/components/font-family/index.js
@@ -72,12 +72,14 @@ export default function FontFamilyControl( {
 		);
 	}
 
+	const selectedValue =
+		options.find( ( option ) => option.key === value ) ?? '';
 	return (
 		<CustomSelectControl
 			__next40pxDefaultSize={ __next40pxDefaultSize }
 			__shouldNotWarnDeprecated36pxSize
 			label={ __( 'Font' ) }
-			value={ value }
+			value={ selectedValue }
 			onChange={ ( { selectedItem } ) => onChange( selectedItem.key ) }
 			options={ options }
 			className={ clsx( 'block-editor-font-family-control', className, {


### PR DESCRIPTION


<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

It's customary to show the selected item in a select list. Let's do that.

Noticed by @talldan over in https://github.com/WordPress/gutenberg/pull/68163#pullrequestreview-2520216524

## Why?

Without showing the selected item, the drop down will always show the default item despite the user's selection.



## Testing Instructions

1. Insert a paragraph or other text block.
2. Change the font of this block. 
3. Save. Refresh the page.
4. Check that the block's font is reflected in the font family control.
5. Check global styles as well please. Thanks!


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/5b404746-c31c-4952-9624-76cdf3fe02a1


