### PR TITLE
NumberControl: Disable drag functionality on touch devices

### DIFF
--- a/packages/components/src/number-control/index.tsx
+++ b/packages/components/src/number-control/index.tsx
@@ -30,6 +30,10 @@ import { maybeWarnDeprecated36pxSize } from '../utils/deprecated-36px-size';
 
 const noop = () => {};
 
+const isTouchDevice = () => {
+	return 'ontouchstart' in window || navigator.maxTouchPoints > 0;
+};
+
 function UnforwardedNumberControl(
 	props: WordPressComponentProps< NumberControlProps, 'input', false >,
 	forwardedRef: ForwardedRef< any >
@@ -219,6 +223,8 @@ function UnforwardedNumberControl(
 				},
 			} );
 
+	const shouldEnableDrag = isDragEnabled && ! isTouchDevice();
+
 	return (
 		<Input
 			autoComplete={ autoComplete }
@@ -227,7 +233,7 @@ function UnforwardedNumberControl(
 			className={ classes }
 			dragDirection={ dragDirection }
 			hideHTMLArrows={ spinControls !== 'native' }
-			isDragEnabled={ isDragEnabled }
+			isDragEnabled={ shouldEnableDrag }
 			label={ label }
 			max={ max }
 			min={ min }


### PR DESCRIPTION
Closes: #38865

## What?
Disable the drag-to-change-value gesture in NumberControl when used on touch devices.

## Why?
- Dragging gesture doesn't work well on touch devices as there's no cursor feedback
- Easy to accidentally change values when trying to tap or move text cursor
- Poor user experience on mobile/tablet devices

## How?
- Added a isTouchDevice() utility function that detects touch capability using:
    - 'ontouchstart' in window
    - navigator.maxTouchPoints

- Modified isDragEnabled to consider both the prop value AND touch device status
- Drag functionality disables on touch devices while remaining enabled for desktop users

## Screencast

### Before
https://github.com/user-attachments/assets/ba2c882f-6ad0-446f-adb3-7f8122d3df41

### After
https://github.com/user-attachments/assets/6bb36275-9d96-41bd-93b3-127276f7c809

