### PR TITLE
Block Editor Storybook: Restructure the directory and add badges to private components

### DIFF
--- a/packages/block-editor/src/components/dimensions-tool/stories/aspect-ratio-tool.story.js
+++ b/packages/block-editor/src/components/dimensions-tool/stories/aspect-ratio-tool.story.js
@@ -13,8 +13,9 @@ import {
 import AspectRatioTool from '../aspect-ratio-tool';
 
 export default {
-	title: 'BlockEditor (Private APIs)/DimensionsTool/AspectRatioTool',
+	title: 'BlockEditor/DimensionsTool/AspectRatioTool',
 	component: AspectRatioTool,
+	tags: [ 'status-private' ],
 	argTypes: {
 		panelId: { control: false },
 		onChange: { action: 'changed' },

--- a/packages/block-editor/src/components/dimensions-tool/stories/index.story.js
+++ b/packages/block-editor/src/components/dimensions-tool/stories/index.story.js
@@ -13,8 +13,9 @@ import {
 import DimensionsTool from '..';
 
 export default {
-	title: 'BlockEditor (Private APIs)/DimensionsTool',
+	title: 'BlockEditor/DimensionsTool/DimensionsTool',
 	component: DimensionsTool,
+	tags: [ 'status-private' ],
 	argTypes: {
 		panelId: { control: false },
 		onChange: { action: 'changed' },

--- a/packages/block-editor/src/components/dimensions-tool/stories/scale-tool.story.js
+++ b/packages/block-editor/src/components/dimensions-tool/stories/scale-tool.story.js
@@ -13,8 +13,9 @@ import {
 import ScaleTool from '../scale-tool';
 
 export default {
-	title: 'BlockEditor (Private APIs)/DimensionsTool/ScaleTool',
+	title: 'BlockEditor/DimensionsTool/ScaleTool',
 	component: ScaleTool,
+	tags: [ 'status-private' ],
 	argTypes: {
 		panelId: { control: false },
 		onChange: { action: 'changed' },

--- a/packages/block-editor/src/components/dimensions-tool/stories/width-height-tool.story.js
+++ b/packages/block-editor/src/components/dimensions-tool/stories/width-height-tool.story.js
@@ -13,8 +13,9 @@ import {
 import WidthHeightTool from '../width-height-tool';
 
 export default {
-	title: 'BlockEditor (Private APIs)/DimensionsTool/WidthHeightTool',
+	title: 'BlockEditor/DimensionsTool/WidthHeightTool',
 	component: WidthHeightTool,
+	tags: [ 'status-private' ],
 	argTypes: {
 		panelId: { control: false },
 		onChange: { action: 'changed' },

--- a/packages/block-editor/src/components/resolution-tool/stories/index.story.js
+++ b/packages/block-editor/src/components/resolution-tool/stories/index.story.js
@@ -13,8 +13,9 @@ import {
 import ResolutionTool from '..';
 
 export default {
-	title: 'BlockEditor (Private APIs)/ResolutionControl',
+	title: 'BlockEditor/ResolutionControl',
 	component: ResolutionTool,
+	tags: [ 'status-private' ],
 	argTypes: {
 		panelId: { control: false },
 		onChange: { action: 'changed' },

--- a/packages/block-editor/src/components/text-alignment-control/stories/index.story.js
+++ b/packages/block-editor/src/components/text-alignment-control/stories/index.story.js
@@ -11,6 +11,7 @@ import TextAlignmentControl from '../';
 const meta = {
 	title: 'BlockEditor/TextAlignmentControl',
 	component: TextAlignmentControl,
+	tags: [ 'status-private' ],
 	parameters: {
 		docs: {
 			canvas: { sourceState: 'shown' },


### PR DESCRIPTION
## What? / Why?

Because of #58123 and #58518, badges have been added to the private components published as `@wordpress/components`.
Meanwhile, private components published in the `@wordpress/block-editor` package are classified in a separate directory. That means the current Storybook is structured as follows:

- Block Editor
- Components
- Components (Experimental)
- Block Editor (Private APIs)
- Components (Deprecated)

This PR also adds badges to the block editor package, as well as the component package.

Furthermore, because adding badges means that a directory for the private API is no longer necessary, restructure it as follows:

- Block Editor
- Components
- Components (Experimental)
- Components (Deprecated)

## How?

The components that will be badged by this PR are actually the following three:

- `DimensionsTool`
- `ResolutionTool`
- `TextAlignmentControl`

The `DimensionsTool` component is composed of three subcomponents, `AspectRatioTool`, `ScaleTool`, and `WidthHeightTool`. These three subcomponents cannot be used independently. It may not be necessary to publish them as a storybook, but for now, I will give private badges to these subcomponents as well. In the future, we might be able to expose each of these three subcomponents as standalone components.

## Testing Instructions

- Run `npm run storybook:dev`
- Compare Storybook and see the differences in directories and badges:
  - This PR: http://localhost:50240/?path=/docs/docs-introduction--page
  - trunk: https://wordpress.github.io/gutenberg/?path=/docs/docs-introduction--page