### PR TITLE
Post Comments Link: Add Border Support

### DIFF
--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -42,6 +42,13 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true
 		}
-	}
+	},
+	"style": "wp-block-post-comments-link"
 }

--- a/packages/block-library/src/post-comments-link/style.scss
+++ b/packages/block-library/src/post-comments-link/style.scss
@@ -1,0 +1,4 @@
+.wp-block-post-comments-link {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -37,6 +37,7 @@
 @import "./post-author-biography/style.scss";
 @import "./post-comments-form/style.scss";
 @import "./post-content/style.scss";
+@import "./post-comments-link/style.scss";
 @import "./post-date/style.scss";
 @import "./post-excerpt/style.scss";
 @import "./post-featured-image/style.scss";


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add border support to the `Post Comments Link` block.

Part of https://github.com/WordPress/gutenberg/issues/43247

## Why?
`Post Comments Link` block is missing border support.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Add the border support in block.json.

## Testing Instructions

- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Make sure that `Post Comments Link` block's border is Configurable via Global Styles.
- Edit `Archive Template` &  Add `Post Comments Link` block and Apply the border Styles.
- Verify that `Post Comments Link` block styles take precedence over global Styles.
- Verify that `Post Comments Link` block borders display correctly in both the Editor and Frontend.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/a1de9ebc-8c39-4b1e-9557-bda24ada94cf

