### PR TITLE
Media & Text: Optimize block editor store subscriptions

### DIFF
--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -200,6 +200,20 @@ function MediaTextEdit( {
 		[ featuredImage ]
 	);
 
+	const { image } = useSelect(
+		( select ) => {
+			return {
+				image:
+					mediaId && isSelected
+						? select( coreStore ).getMedia( mediaId, {
+								context: 'view',
+						  } )
+						: null,
+			};
+		},
+		[ isSelected, mediaId ]
+	);
+
 	const featuredImageURL = useFeaturedImage
 		? featuredImageMedia?.source_url
 		: '';
@@ -223,20 +237,6 @@ function MediaTextEdit( {
 			useFeaturedImage: ! useFeaturedImage,
 		} );
 	};
-
-	const { image } = useSelect(
-		( select ) => {
-			return {
-				image:
-					mediaId && isSelected
-						? select( coreStore ).getMedia( mediaId, {
-								context: 'view',
-						  } )
-						: null,
-			};
-		},
-		[ isSelected, mediaId ]
-	);
 
 	const refMedia = useRef();
 	const imperativeFocalPointPreview = ( value ) => {

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -134,6 +134,31 @@ function attributesFromMedia( {
 	};
 }
 
+function MediaTextResolutionTool( { image, value, onChange } ) {
+	const { imageSizes } = useSelect( ( select ) => {
+		const { getSettings } = select( blockEditorStore );
+		return {
+			imageSizes: getSettings().imageSizes,
+		};
+	}, [] );
+
+	if ( ! imageSizes?.length ) {
+		return null;
+	}
+
+	const imageSizeOptions = imageSizes
+		.filter( ( { slug } ) => getImageSourceUrlBySizeSlug( image, slug ) )
+		.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
+
+	return (
+		<ResolutionTool
+			value={ value }
+			options={ imageSizeOptions }
+			onChange={ onChange }
+		/>
+	);
+}
+
 function MediaTextEdit( {
 	attributes,
 	isSelected,
@@ -199,9 +224,8 @@ function MediaTextEdit( {
 		} );
 	};
 
-	const { imageSizes, image } = useSelect(
+	const { image } = useSelect(
 		( select ) => {
-			const { getSettings } = select( blockEditorStore );
 			return {
 				image:
 					mediaId && isSelected
@@ -209,7 +233,6 @@ function MediaTextEdit( {
 								context: 'view',
 						  } )
 						: null,
-				imageSizes: getSettings()?.imageSizes,
 			};
 		},
 		[ isSelected, mediaId ]
@@ -262,10 +285,6 @@ function MediaTextEdit( {
 	const onVerticalAlignmentChange = ( alignment ) => {
 		setAttributes( { verticalAlignment: alignment } );
 	};
-
-	const imageSizeOptions = imageSizes
-		.filter( ( { slug } ) => getImageSourceUrlBySizeSlug( image, slug ) )
-		.map( ( { name, slug } ) => ( { value: slug, label: name } ) );
 	const updateImage = ( newMediaSizeSlug ) => {
 		const newUrl = getImageSourceUrlBySizeSlug( image, newMediaSizeSlug );
 
@@ -411,9 +430,9 @@ function MediaTextEdit( {
 				</ToolsPanelItem>
 			) }
 			{ mediaType === 'image' && ! useFeaturedImage && (
-				<ResolutionTool
+				<MediaTextResolutionTool
+					image={ image }
 					value={ mediaSizeSlug }
-					options={ imageSizeOptions }
 					onChange={ updateImage }
 				/>
 			) }

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -153,6 +153,7 @@ function MediaTextResolutionTool( { image, value, onChange } ) {
 	return (
 		<ResolutionTool
 			value={ value }
+			defaultValue={ DEFAULT_MEDIA_SIZE_SLUG }
 			options={ imageSizeOptions }
 			onChange={ onChange }
 		/>
@@ -179,12 +180,12 @@ function MediaTextEdit( {
 		mediaType,
 		mediaUrl,
 		mediaWidth,
+		mediaSizeSlug,
 		rel,
 		verticalAlignment,
 		allowedBlocks,
 		useFeaturedImage,
 	} = attributes;
-	const mediaSizeSlug = attributes.mediaSizeSlug || DEFAULT_MEDIA_SIZE_SLUG;
 
 	const [ featuredImage ] = useEntityProp(
 		'postType',


### PR DESCRIPTION
## What?
Similar to #56967.

PR updates the Media & Text block to only subscribe to media resolution settings for the selected block.

## Why?
This is a micro-optimization. Every useSelect added to a frequently used block degrades the load and type bit. Since block usage is project-specific, it's better to promote best practices.

## Testing Instructions
1. Open a post or page.
2. Add Media & Text blocks.
3. Select an image.
4. Confirm that the Resolution setting is working as before.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-12-25 at 14 11 43](https://github.com/user-attachments/assets/7824b22b-3ec8-41ff-887a-4d965048d3e6)

