### PR TITLE
Fixed drag and drop within Submenus 

### DIFF
--- a/packages/block-editor/src/components/use-block-drop-zone/index.js
+++ b/packages/block-editor/src/components/use-block-drop-zone/index.js
@@ -257,17 +257,24 @@ export function isDropTargetValid(
 
 	// Work out if dragged blocks have an allowed parent and if so
 	// check target block matches the allowed parent.
-	const draggedBlockTypes = draggedBlockNames.map( ( name ) =>
-		getBlockType( name )
-	);
+	const draggedBlockTypes = draggedBlockNames.map( ( name ) => {
+		const blockType = getBlockType( name );
+		return {
+			name,
+			parent: blockType.parent || [],
+		};
+	} );
 	const targetMatchesDraggedBlockParents = draggedBlockTypes.every(
 		( block ) => {
+			const [ firstParent ] = draggedBlockTypes[ 0 ]?.parent || [];
 			const [ allowedParentName ] = block?.parent || [];
-			if ( ! allowedParentName ) {
+			if ( ! firstParent && ! allowedParentName ) {
 				return true;
 			}
-
-			return allowedParentName === targetBlockName;
+			return (
+				firstParent === allowedParentName ||
+				allowedParentName === targetBlockName
+			);
 		}
 	);
 


### PR DESCRIPTION
fixes #68178

## What?
Fix drag and drop behavior for navigation submenu blocks. Allow proper nesting and ordering when dragging submenu items.

## Why?
Bug #68178: Submenu items move to top of list when dragged. Different types of submenu items break drag functionality.

## How?
- Modified isDropTargetValid to validate block parent relationships

## Testing Instructions

1. Insert a Navigation block
2. Create multiple submenu items with nested items
3. Drag a nested submenu item - verify it maintains position
4. Select multiple submenu items of different types and drag - verify they stay together
5. Test dragging items between different nesting levels

 ## ScreenCast
 
https://github.com/user-attachments/assets/dd6f149e-3f61-47f5-8077-5645bf0286ad


