### PR TITLE
Storybook: Add Story for Copy Handler Component

### DIFF
--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -21,8 +21,18 @@ export const __unstableUseClipboardHandler = () => {
 };
 
 /**
- * @deprecated
- * @param {Object} props
+ * CopyHandler component displays a copy handler for the block editor.
+ *
+ * @param props Component props.
+ * @return {JSX.Element} CopyHandler component.
+ * @example
+ * ```jsx
+ * function Example(){
+ * return (
+ *   <CopyHandler/>
+ *   );
+ * );
+ * }
  */
 export default function CopyHandler( props ) {
 	deprecated( 'CopyHandler', {

--- a/packages/block-editor/src/components/copy-handler/stories/index.story.js
+++ b/packages/block-editor/src/components/copy-handler/stories/index.story.js
@@ -1,0 +1,38 @@
+/**
+ * Internal dependencies
+ */
+import CopyHandler from '..';
+
+const meta = {
+	title: 'Components/CopyHandler',
+	component: CopyHandler,
+	parameters: {
+		docs: {
+			canvas: {
+				sourceState: 'shown',
+			},
+			description: {
+				component:
+					'The `CopyHandler` component provides a copy handler for the block editor. It is currently deprecated in favor of `BlockCanvas` or `WritingFlow`.',
+			},
+		},
+	},
+	argTypes: {
+		props: {
+			control: { type: 'object' },
+			description:
+				'Additional properties to pass to the `CopyHandler` component.',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( args ) {
+		return <CopyHandler { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for Copy Handler Component 

## Testing Instructions
- Run npm run storybook:dev
- Open the storybook on http://localhost:50240/
- Check the CopyHandler story.

## Screenshots or screencast 
<img width="1470" alt="Screenshot 2025-01-08 at 3 03 24 PM" src="https://github.com/user-attachments/assets/80b7769f-a23a-4f0c-8795-68b49a2894fe" />
