### PR TITLE
Storybook: Add story for Multi-Selection-Inspector component

### DIFF
--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -15,6 +15,8 @@ import { store as blockEditorStore } from '../../store';
 /**
  * MultiSelection Inspector component displays the number of selected blocks.
  *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/multi-selection-inspector/README.md
+ *
  * @example
  * ```jsx
  * import { <MultiSelectionInspector /> } from '@wordpress/block-editor';

--- a/packages/block-editor/src/components/multi-selection-inspector/index.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/index.js
@@ -12,6 +12,22 @@ import { __experimentalHStack as HStack } from '@wordpress/components';
 import BlockIcon from '../block-icon';
 import { store as blockEditorStore } from '../../store';
 
+/**
+ * MultiSelection Inspector component displays the number of selected blocks.
+ *
+ * @example
+ * ```jsx
+ * import { <MultiSelectionInspector /> } from '@wordpress/block-editor';
+ *
+ * const SelectedBlockCount = getSelectedBlockCount();
+ *
+ * if ( SelectedBlockCount > 1 ) {
+ *    const MyMultiSelectionInspector = () => <MultiSelectionInspector />;
+ *}
+ *```
+ *
+ * @return {Element} MultiSelectionInspector
+ */
 export default function MultiSelectionInspector() {
 	const selectedBlockCount = useSelect(
 		( select ) => select( blockEditorStore ).getSelectedBlockCount(),

--- a/packages/block-editor/src/components/multi-selection-inspector/stories/index.story.js
+++ b/packages/block-editor/src/components/multi-selection-inspector/stories/index.story.js
@@ -1,0 +1,26 @@
+/**
+ * Internal dependencies
+ */
+import MultiSelectionInspector from '../';
+
+const meta = {
+	title: 'Components/MultiSelectionInspector',
+	component: MultiSelectionInspector,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `MultiSelectionInspector` component is used to display the inspector for multiple selected blocks. The number of blocks is updated based on the state of the selected blocks in the block editor',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { ...args } ) {
+		return <MultiSelectionInspector { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds storybook for multi-selection-inspector component

## Testing Instructions

- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Verify the Multi Selection Inspector story is present and functioning

## Screenshots or screencast <!-- if applicable -->
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/8297b2ea-b1aa-45b9-97bf-6127062c481a" />
