### PR TITLE
Search block design fix with alignment

### DIFF
--- a/packages/block-library/src/search/style.scss
+++ b/packages/block-library/src/search/style.scss
@@ -1,6 +1,9 @@
 $button-spacing-x: $grid-unit-10 + math.div($grid-unit-05, 2); // 10px
 $button-spacing-y: math.div($grid-unit-15, 2); // 6px
 
+.wp-block-search{
+	display: contents !important;
+}
 .wp-block-search__button {
 	margin-left: $button-spacing-x;
 	word-break: normal;


### PR DESCRIPTION
Fixes #68179 

## What?
Properly apply a width to the search block when left or right alignment is set.

## Testing Instructions

1. Choose Search block.
2. Apply Alignment align-left or align-right.
3. Choose width 50% and see the difference.
4. Now choose width 25% and see the changes.
