### PR TITLE
Storybook: Add story for Editable Text component

### DIFF
--- a/packages/block-editor/src/components/editable-text/stories/index.story.js
+++ b/packages/block-editor/src/components/editable-text/stories/index.story.js
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import EditableText from '../';
+
+const meta = {
+	component: EditableText,
+	title: 'BlockEditor/EditableText',
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `EditableText` component allows to display a text that can be edited by the user.',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+	argTypes: {
+		value: {
+			control: 'text',
+			description: 'The value of the editable text.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			description:
+				'Called when a selection is made. If `null`, _Default_ is selected.',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+		className: {
+			control: 'text',
+			description: 'The class name of the editable text.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( props ) {
+		return (
+			<EditableText
+				className={ props.className }
+				value={ props.value }
+				onChange={ props.onChange }
+			/>
+		);
+	},
+	args: {
+		value: 'Hello World!',
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds storybook for Editable Text component 

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Verify the DuotoneControl story is present and functioning

## Screenshots or screencast <!-- if applicable -->

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/132a9be0-551b-47da-8899-ba1a9760db07" />

