### PR TITLE
MediaReplaceFlow: Remove store subscription in favor of modern CSS

### DIFF
--- a/packages/block-editor/src/components/media-replace-flow/index.js
+++ b/packages/block-editor/src/components/media-replace-flow/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
 import { useRef } from '@wordpress/element';
@@ -61,10 +56,7 @@ const MediaReplaceFlow = ( {
 	handleUpload = true,
 	popoverProps,
 } ) => {
-	const mediaUpload = useSelect( ( select ) => {
-		return select( blockEditorStore ).getSettings().mediaUpload;
-	}, [] );
-	const canUpload = !! mediaUpload;
+	const { getSettings } = useSelect( blockEditorStore );
 	const editMediaButtonRef = useRef();
 	const errorNoticeID = `block-editor/media-replace-flow/error-notice/${ ++uniqueId }`;
 
@@ -107,7 +99,7 @@ const MediaReplaceFlow = ( {
 			return onSelect( files );
 		}
 		onFilesUpload( files );
-		mediaUpload( {
+		getSettings().mediaUpload( {
 			allowedTypes,
 			filesList: files,
 			onFileChange: ( [ media ] ) => {
@@ -219,15 +211,7 @@ const MediaReplaceFlow = ( {
 					</NavigableMenu>
 					{ onSelectURL && (
 						// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
-						<form
-							className={ clsx(
-								'block-editor-media-flow__url-input',
-								{
-									'has-siblings':
-										canUpload || onToggleFeaturedImage,
-								}
-							) }
-						>
+						<form className="block-editor-media-flow__url-input">
 							<span className="block-editor-media-replace-flow__image-url-label">
 								{ __( 'Current media URL:' ) }
 							</span>

--- a/packages/block-editor/src/components/media-replace-flow/style.scss
+++ b/packages/block-editor/src/components/media-replace-flow/style.scss
@@ -9,16 +9,16 @@
 	margin-left: 4px;
 }
 
+.block-editor-media-replace-flow__media-upload-menu:not(:empty) + .block-editor-media-flow__url-input {
+	border-top: $border-width solid $gray-900;
+	margin-top: $grid-unit-10;
+	padding-bottom: $grid-unit-10;
+}
+
 .block-editor-media-flow__url-input {
 	margin-right: -$grid-unit-10;
 	margin-left: -$grid-unit-10;
 	padding: $grid-unit-20;
-
-	&.has-siblings {
-		border-top: $border-width solid $gray-900;
-		margin-top: $grid-unit-10;
-		padding-bottom: $grid-unit-10;
-	}
 
 	.block-editor-media-replace-flow__image-url-label {
 		display: block;


### PR DESCRIPTION
## What?
PR fixes a condition for the `MediaReplaceFlow` form element when it shouldn't render a separation border.

After recent updates, I noticed that the `has-siblings` condition was out of sync. Instead of updating it, I decided to switch to a CSS-only solution.

## Why?
* The border only needs to be rendered when the `NavigableMenu` has child elements. This can be derived with just CSS.
* Now that `getSettings().mediaUpload` is only called inside the callback, a component can use a static selector getter and avoid store subscription.

## Testing Instructions
1. Open a post.
2. Add an Image block and select media.
3. Confirm that media replace dropdown renders with separator.
4. Remove all elements from the `block-editor-media-replace-flow__media-upload-menu` div.
5. Confirm that the separator is no longer rendered.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-12-24 at 19 07 41](https://github.com/user-attachments/assets/b4008c3c-aefa-472f-a58f-9a0a65975a6e)
