### PR TITLE
Show metabox when pattern is accessed directly

### DIFF
--- a/packages/edit-post/src/components/layout/index.js
+++ b/packages/edit-post/src/components/layout/index.js
@@ -405,6 +405,9 @@ function Layout( {
 			const isRenderingPostOnly = getRenderingMode() === 'post-only';
 			const isNotDesignPostType =
 				! DESIGN_POST_TYPES.includes( currentPostType );
+			const isDirectlyEditingPattern =
+				currentPostType === 'wp_block' &&
+				! onNavigateToPreviousEntityRecord;
 
 			return {
 				mode: getEditorMode(),
@@ -415,7 +418,9 @@ function Layout( {
 					!! select( blockEditorStore ).getBlockSelectionStart(),
 				showIconLabels: get( 'core', 'showIconLabels' ),
 				isDistractionFree: get( 'core', 'distractionFree' ),
-				showMetaBoxes: isNotDesignPostType && ! isZoomOut(),
+				showMetaBoxes:
+					( isNotDesignPostType && ! isZoomOut() ) ||
+					isDirectlyEditingPattern,
 				isWelcomeGuideVisible: isFeatureActive( 'welcomeGuide' ),
 				templateId:
 					supportsTemplateMode &&
@@ -433,6 +438,7 @@ function Layout( {
 			currentPostId,
 			isEditingTemplate,
 			settings.supportsTemplateMode,
+			onNavigateToPreviousEntityRecord,
 		]
 	);
 	useMetaBoxInitialization( hasActiveMetaboxes );


### PR DESCRIPTION
A quick fix for #67902

## What? / Why?


The meta box that appears when you navigate to the pattern editor in the post editor is tied to the post editor, not the pattern. This was reported as confusing, so it was fixed in #64990. This PR removes the meta box from always appearing when editing a pattern.

However, as reported in #67902, we found that there are cases where you want to apply meta data to the pattern itself. And since a pattern is a kind of post type, you can edit the pattern directly via `/wp-admin/edit.php?post_type=wp_block`. This PR renders the meta box only when the pattern is accessed directly.

## How?

Ideally, the meta box itself would be reloaded (re-rendered) when you navigate to a pattern in the post editor, but as mentioned in [this comment](https://github.com/WordPress/gutenberg/issues/67902#issuecomment-2546653839), that's a bit tricky.

For now, we check `onNavigateToPreviousEntityRecord` to see if the pattern was accessed directly.

## Testing Instructions


### Testing Instructions for Keyboard

- First, enable the custom field to display the meta box.
- Create a synced pattern.
- Insert the synced pattern in the post editor.
- Click "Edit original" in the block toolbar.
- The meta box will not be displayed.
- Go to `/wp-admin/edit.php?post_type=wp_block` and select the sync pattern you just created.
- The meta box will be displayed.
