### PR TITLE
[Gallery Block]: A11y - Add and Update missing reduce-motion mixing - mostly depreciated

### DIFF
--- a/packages/block-library/src/gallery/editor.scss
+++ b/packages/block-library/src/gallery/editor.scss
@@ -137,8 +137,9 @@
 	top: -2px;
 	margin: $grid-unit-10;
 	z-index: z-index(".block-library-gallery-item__inline-menu");
-	transition: box-shadow 0.2s ease-out;
-	@include reduce-motion("transition");
+	@media not ( prefers-reduced-motion ) {
+		transition: box-shadow 0.2s ease-out;
+	}
 	border-radius: $radius-small;
 	background: $white;
 	border: $border-width solid $gray-900;


### PR DESCRIPTION
Part of #68282

## Considerations

The code is largely deprecated, so I'm unsure if this PR is necessary, especially since we might be cleaning up the CSS soon.

## What?

Refactors animation and transition styles to use @media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?

Currently, many parts of the codebase do not consider users' motion preferences, which may not be ideal for those with reduced motion settings. This PR addresses and fixes that issue.

## How?

This PR updates the old reduce-motion mixin implementation and addresses missing cases to adopt the new approach outlined in the parent issue.

```SASS
	@media not ( prefers-reduced-motion ) {
			transition: opacity 0.1s linear;
		}
```

Standard adopted from @wordpress/components

