### PR TITLE
Home Link: Add Border and Spacing Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -369,7 +369,7 @@ Create a link that always points to the homepage of the site. Usually not necess
 -	**Name:** core/home-link
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** label
 
 ## Custom HTML

--- a/packages/block-library/src/home-link/block.json
+++ b/packages/block-library/src/home-link/block.json
@@ -24,6 +24,14 @@
 	"supports": {
 		"reusable": false,
 		"html": false,
+		"spacing": {
+			"margin": true,
+			"padding": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
 		"typography": {
 			"fontSize": true,
 			"lineHeight": true,
@@ -36,6 +44,12 @@
 			"__experimentalDefaultControls": {
 				"fontSize": true
 			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
 		},
 		"interactivity": {
 			"clientNavigation": true

--- a/packages/block-library/src/home-link/style.scss
+++ b/packages/block-library/src/home-link/style.scss
@@ -1,0 +1,4 @@
+.wp-block-home-link {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -23,6 +23,7 @@
 @import "./gallery/style.scss";
 @import "./group/style.scss";
 @import "./heading/style.scss";
+@import "./home-link/style.scss";
 @import "./image/style.scss";
 @import "./latest-comments/style.scss";
 @import "./latest-posts/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border and Spacing support to the `Home Link` block.

Part of https://github.com/WordPress/gutenberg/issues/43243 and https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Home Link` block is missing border and Spacing support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border and Spacing support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Home Link` block's border and Spacing is Configurable via Global Styles.
- Edit Header &  Add `Home Link` block and Apply the border Styles and Spacing.
- Verify that `Home Link` block styles take precedence over global Styles.
- Verify that `Home Link` block borders and Spacing display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/17a85a6b-ed9b-45ec-b35d-82216153d754
