### PR TITLE
Feature: Added InnerBlock Support for Download Button & Add Support for download attribute

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -52,7 +52,7 @@ Prompt visitors to take action with a button-style link. ([Source](https://githu
 -	**Category:** design
 -	**Parent:** core/buttons
 -	**Supports:** anchor, color (background, gradients, text), interactivity (clientNavigation), shadow (), spacing (padding), splitting, typography (fontSize, lineHeight), ~~alignWide~~, ~~align~~, ~~reusable~~
--	**Attributes:** backgroundColor, gradient, linkTarget, placeholder, rel, tagName, text, textAlign, textColor, title, type, url, width
+-	**Attributes:** backgroundColor, download, gradient, linkTarget, placeholder, rel, tagName, text, textAlign, textColor, title, type, url, width
 
 ## Buttons
 

--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -273,7 +273,7 @@ Add a link to a downloadable file. ([Source](https://github.com/WordPress/gutenb
 -	**Name:** core/file
 -	**Category:** media
 -	**Supports:** align, anchor, color (background, gradients, link, ~~text~~), interactivity, spacing (margin, padding)
--	**Attributes:** blob, displayPreview, downloadButtonText, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
+-	**Attributes:** blob, displayPreview, fileId, fileName, href, id, previewHeight, showDownloadButton, textLinkHref, textLinkTarget
 
 ## Footnotes
 

--- a/packages/block-library/src/button/block.json
+++ b/packages/block-library/src/button/block.json
@@ -55,6 +55,13 @@
 			"attribute": "rel",
 			"role": "content"
 		},
+		"download": {
+			"type": "boolean",
+			"source": "attribute",
+			"selector": "a",
+			"attribute": "download",
+			"role": "content"
+		},
 		"placeholder": {
 			"type": "string"
 		},

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -59,6 +59,10 @@ const LINK_SETTINGS = [
 		id: 'nofollow',
 		title: __( 'Mark as nofollow' ),
 	},
+	{
+		id: 'download',
+		title: __( 'Download file' ),
+	},
 ];
 
 function useEnter( props ) {
@@ -380,6 +384,7 @@ function ButtonEdit( props ) {
 								url: newURL,
 								opensInNewTab: newOpensInNewTab,
 								nofollow: newNofollow,
+								download: newDownload,
 							} ) =>
 								setAttributes(
 									getUpdatedLinkAttributes( {
@@ -387,6 +392,7 @@ function ButtonEdit( props ) {
 										url: newURL,
 										opensInNewTab: newOpensInNewTab,
 										nofollow: newNofollow,
+										download: newDownload,
 									} )
 								)
 							}

--- a/packages/block-library/src/button/get-updated-link-attributes.js
+++ b/packages/block-library/src/button/get-updated-link-attributes.js
@@ -16,12 +16,14 @@ import { prependHTTP } from '@wordpress/url';
  * @param {string}  attributes.url           The current link url.
  * @param {boolean} attributes.opensInNewTab Whether the link should open in a new window.
  * @param {boolean} attributes.nofollow      Whether the link should be marked as nofollow.
+ * @param {boolean} attributes.download      Whether the link should allow download.
  */
 export function getUpdatedLinkAttributes( {
 	rel = '',
 	url = '',
 	opensInNewTab,
 	nofollow,
+	download = false,
 } ) {
 	let newLinkTarget;
 	// Since `rel` is editable attribute, we need to check for existing values and proceed accordingly.
@@ -46,9 +48,33 @@ export function getUpdatedLinkAttributes( {
 		updatedRel = updatedRel?.replace( relRegex, '' ).trim();
 	}
 
+	const allowDownload = url && isSameOrigin( url ) ? download : undefined;
+
 	return {
 		url: prependHTTP( url ),
 		linkTarget: newLinkTarget,
 		rel: updatedRel || undefined,
+		download: allowDownload,
 	};
+}
+
+/**
+ * Checks if the URL is same origin.
+ * Allow relative URLs.
+ *
+ * @param {string} urlString The URL to check.
+ * @return {boolean} Whether the URL is same origin.
+ */
+function isSameOrigin( urlString ) {
+	// Allow relative URLs
+	if ( urlString.startsWith( '/' ) ) {
+		return true;
+	}
+
+	try {
+		const url = new URL( urlString, window.location.origin );
+		return url.origin === window.location.origin;
+	} catch {
+		return false;
+	}
 }

--- a/packages/block-library/src/button/save.js
+++ b/packages/block-library/src/button/save.js
@@ -30,6 +30,7 @@ export default function save( { attributes, className } ) {
 		title,
 		url,
 		width,
+		download,
 	} = attributes;
 
 	const TagName = tagName || 'a';
@@ -83,6 +84,7 @@ export default function save( { attributes, className } ) {
 				value={ text }
 				target={ isButtonTag ? null : linkTarget }
 				rel={ isButtonTag ? null : rel }
+				download={ isButtonTag ? null : download }
 			/>
 		</div>
 	);

--- a/packages/block-library/src/file/block.json
+++ b/packages/block-library/src/file/block.json
@@ -48,12 +48,6 @@
 			"type": "boolean",
 			"default": true
 		},
-		"downloadButtonText": {
-			"type": "rich-text",
-			"source": "rich-text",
-			"selector": "a[download]",
-			"role": "content"
-		},
 		"displayPreview": {
 			"type": "boolean"
 		},

--- a/packages/block-library/src/file/edit.js
+++ b/packages/block-library/src/file/edit.js
@@ -21,7 +21,7 @@ import {
 	RichText,
 	useBlockProps,
 	store as blockEditorStore,
-	InnerBlocks,
+	useInnerBlocksProps,
 } from '@wordpress/block-editor';
 import { useState } from '@wordpress/element';
 import { useCopyToClipboard } from '@wordpress/compose';
@@ -185,6 +185,36 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 
 	const displayPreviewInEditor = browserSupportsPdfs() && displayPreview;
 
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: 'wp-block-file__button-wrapper' },
+		{
+			allowedBlocks: [ 'core/buttons' ],
+			template: [
+				[
+					'core/buttons',
+					{},
+					[
+						[
+							'core/button',
+							{
+								text: __( 'Download' ),
+								lock: {
+									remove: true,
+									move: true,
+								},
+								url: href || temporaryURL,
+								download: true,
+								ariaLabel: __( 'Download button text' ),
+							},
+						],
+					],
+				],
+			],
+			templateLock: 'all',
+			renderAppender: false,
+		}
+	);
+
 	if ( ! href && ! temporaryURL ) {
 		return (
 			<div { ...blockProps }>
@@ -287,36 +317,7 @@ function FileEdit( { attributes, isSelected, setAttributes, clientId } ) {
 						}
 						href={ textLinkHref }
 					/>
-					{ showDownloadButton && (
-						<InnerBlocks
-							allowedBlocks={ [ 'core/buttons' ] }
-							template={ [
-								[
-									'core/buttons',
-									{},
-									[
-										[
-											'core/button',
-											{
-												text: __( 'Download' ),
-												lock: {
-													remove: true,
-													move: true,
-												},
-												url: href || temporaryURL,
-												download: true,
-												ariaLabel: __(
-													'Download button text'
-												),
-											},
-										],
-									],
-								],
-							] }
-							templateLock="all"
-							renderAppender={ false }
-						/>
-					) }
+					{ showDownloadButton && <div { ...innerBlocksProps } /> }
 				</div>
 			</div>
 		</>

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -38,10 +38,6 @@
 		gap: 1em;
 		flex-wrap: wrap;
 		width: 100%;
-
-		.block-editor-inner-blocks {
-			flex: 1;
-		}
 	}
 
 	a {

--- a/packages/block-library/src/file/editor.scss
+++ b/packages/block-library/src/file/editor.scss
@@ -33,7 +33,15 @@
 	}
 
 	.wp-block-file__content-wrapper {
-		flex-grow: 1;
+		display: flex;
+		align-items: center;
+		gap: 1em;
+		flex-wrap: wrap;
+		width: 100%;
+
+		.block-editor-inner-blocks {
+			flex: 1;
+		}
 	}
 
 	a {
@@ -42,10 +50,5 @@
 		&:not(.wp-block-file__button) {
 			display: inline-block;
 		}
-	}
-
-	.wp-block-file__button-richtext-wrapper {
-		display: inline-block;
-		margin-left: 0.75em;
 	}
 }

