### PR TITLE
Document Outline: Use block client ID as unique 'key'

### DIFF
--- a/packages/editor/src/components/document-outline/index.js
+++ b/packages/editor/src/components/document-outline/index.js
@@ -168,7 +168,7 @@ export default function DocumentOutline( {
 						{ title }
 					</DocumentOutlineItem>
 				) }
-				{ headings.map( ( item, index ) => {
+				{ headings.map( ( item ) => {
 					// Headings remain the same, go up by one, or down by any amount.
 					// Otherwise there are missing levels.
 					const isIncorrectLevel =
@@ -184,7 +184,7 @@ export default function DocumentOutline( {
 
 					return (
 						<DocumentOutlineItem
-							key={ index }
+							key={ item.clientId }
 							level={ `H${ item.level }` }
 							isValid={ isValid }
 							isDisabled={ hasOutlineItemsDisabled }


### PR DESCRIPTION
## What?
PR updates the headings list in the `DocumentOutline` component to use the unique `clientId` as the key instead of the item's `index`.

## Why?
Index as a key often leads to subtle and confusing bugs.

## Testing Instructions
1. Open a post or page.
2. Add multiple Heading blocks with different levels.
3. 

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->

![CleanShot 2025-01-06 at 16 05 10](https://github.com/user-attachments/assets/d966ae29-6bf2-4135-8342-3634938ce42b)
