### PR TITLE
docs: fix param name in `gutenberg_add_can_update_block_bindings_editor_setting()`

### DIFF
--- a/lib/compat/wordpress-6.7/block-bindings.php
+++ b/lib/compat/wordpress-6.7/block-bindings.php
@@ -32,7 +32,7 @@ add_action( 'enqueue_block_editor_assets', 'gutenberg_bootstrap_server_block_bin
 /**
  * Initialize `canUpdateBlockBindings` editor setting if it doesn't exist. By default, it is `true` only for admin users.
  *
- * @param array $settings The block editor settings from the `block_editor_settings_all` filter.
+ * @param array $editor_settings The block editor settings from the `block_editor_settings_all` filter.
  * @return array The editor settings including `canUpdateBlockBindings`.
  */
 function gutenberg_add_can_update_block_bindings_editor_setting( $editor_settings ) {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue in the doc-block for `gutenberg_add_can_update_block_bindings_editor_setting()` where the param name ( `$settings` ) did not match that used in the function signature (`$editor_settings`).

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
