### PR TITLE
Fix flaky DataViews list arraow nav e2e tests

### DIFF
--- a/test/e2e/specs/site-editor/command-center.spec.js
+++ b/test/e2e/specs/site-editor/command-center.spec.js
@@ -9,7 +9,10 @@ test.describe( 'Site editor command palette', () => {
 	} );
 
 	test.afterAll( async ( { requestUtils } ) => {
-		await requestUtils.activateTheme( 'twentytwentyone' );
+		await Promise.all( [
+			requestUtils.activateTheme( 'twentytwentyone' ),
+			requestUtils.deleteAllPages(),
+		] );
 	} );
 
 	test.beforeEach( async ( { admin } ) => {


### PR DESCRIPTION
## What?
Fixes #64334.

PR fixes `Navigates the items list via UP/DOWN arrow keys` flaky e2e test in `dataviews-list-layout-keyboard.spec.js`.

## Why?
It has been failing a lot lately.

## How?
Update cleanup for "Command Center" e2e tests and delete pages it creates, which is generally a good practice, especially for pages.

Ideally, the "Dataviews List Layout" would delete pages in `beforeAll`, but this can cause a race condition with `requestUtils.createPage`.

P.S. I think we should refactor the `dataviews-list-layout-keyboard.spec.js` tests and avoid exact label matching for items; we could assert the focused item's position instead.

## Testing Instructions
Let's observe flaky test notices.
