### PR TITLE
Show the same link creation UI in Navigation block canvas and editable list view.

### DIFF
--- a/packages/block-library/src/navigation/constants.js
+++ b/packages/block-library/src/navigation/constants.js
@@ -5,6 +5,7 @@ export const DEFAULT_BLOCK = {
 export const PRIORITIZED_INSERTER_BLOCKS = [
 	'core/navigation-link/page',
 	'core/navigation-link',
+	'core/navigation-submenu',
 ];
 
 // These parameters must be kept aligned with those in

--- a/packages/block-library/src/navigation/edit/inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/inner-blocks.js
@@ -83,7 +83,7 @@ export default function NavigationInnerBlocks( {
 			onChange,
 			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
 			defaultBlock: DEFAULT_BLOCK,
-			directInsert: true,
+			directInsert: false,
 			orientation,
 			templateLock,
 

--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useInnerBlocksProps } from '@wordpress/block-editor';
+import { useInnerBlocksProps, InnerBlocks } from '@wordpress/block-editor';
 import { Disabled } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
@@ -11,7 +11,11 @@ import { useContext, useEffect, useRef } from '@wordpress/element';
  * Internal dependencies
  */
 import { areBlocksDirty } from './are-blocks-dirty';
-import { DEFAULT_BLOCK, SELECT_NAVIGATION_MENUS_ARGS } from '../constants';
+import {
+	DEFAULT_BLOCK,
+	SELECT_NAVIGATION_MENUS_ARGS,
+	PRIORITIZED_INSERTER_BLOCKS,
+} from '../constants';
 
 const EMPTY_OBJECT = {};
 
@@ -51,9 +55,12 @@ export default function UnsavedInnerBlocks( {
 			className: 'wp-block-navigation__container',
 		},
 		{
-			renderAppender: hasSelection ? undefined : false,
+			renderAppender: hasSelection
+				? InnerBlocks.ButtonBlockAppender
+				: false,
 			defaultBlock: DEFAULT_BLOCK,
-			directInsert: true,
+			directInsert: false,
+			prioritizedInserterBlocks: PRIORITIZED_INSERTER_BLOCKS,
 		}
 	);
 


### PR DESCRIPTION
Closes https://github.com/WordPress/gutenberg/issues/68184

## What?
This PR fixes the behavior of the navigation block inserter by disabling direct block insertion and adding 'core/navigation-submenu' to the prioritized block list. It ensures that all navigation block variations, including submenus, are easily accessible and consistent across both the canvas and list views.

## Why?
The current behavior of the navigation block inserter causes an inconsistent user experience by directly inserting blocks without showing the block inserter UI. This makes it difficult to insert navigation blocks, especially submenus. By disabling direct insertion and ensuring proper prioritization of blocks, we aim to provide a more predictable and consistent block insertion process across all contexts.

## How?
- Changed the `directInsert` property from `true` to `false` in both `inner-blocks.js` and `unsaved-inner-blocks.js` to prevent direct block insertion.
- Updated the `PRIORITIZED_INSERTER_BLOCKS` constant to include `'core/navigation-submenu'`, ensuring submenus are prioritized and accessible in the block inserter.
- Modified `renderAppender` logic to ensure that the block inserter UI appears consistently and provides clear navigation options.

## Testing Instructions
1. Open a post or page.
2. Add a navigation block.
3. Verify that the block inserter UI appears rather than direct block insertion.
4. Test adding different types of navigation blocks (including submenus) from both the canvas and list view.
5. Ensure that prioritized blocks, including 'core/navigation-link' and 'core/navigation-submenu', are accessible in the inserter.

## Screenshots or screencast 

https://github.com/user-attachments/assets/523f496d-8e5a-4f11-9ffa-98eebf8946d6
