### PR TITLE
[Block Library]: A11y -  Add and Update missing `reduce-motion` mixing

### DIFF
--- a/packages/block-editor/src/components/block-canvas/style.scss
+++ b/packages/block-editor/src/components/block-canvas/style.scss
@@ -4,7 +4,8 @@ iframe[name="editor-canvas"] {
 	height: 100%;
 	display: block;
 	// Handles transitions between device previews
-	transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: all 400ms cubic-bezier(0.46, 0.03, 0.52, 0.96);
+	}
 	background-color: $gray-300;
 }

--- a/packages/block-editor/src/components/block-draggable/style.scss
+++ b/packages/block-editor/src/components/block-draggable/style.scss
@@ -59,7 +59,9 @@
 	justify-content: center;
 	align-items: center;
 	background-color: transparent;
-	transition: all 0.1s linear 0.1s;
+	@media not ( prefers-reduced-motion ) {
+		transition: all 0.1s linear 0.1s;
+	}
 
 	.block-editor-block-draggable-chip__disabled-icon {
 		width: $grid-unit-50 * 0.5;

--- a/packages/block-editor/src/components/block-list/content.scss
+++ b/packages/block-editor/src/components/block-list/content.scss
@@ -58,10 +58,12 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 			background: var(--wp-admin-theme-color);
 			opacity: 0.4;
 
-			// Animate.
-			animation: selection-overlay__fade-in-animation 0.1s ease-out;
-			animation-fill-mode: forwards;
-			@include reduce-motion("animation");
+			@media not ( prefers-reduced-motion ) {
+
+				// Animate.
+				animation: selection-overlay__fade-in-animation 0.1s ease-out;
+				animation-fill-mode: forwards;
+			}
 
 			// Show outline in high contrast mode.
 			outline: 2px solid transparent;
@@ -271,8 +273,9 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 // Spotlight mode. Fade out blocks unless they contain a selected block.
 .is-focus-mode .block-editor-block-list__block:not(.has-child-selected) {
 	opacity: 0.2;
-	transition: opacity 0.1s linear;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: opacity 0.1s linear;
+	}
 
 	// Nested blocks should never be faded. If the parent block is already faded
 	// out, it shouldn't be faded out more. If the parent block in not faded
@@ -339,9 +342,10 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 // Hide the appender that sits at the end of block lists, when inside a nested block,
 // unless the block itself, or a parent, is selected.
 .wp-block .block-list-appender .block-editor-inserter__toggle {
-	animation: block-editor-inserter__toggle__fade-in-animation 0.1s ease;
-	animation-fill-mode: forwards;
-	@include reduce-motion("animation");
+	@media not ( prefers-reduced-motion ) {
+		animation: block-editor-inserter__toggle__fade-in-animation 0.1s ease;
+		animation-fill-mode: forwards;
+	}
 }
 
 .block-editor-block-list__block:not(.is-selected):not(.has-child-selected) .block-editor-default-block-appender {
@@ -367,8 +371,9 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	font-family: $editor-html-font;
 	font-size: $text-editor-font-size;
 	line-height: 1.5;
-	transition: padding 0.2s linear;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: padding 0.2s linear;
+	}
 
 	&:focus {
 		box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus) var(--wp-admin-theme-color);
@@ -400,7 +405,9 @@ _::-webkit-full-page-media, _:future, :root [data-has-multi-selection="true"] .b
 	// Additional -1px is required to avoid sub pixel rounding errors allowing background to show.
 	margin-left: -1px;
 	margin-right: -1px;
-	transition: background-color 0.3s ease;
+	@media not ( prefers-reduced-motion ) {
+		transition: background-color 0.3s ease;
+	}
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/packages/block-editor/src/components/block-mover/style.scss
+++ b/packages/block-editor/src/components/block-mover/style.scss
@@ -87,10 +87,11 @@
 		right: $grid-unit-10;
 		z-index: -1;
 
-		// Animate in.
-		animation: components-button__appear-animation 0.1s ease;
-		animation-fill-mode: forwards;
-		@include reduce-motion("animation");
+		@media not ( prefers-reduced-motion ) {
+			// Animate in.
+			animation: components-button__appear-animation 0.1s ease;
+			animation-fill-mode: forwards;
+		}
 	}
 
 	// Don't show the focus inherited by the Button component.

