### PR TITLE
#57893 Add 'Use empty alt text' option for Post Featured Image block

### DIFF
--- a/docs/reference-guides/core-blocks.md
+++ b/docs/reference-guides/core-blocks.md
@@ -643,7 +643,7 @@ Display a post's featured image. ([Source](https://github.com/WordPress/gutenber
 -	**Name:** core/post-featured-image
 -	**Category:** theme
 -	**Supports:** align (center, full, left, right, wide), color (~~background~~, ~~text~~), filter (duotone), interactivity (clientNavigation), shadow (), spacing (margin, padding), ~~html~~
--	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useFirstImageFromPost, width
+-	**Attributes:** aspectRatio, customGradient, customOverlayColor, dimRatio, gradient, height, isLink, linkTarget, overlayColor, rel, scale, sizeSlug, useEmptyAlt, useFirstImageFromPost, width
 
 ## Post Navigation Link
 

--- a/packages/block-library/src/post-featured-image/block.json
+++ b/packages/block-library/src/post-featured-image/block.json
@@ -12,6 +12,10 @@
 			"default": false,
 			"role": "content"
 		},
+		"useEmptyAlt": {
+			"type": "boolean",
+			"default": false
+		},
 		"aspectRatio": {
 			"type": "string"
 		},

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -63,6 +63,7 @@ export default function PostFeaturedImageEdit( {
 	const isDescendentOfQueryLoop = Number.isFinite( queryId );
 	const {
 		isLink,
+		useEmptyAlt,
 		aspectRatio,
 		height,
 		width,
@@ -292,6 +293,32 @@ export default function PostFeaturedImageEdit( {
 								value={ rel }
 								onChange={ ( newRel ) =>
 									setAttributes( { rel: newRel } )
+								}
+							/>
+						</ToolsPanelItem>
+					) }
+					{ ! isLink && (
+						<ToolsPanelItem
+							label={ __( 'Alt Text Settings' ) }
+							isShownByDefault
+							hasValue={ () => useEmptyAlt }
+							onDeselect={ () =>
+								setAttributes( {
+									useEmptyAlt: false,
+								} )
+							}
+						>
+							<ToggleControl
+								__nextHasNoMarginBottom
+								label={ __(
+									'Use empty alt text (decorative image)'
+								) }
+								help={ __(
+									'Enable this if the image is purely decorative and should be ignored by screen readers.'
+								) }
+								checked={ useEmptyAlt }
+								onChange={ ( value ) =>
+									setAttributes( { useEmptyAlt: value } )
 								}
 							/>
 						</ToolsPanelItem>

--- a/packages/block-library/src/post-featured-image/edit.js
+++ b/packages/block-library/src/post-featured-image/edit.js
@@ -247,7 +247,10 @@ export default function PostFeaturedImageEdit( {
 									: __( 'Link to post' )
 							}
 							onChange={ () =>
-								setAttributes( { isLink: ! isLink } )
+								setAttributes( {
+									isLink: ! isLink,
+									useEmptyAlt: isLink ? useEmptyAlt : false,
+								} )
 							}
 							checked={ isLink }
 						/>
@@ -310,9 +313,7 @@ export default function PostFeaturedImageEdit( {
 						>
 							<ToggleControl
 								__nextHasNoMarginBottom
-								label={ __(
-									'Use empty alt text (decorative image)'
-								) }
+								label={ __( 'Use empty alt text' ) }
 								help={ __(
 									'Enable this if the image is purely decorative and should be ignored by screen readers.'
 								) }
@@ -375,6 +376,27 @@ export default function PostFeaturedImageEdit( {
 	};
 
 	/**
+	 * Get the alt text for the image.
+	 *
+	 * @return {string} The alt text for the image.
+	 */
+	const getAltText = () => {
+		if ( useEmptyAlt ) {
+			return '';
+		}
+
+		if ( media?.alt_text ) {
+			return sprintf(
+				// translators: %s: The image's alt text.
+				__( 'Featured image: %s' ),
+				media.alt_text
+			);
+		}
+
+		return __( 'Featured image' );
+	};
+
+	/**
 	 * When the post featured image block is placed in a context where:
 	 * - It has a postId (for example in a single post)
 	 * - It is not inside a query loop
@@ -416,15 +438,7 @@ export default function PostFeaturedImageEdit( {
 					<img
 						className={ borderProps.className }
 						src={ temporaryURL || mediaUrl }
-						alt={
-							media && media?.alt_text
-								? sprintf(
-										// translators: %s: The image's alt text.
-										__( 'Featured image: %s' ),
-										media.alt_text
-								  )
-								: __( 'Featured image' )
-						}
+						alt={ getAltText() }
 						style={ imageStyles }
 					/>
 					{ temporaryURL && <Spinner /> }

--- a/packages/block-library/src/post-featured-image/index.php
+++ b/packages/block-library/src/post-featured-image/index.php
@@ -26,7 +26,10 @@ function render_block_core_post_featured_image( $attributes, $content, $block ) 
 	$attr           = get_block_core_post_featured_image_border_attributes( $attributes );
 	$overlay_markup = get_block_core_post_featured_image_overlay_element_markup( $attributes );
 
-	if ( $is_link ) {
+	if ( ! $is_link && isset( $attributes['useEmptyAlt'] ) && $attributes['useEmptyAlt'] ) {
+		// Only allow empty alt for non-linked images.
+		$attr['alt'] = '';
+	} elseif ( $is_link ) {
 		if ( get_the_title( $post_ID ) ) {
 			$attr['alt'] = trim( strip_tags( get_the_title( $post_ID ) ) );
 		} else {

--- a/test/integration/fixtures/blocks/core__post-featured-image.json
+++ b/test/integration/fixtures/blocks/core__post-featured-image.json
@@ -4,6 +4,7 @@
 		"isValid": true,
 		"attributes": {
 			"isLink": false,
+			"useEmptyAlt": false,
 			"scale": "cover",
 			"rel": "",
 			"linkTarget": "_self",

--- a/test/integration/fixtures/blocks/core__separator-color.json
+++ b/test/integration/fixtures/blocks/core__separator-color.json
@@ -4,8 +4,8 @@
 		"isValid": true,
 		"attributes": {
 			"opacity": "alpha-channel",
-			"backgroundColor": "accent",
-			"tagName": "hr"
+			"tagName": "hr",
+			"backgroundColor": "accent"
 		},
 		"innerBlocks": []
 	}

--- a/test/integration/fixtures/blocks/core__separator-custom-color.json
+++ b/test/integration/fixtures/blocks/core__separator-custom-color.json
@@ -4,12 +4,12 @@
 		"isValid": true,
 		"attributes": {
 			"opacity": "alpha-channel",
+			"tagName": "hr",
 			"style": {
 				"color": {
 					"background": "#5da54c"
 				}
-			},
-			"tagName": "hr"
+			}
 		},
 		"innerBlocks": []
 	}


### PR DESCRIPTION
Fixes [#57893](https://github.com/WordPress/gutenberg/issues/57893)

## What?
Adds the ability to set empty alt text (alt="") for decorative images in the Post Featured Image block by introducing a new toggle control in the block settings.

## Why?
Currently, there is no way to set empty alt text (alt="") for the Featured Image block when the image is purely decorative. While it's possible to remove alt text in the media library, this is a global solution that affects the image everywhere it's used. This enhancement allows setting empty alt text specifically for the Featured Image block context, improving accessibility by properly indicating decorative images to screen readers.

## How?
- Added a new useEmptyAlt attribute to the Featured Image block
- Implemented a new toggle control in the block settings panel that only appears for non-linked images
- Modified the block's render logic to output empty alt text (alt="") when the toggle is enabled
- Ensured linked images cannot have empty alt text since they function as link text
- Preserved existing alt text behavior when the decorative image option is not enabled

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->

### Testing Instructions for Keyboard
1. Open a new post or page in the editor
2. Upload or select an featured image for the post
3. Add a Post Featured Image block
3. Open the block settings sidebar (click the cog icon if not already open)
4. Verify that the "Use empty alt text (decorative image)" toggle appears under Settings
5. Enable the toggle and verify that the image's alt attribute is empty in the HTML output
6. Enable "Link to post" and verify that the empty alt text option is hidden
7. Disable "Link to post" and verify that the empty alt text option reappears
8. Verify that the setting persists after saving and reloading the post

## Screenshots or screencast <!-- if applicable -->
https://github.com/user-attachments/assets/3dc59991-13c5-42b9-9810-b7ef9f7744dd


