### PR TITLE
Fixed typo in README of TextTransformControl 

### DIFF
--- a/packages/block-editor/src/components/text-transform-control/README.md
+++ b/packages/block-editor/src/components/text-transform-control/README.md
@@ -2,7 +2,7 @@
 
 The `TextTransformControl` component is responsible for rendering a control element that allows users to select and apply text transformation options to blocks or elements in the Gutenberg editor. It provides an intuitive interface for changing the text appearance by applying different transformations such as `none`, `uppercase`, `lowercase`, `capitalize`.
 
-![TextTransformConrol Element in Inspector Control](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/text-transform-component.png?raw=true)
+![TextTransformControl Element in Inspector Control](https://raw.githubusercontent.com/WordPress/gutenberg/HEAD/docs/assets/text-transform-component.png?raw=true)
 
 ## Development guidelines
 


### PR DESCRIPTION
Fixes: #68442 

## What?
Fixed Typo for `TextTransformControl` README doc. 

## Screenshot
<img width="1456" alt="image" src="https://github.com/user-attachments/assets/7b784b15-a852-4764-9710-e0f372bc25d8" />
