### PR TITLE
fix: invalid `_doing_it_wrong()` for `experimental-link-color`

### DIFF
--- a/lib/class-wp-theme-json-resolver-gutenberg.php
+++ b/lib/class-wp-theme-json-resolver-gutenberg.php
@@ -359,7 +359,7 @@ class WP_Theme_JSON_Resolver_Gutenberg {
 			}
 			if ( current_theme_supports( 'experimental-link-color' ) ) {
 				_doing_it_wrong(
-					current_theme_supports( 'experimental-link-color' ),
+					"add_theme_support( 'experimental-link-color' )",
 					__( '`experimental-link-color` is no longer supported. Use `link-color` instead.', 'gutenberg' ),
 					'6.3.0'
 				);


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue in `WP_Theme_JSON_Resolver_Gutenberg::get_theme_data()` where the `_doing_it_wrong()` _executes_ the `$function_name`, instead of providing a string.

The parameter has been updated to the string `"add_theme_support( 'experimental-link-color' )"`  since that's where the user is "doing_it_wrong()`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
