### PR TITLE
Storybook: Add Story for Observe Typing component

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -703,9 +703,32 @@ Undocumented declaration.
 
 ### ObserveTyping
 
+ObserveTyping component sets and removes the `isTyping` flag based on user actions.
+
 _Related_
 
 -   <https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/observe-typing/README.md>
+
+_Usage_
+
+```jsx
+function Example(){
+ return (
+  <ObserveTyping>
+    <MyInput/>
+  <ObserveTyping/>
+ );
+}
+```
+
+_Parameters_
+
+-   _props_ `Object`:
+-   _props.children_ `JSX.Element`: The children to observe typing on.
+
+_Returns_
+
+-   `Element`: The ObserveTyping component.
 
 ### PanelColorSettings
 

--- a/packages/block-editor/src/components/observe-typing/index.js
+++ b/packages/block-editor/src/components/observe-typing/index.js
@@ -248,11 +248,29 @@ export function useTypingObserver() {
 	return useMergeRefs( [ ref1, ref2 ] );
 }
 
+/**
+ * ObserveTyping component sets and removes the `isTyping` flag based on user actions.
+ *
+ * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/observe-typing/README.md
+ *
+ * @example
+ * ```jsx
+ * function Example(){
+ *  return (
+ *   <ObserveTyping>
+ *     <MyInput/>
+ *   <ObserveTyping/>
+ *  );
+ * }
+ * ```
+ *
+ * @param {Object}      props
+ * @param {JSX.Element} props.children The children to observe typing on.
+ *
+ * @return {Element} The ObserveTyping component.
+ */
 function ObserveTyping( { children } ) {
 	return <div ref={ useTypingObserver() }>{ children }</div>;
 }
 
-/**
- * @see https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/observe-typing/README.md
- */
 export default ObserveTyping;

--- a/packages/block-editor/src/components/observe-typing/stories/index.story.js
+++ b/packages/block-editor/src/components/observe-typing/stories/index.story.js
@@ -1,0 +1,41 @@
+/**
+ * Internal dependencies
+ */
+import ObserveTyping from '..';
+
+export default {
+	title: 'Components/ObserveTyping',
+	component: ObserveTyping,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					"The `ObserveTyping` is a component used in managing the editor's internal typing flag. When used to wrap content, it observes keyboard and mouse events to set and unset the typing flag.",
+			},
+		},
+	},
+	argTypes: {
+		children: {
+			control: {
+				type: null,
+			},
+			description: 'The children elements.',
+			table: {
+				type: {
+					summary: 'ReactNode',
+				},
+			},
+		},
+	},
+};
+
+export const Default = {
+	render: function Template( { ...args } ) {
+		return (
+			<ObserveTyping { ...args }>
+				<input></input>
+			</ObserveTyping>
+		);
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?

This PR adds story for Observe Typing Component 

## Testing Instructions

- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the Observe Typing Component

## Screenshots or screencast 

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/60d640ca-5790-4864-816e-1694db15d4a8" />
