### PR TITLE
Nux: Standardize reduced motion handling using media queries

### DIFF
--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -12,7 +12,6 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 	}
 
 	&::before {
-		animation: nux-pulse 1.6s infinite cubic-bezier(0.17, 0.67, 0.92, 0.62);
 		background: rgba(#00739c, 0.9);
 		opacity: 0.9;
 		height: $dot-size * $dot-scale;
@@ -20,6 +19,14 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 		top: -($dot-size * $dot-scale) * 0.5;
 		transform: scale(math.div(1, $dot-scale));
 		width: $dot-size * $dot-scale;
+
+		@media not (prefers-reduced-motion) {
+			animation: nux-pulse 1.6s infinite cubic-bezier(0.17, 0.67, 0.92, 0.62);
+		}
+
+		@media (prefers-reduced-motion) {
+			animation: none;
+		}
 	}
 
 	&::after {

--- a/packages/nux/src/components/dot-tip/style.scss
+++ b/packages/nux/src/components/dot-tip/style.scss
@@ -23,10 +23,6 @@ $dot-scale: 3;  // How much the pulse animation should scale up by in size
 		@media not (prefers-reduced-motion) {
 			animation: nux-pulse 1.6s infinite cubic-bezier(0.17, 0.67, 0.92, 0.62);
 		}
-
-		@media (prefers-reduced-motion) {
-			animation: none;
-		}
 	}
 
 	&::after {


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/68282

## What?
Refactors animation and transition styles to use media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?
It addresses instances where animations and transitions were not optimized for Data Views for individuals with reduced motion settings, ensuring a smoother and more inclusive user experience.



## How?
This PR updates the outdated reduce-motion mixin implementation and resolves previously missed instances by adopting the new approach defined in the parent issue.

```scss
@media not (prefers-reduced-motion) {
	transition: padding ease-out 0.1s;
}
```

## Screenshots or screencast

