### PR TITLE
Update the WPCS-related composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
 		"wp-coding-standards/wpcs": "~3.1.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
-		"spatie/phpunit-watcher": "^1.23.6",
+		"spatie/phpunit-watcher": "^1.23",
 		"yoast/phpunit-polyfills": "^1.1.0",
 		"gutenberg/gutenberg-coding-standards": "@dev"
 	},

--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
 	},
 	"require-dev": {
 		"phpcompatibility/phpcompatibility-wp": "^2.1.3",
-		"wp-coding-standards/wpcs": "^3.0",
+		"wp-coding-standards/wpcs": "~3.1.0",
 		"sirbrillig/phpcs-variable-analysis": "^2.8",
-		"spatie/phpunit-watcher": "^1.23",
+		"spatie/phpunit-watcher": "^1.23.6",
 		"yoast/phpunit-polyfills": "^1.1.0",
 		"gutenberg/gutenberg-coding-standards": "@dev"
 	},

--- a/test/php/gutenberg-coding-standards/Gutenberg/Tests/AbstractSniffUnitTest.php
+++ b/test/php/gutenberg-coding-standards/Gutenberg/Tests/AbstractSniffUnitTest.php
@@ -29,7 +29,7 @@ abstract class AbstractSniffUnitTest extends BaseAbstractSniffUnitTest {
 	 * This method resets the 'Gutenberg' ruleset in the $GLOBALS['PHP_CODESNIFFER_RULESETS']
 	 * to its original state.
 	 */
-	public static function tearDownAfterClass() {
+	public static function tearDownAfterClass(): void {
 		parent::tearDownAfterClass();
 
 		$GLOBALS['PHP_CODESNIFFER_RULESETS']['Gutenberg'] = static::$original_ruleset;

--- a/test/php/gutenberg-coding-standards/composer.json
+++ b/test/php/gutenberg-coding-standards/composer.json
@@ -16,19 +16,19 @@
 		}
 	],
 	"require": {
-		"php": ">=7.0",
+		"php": ">=7.2",
 		"ext-libxml": "*",
 		"ext-tokenizer": "*",
 		"ext-xmlreader": "*",
-		"squizlabs/php_codesniffer": "^3.7.2",
-		"phpcsstandards/phpcsutils": "^1.0.8"
+		"squizlabs/php_codesniffer": "^3.9.0",
+		"phpcsstandards/phpcsutils": "^1.0.10"
 	},
 	"require-dev": {
 		"phpcompatibility/php-compatibility": "^9.0",
-		"phpunit/phpunit": "^5.0 || ^6.0 || ^7.0",
+		"phpunit/phpunit": "^7.0 || ^8.0 || ^9.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
 		"php-parallel-lint/php-console-highlighter": "^1.0.0",
-		"wp-coding-standards/wpcs": "^3.0"
+		"wp-coding-standards/wpcs": "~3.1.0"
 	},
 	"suggest": {
 		"ext-mbstring": "For improved results"


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?  
This PR updates the WPCS-related composer dependencies to ensure alignment between the Gutenberg and WordPress Core projects.

## Why?  
It is essential for both codebases to use the same versions of composer packages. This helps streamline the synchronization process and maintain consistency between the codebases.

## How?  

- [x] Update Gutenberg to use the same WPCS and related packages as WordPress Core;
- [x] Update GBCS to match the composer dependency versions used by WPCS;
- [x] Fix the fatal error in `AbstractSniffUnitTest` caused by differing method signatures.

## Testing Instructions  
1. Review the changes and confirm that all CI jobs pass successfully.  
2. Navigate to the `test/php/gutenberg-coding-standards` directory.
3. Run the PHPUnit tests with the following command:
   ```bash
   composer run-tests
   ```  
4. Verify that all unit tests pass without errors.  