### PR TITLE
Navigation: Surface the associated Menu name in the List View tab

### DIFF
--- a/packages/block-library/src/navigation/edit/menu-inspector-controls.js
+++ b/packages/block-library/src/navigation/edit/menu-inspector-controls.js
@@ -144,6 +144,9 @@ const MenuInspectorControls = ( props ) => {
 		blockEditingMode,
 	} = props;
 
+	const { navigationMenu } = useNavigationMenu( currentMenuId );
+	const menuTitle = navigationMenu?.title || __( 'Untitled menu' );
+
 	return (
 		<InspectorControls group="list">
 			<PanelBody title={ null }>
@@ -152,7 +155,7 @@ const MenuInspectorControls = ( props ) => {
 						className="wp-block-navigation-off-canvas-editor__title"
 						level={ 2 }
 					>
-						{ __( 'Menu' ) }
+						{ __( 'Menu' ) } ({ menuTitle })
 					</Heading>
 					{ blockEditingMode === 'default' && (
 						<NavigationMenuSelector


### PR DESCRIPTION
Fixes Point 1 of https://github.com/WordPress/gutenberg/issues/68177

## What?

This PR surfaces the name of the currently selected menu next to the word "Menu" in the Navigation block's List View tab, making it easier for users to identify which menu is associated with the block directly within the editor interface.

## Why?

Currently, to identify which menu is linked to a Navigation block, users must navigate through multiple steps:

1. Select the Navigation block,
2. Open the block sidebar,
3. Click on the List View tab,
4. Open the 3-dot menu,
5. See the currently selected menu.

This multi-step process can be cumbersome, especially for less experienced users. This change simplifies this by immediately displaying the menu name alongside the "Menu" label, improving discoverability and usability.

## How?
This change uses the `useNavigationMenu` hook to display the current menu name next to the "Menu" label in the Navigation block's List View tab. The aim is to provide immediate feedback without overloading the UI.

## Testing Instructions

1. Open a post or page in the WordPress editor.
2. Insert a Navigation block or select an existing one.
3. Open the block sidebar.
4. Switch to the "List View" tab.
5. Verify that the name of the currently selected menu is displayed next to the "Menu" label.


## Screencast 

https://github.com/user-attachments/assets/1f1f7372-0a00-4d3d-9bf1-7be7db8171f6


