### PR TITLE
Build: Simplify tsconfig.json files

### DIFF
--- a/bin/tsconfig.json
+++ b/bin/tsconfig.json
@@ -16,6 +16,7 @@
 		"noEmit": true,
 		"outDir": ".cache"
 	},
+	"include": [],
 	"files": [
 		"./api-docs/update-api-docs.js",
 		"./plugin/config.js",

--- a/bin/validate-tsconfig.mjs
+++ b/bin/validate-tsconfig.mjs
@@ -29,14 +29,33 @@ for ( const packageName of packagesWithTypes ) {
 		hasErrors = true;
 	}
 
-	const packageJson = JSON.parse(
-		readFileSync( `packages/${ packageName }/package.json`, 'utf8' )
-	);
-	const tsconfigJson = JSON.parse(
-		stripJsonComments(
-			readFileSync( `packages/${ packageName }/tsconfig.json`, 'utf8' )
-		)
-	);
+	let packageJson;
+	try {
+		packageJson = JSON.parse(
+			readFileSync( `packages/${ packageName }/package.json`, 'utf8' )
+		);
+	} catch ( e ) {
+		console.error(
+			`Error parsing package.json for package ${ packageName }`
+		);
+		throw e;
+	}
+	let tsconfigJson;
+	try {
+		tsconfigJson = JSON.parse(
+			stripJsonComments(
+				readFileSync(
+					`packages/${ packageName }/tsconfig.json`,
+					'utf8'
+				)
+			)
+		);
+	} catch ( e ) {
+		console.error(
+			`Error parsing tsconfig.json for package ${ packageName }`
+		);
+		throw e;
+	}
 	if ( packageJson.dependencies ) {
 		for ( const dependency of Object.keys( packageJson.dependencies ) ) {
 			if ( dependency.startsWith( '@wordpress/' ) ) {

--- a/packages/a11y/tsconfig.json
+++ b/packages/a11y/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../dom-ready" }, { "path": "../i18n" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../dom-ready" }, { "path": "../i18n" } ]
 }

--- a/packages/api-fetch/tsconfig.json
+++ b/packages/api-fetch/tsconfig.json
@@ -1,11 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
 	"references": [ { "path": "../i18n" }, { "path": "../url" } ],
-	"include": [ "src/**/*" ],
-	"exclude": [ "**/test/**/*" ]
+	"exclude": [ "**/test" ]
 }

--- a/packages/autop/tsconfig.json
+++ b/packages/autop/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../dom-ready" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../dom-ready" } ]
 }

--- a/packages/blob/tsconfig.json
+++ b/packages/blob/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -1,10 +1,6 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
 	"references": [
 		{ "path": "../a11y" },
 		{ "path": "../api-fetch" },
@@ -37,5 +33,6 @@
 	// NOTE: This package is being progressively typed. You are encouraged to
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.
-	"files": [ "src/components/block-context/index.js", "src/utils/dom.js" ]
+	"files": [ "src/components/block-context/index.js", "src/utils/dom.js" ],
+	"include": []
 }

--- a/packages/block-library/tsconfig.json
+++ b/packages/block-library/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ],
 		"strictNullChecks": true
 	},

--- a/packages/block-serialization-default-parser/tsconfig.json
+++ b/packages/block-serialization-default-parser/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [
 			"gutenberg-env",
 			"gutenberg-test-env",
@@ -31,7 +29,6 @@
 		{ "path": "../rich-text" },
 		{ "path": "../warning" }
 	],
-	"include": [ "src/**/*" ],
 	"exclude": [
 		"src/**/*.android.js",
 		"src/**/*.ios.js",

--- a/packages/core-data/tsconfig.json
+++ b/packages/core-data/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"checkJs": false,
 		"noImplicitAny": false
 	},
@@ -23,6 +21,5 @@
 		{ "path": "../undo-manager" },
 		{ "path": "../url" },
 		{ "path": "../warning" }
-	],
-	"include": [ "src/**/*" ]
+	]
 }

--- a/packages/data-controls/tsconfig.json
+++ b/packages/data-controls/tsconfig.json
@@ -2,14 +2,11 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
 	},
 	"references": [
 		{ "path": "../api-fetch" },
 		{ "path": "../data" },
 		{ "path": "../deprecated" }
-	],
-	"include": [ "src/**/*" ]
+	]
 }

