### PR TITLE
Changing style block description

### DIFF
--- a/packages/edit-site/src/components/global-styles/screen-root.js
+++ b/packages/edit-site/src/components/global-styles/screen-root.js
@@ -100,7 +100,7 @@ function ScreenRoot() {
 					marginBottom={ 4 }
 				>
 					{ __(
-						'Customize the appearance of specific blocks for the whole site.'
+						'Customize the appearance of block types for the whole site.'
 					) }
 				</Spacer>
 				<ItemGroup>


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/43668

## Why?
Wording in the style block description is confusing as per the ticket details.

## How?
Changed the wording of the description as per the suggestion in ticket.

## Testing Instructions
Go to site editor.
Check global style settings.
Verify the change in the description.


## Screenshots or screencast <!-- if applicable -->


|Before|After|
|-|-|
|![Screenshot (9)](https://github.com/user-attachments/assets/56df9baa-05e5-45ed-9440-055d32717233)|![Screenshot (8)](https://github.com/user-attachments/assets/a57f33f0-5871-46d7-b7aa-e436633e3e82)|
