### PR TITLE
Update the copyright license to 2025

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 ## Gutenberg
 
-    Copyright 2016-2024 by the contributors
+    Copyright 2016-2025 by the contributors
 
 **License for Contributions (on and after April 15, 2021)**
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->

Same as #57481, Updates the date of the copyright license in `LICENSE.md` from 2024 to 2025

