### PR TITLE
Docs: Add Documentation for Adding Block Variations Using get_block_type_variations Hook

### DIFF
--- a/docs/reference-guides/block-api/block-variations.md
+++ b/docs/reference-guides/block-api/block-variations.md
@@ -60,6 +60,43 @@ wp.blocks.registerBlockVariation( 'core/embed', {
 } );
 ```
 
+## Registering block variations in PHP
+
+Block variations can also be registered from PHP using the `get_block_type_variations` filter hook. This approach is particularly useful when you need to dynamically generate variations based on registered post types, taxonomies, or other WordPress data.
+
+Here's an example of how to register a custom variation for the `core/navigation-link` block:
+
+```php
+function my_custom_navigation_link_variations( $variations, $block_type ) {
+    // Only modify variations for the navigation-link block
+    if ( 'core/navigation-link' !== $block_type->name ) {
+        return $variations;
+    }
+
+    // Add a custom variation
+    $variations[] = array(
+		'name'        => 'custom-link',
+		'title'       => __( 'Custom Link', 'textdomain' ),
+		'description' => __( 'A custom navigation link variation', 'textdomain' ),
+		'scope'       => array( 'inserter' ),
+		'isDefault'   => false,
+		'attributes'  => array(
+			'type' => 'custom', // Identifies the link type as custom
+			'kind' => 'custom', // Indicates the kind of link being used
+		),
+    );
+
+    return $variations;
+}
+add_filter( 'get_block_type_variations', 'my_custom_navigation_link_variations', 10, 2 );
+```
+
+The `get_block_type_variations` filter is called when variations are requested for a block type. It receives two parameters:
+- `$variations`: An array of currently registered variations for the block type
+- `$block_type`: The full block type object
+
+Note that variations registered through PHP will be merged with any variations registered through JavaScript using `registerBlockVariation()`.
+
 ## Removing a block variation
 
 Block variations can also be easily removed. To do so, use `wp.blocks.unregisterBlockVariation()`. This function accepts the name of the block and the `name` of the variation that should be unregistered.

--- a/docs/reference-guides/block-api/block-variations.md
+++ b/docs/reference-guides/block-api/block-variations.md
@@ -64,31 +64,30 @@ wp.blocks.registerBlockVariation( 'core/embed', {
 
 Block variations can also be registered from PHP using the `get_block_type_variations` filter hook. This approach is particularly useful when you need to dynamically generate variations based on registered post types, taxonomies, or other WordPress data.
 
-Here's an example of how to register a custom variation for the `core/navigation-link` block:
+Here's an example of how to register a custom variation for the `core/image` block:
 
 ```php
-function my_custom_navigation_link_variations( $variations, $block_type ) {
-    // Only modify variations for the navigation-link block
-    if ( 'core/navigation-link' !== $block_type->name ) {
+function my_custom_image_variation( $variations, $block_type ) {
+    // Only modify variations for the image block
+    if ( 'core/image' !== $block_type->name ) {
         return $variations;
     }
 
     // Add a custom variation
     $variations[] = array(
-		'name'        => 'custom-link',
-		'title'       => __( 'Custom Link', 'textdomain' ),
-		'description' => __( 'A custom navigation link variation', 'textdomain' ),
+		'name'        => 'wide-image',
+		'title'       => __( 'Wide image', 'textdomain' ),
+		'description' => __( 'A wide image', 'textdomain' ),
 		'scope'       => array( 'inserter' ),
 		'isDefault'   => false,
 		'attributes'  => array(
-			'type' => 'custom', // Identifies the link type as custom
-			'kind' => 'custom', // Indicates the kind of link being used
+			'align' => 'wide', // Identifies the link type as custom
 		),
     );
 
     return $variations;
 }
-add_filter( 'get_block_type_variations', 'my_custom_navigation_link_variations', 10, 2 );
+add_filter( 'get_block_type_variations', 'my_custom_image_variation', 10, 2 );
 ```
 
 The `get_block_type_variations` filter is called when variations are requested for a block type. It receives two parameters:

--- a/docs/reference-guides/block-api/block-variations.md
+++ b/docs/reference-guides/block-api/block-variations.md
@@ -96,6 +96,8 @@ The `get_block_type_variations` filter is called when variations are requested f
 
 Note that variations registered through PHP will be merged with any variations registered through JavaScript using `registerBlockVariation()`.
 
+<div class="callout callout-info">Check the <a href="https://developer.wordpress.org/news/2024/03/how-to-register-block-variations-with-php/">How to register block variations with PHP</a> blog post for more info about this</div>
+
 ## Removing a block variation
 
 Block variations can also be easily removed. To do so, use `wp.blocks.unregisterBlockVariation()`. This function accepts the name of the block and the `name` of the variation that should be unregistered.


### PR DESCRIPTION
Issue: https://github.com/WordPress/gutenberg/issues/63182
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
This PR updates the Block Editor Handbook under the "Block API Reference > Variations" section to include detailed instructions on how to add block variations via PHP using the get_block_type_variations hook.

### Changes Made:

- Added a new subsection titled "Adding Block Variations from PHP."
- Explained the get_block_type_variations hook and its parameters.
- Included a practical PHP code example demonstrating how to add a custom variation to the core/navigation-link block.