### PR TITLE
Add support for 'link' type action in DataViews

### DIFF
--- a/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-bulk-actions/index.tsx
@@ -189,37 +189,56 @@ function ActionButton< Item >( {
 	setActionInProgress,
 }: ActionButtonProps< Item > ) {
 	const registry = useRegistry();
-	const selectedEligibleItems = useMemo( () => {
-		return selectedItems.filter( ( item ) => {
-			return ! action.isEligible || action.isEligible( item );
-		} );
-	}, [ action, selectedItems ] );
-	if ( 'RenderModal' in action ) {
+
+	const selectedEligibleItems = useMemo(() => {
+		return selectedItems.filter((item) => {
+			return !action.isEligible || action.isEligible(item);
+		});
+	}, [action, selectedItems]);
+
+	// Handle 'link' type
+	if (action.type === 'link') {
+		return (
+			<a
+				key={action.id}
+				href={action.href}
+				target={action.target || '_self'}
+				rel={action.target === '_blank' ? 'noopener noreferrer' : undefined}
+				className="action-link"
+			>
+				{action.label}
+			</a>
+		);
+	}
+
+	// Handle 'RenderModal' type
+	if ('RenderModal' in action) {
 		return (
 			<ActionWithModal
-				key={ action.id }
-				action={ action }
-				items={ selectedEligibleItems }
-				ActionTriggerComponent={ ActionTrigger }
+				key={action.id}
+				action={action}
+				items={selectedEligibleItems}
+				ActionTriggerComponent={ActionTrigger}
 			/>
 		);
 	}
 	return (
 		<ActionTrigger
-			key={ action.id }
-			action={ action }
-			onClick={ async () => {
-				setActionInProgress( action.id );
-				await action.callback( selectedItems, {
+			key={action.id}
+			action={action}
+			onClick={async () => {
+				setActionInProgress(action.id);
+				await action.callback(selectedItems, {
 					registry,
-				} );
-				setActionInProgress( null );
-			} }
-			items={ selectedEligibleItems }
-			isBusy={ actionInProgress === action.id }
+				});
+				setActionInProgress(null);
+			}}
+			items={selectedEligibleItems}
+			isBusy={actionInProgress === action.id}
 		/>
 	);
 }
+
 
 function renderFooterContent< Item >(
 	data: Item[],

--- a/packages/dataviews/src/components/dataviews-item-actions/index.tsx
+++ b/packages/dataviews/src/components/dataviews-item-actions/index.tsx
@@ -258,38 +258,56 @@ function CompactItemActions< Item >( {
 	);
 }
 
-function PrimaryActions< Item >( {
-	item,
-	actions,
-	registry,
-}: PrimaryActionsProps< Item > ) {
-	const [ activeModalAction, setActiveModalAction ] = useState( null as any );
-	if ( ! Array.isArray( actions ) || actions.length === 0 ) {
-		return null;
-	}
-	return (
-		<>
-			{ actions.map( ( action ) => (
-				<ButtonTrigger
-					key={ action.id }
-					action={ action }
-					onClick={ () => {
-						if ( 'RenderModal' in action ) {
-							setActiveModalAction( action );
-							return;
-						}
-						action.callback( [ item ], { registry } );
-					} }
-					items={ [ item ] }
-				/>
-			) ) }
-			{ !! activeModalAction && (
-				<ActionModal
-					action={ activeModalAction }
-					items={ [ item ] }
-					closeModal={ () => setActiveModalAction( null ) }
-				/>
-			) }
-		</>
-	);
+function PrimaryActions<Item>({
+    item,
+    actions,
+    registry,
+}: PrimaryActionsProps<Item>) {
+    const [activeModalAction, setActiveModalAction] = useState(null as any);
+
+    if (!Array.isArray(actions) || actions.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {actions.map((action) => {
+                if (action.type === 'link') {
+                    return (
+                        <a
+                            href={action.href}
+                            target={action.target || '_self'}
+                            rel={action.target === '_blank' ? 'noopener noreferrer' : undefined}
+                            key={action.label}
+                            className="action-link"
+                        >
+                            {action.label}
+                        </a>
+                    );
+                }
+
+                return (
+                    <ButtonTrigger
+                        key={action.id}
+                        action={action}
+                        onClick={() => {
+                            if ('RenderModal' in action) {
+                                setActiveModalAction(action);
+                                return;
+                            }
+                            action.callback([item], { registry });
+                        }}
+                        items={[item]}
+                    />
+                );
+            })}
+            {!!activeModalAction && (
+                <ActionModal
+                    action={activeModalAction}
+                    items={[item]}
+                    closeModal={() => setActiveModalAction(null)}
+                />
+            )}
+        </>
+    );
 }

--- a/packages/dataviews/src/types.ts
+++ b/packages/dataviews/src/types.ts
@@ -478,7 +478,28 @@ export interface ActionButton< Item > extends ActionBase< Item > {
 	) => void;
 }
 
-export type Action< Item > = ActionModal< Item > | ActionButton< Item >;
+export type Action<Item> = ActionModal<Item> | ActionButton<Item> | ActionLink<Item>;
+
+export interface ActionModal<Item> {
+  type: 'modal';
+  label: string;
+  onOpen: (item: Item) => void;
+}
+
+export interface ActionButton<Item> {
+  type: 'button';
+  label: string;
+  onClick: (item: Item) => void;
+}
+
+export interface ActionLink<Item> {
+  [x: string]: any;
+  type: 'link';
+  href: string;
+  label: string;
+  target?: '_self' | '_blank';
+}
+
 
 export interface ViewBaseProps< Item > {
 	actions: Action< Item >[];


### PR DESCRIPTION
## What?
This PR introduces support for a new "link" type in actions within DataViews. With this feature, actions can now function as hyperlinks, allowing users to click on them and navigate to specific URLs.

## Why?
Currently, DataView actions are limited to basic functionalities like buttons. There’s no way to include navigational links directly, which restricts the scope of interactive use cases. By supporting links, this update enhances the versatility of DataViews, enabling developers to provide seamless access to external or internal resources.

## How?
- Updated the action handler to recognize and process the "link" type.
- Added support for configuring "link" actions with a URL property.
- Implemented rendering logic to display these actions as hyperlinks in the user interface.
- Ensured backward compatibility for existing action types like buttons.

## Testing Instructions
1. Open a DataView configuration and add an action with the type set to "link" and a valid URL.
2. Verify that the link action renders correctly as a clickable hyperlink in the interface.
3. Test the link by clicking it and confirming it navigates to the correct URL.
4. Ensure other action types like buttons still function as expected without any regressions.

### Testing Instructions for Keyboard
1. Navigate to a DataView containing a "link" action using only the keyboard.
2. Tab through to focus on the link and press Enter.
3. Confirm the link opens the intended URL as expected.

## Screenshots or screencast 
--------------------------------------------------------------------------------------------------------------------------------------------
Please let me know if any other changes are required