### PR TITLE
Spacer: Add example attribute to block

### DIFF
--- a/packages/block-library/src/spacer/block.json
+++ b/packages/block-library/src/spacer/block.json
@@ -28,6 +28,12 @@
 			"clientNavigation": true
 		}
 	},
+	"example": {
+		"attributes": {
+			"height": "100px",
+			"width": "100%"
+		}
+	},
 	"editorStyle": "wp-block-spacer-editor",
 	"style": "wp-block-spacer"
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/64707
## What?
This PR adds an example attribute to the Spacer block’s block.json to provide a default height and width in the block’s example configuration.

## Testing Instructions
1. Open a post or page in the WordPress block editor.
2. Open the block inserter by clicking the “+” button.
3. Hover over the Spacer block in the inserter.

## Screenshots or screencast <!-- if applicable -->



|Before|After|
|-|-|
|<img width="666" alt="Screenshot 2024-12-27 at 9 47 44 AM" src="https://github.com/user-attachments/assets/2ef5a444-5187-4ef0-951e-e840267fc9b2" />|<img width="669" alt="Screenshot 2024-12-27 at 9 46 36 AM" src="https://github.com/user-attachments/assets/40070cc7-8f80-4d00-910e-dfa4e26e0a2d" />|
