### PR TITLE
i18n: make example translatable in `query-no-results`

### DIFF
--- a/packages/block-library/src/query-no-results/block.json
+++ b/packages/block-library/src/query-no-results/block.json
@@ -8,16 +8,6 @@
 	"ancestor": [ "core/query" ],
 	"textdomain": "default",
 	"usesContext": [ "queryId", "query" ],
-	"example": {
-		"innerBlocks": [
-			{
-				"name": "core/paragraph",
-				"attributes": {
-					"content": "No posts were found."
-				}
-			}
-		]
-	},
 	"supports": {
 		"align": true,
 		"reusable": false,

--- a/packages/block-library/src/query-no-results/index.js
+++ b/packages/block-library/src/query-no-results/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { loop as icon } from '@wordpress/icons';
 
 /**
@@ -18,6 +19,16 @@ export const settings = {
 	icon,
 	edit,
 	save,
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/paragraph',
+				attributes: {
+					content: __( 'No posts were found.' ),
+				},
+			},
+		],
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: #64707 
Tracker Comment: https://github.com/WordPress/gutenberg/issues/64707#issuecomment-2565021594

## What, Why & How?
This PR refactors the example attribute of block.json to support translatable text.

## Testing Instructions
1. Hover over the inserter to see the preview for `query-no-results`.

## Screenshot

![Screenshot 2024-12-30 at 10 39 15 AM](https://github.com/user-attachments/assets/b607204c-b237-4165-a1ff-609ef1bfbeef)
