### PR TITLE
Fix the Global Styles being Applied Incorrectly in Search Block

### DIFF
--- a/packages/block-library/src/search/block.json
+++ b/packages/block-library/src/search/block.json
@@ -83,7 +83,8 @@
 				"color": true,
 				"radius": true,
 				"width": true
-			}
+			},
+			"__experimentalSelector": ".wp-block-search__input, .wp-block-search__button"
 		},
 		"spacing": {
 			"margin": true


### PR DESCRIPTION
## What?
This PR addresses the issue where global styles are applied properly to indiviual text and button.

## Why?
Issue - https://github.com/WordPress/gutenberg/issues/68195

## How?
This PR adds the experimental selectors to select the button and input element.

## Testing Instructions
1. Open the Site Editor using Appearance > Editor.
2. Click on Style > Blocks.
3. Select the Search Block and change the border color, width and radius.
4. Ensure the styles are being applied to the indiviual input and button element.
5. Now Create a new Post/Page and add the Search Block.
6. Modify the border properties from sidebar panel and ensure they are being applied to the same elements.

## Screenshots or screencast 

https://github.com/user-attachments/assets/975d0705-2a84-4862-b985-9df32a83be96

