### PR TITLE
Docs: Add post meta limitations to Block Bindings API docs

### DIFF
--- a/docs/reference-guides/block-api/block-bindings.md
+++ b/docs/reference-guides/block-api/block-bindings.md
@@ -20,6 +20,9 @@ An example could be connecting an Image block `url` attribute to a function that
 } -->
 ```
 
+<div class="callout callout-alert">
+<strong>Note:</strong> Post meta keys that begin with an underscore (e.g. `_example_key`) are protected and cannot be used with Block Bindings. Additionally, post meta must be registered with `show_in_rest = true` to be available through the Block Bindings API.
+</div>
 
 ## Compatible blocks and their attributes
 

--- a/docs/reference-guides/block-api/block-bindings.md
+++ b/docs/reference-guides/block-api/block-bindings.md
@@ -20,9 +20,6 @@ An example could be connecting an Image block `url` attribute to a function that
 } -->
 ```
 
-<div class="callout callout-alert">
-<strong>Note:</strong> Post meta keys that begin with an underscore (e.g. `_example_key`) are protected and cannot be used with Block Bindings. Additionally, post meta must be registered with `show_in_rest = true` to be available through the Block Bindings API.
-</div>
 
 ## Compatible blocks and their attributes
 
@@ -101,6 +98,10 @@ add_action(
 	}
 );
 ```
+
+<div class="callout callout-alert">
+<strong>Note:</strong> Post meta keys that begin with an underscore (e.g. `_example_key`) are protected and cannot be used with Block Bindings. Additionally, post meta must be registered with `show_in_rest = true` to be available through the Block Bindings API.
+</div>
 
 #### Block bindings source value filter
 


### PR DESCRIPTION
Closes: #68574 

## What?
Add documentation about post-meta limitations in the Block Bindings API documentation, specifically covering protected meta and REST API requirements.


## Why?

The current Block Bindings documentation doesn't mention important limitations regarding post-meta usage. Developers need to know upfront that:
- Protected post meta (prefixed with underscore) cannot be used
- Post meta must be available via REST API


## How?
Add a callout alert section in `docs/reference-guides/block-api/block-bindings.md` before the "Compatible blocks and their attributes" section. The callout follows the existing documentation style and alerts about both limitations clearly.


## Testing Instructions
- Navigate to `/docs/reference-guides/block-api/block-bindings.md`
- Find the new callout alert added before "Compatible blocks and their attributes" section
- Verify the content clearly explains both limitations

