### PR TITLE
Grid block consistency for responsive

### DIFF
--- a/packages/block-library/src/post-template/style.scss
+++ b/packages/block-library/src/post-template/style.scss
@@ -31,7 +31,7 @@
 
 @media ( max-width: $break-small ) {
 	// Temporary specificity bump until "wp-container" layout specificity is revisited.
-	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid {
+	.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid.wp-block-post-template-is-layout-grid, .is-layout-grid.wp-block-group-is-layout-grid {
 		grid-template-columns: 1fr;
 	}
 }


### PR DESCRIPTION
Fixes #67090 

### Step-by-step reproduction instructions

1. Set grid item position to manual;
2. Set the number of columns, for example, 2-3;
3. Put any visible blocks to the Grid;
4. Make the screen width as narrow as possible
5. Observe that the grid turns into a single column on a narrow screen to maintain consistency.