### PR TITLE
Navigation Submenu: Add Border and Spacing support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -493,7 +493,7 @@ Add a submenu to your navigation. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/navigation-submenu
 -	**Category:** design
 -	**Parent:** core/navigation
--	**Supports:** interactivity (clientNavigation), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 -	**Attributes:** description, id, isTopLevelItem, kind, label, opensInNewTab, rel, title, type, url
 
 ## Page Break

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -74,6 +74,26 @@
 		},
 		"interactivity": {
 			"clientNavigation": true
+		},
+		"spacing": {
+			"padding": true,
+			"margin": true,
+			"__experimentalDefaultControls": {
+				"margin": false,
+				"padding": false
+			}
+		},
+		"__experimentalBorder": {
+			"radius": true,
+			"color": true,
+			"width": true,
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"editorStyle": "wp-block-navigation-submenu-editor",

--- a/packages/block-library/src/navigation-submenu/block.json
+++ b/packages/block-library/src/navigation-submenu/block.json
@@ -79,8 +79,8 @@
 			"padding": true,
 			"margin": true,
 			"__experimentalDefaultControls": {
-				"margin": false,
-				"padding": false
+				"margin": true,
+				"padding": true
 			}
 		},
 		"__experimentalBorder": {

--- a/packages/block-library/src/navigation-submenu/style.scss
+++ b/packages/block-library/src/navigation-submenu/style.scss
@@ -1,0 +1,4 @@
+.wp-block-navigation-submenu {
+	// This block has customizable padding, border-box makes that more predictable.
+	box-sizing: border-box;
+}

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -69,5 +69,6 @@
 @import "./verse/style.scss";
 @import "./video/style.scss";
 @import "./footnotes/style.scss";
+@import "./navigation-submenu/style.scss";
 
 @import "common.scss";


### PR DESCRIPTION
## What?
Add border and spacing block support to the Navigation `Submenu` block.

## Why?
Navigation Submenu block is missing border and spacing support.
Part of #43247 
Part of #43243

## How?
Adds the border and spacing block support in block.json

## Testing Instructions
- Go to Global Styles Settings. ( Under Appearance > Editor > Styles > Edit styles > Blocks )
- Ensure the Navigation `Submenu` block’s border and spacing are configurable via Global Styles.
- Confirm Global Styles apply correctly in both the Editor and Frontend.
- Open the Page or Template where you want to add the menu.
- Add a Navigation block (the container block for all navigation links and Submenus).
- Within the Navigation block, add `Submenu` block.
- Verify Border, Radius, and Spacing settings are available for this Submenu block.
- Check that block-specific styles (e.g., borders, spacing) take precedence over Global Styles.
- Ensure borders and spacing display correctly in both the Editor and Frontend.

## Screenshots or screencast 

https://github.com/user-attachments/assets/f3b3c5de-5461-42df-8c87-22baa889d808

