### PR TITLE
Check Storybook build on CI for PRs

### DIFF
--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -1,0 +1,28 @@
+name: Check Storybook build
+
+on: pull_request
+
+# Cancels all previous workflow runs for pull requests that have not completed.
+concurrency:
+    # The concurrency group contains the workflow name and the branch name for pull requests
+    # or the commit hash for any other events.
+    group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        if: ${{ github.repository == 'WordPress/gutenberg' }}
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+              with:
+                  ref: trunk
+                  show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
+
+            - name: Setup Node.js and install dependencies
+              uses: ./.github/setup-node
+
+            - name: Build Storybook
+              run: npm run storybook:build

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
     check:
         runs-on: ubuntu-latest
-        if: ${{ github.repository == 'WordPress/gutenberg' }}
+        if: ${{ github.repository == 'WordPress/gutenberg' || github.event_name == 'pull_request' }}
 
         steps:
             - name: Checkout

--- a/.github/workflows/storybook-check.yml
+++ b/.github/workflows/storybook-check.yml
@@ -10,7 +10,7 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    deploy:
+    check:
         runs-on: ubuntu-latest
         if: ${{ github.repository == 'WordPress/gutenberg' }}
 
@@ -18,7 +18,6 @@ jobs:
             - name: Checkout
               uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
-                  ref: trunk
                   show-progress: ${{ runner.debug == '1' && 'true' || 'false' }}
 
             - name: Setup Node.js and install dependencies

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -118,7 +118,7 @@
 			// This ensure the radius work properly.
 			overflow: hidden;
 
-			@media (prefers-reduced-motion: no-preference) {
+			@media not (prefers-reduced-motion) {
 				transition: border-radius, box-shadow 0.4s;
 			}
 

--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -118,7 +118,7 @@
 			// This ensure the radius work properly.
 			overflow: hidden;
 
-			@media not (prefers-reduced-motion) {
+			@media (prefers-reduced-motion: no-preference) {
 				transition: border-radius, box-shadow 0.4s;
 			}
 


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?

Adds a CI check on PRs to ensure that the Storybook builds without errors.

## Why?

To prevent Storybook-breaking changes (like https://github.com/WordPress/gutenberg/pull/68419#issuecomment-2567550864) from being merged into trunk.

## Testing Instructions

✅ The CI check [passes](https://github.com/WordPress/gutenberg/actions/runs/12584515104/job/35074323029?pr=68466) on a working build (4c12233b111def9a4b124c0ea4ad2c5eaec77c7f)
✅ The CI check [fails](https://github.com/WordPress/gutenberg/actions/runs/12584968340/job/35075730001?pr=68466) on a broken build (fdf8121235296e036646fa58a90bd12c3a2c06c9)