### PR TITLE
Badge: Fix up extra newline in readme

### DIFF
--- a/packages/components/src/badge/README.md
+++ b/packages/components/src/badge/README.md
@@ -4,7 +4,6 @@
 
 🔒 This component is locked as a [private API](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-private-apis/). We do not yet recommend using this outside of the Gutenberg project.
 
-
 <p class="callout callout-info">See the <a href="https://wordpress.github.io/gutenberg/?path=/docs/components-badge--docs">WordPress Storybook</a> for more detailed, interactive documentation.</p>
 
 ## Props


### PR DESCRIPTION
Follow-up to #68317

## What?

Removes an extra newline in the Badge component readme that is currently causing a CI check to fail on trunk.

