### PR TITLE
Storybook: Adds story for responsive block control.

### DIFF
--- a/packages/block-editor/src/components/responsive-block-control/README.md
+++ b/packages/block-editor/src/components/responsive-block-control/README.md
@@ -91,7 +91,7 @@ Used to build accessible labels and ARIA roles for the control group. Should rep
 ### `isResponsive`
 
 -   **Type:** `Boolean`
--   **Default:** `false` )
+-   **Default:** `false`
 -   **Required:** `false`
 
 Determines whether the component displays the default or responsive controls. Updates the state of the toggle control. See also `onIsResponsiveChange` below.

--- a/packages/block-editor/src/components/responsive-block-control/index.js
+++ b/packages/block-editor/src/components/responsive-block-control/index.js
@@ -15,6 +15,44 @@ import { ToggleControl } from '@wordpress/components';
  */
 import ResponsiveBlockControlLabel from './label';
 
+/**
+ * ResponsiveBlockControl Component
+ *
+ * A UI component for managing responsive block properties in the WordPress block editor.
+ * Allows toggling between a unified property value for all screen sizes or custom values
+ * for specific screen sizes.
+ *
+ * @param {Object}        props                            - Component properties.
+ * @param {string}        props.title                      - The title displayed above the control.
+ * @param {string}        props.property                   - The CSS property controlled by the component (e.g., "margin").
+ * @param {string}        [props.toggleLabel]              - Custom label for the toggle control.
+ * @param {Function}      props.onIsResponsiveChange       - Callback function triggered when the responsive toggle is switched.
+ * @param {Function}      props.renderDefaultControl       - Function to render the default (non-responsive) control.
+ * @param {Function}      [props.renderResponsiveControls] - Optional function to render custom responsive controls.
+ * @param {boolean}       [props.isResponsive=false]       - Determines whether responsive controls are displayed.
+ * @param {Object}        [props.defaultLabel]             - Label for the default "All" control.
+ * @param {string}        props.defaultLabel.id            - ID for the default "All" control (e.g., 'all').
+ * @param {string}        props.defaultLabel.label         - Label text for the default "All" control.
+ * @param {Array<Object>} [props.viewports]                - List of viewport configurations for responsive controls.
+ * @param {string}        props.viewports[].id             - ID for the viewport (e.g., 'small', 'medium', 'large').
+ * @param {string}        props.viewports[].label          - Label text for the viewport.
+ * @return {Element|null} The ResponsiveBlockControl component or null if required props are missing.
+ *
+ * @example
+ * <ResponsiveBlockControl
+ *     title="Margin"
+ *     property="margin"
+ *     onIsResponsiveChange={ handleResponsiveChange }
+ *     renderDefaultControl={ (label) => <div>{label} <input type="text" /></div> }
+ *     isResponsive={false}
+ *     defaultLabel={{ id: 'all', label: 'All' }}
+ *     viewports={[
+ *         { id: 'small', label: 'Small screens' },
+ *         { id: 'medium', label: 'Medium screens' },
+ *         { id: 'large', label: 'Large screens' }
+ *     ]}
+ * />
+ */
 function ResponsiveBlockControl( props ) {
 	const {
 		title,

--- a/packages/block-editor/src/components/responsive-block-control/stories/index.story.js
+++ b/packages/block-editor/src/components/responsive-block-control/stories/index.story.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -21,43 +22,88 @@ const meta = {
 	},
 	argTypes: {
 		title: {
-			description: 'The title displayed above the control.',
+			description:
+				"The title of the control group used in the `fieldset`'s `legend` element to label the _entire_ set of controls.",
 			control: 'text',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'undefined' },
+			},
 		},
 		property: {
 			description:
-				'The CSS property controlled by the component (e.g., "margin").',
+				'Used to build accessible labels and ARIA roles for the control group. Should represent the layout property which the component controls (eg: `padding`, `margin`...etc).',
 			control: 'text',
-		},
-		toggleLabel: {
-			description: 'Custom label for the toggle control.',
-			control: 'text',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'undefined' },
+			},
 		},
 		isResponsive: {
 			description:
-				'Controls whether the responsive options are displayed.',
+				'Determines whether the component displays the default or responsive controls. Updates the state of the toggle control. See also `onIsResponsiveChange` below.',
 			control: 'boolean',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: false },