--- a/packages/data/tsconfig.json
+++ b/packages/data/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"checkJs": false
 	},
 	"references": [
@@ -14,6 +12,5 @@
 		{ "path": "../is-shallow-equal" },
 		{ "path": "../priority-queue" },
 		{ "path": "../redux-routine" }
-	],
-	"include": [ "src/**/*" ]
+	]
 }

--- a/packages/dataviews/tsconfig.json
+++ b/packages/dataviews/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [
 			"gutenberg-env",
 			"gutenberg-test-env",
@@ -22,7 +20,6 @@
 		{ "path": "../private-apis" },
 		{ "path": "../warning" }
 	],
-	"include": [ "src" ],
 	"exclude": [
 		"src/**/*.android.js",
 		"src/**/*.ios.js",

--- a/packages/date/tsconfig.json
+++ b/packages/date/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../deprecated" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../deprecated" } ]
 }

--- a/packages/deprecated/tsconfig.json
+++ b/packages/deprecated/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../hooks" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../hooks" } ]
 }

--- a/packages/docgen/tsconfig.json
+++ b/packages/docgen/tsconfig.json
@@ -2,8 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "lib",
-		"declarationDir": "build-types"
+		"rootDir": "lib"
 	},
-	"include": [ "lib/get-leading-comments.js" ]
+	"files": [ "lib/get-leading-comments.js" ],
+	"include": []
 }

--- a/packages/dom-ready/tsconfig.json
+++ b/packages/dom-ready/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/dom/tsconfig.json
+++ b/packages/dom/tsconfig.json
@@ -2,10 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
 	},
-	"include": [ "src/**/*" ],
 	"references": [ { "path": "../deprecated" } ]
 }

--- a/packages/e2e-test-utils-playwright/tsconfig.json
+++ b/packages/e2e-test-utils-playwright/tsconfig.json
@@ -7,16 +7,13 @@
 		"module": "Node16",
 		"moduleResolution": "node16",
 		"types": [ "node" ],
-		"rootDir": "src",
 		"noEmit": false,
 		"outDir": "build",
 		"sourceMap": true,
 		"declaration": true,
 		"declarationMap": true,
-		"declarationDir": "build-types",
 		"emitDeclarationOnly": false,
 		"allowJs": true,
 		"checkJs": false
-	},
-	"include": [ "src/**/*" ]
+	}
 }

--- a/packages/editor/tsconfig.json
+++ b/packages/editor/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"checkJs": false
 	},
 	"references": [
@@ -34,6 +32,5 @@
 		{ "path": "../url" },
 		{ "path": "../warning" },
 		{ "path": "../wordcount" }
-	],
-	"include": [ "src" ]
+	]
 }

--- a/packages/element/tsconfig.json
+++ b/packages/element/tsconfig.json
@@ -2,12 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
-
 		"noImplicitAny": false,
 		"strictNullChecks": false
 	},
-	"references": [ { "path": "../escape-html" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../escape-html" } ]
 }

--- a/packages/escape-html/tsconfig.json
+++ b/packages/escape-html/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/eslint-plugin/tsconfig.json
+++ b/packages/eslint-plugin/tsconfig.json
@@ -3,12 +3,12 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"module": "CommonJS",
-		"rootDir": "rules",
-		"declarationDir": "build-types"
+		"rootDir": "rules"
 	},
 	"references": [ { "path": "../prettier-config" } ],
 	// NOTE: This package is being progressively typed. You are encouraged to
 	// expand this array with files which can be type-checked. At some point in
 	// the future, this can be simplified to an `includes` of `src/**/*`.
-	"files": [ "rules/dependency-group.js", "rules/no-unsafe-wp-apis.js" ]
+	"files": [ "rules/dependency-group.js", "rules/no-unsafe-wp-apis.js" ],
+	"include": []
 }

--- a/packages/fields/tsconfig.json
+++ b/packages/fields/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"checkJs": false
 	},
 	"references": [
@@ -29,6 +27,5 @@
 		{ "path": "../url" },
 		{ "path": "../block-editor" },
 		{ "path": "../warning" }
-	],
-	"include": [ "src" ]
+	]
 }

--- a/packages/hooks/tsconfig.json
+++ b/packages/hooks/tsconfig.json
@@ -2,9 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
-	},
-	"include": [ "src/**/*" ]
+	}
 }

