### PR TITLE
Navigation Submenu: Fix color handling and inheritance

### DIFF
--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -283,6 +283,12 @@ export default function NavigationSubmenuEdit( {
 		}
 	}
 
+	const _textColor = attributes.textColor ?? textColor;
+	const _customTextColor = attributes.style?.color?.text ?? customTextColor;
+	const _backgroundColor = attributes.backgroundColor ?? backgroundColor;
+	const _customBackgroundColor =
+		attributes.style?.color?.background ?? customBackgroundColor;
+
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, listItemRef ] ),
 		className: clsx( 'wp-block-navigation-item', {
@@ -290,16 +296,17 @@ export default function NavigationSubmenuEdit( {
 			'is-dragging-within': isDraggingWithin,
 			'has-link': !! url,
 			'has-child': hasChildren,
-			'has-text-color': !! textColor || !! customTextColor,
-			[ getColorClassName( 'color', textColor ) ]: !! textColor,
-			'has-background': !! backgroundColor || customBackgroundColor,
-			[ getColorClassName( 'background-color', backgroundColor ) ]:
-				!! backgroundColor,
+			'has-text-color': !! _textColor || !! _customTextColor,
+			[ getColorClassName( 'color', _textColor ) ]:
+				!! _textColor && ! _customTextColor,
+			'has-background': !! _backgroundColor || !! _customBackgroundColor,
+			[ getColorClassName( 'background-color', _backgroundColor ) ]:
+				!! _backgroundColor && ! _customBackgroundColor,
 			'open-on-click': openSubmenusOnClick,
 		} ),
 		style: {
-			color: ! textColor && customTextColor,
-			backgroundColor: ! backgroundColor && customBackgroundColor,
+			color: _customTextColor,
+			backgroundColor: _customBackgroundColor,
 		},
 		onKeyDown,
 	} );

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -283,15 +283,11 @@ export default function NavigationSubmenuEdit( {
 		}
 	}
 
-	let _textColor = attributes.textColor ?? textColor;
+	const _textColor = attributes.textColor ?? textColor;
 	const _customTextColor = attributes.style?.color?.text ?? customTextColor;
 	const _backgroundColor = attributes.backgroundColor ?? backgroundColor;
 	const _customBackgroundColor =
 		attributes.style?.color?.background ?? customBackgroundColor;
-
-	if ( ! _textColor && ! _customTextColor ) {
-		_textColor = 'contrast';
-	}
 
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, listItemRef ] ),

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -283,11 +283,15 @@ export default function NavigationSubmenuEdit( {
 		}
 	}
 
-	const _textColor = attributes.textColor ?? textColor;
+	let _textColor = attributes.textColor ?? textColor;
 	const _customTextColor = attributes.style?.color?.text ?? customTextColor;
 	const _backgroundColor = attributes.backgroundColor ?? backgroundColor;
 	const _customBackgroundColor =
 		attributes.style?.color?.background ?? customBackgroundColor;
+
+	if ( ! _textColor && ! _customTextColor ) {
+		_textColor = 'contrast';
+	}
 
 	const blockProps = useBlockProps( {
 		ref: useMergeRefs( [ setPopoverAnchor, listItemRef ] ),

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -280,13 +280,14 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$html = $tag_processor->get_updated_html();
 		}
 
-		$wrapper_attributes = '';
+		$wrapper_attributes = array();
 		if ( ! empty( $style_attribute ) ) {
-			$wrapper_attributes .= sprintf( 'style="%s"', $style_attribute );
+			$wrapper_attributes[] = sprintf( 'style="%s"', $style_attribute );
 		}
 		if ( ! empty( $css_classes ) ) {
-			$wrapper_attributes .= sprintf( 'class="%s"', $css_classes );
+			$wrapper_attributes[] = sprintf( 'class="%s"', $css_classes );
 		}
+		$wrapper_attributes = implode( ' ', $wrapper_attributes );
 
 		$html .= sprintf(
 			'<ul %s>%s</ul>',

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -244,10 +244,6 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 				$attributes['textColor'] = $block->context['textColor'];
 			} elseif ( array_key_exists( 'customTextColor', $block->context ) ) {
 				$attributes['style']['color']['text'] = $block->context['customTextColor'];
-			} else {
-				// If there's no color provided in the context, and nothing to inherit then fallback to defaults.
-				// This is necessary to ensure submenu parent block colors are not inherited by the container.
-				$attributes['textColor'] = 'contrast';
 			}
 		}
 		if ( ! isset( $attributes['backgroundColor'] ) && ! isset( $attributes['style']['color']['background'] ) ) {
@@ -255,8 +251,6 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 				$attributes['backgroundColor'] = $block->context['backgroundColor'];
 			} elseif ( array_key_exists( 'customBackgroundColor', $block->context ) ) {
 				$attributes['style']['color']['background'] = $block->context['customBackgroundColor'];
-			} else {
-				$attributes['backgroundColor'] = 'base';
 			}
 		}
 
