### PR TITLE
Fixed Navigation: Create new Menu produces a warning in the console stating misuse of refs

### DIFF
--- a/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
+++ b/packages/block-library/src/navigation/edit/unsaved-inner-blocks.js
@@ -112,7 +112,15 @@ export default function UnsavedInnerBlocks( {
 		hasSelection,
 	] );
 
-	const Wrapper = isSaving ? Disabled : 'div';
+	if ( isSaving ) {
+		// We will get an error (Function components cannot be given refs) if we pass ref to Disabled component.
+		// So we need to to pass it to the inner div.
+		return (
+			<Disabled>
+				<div { ...innerBlocksProps } />
+			</Disabled>
+		);
+	}
 
-	return <Wrapper { ...innerBlocksProps } />;
+	return <div { ...innerBlocksProps } />;
 }


### PR DESCRIPTION
fixes #68572

## What?

Fix console warning about ref handling when creating a new menu from Navigation block's Block Panel in site editor

## Why?

When creating a new menu from the Navigation block's Block Panel, a warning appears in the developer console: "Function components cannot be given refs". This warning occurs because the Disabled component, being a function component, cannot directly handle refs. This needs to be fixed to maintain a clean developer experience and proper component behavior.

## How?

Modified the UnsavedInnerBlocks component to properly handle refs by:

  - Ensuring the ref from innerBlocksProps is passed to a DOM element (div) instead of the Disabled component
  - Wrapping the div with Disabled component when isSaving is true
  - Maintaining all other props and functionality from innerBlocksProps
  
## Related React Issue
https://github.com/reactjs/react.dev/issues/2120 
 
## Testing Instructions

1. Navigate to the Site Editor
2. Add a Navigation block
3. Open the Block Panel (sidebar settings)
4. Click the three dots menu
5. Click "Create new Menu"
6. Verify no warnings appear in the developer console
7. Verify the menu creation functionality works as expected
8. Verify the block's disabled state works correctly during saving

## ScreenCast

https://github.com/user-attachments/assets/9ffbd86c-b2e7-4583-8c05-428c4d6b9f3a


