### PR TITLE
Highlighting todays date

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -36,6 +36,10 @@
 		&.has-text-color th {
 			color: inherit;
 		}
+
+		td#today {
+			text-decoration: underline;
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes https://github.com/WordPress/gutenberg/issues/68451

## Why?
Todays date is not highlighting in various themes.

## How?
Added style to highlight todays date in the calendar block itself.

## Testing Instructions

- Open post or page in edit mode.
- Add Calendar block.
- Check today's date in calendar and verify.

## Screenshots or screencast <!-- if applicable -->

|Before|After|
|-|-|
|![Screenshot](https://github.com/user-attachments/assets/0a0aaac0-879d-4c04-848c-2d534273acc3)|![Screenshot (1)](https://github.com/user-attachments/assets/10c4677e-5e03-4878-9f6a-6f004e333217)|