--- a/packages/block-editor/src/components/block-pattern-setup/style.scss
+++ b/packages/block-editor/src/components/block-pattern-setup/style.scss
@@ -130,7 +130,9 @@
 				background-color: $white;
 				margin: auto;
 				padding: 0;
-				transition: transform 0.5s, z-index 0.5s;
+				@media not ( prefers-reduced-motion ) {
+					transition: transform 0.5s, z-index 0.5s;
+				}
 				z-index: z-index(".block-editor-block-pattern-setup .pattern-slide");
 
 				&.active-slide {

--- a/packages/block-editor/src/components/block-patterns-list/style.scss
+++ b/packages/block-editor/src/components/block-patterns-list/style.scss
@@ -44,9 +44,9 @@
 			outline: $border-width solid rgba($black, 0.1);
 			outline-offset: -$border-width;
 			border-radius: $radius-medium;
-
-			transition: outline 0.1s linear;
-			@include reduce-motion("transition");
+			@media not ( prefers-reduced-motion ) {
+				transition: outline 0.1s linear;
+			}
 		}
 	}
 

--- a/packages/block-editor/src/components/block-switcher/style.scss
+++ b/packages/block-editor/src/components/block-switcher/style.scss
@@ -129,7 +129,9 @@
 		.block-editor-block-switcher__preview-patterns-container-list__item {
 			height: 100%;
 			border-radius: $radius-small;
-			transition: all 0.05s ease-in-out;
+			@media not ( prefers-reduced-motion ) {
+				transition: all 0.05s ease-in-out;
+			}
 			position: relative;
 			border: $border-width solid transparent;
 

--- a/packages/block-editor/src/components/block-toolbar/style.scss
+++ b/packages/block-editor/src/components/block-toolbar/style.scss
@@ -12,9 +12,11 @@
 	overflow-y: hidden;
 	overflow-x: auto;
 
-	// Animation
-	transition: border-color 0.1s linear, box-shadow 0.1s linear;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+
+		// Animation
+		transition: border-color 0.1s linear, box-shadow 0.1s linear;
+	}
 
 	@include break-small() {
 		overflow: inherit;

--- a/packages/block-editor/src/components/block-tools/style.scss
+++ b/packages/block-editor/src/components/block-tools/style.scss
@@ -191,9 +191,12 @@
 
 	.is-dragging-components-draggable & {
 		opacity: 0;
-		// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details.
-		// It's essential to hide the toolbar/popover so that `dragEnter` events can pass through them to the underlying elements.
-		animation: hide-during-dragging 1ms linear forwards;
+		@media not ( prefers-reduced-motion ) {
+
+			// Use a minimal duration to delay hiding the element, see hide-during-dragging animation for more details.
+			// It's essential to hide the toolbar/popover so that `dragEnter` events can pass through them to the underlying elements.
+			animation: hide-during-dragging 1ms linear forwards;
+		}
 	}
 
 	.block-editor-block-parent-selector {

--- a/packages/block-editor/src/components/button-block-appender/content.scss
+++ b/packages/block-editor/src/components/button-block-appender/content.scss
@@ -79,10 +79,8 @@
 		background-color: var(--wp-admin-theme-color);
 		box-shadow: inset 0 0 0 $border-width $light-gray-placeholder;
 		color: $light-gray-placeholder;
-		transition: background-color 0.2s ease-in-out;
-
-		@media ( prefers-reduced-motion: reduce ) {
-			transition: none;
+		@media not ( prefers-reduced-motion ) {
+			transition: background-color 0.2s ease-in-out;
 		}
 	}
 }

--- a/packages/block-editor/src/components/colors-gradients/style.scss
+++ b/packages/block-editor/src/components/colors-gradients/style.scss
@@ -128,8 +128,9 @@ $swatch-gap: 12px;
 	top: $grid-unit;
 	margin: auto $grid-unit auto;
 	opacity: 0;
-	transition: opacity 0.1s ease-in-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: opacity 0.1s ease-in-out;
+	}
 
 	&.block-editor-panel-color-gradient-settings__reset {
 		border-radius: $radius-small;

--- a/packages/block-editor/src/components/global-styles/style.scss
+++ b/packages/block-editor/src/components/global-styles/style.scss
@@ -53,7 +53,9 @@
 	box-sizing: border-box;
 
 	transform: scale(1);
-	transition: transform 0.1s ease;
+	@media not ( prefers-reduced-motion ) {
+		transition: transform 0.1s ease;
+	}
 	will-change: transform;
 
 	&:focus {

--- a/packages/block-editor/src/components/grid/style.scss
+++ b/packages/block-editor/src/components/grid/style.scss
@@ -125,10 +125,11 @@
 			right: $grid-unit-10;
 			z-index: -1;
 
-			// Animate in.
-			animation: components-button__appear-animation 0.1s ease;
-			animation-fill-mode: forwards;
-			@include reduce-motion("animation");
+			@media not ( prefers-reduced-motion ) {
+				// Animate in.
+				animation: components-button__appear-animation 0.1s ease;
+				animation-fill-mode: forwards;
+			}
 		}
 
 		// Don't show the focus inherited by the Button component.

--- a/packages/block-editor/src/components/iframe/content.scss
+++ b/packages/block-editor/src/components/iframe/content.scss
@@ -4,8 +4,11 @@
 
 .block-editor-iframe__html {
 	transform-origin: top center;
-	// Prevents a flash of background color change when entering/exiting zoom out
-	transition: background-color 400ms;
+
+	@media not ( prefers-reduced-motion ) {
+		// Prevents a flash of background color change when entering/exiting zoom out
+		transition: background-color 400ms;
+	}
 
 	&.zoom-out-animation {
 		$scroll-top: var(--wp-block-editor-iframe-zoom-out-scroll-top, 0);

--- a/packages/block-editor/src/components/inserter-list-item/style.scss
+++ b/packages/block-editor/src/components/inserter-list-item/style.scss
@@ -43,8 +43,9 @@
 	cursor: pointer;
 	background: transparent;
 	word-break: break-word;
-	transition: all 0.05s ease-in-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: all 0.05s ease-in-out;
+	}
 	position: relative;
 	height: auto;
 
@@ -97,8 +98,9 @@
 .block-editor-block-types-list__item-icon {
 	padding: 12px 20px;
 	color: $gray-900;
-	transition: all 0.05s ease-in-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: all 0.05s ease-in-out;
+	}
 
 	.block-editor-block-icon {
 		margin-left: auto;
@@ -106,8 +108,9 @@
 	}
 
 	svg {
-		transition: all 0.15s ease-out;
-		@include reduce-motion("transition");
+		@media not ( prefers-reduced-motion ) {
+			transition: all 0.15s ease-out;
+		}
 	}
 
 	.block-editor-block-types-list__list-item[draggable="true"] & {

--- a/packages/block-editor/src/components/inserter/style.scss
+++ b/packages/block-editor/src/components/inserter/style.scss
@@ -83,8 +83,9 @@ $block-inserter-tabs-height: 44px;
 	border: none;
 	outline: none;
 	padding: 0;
-	transition: color 0.2s ease;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: color 0.2s ease;
+	}
 }
 
 .block-editor-inserter__menu {
@@ -563,8 +564,9 @@ $block-inserter-tabs-height: 44px;
 		outline-color: var(--wp-admin-theme-color);
 		outline-width: var(--wp-admin-border-width-focus);
 		outline-offset: calc((-1 * var(--wp-admin-border-width-focus)));
-		transition: outline 0.1s linear;
-		@include reduce-motion("transition");
+		@media not ( prefers-reduced-motion ) {
+			transition: outline 0.1s linear;
+		}
 	}
 }
 