--- a/packages/html-entities/tsconfig.json
+++ b/packages/html-entities/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/i18n/tsconfig.json
+++ b/packages/i18n/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../hooks" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../hooks" } ]
 }

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ],
 	"references": [ { "path": "../element" }, { "path": "../primitives" } ]
 }

--- a/packages/interactivity-router/tsconfig.json
+++ b/packages/interactivity-router/tsconfig.json
@@ -2,11 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"checkJs": false,
 		"strict": false
 	},
-	"references": [ { "path": "../a11y" }, { "path": "../interactivity" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../a11y" }, { "path": "../interactivity" } ]
 }

--- a/packages/interactivity/tsconfig.json
+++ b/packages/interactivity/tsconfig.json
@@ -2,10 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
-
 		"noImplicitAny": false
-	},
-	"include": [ "src/**/*" ]
+	}
 }

--- a/packages/interactivity/tsconfig.test.json
+++ b/packages/interactivity/tsconfig.test.json
@@ -2,12 +2,12 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
 		"noEmit": true,
 		"emitDeclarationOnly": false,
 		"types": [ "jest" ]
 	},
 	"references": [ { "path": "./tsconfig.json" } ],
 	"files": [ "src/test/store.ts" ],
+	"include": [],
 	"exclude": []
 }

--- a/packages/is-shallow-equal/tsconfig.json
+++ b/packages/is-shallow-equal/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/keycodes/tsconfig.json
+++ b/packages/keycodes/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../i18n" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../i18n" } ]
 }

--- a/packages/lazy-import/tsconfig.json
+++ b/packages/lazy-import/tsconfig.json
@@ -3,8 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",
-		"declarationDir": "build-types",
 		"useUnknownInCatchVariables": false
 	},
-	"include": [ "lib/**/*" ]
+	"include": [ "lib" ]
 }

--- a/packages/media-utils/tsconfig.json
+++ b/packages/media-utils/tsconfig.json
@@ -2,12 +2,9 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ],
 		"checkJs": false
 	},
-	"include": [ "src/**/*" ],
 	"references": [
 		{ "path": "../api-fetch" },
 		{ "path": "../blob" },

--- a/packages/notices/tsconfig.json
+++ b/packages/notices/tsconfig.json
@@ -2,11 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ],
 		"checkJs": false
 	},
-	"references": [ { "path": "../a11y" }, { "path": "../data" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../a11y" }, { "path": "../data" } ]
 }

--- a/packages/plugins/tsconfig.json
+++ b/packages/plugins/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
 	},
 	"references": [
@@ -14,6 +12,5 @@
 		{ "path": "../hooks" },
 		{ "path": "../icons" },
 		{ "path": "../is-shallow-equal" }
-	],
-	"include": [ "src/**/*" ]
+	]
 }

--- a/packages/prettier-config/tsconfig.json
+++ b/packages/prettier-config/tsconfig.json
@@ -3,8 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",
-		"declarationDir": "build-types",
 		"types": [ "node" ]
 	},
-	"include": [ "lib/**/*" ]
+	"include": [ "lib" ]
 }

--- a/packages/primitives/tsconfig.json
+++ b/packages/primitives/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ],
 	"references": [ { "path": "../element" } ]
 }

--- a/packages/priority-queue/tsconfig.json
+++ b/packages/priority-queue/tsconfig.json
@@ -2,9 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "requestidlecallback" ]
-	},
-	"include": [ "src/**/*" ]
+	}
 }

--- a/packages/private-apis/tsconfig.json
+++ b/packages/private-apis/tsconfig.json
@@ -2,9 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
-	},
-	"include": [ "src/**/*" ]
+	}
 }

--- a/packages/project-management-automation/tsconfig.json
+++ b/packages/project-management-automation/tsconfig.json
@@ -3,8 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"rootDir": "lib",
-		"declarationDir": "build-types",
 		"types": [ "node" ]
 	},
-	"include": [ "lib/**/*" ]
+	"include": [ "lib" ]
 }

--- a/packages/react-i18n/tsconfig.json
+++ b/packages/react-i18n/tsconfig.json
@@ -1,10 +1,5 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"references": [ { "path": "../element" }, { "path": "../i18n" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../element" }, { "path": "../i18n" } ]
 }

--- a/packages/redux-routine/tsconfig.json
+++ b/packages/redux-routine/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/report-flaky-tests/tsconfig.json
+++ b/packages/report-flaky-tests/tsconfig.json
@@ -3,10 +3,7 @@
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
 		"module": "CommonJS",
-		"declarationDir": "build-types",
-		"rootDir": "src",
 		"types": [ "jest" ]
 	},