@@ -286,11 +280,13 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$html = $tag_processor->get_updated_html();
 		}
 
-		$wrapper_attributes = sprintf(
-			'style="%1$s" class="%2$s"',
-			$style_attribute,
-			$css_classes
-		);
+		$wrapper_attributes = '';
+		if ( ! empty( $style_attribute ) ) {
+			$wrapper_attributes .= sprintf( 'style="%s"', $style_attribute );
+		}
+		if ( ! empty( $css_classes ) ) {
+			$wrapper_attributes .= sprintf( 'class="%s"', $css_classes );
+		}
 
 		$html .= sprintf(
 			'<ul %s>%s</ul>',

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -214,8 +214,15 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
-		// These properties for submenus should only be applied from context, clear previous values stored directly inside attributes.
-		unset( $attributes['textColor'], $attributes['backgroundColor'], $attributes['customTextColor'], $attributes['customBackgroundColor'] );
+		// These properties for submenus should only be applied from context.
+		// Values directly stored inside attributes should be applied to the parent block only.
+		unset(
+			$attributes['textColor'],
+			$attributes['backgroundColor'],
+			$attributes['customTextColor'],
+			$attributes['customBackgroundColor'],
+			$attributes['style']
+		);
 
 		// Copy some attributes from the parent block to this one.
 		// Ideally this would happen in the client when the block is created.
@@ -230,6 +237,15 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		}
 		if ( array_key_exists( 'customOverlayBackgroundColor', $block->context ) ) {
 			$attributes['style']['color']['background'] = $block->context['customOverlayBackgroundColor'];
+		}
+
+		// If there's no overlay color provided, then fallback to defaults.
+		// This is necessary to ensure parent block colors are not inherited.
+		if ( ! isset( $attributes['textColor'] ) && ! isset( $attributes['style']['color']['text'] ) ) {
+			$attributes['textColor'] = 'contrast';
+		}
+		if ( ! isset( $attributes['backgroundColor'] ) && ! isset( $attributes['style']['color']['background'] ) ) {
+			$attributes['backgroundColor'] = 'base';
 		}
 
 		// This allows us to be able to get a response from wp_apply_colors_support.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -226,21 +226,33 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		// Copy some attributes from the parent block to this one.
 		// Ideally this would happen in the client when the block is created.
+		if ( array_key_exists( 'textColor', $block->context ) ) {
+			$attributes['textColor'] = $block->context['textColor'];
+		}
 		if ( array_key_exists( 'overlayTextColor', $block->context ) ) {
 			$attributes['textColor'] = $block->context['overlayTextColor'];
+		}
+		if ( array_key_exists( 'backgroundColor', $block->context ) ) {
+			$attributes['backgroundColor'] = $block->context['backgroundColor'];
 		}
 		if ( array_key_exists( 'overlayBackgroundColor', $block->context ) ) {
 			$attributes['backgroundColor'] = $block->context['overlayBackgroundColor'];
 		}
+		if ( array_key_exists( 'customTextColor', $block->context ) ) {
+			$attributes['style']['color']['text'] = $block->context['customTextColor'];
+		}
 		if ( array_key_exists( 'customOverlayTextColor', $block->context ) ) {
 			$attributes['style']['color']['text'] = $block->context['customOverlayTextColor'];
+		}
+		if ( array_key_exists( 'customBackgroundColor', $block->context ) ) {
+			$attributes['style']['color']['background'] = $block->context['customBackgroundColor'];
 		}
 		if ( array_key_exists( 'customOverlayBackgroundColor', $block->context ) ) {
 			$attributes['style']['color']['background'] = $block->context['customOverlayBackgroundColor'];
 		}
 
