### PR TITLE
#63959: Add title attribute to post save action

### DIFF
--- a/packages/editor/src/store/actions.js
+++ b/packages/editor/src/store/actions.js
@@ -204,6 +204,7 @@ export const savePost =
 		}
 
 		const content = select.getEditedPostContent();
+		const title = select.getEditedPostAttribute( 'title' );
 
 		if ( ! options.isAutosave ) {
 			dispatch.editPost( { content }, { undoIgnore: true } );
@@ -212,6 +213,7 @@ export const savePost =
 		const previousRecord = select.getCurrentPost();
 		let edits = {
 			id: previousRecord.id,
+			title,
 			...registry
 				.select( coreStore )
 				.getEntityRecordNonTransientEdits(


### PR DESCRIPTION
Fixes [#63959](https://github.com/WordPress/gutenberg/issues/63959)

## What?
Add post title to save payload regardless of modification status to ensure consistent title synchronization across multiple editor sessions.

## Why?
Currently, the post title is only included in the save payload when it has been modified in the current editing session. This creates inconsistent behavior when editing a post in multiple windows/tabs:

Changes to the title in one window can be inadvertently overwritten when saving content from another window
Users experience unexpected title changes when saving, leading to confusion
The current behavior violates the principle of least surprise - users expect all post content (including title) to be saved consistently

## How?
Modified the savePost action to always include the current post title in the save payload by adding:

```js
const title = select.getEditedPostAttribute( 'title' );

let edits = {
	id: previousRecord.id,
	title,
	...registry
		.select( coreStore )
		.getEntityRecordNonTransientEdits(
			'postType',
			previousRecord.type,
			previousRecord.id
		),
	content,
};
```

## Testing Instructions
1. Create a new post with a title and some content
2. Save the post
3. Open the same post in two different browser windows/tabs (Window A and Window B)
4. In Window B, change the post title and save
5. In Window A, make a change to the post content (without modifying the title)
6. Save changes in Window A
7. Verify that the title remains unchanged in Window A (previously, it would revert to the title from Window B)

## Screenshots or screencast <!-- if applicable -->
[screen-capture (1).webm](https://github.com/user-attachments/assets/dbe01047-8912-46c5-8bee-e65005d55d9a)

