### PR TITLE
DataViews: use `action.disabled` state to disable actions (primary and secondary)

### DIFF
--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -75,6 +75,8 @@ function ButtonTrigger< Item >( {
 		<Button
 			label={ label }
 			icon={ action.icon }
+			disabled={ !! action.disabled }
+			accessibleWhenDisabled
 			isDestructive={ action.isDestructive }
 			size="compact"
 			onClick={ onClick }
@@ -90,7 +92,7 @@ function MenuItemTrigger< Item >( {
 	const label =
 		typeof action.label === 'string' ? action.label : action.label( items );
 	return (
-		<Menu.Item onClick={ onClick }>
+		<Menu.Item disabled={ action.disabled } onClick={ onClick }>
 			<Menu.ItemLabel>{ label }</Menu.ItemLabel>
 		</Menu.Item>
 	);

--- a/packages/dataviews/src/dataviews-layouts/list/index.tsx
+++ b/packages/dataviews/src/dataviews-layouts/list/index.tsx
@@ -101,6 +101,8 @@ function PrimaryActionGridCell< Item >( {
 				render={
 					<Button
 						label={ label }
+						disabled={ !! primaryAction.disabled }
+						accessibleWhenDisabled
 						icon={ primaryAction.icon }
 						isDestructive={ primaryAction.isDestructive }
 						size="small"
@@ -124,6 +126,8 @@ function PrimaryActionGridCell< Item >( {
 				render={
 					<Button
 						label={ label }
+						disabled={ !! primaryAction.disabled }
+						accessibleWhenDisabled
 						icon={ primaryAction.icon }
 						isDestructive={ primaryAction.isDestructive }
 						size="small"


### PR DESCRIPTION
Related https://github.com/WordPress/gutenberg/pull/67790#issuecomment-2561166897

## What?

This PR uses the existing `disabled` property in the Actions API to disable the action buttons.

## How?

Pass the `action.disabled` property to the button that renders it.

## Testing Instructions

- Go to the Pages page.
- Make one of the actions disabled. For example, add `disabled: true` to [edit](https://github.com/WordPress/gutenberg/blob/fix/dataviews-actions-disable/packages/edit-site/src/components/dataviews-actions/index.js#L23).
- Switch to every layout and verify that the edit action is disabled (both as primary and secondary).

| List | Grid | Table | 
| --- | --- | --- |
| <img width="291" alt="Screenshot 2024-12-24 at 15 03 20" src="https://github.com/user-attachments/assets/4ce6ccdb-98be-453b-8a08-604bac5aa9c5" /> | <img width="291" alt="Screenshot 2024-12-24 at 15 03 10" src="https://github.com/user-attachments/assets/a7034b7a-8501-41aa-94d6-713a1f278c43" /> | <img width="291" alt="Screenshot 2024-12-24 at 15 03 00" src="https://github.com/user-attachments/assets/3b2b1dc3-e88a-402c-beff-b51531c82ce7" /> |
