### PR TITLE
fix: incorrect condiional check in Gutenberg_Token_Map_6_7::read_small_token()

### DIFF
--- a/lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php
+++ b/lib/compat/wordpress-6.7/class-gutenberg-token-map-6-7.php
@@ -607,7 +607,7 @@ class Gutenberg_Token_Map_6_7 {
 
 				if (
 					$search_text[ $adjust ] !== $this->small_words[ $at + $adjust ] &&
-					( ! $ignore_case || strtoupper( $this->small_words[ $at + $adjust ] !== $search_text[ $adjust ] ) )
+					( ! $ignore_case || strtoupper( $this->small_words[ $at + $adjust ] ) !== $search_text[ $adjust ] )
 				) {
 					$at += $this->key_length + 1;
 					continue 2;


### PR DESCRIPTION

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue in `Gutenberg_Token_Map_6_7::read_small_token()` where a misplaced `)` results in a `strtoupper( {... text check logic ... }`, causing the conditional to incorrectly handle case-insensitive checks.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
