### PR TITLE
Storybook: Add stories for the EditableText component

### DIFF
--- a/packages/block-editor/src/components/editable-text/stories/index.story.js
+++ b/packages/block-editor/src/components/editable-text/stories/index.story.js
@@ -23,7 +23,7 @@ const meta = {
 	argTypes: {
 		value: {
 			control: { type: null },
-			description: 'Text content to make editable.',
+			description: 'String to make editable.',
 			table: {
 				type: { summary: 'string' },
 			},
@@ -31,7 +31,7 @@ const meta = {
 		onChange: {
 			action: 'onChange',
 			control: { type: null },
-			description: 'Called when the text content changes.',
+			description: 'Called when the value changes.',
 			table: {
 				type: { summary: 'function' },
 			},
@@ -53,9 +53,37 @@ const meta = {
 		},
 		disableLineBreaks: {
 			control: 'boolean',
-			description: 'Prevents insertion of line breaks on Enter.',
+			description:
+				"Text won't insert line breaks on Enter if set to true.",
 			table: {
 				type: { summary: 'boolean' },
+			},
+		},
+		onReplace: {
+			action: 'onReplace',
+			control: { type: null },
+			description:
+				'Called when the Text instance can be replaced with the given blocks.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		onMerge: {
+			action: 'onMerge',
+			control: { type: null },
+			description:
+				'Called when blocks can be merged. Forward is true when merging with the next block, false when merging with the previous block.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		onRemove: {
+			action: 'onRemove',
+			control: { type: null },
+			description:
+				'Called when the block can be removed. Forward is true when the selection is expected to move to the next block, false to the previous block.',
+			table: {
+				type: { summary: 'function' },
 			},
 		},
 	},
@@ -65,7 +93,7 @@ export default meta;
 
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
-		const [ value, setValue ] = useState( '' );
+		const [ value, setValue ] = useState();
 		return (
 			<EditableText
 				{ ...args }
@@ -74,7 +102,7 @@ export const Default = {
 					onChange( ...changeArgs );
 					setValue( ...changeArgs );
 				} }
-				placeholder="Type some text..."
+				tagName={ args.tagName || 'div' }
 			/>
 		);
 	},

--- a/packages/block-editor/src/components/editable-text/stories/index.story.js
+++ b/packages/block-editor/src/components/editable-text/stories/index.story.js
@@ -1,0 +1,81 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import EditableText from '../';
+
+const meta = {
+	title: 'BlockEditor/EditableText',
+	component: EditableText,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders an editable text input in which text formatting is not allowed.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: { type: null },
+			description: 'Text content to make editable.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			description: 'Called when the text content changes.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		tagName: {
+			control: 'text',
+			description: 'The HTML tag name of the editable element.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'div' },
+			},
+		},
+		placeholder: {
+			control: 'text',
+			description: 'Placeholder text to show when the field is empty.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		disableLineBreaks: {
+			control: 'boolean',
+			description: 'Prevents insertion of line breaks on Enter.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( '' );
+		return (
+			<EditableText
+				{ ...args }
+				value={ value }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				placeholder="Type some text..."
+			/>
+		);
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds the Storybook stories for the EditableText component in the block editor. 

## Why?
As part of the ongoing effort to improve component documentation and testing (tracked in https://github.com/WordPress/gutenberg/issues/22891), we need comprehensive stories for all Block Editor components. This PR helps users and developers better understand the EditableText component's capabilities and usage.

## Testing Instructions
- Start Storybook by running `npm run storybook:dev`
- Open Storybook at http://localhost:50240/
- Navigate to "BlockEditor/EditableText" in the Storybook sidebar
- Test the behavior

## Screencast 

https://github.com/user-attachments/assets/ac05f780-0655-44f0-9ec1-4971180682e1