-	"include": [ "src/**/*" ],
-	"exclude": [ "src/__tests__/**/*", "src/__fixtures__/**/*" ]
+	"exclude": [ "src/__tests__", "src/__fixtures__" ]
 }

--- a/packages/rich-text/tsconfig.json
+++ b/packages/rich-text/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ],
 		"checkJs": false
 	},
@@ -16,6 +14,5 @@
 		{ "path": "../escape-html" },
 		{ "path": "../i18n" },
 		{ "path": "../keycodes" }
-	],
-	"include": [ "src/**/*" ]
+	]
 }

--- a/packages/router/tsconfig.json
+++ b/packages/router/tsconfig.json
@@ -2,8 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
 	},
 	"references": [
@@ -11,6 +9,5 @@
 		{ "path": "../element" },
 		{ "path": "../private-apis" },
 		{ "path": "../url" }
-	],
-	"include": [ "src/**/*" ]
+	]
 }

--- a/packages/shortcode/tsconfig.json
+++ b/packages/shortcode/tsconfig.json
@@ -2,10 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"checkJs": false
-	},
-	"references": [],
-	"include": [ "src" ]
+	}
 }

--- a/packages/style-engine/tsconfig.json
+++ b/packages/style-engine/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/sync/tsconfig.json
+++ b/packages/sync/tsconfig.json
@@ -2,10 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "node" ]
 	},
-	"include": [ "src/**/*" ],
 	"references": [ { "path": "../url" } ]
 }

--- a/packages/token-list/tsconfig.json
+++ b/packages/token-list/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"outDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/undo-manager/tsconfig.json
+++ b/packages/undo-manager/tsconfig.json
@@ -2,10 +2,7 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "node" ]
 	},
-	"references": [ { "path": "../is-shallow-equal" } ],
-	"include": [ "src/**/*" ]
+	"references": [ { "path": "../is-shallow-equal" } ]
 }

--- a/packages/upload-media/tsconfig.json
+++ b/packages/upload-media/tsconfig.json
@@ -2,11 +2,8 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
 	},
-	"include": [ "src/**/*" ],
 	"references": [
 		{ "path": "../api-fetch" },
 		{ "path": "../blob" },

--- a/packages/url/tsconfig.json
+++ b/packages/url/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/vips/tsconfig.json
+++ b/packages/vips/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/packages/warning/tsconfig.json
+++ b/packages/warning/tsconfig.json
@@ -2,9 +2,6 @@
 	"$schema": "https://json.schemastore.org/tsconfig.json",
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types",
 		"types": [ "gutenberg-env" ]
-	},
-	"include": [ "src/**/*" ]
+	}
 }

--- a/packages/wordcount/tsconfig.json
+++ b/packages/wordcount/tsconfig.json
@@ -1,9 +1,4 @@
 {
 	"$schema": "https://json.schemastore.org/tsconfig.json",
-	"extends": "../../tsconfig.base.json",
-	"compilerOptions": {
-		"rootDir": "src",
-		"declarationDir": "build-types"
-	},
-	"include": [ "src/**/*" ]
+	"extends": "../../tsconfig.base.json"
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -31,8 +31,12 @@
 		"resolveJsonModule": true,
 
 		"typeRoots": [ "./typings", "./node_modules/@types" ],
-		"types": []
+		"types": [],
+
+		"rootDir": "${configDir}/src",
+		"declarationDir": "${configDir}/build-types"
 	},
+	"include": [ "${configDir}/src" ],
 	"exclude": [
 		"**/*.android.js",
 		"**/*.ios.js",


### PR DESCRIPTION


## What?

Simplify tsconfig.json files. [TypeScript 5.5 introduced a `configDir` variable](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-5.html#the-configdir-template-variable-for-configuration-files) that can be used for templating tsconfig.json files. This can vastly reduce repitition in tsconfig.json files.

- Add standardized configuration to base tsconfig.json file.
- Remove redundant configuration from package tsconfig.json files.
- Remove redundant file globs (e.g. `src` instead of `src/**/*`).

## Why?

This removes a lot of repetition from tsconfig.json files.



## Testing Instructions
CI passes. TSC should continue to work as expected locally.
