### PR TITLE
Block Editor: Fix ESLint warnings for the 'useInnerBlockTemplateSync' hook

### DIFF
--- a/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
+++ b/packages/block-editor/src/components/inner-blocks/use-inner-block-template-sync.js
@@ -7,7 +7,7 @@ import fastDeepEqual from 'fast-deep-equal/es6';
  * WordPress dependencies
  */
 import { useRef, useLayoutEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useRegistry } from '@wordpress/data';
 import { synchronizeBlocksWithTemplate } from '@wordpress/blocks';
 
 /**
@@ -42,20 +42,21 @@ export default function useInnerBlockTemplateSync(
 ) {
 	// Instead of adding a useSelect mapping here, please add to the useSelect
 	// mapping in InnerBlocks! Every subscription impacts performance.
-
-	const {
-		getBlocks,
-		getSelectedBlocksInitialCaretPosition,
-		isBlockSelected,
-	} = useSelect( blockEditorStore );
-	const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
-		useDispatch( blockEditorStore );
+	const registry = useRegistry();
 
 	// Maintain a reference to the previous value so we can do a deep equality check.
 	const existingTemplateRef = useRef( null );
 
 	useLayoutEffect( () => {
 		let isCancelled = false;
+
+		const {
+			getBlocks,
+			getSelectedBlocksInitialCaretPosition,
+			isBlockSelected,
+		} = registry.select( blockEditorStore );
+		const { replaceInnerBlocks, __unstableMarkNextChangeAsNotPersistent } =
+			registry.dispatch( blockEditorStore );
 
 		// There's an implicit dependency between useInnerBlockTemplateSync and useNestedSettingsUpdate
 		// The former needs to happen after the latter and since the latter is using microtasks to batch updates (performance optimization),
@@ -110,5 +111,11 @@ export default function useInnerBlockTemplateSync(
 		return () => {
 			isCancelled = true;
 		};
-	}, [ template, templateLock, clientId ] );
+	}, [
+		template,
+		templateLock,
+		clientId,
+		registry,
+		templateInsertUpdatesSelection,
+	] );
 }


### PR DESCRIPTION
## What?
PR fixes missing dependencies ESLint warnings for the 'useInnerBlockTemplateSync' hook.

## How?
* Use the `useRegistry` hook and extract selectors/actions inside the layout effect. Reduces the number of dependencies we need to declare.
* Add `templateInsertUpdatesSelection` to the dependency list. Since it's a boolean value, there should be no side effects.

## Testing Instructions
None. CI checks should be green.
