### PR TITLE
Storybook: Adds story for link-control component

### DIFF
--- a/packages/block-editor/src/components/link-control/stories/index.story.js
+++ b/packages/block-editor/src/components/link-control/stories/index.story.js
@@ -1,0 +1,155 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import LinkControl from '../';
+
+const meta = {
+	title: 'BlockEditor/LinkControl',
+	component: LinkControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Renders a link control. A link control is a controlled input which maintains a value associated with a link (HTML anchor element) and relevant settings for how that link is expected to behave. It is designed to provide a standardized UI for the creation of a link throughout the Editor, see History section at bottom for further background.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: 'object',
+			description: 'The current value of the link (URL and title)',
+		},
+		settings: {
+			control: 'array',
+			description: 'Custom settings for the link control',
+		},
+		onChange: {
+			action: 'onChange',
+			description: 'Callback for when the link value changes',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+			control: false,
+		},
+		onRemove: {
+			action: 'onRemove',
+			description: 'Callback for when the link is removed',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+			control: false,
+		},
+		hasRichPreviews: {
+			control: 'boolean',
+			description: 'Whether to enable rich link previews.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		hasTextControl: {
+			control: 'boolean',
+			description:
+				'Whether to display a text input control for the link title.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		inputValue: {
+			control: 'text',
+			description: 'The current input value for the URL.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		noDirectEntry: {
+			control: 'boolean',
+			description: 'Whether direct URL entry is disallowed.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		noURLSuggestion: {
+			control: 'boolean',
+			description: 'Whether URL suggestions are disabled.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		renderControlBottom: {
+			action: 'renderControlBottom',
+			description:
+				'Optional callback to render content below the link control.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+			control: false,
+		},
+		showSuggestions: {
+			control: 'boolean',
+			description: 'Whether suggestions should be displayed.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+		suggestionsQuery: {
+			control: 'object',
+			description: 'Query parameters for fetching link suggestions.',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+const Template = ( args ) => {
+	const [ linkValue, setLinkValue ] = useState( args.value );
+
+	return (
+		<LinkControl
+			{ ...args }
+			value={ linkValue }
+			onChange={ ( value ) => setLinkValue( value ) }
+		/>
+	);
+};
+
+export const Default = {
+	render: Template,
+	args: {
+		value: { url: 'https://wordpress.org', title: 'Link Title' },
+		settings: [
+			{ id: 'openInNewTab', title: 'Open in new tab' },
+			{ id: 'noFollow', title: 'No Follow' },
+		],
+		forceIsEditingLink: true,
+		hasTextControl: true,
+	},
+};

--- a/packages/block-editor/src/components/link-control/stories/index.story.js
+++ b/packages/block-editor/src/components/link-control/stories/index.story.js
@@ -24,10 +24,20 @@ const meta = {
 		value: {
 			control: 'object',
 			description: 'The current value of the link (URL and title)',
+			table: {
+				type: {
+					summary: 'object',
+				},
+			},
 		},
 		settings: {
 			control: 'array',
 			description: 'Custom settings for the link control',
+			table: {
+				type: {
+					summary: 'array',
+				},
+			},
 		},
 		onChange: {
 			action: 'onChange',


### PR DESCRIPTION
## What?
This PR adds story for `link-control` component.

## Why?
Part of: https://github.com/WordPress/gutenberg/issues/67165

## Testing Instructions
- Start Storybook by running npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Test the story for URLInput

## Screenshots or screencast



https://github.com/user-attachments/assets/4c7e3a3b-ecd9-48c4-85e8-761bff32557d





