### PR TITLE
Button: Update Settings text labels

### DIFF
--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -125,14 +125,14 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			<ToolsPanelItem
-				label={ __( 'Button width' ) }
+				label={ __( 'Width' ) }
 				isShownByDefault
 				hasValue={ () => !! selectedWidth }
 				onDeselect={ () => setAttributes( { width: undefined } ) }
 				__nextHasNoMarginBottom
 			>
 				<ToggleGroupControl
-					label={ __( 'Button width' ) }
+					label={ __( 'Width' ) }
 					value={ selectedWidth }
 					onChange={ ( newWidth ) =>
 						setAttributes( { width: newWidth } )

--- a/test/e2e/specs/editor/blocks/buttons.spec.js
+++ b/test/e2e/specs/editor/blocks/buttons.spec.js
@@ -268,7 +268,7 @@ test.describe( 'Buttons', () => {
 			.getByRole( 'tab', { name: 'Settings' } )
 			.click();
 		await page
-			.getByRole( 'radiogroup', { name: 'Button width' } )
+			.getByRole( 'radiogroup', { name: 'Width' } )
 			.getByRole( 'radio', { name: '25%' } )
 			.click();
 


### PR DESCRIPTION
## What?
PR updates the Button block's Settings text labels to "Width".

## Why?
See https://github.com/WordPress/gutenberg/pull/65346#issuecomment-2557707827.

## Testing Instructions
1. Open a post or page.
2. Insert a Buttons block.
3. Confirm that the width labels are correct.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2024-12-24 at 11 53 24](https://github.com/user-attachments/assets/9d8c1373-f747-4970-a72e-68918ee8e62e)