### PR TITLE
Update: Bundle upload media.

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1968,6 +1968,12 @@
 		"parent": "packages"
 	},
 	{
+		"title": "@wordpress/upload-media",
+		"slug": "packages-upload-media",
+		"markdown_source": "../packages/upload-media/README.md",
+		"parent": "packages"
+	},
+	{
 		"title": "@wordpress/url",
 		"slug": "packages-url",
 		"markdown_source": "../packages/url/README.md",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52660,7 +52660,7 @@
 		},
 		"packages/upload-media": {
 			"name": "@wordpress/upload-media",
-			"version": "1.0.0-prerelease",
+			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@shopify/web-worker": "^6.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -50028,6 +50028,7 @@
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/style-engine": "file:../style-engine",
 				"@wordpress/token-list": "file:../token-list",
+				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/wordcount": "file:../wordcount",
@@ -50054,6 +50055,10 @@
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
+		},
+		"packages/block-editor/node_modules/@wordpress/upload-media": {
+			"resolved": "packages/token-list",
+			"link": true
 		},
 		"packages/block-editor/node_modules/postcss-urlrebase": {
 			"version": "1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8724,6 +8724,7 @@
 			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.48.1.tgz",
 			"integrity": "sha512-s9RtWoxkOLmRJdw3oFvhFbs9OJS0BzrLUc8Hf6l2UdCNd1rqeEyD4BhCJkvzeEoD1FsK4mirsWwGerhVmYKtZg==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright": "1.48.1"
 			},
@@ -37906,6 +37907,7 @@
 			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.48.1.tgz",
 			"integrity": "sha512-j8CiHW/V6HxmbntOfyB4+T/uk08tBy6ph0MpBXwuoofkSnLmlfdYNNkFTYD6ofzzlSqLA1fwH4vwvVFvJgLN0w==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"playwright-core": "1.48.1"
 			},
@@ -37924,6 +37926,7 @@
 			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.48.1.tgz",
 			"integrity": "sha512-Yw/t4VAFX/bBr1OzwCuOMZkY1Cnb4z/doAFSwf4huqAGWmf9eMNjmK7NiOljCdLmxeRYcGPPmcDgU0zOlzP0YA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"bin": {
 				"playwright-core": "cli.js"
 			},
@@ -50055,10 +50058,6 @@
 				"react": "^18.0.0",
 				"react-dom": "^18.0.0"
 			}
-		},
-		"packages/block-editor/node_modules/@wordpress/upload-media": {
-			"resolved": "packages/token-list",
-			"link": true
 		},
 		"packages/block-editor/node_modules/postcss-urlrebase": {
 			"version": "1.4.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -65,6 +65,7 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/style-engine": "file:../style-engine",
 		"@wordpress/token-list": "file:../token-list",
+		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",

--- a/packages/block-editor/src/components/provider/index.js
+++ b/packages/block-editor/src/components/provider/index.js
@@ -4,7 +4,6 @@
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useMemo } from '@wordpress/element';
 import { SlotFillProvider } from '@wordpress/components';
-//eslint-disable-next-line import/no-extraneous-dependencies -- Experimental package, not published.
 import {
 	MediaUploadProvider,
 	store as uploadStore,

--- a/packages/block-editor/tsconfig.json
+++ b/packages/block-editor/tsconfig.json
@@ -27,6 +27,7 @@
 		{ "path": "../style-engine" },
 		{ "path": "../token-list" },
 		{ "path": "../url" },
+		{ "path": "../upload-media" },
 		{ "path": "../warning" },
 		{ "path": "../wordcount" }
 	],

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -10,6 +10,7 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/interface',
 	'@wordpress/sync',
 	'@wordpress/undo-manager',
+	'@wordpress/upload-media',
 	'@wordpress/fields',
 ];
 

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@wordpress/upload-media",
-	"version": "1.0.0-prerelease",
+	"version": "0.0.1",
 	"description": "Core media upload logic.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/upload-media",
 	"version": "1.0.0-prerelease",
-	"private": true,
 	"description": "Core media upload logic.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",
@@ -26,6 +25,7 @@
 	"module": "build-module/index.js",
 	"wpScript": true,
 	"types": "build-types",
+	"sideEffects": false,
 	"dependencies": {
 		"@shopify/web-worker": "^6.4.0",
 		"@wordpress/api-fetch": "file:../api-fetch",

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -41,6 +41,7 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/interface',
 	'@wordpress/sync',
 	'@wordpress/undo-manager',
+	'@wordpress/upload-media',
 	'@wordpress/fields',
 ];
 


### PR DESCRIPTION
The `@wordpress/upload-media` package was referenced in the  `BlockEditorProvider`. But is not published and is not declared as a dependency this will make any package relying on block editor and using the provider failing to build e.g: plugins because they can not resolve the package.

This PR tries to make the `@wordpress/upload-media` a private bundled package.
