### PR TITLE
Customize Widgets: Standardize reduced motion handling using media queries

### DIFF
--- a/packages/customize-widgets/src/components/header/style.scss
+++ b/packages/customize-widgets/src/components/header/style.scss
@@ -42,8 +42,9 @@
 		}
 
 		svg {
-			transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
-			@include reduce-motion("transition");
+			@media not (prefers-reduced-motion) {
+				transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
+			}
 		}
 
 		&.is-pressed {


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/68282

## What?
Refactors animation and transition styles to use media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?
It addresses instances where animations and transitions were not optimized for Data Views for individuals with reduced motion settings, ensuring a smoother and more inclusive user experience.



## How?
This PR updates the outdated reduce-motion mixin implementation and resolves previously missed instances by adopting the new approach defined in the parent issue.

```scss
@media not (prefers-reduced-motion) {
	transition: padding ease-out 0.1s;
}
```

## Testing instruction

- Activate Twenty Twenty-One
- Appearance > Customize > Widgets


## Screencast

https://github.com/user-attachments/assets/b735e02d-fd2b-43a6-ae32-713a730645fa



