### PR TITLE
Added missing classNames on global-styles ToolsPanels

### DIFF
--- a/packages/block-editor/src/components/global-styles/background-panel.js
+++ b/packages/block-editor/src/components/global-styles/background-panel.js
@@ -80,6 +80,7 @@ function BackgroundToolsPanel( {
 			label={ headerLabel }
 			resetAll={ resetAll }
 			panelId={ panelId }
+			className="background-block-support-panel"
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }

--- a/packages/block-editor/src/components/global-styles/border-panel.js
+++ b/packages/block-editor/src/components/global-styles/border-panel.js
@@ -80,6 +80,7 @@ function BorderToolsPanel( {
 			label={ label }
 			resetAll={ resetAll }
 			panelId={ panelId }
+			className="border-block-support-panel"
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }

--- a/packages/block-editor/src/components/global-styles/dimensions-panel.js
+++ b/packages/block-editor/src/components/global-styles/dimensions-panel.js
@@ -191,6 +191,7 @@ function DimensionsToolsPanel( {
 			label={ __( 'Dimensions' ) }
 			resetAll={ resetAll }
 			panelId={ panelId }
+			className="dimensions-block-support-panel"
 			dropdownMenuProps={ dropdownMenuProps }
 		>
 			{ children }


### PR DESCRIPTION
## What?
This PR introduces classNames for the `border`, `dimensions`, and `background` ToolsPanel components located in `packages/block-editor/src/components/global-styles`

## Why?
A unique selector is required to eg. embed a portal within these components. The necessary classes have already been implemented and are also in use within block components.

## Impact?
These changes will not result in any visible differences in the interface. If needed, I can further refine the classNames for better differentiation in the global-styles context.

Let me know if you’d like additional adjustments!

|Before|After|
|-|-|
|<img width="2056" alt="screenshot-before" src="https://github.com/user-attachments/assets/60b7a546-03be-4cc6-949c-a0c9bcf966e5" />|<img width="2056" alt="screenshot-after" src="https://github.com/user-attachments/assets/438a0648-4c0c-4750-9e37-02b95d172589" />|