--- a/packages/block-library/src/file/save.js
+++ b/packages/block-library/src/file/save.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
+import {
+	RichText,
+	useBlockProps,
+	useInnerBlocksProps,
+} from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
@@ -27,9 +31,18 @@ export default function save( { attributes } ) {
 	// actually rendered.
 	const describedById = hasFilename ? fileId : undefined;
 
+	const blockProps = useBlockProps.save( {
+		className: 'wp-block-file',
+	} );
+
+	// Use the `useInnerBlocksProps` hook to get the props for the inner blocks
+	const innerBlocksProps = useInnerBlocksProps.save( {
+		className: 'wp-block-file__button-wrapper',
+	} );
+
 	return (
 		href && (
-			<div { ...useBlockProps.save() }>
+			<div { ...blockProps }>
 				{ displayPreview && (
 					<>
 						<object
@@ -56,11 +69,7 @@ export default function save( { attributes } ) {
 						<RichText.Content value={ fileName } />
 					</a>
 				) }
-				{ showDownloadButton && (
-					<div className="wp-block-file__button_wrapper">
-						<InnerBlocks.Content />
-					</div>
-				) }
+				{ showDownloadButton && <div { ...innerBlocksProps } /> }
 			</div>
 		)
 	);

--- a/packages/block-library/src/file/save.js
+++ b/packages/block-library/src/file/save.js
@@ -1,16 +1,7 @@
 /**
- * External dependencies
- */
-import clsx from 'clsx';
-
-/**
  * WordPress dependencies
  */
-import {
-	RichText,
-	useBlockProps,
-	__experimentalGetElementClassName,
-} from '@wordpress/block-editor';
+import { RichText, useBlockProps, InnerBlocks } from '@wordpress/block-editor';
 
 export default function save( { attributes } ) {
 	const {
@@ -20,7 +11,6 @@ export default function save( { attributes } ) {
 		textLinkHref,
 		textLinkTarget,
 		showDownloadButton,
-		downloadButtonText,
 		displayPreview,
 		previewHeight,
 	} = attributes;
@@ -67,17 +57,9 @@ export default function save( { attributes } ) {
 					</a>
 				) }
 				{ showDownloadButton && (
-					<a
-						href={ href }
-						className={ clsx(
-							'wp-block-file__button',
-							__experimentalGetElementClassName( 'button' )
-						) }
-						download
-						aria-describedby={ describedById }
-					>
-						<RichText.Content value={ downloadButtonText } />
-					</a>
+					<div className="wp-block-file__button_wrapper">
+						<InnerBlocks.Content />
+					</div>
 				) }
 			</div>
 		)

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -23,7 +23,7 @@
 		margin-left: 0.75em;
 	}
 
-	.wp-block-file__button_wrapper {
+	.wp-block-file__button-wrapper {
 		flex: 1;
 	}
 }

--- a/packages/block-library/src/file/style.scss
+++ b/packages/block-library/src/file/style.scss
@@ -1,6 +1,10 @@
 .wp-block-file {
 	// This block has customizable padding, border-box makes that more predictable.
 	box-sizing: border-box;
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 1em;
 
 	&:not(.wp-element-button) {
 		font-size: 0.8em;
@@ -18,6 +22,10 @@
 	* + .wp-block-file__button {
 		margin-left: 0.75em;
 	}
+
+	.wp-block-file__button_wrapper {
+		flex: 1;
+	}
 }
 
 // Lowest specificity to avoid overriding layout styles.
@@ -30,20 +38,20 @@
 }
 
 //This needs a low specificity so it won't override the rules from the button element if defined in theme.json.
-:where(.wp-block-file__button) {
-	border-radius: 2em;
-	padding: 0.5em 1em;
-	display: inline-block;
+// :where(.wp-block-file__button) {
+// 	border-radius: 2em;
+// 	padding: 0.5em 1em;
+// 	display: inline-block;
 
-	&:is(a) {
-		&:hover,
-		&:visited,
-		&:focus,
-		&:active {
-			box-shadow: none;
-			color: $white;
-			opacity: 0.85;
-			text-decoration: none;
-		}
-	}
-}
+// 	&:is(a) {
+// 		&:hover,
+// 		&:visited,
+// 		&:focus,
+// 		&:active {
+// 			box-shadow: none;
+// 			color: $white;
+// 			opacity: 0.85;
+// 			text-decoration: none;
+// 		}
+// 	}
+// }


### PR DESCRIPTION
attempt solution for #57314, #57871

## What?
Converting the File block's download button from a RichText component to an InnerBlocks implementation utilizing the core Button block.

## Why?
The current RichText implementation limits styling options and creates inconsistency with WordPress's block ecosystem. Users cannot access standard button customization features, and developers face challenges maintaining consistent theme styling. This change improves the user experience while reducing technical complexity.
The migration to InnerBlocks addresses longstanding issues with button customization and brings the File block in line with WordPress's modern block architecture. It enables seamless theme integration and provides users with familiar button controls they expect from the block editor.

## How?
The implementation replaces the existing RichText-based button with an InnerBlocks area that specifically allows the core Button block. Key implementation details include:

- Configuring InnerBlocks with a predefined button template
- Implementing template locking to maintain download functionality
- Preserving existing accessibility features and ARIA attributes
- Ensuring proper inheritance of theme styles through theme.json
- Maintaining backward compatibility with existing File block implementations

## Testing Instructions

1. Create a new post or page and add a File block
2. Upload a file and enable the download button
3. Verify that the button appears and maintains download functionality
4. Test button customization options in the sidebar
5. Confirm that theme styles are properly applied to the button
6. Check that the download attribute and link remain functional on the frontend
7. Verify that existing File blocks continue to work after updating
8. Test the block in different themes to ensure consistent styling
9. Confirm that template locking prevents button removal
10. Validate that accessibility features remain intact


## Issues (Identified)
- Download attribute is missing in "core/button", related to https://github.com/WordPress/gutenberg/issues/57871, This requires further discussion to determine whether the attribute should be implemented directly in the "core/button" block or if an alternative solution, such as adding the attribute through custom logic would be more appropriate.
- Solution: For now I have tried adding the attribute support for download button with logic to detect origin. I have addressed the problem pointed out in the issue.

## Screencast

https://github.com/user-attachments/assets/d0273923-b6d9-4d43-a004-159b80a19500

https://github.com/user-attachments/assets/01a71a0c-bf4d-4027-ac62-0e9520f6e8fa



