### PR TITLE
Block Editor: Move state logic inside 'BlockRenameModal'

### DIFF
--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -131,7 +131,8 @@ export default function BlockRenameModal( { clientId, onClose } ) {
 
 						<Button
 							__next40pxDefaultSize
-							aria-disabled={ ! isNameValid }
+							accessibleWhenDisabled
+							disabled={ ! isNameValid }
 							variant="primary"
 							type="submit"
 						>

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -21,7 +21,7 @@ import { useBlockDisplayInformation } from '..';
 import isEmptyString from './is-empty-string';
 
 export default function BlockRenameModal( { clientId, onClose } ) {
-	const [ editedBlockName, setEditedBlockName ] = useState( '' );
+	const [ editedBlockName, setEditedBlockName ] = useState();
 
 	const blockInformation = useBlockDisplayInformation( clientId );
 	const { metadata } = useSelect(
@@ -47,7 +47,8 @@ export default function BlockRenameModal( { clientId, onClose } ) {
 			( binding ) => binding.source === 'core/pattern-overrides'
 		);
 
-	const nameHasChanged = editedBlockName !== blockName;
+	const nameHasChanged =
+		editedBlockName !== undefined && editedBlockName !== blockName;
 	const nameIsOriginal = editedBlockName === originalBlockName;
 	const nameIsEmpty = isEmptyString( editedBlockName );
 
@@ -107,7 +108,7 @@ export default function BlockRenameModal( { clientId, onClose } ) {
 					<TextControl
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
-						value={ editedBlockName || blockName }
+						value={ editedBlockName ?? blockName }
 						label={ __( 'Name' ) }
 						help={
 							hasOverridesWarning

--- a/packages/block-editor/src/components/block-rename/modal.js
+++ b/packages/block-editor/src/components/block-rename/modal.js
@@ -11,22 +11,41 @@ import {
 import { __, sprintf } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { speak } from '@wordpress/a11y';
+import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
+import { store as blockEditorStore } from '../../store';
+import { useBlockDisplayInformation } from '..';
 import isEmptyString from './is-empty-string';
 
-export default function BlockRenameModal( {
-	blockName,
-	originalBlockName,
-	onClose,
-	onSave,
+export default function BlockRenameModal( { clientId, onClose } ) {
+	const [ editedBlockName, setEditedBlockName ] = useState( '' );
+
+	const blockInformation = useBlockDisplayInformation( clientId );
+	const { metadata } = useSelect(
+		( select ) => {
+			const { getBlockAttributes } = select( blockEditorStore );
+
+			return {
+				metadata: getBlockAttributes( clientId )?.metadata,
+			};
+		},
+		[ clientId ]
+	);
+	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+
+	const blockName = metadata?.name || '';
+	const originalBlockName = blockInformation?.title;
 	// Pattern Overrides is a WordPress-only feature but it also uses the Block Binding API.
 	// Ideally this should not be inside the block editor package, but we keep it here for simplicity.
-	hasOverridesWarning,
-} ) {
-	const [ editedBlockName, setEditedBlockName ] = useState( blockName );
+	const hasOverridesWarning =
+		!! blockName &&
+		!! metadata?.bindings &&
+		Object.values( metadata.bindings ).some(
+			( binding ) => binding.source === 'core/pattern-overrides'
+		);
 
 	const nameHasChanged = editedBlockName !== blockName;
 	const nameIsOriginal = editedBlockName === originalBlockName;
@@ -37,6 +56,8 @@ export default function BlockRenameModal( {
 	const autoSelectInputText = ( event ) => event.target.select();
 
 	const handleSubmit = () => {
+		const newName =
+			nameIsOriginal || nameIsEmpty ? undefined : editedBlockName;
 		const message =
 			nameIsOriginal || nameIsEmpty
 				? sprintf(
@@ -52,7 +73,12 @@ export default function BlockRenameModal( {
 
 		// Must be assertive to immediately announce change.
 		speak( message, 'assertive' );
-		onSave( editedBlockName );
+		updateBlockAttributes( [ clientId ], {
+			metadata: {
+				...metadata,
+				name: newName,
+			},
+		} );
 
 		// Immediate close avoids ability to hit save multiple times.
 		onClose();
@@ -81,7 +107,7 @@ export default function BlockRenameModal( {
 					<TextControl
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
-						value={ editedBlockName }
+						value={ editedBlockName || blockName }
 						label={ __( 'Name' ) }
 						help={
 							hasOverridesWarning

--- a/packages/block-editor/src/components/block-rename/rename-control.js
+++ b/packages/block-editor/src/components/block-rename/rename-control.js
@@ -2,53 +2,16 @@
  * WordPress dependencies
  */
 import { MenuItem } from '@wordpress/components';
-import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
-import { store as blockEditorStore } from '../../store';
-import { useBlockDisplayInformation } from '..';
-import isEmptyString from './is-empty-string';
 import BlockRenameModal from './modal';
 
 export default function BlockRenameControl( { clientId } ) {
 	const [ renamingBlock, setRenamingBlock ] = useState( false );
-
-	const { metadata } = useSelect(
-		( select ) => {
-			const { getBlockAttributes } = select( blockEditorStore );
-
-			const _metadata = getBlockAttributes( clientId )?.metadata;
-			return {
-				metadata: _metadata,
-			};
-		},
-		[ clientId ]
-	);
-
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
-
-	const customName = metadata?.name;
-	const hasPatternOverrides =
-		!! customName &&
-		!! metadata?.bindings &&
-		Object.values( metadata.bindings ).some(
-			( binding ) => binding.source === 'core/pattern-overrides'
-		);
-
-	function onChange( newName ) {
-		updateBlockAttributes( [ clientId ], {
-			metadata: {
-				...metadata,
-				name: newName,
-			},
-		} );
-	}
-
-	const blockInformation = useBlockDisplayInformation( clientId );
 
 	return (
 		<>
@@ -63,23 +26,8 @@ export default function BlockRenameControl( { clientId } ) {
 			</MenuItem>
 			{ renamingBlock && (
 				<BlockRenameModal
-					blockName={ customName || '' }
-					originalBlockName={ blockInformation?.title }
-					hasOverridesWarning={ hasPatternOverrides }
+					clientId={ clientId }
 					onClose={ () => setRenamingBlock( false ) }
-					onSave={ ( newName ) => {
-						// If the new value is the block's original name (e.g. `Group`)
-						// or it is an empty string then assume the intent is to reset
-						// the value. Therefore reset the metadata.
-						if (
-							newName === blockInformation?.title ||
-							isEmptyString( newName )
-						) {
-							newName = undefined;
-						}
-
-						onChange( newName );
-					} }
 				/>
 			) }
 		</>

--- a/test/e2e/specs/editor/various/block-renaming.spec.js
+++ b/test/e2e/specs/editor/various/block-renaming.spec.js
@@ -126,8 +126,9 @@ test.describe( 'Block Renaming', () => {
 			await pageUtils.pressKeys( 'primary+a' );
 			await page.keyboard.press( 'Delete' );
 
-			// Check placeholder for input is the original block name.
+			// Check that input is empty and placeholder is the original block name.
 			await expect( nameInput ).toHaveAttribute( 'placeholder', 'Group' );
+			await expect( nameInput ).toHaveValue( '' );
 
 			// It should be possible to submit empty.
 			await expect( saveButton ).toBeEnabled();


### PR DESCRIPTION
## What?
PR updates the `BlockRenameModal` component and colocates all required state and logic.

## Why?
* The state is only needed when rendering a modal; there's no need to select it ahead of time in the block options dropdown.
* This will also make it easier to reuse the modal without duplicating all required logic.

## Testing Instructions
1. Open a post or page. 
2. Add a block.
3. Confirm that the renaming feature works as before.
4. Confirm that all e2e tests are passing for block renaming - `npm run test:e2e -- test/e2e/specs/editor/various/block-renaming.spec.js`

### Testing Instructions for Keyboard
Same.

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-01-09 at 12 44 09](https://github.com/user-attachments/assets/0eb8968a-cc59-4bb8-8ae6-d310c85600b7)
