### PR TITLE
Refactor: Separate input form styles to a dedicated stylesheet

### DIFF
--- a/packages/block-editor/src/components/media-placeholder/content.scss
+++ b/packages/block-editor/src/components/media-placeholder/content.scss
@@ -1,11 +1,3 @@
-.block-editor-media-placeholder__url-input-form {
-	min-width: 260px;
-
-	@include break-small() {
-		width: 300px;
-	}
-}
-
 .block-editor-media-placeholder__cancel-button.is-link {
 	margin: 1em;
 	display: block;

--- a/packages/block-editor/src/components/media-placeholder/style.scss
+++ b/packages/block-editor/src/components/media-placeholder/style.scss
@@ -1,0 +1,7 @@
+.block-editor-media-placeholder__url-input-form {
+	min-width: 260px;
+
+	@include break-small() {
+		width: 300px;
+	}
+}

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -13,6 +13,14 @@
 	align-items: center;
 }
 
+.block-editor-media-placeholder__url-input-form {
+	min-width: 260px;
+
+	@include break-small() {
+		width: 300px;
+	}
+}
+
 // Any children of the popover-row that are not the settings-toggle
 // should take up as much space as possible.
 .block-editor-url-popover__row > :not(.block-editor-url-popover__settings-toggle) {

--- a/packages/block-editor/src/components/url-popover/style.scss
+++ b/packages/block-editor/src/components/url-popover/style.scss
@@ -13,14 +13,6 @@
 	align-items: center;
 }
 
-.block-editor-media-placeholder__url-input-form {
-	min-width: 260px;
-
-	@include break-small() {
-		width: 300px;
-	}
-}
-
 // Any children of the popover-row that are not the settings-toggle
 // should take up as much space as possible.
 .block-editor-url-popover__row > :not(.block-editor-url-popover__settings-toggle) {

--- a/packages/block-editor/src/style.scss
+++ b/packages/block-editor/src/style.scss
@@ -40,6 +40,7 @@
 @import "./components/justify-content-control/style.scss";
 @import "./components/link-control/style.scss";
 @import "./components/list-view/style.scss";
+@import "./components/media-placeholder/style.scss";
 @import "./components/media-replace-flow/style.scss";
 @import "./components/multi-selection-inspector/style.scss";
 @import "./components/responsive-block-control/style.scss";


### PR DESCRIPTION
## What, Why and How?
The following CSS rule is added inside `content.scss` which targets the `iFrame` to apply the styles.
https://github.com/WordPress/gutenberg/blob/72a9996eb8e51ecbac47e40e3e444a7f5aefc6f3/packages/block-editor/src/components/media-placeholder/content.scss#L1-L7

Therefore, the issue arises because this rule targets a class within the `components-popover__content` class, which is outside the iframe, leading to the styles not getting applied.

Hence, it's recommended to extract this rule into a dedicated `style.scss` for it to be applied outside the `iframe` where the `popover component` is rendered.

## Testing Instructions
1. Create an `image/audio/video` block in `site editor`.
2. Notice the size of `Insert from URL` input is now back to normal.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/71346fa3-8bc8-418e-95a7-c95e70cc5e5f)|![after](https://github.com/user-attachments/assets/0b0f1563-5e77-4d1f-972a-fd30addd7523)|

<hr />

#### Works as expected in the `post editor` page.

![in-post-editor](https://github.com/user-attachments/assets/26903ba7-80c4-45a5-bb3d-ae9f4c6f532b)

<hr />

#### Works well with the `image/video` block.

![audio-in-site-editor](https://github.com/user-attachments/assets/dc5d0cee-c21c-46a6-80c3-2c9fdb9b71c0)


Closes: #68494 