### PR TITLE
Add block example attribute for Comments block

### DIFF
--- a/packages/block-library/src/comments/index.js
+++ b/packages/block-library/src/comments/index.js
@@ -17,6 +17,7 @@ export { metadata, name };
 
 export const settings = {
 	icon,
+	example: {},
 	edit,
 	save,
 	deprecated,


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/64707

## What?
Adds block example definition for the Comment block.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/52f0fd1e-d868-4605-99c3-31e85872cab6)|![image](https://github.com/user-attachments/assets/fd45119a-b042-49d1-864b-88cbd67574a3)|
