### PR TITLE
Post Title: Implement debounced title saving and fix title retrieval for post context

### DIFF
--- a/packages/block-library/src/post-title/edit.js
+++ b/packages/block-library/src/post-title/edit.js
@@ -59,15 +59,12 @@ export default function PostTitleEdit( {
 	);
 
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const debouncedSaveTitle = useDebounce( ( newTitle ) => {
+	const setTitle = useDebounce( ( newTitle ) => {
 		saveEntityRecord( 'postType', 'post', {
 			id: postId,
 			title: newTitle,
 		} );
 	}, 500 );
-	const setTitle = ( newTitle ) => {
-		debouncedSaveTitle( newTitle );
-	};
 	const [ link ] = useEntityProp( 'postType', postType, 'link', postId );
 	const onSplitAtEnd = () => {
 		insertBlocksAfter( createBlock( getDefaultBlockName() ) );

--- a/packages/block-library/src/post-title/index.php
+++ b/packages/block-library/src/post-title/index.php
@@ -21,11 +21,7 @@ function render_block_core_post_title( $attributes, $content, $block ) {
 		return '';
 	}
 
-	/**
-	 * The `$post` argument is intentionally omitted so that changes are reflected when previewing a post.
-	 * See: https://github.com/WordPress/gutenberg/pull/37622#issuecomment-1000932816.
-	 */
-	$title = get_the_title();
+	$title = get_the_title( $block->context['postId'] );
 
 	if ( ! $title ) {
 		return '';


### PR DESCRIPTION
## What, Why & How?
As noted in the file packages/block-library/src/post-title/index.php, the context's `Post ID` was removed from the `get_the_title()` function. However, I believe the context's Post ID should be utilized to make the block functional even outside the Query Loop block.

To address the issue of unsynced previews, I’ve implemented a solution that directly dispatches changes to the `post-title` block. This ensures that updates appear in the preview tab, providing a consistent and synced experience.

That said, directly dispatching changes in previews might not always align with the purpose of previews, which are meant to reflect unsaved changes. However, given that significant modifications to the `core/post-title` block are rare, this approach could be acceptable as it prioritizes a fully synced and cohesive look.

## Testing Instructions
1. Create a new block that accepts inner blocks.
2. Copy this to its block.json

```json
"attributes": {
    "postId": {
	    "type": "integer",
	    "default": 165 // A post ID for a post that already exists.
    },
    "postType": {
	    "type": "string",
	    "default": "post"
    }
  },
"providesContext": {
  "postId": "postId",
  "postType": "postType"
},
```

3. Copy this to `edit.js`
```js
/**
 * WordPress dependencies
 */
import { useBlockProps, useInnerBlocksProps } from '@wordpress/block-editor';

function Edit( { attributes, setAttributes } ) {
	const blockProps = useBlockProps();
	const innerBlocksProps = useInnerBlocksProps();

	return (
		<div { ...blockProps }>
			<div { ...innerBlocksProps } />
		</div>
	);
}

export default Edit;
```

4. Copy this to `save.js`
```js
/**
 * WordPress dependencies
 */
import { useBlockProps, InnerBlocks } from '@wordpress/block-editor';

export default function save() {
	const blockProps = useBlockProps.save();
	return (
		<div { ...blockProps }>
			<InnerBlocks.Content />
		</div>
	);
}
```
5. Try inserting `core/post-title` block as an inner block.
6. Verify it functions normally in the `preview` and works outside the `Query Loop`.

## Screencast

### Before

https://github.com/user-attachments/assets/2aed25ea-dc84-43c9-9eb0-6812d1875532


### After

https://github.com/user-attachments/assets/9d5dc885-d9ed-43da-9e12-05c8db87ecfc



Closes: #68369 
