### PR TITLE
Editor: Remove HTML from the post title in the document bar

### DIFF
--- a/packages/editor/src/components/document-bar/index.js
+++ b/packages/editor/src/components/document-bar/index.js
@@ -22,6 +22,7 @@ import { store as commandsStore } from '@wordpress/commands';
 import { useRef, useEffect } from '@wordpress/element';
 import { useReducedMotion } from '@wordpress/compose';
 import { decodeEntities } from '@wordpress/html-entities';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -200,7 +201,7 @@ export default function DocumentBar( props ) {
 						<Text size="body" as="h1">
 							<span className="editor-document-bar__post-title">
 								{ title
-									? decodeEntities( title )
+									? stripHTML( title )
 									: __( 'No title' ) }
 							</span>
 							{ pageTypeBadge && (

--- a/packages/editor/src/components/post-card-panel/index.js
+++ b/packages/editor/src/components/post-card-panel/index.js
@@ -12,7 +12,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { decodeEntities } from '@wordpress/html-entities';
+import { __unstableStripHTML as stripHTML } from '@wordpress/dom';
 
 /**
  * Internal dependencies
@@ -94,7 +94,7 @@ export default function PostCardPanel( {
 			labels?.name
 		);
 	} else if ( postTitle ) {
-		title = decodeEntities( postTitle );
+		title = stripHTML( postTitle );
 	}
 
 	return (


### PR DESCRIPTION
## What?
PR updates the `DocumentBar` and `PostCardPanel` components to remove HTML from the post title before rendering.

## Why?
The post title in this component should be rendered like the post title in Canvas, minus HTML. I couldn't find a reference that this was an intentional design choice; it was just an oversight on our part.

## Testing Instructions
1. Open a post or page.
2. Switch to code editor.
3. Add the title with some HTML and entities (`&amp;`)
4. Confirm that entities are rendered correctly and HTML elements are removed.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->

**Before**
![CleanShot 2024-12-27 at 20 19 35](https://github.com/user-attachments/assets/03aadbb6-54f6-4f02-8e4d-13a4849d6486)

**After**
![CleanShot 2024-12-27 at 20 48 54](https://github.com/user-attachments/assets/edd06dd9-55a2-4a0b-8f76-f482841a7063)

