### PR TITLE
 Adds JSdoc for buttons edit.js

### DIFF
--- a/packages/block-library/src/buttons/edit.js
+++ b/packages/block-library/src/buttons/edit.js
@@ -25,6 +25,18 @@ const DEFAULT_BLOCK = {
 	],
 };
 
+/*
+ * Renders the edit component for the Buttons block in the block editor.
+ *
+ * @param {Object} props                       Component properties.
+ * @param {Object} props.attributes            Block attributes.
+ * @param {string} props.attributes.fontSize   The custom font size for the block.
+ * @param {Object} props.attributes.layout     The layout configuration for the block.
+ * @param {Object} props.attributes.style      The style object, including typography and other styles.
+ * @param {string} props.className             Additional class names to apply to the block.
+ *
+ * @returns {JSX.Element} The Buttons block edit component.
+ */
 function ButtonsEdit( { attributes, className } ) {
 	const { fontSize, layout, style } = attributes;
 	const blockProps = useBlockProps( {


### PR DESCRIPTION
## What?

This PR adds the JSDoc comment for archives block.

## Why?
Part of https://github.com/WordPress/gutenberg/issues/64057