### PR TITLE
Query Total: Remove nested element

### DIFF
--- a/packages/block-library/src/query-total/edit.js
+++ b/packages/block-library/src/query-total/edit.js
@@ -48,27 +48,25 @@ export default function QueryTotalEdit( { attributes, setAttributes } ) {
 
 	// Controls for the block.
 	const controls = (
-		<>
-			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarDropdownMenu
-						icon={ getButtonPositionIcon() }
-						label={ __( 'Change display type' ) }
-						controls={ buttonPositionControls }
-					/>
-				</ToolbarGroup>
-			</BlockControls>
-		</>
+		<BlockControls>
+			<ToolbarGroup>
+				<ToolbarDropdownMenu
+					icon={ getButtonPositionIcon() }
+					label={ __( 'Change display type' ) }
+					controls={ buttonPositionControls }
+				/>
+			</ToolbarGroup>
+		</BlockControls>
 	);
 
 	// Render output based on the selected display type.
 	const renderDisplay = () => {
 		if ( displayType === 'total-results' ) {
-			return <div>{ __( '12 results found' ) }</div>;
+			return <>{ __( '12 results found' ) }</>;
 		}
 
 		if ( displayType === 'range-display' ) {
-			return <div>{ __( 'Displaying 1 – 10 of 12' ) }</div>;
+			return <>{ __( 'Displaying 1 – 10 of 12' ) }</>;
 		}
 
 		return null;

--- a/packages/block-library/src/query-total/index.php
+++ b/packages/block-library/src/query-total/index.php
@@ -40,14 +40,14 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 	switch ( $attributes['displayType'] ) {
 		case 'range-display':
 			if ( $start === $end ) {
-				$range_text = sprintf(
+				$output = sprintf(
 					/* translators: 1: Start index of posts, 2: Total number of posts */
 					__( 'Displaying %1$s of %2$s' ),
 					$start,
 					$max_rows
 				);
 			} else {
-				$range_text = sprintf(
+				$output = sprintf(
 					/* translators: 1: Start index of posts, 2: End index of posts, 3: Total number of posts */
 					__( 'Displaying %1$s – %2$s of %3$s' ),
 					$start,
@@ -56,17 +56,12 @@ function render_block_core_query_total( $attributes, $content, $block ) {
 				);
 			}
 
-			$output = sprintf( '<p>%s</p>', $range_text );
 			break;
 
 		case 'total-results':
 		default:
 			// translators: %d: number of results.
-			$total_text = sprintf( _n( '%d result found', '%d results found', $max_rows ), $max_rows );
-			$output     = sprintf(
-				'<p>%s</p>',
-				$total_text
-			);
+			$output = sprintf( _n( '%d result found', '%d results found', $max_rows ), $max_rows );
 			break;
 	}
 


### PR DESCRIPTION
Related to #67629

## What?

This PR will remove nested elements in the Query Total block.

## Why?

The current HTML does not match between the frontend and the editor:

```html
<!-- Editor -->
<div class="wp-block-query-total">
	<div>12 results found</div>
</div>

<!-- Frontend -->
<div class="wp-block-query-total">
	<p>12 results found</p>
</div>
```

Additionally, because the `p` tag is used on the front end, it will be affected by any global styles applied to the Paragraph block.

## How?

Use only a wrapper `div` tag. This ensures that the HTML is consistent between the frontend and the editor. Additionally, any global styles applied to the Paragraph block will not affect this block.

## Testing Instructions

- Insert a Query Loop block.
- Insert a Query Total block inside it.
- Check the HTML via browser developer tools.
- Check the HTML in the frontend as well.