### PR TITLE
theme.json schema: Fix block list

### DIFF
--- a/schemas/json/theme.json
+++ b/schemas/json/theme.json
@@ -922,6 +922,9 @@
 				"core/file": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
+				"core/footnotes": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
 				"core/freeform": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -1030,9 +1033,6 @@
 				"core/post-terms": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
-				"core/post-time-to-read": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
-				},
 				"core/post-title": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
@@ -1061,6 +1061,9 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/query-title": {
+					"$ref": "#/definitions/settingsPropertiesComplete"
+				},
+				"core/query-total": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/quote": {
@@ -1100,9 +1103,6 @@
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/table": {
-					"$ref": "#/definitions/settingsPropertiesComplete"
-				},
-				"core/table-of-contents": {
 					"$ref": "#/definitions/settingsPropertiesComplete"
 				},
 				"core/tag-cloud": {
@@ -1902,6 +1902,9 @@
 				"core/file": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
+				"core/footnotes": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
 				"core/freeform": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2010,9 +2013,6 @@
 				"core/post-terms": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
-				"core/post-time-to-read": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
-				},
 				"core/post-title": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
@@ -2041,6 +2041,9 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/query-title": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
+				},
+				"core/query-total": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/quote": {
@@ -2080,9 +2083,6 @@
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/table": {
-					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
-				},
-				"core/table-of-contents": {
 					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/tag-cloud": {
@@ -2316,6 +2316,9 @@
 				"core/file": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
+				"core/footnotes": {
+					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
 				"core/freeform": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
@@ -2424,9 +2427,6 @@
 				"core/post-terms": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
-				"core/post-time-to-read": {
-					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
-				},
 				"core/post-title": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
@@ -2456,6 +2456,9 @@
 				},
 				"core/query-title": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
+				},
+				"core/query-total": {
+					"$ref": "#/definitions/stylesPropertiesAndElementsComplete"
 				},
 				"core/quote": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
@@ -2494,9 +2497,6 @@
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/table": {
-					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
-				},
-				"core/table-of-contents": {
 					"$ref": "#/definitions/stylesVariationBlockPropertiesComplete"
 				},
 				"core/tag-cloud": {


### PR DESCRIPTION
## What?

I noticed that the list of blocks in the theme.json schema was incorrect.

## How?

- `core/footnotes`:  This is already shipped in the core, so we need to add it.
- `core/query-total`: This block isn't experimental and should be included in the next WordPress release, so we should add it.
- `core/post-time-to-read`、`core/table-of-contents`: These blocks are not included in the core because the `__experimental` field is `true`, so I think they should be excluded from the schema.

## Testing Instructions

- Open the `test/emptytheme/theme.json` file in a code editor.
- Add the following fields. Verify that the correct blocks appear in the block list (or that experimental blocks don't appear).
  - `settings.blocks`
  - `styles.blocks` 
  - `styles.variations.test.blocks`
