### PR TITLE
Font Size Picker: Add truncation to header hint and adjust styles

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -23,6 +23,7 @@
 -   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
 -   `FontSizePicker`: Add `display:contents` rule to fix overflowing text in the custom size select. ([#68280](https://github.com/WordPress/gutenberg/pull/68280)).
 -   `BoxControl`: Fix aria-valuetext value ([#68362](https://github.com/WordPress/gutenberg/pull/68362)).
+-   `FontSizePicker`: Truncate header hint to fix overflowing hint when the text is too large ([#68452](https://github.com/WordPress/gutenberg/pull/68452)).
 
 ### Experimental
 

--- a/packages/components/src/font-size-picker/index.tsx
+++ b/packages/components/src/font-size-picker/index.tsx
@@ -36,6 +36,7 @@ import FontSizePickerSelect from './font-size-picker-select';
 import FontSizePickerToggleGroup from './font-size-picker-toggle-group';
 import { T_SHIRT_NAMES } from './constants';
 import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
+import { Truncate } from '../truncate';
 
 const DEFAULT_UNITS = [ 'px', 'em', 'rem', 'vw', 'vh' ];
 
@@ -141,7 +142,7 @@ const UnforwardedFontSizePicker = (
 						{ __( 'Size' ) }
 						{ headerHint && (
 							<HeaderHint className="components-font-size-picker__header__hint">
-								{ headerHint }
+								<Truncate>{ headerHint }</Truncate>
 							</HeaderHint>
 						) }
 					</HeaderLabel>

--- a/packages/components/src/font-size-picker/styles.ts
+++ b/packages/components/src/font-size-picker/styles.ts
@@ -36,4 +36,5 @@ export const HeaderLabel = styled( BaseControl.VisualLabel )`
 
 export const HeaderHint = styled.span`
 	color: ${ COLORS.gray[ 700 ] };
+	display: contents;
 `;


### PR DESCRIPTION
## What, Why & How?
When the hint text is too long, it overflows and disrupts the layout, as noted in the original issue. A potential solution was suggested in this [comment](https://github.com/WordPress/gutenberg/issues/68344#issuecomment-2563704780). However, as mentioned, manipulating the height breaks the layout.  

Ideally, excessively long hint text should be truncated to fit within the available space, ensuring it neither overflows nor causes layout inconsistencies.  

This PR introduces text truncation to resolve the overflow issue. The full hint text remains accessible to users via tooltips on hover, offering a practical balance between usability and layout stability.

## Testing Instructions
1. Add the following snippet to the `theme.json`.
```json
"typography": {
	"defaultFontSizes": false,
	"fontSizes": [
		{
			"fluid": false,
			"name": "Small small small small small small small small small small small small small small small",
			"size": "0.875rem",
			"slug": "small"
		}
	]
}
```
2. Navigate to editing a page.
3. Notice the hint text overflow is now fixed.

## Screenshots

|Before|After|
|-|-|
|![Screenshot 2025-01-02 at 10 10 04 AM](https://github.com/user-attachments/assets/1baad2c8-22cf-40ef-a1f9-6d06214d457d)|![Screenshot 2025-01-02 at 10 10 45 AM](https://github.com/user-attachments/assets/6dbc4ed6-ac09-4814-ac2e-c13f8dab62e2)|

## Layout

![Screenshot 2025-01-02 at 10 11 04 AM](https://github.com/user-attachments/assets/126a4c9e-c4a8-47ca-a198-03fc28537a9c)

## Screencast


https://github.com/user-attachments/assets/389c48c3-bb5d-4660-8968-aac9b10d4333


Closely related to: https://github.com/WordPress/gutenberg/pull/68280

Closes: #68344