### PR TITLE
Query Total: Show Border Controls By Default

### DIFF
--- a/packages/block-library/src/query-total/block.json
+++ b/packages/block-library/src/query-total/block.json
@@ -45,7 +45,13 @@
 			"radius": true,
 			"color": true,
 			"width": true,
-			"style": true
+			"style": true,
+			"__experimentalDefaultControls": {
+				"radius": true,
+				"color": true,
+				"width": true,
+				"style": true
+			}
 		}
 	},
 	"style": "wp-block-query-total"


### PR DESCRIPTION
Show Border Controls By Default in `Query Total` Block According to this [Comment](https://github.com/WordPress/gutenberg/pull/68323#issuecomment-2572235392)

### Testing Instructions
- Add  `Query Total` block
- Verify that `Query Total` block border Control are showing by default.

### Screenshot

![image](https://github.com/user-attachments/assets/cd145afa-151e-4d5b-afd1-d0e50044c3af)