### PR TITLE
Editor: Remove constants for notices

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -23,7 +23,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { TRASH_POST_NOTICE_ID } from './constants';
 import { localAutosaveSet } from './local-autosave';
 import {
 	getNotificationArgumentsForSaveSuccess,
@@ -347,7 +346,6 @@ export const trashPost =
 		const postType = await registry
 			.resolveSelect( coreStore )
 			.getPostType( postTypeSlug );
-		registry.dispatch( noticesStore ).removeNotice( TRASH_POST_NOTICE_ID );
 		const { rest_base: restBase, rest_namespace: restNamespace = 'wp/v2' } =
 			postType;
 		dispatch( { type: 'REQUEST_POST_DELETE_START' } );

--- a/packages/editor/src/store/constants.ts
+++ b/packages/editor/src/store/constants.ts
@@ -11,8 +11,6 @@ export const EDIT_MERGE_PROPERTIES = new Set( [ 'meta' ] );
  */
 export const STORE_NAME = 'core/editor';
 
-export const SAVE_POST_NOTICE_ID = 'SAVE_POST_NOTICE_ID';
-export const TRASH_POST_NOTICE_ID = 'TRASH_POST_NOTICE_ID';
 export const PERMALINK_POSTNAME_REGEX = /%(?:postname|pagename)%/;
 export const ONE_MINUTE_IN_MS = 60 * 1000;
 export const AUTOSAVE_PROPERTIES = [ 'title', 'excerpt', 'content' ];

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -4,11 +4,6 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
- */
-import { SAVE_POST_NOTICE_ID, TRASH_POST_NOTICE_ID } from '../constants';
-
-/**
  * Builds the arguments for a success notification dispatch.
  *
  * @param {Object} data Incoming data to build the arguments from.
@@ -68,7 +63,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	return [
 		noticeMessage,
 		{
-			id: SAVE_POST_NOTICE_ID,
+			id: 'editor-save-success',
 			type: 'snackbar',
 			actions,
 		},
@@ -113,7 +108,7 @@ export function getNotificationArgumentsForSaveFail( data ) {
 	return [
 		noticeMessage,
 		{
-			id: SAVE_POST_NOTICE_ID,
+			id: 'editor-save-fail',
 		},
 	];
 }
@@ -131,7 +126,7 @@ export function getNotificationArgumentsForTrashFail( data ) {
 			? data.error.message
 			: __( 'Trashing failed' ),
 		{
-			id: TRASH_POST_NOTICE_ID,
+			id: 'editor-trash-fail',
 		},
 	];
 }

--- a/packages/editor/src/store/utils/notice-builder.js
+++ b/packages/editor/src/store/utils/notice-builder.js
@@ -63,7 +63,7 @@ export function getNotificationArgumentsForSaveSuccess( data ) {
 	return [
 		noticeMessage,
 		{
-			id: 'editor-save-success',
+			id: 'editor-save',
 			type: 'snackbar',
 			actions,
 		},
@@ -108,7 +108,7 @@ export function getNotificationArgumentsForSaveFail( data ) {
 	return [
 		noticeMessage,
 		{
-			id: 'editor-save-fail',
+			id: 'editor-save',
 		},
 	];
 }

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -6,7 +6,6 @@ import {
 	getNotificationArgumentsForSaveFail,
 	getNotificationArgumentsForTrashFail,
 } from '../notice-builder';
-import { SAVE_POST_NOTICE_ID, TRASH_POST_NOTICE_ID } from '../../constants';
 
 describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 	const postType = {
@@ -27,7 +26,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 	};
 	const post = { ...previousPost };
 	const defaultExpectedAction = {
-		id: SAVE_POST_NOTICE_ID,
+		id: 'editor-save-success',
 		actions: [],
 		type: 'snackbar',
 	};
@@ -106,7 +105,7 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 	const error = { code: '42', message: 'Something went wrong.' };
 	const post = { status: 'publish' };
 	const edits = { status: 'publish' };
-	const defaultExpectedAction = { id: SAVE_POST_NOTICE_ID };
+	const defaultExpectedAction = { id: 'editor-save-fail' };
 	[
 		[
 			'when error code is `rest_autosave_no_changes`',
@@ -190,7 +189,7 @@ describe( 'getNotificationArgumentsForTrashFail()', () => {
 	].forEach( ( [ description, error, message ] ) => {
 		// eslint-disable-next-line jest/valid-title
 		it( description, () => {
-			const expectedValue = [ message, { id: TRASH_POST_NOTICE_ID } ];
+			const expectedValue = [ message, { id: 'editor-trash-fail' } ];
 			expect( getNotificationArgumentsForTrashFail( { error } ) ).toEqual(
 				expectedValue
 			);

--- a/packages/editor/src/store/utils/test/notice-builder.js
+++ b/packages/editor/src/store/utils/test/notice-builder.js
@@ -26,7 +26,7 @@ describe( 'getNotificationArgumentsForSaveSuccess()', () => {
 	};
 	const post = { ...previousPost };
 	const defaultExpectedAction = {
-		id: 'editor-save-success',
+		id: 'editor-save',
 		actions: [],
 		type: 'snackbar',
 	};
@@ -105,7 +105,7 @@ describe( 'getNotificationArgumentsForSaveFail()', () => {
 	const error = { code: '42', message: 'Something went wrong.' };
 	const post = { status: 'publish' };
 	const edits = { status: 'publish' };
-	const defaultExpectedAction = { id: 'editor-save-fail' };
+	const defaultExpectedAction = { id: 'editor-save' };
 	[
 		[
 			'when error code is `rest_autosave_no_changes`',


### PR DESCRIPTION
## What?
Closes #11202.

PR updates IDs for editor notices to use string values directly instead of unnecessary constants.

## Testing Instructions
1. Open a post or page.
2. Smoke test post-saving and trashing.
3. Confirm notices work as before.

### Testing Instructions for Keyboard
Same.
