### PR TITLE
Storybook: Add Story for Color Style Selector Component

### DIFF
--- a/packages/block-editor/src/components/color-style-selector/index.js
+++ b/packages/block-editor/src/components/color-style-selector/index.js
@@ -78,6 +78,15 @@ const renderToggleComponent =
 		);
 	};
 
+/**
+ * Block Colors Style Selector component displays a dropdown menu for selecting block colors, with built-in text and background color support.
+ * 
+ * @param {Object} props
+ * @param {JSX.Element} props.children Content to render inside the dropdown.
+ * @param {Object} props.other Other props to pass to the Text
+ * 
+ * @return {Element} Block Colors Style Selector component.
+ */
 const BlockColorsStyleSelector = ( { children, ...other } ) => {
 	deprecated( `wp.blockEditor.BlockColorsStyleSelector`, {
 		alternative: 'block supports API',

--- a/packages/block-editor/src/components/color-style-selector/stories/index.story.js
+++ b/packages/block-editor/src/components/color-style-selector/stories/index.story.js
@@ -1,0 +1,91 @@
+/**
+ * Internal dependencies
+ */
+import BlockColorsStyleSelector from '..';
+
+const meta = {
+	title: 'BlockEditor/BlockColorsStyleSelector',
+	component: BlockColorsStyleSelector,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The `BlockColorsStyleSelector` is a dropdown menu for selecting block colors, with built-in text and background color support.',
+			},
+		},
+	},
+	argTypes: {
+		textColor: {
+			control: 'color',
+			description: 'Text color for the TextColor component.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		backgroundColor: {
+			control: 'color',
+			description: 'Background color for the BackgroundColor component.',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		displayText: {
+			control: { type: null },
+			description: 'Text displayed inside the box (toggle button).',
+			table: {
+				type: { summary: 'string' },
+			},
+		},
+		dropdownContent: {
+			control: 'text',
+			description: 'Content to render inside the dropdown.',
+			table: {
+				type: { summary: 'ReactNode' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		textColor: 'black',
+		backgroundColor: 'lightgray',
+		displayText: 'Select Color',
+		dropdownContent: 'Block Colors Selector Content',
+	},
+	render: function Template( {
+		textColor,
+		backgroundColor,
+		dropdownContent,
+	} ) {
+		const TextColor = () => (
+			<span style={ { color: textColor } }>Hello</span>
+		);
+
+		const BackgroundColor = ( { children } ) => (
+			<div
+				style={ {
+					backgroundColor,
+					padding: '20px',
+					borderRadius: '4px',
+					display: 'inline-block',
+				} }
+			>
+				{ children }
+			</div>
+		);
+
+		return (
+			<BlockColorsStyleSelector
+				TextColor={ TextColor }
+				BackgroundColor={ BackgroundColor }
+				children={ dropdownContent }
+			/>
+		);
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for color style selector component 

## Testing Instructions
- Run npm run storybook:dev
- Open the storybook on http://localhost:50240/
- Check the Color Style Selector story.


## Screenshots or screencast



https://github.com/user-attachments/assets/d19ce874-2f5d-4786-b17a-b51317863098

