### PR TITLE
Storybook: Add BlockSelectionClearer story 

### DIFF
--- a/packages/block-editor/src/components/block-selection-clearer/index.js
+++ b/packages/block-editor/src/components/block-selection-clearer/index.js
@@ -51,6 +51,23 @@ export function useBlockSelectionClearer() {
 	);
 }
 
+/**
+ * The BlockSelectionClearer component clears block selection when clicked.
+ *
+ * @example
+ * ```jsx
+ * function Example() {
+ * return(
+ *    <BlockSelectionClearer { ...args }>
+ * 	  <BlockSelectionClearer/>
+ * );
+ * }
+ * ```
+ *
+ * @param {Object} props The props for the component.
+ * @return {Element} The block type item element.
+ * 
+ */
 export default function BlockSelectionClearer( props ) {
 	return <div ref={ useBlockSelectionClearer() } { ...props } />;
 }

--- a/packages/block-editor/src/components/block-selection-clearer/stories/index.story.js
+++ b/packages/block-editor/src/components/block-selection-clearer/stories/index.story.js
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import BlockSelectionClearer from "..";
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from "@wordpress/i18n";
+
+const meta = {
+    title: 'Components/BlockSelectionClearer',
+    component: BlockSelectionClearer,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component: 'A component that clears block selection when clicked.',
+			},
+		},
+	},
+	argTypes: {
+        props:{
+            control: { type: null },
+            description: 'The props for the component.',
+            table: {
+                type: {
+                    summary: 'Object',
+                },
+            },
+        }
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( args ) {
+		return (
+            <BlockSelectionClearer { ...args }>
+                <button>
+                   { __('Block Selection Clearer') }
+                </button>
+            </BlockSelectionClearer>
+        )
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR will add Block Selection Clearer story 

## Testing Instructions
- Run npm run storybook:dev
- Open the storybook on http://localhost:50240/
- Check the BorderRadiusControl stories.

## Screenshots or screencast 

<img width="1470" alt="Screenshot 2025-01-03 at 10 42 17 AM" src="https://github.com/user-attachments/assets/461f6446-6e29-42eb-b651-484f4dfa552b" />