### PR TITLE
Site Editor: fix "Quick Edit Mode" E2E tests

### DIFF
--- a/test/e2e/specs/site-editor/page-list.spec.js
+++ b/test/e2e/specs/site-editor/page-list.spec.js
@@ -290,7 +290,7 @@ test.describe( 'Page List', () => {
 			await page.getByRole( 'button', { name: 'Layout' } ).click();
 			await page.getByRole( 'menuitemradio', { name: 'Table' } ).click();
 			const privacyPolicyCheckbox = page.getByRole( 'checkbox', {
-				name: 'Select Item: Privacy Policy',
+				name: 'Privacy Policy',
 			} );
 
 			await privacyPolicyCheckbox.check();
@@ -352,7 +352,7 @@ test.describe( 'Page List', () => {
 		// 	page,
 		// } ) => {
 		// 	const samplePage = page.getByRole( 'checkbox', {
-		// 		name: 'Select Item: Sample Page',
+		// 		name: 'Sample Page',
 		// 	} );
 
 		// 	await samplePage.check();


### PR DESCRIPTION
Related PRs:

- #68151
- #67868

## What?

#67868 changed the label of the dataview checkbox from `Select item: {pageName}` to `{pageName}`. Also, #68151 added e2e tests for quick edit mode.

As a result, the e2e tests for quick edit mode expected and actual labels no longer match, causing the tests to fail:

![e2e-test-failure](https://github.com/user-attachments/assets/8f1e4b28-98b0-4c40-b8d6-39127b14f94e)

Perhaps #67868 did not yet include e2e tests for quick edit mode.

## Testing Instructions

Let's see if the e2e test passes.
