### PR TITLE
Header: Adjust layout styles for better responsiveness on mobile devices

### DIFF
--- a/packages/editor/src/components/header/style.scss
+++ b/packages/editor/src/components/header/style.scss
@@ -101,11 +101,17 @@
 	.editor-header:has(> .editor-header__center) & {
 		grid-column: 4 / -1;
 	}
-	justify-self: end;
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: nowrap;
 	padding-right: $grid-unit-05;
+	width: 100%;
+	justify-content: inherit;
+
+	@include break-mobile () {
+		justify-self: end;
+		width: min-content;
+	}
 
 	@include break-small () {
 		padding-right: $grid-unit-10;


### PR DESCRIPTION
## What, Why and How?
On smaller screens with widths less than `335px`, a UI inconsistency was observed in `Firefox`. The header settings container retained its width, causing it to overlap with the `document tools`. 

To resolve this issue, a `width: 100%` property was applied exclusively to `mobile devices`. This adjustment ensured the `header settings` container adapted to the available `screen width`. Additionally, the `justify-content: inherit` rule was introduced to align the `header settings tools` correctly when the `width` became `constrained`. These changes effectively eliminated the overlap and restored the UI consistency.

## Testing Instructions (Firefox)
1. Create a `post`.
2. Navigate to the `post edit` page.
3. Open the `page` in `mobile view`.
4. Set the `width` to anything lesser than or equal to `335px`.
5. Observe the `overflowing` icons.

- Works as intended on chrome.

## Screencast

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/88c4190b-dfd8-4895-aa86-516642378eda)|![after](https://github.com/user-attachments/assets/efb716e0-4c9e-4bc5-a06a-c102f4d428bf)|

Closes: #68480 