### PR TITLE
Fix File block resize glitches

### DIFF
--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -255,10 +255,9 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 			<div { ...blockProps }>
 				{ displayPreviewInEditor && (
 					<ResizableBox
-						size={ { height: previewHeight } }
+						size={ { height: previewHeight, width: '100%' } }
 						minHeight={ MIN_PREVIEW_HEIGHT }
 						maxHeight={ MAX_PREVIEW_HEIGHT }
-						minWidth="100%"
 						// The horizontal grid value must be 1 or else the width may snap during a
 						// resize even though only vertical resizing is enabled.
 						grid={ [ 1, 10 ] }

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -259,7 +259,9 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						minHeight={ MIN_PREVIEW_HEIGHT }
 						maxHeight={ MAX_PREVIEW_HEIGHT }
 						minWidth="100%"
-						grid={ [ 10, 10 ] }
+						// The horizontal grid value must be 1 or else the width may snap during a
+						// resize even though only vertical resizing is enabled.
+						grid={ [ 1, 10 ] }
 						enable={ {
 							top: false,
 							right: false,


### PR DESCRIPTION
## What?
Fixes a couple glitches with the File block’s preview when resized via the in-canvas control.
1. The width can snap to the nearest factor of 10 but shouldn’t because only the height is supposed to change.
2. If resized while the block is wide or full aligned and the align is set to none the width gets stuck.

## Why?
These glitches break the WYSIWYG expectation of the editor.

## How?
Revises use of the `ResizableBox` component’s props.

## Testing Instructions
### Width maintained while resizing
1. With the Twenty Twenty-Five theme active (or any theme whose content width is not evenly divisible by 10).
2. Open a post or page.
3. Insert a File block.
4. Add a PDF file to the block.
5. Resize the block with the in-canvas control.
6. Note the width does not change.

### Width doesn’t get stuck after resizing at Wide/Full alignments
1. Open a post or page.
2. Insert a File block.
3. Add a PDF file to the block.
4. Set the block alignment to Wide or Full.
5. Resize the block with the in-canvas control.
6. Set the block alignment to None.
7. Note the width returns to the regular content-width as expected.

## Screenshots or screencast <!-- if applicable -->

### Before 

https://github.com/user-attachments/assets/71e17c2b-201c-4cb9-9489-6d045ec25aa8

### After

https://github.com/user-attachments/assets/a62c5524-b63e-4fe7-96fe-288a3c48024b
