### PR TITLE
Table Block: Fix margin/padding to include caption in spacing

### DIFF
--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -195,9 +195,14 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-table",
+		"__experimentalSelector": ".wp-block-table > table",
 		"interactivity": {
 			"clientNavigation": true
+		}
+	},
+	"selectors": {
+		"spacing": {
+			"margin": ".wp-block-table"
 		}
 	},
 	"styles": [

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -195,7 +195,7 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-table > table",
+		"__experimentalSelector": ".wp-block-table",
 		"interactivity": {
 			"clientNavigation": true
 		}

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -195,15 +195,13 @@
 				"width": true
 			}
 		},
-		"__experimentalSelector": ".wp-block-table > table",
 		"interactivity": {
 			"clientNavigation": true
 		}
 	},
 	"selectors": {
-		"spacing": {
-			"margin": ".wp-block-table"
-		}
+		"root": ".wp-block-table > table",
+		"spacing": ".wp-block-table"
 	},
 	"styles": [
 		{


### PR DESCRIPTION
Fixes: #68217

## What?
The PR modifies the margin application in table blocks to ensure theme.json margin settings are applied to the figure wrapper instead of the inner table element.

## Why?
When margins are set via theme.json, they are applied to the inner table element, causing undesirable spacing between the table and its caption. This PR fixes these spacing inconsistencies by applying margins to the correct element.

## Testing Instructions
1. Create a new post
2. Insert a table block
3. Add a caption to the table
4. In theme.json, set a margin for the core/table block (e.g., 128px)
5. Check the caption and table block

## Screenshots or screencast <!-- if applicable -->
|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/80c07402-5c2c-471f-8bfe-34c0e992ba33)|![image](https://github.com/user-attachments/assets/c397b388-3161-4c65-8b55-2cd1df18dc04)|
