### PR TITLE
i18n: make example translatable in `table-of-contents`

### DIFF
--- a/packages/block-library/src/table-of-contents/block.json
+++ b/packages/block-library/src/table-of-contents/block.json
@@ -62,57 +62,5 @@
 			}
 		}
 	},
-	"example": {
-		"innerBlocks": [
-			{
-				"name": "core/heading",
-				"attributes": {
-					"level": 2,
-					"content": "Heading"
-				}
-			},
-			{
-				"name": "core/heading",
-				"attributes": {
-					"level": 3,
-					"content": "Subheading"
-				}
-			},
-			{
-				"name": "core/heading",
-				"attributes": {
-					"level": 2,
-					"content": "Heading"
-				}
-			},
-			{
-				"name": "core/heading",
-				"attributes": {
-					"level": 3,
-					"content": "Subheading"
-				}
-			}
-		],
-		"attributes": {
-			"headings": [
-				{
-					"content": "Heading",
-					"level": 2
-				},
-				{
-					"content": "Subheading",
-					"level": 3
-				},
-				{
-					"content": "Heading",
-					"level": 2
-				},
-				{
-					"content": "Subheading",
-					"level": 3
-				}
-			]
-		}
-	},
 	"style": "wp-block-table-of-contents"
 }

--- a/packages/block-library/src/table-of-contents/index.js
+++ b/packages/block-library/src/table-of-contents/index.js
@@ -1,6 +1,7 @@
 /**
  * WordPress dependencies
  */
+import { __ } from '@wordpress/i18n';
 import { tableOfContents as icon } from '@wordpress/icons';
 
 /**
@@ -19,6 +20,58 @@ export const settings = {
 	icon,
 	edit,
 	save,
+	example: {
+		innerBlocks: [
+			{
+				name: 'core/heading',
+				attributes: {
+					level: 2,
+					content: __( 'Heading' ),
+				},
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					level: 3,
+					content: __( 'Subheading' ),
+				},
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					level: 2,
+					content: __( 'Heading' ),
+				},
+			},
+			{
+				name: 'core/heading',
+				attributes: {
+					level: 3,
+					content: __( 'Subheading' ),
+				},
+			},
+		],
+		attributes: {
+			headings: [
+				{
+					content: __( 'Heading' ),
+					level: 2,
+				},
+				{
+					content: __( 'Subheading' ),
+					level: 3,
+				},
+				{
+					content: __( 'Heading' ),
+					level: 2,
+				},
+				{
+					content: __( 'Subheading' ),
+					level: 3,
+				},
+			],
+		},
+	},
 };
 
 export const init = () => initBlock( { name, metadata, settings } );


### PR DESCRIPTION
Part of: #64707 
Tracker Comment: https://github.com/WordPress/gutenberg/issues/64707#issuecomment-2565021594

## What, Why & How?
This PR refactors the example attribute of block.json to support translatable text.

## Testing Instructions
1. Hover over the inserter and see the preview for the `table-of-contents` block.

## Screenshot
![Screenshot 2024-12-30 at 10 53 45 AM](https://github.com/user-attachments/assets/1320656d-78ca-4192-b233-96c8b5bda158)
