### PR TITLE
Add support for the Show button text labels preference to the Widgets editor

### DIFF
--- a/packages/edit-widgets/src/components/header/document-tools/index.js
+++ b/packages/edit-widgets/src/components/header/document-tools/index.js
@@ -8,6 +8,7 @@ import { NavigableToolbar } from '@wordpress/block-editor';
 import { listView, plus } from '@wordpress/icons';
 import { useCallback } from '@wordpress/element';
 import { useViewportMatch } from '@wordpress/compose';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -25,6 +26,7 @@ function DocumentTools() {
 		isListViewOpen,
 		inserterSidebarToggleRef,
 		listViewToggleRef,
+		showIconLabels,
 	} = useSelect( ( select ) => {
 		const {
 			isInserterOpened,
@@ -37,6 +39,10 @@ function DocumentTools() {
 			isListViewOpen: isListViewOpened(),
 			inserterSidebarToggleRef: getInserterSidebarToggleRef(),
 			listViewToggleRef: getListViewToggleRef(),
+			showIconLabels: select( preferencesStore ).get(
+				'core',
+				'showIconLabels'
+			),
 		};
 	}, [] );
 	const { setIsInserterOpened, setIsListViewOpened } =
@@ -51,6 +57,13 @@ function DocumentTools() {
 		() => setIsInserterOpened( ! isInserterOpen ),
 		[ setIsInserterOpened, isInserterOpen ]
 	);
+
+	/* translators: Button label text should, if possible, be under 16 characters. */
+	const longLabel = _x(
+		'Block Inserter',
+		'Generic label for block inserter button'
+	);
+	const shortLabel = ! isInserterOpen ? __( 'Add' ) : __( 'Close' );
 
 	return (
 		<NavigableToolbar
@@ -69,18 +82,23 @@ function DocumentTools() {
 				} }
 				onClick={ toggleInserterSidebar }
 				icon={ plus }
-				/* translators: button label text should, if possible, be under 16
-					characters. */
-				label={ _x(
-					'Block Inserter',
-					'Generic label for block inserter button'
-				) }
+				label={ showIconLabels ? shortLabel : longLabel }
 				size="compact"
+				showTooltip={ ! showIconLabels }
+				aria-expanded={ isInserterOpen }
 			/>
 			{ isMediumViewport && (
 				<>
-					<ToolbarItem as={ UndoButton } />
-					<ToolbarItem as={ RedoButton } />
+					<ToolbarItem
+						as={ UndoButton }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/>
+					<ToolbarItem
+						as={ RedoButton }
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
+					/>
 					<ToolbarItem
 						as={ Button }
 						className="edit-widgets-header-toolbar__list-view-toggle"
@@ -91,6 +109,8 @@ function DocumentTools() {
 						onClick={ toggleListView }
 						ref={ listViewToggleRef }
 						size="compact"
+						showTooltip={ ! showIconLabels }
+						variant={ showIconLabels ? 'tertiary' : undefined }
 					/>
 				</>
 			) }

--- a/packages/edit-widgets/src/components/header/style.scss
+++ b/packages/edit-widgets/src/components/header/style.scss
@@ -74,6 +74,58 @@
 	}
 }
 
