### PR TITLE
[Categories Block]: Adds attributes and support to show current taxonomy in categories block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -79,7 +79,7 @@ Display a list of all terms of a given taxonomy. ([Source](https://github.com/Wo
 -	**Name:** core/categories
 -	**Category:** widgets
 -	**Supports:** align, interactivity (clientNavigation), spacing (margin, padding), typography (fontSize, lineHeight), ~~html~~
--	**Attributes:** displayAsDropdown, label, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
+-	**Attributes:** displayAsDropdown, label, showCurrentTaxonomy, showEmpty, showHierarchy, showLabel, showOnlyTopLevel, showPostCounts, taxonomy
 
 ## Code
 

--- a/packages/block-library/src/categories/block.json
+++ b/packages/block-library/src/categories/block.json
@@ -39,6 +39,10 @@
 		"showLabel": {
 			"type": "boolean",
 			"default": true
+		},
+		"showCurrentTaxonomy": {
+			"type": "boolean",
+			"default": false
 		}
 	},
 	"usesContext": [ "enhancedPagination" ],

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -24,12 +24,6 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
-import { useSelect } from '@wordpress/data';
-
-/**
- * Internal dependencies
- */
-import { store as coreEditorStore } from '../../../../packages/editor';
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -70,11 +64,6 @@ export default function CategoriesEdit( {
 		taxonomySlug,
 		query
 	);
-
-	const isSingular = useSelect( ( select ) => {
-		const currentPostType = select( coreEditorStore ).getCurrentPostType();
-		return currentPostType && currentPostType !== 'wp_template';
-	}, [] );
 
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
@@ -144,13 +133,15 @@ export default function CategoriesEdit( {
 					</VisuallyHidden>
 				) }
 				<select id={ selectId }>
-					<option>
-						{ sprintf(
-							/* translators: %s: taxonomy's singular name */
-							__( 'Select %s' ),
-							taxonomy.labels.singular_name
-						) }
-					</option>
+					{ ! showCurrentTaxonomy && (
+						<option>
+							{ sprintf(
+								/* translators: %s: taxonomy's singular name */
+								__( 'Select %s' ),
+								taxonomy.labels.singular_name
+							) }
+						</option>
+					) }
 					{ categoriesList.map( ( category ) =>
 						renderCategoryDropdownItem( category, 0 )
 					) }
@@ -229,17 +220,18 @@ export default function CategoriesEdit( {
 								checked={ showLabel }
 								onChange={ toggleAttribute( 'showLabel' ) }
 							/>
-							{ ! isSingular && (
-								<ToggleControl
-									__nextHasNoMarginBottom
-									className="wp-block-categories__indentation"
-									label={ __( 'Show Current Taxonomy' ) }
-									checked={ showCurrentTaxonomy }
-									onChange={ toggleAttribute(
-										'showCurrentTaxonomy'
-									) }
-								/>
-							) }
+							<ToggleControl
+								__nextHasNoMarginBottom
+								className="wp-block-categories__indentation"
+								label={ __( 'Show Current Taxonomy' ) }
+								checked={ showCurrentTaxonomy }
+								onChange={ toggleAttribute(
+									'showCurrentTaxonomy'
+								) }
+								help={ __(
+									'Select the current taxonomy by default in the archive pages.'
+								) }
+							/>
 						</>
 					) }
 					<ToggleControl

--- a/packages/block-library/src/categories/edit.js
+++ b/packages/block-library/src/categories/edit.js
@@ -24,6 +24,12 @@ import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { pin } from '@wordpress/icons';
 import { useEntityRecords } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { store as coreEditorStore } from '../../../../packages/editor';
 
 export default function CategoriesEdit( {
 	attributes: {
@@ -35,6 +41,7 @@ export default function CategoriesEdit( {
 		label,
 		showLabel,
 		taxonomy: taxonomySlug,
+		showCurrentTaxonomy,
 	},
 	setAttributes,
 	className,
@@ -63,6 +70,11 @@ export default function CategoriesEdit( {
 		taxonomySlug,
 		query
 	);
+
+	const isSingular = useSelect( ( select ) => {
+		const currentPostType = select( coreEditorStore ).getCurrentPostType();
+		return currentPostType && currentPostType !== 'wp_template';
+	}, [] );
 
 	const getCategoriesList = ( parentId ) => {
 		if ( ! categories?.length ) {
@@ -209,13 +221,26 @@ export default function CategoriesEdit( {
 						onChange={ toggleAttribute( 'displayAsDropdown' ) }
 					/>
 					{ displayAsDropdown && (
-						<ToggleControl
-							__nextHasNoMarginBottom
-							className="wp-block-categories__indentation"
-							label={ __( 'Show label' ) }
-							checked={ showLabel }
-							onChange={ toggleAttribute( 'showLabel' ) }
-						/>
+						<>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								className="wp-block-categories__indentation"
+								label={ __( 'Show label' ) }
+								checked={ showLabel }
+								onChange={ toggleAttribute( 'showLabel' ) }
+							/>
+							{ ! isSingular && (
+								<ToggleControl
+									__nextHasNoMarginBottom
+									className="wp-block-categories__indentation"
+									label={ __( 'Show Current Taxonomy' ) }
+									checked={ showCurrentTaxonomy }
+									onChange={ toggleAttribute(
+										'showCurrentTaxonomy'
+									) }
+								/>
+							) }
+						</>
 					) }
 					<ToggleControl
 						__nextHasNoMarginBottom

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -37,20 +37,19 @@ function render_block_core_categories( $attributes, $content, $block ) {
 	}
 
 	if ( ! empty( $attributes['displayAsDropdown'] ) ) {
-		$id                       = 'wp-block-categories-' . $block_id;
-		$args['id']               = $id;
-		$args['name']             = $taxonomy->query_var;
-		$args['value_field']      = 'slug';
+		$id                  = 'wp-block-categories-' . $block_id;
+		$args['id']          = $id;
+		$args['name']        = $taxonomy->query_var;
+		$args['value_field'] = 'slug';
 
 		if (
-			! empty( $attributes['showCurrentTaxonomy'] ) && 
-			$attributes['showCurrentTaxonomy'] && 
-			isset( $taxonomy->query_var ) && 
-			! empty( $taxonomy->query_var ) 
+			! empty( $attributes['showCurrentTaxonomy'] ) &&
+			$attributes['showCurrentTaxonomy'] &&
+			isset( $taxonomy->query_var ) &&
+			! empty( $taxonomy->query_var )
 		) {
 			$args['selected'] = get_query_var( $taxonomy->query_var );
 		} else {
-
 			$args['show_option_none'] = sprintf(
 				/* translators: %s: taxonomy's singular name */
 				__( 'Select %s' ),

--- a/packages/block-library/src/categories/index.php
+++ b/packages/block-library/src/categories/index.php
@@ -41,11 +41,22 @@ function render_block_core_categories( $attributes, $content, $block ) {
 		$args['id']               = $id;
 		$args['name']             = $taxonomy->query_var;
 		$args['value_field']      = 'slug';
-		$args['show_option_none'] = sprintf(
-			/* translators: %s: taxonomy's singular name */
-			__( 'Select %s' ),
-			$taxonomy->labels->singular_name
-		);
+
+		if (
+			! empty( $attributes['showCurrentTaxonomy'] ) && 
+			$attributes['showCurrentTaxonomy'] && 
+			isset( $taxonomy->query_var ) && 
+			! empty( $taxonomy->query_var ) 
+		) {
+			$args['selected'] = get_query_var( $taxonomy->query_var );
+		} else {
+
+			$args['show_option_none'] = sprintf(
+				/* translators: %s: taxonomy's singular name */
+				__( 'Select %s' ),
+				$taxonomy->labels->singular_name
+			);
+		}
 
 		$show_label     = empty( $attributes['showLabel'] ) ? ' screen-reader-text' : '';
 		$default_label  = $taxonomy->label;

--- a/test/integration/fixtures/blocks/core__categories.json
+++ b/test/integration/fixtures/blocks/core__categories.json
@@ -9,7 +9,8 @@
 			"showPostCounts": false,
 			"showOnlyTopLevel": false,
 			"showEmpty": false,
-			"showLabel": true
+			"showLabel": true,
+			"showCurrentTaxonomy": false
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
## What?
<!-- In a few words, what is the PR actually doing? -->
resolves https://github.com/WordPress/gutenberg/issues/68324

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->

- Adds `showCurrentTaxonomy` attribute to select the current Category (Taxonomy Term) when used in the archive template.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->

- Adds  `Show Current Taxonomy` Toggle setting to the block.
- If it is enabled and the block is used any archive template, the current category (taxonomy term) will be selected by default in the dropdown in the frontend.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Create a new category block template or edit any default archive block template.
2. Add Category list block.
3. Select Display as Dropdown option.
4. Select Show Current Taxonomy.
5. Save the template.
6. Open the archive category page in the frontend, you will notice the current category will be selected by default.

## Screenshots or screencast <!-- if applicable -->

Category block when added in a template:


https://github.com/user-attachments/assets/3aa67e5e-e5be-433c-be11-6593cf0bda5f



