### PR TITLE
Fix: Highlighted heading block breaks when moved into a group block

### DIFF
--- a/packages/format-library/src/text-color/index.js
+++ b/packages/format-library/src/text-color/index.js
@@ -68,10 +68,12 @@ function TextColorEdit( {
 	const [ isAddingColor, setIsAddingColor ] = useState( false );
 	const colorIndicatorStyle = useMemo(
 		() =>
-			fillComputedColors(
-				contentRef.current,
-				getActiveColors( value, name, colors )
-			),
+			contentRef.current
+				? fillComputedColors(
+						contentRef.current,
+						getActiveColors( value, name, colors )
+				  )
+				: {},
 		[ contentRef, value, colors ]
 	);
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

Closes #56025

## What?
<!-- In a few words, what is the PR actually doing? -->
As mentioned in #56025, When we add a heading or p tag with a color highlight into a group block. Then It break on the initial render.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- In the [Text-Color Component on this Line](https://github.com/WordPress/gutenberg/blob/trunk/packages/format-library/src/text-color/index.js#L72), We are using the `contentRef.current` when we drop heading or p. We might be accessing the element before it is fully rendered. Which gives an undefined value and that undefined is passed down in the functions leading to this error.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- As the `contentRef.current` is passed down to the functions to calculate styles, Adding a check in the useMemo callback to only call the `fillComputedColors` function if we have a ref.

## Testing Instructions
1. Open the block editor.
2. Add a Heading/Paragraph
3. Add a background highlight color
4. Add group block
5. And drag and drop the Heading/Paragraph into the group block

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->



#### Before
https://github.com/user-attachments/assets/871c5b32-9e41-40b1-aa46-a010424efa5d

#### After
https://github.com/user-attachments/assets/3cc0b2e7-07d0-4a75-a9f7-2792bb3490c9 