### PR TITLE
DropdownMenu: Deprecate 36px default size for toggle button

### DIFF
--- a/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/alignment-control/test/__snapshots__/index.js.snap
@@ -67,7 +67,7 @@ exports[`AlignmentUI should match snapshot when controls are hidden 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Align text"
-      class="components-button components-dropdown-menu__toggle has-icon"
+      class="components-button components-dropdown-menu__toggle is-compact has-icon"
       data-toolbar-item="true"
       type="button"
     >

--- a/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-alignment-control/test/__snapshots__/index.js.snap
@@ -10,7 +10,7 @@ exports[`BlockAlignmentUI should match snapshot when controls are hidden 1`] = `
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Align"
-      class="components-button components-dropdown-menu__toggle has-icon"
+      class="components-button components-dropdown-menu__toggle is-compact has-icon"
       data-toolbar-item="true"
       type="button"
     >

--- a/packages/block-editor/src/components/block-settings-menu/index.js
+++ b/packages/block-editor/src/components/block-settings-menu/index.js
@@ -18,7 +18,7 @@ export function BlockSettingsMenu( { clientIds, ...props } ) {
 				{ ( toggleProps ) => (
 					<BlockSettingsDropdown
 						clientIds={ clientIds }
-						toggleProps={ toggleProps }
+						toggleProps={ { ...toggleProps, size: 'compact' } }
 						{ ...props }
 					/>
 				) }

--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -334,6 +334,7 @@ export const BlockSwitcher = ( { clientIds } ) => {
 						}
 						text={ blockIndicatorText }
 						toggleProps={ {
+							size: 'compact',
 							description: blockSwitcherDescription,
 							...toggleProps,
 						} }

--- a/packages/block-editor/src/components/block-vertical-alignment-control/test/__snapshots__/index.js.snap
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/test/__snapshots__/index.js.snap
@@ -10,7 +10,7 @@ exports[`BlockVerticalAlignmentUI should match snapshot when controls are hidden
       aria-expanded="false"
       aria-haspopup="true"
       aria-label="Change vertical alignment"
-      class="components-button components-dropdown-menu__toggle has-icon"
+      class="components-button components-dropdown-menu__toggle is-compact has-icon"
       data-toolbar-item="true"
       type="button"
     >

--- a/packages/block-editor/src/components/warning/index.js
+++ b/packages/block-editor/src/components/warning/index.js
@@ -40,6 +40,7 @@ function Warning( { className, actions, children, secondaryActions } ) {
 										className:
 											'block-editor-warning__dropdown',
 									} }
+									toggleProps={ { size: 'compact' } }
 									noIcons
 								>
 									{ () => (

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   `RadioGroup`: Log deprecation warning ([#68067](https://github.com/WordPress/gutenberg/pull/68067)).
 -   Soft deprecate `ButtonGroup` component. Use `ToggleGroupControl` instead ([#65429](https://github.com/WordPress/gutenberg/pull/65429)).
 -   `Navigation`: Log deprecation warning for removal in WP 7.1. Use `Navigator` instead ([#68158](https://github.com/WordPress/gutenberg/pull/68158)).
+-   `DropdownMenu`: Deprecate 36px default size for default toggle button ([#68329](https://github.com/WordPress/gutenberg/pull/68329)).
 
 ### Bug Fixes
 

--- a/packages/components/src/dropdown-menu/README.md
+++ b/packages/components/src/dropdown-menu/README.md
@@ -67,6 +67,7 @@ const MyDropdownMenu = () => (
 	<DropdownMenu
 		icon={ more }
 		label="Select a direction"
+		toggleProps={ { size: 'compact' } }
 		controls={ [
 			{
 				title: 'Up',
@@ -100,7 +101,11 @@ import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { more, arrowUp, arrowDown, trash } from '@wordpress/icons';
 
 const MyDropdownMenu = () => (
-	<DropdownMenu icon={ more } label="Select a direction">
+	<DropdownMenu
+		icon={ more }
+		label="Select a direction"
+		toggleProps={ { size: 'compact' } }
+	>
 		{ ( { onClose } ) => (
 			<>
 				<MenuGroup>

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -20,6 +20,7 @@ import type {
 	DropdownOption,
 	DropdownMenuInternalContext,
 } from './types';
+import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 
 function mergeProps<
 	T extends { className?: string; [ key: string ]: unknown },
@@ -82,6 +83,17 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 		}
 	}
 
+	if ( toggleProps?.as === undefined ) {
+		maybeWarnDeprecated36pxSize( {
+			componentName: 'DropdownMenu',
+			__next40pxDefaultSize: toggleProps?.__next40pxDefaultSize,
+			size: toggleProps?.size,
+			feature:
+				'36px default size for default toggle button in wp.components.DropdownMenu',
+			hint: 'Set `toggleProps={ __next40pxDefaultSize: true }` to start opting into the new default size, which will become the default in a future version. For icon buttons, consider setting a non-default size like `toggleProps={ size: "compact" }`.',
+		} );
+	}
+
 	const mergedPopoverProps = mergeProps(
 		{
 			className: 'components-dropdown-menu__popover',
@@ -120,6 +132,9 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
 				return (
 					<Toggle
 						{ ...mergedToggleProps }
+						{ ...( toggleProps?.as === undefined
+							? { __shouldNotWarnDeprecated36pxSize: true }
+							: {} ) }
 						icon={ icon }
 						onClick={
 							( ( event ) => {

--- a/packages/components/src/dropdown-menu/index.tsx
+++ b/packages/components/src/dropdown-menu/index.tsx
@@ -257,6 +257,7 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
  * 	<DropdownMenu
  * 		icon={ more }
  * 		label="Select a direction"
+ * 		toggleProps={ { size: 'compact' } }
  * 		controls={ [
  * 			{
  * 				title: 'Up',
@@ -291,7 +292,11 @@ function UnconnectedDropdownMenu( dropdownMenuProps: DropdownMenuProps ) {
  * import { more, arrowUp, arrowDown, trash } from '@wordpress/icons';
  *
  * const MyDropdownMenu = () => (
- * 	<DropdownMenu icon={ more } label="Select a direction">
+ * 	<DropdownMenu
+ * 		icon={ more }
+ * 		label="Select a direction"
+ * 		toggleProps={ { size: 'compact' } }
+ * 	>
  * 		{ ( { onClose } ) => (
  * 			<>
  * 				<MenuGroup>

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -123,24 +123,3 @@ export const WithChildren: StoryObj< typeof DropdownMenu > = {
 		),
 	},
 };
-
-export const WithCustomTrigger: StoryObj< typeof DropdownMenu > = {
-	...Default,
-	args: {
-		label: 'Select a direction.',
-		children: ( { onClose } ) => (
-			<MenuItem icon={ arrowUp } onClick={ onClose }>
-				Move Up
-			</MenuItem>
-		),
-		toggleProps: {
-			as: ( props ) => {
-				return (
-					<button { ...props } type="button">
-						Open menu
-					</button>
-				);
-			},
-		},
-	},
-};

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -73,7 +73,11 @@ export const WithChildren: StoryObj< typeof DropdownMenu > = {
 	parameters: {
 		docs: {
 			source: {
-				code: `<DropdownMenu label="Select a direction." icon={ more }>
+				code: `<DropdownMenu
+  label="Select a direction."
+  icon={ more }
+  toggleProps={ { size: 'compact' } }
+>
   <MenuGroup>
     <MenuItem icon={ arrowUp } onClick={ onClose }>
       Move Up

--- a/packages/components/src/dropdown-menu/stories/index.story.tsx
+++ b/packages/components/src/dropdown-menu/stories/index.story.tsx
@@ -47,6 +47,7 @@ export default meta;
 export const Default: StoryObj< typeof DropdownMenu > = {
 	args: {
 		label: 'Select a direction.',
+		toggleProps: { size: 'compact' },
 		icon: menu,
 		controls: [
 			{
@@ -94,6 +95,7 @@ export const WithChildren: StoryObj< typeof DropdownMenu > = {
 	},
 	args: {
 		label: 'Select a direction.',
+		toggleProps: { size: 'compact' },
 		icon: more,
 		children: ( { onClose } ) => (
 			<>
@@ -115,5 +117,26 @@ export const WithChildren: StoryObj< typeof DropdownMenu > = {
 				</MenuGroup>
 			</>
 		),
+	},
+};
+
+export const WithCustomTrigger: StoryObj< typeof DropdownMenu > = {
+	...Default,
+	args: {
+		label: 'Select a direction.',
+		children: ( { onClose } ) => (
+			<MenuItem icon={ arrowUp } onClick={ onClose }>
+				Move Up
+			</MenuItem>
+		),
+		toggleProps: {
+			as: ( props ) => {
+				return (
+					<button { ...props } type="button">
+						Open menu
+					</button>
+				);
+			},
+		},
 	},
 };

--- a/packages/components/src/dropdown-menu/test/index.tsx
+++ b/packages/components/src/dropdown-menu/test/index.tsx
@@ -12,8 +12,18 @@ import { arrowLeft, arrowRight, arrowUp, arrowDown } from '@wordpress/icons';
 /**
  * Internal dependencies
  */
-import DropdownMenu from '..';
+import _DropdownMenu from '..';
 import MenuItem from '../../menu-item';
+
+const DropdownMenu = ( {
+	toggleProps,
+	...restProps
+}: React.ComponentProps< typeof _DropdownMenu > ) => (
+	<_DropdownMenu
+		toggleProps={ { size: 'compact', ...toggleProps } }
+		{ ...restProps }
+	/>
+);
 
 describe( 'DropdownMenu', () => {
 	it( 'should not render when neither controls nor children are assigned', () => {

--- a/packages/components/src/toolbar/stories/index.story.tsx
+++ b/packages/components/src/toolbar/stories/index.story.tsx
@@ -109,7 +109,7 @@ Default.args = {
 									title: 'Align right',
 								},
 							] }
-							toggleProps={ toggleProps }
+							toggleProps={ { ...toggleProps, size: 'compact' } }
 						/>
 					) }
 				</ToolbarItem>

--- a/packages/components/src/toolbar/toolbar-dropdown-menu/index.tsx
+++ b/packages/components/src/toolbar/toolbar-dropdown-menu/index.tsx
@@ -37,7 +37,10 @@ function ToolbarDropdownMenu(
 					popoverProps={ {
 						...props.popoverProps,
 					} }
-					toggleProps={ toolbarItemProps }
+					toggleProps={ {
+						size: 'compact',
+						...toolbarItemProps,
+					} }
 				/>
 			) }
 		</ToolbarItem>

--- a/packages/components/src/toolbar/toolbar-group/toolbar-group-collapsed.tsx
+++ b/packages/components/src/toolbar/toolbar-group/toolbar-group-collapsed.tsx
@@ -28,6 +28,7 @@ function ToolbarGroupCollapsed( {
 			controls={ controls }
 			toggleProps={ {
 				...internalToggleProps,
+				size: 'compact',
 				'data-toolbar-item': true,
 			} }
 			{ ...props }


### PR DESCRIPTION
Part of #65751
Stacked on #68328

## What?

Deprecate the 36px default size on default toggle button for DropdownMenu.

Also updates the consumers so they don't log warnings.

## Testing Instructions

- Unit tests pass
- Storybook stories should not log console warnings
- Code snippets in documentation (JSDoc, Storybook, README) should have the `__next40pxDefaultSize` prop enabled
- There should be no visual changes