+/**
+ * Show icon labels.
+ */
+.show-icon-labels .edit-widgets-header {
+	.components-button.has-icon {
+		width: auto;
+
+		// Hide the button icons when labels are set to display...
+		svg {
+			display: none;
+		}
+		// ... and display labels.
+		&::after {
+			content: attr(aria-label);
+			white-space: nowrap;
+		}
+		&[aria-disabled="true"] {
+			background-color: transparent;
+		}
+	}
+	.is-tertiary {
+		&:active {
+			box-shadow: 0 0 0 1.5px var(--wp-admin-theme-color);
+			background-color: transparent;
+		}
+	}
+	// Exception for drodpdown toggle buttons.
+	.components-button.has-icon.button-toggle {
+		svg {
+			display: block;
+		}
+		&::after {
+			content: none;
+		}
+	}
+
+	// Don't hide MenuItemsChoice check icons
+	.components-menu-items-choice .components-menu-items__item-icon.components-menu-items__item-icon {
+		display: block;
+	}
+	.editor-document-tools__inserter-toggle.editor-document-tools__inserter-toggle,
+	.interface-pinned-items .components-button {
+		padding-left: $grid-unit;
+		padding-right: $grid-unit;
+
+		@include break-small {
+			padding-left: $grid-unit-15;
+			padding-right: $grid-unit-15;
+		}
+	}
+}
+
 .edit-widgets-header__navigable-toolbar-wrapper {
 	display: flex;
 	align-items: center;

--- a/packages/edit-widgets/src/components/layout/index.js
+++ b/packages/edit-widgets/src/components/layout/index.js
@@ -1,11 +1,17 @@
 /**
+ * External dependencies
+ */
+import clsx from 'clsx';
+
+/**
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { PluginArea } from '@wordpress/plugins';
 import { store as noticesStore } from '@wordpress/notices';
 import { __unstableUseNavigateRegions as useNavigateRegions } from '@wordpress/components';
+import { store as preferencesStore } from '@wordpress/preferences';
 
 /**
  * Internal dependencies
@@ -32,14 +38,29 @@ function Layout( { blockEditorSettings } ) {
 		);
 	}
 
+	const { showIconLabels } = useSelect( ( select ) => {
+		return {
+			showIconLabels: select( preferencesStore ).get(
+				'core',
+				'showIconLabels'
+			),
+		};
+	} );
+
 	const navigateRegionsProps = useNavigateRegions();
 
 	return (
 		<ErrorBoundary>
 			<div
-				className={ navigateRegionsProps.className }
 				{ ...navigateRegionsProps }
 				ref={ navigateRegionsProps.ref }
+				className={ clsx(
+					'edit-widgets-layout',
+					navigateRegionsProps.className,
+					{
+						'show-icon-labels': showIconLabels,
+					}
+				) }
 			>
 				<WidgetAreasBlockEditorProvider
 					blockEditorSettings={ blockEditorSettings }

--- a/packages/edit-widgets/src/components/more-menu/index.js
+++ b/packages/edit-widgets/src/components/more-menu/index.js
@@ -10,10 +10,14 @@ import {
 import { useState } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
 import { external, moreVertical } from '@wordpress/icons';
-import { PreferenceToggleMenuItem } from '@wordpress/preferences';
+import {
+	PreferenceToggleMenuItem,
+	store as preferencesStore,
+} from '@wordpress/preferences';
 import { displayShortcut } from '@wordpress/keycodes';
 import { useShortcut } from '@wordpress/keyboard-shortcuts';
 import { useViewportMatch } from '@wordpress/compose';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -36,6 +40,12 @@ export default function MoreMenu() {
 
 	const isLargeViewport = useViewportMatch( 'medium' );
 
+	const showIconLabels = useSelect(
+		( select ) =>
+			select( preferencesStore ).get( 'core', 'showIconLabels' ),
+		[]
+	);
+
 	return (
 		<>
 			<DropdownMenu
@@ -48,6 +58,8 @@ export default function MoreMenu() {
 				toggleProps={ {
 					tooltipPosition: 'bottom',
 					size: 'compact',
+					showTooltip: ! showIconLabels,
+					...( showIconLabels && { variant: 'tertiary' } ),
 				} }
 			>
 				{ ( onClose ) => (


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes https://github.com/WordPress/gutenberg/issues/57646

## What?
<!-- In a few words, what is the PR actually doing? -->
[Apparently](https://github.com/WordPress/gutenberg/issues/57646#issuecomment-1882485109), support for the 'Show button text labels' preference was never implemented in the Widgets editor.

The Poist, Site, and Widgets editors used to have separate preferences stores. The Widgets editor never had an UI to set this preference so the lack of support for `showIconLabels`  wasn't a huge problem. However, now that it's a cross-editor preference, thje lack of suppor tin the Widgets editor is evident and also leads to issues like displaying a wrong icon as reported in https://github.com/WordPress/gutenberg/issues/57646.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
As `showIconLabels` is now a cross-editor preference, it should work in all editors.
Also, displaying a 'check` icon for the Settings toggle button should be prevented. (More on this in a separate comment).

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Adds support for the `showIconLabels` by using the CSS_based approach in use in the other editors.
- Adjusts the variant and tooltips of the buttons when `showIconLabels` is true, for consistency with the other editors.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
- The Widgets editor doesn't have an UI to set this preference. However, when enabled from the other editors, it's now enabled also in the Widgets editor.
- Alternatively, for testing purposes, you can dispatch this in your browser dev tools console to enable the preference: `window.wp.data.dispatch( 'core/preferences' ).set( 'core', 'showIconLabels', true );`
- And this to disable the preference: window.wp.data.dispatch( 'core/preferences' ).set( 'core', 'showIconLabels', false );`
- Enable the preference.
- Activate a non-bock theme to be able to access the Widgets editor e.g. activate Twenty Twenty-One.
- Go to the Widgets editor from the WP admin > Appearance > Widgets.
- Observe the buttons in the editor top bar show visible text instead of icons.
- Select a block in a Widgets area.
- Observe the block toolbar buttons show visible text instead of icons.
- Switch off and on the preferences and observe the various buttons change accordingly.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

Animated GIF to illustrate the preference in action:

![show icon labels widgets](https://github.com/user-attachments/assets/cd860484-e5b2-4f92-ab72-d04849f6f23c)

The styling of the buttons when `showIconLabels` is enabled in the Widgets editor compared with the one in the Post editor:

Widgets editor:

![Screenshot 2025-01-07 at 14 55 03](https://github.com/user-attachments/assets/46611c03-7b3b-4d87-9439-052128331c83)


Post editor:

![Screenshot 2025-01-07 at 14 55 30](https://github.com/user-attachments/assets/89607ad6-1f77-40ef-99ee-db61f394004c)



<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
