### PR TITLE
WIP: Add filter to enable custom classes in "editor-styles-wrapper"

### DIFF
--- a/lib/block-editor-settings.php
+++ b/lib/block-editor-settings.php
@@ -159,6 +159,34 @@ function gutenberg_get_block_editor_settings( $settings ) {
 			);
 	}
 
+	$body_classes = array();
+
+	$post = get_post();
+	if ( $post ) {
+		$body_classes[] = 'post-type-' . sanitize_html_class( $post->post_type );
+		$body_classes[] = 'post-status-' . sanitize_html_class( $post->post_status );
+
+		if ( post_type_supports( $post->post_type, 'post-formats' ) ) {
+			$post_format = get_post_format( $post );
+			if ( $post_format && ! is_wp_error( $post_format ) ) {
+				$body_classes[] = 'post-format-' . sanitize_html_class( $post_format );
+			} else {
+				$body_classes[] = 'post-format-standard';
+			}
+		}
+
+		$page_template = get_page_template_slug( $post );
+
+		if ( false !== $page_template ) {
+			$page_template = empty( $page_template ) ? 'default' : str_replace( '.', '-', basename( $page_template, '.php' ) );
+			$body_classes[] = 'page-template-' . sanitize_html_class( $page_template );
+		}
+	}
+
+	$body_classes[] = 'locale-' . sanitize_html_class( strtolower( str_replace( '_', '-', get_user_locale() ) ) );
+
+	$settings['bodyClasses'] = $body_classes;
+
 	return $settings;
 }
 add_filter( 'block_editor_settings_all', 'gutenberg_get_block_editor_settings', 0 );

--- a/packages/block-editor/src/components/editor-styles/index.js
+++ b/packages/block-editor/src/components/editor-styles/index.js
@@ -21,7 +21,7 @@ import { unlock } from '../../lock-unlock';
 
 extend( [ namesPlugin, a11yPlugin ] );
 
-function useDarkThemeBodyClassName( styles, scope ) {
+function useDarkThemeBodyClassName( scope, bodyClasses ) {
 	return useCallback(
 		( node ) => {
 			if ( ! node ) {
@@ -58,12 +58,12 @@ function useDarkThemeBodyClassName( styles, scope ) {
 				colordBackgroundColor.luminance() > 0.5 ||
 				colordBackgroundColor.alpha() === 0
 			) {
-				body.classList.remove( 'is-dark-theme' );
-			} else {
-				body.classList.add( 'is-dark-theme' );
+				bodyClasses.filter( ( className ) => className !== 'is-dark-theme' );
+			} else if( bodyClasses.includes( 'is-dark-theme' ) === false ) {
+				bodyClasses.push( 'is-dark-theme' );
 			}
 		},
-		[ styles, scope ]
+		[ scope, bodyClasses ]
 	);
 }
 
@@ -98,12 +98,18 @@ function EditorStyles( { styles, scope, transformOptions } ) {
 		];
 	}, [ styles, overrides, scope, transformOptions ] );
 
