### PR TITLE
Prepare upload-media package to be published to NPM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50028,6 +50028,7 @@
 				"@wordpress/rich-text": "file:../rich-text",
 				"@wordpress/style-engine": "file:../style-engine",
 				"@wordpress/token-list": "file:../token-list",
+				"@wordpress/upload-media": "file:../upload-media",
 				"@wordpress/url": "file:../url",
 				"@wordpress/warning": "file:../warning",
 				"@wordpress/wordcount": "file:../wordcount",
@@ -52656,7 +52657,7 @@
 		},
 		"packages/upload-media": {
 			"name": "@wordpress/upload-media",
-			"version": "1.0.0-prerelease",
+			"version": "0.0.1",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@shopify/web-worker": "^6.4.0",

--- a/packages/block-editor/package.json
+++ b/packages/block-editor/package.json
@@ -65,6 +65,7 @@
 		"@wordpress/rich-text": "file:../rich-text",
 		"@wordpress/style-engine": "file:../style-engine",
 		"@wordpress/token-list": "file:../token-list",
+		"@wordpress/upload-media": "file:../upload-media",
 		"@wordpress/url": "file:../url",
 		"@wordpress/warning": "file:../warning",
 		"@wordpress/wordcount": "file:../wordcount",

--- a/packages/dependency-extraction-webpack-plugin/lib/util.js
+++ b/packages/dependency-extraction-webpack-plugin/lib/util.js
@@ -11,6 +11,7 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/sync',
 	'@wordpress/undo-manager',
 	'@wordpress/fields',
+	'@wordpress/upload-media',
 ];
 
 /**

--- a/packages/upload-media/package.json
+++ b/packages/upload-media/package.json
@@ -1,7 +1,6 @@
 {
 	"name": "@wordpress/upload-media",
-	"version": "1.0.0-prerelease",
-	"private": true,
+	"version": "0.0.1",
 	"description": "Core media upload logic.",
 	"author": "The WordPress Contributors",
 	"license": "GPL-2.0-or-later",

--- a/tools/webpack/packages.js
+++ b/tools/webpack/packages.js
@@ -42,6 +42,7 @@ const BUNDLED_PACKAGES = [
 	'@wordpress/sync',
 	'@wordpress/undo-manager',
 	'@wordpress/fields',
+	'@wordpress/upload-media',
 ];
 
 // PHP files in packages that have to be copied during build.


### PR DESCRIPTION
Fixes #68490 by implementing the suggestions in https://github.com/WordPress/gutenberg/issues/68490#issuecomment-2575146781:
1. `@wordpress/upload-media` is no longer `private: true` and gets a `0.0.1` version number to indicate that it's alpha.
2. `@wordpress/block-editor` properly declares it as a dependency, because it uses the package.
3. Inform build tools that they should bundle the package, i.e., don't externalize it and don't create a `wp-upload-media` WP script for it.

