### PR TITLE
fix: ensure `base_convert()` is type `int` before division

### DIFF
--- a/lib/block-supports/duotone.php
+++ b/lib/block-supports/duotone.php
@@ -309,7 +309,7 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 		);
 
 		$rgb['a'] = gutenberg_tinycolor_bound_alpha(
-			base_convert( $match[4], 16, 10 ) / 255
+			absint( base_convert( $match[4], 16, 10 ) ) / 255
 		);
 
 		return $rgb;
@@ -341,7 +341,7 @@ function gutenberg_tinycolor_string_to_rgb( $color_str ) {
 		);
 
 		$rgb['a'] = gutenberg_tinycolor_bound_alpha(
-			base_convert( $match[4] . $match[4], 16, 10 ) / 255
+			absint( base_convert( $match[4] . $match[4], 16, 10 ) ) / 255
 		);
 
 		return $rgb;

--- a/lib/class-wp-duotone-gutenberg.php
+++ b/lib/class-wp-duotone-gutenberg.php
@@ -206,7 +206,7 @@ class WP_Duotone_Gutenberg {
 				'r' => (int) base_convert( $hex[0] . $hex[0], 16, 10 ),
 				'g' => (int) base_convert( $hex[1] . $hex[1], 16, 10 ),
 				'b' => (int) base_convert( $hex[2] . $hex[2], 16, 10 ),
-				'a' => 4 === strlen( $hex ) ? round( base_convert( $hex[3] . $hex[3], 16, 10 ) / 255, 2 ) : 1,
+				'a' => 4 === strlen( $hex ) ? round( absint( base_convert( $hex[3] . $hex[3], 16, 10 ) ) / 255, 2 ) : 1,
 			);
 		}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes several issues of string-number division in duotone-related functionality, due to the direct use of `base_convert()` in the operation (which returns a numeric `string`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

`absint()` was used over casting for readability, since these are inline mathematical expressions. 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
