### PR TITLE
docs: fix missing filter `@param` names in WP_Theme_JSON_Resolver_Gutenberg`

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -170,7 +170,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @since 6.1.0
 		 *
-		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
+		 * @param WP_Theme_JSON_Data_Gutenberg $instance Class to access and update the underlying data.
 		 */
 		$theme_json   = apply_filters( 'wp_theme_json_data_default', new WP_Theme_JSON_Data_Gutenberg( $config, 'default' ) );
 		static::$core = $theme_json->get_theme_json();
@@ -276,7 +276,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			 *
 			 * @since 6.1.0
 			 *
-			 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
+			 * @param WP_Theme_JSON_Data_Gutenberg $instance Class to access and update the underlying data.
 			 */
 			$theme_json    = apply_filters( 'wp_theme_json_data_theme', new WP_Theme_JSON_Data_Gutenberg( $theme_json_data, 'theme' ) );
 			static::$theme = $theme_json->get_theme_json();
@@ -411,7 +411,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 		 *
 		 * @since 6.1.0
 		 *
-		 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
+		 * @param WP_Theme_JSON_Data_Gutenberg $instance Class to access and update the underlying data.
 		 */
 		$theme_json     = apply_filters( 'wp_theme_json_data_blocks', new WP_Theme_JSON_Data_Gutenberg( $config, 'blocks' ) );
 		static::$blocks = $theme_json->get_theme_json();
@@ -544,7 +544,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 				 *
 				 * @since 6.1.0
 				 *
-				 * @param WP_Theme_JSON_Data_Gutenberg Class to access and update the underlying data.
+				 * @param WP_Theme_JSON_Data_Gutenberg $instance Class to access and update the underlying data.
 				 */
 				$theme_json = apply_filters( 'wp_theme_json_data_user', new WP_Theme_JSON_Data_Gutenberg( $config, 'custom' ) );
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue with several `apply_filters()` doc-blocks in WP_Theme_JSON_Resolver_Gutenberg where the `@param` name was missing.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
