### PR TITLE
Site Editor: Move `Styles` to top of sidebar navigation

### DIFF
--- a/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
+++ b/packages/edit-site/src/components/sidebar-navigation-screen-main/index.js
@@ -22,6 +22,13 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 		<ItemGroup className="edit-site-sidebar-navigation-screen-main">
 			{ isBlockBasedTheme && (
 				<>
+					<SidebarNavigationItemGlobalStyles
+						to="/styles"
+						uid="global-styles-navigation-item"
+						icon={ styles }
+					>
+						{ __( 'Styles' ) }
+					</SidebarNavigationItemGlobalStyles>
 					<SidebarNavigationItem
 						uid="navigation-navigation-item"
 						to="/navigation"
@@ -30,13 +37,6 @@ export function MainSidebarNavigationContent( { isBlockBasedTheme = true } ) {
 					>
 						{ __( 'Navigation' ) }
 					</SidebarNavigationItem>
-					<SidebarNavigationItemGlobalStyles
-						to="/styles"
-						uid="global-styles-navigation-item"
-						icon={ styles }
-					>
-						{ __( 'Styles' ) }
-					</SidebarNavigationItemGlobalStyles>
 					<SidebarNavigationItem
 						uid="page-navigation-item"
 						to="/page"


### PR DESCRIPTION
Fixes: #68576 

## What?

Move the Styles navigation item to the top position in the Site Editor's main sidebar navigation, before Navigation, Pages, Templates, and Patterns.

## Why?

The current hierarchy of the main menu feels unbalanced. "Styles" is a global customization tool that affects the entire site, unlike other sections that manage specific entities. Moving it to the top:
- Better aligns with the editor's description: "Customize the appearance of your website using the block editor"
- Creates a clearer distinction between global tools and entity management
- Improves accessibility to this frequently used feature


## Testing Instructions

- Navigate to Site Editor (Appearance > Editor)
- Verify Styles appear at the top of the navigation menu
- Click each navigation item to ensure they all work as expected



## Screenshots 

|Before|After|
|-|-|
|![image](https://github.com/user-attachments/assets/11d2528d-9da2-424d-bbca-4ea379f4847d)|![image](https://github.com/user-attachments/assets/11a86f5e-f7a3-49ea-88a8-be97e117b4b9)|

## Screencast



https://github.com/user-attachments/assets/361837ca-b2a0-4f0e-aaa1-e346750c9284