--- a/packages/block-editor/src/components/link-control/style.scss
+++ b/packages/block-editor/src/components/link-control/style.scss
@@ -289,8 +289,10 @@ $block-editor-link-control-number-of-actions: 1;
 			right: 0;
 			bottom: 0;
 			border-radius: 100%;
-			animation: loadingpulse 1s linear infinite;
-			animation-delay: 0.5s; // avoid animating for fast network responses
+			@media not ( prefers-reduced-motion ) {
+				animation: loadingpulse 1s linear infinite;
+				animation-delay: 0.5s; // avoid animating for fast network responses
+			}
 		}
 	}
 }
@@ -381,16 +383,19 @@ $block-editor-link-control-number-of-actions: 1;
 		// Point downwards when open (same as list view expander)
 		&[aria-expanded="true"] svg {
 			visibility: visible;
-			transition: transform 0.1s ease;
+			@media not ( prefers-reduced-motion ) {
+				transition: transform 0.1s ease;
+			}
 			transform: rotate(90deg);
-			@include reduce-motion("transition");
+
 		}
 		// Point rightwards when closed (same as list view expander)
 		&[aria-expanded="false"] svg {
 			visibility: visible;
 			transform: rotate(0deg);
-			transition: transform 0.1s ease;
-			@include reduce-motion("transition");
+			@media not ( prefers-reduced-motion ) {
+				transition: transform 0.1s ease;
+			}
 		}
 	}
 }

