### PR TITLE
NumberControl: Disable dragging on touch devices

### DIFF
--- a/packages/components/src/input-control/styles/input-control-styles.tsx
+++ b/packages/components/src/input-control/styles/input-control-styles.tsx
@@ -276,6 +276,7 @@ export const Input = styled.input< InputProps >`
 		font-family: inherit;
 		margin: 0;
 		outline: none;
+		touch-action: none;
 		width: 100%;
 
 		${ dragStyles }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Fixes issue - https://github.com/WordPress/gutenberg/issues/38865
It disables the drag gesture on touch devices by adding `touch-action: none`

## Testing Instructions
1. Insert a block to any post in mobile device.
2. Select the inserted block and focus on the input field from the sidebar controls.
3. Drag around input field - up and down.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

https://github.com/user-attachments/assets/30d27f4f-c3c6-4ebb-8103-7050eb23d055


