### PR TITLE
Post Featured Image: Use the 'ResolutionTool' component

### DIFF
--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -12,9 +12,17 @@ import {
 } from '@wordpress/components';
 import {
 	useSettings,
+	privateApis as blockEditorPrivateApis,
 	store as blockEditorStore,
 } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { unlock } from '../lock-unlock';
+
+const { ResolutionTool } = unlock( blockEditorPrivateApis );
 
 const SCALE_OPTIONS = (
 	<>
@@ -223,30 +231,16 @@ const DimensionControls = ( {
 				</ToolsPanelItem>
 			) }
 			{ !! imageSizeOptions.length && (
-				<ToolsPanelItem
-					hasValue={ () => !! sizeSlug }
-					label={ __( 'Resolution' ) }
-					onDeselect={ () =>
-						setAttributes( { sizeSlug: undefined } )
-					}
-					resetAllFilter={ () => ( {
-						sizeSlug: undefined,
-					} ) }
-					isShownByDefault={ false }
+				<ResolutionTool
 					panelId={ clientId }
-				>
-					<SelectControl
-						__next40pxDefaultSize
-						__nextHasNoMarginBottom
-						label={ __( 'Resolution' ) }
-						value={ sizeSlug || DEFAULT_SIZE }
-						options={ imageSizeOptions }
-						onChange={ ( nextSizeSlug ) =>
-							setAttributes( { sizeSlug: nextSizeSlug } )
-						}
-						help={ __( 'Select the size of the source image.' ) }
-					/>
-				</ToolsPanelItem>
+					value={ sizeSlug }
+					defaultValue={ DEFAULT_SIZE }
+					options={ imageSizeOptions }
+					onChange={ ( nextSizeSlug ) =>
+						setAttributes( { sizeSlug: nextSizeSlug } )
+					}
+					isShownByDefault={ false }
+				/>
 			) }
 		</>
 	);

--- a/packages/block-library/src/post-featured-image/dimension-controls.js
+++ b/packages/block-library/src/post-featured-image/dimension-controls.js
@@ -240,6 +240,9 @@ const DimensionControls = ( {
 						setAttributes( { sizeSlug: nextSizeSlug } )
 					}
 					isShownByDefault={ false }
+					resetAllFilter={ () => ( {
+						sizeSlug: DEFAULT_SIZE,
+					} ) }
 				/>
 			) }
 		</>


### PR DESCRIPTION
## What?
PR refactors Featured Image custom dimensions controls to use the new `ResolutionTool` private component.

## Why?
This matches the pattern used in other media blocks. The original implementation pre-dates the new component. See: #38044.

## Testing Instructions
1. Open a post.
2. Insert a Featured Image block.
3. Set a featured image.
4. Confirm that Resolutions settings work as before in the Dimensions panel.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-12-25 at 15 55 00](https://github.com/user-attachments/assets/b1664855-b853-4e05-8d14-83a7fc618ce1)

