### PR TITLE
Comments Pagination: Add example attribute to block

### DIFF
--- a/packages/block-library/src/comments-pagination/block.json
+++ b/packages/block-library/src/comments-pagination/block.json
@@ -18,6 +18,11 @@
 			"default": "none"
 		}
 	},
+	"example": {
+		"attributes": {
+			"paginationArrow": "none"
+		}
+	},
 	"providesContext": {
 		"comments/paginationArrow": "paginationArrow"
 	},


### PR DESCRIPTION
Part of #64707

## What?
This PR adds an example attribute to the Comments Pagination block’s block.json to provide a default paginationArrow.

## Testing Instructions

1. Open a post or page in the WordPress block editor.
2. Open the block inserter by clicking the “+” button.
3. Add comments block and search for comments pagination block.
4. Hover over the comments pagination block in the inserter.

## Screenshots

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/347e2f42-9ca2-4334-b8df-88748214525b)|![image](https://github.com/user-attachments/assets/d67197f0-16c1-4de4-bf22-f151835955b2)|
