### PR TITLE
Post Featured Image: Adds control to clear the the overlay color.

### DIFF
--- a/packages/block-library/src/post-featured-image/overlay-controls.js
+++ b/packages/block-library/src/post-featured-image/overlay-controls.js
@@ -47,6 +47,7 @@ const Overlay = ( {
 							gradient: undefined,
 							customGradient: undefined,
 						} ),
+						clearable: true,
 					},
 				] }
 				panelId={ clientId }


### PR DESCRIPTION
Fixes: #68524

## What?
- Adds a clear option to clear the overlay color of the featured image block.

## Testing Instructions
1. Add Featured Image Block.
2. Set a featured image.
3. Click on the 'Overlay Color' dropdown under 'Settings/Style' > 'Color' > 'Overlay
4. Observe that the 'Clear' button.

## Screenshots or screencast

|Before|After|
|-|-|
|<img width="1441" alt="image" src="https://github.com/user-attachments/assets/634144c9-9545-473a-b5f0-423804410bee" />|<img width="1454" alt="image" src="https://github.com/user-attachments/assets/a07d6863-1feb-4602-a0f6-48c091e4dad1" />|
