### PR TITLE
Changed publish word to publish date

### DIFF
--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -33,7 +33,7 @@ export function PublishDateTimePicker(
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
 			<InspectorPopoverHeader
-				title={ __( 'Publish' ) }
+				title={ __( 'Publish Date & Time' ) }
 				actions={
 					showPopoverHeaderActions
 						? [

--- a/packages/block-editor/src/components/publish-date-time-picker/index.js
+++ b/packages/block-editor/src/components/publish-date-time-picker/index.js
@@ -33,7 +33,7 @@ export function PublishDateTimePicker(
 	return (
 		<div ref={ ref } className="block-editor-publish-date-time-picker">
 			<InspectorPopoverHeader
-				title={ __( 'Publish Date & Time' ) }
+				title={ __( 'Publish Date' ) }
 				actions={
 					showPopoverHeaderActions
 						? [

--- a/packages/editor/src/components/post-schedule/panel.js
+++ b/packages/editor/src/components/post-schedule/panel.js
@@ -61,7 +61,10 @@ export default function PostSchedulePanel() {
 
 	return (
 		<PostScheduleCheck>
-			<PostPanelRow label={ __( 'Publish' ) } ref={ setPopoverAnchor }>
+			<PostPanelRow
+				label={ __( 'Publish Date' ) }
+				ref={ setPopoverAnchor }
+			>
 				<Dropdown
 					popoverProps={ popoverProps }
 					focusOnMount


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/41319

## Why?
The word "Publish" is not descriptive as to what the option modifies. It should give the user a clear indication of what will be changed or modified.

## How?
Changed publish word to publish date in sidebar and also in modal.

## Testing Instructions
1. Open a post or page. 
2. Publish the page.
3. Check publish details in sidebar and verify.


## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![Screenshot (12)](https://github.com/user-attachments/assets/83407d29-c04f-4d7f-b131-26d1697f391d)![Screenshot (13)](https://github.com/user-attachments/assets/020fee1a-d1c9-4e92-baf7-8246426279b1)|![Screenshot (10)](https://github.com/user-attachments/assets/3c87c770-8c81-40a8-9f19-258bf4ec4d96)![Screenshot (14)](https://github.com/user-attachments/assets/fa44c119-108f-42b4-b7ac-624b5be1df5f)|
