### PR TITLE
Button: Update hover styles to account for pressed state for `tertiary button`

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -103,7 +103,7 @@
 -   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
 -   `FontSizePicker`: Add `display:contents` rule to fix overflowing text in the custom size select. ([#68280](https://github.com/WordPress/gutenberg/pull/68280)).
 -   `BoxControl`: Fix aria-valuetext value ([#68362](https://github.com/WordPress/gutenberg/pull/68362)).
--   `Button`: Fix tertiary variant displaying incorrect accent color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
+-   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
 
 ### Experimental
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -103,6 +103,7 @@
 -   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
 -   `FontSizePicker`: Add `display:contents` rule to fix overflowing text in the custom size select. ([#68280](https://github.com/WordPress/gutenberg/pull/68280)).
 -   `BoxControl`: Fix aria-valuetext value ([#68362](https://github.com/WordPress/gutenberg/pull/68362)).
+-   `Button`: Fix tertiary variant displaying incorrect accent color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
 
 ### Experimental
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
+
 ## 29.7.0 (2025-03-27)
 
 ### Bug Fixes
@@ -11,7 +15,6 @@
 -   `CustomSelectControl`: Fix check icon color to adapt with dark theme ([#69626](https://github.com/WordPress/gutenberg/pull/69626)).
 -   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 -   `NumberControl`: update stepping to match HTML number input stepping ([#34566](https://github.com/WordPress/gutenberg/pull/34566)).
--   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
 
 ## 29.6.0 (2025-03-13)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -11,6 +11,7 @@
 -   `CustomSelectControl`: Fix check icon color to adapt with dark theme ([#69626](https://github.com/WordPress/gutenberg/pull/69626)).
 -   `Autocomplete`: Extracts `getNodeText` function into a separate file and adds unit tests ([#69135](https://github.com/WordPress/gutenberg/pull/69135)).
 -   `NumberControl`: update stepping to match HTML number input stepping ([#34566](https://github.com/WordPress/gutenberg/pull/34566)).
+-   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
 
 ## 29.6.0 (2025-03-13)
 
@@ -103,7 +104,6 @@
 -   `BoxControl`: Better respect for the `min` prop in the Range Slider ([#67819](https://github.com/WordPress/gutenberg/pull/67819)).
 -   `FontSizePicker`: Add `display:contents` rule to fix overflowing text in the custom size select. ([#68280](https://github.com/WordPress/gutenberg/pull/68280)).
 -   `BoxControl`: Fix aria-valuetext value ([#68362](https://github.com/WordPress/gutenberg/pull/68362)).
--   `Button`: Fix tertiary variant displaying incorrect text color in pressed and hover states ([#68542](https://github.com/WordPress/gutenberg/pull/68542)).
 
 ### Experimental
 

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -174,6 +174,7 @@
 
 		&:active:not(:disabled, [aria-disabled="true"]) {
 			background: color-mix(in srgb, $components-color-accent 8%, transparent);
+			color: $components-color-accent-darker-20;
 		}
 
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -167,7 +167,7 @@
 		color: $components-color-accent;
 		background: transparent;
 
-		&:hover:not(:disabled, [aria-disabled="true"]) {
+		&:hover:not(:disabled, [aria-disabled="true"], .is-pressed) {
 			background: color-mix(in srgb, $components-color-accent 4%, transparent);
 			color: $components-color-accent-darker-20;
 		}

--- a/packages/components/src/button/style.scss
+++ b/packages/components/src/button/style.scss
@@ -174,7 +174,6 @@
 
 		&:active:not(:disabled, [aria-disabled="true"]) {
 			background: color-mix(in srgb, $components-color-accent 8%, transparent);
-			color: $components-color-accent-darker-20;
 		}
 
 		// Pull left if the tertiary button stands alone after a description, so as to vertically align with items above.


### PR DESCRIPTION
## What, Why and How?
As noted in the [comment](https://github.com/WordPress/gutenberg/issues/68535#issuecomment-2576733579), the is-pressed CSS rule was overridden on hover, resulting in a dark blue accent that reduced readability.

https://github.com/WordPress/gutenberg/blob/ef7afefc5988eaab30da0025aa48bfbddb09a79f/packages/components/src/button/style.scss#L172

This PR introduces an additional `:not` condition to ensure the color property is applied only when the `is-pressed` state is not active.

## Testing Instructions
1. Start `storybook` using `npm run storybook:dev` command.
2. Navigate to `Button` component.
3. Make sure the `variant` is `tertiary`.
4. Notice, the `text color` stays `white` on `hover`.

## Screencasts <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|![before](https://github.com/user-attachments/assets/78f7bdb1-c61e-4f40-a4f8-c043afdbbc32)|![after](https://github.com/user-attachments/assets/db7258aa-fed0-4c65-b8d4-31fc1603b196)|

### The settings button hover effect
![MOV to GIF output](https://github.com/user-attachments/assets/52576055-ab0e-4dc0-b972-3185aed8e62b)
It was found to work as expected.

Closes: #68535 