### PR TITLE
Edit Post: Standardize reduced motion handling using media queries

### DIFF
--- a/packages/edit-post/src/components/back-button/style.scss
+++ b/packages/edit-post/src/components/back-button/style.scss
@@ -23,8 +23,9 @@
 		}
 
 		&::before {
-			transition: box-shadow 0.1s ease;
-			@include reduce-motion("transition");
+			@media not (prefers-reduced-motion) {
+				transition: box-shadow 0.1s ease;
+			}
 			content: "";
 			display: block;
 			position: absolute;

--- a/packages/edit-post/src/components/layout/style.scss
+++ b/packages/edit-post/src/components/layout/style.scss
@@ -73,8 +73,9 @@
 				width: inherit;
 				height: $grid-unit-05;
 				border-radius: $radius-small;
-				transition: width 0.3s ease-out;
-				@include reduce-motion("transition");
+				@media not (prefers-reduced-motion) {
+					transition: width 0.3s ease-out;
+				}
 			}
 		}
 


### PR DESCRIPTION
Part of: https://github.com/WordPress/gutenberg/issues/68282

## What?
Refactors animation and transition styles to use media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?
It addresses instances where animations and transitions were not optimized for Data Views for individuals with reduced motion settings, ensuring a smoother and more inclusive user experience.



## How?
This PR updates the outdated reduce-motion mixin implementation and resolves previously missed instances by adopting the new approach defined in the parent issue.

```scss
@media not (prefers-reduced-motion) {
	transition: padding ease-out 0.1s;
}
```



## Screencast

https://github.com/user-attachments/assets/d7450656-931e-49dd-ae53-cbd0ad2ccd2e


Testing instructions:
- Install and activate a plugin with meta boxes like Yoast SEO

https://github.com/user-attachments/assets/e2e4a424-8e93-4510-89ac-e0a4bd2474b0





