### PR TITLE
Storybook: Adds story for Spacing-sizes-control.

### DIFF
--- a/packages/block-editor/src/components/spacing-sizes-control/stories/index.story.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/stories/index.story.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import SpacingSizesControl from '../';
@@ -6,12 +11,116 @@ import SpacingSizesControl from '../';
 const meta = {
 	title: 'BlockEditor/SpacingSizesControl',
 	component: SpacingSizesControl,
+	argTypes: {
+		label: {
+			control: 'text',
+			description:
+				'Label for the control, describing the type of spacing being modified.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		values: {
+			control: 'object',
+			description: 'Current spacing values for each side.',
+			table: {
+				type: { summary: 'object' },
+				defaultValue: {
+					summary: '{ top: 0, right: 0, bottom: 0, left: 0 }',
+				},
+			},
+		},
+		onChange: {
+			control: false,
+			description: 'Callback triggered when spacing values are updated.',
+			table: {
+				type: { summary: 'Function' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		minimumCustomValue: {
+			control: 'number',
+			description: 'Minimum custom spacing value allowed.',
+			table: {
+				type: { summary: 'number' },
+				defaultValue: { summary: 0 },
+			},
+		},
+		sides: {
+			control: 'array',
+			description:
+				'Array of sides to be controlled (e.g., top, right, bottom, left).',
+			table: {
+				type: { summary: 'array' },
+				defaultValue: {
+					summary: '[ "top", "right", "bottom", "left" ]',
+				},
+			},
+		},
+		showSideInLabel: {
+			control: 'boolean',
+			description: 'Whether to include the side name in the label.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: true },
+			},
+		},
+		useSelect: {
+			control: false,
+			description: 'Optional hook for custom select logic.',
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		onMouseOver: {
+			control: false,
+			description:
+				'Callback triggered when the mouse hovers over a side.',
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+		onMouseOut: {
+			control: false,
+			description: 'Callback triggered when the mouse leaves a side.',
+			table: {
+				type: { summary: 'function' },
+				defaultValue: { summary: 'undefined' },
+			},
+		},
+	},
 };
 
 export default meta;
 
 export const Default = {
-	render: ( args ) => {
-		return <SpacingSizesControl { ...args } />;
+	render: function Template( args ) {
+		// Using state to demonstrate interactivity
+		const [ values, setValues ] = useState( args.values );
+
+		return (
+			<SpacingSizesControl
+				{ ...args }
+				values={ values }
+				onChange={ ( newValues ) => {
+					setValues( newValues );
+				} }
+			/>
+		);
+	},
+	args: {
+		label: 'Padding',
+		values: {
+			top: 10,
+			right: 12,
+			bottom: 23,
+			left: 25,
+		},
+		minimumCustomValue: 0,
+		sides: [ 'top', 'right', 'bottom', 'left' ],
+		showSideInLabel: true,
 	},
 };

--- a/packages/block-editor/src/components/spacing-sizes-control/stories/index.story.js
+++ b/packages/block-editor/src/components/spacing-sizes-control/stories/index.story.js
@@ -1,0 +1,17 @@
+/**
+ * Internal dependencies
+ */
+import SpacingSizesControl from '../';
+
+const meta = {
+	title: 'BlockEditor/SpacingSizesControl',
+	component: SpacingSizesControl,
+};
+
+export default meta;
+
+export const Default = {
+	render: ( args ) => {
+		return <SpacingSizesControl { ...args } />;
+	},
+};


### PR DESCRIPTION
## What?
This PR adds story for `SpacingSizesControl` component.

## Why?
Part of: #67165

## Testing Instructions

1. Start Storybook by running npm run storybook:dev
2. Open Storybook at http://localhost:50240/
3. Test the story for `SpacingSizesControl`

## Screenshots or screencast 

https://github.com/user-attachments/assets/c7f3b108-c61b-437e-bc04-f7379fa60545

