### PR TITLE
Storybook: Add Story for Floating Toolbar component

### DIFF
--- a/packages/block-editor/src/components/floating-toolbar/stories/index.story.js
+++ b/packages/block-editor/src/components/floating-toolbar/stories/index.story.js
@@ -1,0 +1,69 @@
+/**
+ * Internal dependencies
+ */
+import { FloatingToolbar } from '..';
+
+const meta = {
+	title: 'Components/FloatingToolbar',
+	component: FloatingToolbar,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: 'This is `FloatingToolbar` component.',
+			},
+		},
+	},
+	argTypes: {
+		selectedClientId: {
+			control: {
+				type: 'text',
+			},
+			description: 'The selected block client ID.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		parentId: {
+			control: {
+				type: 'text',
+			},
+			description: 'The parent block client ID.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		showFloatingToolbar: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Whether the floating toolbar should be shown.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+		isRTL: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Whether the site is RTL.',
+			table: {
+				type: { summary: 'boolean' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		selectedClientId: 'block_1',
+		parentId: 'block_0',
+		showFloatingToolbar: true,
+		isRTL: false,
+	},
+	render: function Template( args ) {
+		return <FloatingToolbar { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of #https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for Floating Toolbar Component 

### Testing Instructions for Keyboard
- Start Storybook by running npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Navigate to "Components/FloatingToolbar" in the Storybook sidebar

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->
