### PR TITLE
Storybook: Add story for Typewriter component

### DIFF
--- a/packages/block-editor/src/components/typewriter/index.js
+++ b/packages/block-editor/src/components/typewriter/index.js
@@ -260,6 +260,25 @@ export function useTypewriter() {
 	);
 }
 
+/**
+ * Typewriter component displays its children with a typewriter effect.
+ *
+ * @example
+ * ```jsx
+ * function Example(){
+ *   return (
+ *     <Typewriter>
+ *       Hello World
+ *     </Typewriter>
+ *   );
+ * }
+ * ```
+ *
+ * @param {Object}               props
+ * @param {JSX.Element | string} props.children The children to display with a typewriter effect.
+ *
+ * @return {JSX.Element} The rendered Typewriter component.
+ */
 function Typewriter( { children } ) {
 	return (
 		<div ref={ useTypewriter() } className="block-editor__typewriter">

--- a/packages/block-editor/src/components/typewriter/stories/index.story.js
+++ b/packages/block-editor/src/components/typewriter/stories/index.story.js
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import TypewriterOrIEBypass from '../';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+const meta = {
+	title: 'BlockEditor/Typewriter',
+	component: TypewriterOrIEBypass,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `Typewriter` component ensures that the text selection keeps the same vertical distance from the viewport during keyboard events within this component. It provides a typewriter-like behavior for its children.',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+	argTypes: {
+		children: {
+			control: 'text',
+			description: 'The children of the component.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		children: __( 'Typewriter Text' ),
+	},
+	render( { children } ) {
+		return <TypewriterOrIEBypass>{ children }</TypewriterOrIEBypass>;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?

This PR adds storybook for typewriter component

## Testing 

- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Verify the Typewriter story is present and functioning

## Screenshots or screencast <!-- if applicable -->

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/543b5984-e212-4692-a0fb-690c2a587948" />
