### PR TITLE
Editor: Fix custom settings not appearing in block editor store

### DIFF
--- a/packages/editor/src/components/provider/use-block-editor-settings.js
+++ b/packages/editor/src/components/provider/use-block-editor-settings.js
@@ -278,6 +278,7 @@ function useBlockEditorSettings( settings, postType, postId, renderingMode ) {
 
 	return useMemo( () => {
 		const blockEditorSettings = {
+			...settings,
 			...Object.fromEntries(
 				Object.entries( settings ).filter( ( [ key ] ) =>
 					BLOCK_EDITOR_SETTINGS.includes( key )


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Fixes: https://github.com/WordPress/gutenberg/issues/68541

## What?
Fixes an inconsistency where custom settings added through `block_editor_settings_all` filter are available in `core/editor` store but not in `core/block-editor` store.

## Why?
   - In `useBlockEditorSettings`, settings are being filtered through a whitelist defined in `BLOCK_EDITOR_SETTINGS` array
   - Custom attributes added via `block_editor_settings_all` are getting dropped during this filtering

## How?
Modified `useBlockEditorSettings` to first spread all settings, then override with filtered core settings