--- a/packages/block-editor/src/components/list-view/style.scss
+++ b/packages/block-editor/src/components/list-view/style.scss
@@ -158,21 +158,27 @@
 	// without attaching the transition to the list view leaf itself. This prevents rows
 	// from animating too much once the user has dropped the block.
 	&.is-displacement-normal {
-		transition: transform 0.2s;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.2s;
+		}
 		transform: translateY(0);
-		@include reduce-motion("transition");
+
 	}
 
 	&.is-displacement-up {
-		transition: transform 0.2s;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.2s;
+		}
 		transform: translateY(-32px);
-		@include reduce-motion("transition");
+
 	}
 
 	&.is-displacement-down {
-		transition: transform 0.2s;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.2s;
+		}
 		transform: translateY(32px);
-		@include reduce-motion("transition");
+
 	}
 
 	// Collapse multi-selections down into a single row space while dragging. The following
@@ -180,23 +186,30 @@
 	// when displacing up and down. The result is that there should only ever be a single row's
 	// worth of space for the visual indicator of where a block will be placed when dropped.
 	&.is-after-dragged-blocks {
-		transition: transform 0.2s;
+
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.2s;
+		}
 		transform: translateY(calc(var(--wp-admin--list-view-dragged-items-height, 32px) * -1));
-		@include reduce-motion("transition");
+
 	}
 
 	&.is-after-dragged-blocks.is-displacement-up {
-		transition: transform 0.2s;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.2s;
+		}
 		transform: translateY(calc(-32px + var(--wp-admin--list-view-dragged-items-height, 32px) * -1));
-		@include reduce-motion("transition");
+
 	}
 
 	&.is-after-dragged-blocks.is-displacement-down {
-		transition: transform 0.2s;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.2s;
+		}
 		transform:
 			translateY(calc(32px + var(--wp-admin--list-view-dragged-items-height, 32px) *
 			-1));
-		@include reduce-motion("transition");
+
 	}
 
 	// To ensure displaced rows behave correctly, ensure that blocks that are currently being dragged
@@ -233,7 +246,9 @@
 		font-weight: 400;
 		margin: 0;
 		text-decoration: none;
