### PR TITLE
fix: setcookie() $value must be string in Gutenberg_HTTP_Signaling_Server::handle_read_pending_messages()

### DIFF
--- a/lib/experimental/sync/class-gutenberg-http-signaling-server.php
+++ b/lib/experimental/sync/class-gutenberg-http-signaling-server.php
@@ -172,7 +172,7 @@ class Gutenberg_HTTP_Signaling_Server {
 		if ( ! $fd ) {
 			$retries = isset( $_COOKIE['signaling_server_retries'] ) ? intval( $_COOKIE['signaling_server_retries'] ) : 0;
 			$secure  = ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) );
-			setcookie( 'signaling_server_retries', $retries + 1, time() + DAY_IN_SECONDS, SITECOOKIEPATH, '', $secure );
+			setcookie( 'signaling_server_retries', (string) ( $retries + 1 ), time() + DAY_IN_SECONDS, SITECOOKIEPATH, '', $secure );
 			echo 'id: ' . time() . PHP_EOL;
 			echo 'event: error' . PHP_EOL;
 			echo 'data: ' . 'Could not open required file.' . PHP_EOL . PHP_EOL;
@@ -183,7 +183,7 @@ class Gutenberg_HTTP_Signaling_Server {
 		if ( isset( $_COOKIE['signaling_server_retries'] ) ) {
 			$secure = ( 'https' === parse_url( home_url(), PHP_URL_SCHEME ) );
 			// unset the cookie using a past expiration date.
-			setcookie( 'signaling_server_retries', 0, time() - DAY_IN_SECONDS, SITECOOKIEPATH, '', $secure );
+			setcookie( 'signaling_server_retries', '0', time() - DAY_IN_SECONDS, SITECOOKIEPATH, '', $secure );
 		}
 
 		echo 'retry: 3000' . PHP_EOL;


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

This PR fixes an issue in `Gutenberg_HTTP_Signaling_Server::handle_read_pending_messages()` where the `$value` used in `setcookie()` is passed as an `integer` instead of type `string`.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

While this issue was surfaced by PHPStan (via #66693) it can be remediated independently as part of #66598

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
