### PR TITLE
Storybook: Add stories for URLInputButton component

### DIFF
--- a/packages/block-editor/src/components/url-input/stories/button.story.js
+++ b/packages/block-editor/src/components/url-input/stories/button.story.js
@@ -41,15 +41,4 @@ const meta = {
 
 export default meta;
 
-export const Default = {
-	render: function Template( { onChange, ...args } ) {
-		return (
-			<URLInputButton
-				{ ...args }
-				onChange={ ( ...changeArgs ) => {
-					onChange( ...changeArgs );
-				} }
-			/>
-		);
-	},
-};
+export const Default = {};

--- a/packages/block-editor/src/components/url-input/stories/button.story.js
+++ b/packages/block-editor/src/components/url-input/stories/button.story.js
@@ -1,0 +1,60 @@
+/**
+ * Internal dependencies
+ */
+import URLInputButton from '../button';
+
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+const meta = {
+	title: 'BlockEditor/URLInputButton',
+	component: URLInputButton,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders the URL input field used by the `URLInputButton` component. It can be used directly to display the input field in different ways such as in a `Popover` or inline.',
+			},
+		},
+	},
+	argTypes: {
+		url: {
+			control: 'text',
+			description:
+				'The current URL value. Should be tied to the component state or an attribute.',
+			type: { name: 'string', required: true },
+		},
+		onChange: {
+			action: 'onChange',
+			description: `Callback function triggered when the URL value changes.
+		  The first parameter is the new URL (String).
+		  The second parameter is the selected post object (Object) if a post is selected, or \`null\` if the input is arbitrary.`,
+			table: {
+				type: {
+					summary: '(url: string, post?: object) => void',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
+		return (
+			<URLInputButton
+				{ ...args }
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
+				} }
+				value={ value }
+			/>
+		);
+	},
+};

--- a/packages/block-editor/src/components/url-input/stories/button.story.js
+++ b/packages/block-editor/src/components/url-input/stories/button.story.js
@@ -16,7 +16,7 @@ const meta = {
 			canvas: { sourceState: 'shown' },
 			description: {
 				component:
-					'Renders the URL input field used by the `URLInputButton` component. It can be used directly to display the input field in different ways such as in a `Popover` or inline.',
+					'Render a URL input button that pops up an input to search for and select a post or enter any arbitrary URL.',
 			},
 		},
 	},
@@ -24,19 +24,22 @@ const meta = {
 		url: {
 			control: 'text',
 			description:
-				'The current URL value. Should be tied to the component state or an attribute.',
-			type: { name: 'string', required: true },
+				'This should be set to the attribute (or component state) property used to store the URL.',
+			type: {
+				required: true,
+				name: 'string',
+			},
 		},
 		onChange: {
-			action: 'onChange',
-			description: `Callback function triggered when the URL value changes.
-		  The first parameter is the new URL (String).
-		  The second parameter is the selected post object (Object) if a post is selected, or \`null\` if the input is arbitrary.`,
-			table: {
-				type: {
-					summary: '(url: string, post?: object) => void',
-				},
+			control: {
+				type: null,
 			},
+			description: `Called when the value changes. The second parameter is null unless the user selects a post from the suggestions dropdown.`,
+			type: {
+				required: true,
+				name: 'function',
+			},
+			action: 'onChange',
 		},
 	},
 };

--- a/packages/block-editor/src/components/url-input/stories/button.story.js
+++ b/packages/block-editor/src/components/url-input/stories/button.story.js
@@ -3,11 +3,6 @@
  */
 import URLInputButton from '../button';
 
-/**
- * WordPress dependencies
- */
-import { useState } from '@wordpress/element';
-
 const meta = {
 	title: 'BlockEditor/URLInputButton',
 	component: URLInputButton,
@@ -48,15 +43,12 @@ export default meta;
 
 export const Default = {
 	render: function Template( { onChange, ...args } ) {
-		const [ value, setValue ] = useState();
 		return (
 			<URLInputButton
 				{ ...args }
 				onChange={ ( ...changeArgs ) => {
 					onChange( ...changeArgs );
-					setValue( ...changeArgs );
 				} }
-				value={ value }
 			/>
 		);
 	},


### PR DESCRIPTION
Part of #67165

## What?
This PR adds Storybook stories for the URLInputButton component to improve component documentation and testability.

## Why?
- To provide clear visual documentation for the URLInputButton component.
- To enable interactive testing for various URLInputButton scenarios.
- To enhance the development experience for Block Editor components.

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open Storybook at http://localhost:50240/
3. Verify working of URLInputButton story

## Screenshots 

https://github.com/user-attachments/assets/14acee9b-187c-4ae3-b8b2-423a3f8514cc




