### PR TITLE
Drag and Drop: Skip sibling insertion check if block is moving within same parent

### DIFF
--- a/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
+++ b/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js
@@ -394,19 +394,18 @@ export function getListViewDropTarget(
 	);
 
 	// Skip sibling insertion check if block is moving within same parent.
-	const hasDifferentParent = draggedBlocksData?.some(
-		( draggedBlock ) =>
-			! candidateBlockParents?.find(
-				( blockData ) =>
-					blockData.clientId === draggedBlock.rootClientId &&
-					blockData.nestingLevel === draggedBlock.nestingLevel - 1
-			)
+	const hasSameParent = draggedBlocksData?.some( ( draggedBlock ) =>
+		candidateBlockParents?.find(
+			( blockData ) =>
+				blockData.clientId === draggedBlock.rootClientId &&
+				blockData.nestingLevel === draggedBlock.nestingLevel - 1
+		)
 	);
 
 	// If dropping as a sibling, but block cannot be inserted in
 	// this context, return early.
 	if (
-		hasDifferentParent &&
+		! hasSameParent &&
 		! candidateBlockData.canInsertDraggedBlocksAsSibling
 	) {
 		return;


### PR DESCRIPTION
## What, Why & How?
The following condition needs to be updated:
https://github.com/WordPress/gutenberg/blob/4b39807903bb1c89ef2d91b4a7c223bcad3d0fec/packages/block-editor/src/components/list-view/use-list-view-drop-zone.js#L388-L390

Here, the insertion is checked with the help of `canInsertDraggedBlocksAsSibling` which in turn is determined with the help of `canInsertBlock` in the following code block:
https://github.com/WordPress/gutenberg/blob/4b39807903bb1c89ef2d91b4a7c223bcad3d0fec/packages/block-editor/src/store/selectors.js#L1673-L1676

When the lock is not set to `Lock Movement`, `getTemplateLock` returns `insert` which evaluates to `True`, and early returns `False` leading to this bug.

If a block is inserted within the same parent to a different position, it shouldn't be counted as an insertion but rather as an internal movement of the block. Hence, checking for this condition does not make sense when the block is moved within the same parent.

Therefore, in the PR, if the block is just moved within the same parent, i.e., if the parent's ID before and after dropping the block remains the same, then we can skip the insertion check as the block is not inserted but rather moved.

## Testing Instructions
1. Create a `Grid/Row/Column` block.
2. Insert some image elements in it.
3. Try locking the `Grid/Row/Column` block but don't lock the `Movement`.
4. Notice, that it's possible to move the inner blocks of `Grid/Row/Column` by both `Toolbar Move Buttons` and `Drag and Drop`.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

### Before
![before-1](https://github.com/user-attachments/assets/c33c1a84-4b7a-40f7-9909-e759dd8d07e7)

### After
![after](https://github.com/user-attachments/assets/753db10d-ac0b-4d8b-9e93-cdd586758c35)

Closes: #67869 
