### PR TITLE
i18n: make example translatable in comments-pagination-previous

### DIFF
--- a/packages/block-library/src/comments-pagination-previous/block.json
+++ b/packages/block-library/src/comments-pagination-previous/block.json
@@ -12,11 +12,6 @@
 			"type": "string"
 		}
 	},
-	"example": {
-		"attributes": {
-			"label": "Comments Previous Page"
-		}
-	},
 	"usesContext": [ "postId", "comments/paginationArrow" ],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/comments-pagination-previous/index.js
+++ b/packages/block-library/src/comments-pagination-previous/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { queryPaginationPrevious as icon } from '@wordpress/icons';
 
 /**
@@ -19,10 +19,7 @@ export const settings = {
 	edit,
 	example: {
 		attributes: {
-			label: _x(
-				'Comments Previous Page',
-				'Example label for the Comments Pagination Previous block'
-			),
+			label: __( 'Comments Previous Page' ),
 		},
 	},
 };

--- a/packages/block-library/src/comments-pagination-previous/index.js
+++ b/packages/block-library/src/comments-pagination-previous/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { _x } from '@wordpress/i18n';
 import { queryPaginationPrevious as icon } from '@wordpress/icons';
 
 /**
@@ -16,6 +17,14 @@ export { metadata, name };
 export const settings = {
 	icon,
 	edit,
+	example: {
+		attributes: {
+			label: _x(
+				'Comments Previous Page',
+				'Example label for the Comments Pagination Previous block'
+			),
+		},
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/comments-pagination-previous/index.js
+++ b/packages/block-library/src/comments-pagination-previous/index.js
@@ -19,7 +19,7 @@ export const settings = {
 	edit,
 	example: {
 		attributes: {
-			label: __( 'Comments Previous Page' ),
+			label: __( 'Older Comments' ),
 		},
 	},
 };


### PR DESCRIPTION
Part of: #64707 
Tracker Comment: https://github.com/WordPress/gutenberg/issues/64707#issuecomment-2565021594

## What, Why & How?
This PR refactors the example attribute of block.json to support translatable text.

## Testing Instructions
1. Create a comments block.
2. Add a pagination block to it.
3. Hover over the inserter to see the preview for `comments pagination previous`.

## Screenshot
![Screenshot 2024-12-30 at 10 20 27 AM](https://github.com/user-attachments/assets/9e1d41ef-f4b0-4ccd-b80c-8eb5097d9158)
