### PR TITLE
fix: check contents of `$matches[1]` in gutenberg_get_block_style_variation_name_from_class()

### DIFF
--- a/lib/block-supports/block-style-variations.php
+++ b/lib/block-supports/block-style-variations.php
@@ -38,7 +38,7 @@ function gutenberg_get_block_style_variation_name_from_class( $class_string ) {
 	}
 
 	preg_match_all( '/\bis-style-(?!default)(\S+)\b/', $class_string, $matches );
-	return $matches[1] ?? null;
+	return ! empty( $matches[1] ) ? $matches[1] : null;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue in `gutenberg_get_block_style_variation_name_from_class()` where an `array` would be returned even if the variation name was not matched in the CSS class string.

This is due to the fact that `preg_match_all()` will _always_ set `$matches[1]`, and instead uses an empty string if no match is found.


## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
