### PR TITLE
Update SiteTitle block  to Fix `isLink` Toggle Behavior

### DIFF
--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -123,16 +123,16 @@ export default function SiteTitleEdit( {
 					label={ __( 'Settings' ) }
 					resetAll={ () => {
 						setAttributes( {
-							isLink: false,
+							isLink: true,
 							linkTarget: '_self',
 						} );
 					} }
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						hasValue={ () => isLink !== false }
+						hasValue={ () => isLink === false }
 						label={ __( 'Make title link to home' ) }
-						onDeselect={ () => setAttributes( { isLink: false } ) }
+						onDeselect={ () => setAttributes( { isLink: true } ) }
 						isShownByDefault
 					>
 						<ToggleControl

--- a/packages/block-library/src/site-title/edit.js
+++ b/packages/block-library/src/site-title/edit.js
@@ -130,7 +130,7 @@ export default function SiteTitleEdit( {
 					dropdownMenuProps={ dropdownMenuProps }
 				>
 					<ToolsPanelItem
-						hasValue={ () => isLink === false }
+						hasValue={ () => ! isLink }
 						label={ __( 'Make title link to home' ) }
 						onDeselect={ () => setAttributes( { isLink: true } ) }
 						isShownByDefault


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: https://github.com/WordPress/gutenberg/pull/67898#discussion_r1895812854
Part of: https://github.com/WordPress/gutenberg/issues/67901

## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/fe3e7c52-6746-4acf-8bf0-c62120055e10

