### PR TITLE
DocumentTools: Use standard ToolbarButton for inserter

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -10,7 +10,7 @@ import { useViewportMatch } from '@wordpress/compose';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __, _x } from '@wordpress/i18n';
 import { NavigableToolbar, ToolSelector } from '@wordpress/block-editor';
-import { Button, ToolbarItem } from '@wordpress/components';
+import { ToolbarButton, ToolbarItem } from '@wordpress/components';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import { store as keyboardShortcutsStore } from '@wordpress/keyboard-shortcuts';
@@ -118,9 +118,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 		>
 			<div className="editor-document-tools__left">
 				{ ! isDistractionFree && (
-					<ToolbarItem
+					<ToolbarButton
 						ref={ inserterSidebarToggleRef }
-						as={ Button }
 						className="editor-document-tools__inserter-toggle"
 						variant="primary"
 						isPressed={ isInserterOpened }
@@ -159,8 +158,7 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 							size="compact"
 						/>
 						{ ! isDistractionFree && (
-							<ToolbarItem
-								as={ Button }
+							<ToolbarButton
 								className="editor-document-tools__document-overview-toggle"
 								icon={ listView }
 								disabled={ disableBlockTools }
@@ -175,7 +173,6 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 								}
 								aria-expanded={ isListViewOpen }
 								ref={ listViewToggleRef }
-								size="compact"
 							/>
 						) }
 					</>

--- a/packages/editor/src/components/document-tools/style.scss
+++ b/packages/editor/src/components/document-tools/style.scss
@@ -74,14 +74,8 @@
 }
 
 .editor-document-tools .editor-document-tools__left > .editor-document-tools__inserter-toggle.has-icon {
-	min-width: $button-size-compact;
-	width: $button-size-compact;
-	height: $button-size-compact;
-	padding: 0;
-
 	.show-icon-labels & {
 		width: auto;
-		height: $button-size-compact;
 		padding: 0 $grid-unit-10;
 	}
 }


### PR DESCRIPTION
In preparation for #68328

## What?

Use a standard `ToolbarButton` for the inserter button in `DocumentTools`.

## Why?

To reduce unnecessary style overrides (ToolbarButton uses the `"compact"` Button size by default). This will also prevent a size deprecation warning when we start logging them in #68328.

## Testing Instructions

In the block editor, check the main inserter button in the top left and see that there are no visual changes.

Note that there are multiple states to check:

- Clicking the button triggers an animation and changes the look.
- With Icon Labels enabled (Preferences ▸ Accessibility ▸ Show button text labels).

## Screenshots or screencast <!-- if applicable -->

This is the inserter button in DocumentTools:

<img src="https://github.com/user-attachments/assets/010be14f-550c-4eb3-b4be-f2e2ba3ab055" alt="Inserter button" width="240">