### PR TITLE
Block Library: Don't fetch media details if the block doesn't use a featured image

### DIFF
--- a/packages/block-library/src/cover/edit/index.js
+++ b/packages/block-library/src/cover/edit/index.js
@@ -114,11 +114,18 @@ function CoverEdit( {
 
 	const { __unstableMarkNextChangeAsNotPersistent } =
 		useDispatch( blockEditorStore );
-	const media = useSelect(
-		( select ) =>
-			featuredImage &&
-			select( coreStore ).getMedia( featuredImage, { context: 'view' } ),
-		[ featuredImage ]
+	const { media } = useSelect(
+		( select ) => {
+			return {
+				media:
+					featuredImage && useFeaturedImage
+						? select( coreStore ).getMedia( featuredImage, {
+								context: 'view',
+						  } )
+						: undefined,
+			};
+		},
+		[ featuredImage, useFeaturedImage ]
 	);
 	const mediaUrl =
 		media?.media_details?.sizes?.[ sizeSlug ]?.source_url ??

--- a/packages/block-library/src/media-text/edit.js
+++ b/packages/block-library/src/media-text/edit.js
@@ -168,11 +168,18 @@ function MediaTextEdit( {
 		postId
 	);
 
-	const featuredImageMedia = useSelect(
-		( select ) =>
-			featuredImage &&
-			select( coreStore ).getMedia( featuredImage, { context: 'view' } ),
-		[ featuredImage ]
+	const { featuredImageMedia } = useSelect(
+		( select ) => {
+			return {
+				featuredImageMedia:
+					featuredImage && useFeaturedImage
+						? select( coreStore ).getMedia( featuredImage, {
+								context: 'view',
+						  } )
+						: undefined,
+			};
+		},
+		[ featuredImage, useFeaturedImage ]
 	);
 
 	const featuredImageURL = useFeaturedImage


### PR DESCRIPTION
## What?
PR fixes the condition for selecting feature image data from the store and adds the missing `useFeaturedImage` check.

## Why?
This prevents unnecessary network requests when a post has a featured image, but these blocks don't display it. It doesn't affect post-editor performance but can improve template loading time depending on the query block pattern.

## Testing Instructions
1. Open a post.
2. Set the featured image and close the sidebar.
3. Insert a Media & Text blocks and select an image.
4. Refresh the editor.
5. Confirm that no network request was made for the featured image.
6. Confirm that "Use featured image" toggle works as before.
7. Remove the Media & Text block.
8. Repeat the same steps for the Cover block.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-12-25 at 18 36 58](https://github.com/user-attachments/assets/ca8a523f-af4b-479d-ada7-a549fe4a6616)

