### PR TITLE
Storybook: Add stories for BlockInspector component.

### DIFF
--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -39,6 +39,19 @@ function BlockStylesPanel( { clientId } ) {
 	);
 }
 
+/**
+ * The Block inspector is one of the panels that is displayed in the editor; it is mainly used to view and modify the settings of the selected block.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/block-inspector/README.md
+ *
+ * @example
+ * ```jsx
+ * import { BlockInspector } from '@wordpress/block-editor';
+ * const MyBlockInspector = () => <BlockInspector />;
+ * ```
+ *
+ * @return {Element} BlockInspector component.
+ */
 function BlockInspector() {
 	const {
 		count,

--- a/packages/block-editor/src/components/block-inspector/stories/index.story.js
+++ b/packages/block-editor/src/components/block-inspector/stories/index.story.js
@@ -1,0 +1,78 @@
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock } from '@wordpress/blocks';
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { store as blockEditorStore } from '@wordpress/block-editor';
+
+/**
+ * Internal dependencies
+ */
+import { ExperimentalBlockEditorProvider } from '../../provider';
+import BlockInspector from '../';
+
+registerCoreBlocks();
+
+const blocks = [ createBlock( 'core/paragraph' ) ];
+
+const BlockSelector = ( { children, clientId } ) => {
+	const { selectBlock } = useDispatch( blockEditorStore );
+
+	useEffect( () => {
+		if ( clientId ) {
+			selectBlock( clientId );
+		}
+	}, [ clientId, selectBlock ] );
+
+	return children;
+};
+
+const meta = {
+	title: 'BlockEditor/BlockInspector',
+	component: BlockInspector,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The Block inspector is one of the panels that is displayed in the editor; it is mainly used to view and modify the settings of the selected block.',
+			},
+		},
+	},
+	decorators: [
+		( Story ) => (
+			<ExperimentalBlockEditorProvider value={ blocks }>
+				<Story />
+			</ExperimentalBlockEditorProvider>
+		),
+	],
+	argTypes: {
+		showNoBlockSelectedMessage: {
+			control: 'boolean',
+			description:
+				'Determines whether the Block Inspector displays a "No block selected" message or not when no block is selected.',
+			table: {
+				type: { summary: 'boolean' },
+				defaultValue: { summary: 'true' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {};
+
+export const WithSelectedBlock = {
+	decorators: [
+		( Story ) => (
+			<ExperimentalBlockEditorProvider value={ blocks }>
+				<BlockSelector clientId={ blocks[ 0 ].clientId }>
+					<Story />
+				</BlockSelector>
+			</ExperimentalBlockEditorProvider>
+		),
+	],
+};

--- a/packages/block-editor/src/components/block-inspector/stories/index.story.js
+++ b/packages/block-editor/src/components/block-inspector/stories/index.story.js
@@ -45,7 +45,7 @@ const meta = {
 		showNoBlockSelectedMessage: {
 			control: 'boolean',
 			description:
-				'Determines whether the Block Inspector displays a "No block selected" message or not when no block is selected.',
+				'Whether to display a "No block selected" message when no block is selected.',
 			table: {
 				type: { summary: 'boolean' },
 			},

--- a/packages/block-editor/src/components/block-inspector/stories/index.story.js
+++ b/packages/block-editor/src/components/block-inspector/stories/index.story.js
@@ -41,16 +41,13 @@ const meta = {
 			},
 		},
 	},
-	argTypes: {
-		showNoBlockSelectedMessage: {
-			control: 'boolean',
-			description:
-				'Whether to display a "No block selected" message when no block is selected.',
-			table: {
-				type: { summary: 'boolean' },
-			},
-		},
-	},
+	decorators: [
+		( Story ) => (
+			<ExperimentalBlockEditorProvider value={ blocks }>
+				<Story />
+			</ExperimentalBlockEditorProvider>
+		),
+	],
 };
 
 export default meta;
@@ -60,11 +57,9 @@ export const Default = {};
 export const WithSelectedBlock = {
 	decorators: [
 		( Story ) => (
-			<ExperimentalBlockEditorProvider value={ blocks }>
-				<BlockSelector clientId={ blocks[ 0 ].clientId }>
-					<Story />
-				</BlockSelector>
-			</ExperimentalBlockEditorProvider>
+			<BlockSelector clientId={ blocks[ 0 ].clientId }>
+				<Story />
+			</BlockSelector>
 		),
 	],
 };

--- a/packages/block-editor/src/components/block-inspector/stories/index.story.js
+++ b/packages/block-editor/src/components/block-inspector/stories/index.story.js
@@ -41,13 +41,6 @@ const meta = {
 			},
 		},
 	},
-	decorators: [
-		( Story ) => (
-			<ExperimentalBlockEditorProvider value={ blocks }>
-				<Story />
-			</ExperimentalBlockEditorProvider>
-		),
-	],
 	argTypes: {
 		showNoBlockSelectedMessage: {
 			control: 'boolean',
@@ -55,7 +48,6 @@ const meta = {
 				'Determines whether the Block Inspector displays a "No block selected" message or not when no block is selected.',
 			table: {
 				type: { summary: 'boolean' },
-				defaultValue: { summary: 'true' },
 			},
 		},
 	},


### PR DESCRIPTION
Part of #67165  

## What?
This PR adds Storybook stories for the BlockInspector component to improve component documentation and testability.

## Why?
- To provide clear visual documentation for the BlockInspector component.
- To enable interactive testing for various BlockInspector scenarios.
- To enhance the development experience for Block Editor components.

## Testing Instructions
1. Run `npm run storybook:dev`
2. Open Storybook at http://localhost:50240/
3.  Verify the functionality of the BlockInspector story

## Screenshots or screencast

<img width="1920" alt="Screenshot 2025-01-15 at 12 14 08 PM" src="https://github.com/user-attachments/assets/923ea97f-b1fb-4348-98b2-2a9f6babb79f" />

