### PR TITLE
StoryBook: Add Story for DuotoneControl

### DIFF
--- a/packages/block-editor/src/components/duotone-control/stories/index.story.js
+++ b/packages/block-editor/src/components/duotone-control/stories/index.story.js
@@ -8,9 +8,6 @@ import { useState } from '@wordpress/element';
  */
 import DuotoneControl from '../';
 
-/**
- * Storybook Meta Information
- */
 const meta = {
 	title: 'BlockEditor/DuotoneControl',
 	component: DuotoneControl,
@@ -75,9 +72,6 @@ const meta = {
 
 export default meta;
 
-/**
- * Default Story
- */
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
 		const [ value, setValue ] = useState( 'unset' );

--- a/packages/block-editor/src/components/duotone-control/stories/index.story.js
+++ b/packages/block-editor/src/components/duotone-control/stories/index.story.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import DuotoneControl from '../';
+
+/**
+ * Storybook Meta Information
+ */
+const meta = {
+	title: 'BlockEditor/DuotoneControl',
+	component: DuotoneControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: 'Control to facilitate duotone filter selections.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: 'text',
+			description: 'Currently selected duotone value.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			description: 'Handles change in duotone selection.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		colorPalette: {
+			control: null,
+			description: 'Array of available colors for the duotone filter.',
+			table: {
+				type: { summary: 'array' },
+			},
+		},
+		duotonePalette: {
+			control: null,
+			description: 'Array of duotone preset palettes.',
+			table: {
+				type: { summary: 'array' },
+			},
+		},
+		disableCustomColors: {
+			control: 'boolean',
+			description: 'Disables the option to customize duotone colors.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+		disableCustomDuotone: {
+			control: 'boolean',
+			description: 'Disables the option to customize the duotone effect.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+/**
+ * Default Story
+ */
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState( 'unset' );
+
+		const colorPalette = args.colorPalette || [];
+		const duotonePalette = args.duotonePalette || [];
+
+		const handleChange = ( newValue ) => {
+			setValue( newValue );
+			onChange?.( newValue );
+		};
+
+		return (
+			<DuotoneControl
+				{ ...args }
+				value={ value }
+				onChange={ handleChange }
+				colorPalette={ colorPalette }
+				duotonePalette={ duotonePalette }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
# Work in progress
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds Storybook stories for the DuotoneControl component to improve component documentation and testability.

## Testing Instructions

1. Run npm run storybook:dev
2. Open Storybook at http://localhost:50240/
3. Verify the DuotoneControl story is present and functioning


## Screenshots or screencast
