### PR TITLE
Fix SCSS Media Query Compilation Issue in Storybook

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -118,7 +118,7 @@
 			// This ensure the radius work properly.
 			overflow: hidden;
 
-			@media not (prefers-reduced-motion) {
+			@media (prefers-reduced-motion: no-preference) {
 				transition: border-radius, box-shadow 0.4s;
 			}
 


### PR DESCRIPTION
Follow up: https://github.com/WordPress/gutenberg/pull/68419
Comment: https://github.com/WordPress/gutenberg/pull/68419#issuecomment-2567550864

## What?
Fixed an issue where the preprocessor was incorrectly compiling SCSS media queries in Storybook.

## Why?
Replaced the previous media query syntax with a corrected version to ensure SCSS compiles properly in Storybook, resolving CI failures.

## How?
Replaced the syntax: `@media (prefers-reduced-motion: no-preference)`.

## Testing Instructions
1. Run  `npm run storybook:dev`
2. Observe the storybook compiles without any errors.




