### PR TITLE
Remove isolated template editing actions in write mode

### DIFF
--- a/packages/block-library/src/block/edit.js
+++ b/packages/block-library/src/block/edit.js
@@ -111,19 +111,24 @@ function ReusableBlockControl( {
 	handleEditOriginal,
 	resetContent,
 } ) {
-	const canUserEdit = useSelect(
-		( select ) =>
-			!! select( coreStore ).canUser( 'update', {
-				kind: 'postType',
-				name: 'wp_block',
-				id: recordId,
-			} ),
+	const { canUserEdit, isNavigationMode } = useSelect(
+		( select ) => {
+			const { canUser } = select( coreStore );
+			return {
+				canUserEdit: !! canUser( 'update', {
+					kind: 'postType',
+					name: 'wp_block',
+					id: recordId,
+				} ),
+				isNavigationMode: select( blockEditorStore ).isNavigationMode(),
+			};
+		},
 		[ recordId ]
 	);
 
 	return (
 		<>
-			{ canUserEdit && !! handleEditOriginal && (
+			{ canUserEdit && ! isNavigationMode && !! handleEditOriginal && (
 				<BlockControls>
 					<ToolbarGroup>
 						<ToolbarButton onClick={ handleEditOriginal }>

--- a/packages/block-library/src/template-part/edit/index.js
+++ b/packages/block-library/src/template-part/edit/index.js
@@ -126,11 +126,16 @@ export default function TemplatePartEdit( {
 		onNavigateToEntityRecord,
 		title,
 		canUserEdit,
+		isNavigationMode,
 	} = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord, hasFinishedResolution } =
 				select( coreStore );
-			const { getBlockCount, getSettings } = select( blockEditorStore );
+			const {
+				getBlockCount,
+				getSettings,
+				isNavigationMode: _isNavigationMode,
+			} = select( blockEditorStore );
 
 			const getEntityArgs = [
 				'postType',
@@ -168,6 +173,7 @@ export default function TemplatePartEdit( {
 					getSettings().onNavigateToEntityRecord,
 				title: entityRecord?.title,
 				canUserEdit: !! _canUserEdit,
+				isNavigationMode: _isNavigationMode(),
 			};
 		},
 		[ templatePartId, attributes.area, clientId ]
@@ -236,6 +242,7 @@ export default function TemplatePartEdit( {
 		<>
 			<RecursionProvider uniqueId={ templatePartId }>
 				{ isEntityAvailable &&
+					! isNavigationMode &&
 					onNavigateToEntityRecord &&
 					canUserEdit && (
 						<BlockControls group="other">

--- a/packages/block-library/src/template-part/edit/inner-blocks.js
+++ b/packages/block-library/src/template-part/edit/inner-blocks.js
@@ -100,9 +100,16 @@ function EditableTemplatePartInnerBlocks( {
 	tagName: TagName,
 	blockProps,
 } ) {
-	const onNavigateToEntityRecord = useSelect(
-		( select ) =>
-			select( blockEditorStore ).getSettings().onNavigateToEntityRecord,
+	const { onNavigateToEntityRecord, isNavigationMode } = useSelect(
+		( select ) => {
+			const { getSettings, isNavigationMode: _isNavigationMode } =
+				select( blockEditorStore );
+			return {
+				onNavigateToEntityRecord:
+					getSettings().onNavigateToEntityRecord,
+				isNavigationMode: _isNavigationMode(),
+			};
+		},
 		[]
 	);
 
@@ -123,7 +130,9 @@ function EditableTemplatePartInnerBlocks( {
 	const blockEditingMode = useBlockEditingMode();
 
 	const customProps =
-		blockEditingMode === 'contentOnly' && onNavigateToEntityRecord
+		! isNavigationMode &&
+		blockEditingMode === 'contentOnly' &&
+		onNavigateToEntityRecord
 			? {
 					onDoubleClick: () =>
 						onNavigateToEntityRecord( {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Follows up on #67372, in particular @annezazu's comments about:
- Removing Edit buttons from the block toolbar or template parts and synced patterns when in Write Mode (https://github.com/WordPress/gutenberg/pull/67372#issuecomment-2508103261)
- Removing the double-click for editing templates and template parts when in Write Mode

## Why?
The general idea is that Write Mode is kept very simple, and access to those more advanced options isn't available without switching out of Write Mode.

I think it needs some wider feedback though, as it didn't seem like there was consensus in #67372

## How?
Adds a few conditions to the rendering of these elements

## Testing Instructions
#### Double click behavior
1. Edit a page
2. Ensure Show Template is on in the Page settings
3. Switch to Write Mode
4. Try double clicking the header or footer, see that nothing happens
5. Try double clicking other parts of the template - note that the modal that asks if you want to edit the template isn't shown

#### Edit button on synced patterns and template parts
1. Continuing from the previous testing instructions, select the header or footer. Note that there's no 'Edit' button in the block toolbar
2. Switch back to Design mode
3. Insert a Synced Pattern
4. Switch back to Write Mode
5. Select the Synced Pattern. Note that there's no 'Edit original' button on the toolbar.


## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| <img width="798" alt="Screenshot 2024-12-24 at 2 33 20 pm" src="https://github.com/user-attachments/assets/373a6696-fd84-4ff3-af14-05d26771b514" /> | <img width="798" alt="Screenshot 2024-12-24 at 2 32 58 pm" src="https://github.com/user-attachments/assets/996718da-d261-4d8e-94d2-21c7d542373b" />  |
