### PR TITLE
Storybook: Refactor FontFamilyControl story

### DIFF
--- a/packages/block-editor/src/components/font-family/stories/index.story.js
+++ b/packages/block-editor/src/components/font-family/stories/index.story.js
@@ -8,10 +8,12 @@ import { useState } from '@wordpress/element';
  */
 import FontFamilyControl from '..';
 
-export default {
+const meta = {
 	component: FontFamilyControl,
 	title: 'BlockEditor/FontFamilyControl',
 };
+
+export default meta;
 
 export const Default = {
 	render: function Template( props ) {

--- a/packages/block-editor/src/components/font-family/stories/index.story.js
+++ b/packages/block-editor/src/components/font-family/stories/index.story.js
@@ -11,6 +11,62 @@ import FontFamilyControl from '..';
 const meta = {
 	component: FontFamilyControl,
 	title: 'BlockEditor/FontFamilyControl',
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'FontFamilyControl is a React component that renders a UI for selecting a font family from predefined `typography.fontFamilies` presets.',
+			},
+			canvas: { sourceState: 'shown' },
+		},
+	},
+	argTypes: {
+		onChange: {
+			control: false,
+			description:
+				'A function that receives the new font family value. If called without parameters, it should reset the value.',
+			table: {
+				type: { summary: 'function' },
+				required: true,
+			},
+		},
+		fontFamilies: {
+			control: 'object',
+			description:
+				'A user-provided set of font families to override predefined ones. Each item should have fontFamily (string) and name (string) properties.',
+			table: {
+				type: {
+					summary: 'Array<{ fontFamily: string, name: string }>',
+				},
+			},
+		},
+		value: {
+			control: 'text',
+			description: 'The current font family value.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: '""' },
+			},
+		},
+		__next40pxDefaultSize: {
+			control: 'boolean',
+			description:
+				'Start opting into the larger default height that will become the default size in a future version.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+		},
+		__nextHasNoMarginBottom: {
+			control: 'boolean',
+			description:
+				'Start opting into the new margin-free styles that will become the default in a future version.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'false' },
+			},
+		},
+	},
 };
 
 export default meta;


### PR DESCRIPTION
Related to: #67165

## What?
This PR will update the story for Font Family Control Component for consistency.

## Testing Instructions
- Run `npm run storybook:dev`
- Open Storybook at `http://localhost:50240/`
- Check the Font Family Control story

## Screencast 

https://github.com/user-attachments/assets/c5f88e11-35f0-4d2a-a3cd-187243f8c5ef

