### PR TITLE
Fix CSS classes for the post editor iframe body.

### DIFF
--- a/packages/block-editor/src/components/iframe/index.js
+++ b/packages/block-editor/src/components/iframe/index.js
@@ -131,26 +131,29 @@ function Iframe( {
 		function preventFileDropDefault( event ) {
 			event.preventDefault();
 		}
+
+		const { ownerDocument } = node;
+
+		// Ideally ALL classes that are added through get_body_class should
+		// be added in the editor too, which we'll somehow have to get from
+		// the server in the future (which will run the PHP filters).
+		setBodyClasses(
+			Array.from( ownerDocument.body.classList ).filter(
+				( name ) =>
+					name.startsWith( 'admin-color-' ) ||
+					name.startsWith( 'post-type-' ) ||
+					name === 'wp-embed-responsive'
+			)
+		);
+
 		function onLoad() {
-			const { contentDocument, ownerDocument } = node;
+			const { contentDocument } = node;
 			const { documentElement } = contentDocument;
 			iFrameDocument = contentDocument;
 
 			documentElement.classList.add( 'block-editor-iframe__html' );
 
 			clearerRef( documentElement );
-
-			// Ideally ALL classes that are added through get_body_class should
-			// be added in the editor too, which we'll somehow have to get from
-			// the server in the future (which will run the PHP filters).
-			setBodyClasses(
-				Array.from( ownerDocument.body.classList ).filter(
-					( name ) =>
-						name.startsWith( 'admin-color-' ) ||
-						name.startsWith( 'post-type-' ) ||
-						name === 'wp-embed-responsive'
-				)
-			);
 
 			contentDocument.dir = ownerDocument.dir;
 

--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -5,10 +5,25 @@
 	position: absolute;
 	top: 0;
 	left: 0;
+	opacity: 0;
 	align-items: center;
 	justify-content: center;
 
+	@media not (prefers-reduced-motion) {
+		animation: 0.5s ease 0.2s edit-site-canvas-loader__fade-in-animation;
+		animation-fill-mode: forwards;
+	}
+
 	& > div {
 		width: 160px;
+	}
+}
+
+@keyframes edit-site-canvas-loader__fade-in-animation {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
 	}
 }

--- a/packages/edit-site/src/components/canvas-loader/style.scss
+++ b/packages/edit-site/src/components/canvas-loader/style.scss
@@ -5,25 +5,10 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	opacity: 0;
 	align-items: center;
 	justify-content: center;
 
-	@media not (prefers-reduced-motion) {
-		animation: 0.5s ease 0.2s edit-site-canvas-loader__fade-in-animation;
-		animation-fill-mode: forwards;
-	}
-
 	& > div {
 		width: 160px;
-	}
-}
-
-@keyframes edit-site-canvas-loader__fade-in-animation {
-	from {
-		opacity: 0;
-	}
-	to {
-		opacity: 1;
 	}
 }

--- a/test/e2e/specs/editor/various/block-editor-dark-background.spec.js
+++ b/test/e2e/specs/editor/various/block-editor-dark-background.spec.js
@@ -1,0 +1,52 @@
+/**
+ * WordPress dependencies
+ */
+const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
+
+test.describe( 'Block editor with dark background theme', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'darktheme' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.describe( 'block editor iframe body', () => {
+		test( 'should have the is-dark-theme CSS class', async ( {
+			editor,
+		} ) => {
+			const canvasBody = editor.canvas.locator( 'body' );
+
+			await expect( canvasBody ).toHaveClass( /is-dark-theme/ );
+		} );
+	} );
+} );
+
+test.describe( 'Block editor with light background theme', () => {
+	test.beforeAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyfour' );
+	} );
+
+	test.beforeEach( async ( { admin } ) => {
+		await admin.createNewPost();
+	} );
+
+	test.afterAll( async ( { requestUtils } ) => {
+		await requestUtils.activateTheme( 'twentytwentyone' );
+	} );
+
+	test.describe( 'block editor iframe body', () => {
+		test( 'should not have the is-dark-theme CSS class', async ( {
+			editor,
+		} ) => {
+			const canvasBody = editor.canvas.locator( 'body' );
+
+			await expect( canvasBody ).not.toHaveClass( /is-dark-theme/ );
+		} );
+	} );
+} );

--- a/test/e2e/specs/site-editor/site-editor-dark-background.spec.js
+++ b/test/e2e/specs/site-editor/site-editor-dark-background.spec.js
@@ -3,20 +3,20 @@
  */
 const { test, expect } = require( '@wordpress/e2e-test-utils-playwright' );
 
-test.describe( 'Block editor with dark background theme', () => {
+test.describe( 'Site editor with dark background theme', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'darktheme' );
 	} );
 
 	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
