### PR TITLE
Fix Bug/issue #68368 - SCRIPT_DEBUG not working properly in gutenberg plugin

### DIFF
--- a/lib/client-assets.php
+++ b/lib/client-assets.php
@@ -617,6 +617,7 @@ add_action( 'wp_default_scripts', 'gutenberg_register_vendor_scripts' );
  * @since 19.3.0
  */
 function gutenberg_default_script_modules() {
+	$suffix = wp_scripts_get_suffix();
 	/*
 	 * Expects multidimensional array like:
 	 *
@@ -624,7 +625,7 @@ function gutenberg_default_script_modules() {
 	 *     'interactivity/debug.min.js' => array('dependencies' => array(…), 'version' => '…'),
 	 *     'interactivity-router/index.min.js' => …
 	 */
-	$assets = include gutenberg_dir_path() . '/build-module/assets.php';
+	$assets = include gutenberg_dir_path() . "/build-module/assets{$suffix}.php";
 
 	foreach ( $assets as $file_name => $script_module_data ) {
 		/*
@@ -634,7 +635,7 @@ function gutenberg_default_script_modules() {
 		 *   - interactivity/debug.min.js  => @wordpress/interactivity/debug
 		 *   - block-library/query/view.js => @wordpress/block-library/query/view
 		 */
-		$script_module_id = '@wordpress/' . preg_replace( '~(?:/index)?\.min\.js$~D', '', $file_name, 1 );
+		$script_module_id = '@wordpress/' . preg_replace( '~(?:/index)?(?:\.min)?\.js$~D', '', $file_name, 1 );
 		switch ( $script_module_id ) {
 			/*
 			 * Interactivity exposes two entrypoints, "/index" and "/debug".

--- a/tools/webpack/script-modules.js
+++ b/tools/webpack/script-modules.js
@@ -66,38 +66,42 @@ for ( const packageDir of packageDirs ) {
 		);
 	}
 }
+module.exports = function () {
+	const suffix = baseConfig.mode === 'production' ? '.min' : '';
 
-module.exports = {
-	...baseConfig,
-	name: 'script-modules',
-	entry: Object.fromEntries( gutenbergScriptModules.entries() ),
-	experiments: {
-		outputModule: true,
-	},
-	output: {
-		devtoolNamespace: 'wp',
-		filename: '[name].min.js',
-		library: {
-			type: 'module',
+	const config = {
+		...baseConfig,
+		name: 'script-modules',
+		entry: Object.fromEntries( gutenbergScriptModules.entries() ),
+		experiments: {
+			outputModule: true,
 		},
-		path: join( __dirname, '..', '..', 'build-module' ),
-		environment: { module: true },
-		module: true,
-		chunkFormat: 'module',
-		asyncChunks: false,
-	},
-	resolve: {
-		extensions: [ '.js', '.ts', '.tsx' ],
-	},
-	plugins: [
-		...plugins,
-		new DependencyExtractionWebpackPlugin( {
-			combineAssets: true,
-			combinedOutputFile: `./assets.php`,
-		} ),
-	],
-	watchOptions: {
-		ignored: [ '**/node_modules' ],
-		aggregateTimeout: 500,
-	},
+		output: {
+			devtoolNamespace: 'wp',
+			filename: `[name]${ suffix }.js`,
+			library: {
+				type: 'module',
+			},
+			path: join( __dirname, '..', '..', 'build-module' ),
+			environment: { module: true },
+			module: true,
+			chunkFormat: 'module',
+			asyncChunks: false,
+		},
+		resolve: {
+			extensions: [ '.js', '.ts', '.tsx' ],
+		},
+		plugins: [
+			...plugins,
+			new DependencyExtractionWebpackPlugin( {
+				combineAssets: true,
+				combinedOutputFile: `./assets${ suffix }.php`,
+			} ),
+		],
+		watchOptions: {
+			ignored: [ '**/node_modules' ],
+			aggregateTimeout: 500,
+		},
+	};
+	return config;
 };


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
Before it was loading the minified version of javascript even the script_debug is turned on. ( It was only issue in gutenberg plugin )

## Why?
After this PR merge, it will load minified version javascript when script debug is turned off and it will load non-minified version when script debug is turned on.

## How?
So, Added changes as per the reference from WordPress develop
https://github.com/WordPress/wordpress-develop/blob/trunk/tools/webpack/script-modules.js
https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/script-modules.php

## Testing Instructions
1. Merge PR
2. Go to the wp-config.php file and enable script to debug to true define( 'SCRIPT_DEBUG', true );
3. Check in console.

## Screenshots or screencast <!-- if applicable -->

<img width="1435" alt="image" src="https://github.com/user-attachments/assets/4a05f8b9-7f33-434a-80ec-fe76165d31a1" />

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/455027d3-56a1-4d53-bf6d-4c08fb30045a)|<img width="1435" alt="image" src="https://github.com/user-attachments/assets/921bb7fd-4bdc-4c25-a0c8-a55739f7f776" />|
