### PR TITLE
Add block example attribute for Comments Form block

### DIFF
--- a/packages/block-library/src/post-comments-form/block.json
+++ b/packages/block-library/src/post-comments-form/block.json
@@ -56,5 +56,10 @@
 		"wp-block-post-comments-form",
 		"wp-block-buttons",
 		"wp-block-button"
-	]
+	],
+	"example": {
+		"attributes": {
+			"textAlign": "center"
+		}
+	}
 }


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/64707

## What?
Adds block example definition for the Comments Form block

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/82751258-a538-42c1-98be-d0966d1ecb62)|![image](https://github.com/user-attachments/assets/2f79f988-dfaf-444b-9b32-17d43479aa7f)|
