### PR TITLE
Storybook: Add Story for InspectorPopoverHeader

### DIFF
--- a/packages/block-editor/src/components/inspector-popover-header/stories/index.story.js
+++ b/packages/block-editor/src/components/inspector-popover-header/stories/index.story.js
@@ -1,0 +1,98 @@
+/**
+ * WordPress dependencies
+ */
+import { Dropdown, Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import InspectorPopoverHeader from '../';
+
+const meta = {
+	title: 'BlockEditor/InspectorPopoverHeader',
+	component: InspectorPopoverHeader,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders a header that is suitable for use in an inspector sidebar popover.',
+			},
+		},
+	},
+	argTypes: {
+		title: {
+			control: { type: 'string' },
+			description: 'Title to display in the header.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		actions: {
+			control: { type: null },
+			table: {
+				type: { summary: 'array' },
+			},
+			description:
+				'Array of actions to display in the header as a row of buttons.',
+		},
+		onClose: {
+			control: { type: null },
+			description:
+				'Function called when the user presses the close button.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		help: {
+			control: { type: 'string' },
+			description: 'Help text to display at the bottom of the header..',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+const Template = ( args ) => {
+	return (
+		<Dropdown
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button onClick={ onToggle } aria-expanded={ isOpen }>
+					Select post date
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<>
+					<InspectorPopoverHeader
+						title={ args.title }
+						actions={ args.actions }
+						onClose={ onClose }
+					/>
+					Place form for editing post date here.
+				</>
+			) }
+		/>
+	);
+};
+
+export const Default = {
+	render: Template,
+	args: {
+		title: 'Post date',
+		actions: [
+			{
+				label: 'Reset ',
+				onClick: () => {},
+			},
+		],
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/67165 

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR will add story for `inspector-popover-header` component in the Storybook.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run npm run storybook:dev
2. Open the storybook on [localhost](http://localhost:50240/)
3. Check the `InspectorPopoverHeader` story.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
<img width="1440" alt="Screenshot 2024-12-24 at 6 42 43 PM" src="https://github.com/user-attachments/assets/2968b57a-bf1a-45f9-9b8a-5de6e8b56f16" />


