### PR TITLE
Upgrade Playwright to v1.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@octokit/rest": "16.26.0",
 				"@octokit/types": "6.34.0",
 				"@octokit/webhooks-types": "5.8.0",
-				"@playwright/test": "1.48.1",
+				"@playwright/test": "1.49.1",
 				"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 				"@react-native/babel-preset": "0.73.10",
 				"@react-native/metro-babel-transformer": "0.73.10",
@@ -8720,12 +8720,12 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.48.1",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
-			"integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+			"integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
 			"dev": true,
 			"dependencies": {
-				"playwright": "1.48.1"
+				"playwright": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -37902,12 +37902,12 @@
 			"dev": true
 		},
 		"node_modules/playwright": {
-			"version": "1.48.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
-			"integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+			"integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
 			"dev": true,
 			"dependencies": {
-				"playwright-core": "1.48.1"
+				"playwright-core": "1.49.1"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -37920,9 +37920,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.48.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
-			"integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
+			"version": "1.49.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+			"integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
 			"dev": true,
 			"bin": {
 				"playwright-core": "cli.js"
@@ -52381,7 +52381,7 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": "^1.48.1",
+				"@playwright/test": "^1.49.1",
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@octokit/rest": "16.26.0",
 		"@octokit/types": "6.34.0",
 		"@octokit/webhooks-types": "5.8.0",
-		"@playwright/test": "1.48.1",
+		"@playwright/test": "1.49.1",
 		"@pmmmwh/react-refresh-webpack-plugin": "0.5.11",
 		"@react-native/babel-preset": "0.73.10",
 		"@react-native/metro-babel-transformer": "0.73.10",

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -95,7 +95,7 @@
 		"webpack-dev-server": "^4.15.1"
 	},
 	"peerDependencies": {
-		"@playwright/test": "^1.48.1",
+		"@playwright/test": "^1.49.1",
 		"react": "^18.0.0",
 		"react-dom": "^18.0.0"
 	},


### PR DESCRIPTION
## What?
Upgrade Playwright to v1.49

## What's new?
https://playwright.dev/docs/release-notes#version-149

## Testing Instructions
* Run any e2e test locally; the command should download new browsers and run the test successfully.
* CI checks are green.