### PR TITLE
Storybook: Add stories for BlockVerticalAlignmentControl component

### DIFF
--- a/packages/block-editor/src/components/block-vertical-alignment-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/stories/index.story.js
@@ -26,7 +26,7 @@ const meta = {
 	argTypes: {
 		value: {
 			control: { type: null },
-			description: 'Currently selected vertical alignment value.',
+			description: 'The current value of the alignment setting.',
 			table: {
 				type: {
 					summary: 'string',
@@ -36,7 +36,8 @@ const meta = {
 		onChange: {
 			action: 'onChange',
 			control: { type: null },
-			description: 'Handles change in vertical alignment selection.',
+			description:
+				"A callback function invoked when the toolbar's alignment value is changed via an interaction with any of the toolbar's buttons",
 			table: {
 				type: {
 					summary: 'function',
@@ -63,9 +64,9 @@ export const Default = {
 		return (
 			<BlockVerticalAlignmentControl
 				{ ...args }
-				onChange={ ( newValue ) => {
-					onChange( newValue );
-					setValue( newValue );
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
 				} }
 				value={ value }
 			/>
@@ -79,9 +80,9 @@ export const Toolbar = {
 		return (
 			<BlockVerticalAlignmentToolbar
 				{ ...args }
-				onChange={ ( newValue ) => {
-					onChange( newValue );
-					setValue( newValue );
+				onChange={ ( ...changeArgs ) => {
+					onChange( ...changeArgs );
+					setValue( ...changeArgs );
 				} }
 				value={ value }
 			/>

--- a/packages/block-editor/src/components/block-vertical-alignment-control/stories/index.story.js
+++ b/packages/block-editor/src/components/block-vertical-alignment-control/stories/index.story.js
@@ -1,0 +1,90 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import {
+	BlockVerticalAlignmentControl,
+	BlockVerticalAlignmentToolbar,
+} from '../';
+
+const meta = {
+	title: 'BlockEditor/BlockVerticalAlignmentControl',
+	component: BlockVerticalAlignmentControl,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'Controls for vertical alignment of content within a block.',
+			},
+		},
+	},
+	argTypes: {
+		value: {
+			control: { type: null },
+			description: 'Currently selected vertical alignment value.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		onChange: {
+			action: 'onChange',
+			control: { type: null },
+			description: 'Handles change in vertical alignment selection.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		controls: {
+			control: 'check',
+			description: 'Array of vertical alignment options to display.',
+			options: [ 'top', 'center', 'bottom' ],
+			table: {
+				type: { summary: 'array' },
+				defaultValue: { summary: "['top', 'center', 'bottom']" },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
+		return (
+			<BlockVerticalAlignmentControl
+				{ ...args }
+				onChange={ ( newValue ) => {
+					onChange( newValue );
+					setValue( newValue );
+				} }
+				value={ value }
+			/>
+		);
+	},
+};
+
+export const Toolbar = {
+	render: function Template( { onChange, ...args } ) {
+		const [ value, setValue ] = useState();
+		return (
+			<BlockVerticalAlignmentToolbar
+				{ ...args }
+				onChange={ ( newValue ) => {
+					onChange( newValue );
+					setValue( newValue );
+				} }
+				value={ value }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR improves the Storybook stories for the BlockVerticalAlignmentControl component in the block editor. It includes comprehensive stories demonstrating different block vertical alignment states.

## Testing Instructions
- Start Storybook by running `npm run storybook:dev`
- Open Storybook at http://localhost:50240/
- Navigate to "BlockEditor/BlockVerticalAlignmentControl" in the Storybook sidebar
- Test the stories

## Screencast


https://github.com/user-attachments/assets/aeb9265d-5778-4c70-926f-51df8f579517









