### PR TITLE
Updated Small Typo in documentation in docs/getting-started/faq.md file

### DIFF
--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -8,7 +8,7 @@ What follows is a set of questions that have come up from the last few years of 
 
 “Gutenberg” is the name of the project to create a new editor experience for WordPress — contributors have been working on it since January 2017 and it’s one of the most significant changes to WordPress in years. It’s built on the idea of using “blocks” to write and design posts and pages. This will serve as the foundation for future improvements to WordPress, including blocks as a way not just to design posts and pages, but also entire sites. The overall goal is to simplify the first-time user experience of WordPress — for those who are writing, editing, publishing, and designing web pages. The editing experience is intended to give users a better visual representation of what their post or page will look like when they hit publish. Originally, this was the kickoff goal:
 
-> The editor will endeavour to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.
+> The editor will endeavor to create a new page and post building experience that makes writing rich posts effortless, and has “blocks” to make it easy what today might take shortcodes, custom HTML, or “mystery meat” embed discovery.
 
 Key takeaways include the following points:
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
In docs/getting-started/faq.md file Line no 11 `endeavour` it Should be `endeavor`. Because Handbook says to use [American spelling](https://make.wordpress.org/core/handbook/best-practices/spelling/)

### Testing Instructions for Keyboard
- Open docs/getting-started/faq.md file
- Go to Line 11 
- See Typo Issue