### PR TITLE
Block Directory: Standardize reduced motion handling using media queries #68419

### DIFF
--- a/packages/block-directory/src/components/downloadable-block-list-item/style.scss
+++ b/packages/block-directory/src/components/downloadable-block-list-item/style.scss
@@ -15,7 +15,10 @@
 	background: none;
 	border: 0;
 	text-align: left;
-	transition: box-shadow 0.1s linear;
+
+	@media not (prefers-reduced-motion) {
+		transition: box-shadow 0.1s linear;
+	}
 
 	// The item contains absolutely positioned items.
 	// Set `position: relative` on the parent to prevent overflow issues


### PR DESCRIPTION
### WIP
Part of: https://github.com/WordPress/gutenberg/issues/68282

## What?
Refactors animation and transition styles to use `@media not (prefers-reduced-motion)` for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?
Currently, many parts of the codebase do not consider users' motion preferences, which may not be ideal for those with reduced motion settings. This PR addresses and fixes that issue.

## How?
This PR updates the old reduce-motion mixin implementation and addresses missing cases to adopt the new approach outlined in the parent issue.

```scss
@media not ( prefers-reduced-motion ) {
      transition: box-shadow 0.1s linear;
}
```

## Screenshots or screencast 

https://github.com/user-attachments/assets/e2970660-3db1-40b9-981d-012f9141bdfc



