### PR TITLE
Comment Template: Add Layout Support

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -178,7 +178,7 @@ Contains the block elements used to display a comment, like the title, date, aut
 -	**Name:** core/comment-template
 -	**Category:** design
 -	**Parent:** core/comments
--	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
+-	**Supports:** align, interactivity (clientNavigation), layout, spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~, ~~reusable~~
 
 ## Comments
 

--- a/packages/block-library/src/comment-template/block.json
+++ b/packages/block-library/src/comment-template/block.json
@@ -10,6 +10,7 @@
 	"usesContext": [ "postId" ],
 	"supports": {
 		"align": true,
+		"layout": true,
 		"html": false,
 		"reusable": false,
 		"spacing": {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Added Layout support to the Comment Template Block.

Part of : https://github.com/WordPress/gutenberg/issues/43248

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The block was missing Layout Support Features.

## Testing Instructions
- Test the `Comment Template` block in both the block editor and site editor.
- Confirm that the layout setting work correctly, and display correctly on the front.
-In the Site Editor, Open or Create the template for single posts. Add a `Comment Template` block & Test the layout setting work correctly.

## Screenshots or Screencast <!-- if applicable -->

https://github.com/user-attachments/assets/b5498545-4277-4b0f-bee0-6dd67df28f48

