### PR TITLE
Adding extra blocks to navigation block - Heading , Paragraph and Image

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -471,7 +471,7 @@ A collection of blocks that allow visitors to get around your site. ([Source](ht
 
 -	**Name:** core/navigation
 -	**Category:** theme
--	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons
+-	**Allowed Blocks:** core/navigation-link, core/search, core/social-links, core/page-list, core/spacer, core/home-link, core/site-title, core/site-logo, core/navigation-submenu, core/loginout, core/buttons, core/paragraph, core/heading, core/image
 -	**Supports:** align (full, wide), ariaLabel, inserter, interactivity, layout (allowSizingOnChildren, default, ~~allowInheriting~~, ~~allowSwitching~~, ~~allowVerticalAlignment~~), spacing (blockGap, units), typography (fontSize, lineHeight), ~~html~~, ~~renaming~~
 -	**Attributes:** __unstableLocation, backgroundColor, customBackgroundColor, customOverlayBackgroundColor, customOverlayTextColor, customTextColor, hasIcon, icon, maxNestingLevel, openSubmenusOnClick, overlayBackgroundColor, overlayMenu, overlayTextColor, ref, rgbBackgroundColor, rgbTextColor, showSubmenuIcon, templateLock, textColor
 

--- a/packages/block-library/src/navigation/block.json
+++ b/packages/block-library/src/navigation/block.json
@@ -15,7 +15,10 @@
 		"core/site-logo",
 		"core/navigation-submenu",
 		"core/loginout",
-		"core/buttons"
+		"core/buttons",
+		"core/paragraph",
+		"core/heading",
+		"core/image"
 	],
 	"description": "A collection of blocks that allow visitors to get around your site.",
 	"keywords": [ "menu", "navigation", "links" ],


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/46256

## Why?
As per the issue mentioned in the ticket, Currently, we can only add menu links and the social block to the navigation menu, which is limiting for designers - especially for mobile menus. Many platforms allow for multiple types of content to be displayed throughout a menu.

## How?
Adding support for Heading, Paragraph, Image to navigation block.

## Testing Instructions

- Open page/post in edit mode.
- Add navigation block.
- Try to add other blocks by clicking on `Add block`
- Verify Paragraph, Heading and Image blocks available in the list.
- Verify these newly added blocks are working fine in frontend and editor.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/017622fb-9715-49e9-82a0-090f45e6a404


