### PR TITLE
Details: Add allowedBlocks attributes

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -255,7 +255,7 @@ Hide and show additional content. ([Source](https://github.com/WordPress/gutenbe
 -	**Name:** core/details
 -	**Category:** text
 -	**Supports:** align (full, wide), anchor, color (background, gradients, link, text), interactivity (clientNavigation), layout (~~allowEditing~~), spacing (blockGap, margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** showContent, summary
+-	**Attributes:** allowedBlocks, showContent, summary
 
 ## Embed
 

--- a/packages/block-library/src/details/block.json
+++ b/packages/block-library/src/details/block.json
@@ -16,6 +16,9 @@
 			"type": "rich-text",
 			"source": "rich-text",
 			"selector": "summary"
+		},
+		"allowedBlocks": {
+			"type": "array"
 		}
 	},
 	"supports": {

--- a/packages/block-library/src/details/edit.js
+++ b/packages/block-library/src/details/edit.js
@@ -31,11 +31,12 @@ const TEMPLATE = [
 ];
 
 function DetailsEdit( { attributes, setAttributes, clientId } ) {
-	const { showContent, summary } = attributes;
+	const { showContent, summary, allowedBlocks } = attributes;
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: TEMPLATE,
 		__experimentalCaptureToolbars: true,
+		allowedBlocks,
 	} );
 	const dropdownMenuProps = useToolsPanelDropdownMenuProps();
 


### PR DESCRIPTION
Similar PRs:

- https://github.com/WordPress/gutenberg/pull/35342
- https://github.com/WordPress/gutenberg/pull/31326
- https://github.com/WordPress/gutenberg/pull/49128
- https://github.com/WordPress/gutenberg/pull/49981

## Why?

The Details block supports inner blocks. As with other blocks, it would be useful to be able to control which blocks can be inserted.

## Testing Instructions

Use the following code to verify that the attribute works correctly.

### HTML

```html
<!-- wp:details {"allowedBlocks":["core/paragraph","core/list"]} -->
<details class="wp-block-details">
  <summary>Summary</summary>
  <!-- wp:paragraph {"placeholder":"Type / to add a hidden block"} -->
  <p></p>
  <!-- /wp:paragraph -->
</details>
<!-- /wp:details -->
```

### JS

Add the following code to any JS file (such as the `packages/block-directory/src/plugins/index.js` file).

```javascript
function overrideAllowedBlocks( settings, name ) {
	if ( name !== 'core/details' ) {
		return settings;
	}
	return {
		...settings,
		attributes: {
			...settings.attributes,
			allowedBlocks: {
				...settings.attributes.allowedBlocks,
				default: [ 'core/paragraph', 'core/list' ],
			},
		},
	};
}

wp.hooks.addFilter(
	'blocks.registerBlockType',
	'my-plugin/details-block',
	overrideAllowedBlocks
);
```

### PHP

Add the following code to any PHP file (such as the `gutenberg.php` file).

```php
function example_details_block_allowed_blocks( $metadata ) {
	if ( 'core/details' !== $metadata['name'] ) {
		return $metadata;
	}
	$metadata['attributes']['allowedBlocks']['default'] = array(
		'core/paragraph',
		'core/list',
	);
	return $metadata;
}
add_filter( 'block_type_metadata', 'example_details_block_allowed_blocks' );
```