### PR TITLE
Fix e2e storybook

### DIFF
--- a/test/storybook-playwright/storybook/main.js
+++ b/test/storybook-playwright/storybook/main.js
@@ -5,7 +5,10 @@ const baseConfig = require( '../../../storybook/main' );
 
 const config = {
 	...baseConfig,
-	addons: [ '@storybook/addon-toolbars' ],
+	addons: [
+		'@storybook/addon-toolbars',
+		'@storybook/addon-webpack5-compiler-babel',
+	],
 	docs: undefined,
 	staticDirs: undefined,
 	stories: [


### PR DESCRIPTION
Fixes #68306

## What?

This issue appeared when Storybook was upgraded to version 8.0.x. It seems to be caused by a missing addon in the E2E Storybook.

See: https://github.com/WordPress/gutenberg/pull/67574#discussion_r1872755718

## Testing Instructions

Run `npm run storybook:e2e:dev`