### PR TITLE
Remove geriux as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 
 # Blocks
 /packages/block-library                         @ajitbohra @fabiankaegy
-/packages/block-library/src/gallery             @geriux
+/packages/block-library/src/gallery
 /packages/block-library/src/comment-template    @michalczaplinski
 /packages/block-library/src/comments            @michalczaplinski
 /packages/block-library/src/table-of-contents   @ZebulanStanphill
@@ -138,10 +138,7 @@
 /lib/compat/*/html-api                          @dmsnell
 /lib/experimental/rest-api.php                  @timothybjacobs
 /lib/experimental/class-wp-rest-*               @timothybjacobs
-/lib/experimental/class-wp-rest-block-editor-settings-controller.php @timothybjacobs @spacedmonkey @geriux
-
-# Native
-/packages/components/src/mobile/global-styles-context                @geriux
+/lib/experimental/class-wp-rest-block-editor-settings-controller.php @timothybjacobs @spacedmonkey
 
 # Native (Unowned)
 *.native.js


### PR DESCRIPTION
## What?
Removing geriux as code owner for the Gallery block and experimental native endpoint changes.

## Why?
I'm no longer tracking the changes of these files.

## How?
Updating the CODEOWNERS file.

## Testing Instructions
N/A no testing needed.

### Testing Instructions for Keyboard
N/A No testing required for these changes.

## Screenshots or screencast <!-- if applicable -->
N/A 