### PR TITLE
Fix - Table block column alignment is not working properly

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -904,7 +904,7 @@ Create structured content in rows and columns to display information. ([Source](
 -	**Name:** core/table
 -	**Category:** text
 -	**Supports:** align, anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** body, caption, foot, hasFixedLayout, head
+-	**Attributes:** alignAllColumns, body, caption, foot, hasFixedLayout, head
 
 ## Table of Contents
 

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -16,6 +16,11 @@
 			"source": "rich-text",
 			"selector": "figcaption"
 		},
+		"alignAllColumns": {
+			"type": "string",
+			"source": "attribute",
+			"attribute": "data-align-all-columns"
+		},
 		"head": {
 			"type": "array",
 			"default": [],

--- a/packages/block-library/src/table/block.json
+++ b/packages/block-library/src/table/block.json
@@ -19,6 +19,7 @@
 		"alignAllColumns": {
 			"type": "string",
 			"source": "attribute",
+			"selector": "table",
 			"attribute": "data-align-all-columns"
 		},
 		"head": {

--- a/packages/block-library/src/table/edit.js
+++ b/packages/block-library/src/table/edit.js
@@ -77,6 +77,24 @@ const ALIGNMENT_CONTROLS = [
 	},
 ];
 
+const ALIGNMENT_CONTROLS_ALL_COLUMNS = [
+	{
+		icon: alignLeft,
+		title: __( 'Align all columns left' ),
+		align: 'left',
+	},
+	{
+		icon: alignCenter,
+		title: __( 'Align all columns center' ),
+		align: 'center',
+	},
+	{
+		icon: alignRight,
+		title: __( 'Align all columns right' ),
+		align: 'right',
+	},
+];
+
 const cellAriaLabel = {
 	head: __( 'Header cell text' ),
 	body: __( 'Body cell text' ),
@@ -343,6 +361,15 @@ function TableEdit( {
 		);
 	}
 
+	/**
+	 * Align text of all the columns.
+	 *
+	 * @param {string} align The new alignment to apply to the all columns.
+	 */
+	function onChangeAllColumnsAlignment( align ) {
+		setAttributes( { ...attributes, alignAllColumns: align } );
+	}
+
 	useEffect( () => {
 		if ( ! isSingleSelected ) {
 			setSelectedCell();
@@ -424,6 +451,9 @@ function TableEdit( {
 								rowSpan={ rowspan }
 								className={ clsx(
 									{
+										[ `has-text-align-${ attributes.alignAllColumns }` ]:
+											attributes.alignAllColumns &&
+											align === undefined,
 										[ `has-text-align-${ align }` ]: align,
 									},
 									'wp-block-table__cell-content'
@@ -472,6 +502,12 @@ function TableEdit( {
 							icon={ table }
 							label={ __( 'Edit table' ) }
 							controls={ tableControls }
+						/>
+						<AlignmentControl
+							label={ __( 'Change all columns alignment' ) }
+							alignmentControls={ ALIGNMENT_CONTROLS_ALL_COLUMNS }
+							value={ attributes.alignAllColumns }
+							onChange={ onChangeAllColumnsAlignment }
 						/>
 					</BlockControls>
 				</>

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -55,6 +55,9 @@ export default function save( { attributes } ) {
 								cellIndex
 							) => {
 								const cellClasses = clsx( {
+									[ `has-text-align-${ attributes.alignAllColumns }` ]:
+										attributes.alignAllColumns &&
+										align === undefined,
 									[ `has-text-align-${ align }` ]: align,
 								} );
 
@@ -66,6 +69,9 @@ export default function save( { attributes } ) {
 												: undefined
 										}
 										data-align={ align }
+										data-align-all-columns={
+											attributes.alignAllColumns
+										}
 										tagName={ tag }
 										value={ content }
 										key={ cellIndex }

--- a/packages/block-library/src/table/save.js
+++ b/packages/block-library/src/table/save.js
@@ -69,9 +69,6 @@ export default function save( { attributes } ) {
 												: undefined
 										}
 										data-align={ align }
-										data-align-all-columns={
-											attributes.alignAllColumns
-										}
 										tagName={ tag }
 										value={ content }
 										key={ cellIndex }
@@ -95,6 +92,7 @@ export default function save( { attributes } ) {
 			<table
 				className={ classes === '' ? undefined : classes }
 				style={ { ...colorProps.style, ...borderProps.style } }
+				data-align-all-columns={ attributes.alignAllColumns }
 			>
 				<Section type="head" rows={ head } />
 				<Section type="body" rows={ body } />


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: https://github.com/WordPress/gutenberg/issues/67359
## What?
<!-- In a few words, what is the PR actually doing? -->
Added a toolbar option to add alignment for all the columns.
## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As we have only option to add alignment for single column and not for all the columns at once.
## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added alignment control in block controls for all the columns option.


## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/2c5c1798-99c9-4601-a2a7-06f576ee20f7



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

