### PR TITLE
Storybook: Add Story for Block Switcher

### DIFF
--- a/packages/block-editor/src/components/block-switcher/index.js
+++ b/packages/block-editor/src/components/block-switcher/index.js
@@ -186,6 +186,24 @@ function BlockSwitcherDropdownMenuContents( {
 	);
 }
 
+/**
+ * BlockSwitcher component switches between block types and styles.
+ *
+ *
+ * @example
+ * ```jsx
+ * function Example(){
+ * return (
+ *   <BlockSwitcher clientIds={ [ 'block-1', 'block-2' ] } />
+ * );
+ * }
+ *
+ * ```
+ * @param {Object}   props           Component props.
+ * @param {string[]} props.clientIds The client IDs of the blocks to switch.
+ *
+ * @return {Element} The BlockSwitcher component.
+ */
 export const BlockSwitcher = ( { clientIds } ) => {
 	const {
 		hasContentOnlyLocking,

--- a/packages/block-editor/src/components/block-switcher/stories/index.story.js
+++ b/packages/block-editor/src/components/block-switcher/stories/index.story.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import BlockSwitcher from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock } from '@wordpress/blocks';
+import { dispatch } from '@wordpress/data';
+
+// Register core blocks for the story environment
+registerCoreBlocks();
+
+const blockEditorState = [
+	createBlock( 'core/paragraph' ),
+	createBlock( 'core/heading' ),
+];
+
+dispatch( 'core/block-editor' ).resetBlocks( blockEditorState );
+
+const meta = {
+	title: 'Components/BlockSwitcher',
+	component: BlockSwitcher,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The BlockSwitcher component is used to switch between different block types.',
+			},
+		},
+	},
+	argTypes: {
+		clientIds: {
+			control: { type: null },
+			description: 'The client IDs of the blocks to switch between.',
+			table: {
+				type: {
+					summary: 'Array',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		clientIds: blockEditorState.map( ( block ) => block.clientId ),
+	},
+	render: function Template( args ) {
+		return <BlockSwitcher { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds storybook for Block Switcher component

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the BlockSwitcher Story 

## Screenshots or screencast

https://github.com/user-attachments/assets/e0995202-afde-4b4e-a5c7-185f0a425217