### PR TITLE
Classic theme preview: remove admin-bar class name

### DIFF
--- a/packages/edit-site/src/components/maybe-editor/index.js
+++ b/packages/edit-site/src/components/maybe-editor/index.js
@@ -43,6 +43,9 @@ export function MaybeEditor( { showEditor = true } ) {
 				document
 					.getElementsByTagName( 'html' )[ 0 ]
 					.setAttribute( 'style', 'margin-top: 0 !important;' );
+				document
+					.getElementsByTagName( 'body' )[ 0 ]
+					.classList.remove( 'admin-bar' );
 				// Make interactive elements unclickable.
 				const interactiveElements = document.querySelectorAll(
 					'a, button, input, details, audio'


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Follow up to https://github.com/WordPress/gutenberg/pull/66851

This PR removes the class name `admin-bar` from the `body` element in the iframe in the Site Editor preview.
The admin bar  itself was already removed, but the class name remained and this caused some styling issues for themes that use this CSS class.

Closes https://github.com/WordPress/gutenberg/issues/68511

## Testing Instructions
Activate the theme Twenty Fourteen.
Activate Gutenberg with the PR applied.
Go to Appearance > Design
Confirm that there is no blank gap above the sticky header.
Scroll the page content up and down. Confirm that no content is showing above the sticky header,
