### PR TITLE
Read More: Add example preview

### DIFF
--- a/packages/block-library/src/read-more/block.json
+++ b/packages/block-library/src/read-more/block.json
@@ -15,6 +15,11 @@
 			"default": "_self"
 		}
 	},
+	"example": {
+		"attributes": {
+			"content": "Read More"
+		}
+	},
 	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,

--- a/packages/block-library/src/read-more/block.json
+++ b/packages/block-library/src/read-more/block.json
@@ -15,11 +15,6 @@
 			"default": "_self"
 		}
 	},
-	"example": {
-		"attributes": {
-			"content": "Read More"
-		}
-	},
 	"usesContext": [ "postId" ],
 	"supports": {
 		"html": false,

--- a/packages/block-library/src/read-more/index.js
+++ b/packages/block-library/src/read-more/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { link as icon } from '@wordpress/icons';
 
 /**

--- a/packages/block-library/src/read-more/index.js
+++ b/packages/block-library/src/read-more/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { _x } from '@wordpress/i18n';
 import { link as icon } from '@wordpress/icons';
 
 /**
@@ -16,6 +17,11 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {
+		attributes: {
+			content: _x( 'Read More', 'Example text for the Read More block' ),
+		},
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/read-more/index.js
+++ b/packages/block-library/src/read-more/index.js
@@ -19,7 +19,7 @@ export const settings = {
 	edit,
 	example: {
 		attributes: {
-			content: _x( 'Read More', 'Example text for the Read More block' ),
+			content: __( 'Read more' ),
 		},
 	},
 };


### PR DESCRIPTION
Part of: #64707 

## What, Why & How?
This PR introduces an example preview for the `Read More` block.

## Testing Instructions
1. Navigate to `Global Inserter`
2. Hover over the `Read More` block and notice the new preview.

## Screenshots

|Before|After|
|-|-|
|![Screenshot 2024-12-25 at 2 48 13 PM](https://github.com/user-attachments/assets/212a8666-f37b-4e46-bf5d-fb4040620f8b)|![Screenshot 2024-12-25 at 2 48 30 PM](https://github.com/user-attachments/assets/8e60c21b-01fd-459e-ac1d-ca3f674636e1)|
