### PR TITLE
Storybook: Add Story for CopyHandler

### DIFF
--- a/packages/block-editor/README.md
+++ b/packages/block-editor/README.md
@@ -347,9 +347,15 @@ _Related_
 
 > **Deprecated**
 
+'The CopyHandler component catches copy/cut and paste events coming from its props.children.
+
 _Parameters_
 
--   _props_ `Object`:
+-   _props_ `Object`: The props for the component.
+
+_Returns_
+
+-   `Element`: The block type item element.
 
 ### createCustomColorsHOC
 

--- a/packages/block-editor/src/components/copy-handler/index.js
+++ b/packages/block-editor/src/components/copy-handler/index.js
@@ -21,8 +21,12 @@ export const __unstableUseClipboardHandler = () => {
 };
 
 /**
+ * 'The CopyHandler component catches copy/cut and paste events coming from its props.children.
+ *
  * @deprecated
- * @param {Object} props
+ *
+ * @param {Object} props The props for the component.
+ * @return {Element} The block type item element.
  */
 export default function CopyHandler( props ) {
 	deprecated( 'CopyHandler', {

--- a/packages/block-editor/src/components/copy-handler/stories/index.story.js
+++ b/packages/block-editor/src/components/copy-handler/stories/index.story.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import CopyHandler from '../';
+
+export default {
+	title: 'BlockEditor/CopyHandler',
+	component: CopyHandler,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The `CopyHandler` component catches copy/cut and paste events coming from its props.children.',
+			},
+		},
+	},
+	argTypes: {
+		props: {
+			control: false,
+			description: 'The props for the component.',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+	},
+};
+
+export const Default = {
+	render: function Template( args ) {
+		return (
+			<CopyHandler { ...args }>
+				<button>{ __( 'Copy Handler' ) }</button>
+			</CopyHandler>
+		);
+	},
+};


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->
Part of https://github.com/WordPress/gutenberg/issues/67165 

## What?
<!-- In a few words, what is the PR actually doing? -->
This PR will add story for `copy-handler` component in the Storybook.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
1. Run npm run storybook:dev
2. Open the storybook on [localhost](http://localhost:50240/)
3. Check the `CopyHandler` story.

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->


<img width="1440" alt="Screenshot 2025-01-09 at 5 56 06 PM" src="https://github.com/user-attachments/assets/9204d5d9-0c38-4eac-983b-0c45a8b33217" />

