### PR TITLE
fix: remove invalid param from wp_register_style() in gutenberg_enqueue_stored_styles()

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -539,7 +539,7 @@ function gutenberg_enqueue_stored_styles( $options = array() ) {
 
 	// Combines Core styles.
 	if ( ! empty( $compiled_core_stylesheet ) ) {
-		wp_register_style( $style_tag_id, false, array(), true, true );
+		wp_register_style( $style_tag_id, false, array(), true );
 		wp_add_inline_style( $style_tag_id, $compiled_core_stylesheet );
 		wp_enqueue_style( $style_tag_id );
 	}
@@ -562,7 +562,7 @@ function gutenberg_enqueue_stored_styles( $options = array() ) {
 		$styles = gutenberg_style_engine_get_stylesheet_from_context( $store_name, $options );
 		if ( ! empty( $styles ) ) {
 			$key = "wp-style-engine-$store_name";
-			wp_register_style( $key, false, array(), true, true );
+			wp_register_style( $key, false, array(), true );
 			wp_add_inline_style( $key, $styles );
 			wp_enqueue_style( $key );
 		}


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue in `gutenberg_enqueue_stored_styles()` where `wp_register_style()` is called with an invalid `$media` arg value of `true`.

To resolve, the entire `$media` arg has been removed from the function call, in favor of the default `$media = 'all'`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
