### PR TITLE
Return new state instead of old one to maintain immutability.

### DIFF
--- a/packages/block-editor/src/store/reducer.js
+++ b/packages/block-editor/src/store/reducer.js
@@ -255,7 +255,7 @@ const withBlockTree =
 		const newState = reducer( state, action );
 
 		if ( newState === state ) {
-			return state;
+			return { ...state };
 		}
 
 		newState.tree = state.tree ? state.tree : new Map();
@@ -452,7 +452,7 @@ function withPersistentBlockChange( reducer ) {
 		if ( explicitPersistent !== undefined ) {
 			nextIsPersistentChange = explicitPersistent;
 			return nextIsPersistentChange === nextState.isPersistentChange
-				? nextState
+				? { ...nextState }
 				: {
 						...nextState,
 						isPersistentChange: nextIsPersistentChange,
@@ -471,7 +471,7 @@ function withPersistentBlockChange( reducer ) {
 
 			nextIsPersistentChange = state?.isPersistentChange ?? true;
 			if ( state.isPersistentChange === nextIsPersistentChange ) {
-				return state;
+				return { ...state };
 			}
 
 			return {
@@ -494,7 +494,7 @@ function withPersistentBlockChange( reducer ) {
 		markNextChangeAsNotPersistent =
 			action.type === 'MARK_NEXT_CHANGE_AS_NOT_PERSISTENT';
 
-		return nextState;
+		return { ...nextState };
 	};
 }
 


### PR DESCRIPTION
## What?
This PR adds a fix for preventing old state mutation in the useBlockTree and usePersistentBlockChange hooks.

## Why?
Reference Issue - https://github.com/WordPress/gutenberg/issues/67363

## How?
When returning, with no change in state, we return the new references instead of the old state.


