### PR TITLE
Site Editor: Fix obsolete `getLocationWithParams` usage

### DIFF
--- a/packages/edit-site/src/components/add-new-pattern/index.js
+++ b/packages/edit-site/src/components/add-new-pattern/index.js
@@ -25,7 +25,7 @@ import {
 	TEMPLATE_PART_POST_TYPE,
 } from '../../utils/constants';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 const { CreatePatternModal, useAddPatternCategory } = unlock(
 	editPatternsPrivateApis
 );
@@ -33,6 +33,7 @@ const { CreateTemplatePartModal } = unlock( editorPrivateApis );
 
 export default function AddNewPattern() {
 	const history = useHistory();
+	const location = useLocation();
 	const [ showPatternModal, setShowPatternModal ] = useState( false );
 	const [ showTemplatePartModal, setShowTemplatePartModal ] =
 		useState( false );
@@ -159,13 +160,12 @@ export default function AddNewPattern() {
 						return;
 					}
 					try {
-						const {
-							params: { postType, categoryId },
-						} = history.getLocationWithParams();
 						let currentCategoryId;
 						// When we're not handling template parts, we should
 						// add or create the proper pattern category.
-						if ( postType !== TEMPLATE_PART_POST_TYPE ) {
+						if (
+							location.query.postType !== TEMPLATE_PART_POST_TYPE
+						) {
 							/*
 							 * categoryMap.values() returns an iterator.
 							 * Iterator.prototype.find() is not yet widely supported.
@@ -173,7 +173,10 @@ export default function AddNewPattern() {
 							 */
 							const currentCategory = Array.from(
 								categoryMap.values()
-							).find( ( term ) => term.name === categoryId );
+							).find(
+								( term ) =>
+									term.name === location.query.categoryId
+							);
 							if ( currentCategory ) {
 								currentCategoryId =
 									currentCategory.id ||
@@ -194,7 +197,7 @@ export default function AddNewPattern() {
 						// category.
 						if (
 							! currentCategoryId &&
-							categoryId !== 'my-patterns'
+							location.query.categoryId !== 'my-patterns'
 						) {
 							history.navigate(
 								`/pattern?categoryId=${ PATTERN_DEFAULT_CATEGORY }`

--- a/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
+++ b/packages/edit-site/src/components/sidebar-dataviews/custom-dataviews-list.js
@@ -27,7 +27,7 @@ import DataViewItem from './dataview-item';
 import AddNewItem from './add-new-view';
 import { unlock } from '../../lock-unlock';
 
-const { useHistory } = unlock( routerPrivateApis );
+const { useHistory, useLocation } = unlock( routerPrivateApis );
 
 const EMPTY_ARRAY = [];
 
@@ -85,6 +85,7 @@ function RenameItemModalContent( { dataviewId, currentTitle, setIsRenaming } ) {
 
 function CustomDataViewItem( { dataviewId, isActive } ) {
 	const history = useHistory();
+	const location = useLocation();
 	const { dataview } = useSelect(
 		( select ) => {
 			const { getEditedEntityRecord } = select( coreStore );
@@ -145,10 +146,10 @@ function CustomDataViewItem( { dataviewId, isActive } ) {
 											}
 										);
 										if ( isActive ) {
-											const {
-												params: { postType },
-											} = history.getLocationWithParams();
-											history.replace( { postType } );
+											history.replace( {
+												postType:
+													location.query.postType,
+											} );
 										}
 										onClose();
 									} }


### PR DESCRIPTION
## What?
Fixing two instances of `history.getLocationWithParams()` that were causing errors.

Reported in https://github.com/WordPress/gutenberg/pull/67199#issuecomment-2564397118 and #68367.

Fixes #68367.

## Why?
In #67199 we got rid of `useHistory()`'s `getLocationWithParams()` method. However, we forgot to update a couple of instances.

## How?
We're using `useLocation()` to retrieve query arguments.

## Testing Instructions
* Go to Site Editor > Patterns
* Import a pattern from a json file
* Verify it works well and you no longer get an error. 
* Verify you can still delete custom DataViews views.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
The error that was appearing in the snackbar notice:
<img width="1470" alt="399210539-2bc82b09-1dba-43ce-8f43-e3595976440e" src="https://github.com/user-attachments/assets/f7dfbc80-ca28-4dc5-adfe-9f311394daea" />

