### PR TITLE
BlockInspector: Add showNoBlockSelectedMessage prop documentation.

### DIFF
--- a/packages/block-editor/src/components/block-inspector/README.md
+++ b/packages/block-editor/src/components/block-inspector/README.md
@@ -16,6 +16,16 @@ import { BlockInspector } from '@wordpress/block-editor';
 const MyBlockInspector = () => <BlockInspector />;
 ```
 
+### Props
+
+#### showNoBlockSelectedMessage
+
+Whether to display a "No block selected" message when no block is selected.
+
+- Type: `boolean`
+- Required: No
+- Default: `true`
+
 ## Related components
 
 Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/block-inspector/README.md
+++ b/packages/block-editor/src/components/block-inspector/README.md
@@ -22,9 +22,9 @@ const MyBlockInspector = () => <BlockInspector />;
 
 Whether to display a "No block selected" message when no block is selected.
 
-- Type: `boolean`
-- Required: No
-- Default: `true`
+-   Type: `boolean`
+-   Required: No
+-   Default: `true`
 
 ## Related components
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

related to #22891

## What?
This PR adds missing documentation for the showNoBlockSelectedMessage prop in the BlockInspector component.

## Why?
The showNoBlockSelectedMessage prop was introduced but lacked documentation. Adding this prop to the README ensures that developers understand its purpose and usage when working with the BlockInspect

## Testing Instructions
1.	Navigate to the BlockInspector component's README file.
2.	Verify that the showNoBlockSelectedMessage prop is documented correctly.
3.	Ensure that the prop’s description is clear, including its default value and type.
