### PR TITLE
Feat: Add JSDOC and README for Inserter list item.

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/README.md
+++ b/packages/block-editor/src/components/inserter-list-item/README.md
@@ -1,0 +1,95 @@
+# InserterListItem
+
+The `InserterListItem` component represents a single item in the inserter listbox, providing functionality for selection, hover, and optional drag-and-drop. It is used to display blocks or patterns within the WordPress editor environment and supports custom styling and behavior through props.
+
+## Usage
+
+```jsx
+import { InserterListItem } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+
+const item = {
+	id: 'core/paragraph',
+	title: 'Paragraph',
+	icon: { background: '#f3f4f6', foreground: '#000' },
+	initialAttributes: { content: 'This is a paragraph block.' },
+	innerBlocks: [],
+};
+
+const handleSelect = (item) => {
+	console.log('Block selected:', item);
+};
+
+const handleHover = (item) => {
+	console.log('Block hovered:', item);
+};
+
+const MyComponent = () => {
+	return (
+		<InserterListItem
+			className="custom-class"
+			isFirst={true}
+			item={item}
+			onSelect={handleSelect}
+			onHover={handleHover}
+			isDraggable={true}
+		/>
+	);
+};
+```
+
+## Props
+
+### `className`
+
+-   **Type:** `string`
+-   **Default:** `''`
+
+Additional CSS class to apply to the list item.
+
+### `isFirst`
+
+-   **Type:** `boolean`
+-   **Default:** `false`
+
+Indicates whether this is the first item in its row.
+
+### `item`
+
+-   **Type:** `Object`
+-   **Default:** `{}`
+
+The block or pattern item to display. Should include properties like `id`, `title`, `icon`, `initialAttributes`, and `innerBlocks`.
+
+### `onSelect`
+
+-   **Type:** `Function`
+-   **Default:** `null`
+
+Callback function invoked when the item is selected. Receives the selected item as an argument.
+
+### `onHover`
+
+-   **Type:** `Function`
+-   **Default:** `null`
+
+Callback function invoked when the item is hovered or hover ends.
+
+### `isDraggable`
+
+-   **Type:** `boolean`
+-   **Default:** `false`
+
+Whether dragging is enabled for this item.
+
+### `props`
+
+-   **Type:** `Object`
+-   **Default:** `{}`
+
+Optional additional props for customization, passed to the `InserterListboxItem`.
+
+## Notes
+
+- This component is typically used within the `InserterListboxGroup` to represent individual blocks or patterns.
+- Drag-and-drop functionality is disabled if `isDraggable` is `false` or the item is marked as disabled.

--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -23,6 +23,22 @@ import BlockIcon from '../block-icon';
 import { InserterListboxItem } from '../inserter-listbox';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 
+/**
+ * InserterListItem Component
+ *
+ * A component that displays a block or pattern in the inserter list,
+ * providing selection, hover, and optional drag-and-drop functionality.
+ *
+ * @param {Object}   props             Component properties.
+ * @param {string}   props.className   Additional class name to add to the list item.
+ * @param {boolean}  props.isFirst     Whether this is the first item in its row.
+ * @param {Object}   props.item        Block or pattern item to display.
+ * @param {Function} props.onSelect    Callback invoked when the item is selected.
+ * @param {Function} props.onHover     Callback invoked when the item is hovered.
+ * @param {boolean}  props.isDraggable Whether dragging is enabled for the item.
+ * @param {Object}   props.props       Additional props passed to the `InserterListboxItem`.
+ * @return {JSX.Element} Draggable or selectable list item element.
+ */
 function InserterListItem( {
 	className,
 	isFirst,


### PR DESCRIPTION
## What?
Add JSDOC and README for `Inserter list item`.

## Why?
Part of - #22891
Resolves Issue -: https://github.com/WordPress/gutenberg/issues/52056
