### PR TITLE
Social links block: Add Clear button for color option

### DIFF
--- a/packages/block-library/src/social-links/edit.js
+++ b/packages/block-library/src/social-links/edit.js
@@ -269,6 +269,7 @@ export function SocialLinksEdit( props ) {
 										isShownByDefault: true,
 										resetAllFilter,
 										enableAlpha: true,
+										clearable: true,
 									},
 								] }
 								panelId={ clientId }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
Add a clear button just like the other color controls.
Similer #63580

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
Add a clear button for consistency

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
Added clearable: true 

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
1. Open a post or page.
2. Insert a Social links block block.
3. You can see that a clear button has been added to the Icon Color and Icon Background.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
| ![before1](https://github.com/user-attachments/assets/6321a4b2-ec6a-4a8a-b8ee-2627ba0083cd) | ![after1](https://github.com/user-attachments/assets/bcd81c27-1317-4d4f-9328-335610d710a8) |
![before2](https://github.com/user-attachments/assets/6c256c6a-7cb8-4655-8505-0a23f5e7d537) | ![after2](https://github.com/user-attachments/assets/4407444c-6a90-4018-8b05-ce93e8f86c00) |
![before3](https://github.com/user-attachments/assets/461501ca-f27f-48e9-8b61-22c68467f2c6) | ![after3](https://github.com/user-attachments/assets/065d462f-3aef-4cfc-b895-6639aa304437) |

