### PR TITLE
Components: Restore Non-Themed Text Colors for `optimizeReadabilityFor`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -8,6 +8,8 @@
 -   `Navigation`: Upsize back buttons ([#68157](https://github.com/WordPress/gutenberg/pull/68157)).
 -   `Heading`: Fix text contrast for dark mode ([#68349](https://github.com/WordPress/gutenberg/pull/68349)).
 -   `Text`: Fix text contrast for dark mode ([#68349](https://github.com/WordPress/gutenberg/pull/68349)).
+-   `Heading`: Revert text contrast fix for dark mode with optimizeReadabilityFor ([#68472](https://github.com/WordPress/gutenberg/pull/68472)).
+-   `Text`: Revert text contrast fix for dark mode with optimizeReadabilityFor ([#68472](https://github.com/WordPress/gutenberg/pull/68472)).
 
 ### Deprecations
 

--- a/packages/components/src/text/hook.ts
+++ b/packages/components/src/text/hook.ts
@@ -104,9 +104,10 @@ export default function useText(
 			const isOptimalTextColorDark =
 				getOptimalTextShade( optimizeReadabilityFor ) === 'dark';
 
+			// Should not use theme colors
 			sx.optimalTextColor = isOptimalTextColorDark
-				? css( { color: COLORS.theme.foreground } )
-				: css( { color: COLORS.theme.foregroundInverted } );
+				? css( { color: COLORS.gray[ 900 ] } )
+				: css( { color: COLORS.white } );
 		}
 
 		return cx(

--- a/packages/components/src/text/test/index.tsx
+++ b/packages/components/src/text/test/index.tsx
@@ -25,7 +25,7 @@ describe( 'Text', () => {
 			</Text>
 		);
 		expect( screen.getByRole( 'heading' ) ).toHaveStyle( {
-			color: 'rgb( 255, 255, 255 )',
+			color: COLORS.white,
 		} );
 	} );
 


### PR DESCRIPTION
Follow up: https://github.com/WordPress/gutenberg/pull/68349
Related comment: https://github.com/WordPress/gutenberg/pull/68349#discussion_r1900701530

## What?
Reverted to using non-theme-based CSS values when the `optimizeReadabilityFor` prop is used, aligning with its intended functionality.


## Why?
The `optimizeReadabilityFor` prop takes a static background color as input. To ensure consistent readability, the corresponding text colors must remain as non-themed values.

## How?
Reverted the specific changes to `optimizeReadabilityFor` introduced in [PR #68349](https://github.com/WordPress/gutenberg/pull/68349)
