### PR TITLE
Storybook: Add Story for InsertListItem component

### DIFF
--- a/packages/block-editor/src/components/inserter-list-item/index.js
+++ b/packages/block-editor/src/components/inserter-list-item/index.js
@@ -23,6 +23,33 @@ import BlockIcon from '../block-icon';
 import { InserterListboxItem } from '../inserter-listbox';
 import InserterDraggableBlocks from '../inserter-draggable-blocks';
 
+/**
+ * InserterListItem component displays a single block type in the inserter.
+ *
+ * @example
+ * ```jsx
+ * function Example() {
+ *   return (
+ *     <InserterListItem
+ *       className="my-class"
+ *       isFirst={ true }
+ *       item={ item }
+ *       onSelect={ onSelect }
+ *       onHover={ onHover }
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @param {Object}   props             The component props.
+ * @param {string}   props.className   Additional class name to apply to the item.
+ * @param {boolean}  props.isFirst     Whether the item is the first in the list.
+ * @param {Object}   props.item        The block type item to display.
+ * @param {Function} props.onSelect    Callback to run when the item is selected.
+ * @param {Function} props.onHover     Callback to run when the item is hovered.
+ * @param {boolean}  props.isDraggable Whether the item is draggable.
+ * @return {Element}                    The block type item element.
+ */
 function InserterListItem( {
 	className,
 	isFirst,

--- a/packages/block-editor/src/components/inserter-list-item/stories/index.story.js
+++ b/packages/block-editor/src/components/inserter-list-item/stories/index.story.js
@@ -1,0 +1,106 @@
+/**
+ * Internal dependencies
+ */
+import InserterListItem from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType( 'core/paragraph', {
+	title: 'Paragraph',
+} );
+
+const meta = {
+	title: 'BlockEditor/Inserter/InserterListItem',
+	component: InserterListItem,
+	argTypes: {
+		className: {
+			control: {
+				type: 'text',
+			},
+			description: 'The class name of the inserter list item',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+
+		isFirst: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Is the item the first in the list',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+
+		item: {
+			control: {
+				type: 'object',
+			},
+			description: 'The item to render',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+
+		onSelect: {
+			control: {
+				type: 'function',
+			},
+			description: 'Function to call when the item is selected',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+
+		onHover: {
+			control: {
+				type: 'function',
+			},
+			description: 'Function to call when the item is hovered',
+			table: {
+				type: { summary: 'function' },
+			},
+		},
+
+		isDraggable: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Is the item draggable',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+const itemConfig = {
+	name: 'core/paragraph',
+	title: 'Paragraph',
+	icon: <span>P</span>,
+	initialAttributes: {
+		placeholder: 'Write something...',
+	},
+	innerBlocks: [],
+	isDisabled: false,
+	syncStatus: 'synced',
+};
+
+export const Default = {
+	args: {
+		isFirst: true,
+		item: itemConfig,
+		onSelect: () => {},
+		onHover: () => {},
+		isDraggable: true,
+	},
+	render: function Template( { ...args } ) {
+		return <InserterListItem { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add story for Insert List Item Component 

### Testing Instructions

- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the Insert List Item story

## Screenshots or screencast

https://github.com/user-attachments/assets/02412e95-221d-4116-8176-079fb06fb4dd




