### PR TITLE
[Social Block]: A11y - Add and Update missing reduce-motion mixing

### DIFF
--- a/packages/block-library/src/social-links/style.scss
+++ b/packages/block-library/src/social-links/style.scss
@@ -70,8 +70,9 @@
 .wp-block-social-link {
 	display: block;
 	border-radius: 9999px; // This makes it pill-shaped instead of oval, in cases where the image fed is not perfectly sized.
-	transition: transform 0.1s ease;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: transform 0.1s ease;
+	}
 
 	// Dimensions.
 	height: auto;
@@ -80,7 +81,9 @@
 		align-items: center;
 		display: flex;
 		line-height: 0;
-		transition: transform 0.1s ease;
+		@media not ( prefers-reduced-motion ) {
+			transition: transform 0.1s ease;
+		}
 	}
 
 	&:hover {


### PR DESCRIPTION
part of #68282

## What?

Refactors animation and transition styles to use @media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?

Currently, many parts of the codebase do not consider users' motion preferences, which may not be ideal for those with reduced motion settings. This PR addresses and fixes that issue.

## How?

This PR updates the old reduce-motion mixin implementation and addresses missing cases to adopt the new approach outlined in the parent issue.

```SASS
	@media not ( prefers-reduced-motion ) {
			transition: opacity 0.1s linear;
		}
```

Standard adopted from @wordpress/components

## Testing Instructions

1. **Open the Block Editor**  
   - Navigate to the WordPress Block Editor.

2. **Add a Social Block**  
   - Insert a Social block.  
   - Add a few icons.

3. **Test Normal Behavior**  
   - Hover over the icons.  
   - Observe the zoom in and out animations/transitions.

4. **Test with Reduced Motion Preference**  
   - Enable the "Reduced Motion" preference:  
     - Open Chrome DevTools.  
     - Go to **More Tools** > **Rendering**.  
     - Under "Emulate CSS media feature prefers-reduced-motion," select **Reduce**.  
   - Repeat the tests:  
     - Hover over the icons.  
     - Observe the behavior to ensure animations are disabled or minimized as expected.

5. **Disable Reduced Motion Preference**  
   - Turn off the "Reduced Motion" preference in DevTools.  
   - Verify that all original animations and transitions work correctly.

## Screencast

https://github.com/user-attachments/assets/6387843e-687c-4281-adda-c37085b10664


 
