### PR TITLE
Storybook: Add Story for BlockDraggable

### DIFF
--- a/packages/block-editor/src/components/block-draggable/draggable-chip.js
+++ b/packages/block-editor/src/components/block-draggable/draggable-chip.js
@@ -10,6 +10,32 @@ import { dragHandle } from '@wordpress/icons';
  */
 import BlockIcon from '../block-icon';
 
+/**
+ * The BlockDraggableChip component renders a chip that can display
+ * additional metadata for draggable blocks.
+ *
+ * @example
+ * ```jsx
+ * function Example() {
+ *   return (
+ *     <BlockDraggableChip
+ *       count={3}
+ *       icon={<svg>...</svg>}
+ *       isPattern={true}
+ *       fadeWhenDisabled={false}
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @param {Object}        props                  The props for the BlockDraggableChip component.
+ * @param {number}        props.count            The number of blocks associated with the draggable chip.
+ * @param {string|Object} props.icon             The icon of the block. This can be any of [WordPress' Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.
+ * @param {boolean}       props.isPattern        Whether the chip represents a pattern block.
+ * @param {boolean}       props.fadeWhenDisabled Whether to visually fade the chip when dragging is disabled.
+ *
+ * @return {Element} The rendered BlockDraggableChip component.
+ */
 export default function BlockDraggableChip( {
 	count,
 	icon,

--- a/packages/block-editor/src/components/block-draggable/stories/index.story.js
+++ b/packages/block-editor/src/components/block-draggable/stories/index.story.js
@@ -3,14 +3,81 @@
  */
 import BlockDraggableChip from '../draggable-chip';
 
-export default { title: 'BlockEditor/BlockDraggable' };
+/**
+ * WordPress dependencies
+ */
+import { paragraph } from '@wordpress/icons';
 
-export const _default = () => {
-	// Create a wrapper box for the absolutely-positioned child component.
-	const wrapperStyle = { margin: '24px 0', position: 'relative' };
-	return (
-		<div style={ wrapperStyle }>
-			<BlockDraggableChip count={ 2 } />
-		</div>
-	);
+export default {
+	title: 'BlockEditor/BlockDraggable',
+	component: BlockDraggableChip,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `BlockDraggableChip` component allows to display a "chip" which contains the count of blocks.',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+	argTypes: {
+		count: {
+			control: 'number',
+			description: 'The count of blocks.',
+			table: {
+				type: { summary: 'number' },
+			},
+		},
+		icon: {
+			control: 'select',
+			options: [ 'none', 'paragraph' ],
+			mapping: {
+				none: null,
+				paragraph,
+			},
+			description:
+				'The icon of the block. This can be any of [WordPress Dashicons](https://developer.wordpress.org/resource/dashicons/), or a custom `svg` element.',
+			table: {
+				type: { summary: 'string | object' },
+			},
+		},
+		isPattern: {
+			control: 'boolean',
+			description: 'Whether the block is a pattern.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+		fadeWhenDisabled: {
+			control: 'boolean',
+			description: 'Whether the block should fade when disabled.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+	},
+};
+
+export const Default = {
+	args: {
+		count: 2,
+		fadeWhenDisabled: false,
+		icon: null,
+		isPattern: false,
+	},
+	render: ( props ) => {
+		// Create a wrapper box for the absolutely-positioned child component.
+		const wrapperStyle = { margin: '24px 0', position: 'relative' };
+		const count = props.count < 0 ? 0 : props.count;
+		return (
+			<div style={ wrapperStyle }>
+				<BlockDraggableChip
+					count={ count }
+					fadeWhenDisabled={ props.fadeWhenDisabled }
+					icon={ props.icon !== null ? props.icon : undefined }
+					isPattern={ props.isPattern }
+				/>
+			</div>
+		);
+	},
 };


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/67165

## What?

This PR introduces stories for the BlockDraggable component in Storybook, providing a visual representation and testing environment for its functionality.

## Testing Instruction 

- Run npm run storybook:dev
- Open the storybook on http://localhost:50240/
- Check the BlockDraggable stories.

## Screencast 

https://github.com/user-attachments/assets/b913cf44-03e4-42d2-95c8-97edfbac222c


