### PR TITLE
Dot Tip: Use new placement prop instead of legacy position prop

### DIFF
--- a/packages/nux/src/components/dot-tip/README.md
+++ b/packages/nux/src/components/dot-tip/README.md
@@ -25,13 +25,19 @@ A string that uniquely identifies the tip. Identifiers should be prefixed with t
 -   Type: `string`
 -   Required: Yes
 
-### position
+### placement
 
-The direction in which the popover should open relative to its parent node. Specify y- and x-axis as a space-separated string. Supports `"top"`, `"middle"`, `"bottom"` y axis, and `"left"`, `"center"`, `"right"` x axis.
+The placement of the popover relative to its parent node. Determines where the popover will be positioned relative to its reference element.
 
--   Type: `String`
--   Required: No
--   Default: `"middle right"`
+- Type: `string`
+- Required: No
+- Default: `"right"`
+- Possible values: 
+  - `'top'`, `'top-start'`, `'top-end'`
+  - `'right'`, `'right-start'`, `'right-end'`
+  - `'bottom'`, `'bottom-start'`, `'bottom-end'`
+  - `'left'`, `'left-start'`, `'left-end'`
+  - `'overlay'`
 
 ### children
 

--- a/packages/nux/src/components/dot-tip/index.js
+++ b/packages/nux/src/components/dot-tip/index.js
@@ -20,7 +20,7 @@ function onClick( event ) {
 }
 
 export function DotTip( {
-	position = 'middle right',
+	placement = 'right',
 	children,
 	isVisible,
 	hasNextTip,
@@ -47,7 +47,7 @@ export function DotTip( {
 	return (
 		<Popover
 			className="nux-dot-tip"
-			position={ position }
+			placement={ placement }
 			focusOnMount
 			role="dialog"
 			aria-label={ __( 'Editor tips' ) }


### PR DESCRIPTION
## What?

Part of https://github.com/WordPress/gutenberg/issues/44401

Use the new placement prop instead of the legacy position prop to define the Popover's placement when it is opened.


## Why?
With the recent refactoring of the Popover component to floating-ui, we're in the process of refactoring all of its usages to the new placement prop (native to floating-ui). See https://github.com/WordPress/gutenberg/issues/44401 for more details

## How?
Swap position with the new corresponding placement.

See this [conversion table](https://github.com/WordPress/gutenberg/blob/0a9402ac623876cc2a29d0f4a72eaefba3310501/packages/components/src/popover/utils.ts#L17-L71) that we're currently using to map position values to placement values.

## Testing Instructions

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
