### PR TITLE
Navigation: Add clearable option to color picker in `navigation` block

### DIFF
--- a/packages/block-library/src/navigation/edit/index.js
+++ b/packages/block-library/src/navigation/edit/index.js
@@ -142,24 +142,28 @@ function ColorTools( {
 						label: __( 'Text' ),
 						onColorChange: setTextColor,
 						resetAllFilter: () => setTextColor(),
+						clearable: true,
 					},
 					{
 						colorValue: backgroundColor.color,
 						label: __( 'Background' ),
 						onColorChange: setBackgroundColor,
 						resetAllFilter: () => setBackgroundColor(),
+						clearable: true,
 					},
 					{
 						colorValue: overlayTextColor.color,
 						label: __( 'Submenu & overlay text' ),
 						onColorChange: setOverlayTextColor,
 						resetAllFilter: () => setOverlayTextColor(),
+						clearable: true,
 					},
 					{
 						colorValue: overlayBackgroundColor.color,
 						label: __( 'Submenu & overlay background' ),
 						onColorChange: setOverlayBackgroundColor,
 						resetAllFilter: () => setOverlayBackgroundColor(),
+						clearable: true,
 					},
 				] }
 				panelId={ clientId }


### PR DESCRIPTION
## What, Why and How?
This PR introduces a `clearable` button, allowing users to easily clear applied colors. It ensures consistency between the `Color Picker` in the `Sub Menu` and the one in the `Navigation` block.  

The `clearable` option has been added to the settings for all applicable settings, effectively addressing the issue.

## Testing Instructions
1. Add a `Navigation block` to your page.
2. Apply a `Background Color` to the block.
3. Use the `Clear button` to remove the applied color and verify that it works as expected.

## Screenshots

|Before|After|
|-|-|
|![Screenshot 2025-01-02 at 11 38 39 AM](https://github.com/user-attachments/assets/84fb67cd-6ddb-4daf-bde5-471f66bd8495)|![Screenshot 2025-01-02 at 11 29 39 AM](https://github.com/user-attachments/assets/cbbd3cae-1093-4868-8dc5-5c47968ab715)|

## Screencast

![Screencast](https://github.com/user-attachments/assets/c62db7e6-ea8c-440a-960e-4ef87c398522)


Closes: #68453 
