### PR TITLE
Editor: Fix initial edits applied again after saving the post

### DIFF
--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -300,15 +300,7 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					}
 				);
 			}
-		}, [
-			createWarningNotice,
-			initialEdits,
-			settings,
-			post,
-			recovery,
-			setupEditor,
-			updatePostLock,
-		] );
+		}, [] );
 
 		// Synchronizes the active post with the state
 		useEffect( () => {

--- a/packages/editor/src/components/provider/index.js
+++ b/packages/editor/src/components/provider/index.js
@@ -300,6 +300,10 @@ export const ExperimentalEditorProvider = withRegistryProvider(
 					}
 				);
 			}
+
+			// The dependencies of the hook are omitted deliberately
+			// We only want to run setupEditor (with initialEdits) only once per post.
+			// A better solution in the future would be to split this effect into multiple ones.
 		}, [] );
 
 		// Synchronizes the active post with the state


### PR DESCRIPTION
Bug introduced in https://github.com/WordPress/gutenberg/pull/62304/files#r1896745958

Basically the "setupEditor" action is only meant to run once and the addition of the extra dependencies (I'm assuming it was done to please the linter) caused the "initial edits" to be applied again if a post was loaded with initial edits and was saved again.

I think this hook can be rewritten in a different way but for now, I think it's better to just revert to the previous behavior.

## Testing Instructions

1- Install Jetpack and enable the "Copy post" writing feature
2- Open the post list
3- Click "copy post"
4- Edit the copied post title
5- Hit save
6- The post title shouldn't revert to the original title and the modified title should be kept.