### PR TITLE
Editor: Include additional details when saving post fails

### DIFF
--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -100,10 +100,16 @@ export function getNotificationArgumentsForSaveFail( data ) {
 			? messages[ edits.status ]
 			: __( 'Updating failed.' );
 
-	// Check if message string contains HTML. Notice text is currently only
-	// supported as plaintext, and stripping the tags may muddle the meaning.
-	if ( error.message && ! /<\/?[^>]*>/.test( error.message ) ) {
-		noticeMessage = [ noticeMessage, error.message ].join( ' ' );
+	const errorMessages = [ error.message ]
+		.concat( error.additional_data )
+		.filter( ( message ) => {
+			// Check if message string contains HTML. Notice text is currently only
+			// supported as plaintext, and stripping the tags may muddle the meaning.
+			return message && ! /<\/?[^>]*>/.test( message );
+		} );
+
+	if ( errorMessages.length > 0 ) {
+		noticeMessage = [ noticeMessage, ...errorMessages ].join( ' ' );
 	}
 	return [
 		noticeMessage,


### PR DESCRIPTION
## What?
Closes #64158.

PR updates the `getNotificationArgumentsForSaveFail` builder to include additional error messages returned by REST API.

## Why?
Additional details inform users how to fix the problem.

## Testing Instructions
1. Remove max length limit for post password [here](https://github.com/WordPress/gutenberg/blob/9ae31d376e4496034793c84e0450ddfbc4a46c50/packages/editor/src/components/post-status/index.js#L259).
2. Open a post.
3. Try setting a post password that's longer than 255 chars.
4. Save the post.
5. Confirm that the error notice includes additional data about the failure.

**Long password**

```
glom-our-stir-bespeak-normalcy-wavelet-spitz-alsatian-miami-gizmo-sibling-riflemen-fugal-caiman-guy-tern-flick-nearer-dow-patch-grudge-prawn-debuting-scorch-brunei-waif-hibachi-beijing-tweet-share-homeward-ratline-postal-dissent-tigris-baldpate-clumsy-centre
```

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2024-12-27 at 21 47 46](https://github.com/user-attachments/assets/e93c5cb4-172c-42bb-bf89-1a1eed5d4e77)
