### PR TITLE
TextControl: Fix text direction for URL and email fields in block editor for RTL languages

### DIFF
--- a/packages/block-library/src/form/edit.js
+++ b/packages/block-library/src/form/edit.js
@@ -123,6 +123,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 							help={ __(
 								'The email address where form submissions will be sent. Separate multiple email addresses with a comma.'
 							) }
+							type="email"
 						/>
 					) }
 				</PanelBody>
@@ -159,6 +160,7 @@ const Edit = ( { attributes, setAttributes, clientId } ) => {
 						help={ __(
 							'The URL where the form should be submitted.'
 						) }
+						type="url"
 					/>
 				</InspectorControls>
 			) }

--- a/packages/block-library/src/navigation-link/edit.js
+++ b/packages/block-library/src/navigation-link/edit.js
@@ -201,6 +201,7 @@ function Controls( { attributes, setAttributes, setIsLabelFieldFocused } ) {
 						);
 					} }
 					autoComplete="off"
+					type="url"
 				/>
 			</ToolsPanelItem>
 

--- a/packages/block-library/src/navigation-submenu/edit.js
+++ b/packages/block-library/src/navigation-submenu/edit.js
@@ -431,6 +431,7 @@ export default function NavigationSubmenuEdit( {
 							} }
 							label={ __( 'Link' ) }
 							autoComplete="off"
+							type="url"
 						/>
 					</ToolsPanelItem>
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ## 29.3.0 (2025-01-29)
 
+### Bug Fixes
+
+-   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
+
 ### Enhancements
 
 -   `BorderBoxControl`, `BoxControl`: Remove `Tooltip` component from linked button ([#68498](https://github.com/WordPress/gutenberg/pull/68498)).

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+-   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
+
 ### Enhancement
+
 -   `BorderControlDropdown`, `BorderControl`: Reset button is always visible. ([#69066](https://github.com/WordPress/gutenberg/pull/69066)).
 
 ### Internal
@@ -18,12 +23,6 @@
 -   `FontSizePicker`: Remove Custom option from dropdown to prevent unexpected context changes during keyboard navigation ([#69038](https://github.com/WordPress/gutenberg/pull/69038)).
 
 -   `ComboboxControl`: Add an `isLoading` prop to show a loading spinner ([#68990](https://github.com/WordPress/gutenberg/pull/68990))
-
-## 29.3.0 (2025-01-29)
-
-### Bug Fixes
-
--   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
 
 ## 29.3.0 (2025-01-29)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -25,6 +25,8 @@
 
 -   `TextControl`: Ensures email and url inputs have consistent LTR alignment in RTL languages ([#68561](https://github.com/WordPress/gutenberg/pull/68561)).
 
+## 29.3.0 (2025-01-29)
+
 ### Enhancements
 
 -   `BorderBoxControl`, `BoxControl`: Remove `Tooltip` component from linked button ([#68498](https://github.com/WordPress/gutenberg/pull/68498)).

--- a/packages/components/src/text-control/style.scss
+++ b/packages/components/src/text-control/style.scss
@@ -28,3 +28,9 @@
 		padding-right: $grid-unit-15;
 	}
 }
+
+.components-text-control__input[type="email"],
+.components-text-control__input[type="url"] {
+	/* rtl:ignore */
+	direction: ltr;
+}


### PR DESCRIPTION
Fixes TextControl Component Part of this issue.

Related issues: https://github.com/WordPress/gutenberg/issues/65893
Related comment: https://github.com/WordPress/gutenberg/pull/68188#pullrequestreview-2523867751

## What?
Adds direction: ltr for URL and email input fields in the block editor to ensure correct text alignment, especially for RTL languages. 

## Why?
Currently, in RTL languages, the block editor shows URL and email fields from right to left, which is not ideal. As suggested in the issue, these fields should be displayed left to right (LTR) regardless of the language direction for consistency and better usability.



## How?
Added the below CSS

```scss
.components-text-control__input[type="email"],
.components-text-control__input[type="url"] {
	/* rtl:ignore */
	direction: ltr;
}

```

## Screenshots

**Before**

https://github.com/user-attachments/assets/2907dfa9-f286-458b-9f1a-7e43ce0c31a1


**After**

https://github.com/user-attachments/assets/73913a70-c4d9-43e7-9b57-3c4b28f1b3ae


