### PR TITLE
BlockInspector: Remove unused 'showNoBlockSelectedMessage' prop

### DIFF
--- a/packages/block-editor/src/components/block-inspector/README.md
+++ b/packages/block-editor/src/components/block-inspector/README.md
@@ -16,16 +16,6 @@ import { BlockInspector } from '@wordpress/block-editor';
 const MyBlockInspector = () => <BlockInspector />;
 ```
 
-### Props
-
-#### showNoBlockSelectedMessage
-
-Whether to display a "No block selected" message when no block is selected.
-
--   Type: `boolean`
--   Required: No
--   Default: `true`
-
 ## Related components
 
 Block Editor components are components that can be used to compose the UI of your block editor. Thus, they can only be used under a [BlockEditorProvider](https://github.com/WordPress/gutenberg/blob/HEAD/packages/block-editor/src/components/provider/README.md) in the components tree.

--- a/packages/block-editor/src/components/block-inspector/index.js
+++ b/packages/block-editor/src/components/block-inspector/index.js
@@ -39,7 +39,7 @@ function BlockStylesPanel( { clientId } ) {
 	);
 }
 
-const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
+function BlockInspector() {
 	const {
 		count,
 		selectedBlockName,
@@ -137,14 +137,11 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 		! selectedBlockClientId ||
 		isSelectedBlockUnregistered
 	) {
-		if ( showNoBlockSelectedMessage ) {
-			return (
-				<span className="block-editor-block-inspector__no-blocks">
-					{ __( 'No block selected.' ) }
-				</span>
-			);
-		}
-		return null;
+		return (
+			<span className="block-editor-block-inspector__no-blocks">
+				{ __( 'No block selected.' ) }
+			</span>
+		);
 	}
 
 	return (
@@ -168,7 +165,7 @@ const BlockInspector = ( { showNoBlockSelectedMessage = true } ) => {
 			/>
 		</BlockInspectorSingleBlockWrapper>
 	);
-};
+}
 
 const BlockInspectorSingleBlockWrapper = ( { animate, wrapper, children } ) => {
 	return animate ? wrapper( children ) : children;


### PR DESCRIPTION
## What?
PR removes the unused `showNoBlockSelectedMessage` prop from the `BlockInspector` component. It hasn't been used since #22467.

## Why?
Composition should be preferred over similar props:

```jsx
return condition ? <BlockInspector /> : <span>fallback text</span>;
```

## Testing Instructions
None. CI checks should be green.

### Testing Instructions for Keyboard
Same.
