### PR TITLE
Try: Fix e2e tests 'visitSiteEditor' helper

### DIFF
--- a/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
+++ b/packages/e2e-test-utils-playwright/src/admin/visit-site-editor.ts
@@ -39,6 +39,15 @@ export async function visitSiteEditor(
 
 	await this.visitAdminPage( 'site-editor.php', query.toString() );
 
+	if ( ! options.showWelcomeGuide ) {
+		await this.editor.setPreferences( 'core/edit-site', {
+			welcomeGuide: false,
+			welcomeGuideStyles: false,
+			welcomeGuidePage: false,
+			welcomeGuideTemplate: false,
+		} );
+	}
+
 	/**
 	 * @todo This is a workaround for the fact that the editor canvas is seen as
 	 * ready and visible before the loading spinner is hidden. Ideally, the
@@ -61,15 +70,6 @@ export async function visitSiteEditor(
 			// HTML fixture that we load for performance tests, which often
 			// doesn't make it under the default timeout value.
 			timeout: 60_000,
-		} );
-	}
-
-	if ( ! options.showWelcomeGuide ) {
-		await this.editor.setPreferences( 'core/edit-site', {
-			welcomeGuide: false,
-			welcomeGuideStyles: false,
-			welcomeGuidePage: false,
-			welcomeGuideTemplate: false,
 		} );
 	}
 }


### PR DESCRIPTION
## What?
Trying to fix flaky tests like #61884.

I see a welcome modal in report files, which might be causing test failures.

## Why?
The welcome modals should be hidden before asserting any other locators on a page.

## Testing Instructions
CI checks should be green.

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![test-failed-1](https://github.com/user-attachments/assets/66c5bfb9-fa08-41eb-ade8-704526ee6441)