-		transition: box-shadow 0.1s linear;
+		@media not ( prefers-reduced-motion ) {
+			transition: box-shadow 0.1s linear;
+		}
 
 		.components-modal__content & {
 			padding-left: 0;
@@ -500,9 +515,10 @@ $block-navigation-max-indent: 8;
 .block-editor-list-view__expander
 svg {
 	visibility: visible;
-	transition: transform 0.2s ease;
+	@media not ( prefers-reduced-motion ) {
+		transition: transform 0.2s ease;
+	}
 	transform: rotate(90deg);
-	@include reduce-motion("transition");
 }
 
 // Point rightwards when closed
@@ -511,8 +527,9 @@ svg {
 svg {
 	visibility: visible;
 	transform: rotate(0deg);
-	transition: transform 0.2s ease;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: transform 0.2s ease;
+	}
 }
 
 .block-editor-list-view-drop-indicator {

--- a/packages/block-editor/src/components/url-input/style.scss
+++ b/packages/block-editor/src/components/url-input/style.scss
@@ -33,8 +33,9 @@ $input-size: 300px;
 // Suggestions
 .block-editor-url-input__suggestions {
 	max-height: 200px;
-	transition: all 0.15s ease-in-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: all 0.15s ease-in-out;
+	}
 	padding: 4px 0;
 	// To match the url-input width: input width + padding + 2 buttons.
 	width: $input-size + 2;

--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -240,8 +240,9 @@
 
 div[data-type="core/freeform"] {
 	&::before {
-		transition: border-color 0.1s linear, box-shadow 0.1s linear;
-		@include reduce-motion("transition");
+		@media not ( prefers-reduced-motion ) {
+			transition: border-color 0.1s linear, box-shadow 0.1s linear;
+		}
 		border: $border-width solid $gray-300;
 
 		// Windows High Contrast mode will show this outline.

--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -137,8 +137,9 @@
 	top: -2px;
 	margin: $grid-unit-10;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
-	transition: box-shadow 0.2s ease-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: box-shadow 0.2s ease-out;
+	}
 	border-radius: $radius-small;
 	background: $white;
 	border: $border-width solid $gray-900;

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -167,7 +167,9 @@
 		text-align: center;
 		padding: 0;
 		border-radius: 4px;
-		transition: opacity 0.2s ease;
+		@media not ( prefers-reduced-motion ) {
+			transition: opacity 0.2s ease;
+		}
 
 		&:focus-visible {
 			outline: 3px auto rgb(90 90 90 / 25%);
@@ -280,16 +282,24 @@
 	// or faster than the scrim to give a sense of depth.
 	&.active {
 		visibility: visible;
-		animation: both turn-on-visibility 0.25s;
+		@media not ( prefers-reduced-motion ) {
+			animation: both turn-on-visibility 0.25s;
+		}
 		img {
-			animation: both turn-on-visibility 0.35s;
+			@media not ( prefers-reduced-motion ) {
+				animation: both turn-on-visibility 0.35s;
+			}
 		}
 	}
 	&.show-closing-animation {
 		&:not(.active) {
-			animation: both turn-off-visibility 0.35s;
+			@media not ( prefers-reduced-motion ) {
+				animation: both turn-off-visibility 0.35s;
+			}
 			img {
-				animation: both turn-off-visibility 0.25s;
+				@media not ( prefers-reduced-motion ) {
+					animation: both turn-off-visibility 0.25s;
+				}
 			}
 		}
 	}

--- a/packages/block-library/src/image/style.scss
+++ b/packages/block-library/src/image/style.scss
@@ -167,7 +167,7 @@
 		text-align: center;
 		padding: 0;
 		border-radius: 4px;
-		@media not ( prefers-reduced-motion ) {
+		@media (prefers-reduced-motion: no-preference) {
 			transition: opacity 0.2s ease;
 		}
 
@@ -282,22 +282,22 @@
 	// or faster than the scrim to give a sense of depth.
 	&.active {
 		visibility: visible;
-		@media not ( prefers-reduced-motion ) {
+		@media (prefers-reduced-motion: no-preference) {
 			animation: both turn-on-visibility 0.25s;
 		}
 		img {
-			@media not ( prefers-reduced-motion ) {
+			@media (prefers-reduced-motion: no-preference) {
 				animation: both turn-on-visibility 0.35s;
 			}
 		}
 	}
 	&.show-closing-animation {
 		&:not(.active) {
-			@media not ( prefers-reduced-motion ) {
+			@media (prefers-reduced-motion: no-preference) {
 				animation: both turn-off-visibility 0.35s;
 			}
 			img {
-				@media not ( prefers-reduced-motion ) {
+				@media (prefers-reduced-motion: no-preference) {
 					animation: both turn-off-visibility 0.25s;
 				}
 			}

--- a/packages/block-library/src/navigation/style.scss
+++ b/packages/block-library/src/navigation/style.scss
@@ -166,7 +166,9 @@ $navigation-icon-size: 24px;
 
 		// Hide until hover or focus within.
 		opacity: 0;
-		transition: opacity 0.1s linear;
+		@media not ( prefers-reduced-motion ) {
+			transition: opacity 0.1s linear;
+		}
 		visibility: hidden;
 
 		// Don't take up space when the menu is collapsed.
@@ -502,9 +504,10 @@ button.wp-block-navigation-item__content {
 		background-color: inherit;
 
 		// Animation.
-		animation: overlay-menu__fade-in-animation 0.1s ease-out;
-		animation-fill-mode: forwards;
-		@include reduce-motion("animation");
+		@media not ( prefers-reduced-motion ) {
+			animation: overlay-menu__fade-in-animation 0.1s ease-out;
+			animation-fill-mode: forwards;
+		}
 
 		// Try to inherit any root paddings set, so the X can align to a top-right aligned menu.
 		padding-top: clamp(1rem, var(--wp--style--root--padding-top), 20rem);

--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -70,8 +70,9 @@
 .wp-block-social-link {
 	display: block;
 	border-radius: 9999px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
-	transition: transform 0.1s ease;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: transform 0.1s ease;
+	}
 
 	// Dimensions.
 	height: auto;
@@ -80,7 +81,9 @@
 		align-items: center;
 		display: flex;
 		line-height: 0;
-		transition: transform 0.1s ease;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.1s ease;
+		}
 	}
 
 	&:hover {


### PR DESCRIPTION
Part of #68282

## What?

Refactors animation and transition styles to use @media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?

Currently, many parts of the codebase do not consider users' motion preferences, which may not be ideal for those with reduced motion settings. This PR addresses and fixes that issue.

## How?

This PR updates the old reduce-motion mixin implementation and addresses missing cases to adopt the new approach outlined in the parent issue.

```SASS
	@media not ( prefers-reduced-motion ) {
			transition: opacity 0.1s linear;
		}
```

Standard adopted from @wordpress/components


# Navigation Block
##  Testing Instructions
1. **Open the Block Editor**  
   - Navigate to the WordPress Block Editor.

2. **Add a Navigation Block**  
   - Insert a Navigation block.  
   - Create a menu and include submenus and nested submenus.

3. **Test Normal Behavior**  
   - Hover over the submenu and nested submenus.  
   - Observe the opening and closing animations/transitions.

4. **Test with Reduced Motion Preference**  
   - Enable the "Reduced Motion" preference:  
     - Open Chrome DevTools.  
     - Go to **More Tools** > **Rendering**.  
     - Under "Emulate CSS media feature prefers-reduced-motion," select **Reduce**.  
   - Repeat the tests:  
     - Hover over the submenu and nested submenus.  
     - Observe the behavior to ensure animations are disabled or minimized as expected.

5. **Disable Reduced Motion Preference**  
   - Turn off the "Reduced Motion" preference in DevTools.  
   - Verify that all original animations and transitions work correctly.
   
## Screencast
(its hard to notice the difference, because its only 0.1s.)

https://github.com/user-attachments/assets/a6fba2d1-ae9b-437e-b1df-846c5da60b41

https://github.com/user-attachments/assets/6d6fc6ed-a605-4b02-a0e2-54e99184ae4c

# Social Block
## Testing Instructions

1. **Open the Block Editor**  
   - Navigate to the WordPress Block Editor.

2. **Add a Social Block**  
   - Insert a Social block.  
   - Add a few icons.

3. **Test Normal Behavior**  
   - Hover over the icons.  
   - Observe the zoom in and out animations/transitions.

4. **Test with Reduced Motion Preference**  
   - Enable the "Reduced Motion" preference:  
     - Open Chrome DevTools.  
     - Go to **More Tools** > **Rendering**.  
     - Under "Emulate CSS media feature prefers-reduced-motion," select **Reduce**.  
   - Repeat the tests:  
     - Hover over the icons.  
     - Observe the behavior to ensure animations are disabled or minimized as expected.

5. **Disable Reduced Motion Preference**  
   - Turn off the "Reduced Motion" preference in DevTools.  
   - Verify that all original animations and transitions work correctly.

## Screencast

https://github.com/user-attachments/assets/6387843e-687c-4281-adda-c37085b10664

# Gallery Block

## Considerations

The code is largely deprecated, so I'm unsure if this PR is necessary, especially since we might be cleaning up the CSS soon.

# FreeForm Block (classic editor)

## Screencast

https://github.com/user-attachments/assets/29c6108e-b3b8-4466-9df0-c95766cd398f

# Image Block

1. **Open the Block Editor**  
   - Navigate to the WordPress Block Editor.

2. **Add an Image Block**  
   - Insert an Image block and upload an image.

3. **Enable the Lightbox Feature**  
   - In the block settings, enable the Lightbox feature.

4. **Test Normal Behavior**  
   - Click on the image to open the Lightbox.  
   - Observe the opening and closing animations.  
   - Test the zoom functionality.

5. **Test with Reduced Motion Preference**  
   - Enable the "Reduced Motion" preference:  
     - Open Chrome DevTools.  
     - Go to **More Tools** > **Rendering**.  
     - Under "Emulate CSS media feature prefers-reduced-motion," select **Reduce**.  
   - Repeat the tests:  
     - Click on the image to open the Lightbox.  
     - Verify that the Lightbox opens and closes without animations.  
     - Ensure there are no zoom animations.

6. **Disable Reduced Motion Preference**  
   - Turn off the "Reduced Motion" preference in DevTools.  
   - Verify that all original animations, including opening/closing and zoom, work correctly.
   
   



