### PR TITLE
Fix: Page scroll is restricted when block inserter is shown in the editor

### DIFF
--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -84,7 +84,7 @@ $block-inserter-tabs-height: 44px;
 	outline: none;
 	padding: 0;
 	transition: color 0.2s ease;
-	@include reduce-motion("transition");
+	@include reduce-motion( "transition" );
 }
 
 .block-editor-inserter__menu {
@@ -147,7 +147,8 @@ $block-inserter-tabs-height: 44px;
 	font-weight: 500;
 }
 
-.block-editor-inserter__panel-dropdown select.components-select-control__input.components-select-control__input.components-select-control__input {
+.block-editor-inserter__panel-dropdown
+select.components-select-control__input.components-select-control__input.components-select-control__input {
 	height: 36px;
 	line-height: 36px;
 }
@@ -317,14 +318,17 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-.block-editor-inserter__quick-inserter-results .block-editor-inserter__panel-header {
+.block-editor-inserter__quick-inserter-results
+.block-editor-inserter__panel-header {
 	height: 0;
 	padding: 0;
 	float: left;
 }
 
-.block-editor-inserter__quick-inserter.has-search .block-editor-inserter__panel-content,
-.block-editor-inserter__quick-inserter.has-expand .block-editor-inserter__panel-content {
+.block-editor-inserter__quick-inserter.has-search
+.block-editor-inserter__panel-content,
+.block-editor-inserter__quick-inserter.has-expand
+.block-editor-inserter__panel-content {
 	padding: $grid-unit-20;
 }
 
@@ -522,7 +526,10 @@ $block-inserter-tabs-height: 44px;
 			}
 
 			&:hover {
-				box-shadow: inset 0 0 0 2px $white, 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
+				box-shadow:
+					inset 0 0 0 2px $white,
+					0 0 0 var(--wp-admin-border-width-focus)
+					var(--wp-admin-theme-color);
 
 				// Windows High Contrast mode will show this outline, but not the box-shadow.
 				outline: 2px solid transparent;
@@ -533,11 +540,11 @@ $block-inserter-tabs-height: 44px;
 
 .block-editor-inserter__media-list__item {
 	height: 100%;
+	overflow: auto;
 
 	.block-editor-inserter__media-list__item-preview {
 		display: flex;
 		align-items: center;
-		overflow: hidden;
 		border-radius: $radius-small;
 
 		> * {
@@ -562,9 +569,9 @@ $block-inserter-tabs-height: 44px;
 	&:focus .block-editor-inserter__media-list__item-preview > * {
 		outline-color: var(--wp-admin-theme-color);
 		outline-width: var(--wp-admin-border-width-focus);
-		outline-offset: calc((-1 * var(--wp-admin-border-width-focus)));
+		outline-offset: calc(( -1 * var(--wp-admin-border-width-focus) ));
 		transition: outline 0.1s linear;
-		@include reduce-motion("transition");
+		@include reduce-motion( "transition" );
 	}
 }
 
@@ -574,7 +581,6 @@ $block-inserter-tabs-height: 44px;
 	}
 }
 
-
 .block-editor-inserter__mobile-tab-navigation {
 	padding: $grid-unit-20;
 	height: 100%;
@@ -583,7 +589,6 @@ $block-inserter-tabs-height: 44px;
 		height: 100%;
 	}
 }
-
 
 .block-editor-inserter-media-tab-media-preview-inserter-external-image-modal {
 	@include break-small() {
@@ -627,7 +632,8 @@ $block-inserter-tabs-height: 44px;
 
 .show-icon-labels {
 	@media (max-width: #{ ($break-large - 1) }) {
-		.block-editor-block-patterns-explorer .block-editor-patterns__grid-pagination {
+		.block-editor-block-patterns-explorer
+		.block-editor-patterns__grid-pagination {
 			flex-direction: column;
 			.block-editor-patterns__grid-pagination-previous,
 			.block-editor-patterns__grid-pagination-next {
@@ -636,7 +642,8 @@ $block-inserter-tabs-height: 44px;
 		}
 	}
 
-	.block-editor-inserter__category-panel .block-editor-patterns__grid-pagination {
+	.block-editor-inserter__category-panel
+	.block-editor-patterns__grid-pagination {
 		flex-direction: column;
 		.block-editor-patterns__grid-pagination-previous,
 		.block-editor-patterns__grid-pagination-next {


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->

## Why?
Fixes issue number https://github.com/WordPress/gutenberg/issues/68381

## How?
Updates the `overflow` property 

## Testing Instructions
1. Open editor
2. Hover between blocks to see block inserter
3. Now try scrolling the page (mouse is on block inserter)
4. Observe that page scroll is disabled.

## Screenshots or screencast <!-- if applicable -->
