### PR TITLE
BoxControl: Fix `aria-valuetext` value

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fixes
 
 -   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
+-   `BoxControl`: Fix aria-valuetext value ([#68362](https://github.com/WordPress/gutenberg/pull/68362)).
 
 ### Experimental
 

--- a/packages/components/src/box-control/input-control.tsx
+++ b/packages/components/src/box-control/input-control.tsx
@@ -264,7 +264,7 @@ export default function BoxInputControl( {
 					}
 					aria-valuetext={
 						marks[ presetIndex !== undefined ? presetIndex + 1 : 0 ]
-							.label
+							.tooltip
 					}
 					renderTooltipContent={ ( index ) =>
 						marks[ ! index ? 0 : index ].tooltip


### PR DESCRIPTION
Related to #67688

## What?

This PR applies the appropriate label to `aria-valuetext` when the `BoxControl` component has presets, allowing screen readers to properly announce the preset values.

## Why?

The `aria-valuenow` attribute is used in a range widget to communicate the current value, and the `aria-valuetext` attribute is used to provide more human-readable text.

The current implementation references the `label` field, which is [always an empty string](https://github.com/WordPress/gutenberg/blob/2ae1f243dde8f3eb0f298425954e14876d951425/packages/components/src/box-control/input-control.tsx#L182-L185), so `aria-valuetext` is effectively non-functional.

## How?

From my understanding, the reason the `label` field is empty is because we do not want to display a visual mark label, so the `label` field should be left empty. Instead, apply the tooltip text to `aria-valuetext` as well, so that the text read by screen readers matches the visual tooltip text.

This should match the implementation of [the `SpacingSizesControl` component](https://github.com/WordPress/gutenberg/blob/2ae1f243dde8f3eb0f298425954e14876d951425/packages/block-editor/src/components/spacing-sizes-control/input-controls/spacing-input-control.js#L291).

## Testing Instructions

- Run `npm run storybook:dev`
- Access http://localhost:50240/?path=/story/components-boxcontrol--control-with-presets
- Change the value.
- Your screen reader should now read out the actual preset label.
- Confirm the `aria-valuetext` attribute via your browser developer tools.

## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/66d79582-13a2-44bf-bfc1-e39bcbdcd7b0