### PR TITLE
Upgrade sass to version 1.54.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -145,7 +145,7 @@
 				"resize-observer-polyfill": "1.5.1",
 				"rimraf": "5.0.10",
 				"rtlcss": "4.3.0",
-				"sass": "1.50.1",
+				"sass": "1.54.0",
 				"sass-loader": "16.0.3",
 				"semver": "7.5.4",
 				"simple-git": "3.24.0",
@@ -41552,9 +41552,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.50.1",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.50.1.tgz",
-			"integrity": "sha512-noTnY41KnlW2A9P8sdwESpDmo+KBNkukI1i8+hOK3footBUcohNHtdOJbckp46XO95nuvcHDDZ+4tmOnpK3hjw==",
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.54.0.tgz",
+			"integrity": "sha512-C4zp79GCXZfK0yoHZg+GxF818/aclhp9F48XBu/+bm9vXEVAYov9iU3FBVRMq3Hx3OA4jfKL+p2K9180mEh0xQ==",
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": ">=3.0.0 <4.0.0",
@@ -52361,7 +52361,7 @@
 				"read-pkg-up": "^7.0.1",
 				"resolve-bin": "^0.4.0",
 				"rtlcss": "^4.3.0",
-				"sass": "^1.50.1",
+				"sass": "^1.54.0",
 				"sass-loader": "^16.0.3",
 				"schema-utils": "^4.2.0",
 				"source-map-loader": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
 		"resize-observer-polyfill": "1.5.1",
 		"rimraf": "5.0.10",
 		"rtlcss": "4.3.0",
-		"sass": "1.50.1",
+		"sass": "1.54.0",
 		"sass-loader": "16.0.3",
 		"semver": "7.5.4",
 		"simple-git": "3.24.0",

--- a/packages/scripts/CHANGELOG.md
+++ b/packages/scripts/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Internal
 
 -   The bundled `rtlcss-webpack-plugin` dependency has been replaced with a modified fork of the plugin to fix issues with the original package ([#68201](https://github.com/WordPress/gutenberg/pull/68201)).
+-   The bundled `sass` dependency has been updated from `^1.50.0` to `^1.54.0` ([#68380](https://github.com/WordPress/gutenberg/pull/68380)).
 
 ## 30.7.0 (2024-12-11)
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -81,7 +81,7 @@
 		"read-pkg-up": "^7.0.1",
 		"resolve-bin": "^0.4.0",
 		"rtlcss": "^4.3.0",
-		"sass": "^1.50.1",
+		"sass": "^1.54.0",
 		"sass-loader": "^16.0.3",
 		"schema-utils": "^4.2.0",
 		"source-map-loader": "^3.0.0",


### PR DESCRIPTION
Discovered while working on #68282

## What?

This PR updates the sass version from `1.50.1` to `1.54.0` in the Gutenberg project and scripts package.


## Why?

In #68282, I proposed adding the missing [`reduce-motion` mixin](https://github.com/WordPress/gutenberg/blob/b4304f8bf6bd9b890b4108adcc326cd586a3ab4e/packages/base-styles/_mixins.scss#L237-L257). However, I found that the `components` package uses the following standard pattern instead of the mixin:

```css
@media not ( prefers-reduced-motion ) {
	transition: all 400ms linear;
}
```

So I tried to introduce a similar standard pattern to packages other than the `components` package, but sass, which is used in Gutenberg and scripts, does not support this pattern, so [the following error](https://github.com/WordPress/gutenberg/actions/runs/12502541314/job/34881643891) occurs during build.


## How?

To make such CSS patterns available, upgrade sass version to `1.54.0`, which supports the new media query syntax.

Actually, we can upgrade up to `1.77.6`. We cannot upgrade to `1.77.7` or higher, because `1.77.7` added a deprecation related to nested rules.

[dart-sass CHANGELOG](https://github.com/sass/dart-sass/blob/main/CHANGELOG.md)

## Testing Instructions

Add the following style to any package:

```scss
.selector {
	@media not (prefers-reduced-motion) {
		width: 100px;
	}

	@media (400px < width < 600px ) {
		width: 100px;
	}

	@media screen {
		width: 100px;
	}

	@media print {
		width: 50px;
	}
}
```

Run `npm run build:packages`

### wp-scripts

```
npx wp-create-block my-block --no-wp-scripts
cd my-block
```

Add the above style to any stylesheet and run `../node_modules/.bin/wp-scripts build`
