### PR TITLE
Adding block description settings in preference

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -16,6 +16,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import deprecated from '@wordpress/deprecated';
 import { __, isRTL } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -78,7 +79,9 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 			)[ 0 ],
 		};
 	}, [] );
-
+	const showBlockDescription = useSelect( ( select ) => {
+		return select( preferencesStore ).get( 'core', 'showBlockDescription' );
+	}, [] );
 	const { selectBlock } = useDispatch( blockEditorStore );
 
 	return (
@@ -104,7 +107,7 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 					</span>
 					{ !! name?.length && <Badge>{ title }</Badge> }
 				</h2>
-				{ description && (
+				{ description && showBlockDescription && (
 					<Text className="block-editor-block-card__description">
 						{ description }
 					</Text>

--- a/packages/edit-post/src/index.js
+++ b/packages/edit-post/src/index.js
@@ -72,6 +72,7 @@ export function initializeEditor(
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
 		isPublishSidebarEnabled: true,
+		showBlockDescription: true,
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/edit-site/src/index.js
+++ b/packages/edit-site/src/index.js
@@ -74,6 +74,7 @@ export function initializeEditor( id, settings ) {
 		showBlockBreadcrumbs: true,
 		showListViewByDefault: false,
 		enableChoosePatternModal: true,
+		showBlockDescription: true,
 	} );
 
 	if ( window.__experimentalMediaProcessing ) {

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -232,6 +232,12 @@ function PreferencesModalContents( { extraSections = {} } ) {
 								label={ __( 'Spotlight mode' ) }
 							/>
 							{ extraSections?.appearance }
+							<PreferenceToggleControl
+								scope="core"
+								featureName="showBlockDescription"
+								help={ __( 'Show block description' ) }
+								label={ __( 'Show block description' ) }
+							/>
 						</PreferencesModalSection>
 					),
 				},

--- a/packages/editor/src/components/preferences-modal/index.js
+++ b/packages/editor/src/components/preferences-modal/index.js
@@ -235,8 +235,10 @@ function PreferencesModalContents( { extraSections = {} } ) {
 							<PreferenceToggleControl
 								scope="core"
 								featureName="showBlockDescription"
-								help={ __( 'Show block description' ) }
-								label={ __( 'Show block description' ) }
+								help={ __(
+									'Show block descriptions in the editor sidebar.'
+								) }
+								label={ __( 'Show block descriptions' ) }
 							/>
 						</PreferencesModalSection>
 					),


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/42197

## How?
Added a toggle to the Appearance section in  Preferences modal, which allows you to turn off block descriptions.

## Testing Instructions

- Go to WP admin dashboard.
- Open any page/post in edit mode.
- Add any block, check its description in the editor sidebar.
- Open Preference modal from the Options.
- Turn off/on the `Show block descriptions` option from Appearance section.
- Check the block description based on the settings and verify.



## Screenshots or screencast <!-- if applicable -->

https://github.com/user-attachments/assets/225ea727-5132-4c2c-be9f-77f34059e00a




