### PR TITLE
ESLint: Improve regex for valid-sprintf rule to handle '%%'

### DIFF
--- a/packages/eslint-plugin/rules/__tests__/valid-sprintf.js
+++ b/packages/eslint-plugin/rules/__tests__/valid-sprintf.js
@@ -71,6 +71,18 @@ sprintf(
 		{
 			code: `sprintf( '%(greeting)s %(toWhom)s', 'Hello', 'World' )`,
 		},
+		{
+			code: `sprintf( 'Rotated at %d %% degrees', 90 )`,
+		},
+		{
+			code: `sprintf( 'Rotated at %d%% degrees', 90 )`,
+		},
+		{
+			code: `sprintf( __( 'Rotated at %d%% degrees' ), 90 )`,
+		},
+		{
+			code: `sprintf( 'Rotated at %1$d %% degrees, %2$d %% angles', 90, 180 )`,
+		},
 	],
 	invalid: [
 		{

--- a/packages/eslint-plugin/utils/constants.js
+++ b/packages/eslint-plugin/utils/constants.js
@@ -37,13 +37,13 @@ const TRANSLATION_FUNCTIONS = new Set( [ '__', '_x', '_n', '_nx' ] );
  * @type {RegExp}
  */
 const REGEXP_SPRINTF_PLACEHOLDER =
-	/%(((\d+)\$)|(\(([$_a-zA-Z][$_a-zA-Z0-9]*)\)))?[ +0#-]*\d*(\.(\d+|\*))?(ll|[lhqL])?([cduxXefgsp%])/g;
-//               ▲         ▲                    ▲       ▲  ▲            ▲           ▲ type
-//               │         │                    │       │  │            └ Length (unsupported)
-//               │         │                    │       │  └ Precision / max width
-//               │         │                    │       └ Min width (unsupported)
-//               │         │                    └ Flags (unsupported)
-//               └ Index   └ Name (for named arguments)
+	/(?<!%)%(((\d+)\$)|(\(([$_a-zA-Z][$_a-zA-Z0-9]*)\)))?[ +0#-]*\d*(\.(\d+|\*))?(ll|[lhqL])?([cduxXefgsp])/g;
+//               	  ▲         ▲                    ▲       ▲  ▲            ▲           ▲ type
+//               	  │         │                    │       │  │            └ Length (unsupported)
+//               	  │         │                    │       │  └ Precision / max width
+//               	  │         │                    │       └ Min width (unsupported)
+//               	  │         │                    └ Flags (unsupported)
+//               	  └ Index   └ Name (for named arguments)
 
 /**
  * "Unordered" means there's no position specifier: '%s', not '%2$s'.


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/52787

## What?
Updated the regex in the valid-sprintf ESLint rule to correctly handle escaped percent signs (%%). Added 4 new test cases that cover various scenarios involving %%.

## Why?
The current regex fails to handle cases like sprintf('Rotated at %d %% degrees', 90) by mistakenly flagging valid format strings with escaped percent signs as incorrect. This update ensures proper handling of %d %% and similar cases.


## Screenshots or screencast <!-- if applicable -->
<img width="786" alt="Screenshot 2024-12-24 at 5 24 38 PM" src="https://github.com/user-attachments/assets/6bbb0f0c-3131-4c37-9ada-b3f028932ac8" />


