### PR TITLE
#59094: Sort font library modal tabs alphabetically

### DIFF
--- a/packages/edit-site/src/components/global-styles/font-library-modal/index.js
+++ b/packages/edit-site/src/components/global-styles/font-library-modal/index.js
@@ -59,6 +59,10 @@ function FontLibraryModal( {
 		tabs.push( ...tabsFromCollections( collections || [] ) );
 	}
 
+	const sortedTabs = [ ...tabs ].sort( ( a, b ) =>
+		a.title.localeCompare( b.title )
+	);
+
 	return (
 		<Modal
 			title={ __( 'Fonts' ) }
@@ -69,14 +73,14 @@ function FontLibraryModal( {
 			<Tabs defaultTabId={ defaultTabId }>
 				<div className="font-library-modal__tablist-container">
 					<Tabs.TabList>
-						{ tabs.map( ( { id, title } ) => (
+						{ sortedTabs.map( ( { id, title } ) => (
 							<Tabs.Tab key={ id } tabId={ id }>
 								{ title }
 							</Tabs.Tab>
 						) ) }
 					</Tabs.TabList>
 				</div>
-				{ tabs.map( ( { id } ) => {
+				{ sortedTabs.map( ( { id } ) => {
 					let contents;
 					switch ( id ) {
 						case 'upload-fonts':


### PR DESCRIPTION
Fixes [#59094](https://github.com/WordPress/gutenberg/issues/59094)

## What?
Add alphabetical sorting to Font Library modal tabs to provide a consistent and predictable tab order.

## Why?
When multiple font collections are added to the site, the Font Library modal tabs need a defined ordering system. Alphabetical sorting provides a logical, user-friendly organization that makes it easier to locate specific font collections.

## How?
Implemented alphabetical sorting of tabs using JavaScript's sort method with localeCompare for proper string comparison. The tabs array is sorted before rendering while maintaining the connection between tab headers and their corresponding content panels.

```js
const sortedTabs = [ ...tabs ].sort( ( a, b ) => 
    a.title.localeCompare( b.title ) 
);
```

## Testing Instructions
1. Open the Site Editor
2. Go to Styles panel
3. Click on Manage Fonts icon
4. Check the Font Library Modal

## Screenshots or screencast
![Screenshot 2025-01-08 at 1 59 50 PM](https://github.com/user-attachments/assets/d5780b03-156a-40da-81f2-fabc26b12ff2)

