### PR TITLE
Edit Widgets and Base Styles: Standardize reduced motion handling using media queries

### DIFF
--- a/packages/base-styles/_animations.scss
+++ b/packages/base-styles/_animations.scss
@@ -14,10 +14,10 @@
 		}
 	}
 
-
-	animation: __wp-base-styles-fade-in $speed $easing $delay;
-	animation-fill-mode: forwards;
-	@include reduce-motion("animation");
+	@media not (prefers-reduced-motion) {
+		animation: __wp-base-styles-fade-in $speed $easing $delay;
+		animation-fill-mode: forwards;
+	}
 }
 
 @mixin animation__fade-out($speed: 0.08s, $delay: 0s, $easing: linear) {
@@ -30,10 +30,10 @@
 		}
 	}
 
-
-	animation: __wp-base-styles-fade-out $speed $easing $delay;
-	animation-fill-mode: forwards;
-	@include reduce-motion("animation");
+	@media not (prefers-reduced-motion) {
+		animation: __wp-base-styles-fade-out $speed $easing $delay;
+		animation-fill-mode: forwards;
+	}
 }
 
 // Deprecated

--- a/packages/base-styles/_mixins.scss
+++ b/packages/base-styles/_mixins.scss
@@ -141,10 +141,13 @@
 // Tabs, Inputs, Square buttons.
 @mixin input-style__neutral() {
 	box-shadow: 0 0 0 transparent;
-	transition: box-shadow 0.1s linear;
+
+	@media not (prefers-reduced-motion) {
+		transition: box-shadow 0.1s linear;
+	}
+
 	border-radius: $radius-small;
 	border: $border-width solid $gray-600;
-	@include reduce-motion("transition");
 }
 
 

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -147,8 +147,9 @@
 	}
 
 	svg {
-		transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
-		@include reduce-motion("transition");
+		@media not (prefers-reduced-motion) {
+			transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
+		}
 	}
 
 	&.is-pressed {


### PR DESCRIPTION
Part of: #68282

<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Refactors animation and transition styles to use media not (prefers-reduced-motion) for improved accessibility, ensuring a better experience for users who prefer reduced motion.

## Why?
It addresses instances where animations and transitions were not optimized for Edit Widgets and Base Styles for individuals with reduced motion settings, ensuring a smoother and more inclusive user experience.

## How?
It addresses instances where animations and transitions were not optimized for Data Views for individuals with reduced motion settings, ensuring a smoother and more inclusive user experience.

```css
@media not (prefers-reduced-motion) {
       transition: transform cubic-bezier(0.165, 0.84, 0.44, 1) 0.2s;
}
```
## Screencast:

https://github.com/user-attachments/assets/8df38c86-3e7e-48ab-be6d-ca883288399f
