### PR TITLE
StoryBook: Fix error that could occur when loading compiled CSS

### DIFF
--- a/packages/edit-site/src/components/layout/style.scss
+++ b/packages/edit-site/src/components/layout/style.scss
@@ -118,7 +118,7 @@
 			// This ensure the radius work properly.
 			overflow: hidden;
 
-			@media (prefers-reduced-motion: no-preference) {
+			@media not (prefers-reduced-motion) {
 				transition: border-radius, box-shadow 0.4s;
 			}
 

--- a/storybook/package-styles/block-editor-ltr.lazy.scss
+++ b/storybook/package-styles/block-editor-ltr.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/block-editor/build-style/style";
+@import "../../packages/block-editor/build-style/style.css";

--- a/storybook/package-styles/block-editor-rtl.lazy.scss
+++ b/storybook/package-styles/block-editor-rtl.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/block-editor/build-style/style-rtl";
+@import "../../packages/block-editor/build-style/style-rtl.css";

--- a/storybook/package-styles/block-library-ltr.lazy.scss
+++ b/storybook/package-styles/block-library-ltr.lazy.scss
@@ -1,3 +1,3 @@
-@import "../../packages/block-library/build-style/style";
-@import "../../packages/block-library/build-style/theme";
-@import "../../packages/block-library/build-style/editor";
+@import "../../packages/block-library/build-style/style.css";
+@import "../../packages/block-library/build-style/theme.css";
+@import "../../packages/block-library/build-style/editor.css";

--- a/storybook/package-styles/block-library-rtl.lazy.scss
+++ b/storybook/package-styles/block-library-rtl.lazy.scss
@@ -1,3 +1,3 @@
-@import "../../packages/block-library/build-style/style-rtl";
-@import "../../packages/block-library/build-style/theme-rtl";
-@import "../../packages/block-library/build-style/editor-rtl";
+@import "../../packages/block-library/build-style/style-rtl.css";
+@import "../../packages/block-library/build-style/theme-rtl.css";
+@import "../../packages/block-library/build-style/editor-rtl.css";

--- a/storybook/package-styles/components-ltr.lazy.scss
+++ b/storybook/package-styles/components-ltr.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/components/build-style/style";
+@import "../../packages/components/build-style/style.css";

--- a/storybook/package-styles/components-rtl.lazy.scss
+++ b/storybook/package-styles/components-rtl.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/components/build-style/style-rtl";
+@import "../../packages/components/build-style/style-rtl.css";

--- a/storybook/package-styles/dataviews-ltr.lazy.scss
+++ b/storybook/package-styles/dataviews-ltr.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/dataviews/build-style/style";
+@import "../../packages/dataviews/build-style/style.css";

--- a/storybook/package-styles/dataviews-rtl.lazy.scss
+++ b/storybook/package-styles/dataviews-rtl.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/dataviews/build-style/style-rtl";
+@import "../../packages/dataviews/build-style/style-rtl.css";

--- a/storybook/package-styles/edit-site-ltr.lazy.scss
+++ b/storybook/package-styles/edit-site-ltr.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/edit-site/build-style/style";
+@import "../../packages/edit-site/build-style/style.css";

--- a/storybook/package-styles/edit-site-rtl.lazy.scss
+++ b/storybook/package-styles/edit-site-rtl.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/edit-site/build-style/style-rtl";
+@import "../../packages/edit-site/build-style/style-rtl.css";

--- a/storybook/package-styles/format-library-ltr.lazy.scss
+++ b/storybook/package-styles/format-library-ltr.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/format-library/build-style/style";
+@import "../../packages/format-library/build-style/style.css";

--- a/storybook/package-styles/format-library-rtl.lazy.scss
+++ b/storybook/package-styles/format-library-rtl.lazy.scss
@@ -1,1 +1,1 @@
-@import "../../packages/format-library/build-style/style-rtl";
+@import "../../packages/format-library/build-style/style-rtl.css";


### PR DESCRIPTION
See this comment: https://github.com/WordPress/gutenberg/pull/68419#issuecomment-2568985996

## What?

This PR fixes an issue where StoryBook may not be able to load compiled CSS when `@media not` queries are used.

## Why?

This issue was discovered during the work in #68282 to standardize the format for the `prefers-reduced-motion` media feature.

For example, write the following SCSS:

```scss
.selector {
	@include break-medium {
		@media not (prefers-reduced-motion) {
			transition: border-radius, box-shadow 0.4s;
		}
	}
}
```

This code will be compiled into the following CSS:

```css
@media (min-width: 782px) and (not (prefers-reduced-motion)) {
  .selector {
    transition: border-radius, box-shadow 0.4s;
  }
}
```

This media query format is valid, but when you run Storybook, you will get the following error:

<details><summary>Details</summary>

```bash
[1] ERROR in ./storybook/package-styles/components-ltr.lazy.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[16].use[2]!./node_modules/sass-loader/dist/cjs.js!./storybook/package-styles/components-ltr.lazy.scss)
[1] Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
[1] Parentheses aren't allowed in plain CSS.
[1]     ╷
[1] 278 │ @media (min-width: 782px) and (not (prefers-reduced-motion)) {
[1]     │                                    ^
[1]     ╵
[1]   packages/components/build-style/style.css 278:36       @import
[1]   storybook/package-styles/components-ltr.lazy.scss 1:9  root stylesheet
[1]  @ ./storybook/package-styles/components-ltr.lazy.scss 10:6-235 12:10-17 12:21-35 13:32-46 31:17-24 45:7-21 77:25-39 78:36-47 78:50-64 82:6-94:7 83:54-65 83:68-82 89:42-53 89:56-70 92:29-36 106:0-205 106:0-205 80:4-95:5
[1]  @ ./storybook/package-styles/config.js 8:0-71 27:8-21 31:8-21 35:8-21 39:8-21 43:8-21
[1]  @ ./storybook/decorators/with-rtl.js 10:0-46 29:4-18
[1]  @ ./storybook/preview.js 12:0-48 108:61-68
[1]  @ ./storybook-config-entry.js 8:648-713 29:2-32:4 29:634-32:3
[1] 
[1] ERROR in ./storybook/package-styles/components-rtl.lazy.scss (./node_modules/css-loader/dist/cjs.js!./node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[16].use[2]!./node_modules/sass-loader/dist/cjs.js!./storybook/package-styles/components-rtl.lazy.scss)
[1] Module build failed (from ./node_modules/sass-loader/dist/cjs.js):
[1] Parentheses aren't allowed in plain CSS.
[1]     ╷
[1] 278 │ @media (min-width: 782px) and (not (prefers-reduced-motion)) {
[1]     │                                    ^
[1]     ╵
[1]   packages/components/build-style/style-rtl.css 278:36   @import
[1]   storybook/package-styles/components-rtl.lazy.scss 1:9  root stylesheet
[1]  @ ./storybook/package-styles/components-rtl.lazy.scss 10:6-235 12:10-17 12:21-35 13:32-46 31:17-24 45:7-21 77:25-39 78:36-47 78:50-64 82:6-94:7 83:54-65 83:68-82 89:42-53 89:56-70 92:29-36 106:0-205 106:0-205 80:4-95:5
[1]  @ ./storybook/package-styles/config.js 9:0-71 28:8-21 32:8-21 36:8-21 40:8-21 44:8-21
[1]  @ ./storybook/decorators/with-rtl.js 10:0-46 29:4-18
[1]  @ ./storybook/preview.js 12:0-48 108:61-68
[1]  @ ./storybook-config-entry.js 8:648-713 29:2-32:4 29:634-32:3
[1] 
[1] preview compiled with 2 errors
[1] => Failed to build the preview
[1] <s> [webpack.Progress] 99% end closing watch compilation
[1] <s> [webpack.Progress] 99% end closing watch compilation
[1] WARN Force closed preview build
[1] SB_BUILDER-WEBPACK5_0003 (WebpackCompilationError): There were problems when compiling your code with Webpack.
[1] Run Storybook with --debug-webpack for more information.
[1]     at starter (./node_modules/@storybook/builder-webpack5/dist/index.js:1:23903)
[1]     at starter.next (<anonymous>)
[1]     at Module.start (./node_modules/@storybook/builder-webpack5/dist/index.js:1:25882)
[1]     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
[1] 
[1] WARN Broken build, fix the error above.
[1] WARN You may need to refresh the browser.
```

</details> 


## How?

I don't know the exact cause, but I suspect that the compiled CSS file is being imported as an SCSS file.

Therefore, I explicitly define the extension in the import statement. This seems to allow the media query that causes the error to work correctly.

## Testing Instructions

1. Run `npm run storybook:dev`.
2. Storybook should start correctly.
3. Check a few stories and verify that the style has been applied correctly.
4. Add code like the following to `packages/components/src/button/style.scss`:
  ```scss
  .components-button {
  	@include break-medium {
  		@media not (prefers-reduced-motion) {
  			background: #f00 !important;
  		}
  	}
  }
  ```
5. Open the story for the `Button` component.
6. Verify that the style has been applied correctly.

## Screenshots or screencast <!-- if applicable -->

Style applied to the button by the `@media (min-width: 782px) and (not (prefers-reduced-motion))` query:

![screenshot](https://github.com/user-attachments/assets/21f7c011-6946-494c-8288-d5fb9f474aa3)
