### PR TITLE
[FreeForm Block]: A11y - Add and Update missing reduce-motion mixing

### DIFF
--- a/packages/block-library/src/freeform/editor.scss
+++ b/packages/block-library/src/freeform/editor.scss
@@ -240,8 +240,9 @@
 
 div[data-type="core/freeform"] {
 	&::before {
-		transition: border-color 0.1s linear, box-shadow 0.1s linear;
-		@include reduce-motion("transition");
+		@media not ( prefers-reduced-motion ) {
+			transition: border-color 0.1s linear, box-shadow 0.1s linear;
+		}
 		border: $border-width solid $gray-300;
 
 		// Windows High Contrast mode will show this outline.


### PR DESCRIPTION
Part of #68282

## What?

Refactors animation and transition styles to use @media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?

Currently, many parts of the codebase do not consider users' motion preferences, which may not be ideal for those with reduced motion settings. This PR addresses and fixes that issue.

## How?

This PR updates the old reduce-motion mixin implementation and addresses missing cases to adopt the new approach outlined in the parent issue.

```SASS
	@media not ( prefers-reduced-motion ) {
			transition: opacity 0.1s linear;
		}
```

Standard adopted from @wordpress/components

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

## Screencast

https://github.com/user-attachments/assets/29c6108e-b3b8-4466-9df0-c95766cd398f


