### PR TITLE
Navigation Submenu Block: Add example preview

### DIFF
--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -40,6 +40,13 @@
 			"type": "boolean"
 		}
 	},
+	"example": {
+		"attributes": {
+			"label": "About",
+			"type": "page",
+			"title": "About Us"
+		}
+	},
 	"usesContext": [
 		"textColor",
 		"customTextColor",

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -40,13 +40,6 @@
 			"type": "boolean"
 		}
 	},
-	"example": {
-		"attributes": {
-			"label": "About",
-			"type": "page",
-			"title": "About Us"
-		}
-	},
 	"usesContext": [
 		"textColor",
 		"customTextColor",

--- a/packages/block-library/src/navigation-submenu/index.js
+++ b/packages/block-library/src/navigation-submenu/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { page, addSubmenu } from '@wordpress/icons';
+import { _x } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -37,6 +38,12 @@ export const settings = {
 		return label;
 	},
 	edit,
+	example: {
+		attributes: {
+			label: _x( 'About', 'Example link text for Navigation Submenu' ),
+			type: 'page',
+		},
+	},
 	save,
 	transforms,
 };


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/64707

## What?

Add translatable example preview text in the Navigation Submenu block.

## Testing Instructions

- Navigate to a page or post editor
- Click the inserter button (+)
- Search for "Navigation Submenu"
- Verify the block preview appears in the inserter with translatable text

## Screenshot


![image](https://github.com/user-attachments/assets/f7ce6501-ce22-4d93-8df9-1413a5913db1)
