### PR TITLE
Components: Fixing Text Contrast for Dark Mode

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 -   `BoxControl`: Add presets support ([#67688](https://github.com/WordPress/gutenberg/pull/67688)).
 -   `Navigation`: Upsize back buttons ([#68157](https://github.com/WordPress/gutenberg/pull/68157)).
+-   `Heading`: Fix text contrast for dark mode ([#68349](https://github.com/WordPress/gutenberg/pull/68349)).
+-   `Text`: Fix text contrast for dark mode ([#68349](https://github.com/WordPress/gutenberg/pull/68349)).
 
 ### Deprecations
 

--- a/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
+++ b/packages/components/src/dimension-control/test/__snapshots__/index.test.js.snap
@@ -63,7 +63,7 @@ exports[`DimensionControl rendering renders with custom sizes 1`] = `
 }
 
 .emotion-12 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;
@@ -345,7 +345,7 @@ exports[`DimensionControl rendering renders with defaults 1`] = `
 }
 
 .emotion-12 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;
@@ -637,7 +637,7 @@ exports[`DimensionControl rendering renders with icon and custom icon label 1`] 
 }
 
 .emotion-12 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;
@@ -941,7 +941,7 @@ exports[`DimensionControl rendering renders with icon and default icon label 1`]
 }
 
 .emotion-12 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;

--- a/packages/components/src/heading/hook.ts
+++ b/packages/components/src/heading/hook.ts
@@ -14,7 +14,7 @@ export function useHeading(
 	const {
 		as: asProp,
 		level = 2,
-		color = COLORS.gray[ 900 ],
+		color = COLORS.theme.foreground,
 		isBlock = true,
 		weight = CONFIG.fontWeightHeading as import('react').CSSProperties[ 'fontWeight' ],
 		...otherProps

--- a/packages/components/src/heading/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/heading/test/__snapshots__/index.tsx.snap
@@ -2,12 +2,12 @@
 
 exports[`props should render correctly 1`] = `
 .emotion-0 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;
   text-wrap: pretty;
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   font-size: calc(1.95 * 13px);
   font-weight: 600;
   display: block;
@@ -30,7 +30,7 @@ Snapshot Diff:
 @@ -1,10 +1,10 @@
   Array [
     Object {
-      "color": "#1e1e1e",
+      "color": "var(--wp-components-color-foreground, #1e1e1e)",
       "display": "block",
 -     "font-size": "calc(1.25 * 13px)",
 +     "font-size": "calc(1.95 * 13px)",
@@ -49,7 +49,7 @@ Snapshot Diff:
 @@ -1,10 +1,10 @@
   Array [
     Object {
-      "color": "#1e1e1e",
+      "color": "var(--wp-components-color-foreground, #1e1e1e)",
       "display": "block",
 -     "font-size": "calc(1.25 * 13px)",
 +     "font-size": "calc(1.95 * 13px)",

--- a/packages/components/src/text/hook.ts
+++ b/packages/components/src/text/hook.ts
@@ -105,8 +105,8 @@ export default function useText(
 				getOptimalTextShade( optimizeReadabilityFor ) === 'dark';
 
 			sx.optimalTextColor = isOptimalTextColorDark
-				? css( { color: COLORS.gray[ 900 ] } )
-				: css( { color: COLORS.white } );
+				? css( { color: COLORS.theme.foreground } )
+				: css( { color: COLORS.theme.foregroundInverted } );
 		}
 
 		return cx(

--- a/packages/components/src/text/styles.ts
+++ b/packages/components/src/text/styles.ts
@@ -9,7 +9,7 @@ import { css } from '@emotion/react';
 import { COLORS, CONFIG } from '../utils';
 
 export const Text = css`
-	color: ${ COLORS.gray[ 900 ] };
+	color: ${ COLORS.theme.foreground };
 	line-height: ${ CONFIG.fontLineHeightBase };
 	margin: 0;
 	text-wrap: balance; /* Fallback for Safari. */

--- a/packages/components/src/text/test/__snapshots__/index.tsx.snap
+++ b/packages/components/src/text/test/__snapshots__/index.tsx.snap
@@ -6,7 +6,7 @@ Snapshot Diff:
 + Base styles
 
 @@ -3,8 +3,9 @@
-      "color": "#1e1e1e",
+      "color": "var(--wp-components-color-foreground, #1e1e1e)",
       "font-size": "calc((13 / 13) * 13px)",
       "font-weight": "normal",
       "line-height": "1.4",
@@ -19,7 +19,7 @@ Snapshot Diff:
 
 exports[`Text should render highlighted words with highlightCaseSensitive 1`] = `
 .emotion-0 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;
@@ -52,7 +52,7 @@ exports[`Text should render highlighted words with highlightCaseSensitive 1`] = 
 
 exports[`Text snapshot tests should render correctly 1`] = `
 .emotion-0 {
-  color: #1e1e1e;
+  color: var(--wp-components-color-foreground, #1e1e1e);
   line-height: 1.4;
   margin: 0;
   text-wrap: balance;

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -25,7 +25,7 @@ describe( 'Text', () => {
 			</Text>
 		);
 		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
-			color: COLORS.white,
+			color: 'rgb( 255, 255, 255 )',
 		} );
 	} );
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/66454
Comment: https://github.com/WordPress/gutenberg/issues/66454#issuecomment-2562238953

# Work in progress
## What?
Fixes the components labels/headings in the dark mode 

## Testing Instructions

1. Run npm run storybook:dev.
2. Open Storybook at http://localhost:50240/.
3. Verify that the following components work well in dark mode, and ensure that all other modes continue to function as they did previously.

## Screenshots or screencast

### AnglePickerControl  


|Before|After|
|-|-|
|<img width="1006" alt="image" src="https://github.com/user-attachments/assets/5722546e-c4b1-4b0e-9fca-b54c4eeb2fc5" />|<img width="1016" alt="image" src="https://github.com/user-attachments/assets/4d88acaf-d7ee-43da-a356-f974729c5fcb" />|

### CustomGradientPicker  

|Before|After|
|-|-|
|<img width="1016" alt="image" src="https://github.com/user-attachments/assets/5bc14738-f272-40ff-8cdf-b5744e691c73" />|<img width="1031" alt="image" src="https://github.com/user-attachments/assets/90c62856-261b-43e4-a9e1-b2a5d72f43c0" />|

### FocalPointPicker  

|Before|After|
|-|-|
|<img width="1012" alt="image" src="https://github.com/user-attachments/assets/b871ba03-4566-4e12-b0c2-fee26fcaf353" />|<img width="1009" alt="image" src="https://github.com/user-attachments/assets/4f774e61-eb49-4ae6-b2d5-bb728c245008" />|

### GradientPicker  

|Before|After|
|-|-|
|<img width="1005" alt="image" src="https://github.com/user-attachments/assets/ee0c746c-c7db-48da-be56-1561120dff6b" />|<img width="1020" alt="image" src="https://github.com/user-attachments/assets/77851e74-ef14-4710-a547-cd17b7ca9d82" />|

### InputControl  

|Before|After|
|-|-|
|<img width="1004" alt="image" src="https://github.com/user-attachments/assets/2a41dc34-44ba-4138-bcf1-ab48405b3543" />|<img width="1008" alt="image" src="https://github.com/user-attachments/assets/149efc3f-4840-47f8-a4c6-3f41f34b7343" />|

### NumberControl  

|Before|After|
|-|-|
|<img width="1012" alt="image" src="https://github.com/user-attachments/assets/332cc21d-9220-4f30-90ec-2c89b4710d0c" />|<img width="1019" alt="image" src="https://github.com/user-attachments/assets/d578310c-6a0f-40f7-8df6-8c24e5c42914" />|

### PaletteEdit  

|Before|After|
|-|-|
|<img width="1009" alt="image" src="https://github.com/user-attachments/assets/a052c37c-63e1-42ff-ae2f-4db054f2e719" />|<img width="1007" alt="image" src="https://github.com/user-attachments/assets/dc887f45-f1de-431f-bd12-d7f5e7de6fef" />|

### QueryControl  

|Before|After|
|-|-|
|<img width="1023" alt="image" src="https://github.com/user-attachments/assets/42c6000b-e974-461e-9cb1-962fc546e37e" />|<img width="1013" alt="image" src="https://github.com/user-attachments/assets/0fe152b1-2e85-4a0e-adc6-ac7ad96b1123" />|

### SelectControl  

|Before|After|
|-|-|
|<img width="1013" alt="image" src="https://github.com/user-attachments/assets/c98b2fb1-34fd-4bfe-8c3a-3646b2f5d696" />|<img width="1008" alt="image" src="https://github.com/user-attachments/assets/f49f56d2-dc73-4510-9b3a-50dc0040327c" />|

### TreeSelect  

|Before|After|
|-|-|
|<img width="1004" alt="image" src="https://github.com/user-attachments/assets/c22245ad-8aa2-43a8-bbcc-8e9456e0e7a0" />|<img width="1003" alt="image" src="https://github.com/user-attachments/assets/9fae14ab-7bc9-4293-98c3-ecd3690ff965" />|

### UnitControl

|Before|After|
|-|-|
|<img width="1004" alt="image" src="https://github.com/user-attachments/assets/6cbca6f4-7ee6-4265-bf9d-14559dacb5b8" />|<img width="1005" alt="image" src="https://github.com/user-attachments/assets/e40708e5-5f42-4378-ba2d-b8837b8b738f" />|




