### PR TITLE
Enhance Block Card and Inspector Controls with Secondary Description

### DIFF
--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -23,6 +23,7 @@ import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { unlock } from '../../lock-unlock';
 import { store as blockEditorStore } from '../../store';
 import BlockIcon from '../block-icon';
+import { default as InspectorControls } from '../inspector-controls';
 
 const { Badge } = unlock( componentsPrivateApis );
 
@@ -109,6 +110,11 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 						{ description }
 					</Text>
 				) }
+				<InspectorControls.Slot
+					group="secondaryDescription"
+					className="block-editor-block-card__secondary-description"
+					data-testid="block-editor-block-card__secondary-description"
+				/>
 			</VStack>
 		</div>
 	);

--- a/packages/block-editor/src/components/block-card/index.js
+++ b/packages/block-editor/src/components/block-card/index.js
@@ -113,7 +113,6 @@ function BlockCard( { title, icon, description, blockType, className, name } ) {
 				<InspectorControls.Slot
 					group="secondaryDescription"
 					className="block-editor-block-card__secondary-description"
-					data-testid="block-editor-block-card__secondary-description"
 				/>
 			</VStack>
 		</div>

--- a/packages/block-editor/src/components/block-card/style.scss
+++ b/packages/block-editor/src/components/block-card/style.scss
@@ -35,3 +35,7 @@
 	color: var(--wp-block-synced-color);
 }
 
+.block-editor-block-card__secondary-description {
+	margin-top: $grid-unit-10;
+	font-style: italic;
+}

--- a/packages/block-editor/src/components/inspector-controls/groups.js
+++ b/packages/block-editor/src/components/inspector-controls/groups.js
@@ -22,6 +22,9 @@ const InspectorControlsTypography = createSlotFill(
 const InspectorControlsListView = createSlotFill( 'InspectorControlsListView' );
 const InspectorControlsStyles = createSlotFill( 'InspectorControlsStyles' );
 const InspectorControlsEffects = createSlotFill( 'InspectorControlsEffects' );
+const InspectorControlsSecondaryDescription = createSlotFill(
+	'InspectorControlsSecondaryDescription'
+);
 
 const groups = {
 	default: InspectorControlsDefault,
@@ -35,6 +38,7 @@ const groups = {
 	filter: InspectorControlsFilter,
 	list: InspectorControlsListView,
 	position: InspectorControlsPosition,
+	secondaryDescription: InspectorControlsSecondaryDescription,
 	settings: InspectorControlsDefault, // Alias for default.
 	styles: InspectorControlsStyles,
 	typography: InspectorControlsTypography,

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -31,6 +31,7 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
+	__experimentalText as Text,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { Icon, search } from '@wordpress/icons';
@@ -406,6 +407,14 @@ export default function SearchEdit( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
+
+			<InspectorControls group="secondaryDescription">
+				<Text>
+					{ __(
+						'Uses instant search for seamless results without reloading the page. Configuration is managed in the Query Loop block.'
+					) }
+				</Text>
+			</InspectorControls>
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -31,7 +31,6 @@ import {
 	__experimentalUnitControl as UnitControl,
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
-	__experimentalText as Text,
 } from '@wordpress/components';
 import { useInstanceId } from '@wordpress/compose';
 import { Icon, search } from '@wordpress/icons';
@@ -407,14 +406,6 @@ export default function SearchEdit( {
 					) }
 				</ToolbarGroup>
 			</BlockControls>
-
-			<InspectorControls group="secondaryDescription">
-				<Text>
-					{ __(
-						'Uses instant search for seamless results without reloading the page. Configuration is managed in the Query Loop block.'
-					) }
-				</Text>
-			</InspectorControls>
 
 			<InspectorControls>
 				<PanelBody title={ __( 'Settings' ) }>


### PR DESCRIPTION
## What?
Adds a new InspectorControls slot for a secondary block description.

## Why?
It's needed it for the UI that was designed for the Instant Search functionality of the Query + Search blocks (#67181)

More details in this comment: https://github.com/WordPress/gutenberg/pull/67181#discussion_r1900102007

## How?
By adding the `<InspectorControls.Slot group="secondaryDescription"/>` in the BlockCard and creating the relevant groups.

## Testing Instructions

You can test it e.g. by adding the following snippet in `packages/block-library/src/search/edit.js`:

```jsx
<InspectorControls group="secondaryDescription">
  <Text>
    { __( 'Uses instant search for seamless results without reloading the page. Configuration is managed in the Query Loop block.' ) }
  </Text>
</InspectorControls>
```


|Before|After|
|-|-|
|<img width="277" alt="Screenshot 2024-12-31 at 16 58 23" src="https://github.com/user-attachments/assets/d728c925-a690-436d-94af-15d40e0c290e" />|<img width="279" alt="Screenshot 2024-12-31 at 16 59 57" src="https://github.com/user-attachments/assets/415fe1c9-ccf9-41be-ae3d-69eac4f08260" />|
