### PR TITLE
Editor: Simplify Block Inserter Button Label and Remove Dynamic Label Behavior

### DIFF
--- a/packages/editor/src/components/document-tools/index.js
+++ b/packages/editor/src/components/document-tools/index.js
@@ -96,11 +96,8 @@ function DocumentTools( { className, disableBlockTools = false } ) {
 	);
 
 	/* translators: button label text should, if possible, be under 16 characters. */
-	const longLabel = _x(
-		'Block Inserter',
-		'Generic label for block inserter button'
-	);
-	const shortLabel = ! isInserterOpened ? __( 'Add' ) : __( 'Close' );
+	const longLabel = _x( 'Add', 'Generic label for block inserter button' );
+	const shortLabel = __( 'Add' );
 
 	return (
 		// Some plugins expect and use the `edit-post-header-toolbar` CSS class to


### PR DESCRIPTION
Fixes : https://github.com/WordPress/gutenberg/issues/68536

## What?
- Simplifies the Block Inserter button label to "Add" for better user-friendliness.
- Removes the dynamic label behavior where the label changes from "Add" to "Close" when toggling the Block Inserter.

## Why?

- The dynamic label behavior was unnecessary, as visual and semantic cues like color inversion and aria-pressed/aria-expanded already convey the button's state.
- Simplifying "Block Inserter" to "Add" improves usability by making the label more intuitive and user-friendly.

## How?

- Updated the button's label to consistently display "Add" regardless of whether the Block Inserter is open or closed.
- Replaced the technical term "Block Inserter" with "Add" when the "Show button text labels" preference is disabled.

## Testing Instructions

1. Open the Post or Site Editor.
2. Hover or focus on the Block Inserter button and observe the tooltip text (label).
3. Expected: The label should display "Add" instead of "Block Inserter."
4. Enable the preference Show button text labels from the top bar (Options > Preferences > Accessibility).
5. Expected: The button should display "Add" as its text label.
6. Open and close the Block Inserter.
7. Expected: The label remains static as "Add" and does not change to "Close."


## Screenshots or screencast 



|Before|After|
|-|-|
|<img width="249" alt="image" src="https://github.com/user-attachments/assets/fab97ffb-796a-43e9-9cf7-c9f58fc8c54b" />|<img width="249" alt="image" src="https://github.com/user-attachments/assets/3acfa819-de3a-4260-9e3a-6611d80333e5" />|




|Before|After|
|-|-|
|<img width="249" alt="image" src="https://github.com/user-attachments/assets/5888d962-439c-4f17-84d4-ff3b59c8b05a" />|<img width="249" alt="image" src="https://github.com/user-attachments/assets/e628721d-6984-408b-9845-8f1e711061a0" />|






|Before|After|
|-|-|
|<img width="249" alt="image" src="https://github.com/user-attachments/assets/05d5f876-dfb4-4992-9a5d-f84677065fc4" />|<img width="249" alt="image" src="https://github.com/user-attachments/assets/76d102e8-8129-417f-9183-a4f7670ec2b9" />|




