### PR TITLE
chore: remove always-true conditionals in `gutenberg_register_shadow_support()`

### DIFF
--- a/lib/block-supports/shadow.php
+++ b/lib/block-supports/shadow.php
@@ -21,13 +21,13 @@ function gutenberg_register_shadow_support( $block_type ) {
 		$block_type->attributes = array();
 	}
 
-	if ( $has_shadow_support && ! array_key_exists( 'style', $block_type->attributes ) ) {
+	if ( ! array_key_exists( 'style', $block_type->attributes ) ) {
 		$block_type->attributes['style'] = array(
 			'type' => 'object',
 		);
 	}
 
-	if ( $has_shadow_support && ! array_key_exists( 'shadow', $block_type->attributes ) ) {
+	if ( ! array_key_exists( 'shadow', $block_type->attributes ) ) {
 		$block_type->attributes['shadow'] = array(
 			'type' => 'string',
 		);


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR removes the unnecessary `$has_shadow_support` from the conditional checks inside `gutenberg_register_shadow_support()`, as the function already early-returns if `$has_shadow_support` is falsey.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
