### PR TITLE
i18n: make example and variations translatable in `post-navigation-link`

### DIFF
--- a/packages/block-library/src/post-navigation-link/block.json
+++ b/packages/block-library/src/post-navigation-link/block.json
@@ -34,12 +34,6 @@
 			"default": ""
 		}
 	},
-	"example": {
-		"attributes": {
-			"label": "Next post",
-			"arrow": "arrow"
-		}
-	},
 	"usesContext": [ "postType" ],
 	"supports": {
 		"reusable": false,

--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { _x } from '@wordpress/i18n';
+
+/**
  * Internal dependencies
  */
 import initBlock from '../utils/init-block';
@@ -12,6 +17,15 @@ export { metadata, name };
 export const settings = {
 	edit,
 	variations,
+	example: {
+		attributes: {
+			label: _x(
+				'Next post',
+				'Example label for Post Navigation Link block'
+			),
+			arrow: 'arrow',
+		},
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );

--- a/packages/block-library/src/post-navigation-link/index.js
+++ b/packages/block-library/src/post-navigation-link/index.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { _x } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -19,10 +19,7 @@ export const settings = {
 	variations,
 	example: {
 		attributes: {
-			label: _x(
-				'Next post',
-				'Example label for Post Navigation Link block'
-			),
+			label: __( 'Next post' ),
 			arrow: 'arrow',
 		},
 	},

--- a/packages/block-library/src/post-navigation-link/variations.js
+++ b/packages/block-library/src/post-navigation-link/variations.js
@@ -17,7 +17,7 @@ const variations = [
 		scope: [ 'inserter', 'transform' ],
 		example: {
 			attributes: {
-				label: 'Next post',
+				label: __( 'Next post' ),
 				arrow: 'arrow',
 			},
 		},
@@ -33,7 +33,7 @@ const variations = [
 		scope: [ 'inserter', 'transform' ],
 		example: {
 			attributes: {
-				label: 'Previous post',
+				label: __( 'Previous post' ),
 				arrow: 'arrow',
 			},
 		},


### PR DESCRIPTION
Part of: #64707 
Tracker Comment: https://github.com/WordPress/gutenberg/issues/64707#issuecomment-2565021594

## What, Why & How?
This PR refactors the example attribute of block.json to support translatable text.

## Testing Instructions
1. Hover over the inserter and see the preview for the `post navigation link` block.

## Screenshots
![Screenshot 2024-12-30 at 10 30 42 AM](https://github.com/user-attachments/assets/c131e368-ea15-41d6-afd2-3285d5eaf62e)
![Screenshot 2024-12-30 at 10 30 46 AM](https://github.com/user-attachments/assets/138ad4de-8934-4ee7-b58f-7d33a7b78f16)
