### PR TITLE
Adding line numbers to the code

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -88,7 +88,7 @@ Display code snippets that respect your spacing and tabs. ([Source](https://gith
 -	**Name:** core/code
 -	**Category:** text
 -	**Supports:** align (wide), anchor, color (background, gradients, text), interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight)
--	**Attributes:** content
+-	**Attributes:** content, showLineNumbers
 
 ## Column
 

--- a/packages/block-library/src/code/block.json
+++ b/packages/block-library/src/code/block.json
@@ -12,6 +12,10 @@
 			"source": "rich-text",
 			"selector": "code",
 			"__unstablePreserveWhiteSpace": true
+		},
+		"showLineNumbers": {
+			"type": "boolean",
+			"default": true
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -1,9 +1,15 @@
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import {
+	RichText,
+	useBlockProps,
+	InspectorControls,
+} from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
 import { useState, useEffect } from '@wordpress/element';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 
 export default function CodeEdit( {
 	attributes,
@@ -14,49 +20,73 @@ export default function CodeEdit( {
 } ) {
 	const blockProps = useBlockProps();
 	const [ lineNumbers, setLineNumbers ] = useState( [] );
+	const { content, showLineNumbers } = attributes;
 
-	// Function to calculate line numbers dynamically
+	// eslint-disable-next-line no-shadow
 	const calculateLineNumbers = ( content ) => {
 		return content.split( '\n' ).map( ( _, index ) => index + 1 );
 	};
 
 	// Update line numbers whenever the content changes
 	useEffect( () => {
-		const content =
-			typeof attributes.content === 'string'
-				? attributes.content
-				: attributes.content.toHTMLString( {
+		const contentString =
+			typeof content === 'string'
+				? content
+				: content.toHTMLString( {
 						preserveWhiteSpace: true,
 				  } );
-		setLineNumbers( calculateLineNumbers( content ) );
-	}, [ attributes.content ] );
+		setLineNumbers( calculateLineNumbers( contentString ) );
+	}, [ content ] );
 
 	return (
-		<div { ...blockProps } className="wp-block-code-with-line-numbers">
-			<div className="line-numbers">
-				{ lineNumbers.map( ( num ) => (
-					<div key={ num }>{ num }</div>
-				) ) }
+		<>
+			{ /* Inspector Controls */ }
+			<InspectorControls>
+				<PanelBody title={ __( 'Code Block Settings' ) }>
+					<ToggleControl
+						label={ __( 'Show Line Numbers' ) }
+						__nextHasNoMarginBottom
+						checked={ showLineNumbers }
+						onChange={ ( value ) =>
+							setAttributes( { showLineNumbers: value } )
+						}
+					/>
+				</PanelBody>
+			</InspectorControls>
+
+			{ /* Block Content */ }
+			<div { ...blockProps } className="wp-block-code-with-line-numbers">
+				{ /* Line Numbers */ }
+				{ showLineNumbers && (
+					<div className="line-numbers">
+						{ lineNumbers.map( ( num ) => (
+							<div key={ num }>{ num }</div>
+						) ) }
+					</div>
+				) }
+
+				{ /* Code Content */ }
+				<pre className="code-content">
+					<RichText
+						tagName="code"
+						identifier="content"
+						value={ content }
+						// eslint-disable-next-line no-shadow
+						onChange={ ( content ) => setAttributes( { content } ) }
+						onRemove={ onRemove }
+						onMerge={ mergeBlocks }
+						placeholder={ __( 'Write code…' ) }
+						aria-label={ __( 'Code' ) }
+						preserveWhiteSpace
+						__unstablePastePlainText
+						__unstableOnSplitAtDoubleLineEnd={ () =>
+							insertBlocksAfter(
+								createBlock( getDefaultBlockName() )
+							)
+						}
+					/>
+				</pre>
 			</div>
-			<pre className="code-content">
-				<RichText
-					tagName="code"
-					identifier="content"
-					value={ attributes.content }
-					onChange={ ( content ) => setAttributes( { content } ) }
-					onRemove={ onRemove }
-					onMerge={ mergeBlocks }
-					placeholder="Write code…"
-					aria-label="Code"
-					preserveWhiteSpace
-					__unstablePastePlainText
-					__unstableOnSplitAtDoubleLineEnd={ () =>
-						insertBlocksAfter(
-							createBlock( getDefaultBlockName() )
-						)
-					}
-				/>
-			</pre>
-		</div>
+		</>
 	);
 }

--- a/packages/block-library/src/code/edit.js
+++ b/packages/block-library/src/code/edit.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { createBlock, getDefaultBlockName } from '@wordpress/blocks';
+import { useState, useEffect } from '@wordpress/element';
 
 export default function CodeEdit( {
 	attributes,
@@ -13,23 +13,50 @@ export default function CodeEdit( {
 	mergeBlocks,
 } ) {
 	const blockProps = useBlockProps();
+	const [ lineNumbers, setLineNumbers ] = useState( [] );
+
+	// Function to calculate line numbers dynamically
+	const calculateLineNumbers = ( content ) => {
+		return content.split( '\n' ).map( ( _, index ) => index + 1 );
+	};
+
+	// Update line numbers whenever the content changes
+	useEffect( () => {
+		const content =
+			typeof attributes.content === 'string'
+				? attributes.content
+				: attributes.content.toHTMLString( {
+						preserveWhiteSpace: true,
+				  } );
+		setLineNumbers( calculateLineNumbers( content ) );
+	}, [ attributes.content ] );
+
 	return (
-		<pre { ...blockProps }>
-			<RichText
-				tagName="code"
-				identifier="content"
-				value={ attributes.content }
-				onChange={ ( content ) => setAttributes( { content } ) }
-				onRemove={ onRemove }
-				onMerge={ mergeBlocks }
-				placeholder={ __( 'Write code…' ) }
-				aria-label={ __( 'Code' ) }
-				preserveWhiteSpace
-				__unstablePastePlainText
-				__unstableOnSplitAtDoubleLineEnd={ () =>
-					insertBlocksAfter( createBlock( getDefaultBlockName() ) )
-				}
-			/>
-		</pre>
+		<div { ...blockProps } className="wp-block-code-with-line-numbers">
+			<div className="line-numbers">
+				{ lineNumbers.map( ( num ) => (
+					<div key={ num }>{ num }</div>
+				) ) }
+			</div>
+			<pre className="code-content">
+				<RichText
+					tagName="code"
+					identifier="content"
+					value={ attributes.content }
+					onChange={ ( content ) => setAttributes( { content } ) }
+					onRemove={ onRemove }
+					onMerge={ mergeBlocks }
+					placeholder="Write code…"
+					aria-label="Code"
+					preserveWhiteSpace
+					__unstablePastePlainText
+					__unstableOnSplitAtDoubleLineEnd={ () =>
+						insertBlocksAfter(
+							createBlock( getDefaultBlockName() )
+						)
+					}
+				/>
+			</pre>
+		</div>
 	);
 }

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -9,37 +9,41 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { escape } from './utils';
 
 export default function save( { attributes } ) {
-	// Calculate the number of lines dynamically
+	const { content, showLineNumbers } = attributes;
+
+	// eslint-disable-next-line no-shadow
 	const calculateLineNumbers = ( content ) => {
 		return content.split( '\n' ).map( ( _, index ) => index + 1 );
 	};
 
-	const content =
-		typeof attributes.content === 'string'
-			? attributes.content
-			: attributes.content.toHTMLString( {
+	const contentString =
+		typeof content === 'string'
+			? content
+			: content.toHTMLString( {
 					preserveWhiteSpace: true,
 			  } );
 
-	const lineNumbers = calculateLineNumbers( content );
+	const lineNumbers = calculateLineNumbers( contentString );
 
 	return (
 		<div
 			{ ...useBlockProps.save() }
 			className="wp-block-code-with-line-numbers"
 		>
-			<div className="line-numbers">
-				{ lineNumbers.map( ( num ) => (
-					<div key={ num }>{ num }</div>
-				) ) }
-			</div>
+			{ /* Conditionally render line numbers */ }
+			{ showLineNumbers && (
+				<div className="line-numbers">
+					{ lineNumbers.map( ( num ) => (
+						<div key={ num }>{ num }</div>
+					) ) }
+				</div>
+			) }
+
+			{ /* Render code content */ }
 			<pre className="code-content">
 				<RichText.Content
 					tagName="code"
-					// To do: `escape` encodes characters in shortcodes and URLs to
-					// prevent embedding in PHP. Ideally checks for the code block,
-					// or pre/code tags, should be made on the PHP side?
-					value={ escape( content ) }
+					value={ escape( contentString ) }
 				/>
 			</pre>
 		</div>

--- a/packages/block-library/src/code/save.js
+++ b/packages/block-library/src/code/save.js
@@ -9,21 +9,39 @@ import { RichText, useBlockProps } from '@wordpress/block-editor';
 import { escape } from './utils';
 
 export default function save( { attributes } ) {
+	// Calculate the number of lines dynamically
+	const calculateLineNumbers = ( content ) => {
+		return content.split( '\n' ).map( ( _, index ) => index + 1 );
+	};
+
+	const content =
+		typeof attributes.content === 'string'
+			? attributes.content
+			: attributes.content.toHTMLString( {
+					preserveWhiteSpace: true,
+			  } );
+
+	const lineNumbers = calculateLineNumbers( content );
+
 	return (
-		<pre { ...useBlockProps.save() }>
-			<RichText.Content
-				tagName="code"
-				// To do: `escape` encodes characters in shortcodes and URLs to
-				// prevent embedding in PHP. Ideally checks for the code block,
-				// or pre/code tags, should be made on the PHP side?
-				value={ escape(
-					typeof attributes.content === 'string'
-						? attributes.content
-						: attributes.content.toHTMLString( {
-								preserveWhiteSpace: true,
-						  } )
-				) }
-			/>
-		</pre>
+		<div
+			{ ...useBlockProps.save() }
+			className="wp-block-code-with-line-numbers"
+		>
+			<div className="line-numbers">
+				{ lineNumbers.map( ( num ) => (
+					<div key={ num }>{ num }</div>
+				) ) }
+			</div>
+			<pre className="code-content">
+				<RichText.Content
+					tagName="code"
+					// To do: `escape` encodes characters in shortcodes and URLs to
+					// prevent embedding in PHP. Ideally checks for the code block,
+					// or pre/code tags, should be made on the PHP side?
+					value={ escape( content ) }
+				/>
+			</pre>
+		</div>
 	);
 }

--- a/packages/block-library/src/code/style.scss
+++ b/packages/block-library/src/code/style.scss
@@ -16,3 +16,21 @@
 		/*!rtl:end:ignore*/
 	}
 }
+.wp-block-code-with-line-numbers {
+	display: flex;
+}
+
+.line-numbers {
+	padding-right: 8px;
+	text-align: right;
+	border-right: 1px solid #ddd;
+	color: #6a737d;
+	user-select: none;
+	margin: 1em 0;
+}
+
+.code-content {
+	flex-grow: 1;
+	padding-left: 8px;
+	overflow: auto;
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Fixes: https://github.com/WordPress/gutenberg/issues/38479

## How?
Added line numbers along with the code

## Testing Instructions

- Go to WP admin.
- Open any page or post in edit mode.
- Add code block.
- Insert some code.
- Observe and verify the line numbers are adding properly.


## Screenshots or screencast <!-- if applicable -->


https://github.com/user-attachments/assets/35aa4e41-344c-4725-984d-b67cab842094