-		// If there's no overlay color provided, then fallback to defaults.
-		// This is necessary to ensure parent block colors are not inherited.
+		// If there's no color provided in the context, then fallback to defaults.
+		// This is necessary to ensure submenu parent block colors are not inherited by the container.
 		if ( ! isset( $attributes['textColor'] ) && ! isset( $attributes['style']['color']['text'] ) ) {
 			$attributes['textColor'] = 'contrast';
 		}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -255,9 +255,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		}
 
 		// This allows us to be able to get a response from wp_apply_colors_support.
-		$block->block_type->supports['color'] = true;
-		$colors_supports                      = wp_apply_colors_support( $block->block_type, $attributes );
-		$css_classes                          = 'wp-block-navigation__submenu-container';
+		$colors_supports = wp_apply_colors_support( $block->block_type, $attributes );
+		$css_classes     = 'wp-block-navigation__submenu-container';
 		if ( array_key_exists( 'class', $colors_supports ) ) {
 			$css_classes .= ' ' . $colors_supports['class'];
 		}

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -99,6 +99,17 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	$open_on_hover_and_click = isset( $block->context['openSubmenusOnClick'] ) && ! $block->context['openSubmenusOnClick'] &&
 		$show_submenu_indicators;
 
+	$block->block_type->supports['color'] = true;
+	$colors_supports                      = wp_apply_colors_support( $block->block_type, $attributes );
+	if ( array_key_exists( 'class', $colors_supports ) ) {
+		$css_classes .= ' ' . $colors_supports['class'];
+	}
+
+	$style_attribute = '';
+	if ( array_key_exists( 'style', $colors_supports ) ) {
+		$style_attribute = $colors_supports['style'];
+	}
+
 	$wrapper_attributes = get_block_wrapper_attributes(
 		array(
 			'class' => $css_classes . ' wp-block-navigation-item' . ( $has_submenu ? ' has-child' : '' ) .
@@ -203,6 +214,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 	}
 
 	if ( $has_submenu ) {
+		// These properties for submenus should only be applied from context, clear previous values stored directly inside attributes.
+		unset( $attributes['textColor'], $attributes['backgroundColor'], $attributes['customTextColor'], $attributes['customBackgroundColor'] );
+
 		// Copy some attributes from the parent block to this one.
 		// Ideally this would happen in the client when the block is created.
 		if ( array_key_exists( 'overlayTextColor', $block->context ) ) {
@@ -244,11 +258,10 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 			$html = $tag_processor->get_updated_html();
 		}
 
-		$wrapper_attributes = get_block_wrapper_attributes(
-			array(
-				'class' => $css_classes,
-				'style' => $style_attribute,
-			)
+		$wrapper_attributes = sprintf(
+			'class="%s" style="%s"',
+			$css_classes,
+			$style_attribute
 		);
 
 		$html .= sprintf(

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -105,9 +105,8 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		$css_classes .= ' ' . $colors_supports['class'];
 	}
 
-	$style_attribute = '';
 	if ( array_key_exists( 'style', $colors_supports ) ) {
-		$style_attribute = $colors_supports['style'];
+		$style_attribute .= $colors_supports['style'];
 	}
 
 	$wrapper_attributes = get_block_wrapper_attributes(
@@ -226,38 +225,39 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 
 		// Copy some attributes from the parent block to this one.
 		// Ideally this would happen in the client when the block is created.
-		if ( array_key_exists( 'textColor', $block->context ) ) {
-			$attributes['textColor'] = $block->context['textColor'];
-		}
 		if ( array_key_exists( 'overlayTextColor', $block->context ) ) {
 			$attributes['textColor'] = $block->context['overlayTextColor'];
-		}
-		if ( array_key_exists( 'backgroundColor', $block->context ) ) {
-			$attributes['backgroundColor'] = $block->context['backgroundColor'];
 		}
 		if ( array_key_exists( 'overlayBackgroundColor', $block->context ) ) {
 			$attributes['backgroundColor'] = $block->context['overlayBackgroundColor'];
 		}
-		if ( array_key_exists( 'customTextColor', $block->context ) ) {
-			$attributes['style']['color']['text'] = $block->context['customTextColor'];
-		}
 		if ( array_key_exists( 'customOverlayTextColor', $block->context ) ) {
 			$attributes['style']['color']['text'] = $block->context['customOverlayTextColor'];
-		}
-		if ( array_key_exists( 'customBackgroundColor', $block->context ) ) {
-			$attributes['style']['color']['background'] = $block->context['customBackgroundColor'];
 		}
 		if ( array_key_exists( 'customOverlayBackgroundColor', $block->context ) ) {
 			$attributes['style']['color']['background'] = $block->context['customOverlayBackgroundColor'];
 		}
 
-		// If there's no color provided in the context, then fallback to defaults.
-		// This is necessary to ensure submenu parent block colors are not inherited by the container.
+		// If there are no overlay colors provided, then inherit the colors from the parent block.
 		if ( ! isset( $attributes['textColor'] ) && ! isset( $attributes['style']['color']['text'] ) ) {
-			$attributes['textColor'] = 'contrast';
+			if ( array_key_exists( 'textColor', $block->context ) ) {
+				$attributes['textColor'] = $block->context['textColor'];
+			} elseif ( array_key_exists( 'customTextColor', $block->context ) ) {
+				$attributes['style']['color']['text'] = $block->context['customTextColor'];
+			} else {
+				// If there's no color provided in the context, and nothing to inherit then fallback to defaults.
+				// This is necessary to ensure submenu parent block colors are not inherited by the container.
+				$attributes['textColor'] = 'contrast';
+			}
 		}
 		if ( ! isset( $attributes['backgroundColor'] ) && ! isset( $attributes['style']['color']['background'] ) ) {
-			$attributes['backgroundColor'] = 'base';
+			if ( array_key_exists( 'backgroundColor', $block->context ) ) {
+				$attributes['backgroundColor'] = $block->context['backgroundColor'];
+			} elseif ( array_key_exists( 'customBackgroundColor', $block->context ) ) {
+				$attributes['style']['color']['background'] = $block->context['customBackgroundColor'];
+			} else {
+				$attributes['backgroundColor'] = 'base';
+			}
 		}
 
 		// This allows us to be able to get a response from wp_apply_colors_support.

--- a/packages/block-library/src/navigation-submenu/index.php
+++ b/packages/block-library/src/navigation-submenu/index.php
@@ -287,9 +287,9 @@ function render_block_core_navigation_submenu( $attributes, $content, $block ) {
 		}
 
 		$wrapper_attributes = sprintf(
-			'class="%s" style="%s"',
-			$css_classes,
-			$style_attribute
+			'style="%1$s" class="%2$s"',
+			$style_attribute,
+			$css_classes
 		);
 
 		$html .= sprintf(

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -61,29 +61,37 @@ export function getColors( context, isSubMenu ) {
 	} = context;
 
 	const colors = {};
+	const defaultColor = {
+		textColor: '#000',
+		backgroundColor: '#fff',
+	};
 
 	if ( isSubMenu && !! customOverlayTextColor ) {
 		colors.customTextColor = customOverlayTextColor;
 	} else if ( isSubMenu && !! overlayTextColor ) {
 		colors.textColor = overlayTextColor;
-	} else if ( !! customTextColor ) {
+	} else if ( ! isSubMenu && !! customTextColor ) {
 		colors.customTextColor = customTextColor;
-	} else if ( !! textColor ) {
+	} else if ( ! isSubMenu && !! textColor ) {
 		colors.textColor = textColor;
-	} else if ( !! style?.color?.text ) {
+	} else if ( ! isSubMenu && !! style?.color?.text ) {
 		colors.customTextColor = style.color.text;
+	} else {
+		colors.customTextColor = defaultColor.textColor;
 	}
 
 	if ( isSubMenu && !! customOverlayBackgroundColor ) {
 		colors.customBackgroundColor = customOverlayBackgroundColor;
 	} else if ( isSubMenu && !! overlayBackgroundColor ) {
 		colors.backgroundColor = overlayBackgroundColor;
-	} else if ( !! customBackgroundColor ) {
+	} else if ( ! isSubMenu && !! customBackgroundColor ) {
 		colors.customBackgroundColor = customBackgroundColor;
-	} else if ( !! backgroundColor ) {
+	} else if ( ! isSubMenu && !! backgroundColor ) {
 		colors.backgroundColor = backgroundColor;
-	} else if ( !! style?.color?.background ) {
+	} else if ( ! isSubMenu && !! style?.color?.background ) {
 		colors.customTextColor = style.color.background;
+	} else {
+		colors.customBackgroundColor = defaultColor.backgroundColor;
 	}
 
 	return colors;

--- a/packages/block-library/src/navigation/edit/utils.js
+++ b/packages/block-library/src/navigation/edit/utils.js
@@ -61,37 +61,29 @@ export function getColors( context, isSubMenu ) {
 	} = context;
 
 	const colors = {};
-	const defaultColor = {
-		textColor: '#000',
-		backgroundColor: '#fff',
-	};
 
 	if ( isSubMenu && !! customOverlayTextColor ) {
 		colors.customTextColor = customOverlayTextColor;
 	} else if ( isSubMenu && !! overlayTextColor ) {
 		colors.textColor = overlayTextColor;
-	} else if ( ! isSubMenu && !! customTextColor ) {
+	} else if ( !! customTextColor ) {
 		colors.customTextColor = customTextColor;
-	} else if ( ! isSubMenu && !! textColor ) {
+	} else if ( !! textColor ) {
 		colors.textColor = textColor;
-	} else if ( ! isSubMenu && !! style?.color?.text ) {
+	} else if ( !! style?.color?.text ) {
 		colors.customTextColor = style.color.text;
-	} else {
-		colors.customTextColor = defaultColor.textColor;
 	}
 
 	if ( isSubMenu && !! customOverlayBackgroundColor ) {
 		colors.customBackgroundColor = customOverlayBackgroundColor;
 	} else if ( isSubMenu && !! overlayBackgroundColor ) {
 		colors.backgroundColor = overlayBackgroundColor;
-	} else if ( ! isSubMenu && !! customBackgroundColor ) {
+	} else if ( !! customBackgroundColor ) {
 		colors.customBackgroundColor = customBackgroundColor;
-	} else if ( ! isSubMenu && !! backgroundColor ) {
+	} else if ( !! backgroundColor ) {
 		colors.backgroundColor = backgroundColor;
-	} else if ( ! isSubMenu && !! style?.color?.background ) {
+	} else if ( !! style?.color?.background ) {
 		colors.customTextColor = style.color.background;
-	} else {
-		colors.customBackgroundColor = defaultColor.backgroundColor;
 	}
 
 	return colors;


### PR DESCRIPTION
## What, Why & How?


### Testing Instructions for Keyboard

1. Navigate to a Post/Page edit screen.
2. Create a Navigation Block.
3. Try setting up different permutations for text and background properties along with custom colors.
4. Notice the bugs mentioned in the issue are now fixed.

## Screencasts

The following are the expected outcomes that the submenu block should abide by.

If the `navigation block` has either a `background` or a `text` color assigned, and there's no color provided for the `submenu & overlay text` or `submenu & overlay background`, then `navigation` blocks color should be inherited. ( ✅ ) 

![one](https://github.com/user-attachments/assets/5de4c3a3-c54d-46ac-be8f-7b51c16f6e39)

If the `navigation block` has specified a color, but, the `submenu parent` has also specified a color (background and text ), the submenu container should still inherit the color from the `navigation block`. ( ✅ ) 

![two](https://github.com/user-attachments/assets/40a785ce-03e2-4c91-9212-0efd234663db)

If `submenu & overlay text` or `submenu & overlay background` values are provided, these should overwrite the values of `navigation block`. ( ✅ ) 

![three](https://github.com/user-attachments/assets/85ede569-9f6b-42a6-a4f7-a1800c9edbe6)

if only `submenu's` color and background value are passed, then it shouldn't override the value of the `submenu container`. `Container's` values must be either inherited from `navigation` or from the dedicated `submenu` control options on `navigation`. ( ✅ ) 

![four](https://github.com/user-attachments/assets/53daa545-e9f2-441e-b7cf-11df18e692be)

Closes: #68350 