### PR TITLE
Post Comment Link: Show Border Controls By Default

### DIFF
--- a/packages/block-library/src/post-comments-link/block.json
+++ b/packages/block-library/src/post-comments-link/block.json
@@ -47,7 +47,13 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-post-comments-link"


### PR DESCRIPTION
Show Border Controls By Default in `Post Comment Link` Block According to this [Comment](https://github.com/WordPress/gutenberg/pull/68450#issuecomment-2572226411)

### Testing Instructions
- Add  `Post Comments Link` block
- Verify that `Post Comments Link` block border Control are showing by default.

### Screenshot

![image](https://github.com/user-attachments/assets/c7f94711-b2b8-4f3c-8e86-ce7417734d82)
