### PR TITLE
Storybook: Add Story for Block Patterns Setup Component

### DIFF
--- a/packages/block-editor/src/components/block-pattern-setup/index.js
+++ b/packages/block-editor/src/components/block-pattern-setup/index.js
@@ -137,6 +137,30 @@ function BlockPatternSlide( { active, className, pattern, minHeight } ) {
 	);
 }
 
+/**
+ * BlockPatternSetup component displays a list of block patterns in a carousel or grid view.
+ *
+ * @param {Object}   props                      Component props.
+ * @param {string}   props.clientId             The client ID of the block being edited.
+ * @param {string}   props.blockName            The name of the block being edited.
+ * @param {Function} props.filterPatternsFn     Function to filter patterns.
+ * @param {Function} props.onBlockPatternSelect Function to call when a pattern is selected.
+ * @param {string}   props.initialViewMode      The initial view mode for the block pattern setup.
+ * @param {boolean}  props.showTitles           Whether to show pattern titles.
+ *
+ * @return {Element} The block pattern setup component.
+ *
+ * @example
+ * ```jsx
+ * <BlockPatternSetup
+ * 	clientId="clientId"
+ * 	blockName="core/paragraph"
+ * 	filterPatternsFn={ ( pattern ) => pattern.name === 'pattern-name' }
+ * 	onBlockPatternSelect={ ( ) => { } }
+ * 	initialViewMode="carousel"
+ * 	showTitles={ false }
+ * />
+ */
 const BlockPatternSetup = ( {
 	clientId,
 	blockName,

--- a/packages/block-editor/src/components/block-pattern-setup/stories/index.story.js
+++ b/packages/block-editor/src/components/block-pattern-setup/stories/index.story.js
@@ -1,0 +1,115 @@
+/**
+ * Internal dependencies
+ */
+import BlockPatternSetup from '..';
+
+/**
+ * WordPress dependencies
+ */
+import { registerCoreBlocks } from '@wordpress/block-library';
+import { createBlock } from '@wordpress/blocks';
+
+registerCoreBlocks();
+const block = createBlock( 'core/paragraph', {
+	content: 'Sample paragraph content',
+} );
+
+/**
+ * Storybook metadata
+ */
+const meta = {
+	title: 'Components/BlockPatternSetup',
+	component: BlockPatternSetup,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'BlockPatternSetup component displays a list of block patterns in a carousel or grid view.',
+			},
+		},
+	},
+	argTypes: {
+		clientId: {
+			control: { type: null },
+			description: 'The client ID of the block being edited.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		blockName: {
+			control: {
+				type: 'text',
+			},
+			description: 'The name of the block being edited.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		filterPatternsFn: {
+			control: { type: null },
+			description: 'Function to filter patterns.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		onBlockPatternSelect: {
+			control: { type: null },
+			description: 'Function to call when a pattern is selected.',
+			table: {
+				type: {
+					summary: 'function',
+				},
+			},
+		},
+		initialViewMode: {
+			control: {
+				type: 'text',
+			},
+			description: 'The initial view mode for the block pattern setup.',
+			table: {
+				type: {
+					summary: 'string',
+				},
+			},
+		},
+		showTitles: {
+			control: {
+				type: 'boolean',
+			},
+			description: 'Whether to show titles for block patterns.',
+			table: {
+				type: {
+					summary: 'boolean',
+				},
+			},
+		},
+	},
+};
+
+export default meta;
+
+/**
+ * Default story for the BlockPatternSetup component
+ */
+export const Default = {
+	args: {
+		clientId: block.clientId,
+		blockName: 'core/paragraph',
+		filterPatternsFn: null,
+		onBlockPatternSelect: () => {},
+		initialViewMode: 'carousel',
+		showTitles: true,
+	},
+	render: function Template( args ) {
+		return <BlockPatternSetup { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for Block Patterns Setup component 

## Testing Instructions
- Run npm run storybook:dev
- Open Storybook at http://localhost:50240/
- Check the BlockPatternsSetup Story


## Screenshots or screencast 
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/bca6826a-199e-46fb-8680-a19e2a68c163" />

