### PR TITLE
Feature : Identification for Third Party Commands

### DIFF
--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -117,29 +117,42 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 
 	return (
 		<Command.Group>
-			{ commands.map( ( command ) => (
-				<Command.Item
-					key={ command.name }
-					value={ command.searchLabel ?? command.label }
-					onSelect={ () => command.callback( { close } ) }
-					id={ command.name }
-				>
-					<HStack
-						alignment="left"
-						className={ clsx( 'commands-command-menu__item', {
-							'has-icon': command.icon,
-						} ) }
+			{ commands.map( ( command ) => {
+				let pluginName = command.name.split( '/' )[ 0 ];
+
+				if ( pluginName?.length > 10 ) {
+					pluginName = pluginName.slice( 0, 12 ) + '...';
+				}
+
+				return (
+					<Command.Item
+						key={ command.name }
+						value={ command.searchLabel ?? command.label }
+						onSelect={ () => command.callback( { close } ) }
+						id={ command.name }
 					>
-						{ command.icon && <Icon icon={ command.icon } /> }
-						<span>
-							<TextHighlight
-								text={ command.label }
-								highlight={ search }
-							/>
-						</span>
-					</HStack>
-				</Command.Item>
-			) ) }
+						<HStack
+							alignment="left"
+							className={ clsx( 'commands-command-menu__item', {
+								'has-icon': command.icon,
+							} ) }
+						>
+							{ command.icon && <Icon icon={ command.icon } /> }
+							<span>
+								<TextHighlight
+									text={ command.label }
+									highlight={ search }
+								/>
+							</span>
+							<span className="commands-command-menu__item__plugin">
+								{ pluginName !== 'core' &&
+									pluginName.charAt( 0 ).toUpperCase() +
+										pluginName.slice( 1 ) }
+							</span>
+						</HStack>
+					</Command.Item>
+				);
+			} ) }
 			{ loaders.map( ( loader ) => (
 				<CommandMenuLoaderWrapper
 					key={ loader.name }

--- a/packages/commands/src/components/command-menu.js
+++ b/packages/commands/src/components/command-menu.js
@@ -120,7 +120,7 @@ export function CommandMenuGroup( { isContextual, search, setLoader, close } ) {
 			{ commands.map( ( command ) => {
 				let pluginName = command.name.split( '/' )[ 0 ];
 
-				if ( pluginName?.length > 10 ) {
+				if ( pluginName?.length > 12 ) {
 					pluginName = pluginName.slice( 0, 12 ) + '...';
 				}
 

--- a/packages/commands/src/components/style.scss
+++ b/packages/commands/src/components/style.scss
@@ -137,16 +137,24 @@
 	}
 }
 
-.commands-command-menu__item span {
-	// Ensure commands do not run off the edge (great for post titles).
-	display: inline-block;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
-}
+.commands-command-menu__item {
 
-.commands-command-menu__item mark {
-	color: inherit;
-	background: unset;
-	font-weight: 600;
+	span {
+		// Ensure commands do not run off the edge (great for post titles).
+		display: inline-block;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	mark {
+		color: inherit;
+		background: unset;
+		font-weight: 600;
+	}
+
+	&__plugin {
+		margin-left: auto;
+		margin-right: 5px;
+	}
 }


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
- Show Plugin Name beside commands registered by Third Party

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
- https://github.com/WordPress/gutenberg/issues/53192

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
- Extract the `plugin name` via `command.name`
- Limit the `plugin name` to `12 characters` and show `ellipsis` is greater than `12`

## Screenshots or screencast <!-- if applicable -->
<img width="426" alt="Screenshot 2025-01-09 at 6 52 44 PM" src="https://github.com/user-attachments/assets/fa8d145f-82c6-4fa6-ba4e-9a2d86f60a1e" />