+	const bodyClasses = useSelect( ( select ) => {
+		const { getEditorSettings } = select( 'core/editor' );
+		const editorSettings = getEditorSettings();
+		return editorSettings.bodyClasses;
+	}, [] );
+
 	return (
 		<>
 			{ /* Use an empty style element to have a document reference,
 			     but this could be any element. */ }
 			<style
-				ref={ useDarkThemeBodyClassName( transformedStyles, scope ) }
+				ref={ useDarkThemeBodyClassName( scope, bodyClasses ) }
 			/>
 			{ transformedStyles.map( ( css, index ) => (
 				<style key={ index }>{ css }</style>

--- a/packages/editor/src/components/post-template/reset-default-template.js
+++ b/packages/editor/src/components/post-template/reset-default-template.js
@@ -14,6 +14,7 @@ import {
 	useCurrentTemplateSlug,
 	useEditedPostContext,
 } from './hooks';
+import { store as editorStore } from '../../store';
 
 export default function ResetDefaultTemplate( { onClick } ) {
 	const currentTemplateSlug = useCurrentTemplateSlug();
@@ -21,11 +22,11 @@ export default function ResetDefaultTemplate( { onClick } ) {
 	const { postType, postId } = useEditedPostContext();
 	const { editEntityRecord } = useDispatch( coreStore );
 	const bodyClasses = useSelect( ( select ) => {
-			const { getEditorSettings } = select( 'core/editor' );
+			const { getEditorSettings } = select( editorStore );
 			const editorSettings = getEditorSettings();
 			return editorSettings.bodyClasses;
 		 }, [] );
-	const { updateEditorSettings } = useDispatch( 'core/editor' );
+	const { updateEditorSettings } = useDispatch( editorStore );
 	// The default template in a post is indicated by an empty string.
 	if ( ! currentTemplateSlug || ! allowSwitchingTemplate ) {
 		return null;

--- a/packages/editor/src/components/post-template/reset-default-template.js
+++ b/packages/editor/src/components/post-template/reset-default-template.js
@@ -3,7 +3,7 @@
  */
 import { MenuItem } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { store as coreStore } from '@wordpress/core-data';
 
 /**
@@ -20,6 +20,12 @@ export default function ResetDefaultTemplate( { onClick } ) {
 	const allowSwitchingTemplate = useAllowSwitchingTemplates();
 	const { postType, postId } = useEditedPostContext();
 	const { editEntityRecord } = useDispatch( coreStore );
+	const bodyClasses = useSelect( ( select ) => {
+			const { getEditorSettings } = select( 'core/editor' );
+			const editorSettings = getEditorSettings();
+			return editorSettings.bodyClasses;
+		 }, [] );
+	const { updateEditorSettings } = useDispatch( 'core/editor' );
 	// The default template in a post is indicated by an empty string.
 	if ( ! currentTemplateSlug || ! allowSwitchingTemplate ) {
 		return null;
@@ -34,6 +40,18 @@ export default function ResetDefaultTemplate( { onClick } ) {
 					{ template: '' },
 					{ undoIgnore: true }
 				);
+				let hasPageTemplateClass = false;
+				const updatedBodyClasses = bodyClasses.map( className => {
+					if ( className.startsWith( 'page-template-' )) {
+						hasPageTemplateClass = true;
+						return `page-template-default`;
+					}
+					return className;
+				});
+				if ( ! hasPageTemplateClass ) {
+					updatedBodyClasses.push( `page-template-default` );
+				}
+				updateEditorSettings( { bodyClasses: updatedBodyClasses } );
 				onClick();
 			} }
 		>

--- a/packages/editor/src/components/post-template/swap-template-button.js
+++ b/packages/editor/src/components/post-template/swap-template-button.js
@@ -14,6 +14,7 @@ import { parse } from '@wordpress/blocks';
  * Internal dependencies
  */
 import { useAvailableTemplates, useEditedPostContext } from './hooks';
+import { store as editorStore } from '../../store';
 
 export default function SwapTemplateButton( { onClick } ) {
 	const [ showModal, setShowModal ] = useState( false );
@@ -21,11 +22,11 @@ export default function SwapTemplateButton( { onClick } ) {
 	const availableTemplates = useAvailableTemplates( postType );
 	const { editEntityRecord } = useDispatch( coreStore );
 	const bodyClasses = useSelect( ( select ) => {
-		const { getEditorSettings } = select( 'core/editor' );
+		const { getEditorSettings } = select( editorStore );
 		const editorSettings = getEditorSettings();
 		return editorSettings.bodyClasses;
 	 }, [] );
-	const { updateEditorSettings } = useDispatch( 'core/editor' );
+	const { updateEditorSettings } = useDispatch( editorStore );
 	if ( ! availableTemplates?.length ) {
 		return null;
 	}


### PR DESCRIPTION
## What?
Adds a 'bodyClasses' property to the block editor settings that emulates the classes applied to the pre-Gutenberg TinyMCE iframe and applies those classes to the block editor's iframe. This allows, for example, targeting CSS for the iframe based on the page template selected.

## Why?
Addresses https://github.com/WordPress/gutenberg/issues/17854 and https://github.com/WordPress/gutenberg/issues/56831 and https://github.com/WordPress/gutenberg/issues/60299

## How?
Adds a 'bodyClasses' property to the block editor settings that emulates the classes applied to the TinyMCE iframe.
The body classes can be modified by extenders via the block_editor_settings_all filter
The body classes are applied to the post/site editor iframe.
The body classes can be modified by updating the editor settings state. For example, when using the "swap template" or "use default template" buttons, the page template class is updated on the iframe.
The useDarkThemeBodyClassName hook can correctly add the class to the body of the iframe.

## Questions/Problems

1. This basically copies the code from TinyMCE to add the following classes: post-type, post-status, post-format, page-template, and locale. Are those still the classes we want added to the iframe?
~~2. Because attributes added to get_block_editor_settings are not available on the core/block-editor store, only on the deprecated core/editor store, how can this be modified to be merged?~~
3. ~~This only modifies the page-template class when the user swaps the template or restores the default template.~~ Creating a new template is still to do. Are there other actions that should update the body classes?
4. I couldn't figure out how to reference the 'core/editor' store by variable for components in the block-editor so I just kept referring to it by string and I use --no-verify to ignore the js lint errors.
