### PR TITLE
Added Global Documentation in load.php

### DIFF
--- a/lib/experimental/media/load.php
+++ b/lib/experimental/media/load.php
@@ -247,6 +247,8 @@ add_action( 'load-widgets.php', 'gutenberg_set_up_cross_origin_isolation' );
  * Uses an output buffer to add crossorigin="anonymous" where needed.
  *
  * @link https://web.dev/coop-coep/
+ *
+ * @global bool $is_safari
  */
 function gutenberg_start_cross_origin_isolation_output_buffer(): void {
 	global $is_safari;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Added Missing Global Documentation in lib/experimental/media/load.php file.

## Testing Instructions

- Open lib/experimental/media/load.php file
- See global documentation is missing.