+			},
 		},
+		onIsResponsiveChange: {
+			description:
+				"A callback function invoked when the component's toggle value is changed between responsive and non-responsive mode. Should be used to update the value of the `isResponsive` prop to reflect the current state of the toggle control.",
+			action: 'onIsResponsiveChange',
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: undefined },
+			},
+		},
+		renderDefaultControl: {
+			description:
+				'A render function (prop) used to render the control for which you would like to display per viewport settings.',
+			control: 'function',
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		renderResponsiveControls: {
+			description:
+				'An optional render function (prop) used to render the controls for the _responsive_ settings. If not provided, by default, responsive controls will be _automatically_ rendered using the component returned by the `renderDefaultControl` prop.',
+			control: 'function',
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		toggleLabel: {
+			description:
+				'Optional label used for the toggle control which switches the interface between showing responsive controls or not.',
+			control: 'text',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+
 		defaultLabel: {
 			description: 'Default label for the "All" control.',
 			control: 'object',
+			table: {
+				type: { summary: 'object' },
+				defaultValue: {
+					summary: `{ id: 'all', label: 'All' }`,
+				},
+			},
 		},
 		viewports: {
 			description:
 				'Defines the viewport labels and IDs for responsive controls.',
-			control: 'object',
-		},
-		onIsResponsiveChange: {
-			description:
-				'Callback function triggered when the toggle state changes.',
-			action: 'onIsResponsiveChange',
-		},
-		renderDefaultControl: {
-			description:
-				'Function to render the default (non-responsive) control.',
-		},
-		renderResponsiveControls: {
-			description: 'Function to render custom responsive controls.',
+			control: 'array',
+			table: {
+				type: { summary: 'array' },
+				defaultValue: {
+					summary: `[{ id: 'small', label: 'Small screens', }, { id: 'medium', label: 'Medium screens', }, { id: 'large', label: 'Large screens', }]`,
+				},
+			},
 		},
 	},
 };
@@ -66,8 +112,15 @@ export default meta;
 const Template = ( args ) => {
 	const [ isResponsive, setIsResponsive ] = useState( args.isResponsive );
 
+	const style = {
+		marginTop: '1em',
+		marginBottom: '1em',
+		display: 'flex',
+		gap: '1em',
+	};
+
 	const renderDefaultControl = ( label ) => (
-		<div>
+		<div style={ style }>
 			{ label }
 			<input type="text" placeholder="Enter value" />
 		</div>
@@ -88,16 +141,30 @@ export const Default = {
 	args: {
 		title: 'Margin',
 		property: 'margin',
-		toggleLabel: 'Use the same margin on all screen sizes',
+		toggleLabel: __( 'Use the same margin on all screen sizes' ),
 		defaultLabel: {
 			id: 'all',
 			label: 'All',
 		},
 		viewports: [
-			{ id: 'small', label: 'Small screens' },
-			{ id: 'medium', label: 'Medium screens' },
-			{ id: 'large', label: 'Large screens' },
+			{ id: 'small', label: __( 'Small screens' ) },
+			{ id: 'medium', label: __( 'Medium screens' ) },
+			{ id: 'large', label: __( 'Large screens' ) },
 		],
 		isResponsive: false,
+	},
+};
+
+export const Responsive = {
+	render: Template,
+	args: {
+		title: 'Margin',
+		property: 'margin',
+		toggleLabel: __( 'Use the same margin on all screen sizes' ),
+		defaultLabel: {
+			id: 'all',
+			label: __( 'All' ),
+		},
+		isResponsive: true,
 	},
 };

--- a/packages/block-editor/src/components/responsive-block-control/stories/index.story.js
+++ b/packages/block-editor/src/components/responsive-block-control/stories/index.story.js
@@ -154,17 +154,3 @@ export const Default = {
 		isResponsive: false,
 	},
 };
-
-export const Responsive = {
-	render: Template,
-	args: {
-		title: 'Margin',
-		property: 'margin',
-		toggleLabel: __( 'Use the same margin on all screen sizes' ),
-		defaultLabel: {
-			id: 'all',
-			label: __( 'All' ),
-		},
-		isResponsive: true,
-	},
-};

--- a/packages/block-editor/src/components/responsive-block-control/stories/index.story.js
+++ b/packages/block-editor/src/components/responsive-block-control/stories/index.story.js
@@ -1,0 +1,103 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import ResponsiveBlockControl from '..';
+
+const meta = {
+	title: 'BlockEditor/ResponsiveBlockControl',
+	component: ResponsiveBlockControl,
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The `ResponsiveBlockControl` component provides a UI to toggle between a single value for all screen sizes and custom values for different screen sizes.',
+			},
+		},
+	},
+	argTypes: {
+		title: {
+			description: 'The title displayed above the control.',
+			control: 'text',
+		},
+		property: {
+			description:
+				'The CSS property controlled by the component (e.g., "margin").',
+			control: 'text',
+		},
+		toggleLabel: {
+			description: 'Custom label for the toggle control.',
+			control: 'text',
+		},
+		isResponsive: {
+			description:
+				'Controls whether the responsive options are displayed.',
+			control: 'boolean',
+		},
+		defaultLabel: {
+			description: 'Default label for the "All" control.',
+			control: 'object',
+		},
+		viewports: {
+			description:
+				'Defines the viewport labels and IDs for responsive controls.',
+			control: 'object',
+		},
+		onIsResponsiveChange: {
+			description:
+				'Callback function triggered when the toggle state changes.',
+			action: 'onIsResponsiveChange',
+		},
+		renderDefaultControl: {
+			description:
+				'Function to render the default (non-responsive) control.',
+		},
+		renderResponsiveControls: {
+			description: 'Function to render custom responsive controls.',
+		},
+	},
+};
+export default meta;
+
+const Template = ( args ) => {
+	const [ isResponsive, setIsResponsive ] = useState( args.isResponsive );
+
+	const renderDefaultControl = ( label ) => (
+		<div>
+			{ label }
+			<input type="text" placeholder="Enter value" />
+		</div>
+	);
+
+	return (
+		<ResponsiveBlockControl
+			{ ...args }
+			isResponsive={ isResponsive }
+			onIsResponsiveChange={ () => setIsResponsive( ! isResponsive ) }
+			renderDefaultControl={ renderDefaultControl }
+		/>
+	);
+};
+
+export const Default = {
+	render: Template,
+	args: {
+		title: 'Margin',
+		property: 'margin',
+		toggleLabel: 'Use the same margin on all screen sizes',
+		defaultLabel: {
+			id: 'all',
+			label: 'All',
+		},
+		viewports: [
+			{ id: 'small', label: 'Small screens' },
+			{ id: 'medium', label: 'Medium screens' },
+			{ id: 'large', label: 'Large screens' },
+		],
+		isResponsive: false,
+	},
+};


### PR DESCRIPTION
## What?
This PR adds story and JSDoc for `ResponsiveBlockControl` component.

## Why?
Part of: #67165
Part of: #22891

## Testing Instructions

1. Start Storybook by running npm run storybook:dev
2. Open Storybook at http://localhost:50240/
3. Test the story for `ResponsiveBlockControl`

## Screenshots or screencast 

https://github.com/user-attachments/assets/cc5145ad-e014-4c4b-9328-da67a0d4999c