+		await admin.visitSiteEditor();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.describe( 'Block editor iframe body', () => {
+	test.describe( 'Site editor iframe body', () => {
 		test( 'Should have the is-dark-theme CSS class', async ( {
 			editor,
 		} ) => {
@@ -27,24 +27,47 @@ test.describe( 'Block editor with dark background theme', () => {
 	} );
 } );
 
-test.describe( 'Block editor with light background theme', () => {
+test.describe( 'Site editor with light background theme and theme variations', () => {
 	test.beforeAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyfour' );
 	} );
 
 	test.beforeEach( async ( { admin } ) => {
-		await admin.createNewPost();
+		await admin.visitSiteEditor();
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
 		await requestUtils.activateTheme( 'twentytwentyone' );
 	} );
 
-	test.describe( 'Block editor iframe body', () => {
+	test.describe( 'Site editor iframe body', () => {
 		test( 'Should not have the is-dark-theme CSS class', async ( {
 			editor,
 		} ) => {
 			const canvasBody = editor.canvas.locator( 'body' );
+
+			await expect( canvasBody ).not.toHaveClass( /is-dark-theme/ );
+		} );
+
+		test( 'Should add and remove the is-dark-theme CSS class with dark and light theme variation', async ( {
+			page,
+			editor,
+		} ) => {
+			// Click "Styles"
+			await page.getByRole( 'button', { name: 'Styles' } ).click();
+
+			// Click "Browse styles"
+			await page.getByRole( 'button', { name: 'Browse styles' } ).click();
+
+			const canvasBody = editor.canvas.locator( 'body' );
+
+			// Activate "Maelstrom" Theme Variation.
+			await page.getByRole( 'button', { name: 'Maelstrom' } ).click();
+
+			await expect( canvasBody ).toHaveClass( /is-dark-theme/ );
+
+			// Activate "Ember" Theme Variation.
+			await page.getByRole( 'button', { name: 'Ember' } ).click();
 
 			await expect( canvasBody ).not.toHaveClass( /is-dark-theme/ );
 		} );

--- a/test/gutenberg-test-themes/darktheme/block-templates/index.html
+++ b/test/gutenberg-test-themes/darktheme/block-templates/index.html
@@ -1,0 +1,11 @@
+<!-- wp:query {"queryId":1,"query":{"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","sticky":""}} -->
+<div class="wp-block-query">
+	<!-- wp:post-template -->
+	<!-- wp:post-title {"isLink":true} /-->
+	<!-- wp:post-excerpt /-->
+	<!-- /wp:post-template -->
+</div>
+<!-- /wp:query -->
+<!-- wp:paragraph -->
+<p>My awesome paragraph</p>
+<!-- /wp:paragraph -->

--- a/test/gutenberg-test-themes/darktheme/block-templates/singular.html
+++ b/test/gutenberg-test-themes/darktheme/block-templates/singular.html
@@ -1,0 +1,2 @@
+<!-- wp:post-title /-->
+<!-- wp:post-content {"layout":{"inherit":true}} /-->

--- a/test/gutenberg-test-themes/darktheme/index.php
+++ b/test/gutenberg-test-themes/darktheme/index.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Theme index.php file.
+ *
+ * @package Gutenberg
+ */
+
+// Silence is golden.
+return;

--- a/test/gutenberg-test-themes/darktheme/style.css
+++ b/test/gutenberg-test-themes/darktheme/style.css
@@ -1,0 +1,15 @@
+/*
+Theme Name: Dark Theme
+Theme URI: https://github.com/wordpress/gutenberg/
+Author: the WordPress team
+Description: Dark background test theme.
+Requires at least: 5.3
+Tested up to: 5.5
+Requires PHP: 5.6
+Version: 1.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Text Domain: dark-theme
+Dark Theme WordPress Theme, (C) 2021 WordPress.org
+Dark Theme is distributed under the terms of the GNU GPL.
+*/

--- a/test/gutenberg-test-themes/darktheme/theme.json
+++ b/test/gutenberg-test-themes/darktheme/theme.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "../../../schemas/json/theme.json",
+	"version": 3,
+	"styles": {
+		"color": {
+			"background": "#000",
+			"text": "#fff"
+		}
+	}
+}


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/60299

Second attempt to fix this issue after https://github.com/WordPress/gutenberg/pull/60300 was reverted for a bug in Safari, see https://github.com/WordPress/gutenberg/pull/60616. A follow-up was planned but it never happened.

## What?
<!-- In a few words, what is the PR actually doing? -->
In the post editor, the `is-dark-theme` CSS class gets removed from the iframe body when the iframe fully loads. This happens only in the post editor, it doesn't in the site editor as the implementation is different. 

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The `is-dark-theme` CSS class is necessary to correctly style some UIs when a dark theme is in use.
For example, for accessibility, the block placeholder text should use a sufficient contrast ratio when the theme is dark.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Moves setting the iframe body classes at an earlier time in `useRefEffect` rather than in the iframe `onLoad` callback. 
- Adds a basic test theme `darktheme` to be used in the tests.
- Adds e2e tests for both the post editor and the site editor.

I'm not sure there was a specific reason to set the classes _after_ the iframe is fully loaded. The `onLoad` callback appears to be too late, as at that point the existing classes get replaced.
In this PR the setting of the classes happens earlier, in the `useRefEffect` hook. It appears everything works as expected because at that point the iframe element is rendered. Theoretically there shouldn't be drawbacks but please double check any potential undesired side effect.

Cc @glendaviesnz @ellatrix  

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

Reproduce the issue on trunk:
- Use a dark theme e.g. Twenty Twenty-Four > Maelstrom style 
- To make testing easier, edit a post that contains a big image so that the iframe `load` event takes a while to fire.
- Inspect the DOM and refresh the page.
- You need to inspect very quickly the iframe body with class `block-editor-iframe__body` to check the intial classes before the iframe fully loads are: `block-editor-iframe__body editor-styles-wrapper is-dark-theme`
- Observe that after the iframe fully loads, the CSS classes are replaced with: `block-editor-iframe__body editor-styles-wrapper post-type-post admin-color-fresh wp-embed-responsive`
- Observe the `is-dark-theme` class is now missing.
- Switch to this PR's branch.
- Repeat the steps above.
- Observe the initial classes are: `block-editor-iframe__body editor-styles-wrapper post-type-post admin-color-fresh wp-embed-responsive is-dark-theme`
- Onserve thtat after the iframe is fully loader, the classes don't change and the `is-dark-theme` class isstill there.
- Observe that the classes are set correctly e.g. change admin color scheme to 'Midnight` and observe the `admin-color-fresh` class is now `admin-color-midnight`.
- Edit a page insteaad of a post and observe the `post-type-post` class is now `post-type-pag`.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
