### PR TITLE
Fix Calendar block todays date issue.

### DIFF
--- a/packages/block-library/src/calendar/style.scss
+++ b/packages/block-library/src/calendar/style.scss
@@ -36,6 +36,11 @@
 		&.has-text-color th {
 			color: inherit;
 		}
+		td {
+			&#today {
+				text-decoration: underline;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
I have fixed calendar block "Today's Date" highlighting issue. #68451 

## Why?
Today's date of "Calendar Block" is not highlighting in various themes.

## How?
I have added style to highlight today's date in the calendar block itself.

## Testing Instructions

- Open post or page in edit mode.
- Add Calendar block.
- Check today's date in calendar and verify.

## Screenshots or screencast <!-- if applicable -->

![after_resolved_calendar_block_front_end](https://github.com/user-attachments/assets/97046c40-a36b-492c-816c-aac791d146fe)
![after_resolved_calendar_block](https://github.com/user-attachments/assets/7e81131c-5f29-4d7a-b362-0b45a5c2a22f)

Thanks,
