### PR TITLE
fix: Rename API Reference to Directives and Store API Reference

### DIFF
--- a/docs/reference-guides/interactivity-api/README.md
+++ b/docs/reference-guides/interactivity-api/README.md
@@ -20,7 +20,7 @@ Use the following links to locate the topic you're interested in. If you have ne
 -   **[Quick Start Guide](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/iapi-quick-start-guide/):** Get a custom block using the Interactivity API up and running in less than one minute.
 -   **[Tutorial: A first look at the Interactivity API](https://developer.wordpress.org/news/2024/04/11/a-first-look-at-the-interactivity-api/)** This article from the [WordPress Developer Blog](https://developer.wordpress.org/news/) is a great way to get introduced to the Interactivity API.
 -   **[Core Concepts](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/core-concepts/)** Gain a better understanding of concepts and mental models related to Interactivity API development from this section.
--   **[API Reference](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/api-reference/):** To take a deep dive into how the API works internally, the list of Directives, and how the Store works.
+-   **[Directives and Store API Reference](https://developer.wordpress.org/block-editor/reference-guides/interactivity-api/directives-store-api-reference/):** To take a deep dive into how the API works internally, the list of Directives, and how the Store works.
 -   **[Docs and Examples](#docs-examples):** Additional resources to learn/read more about the Interactivity API.
 
 To get a deeper understanding of what the Interactivity API is or find answers to questions you may have about this standard, check the following resources:

--- a/docs/reference-guides/interactivity-api/directives-store-api-reference.md
+++ b/docs/reference-guides/interactivity-api/directives-store-api-reference.md
@@ -1,4 +1,4 @@
-# API Reference
+# Directives and Store API Reference
 
 <div class="callout callout-alert">
 Interactivity API is only available for WordPress 6.5 and above.
@@ -712,8 +712,8 @@ For server-side rendered lists, another directive called `data-wp-each-child` en
 
 ```html
 <ul data-wp-context='{ "list": [ "hello", "hola", "olá" ] }'>
-	<template data-wp-each--greeting="context.list">
-		<li data-wp-text="context.greeting"></li>
+	<template data-wp-each="context.list">
+		<li data-wp-text="context.item"></li>
 	</template>
 	<li data-wp-each-child>hello</li>
 	<li data-wp-each-child>hola</li>

--- a/docs/toc.json
+++ b/docs/toc.json
@@ -227,7 +227,7 @@
 						"docs/reference-guides/interactivity-api/iapi-quick-start-guide.md": []
 					},
 					{
-						"docs/reference-guides/interactivity-api/api-reference.md": []
+						"docs/reference-guides/interactivity-api/directives-store-api-reference.md": []
 					},
 					{
 						"docs/reference-guides/interactivity-api/iapi-about.md": []


### PR DESCRIPTION
Fixes #61207

Rename the "API Reference" to "Directives and Store API Reference" in the Interactivity API documentation.

* Rename the file `docs/reference-guides/interactivity-api/api-reference.md` to `docs/reference-guides/interactivity-api/directives-store-api-reference.md`.
* Update the title in `directives-store-api-reference.md` to "Directives and Store API Reference".
* Update the reference in `docs/toc.json` from "api-reference.md" to "directives-store-api-reference.md".
* Update the mention of "API Reference" to "Directives and Store API Reference" in the navigation section of `docs/reference-guides/interactivity-api/README.md`.

