### PR TITLE
Update AnglePickerControl README and types

### DIFF
--- a/packages/components/src/angle-picker-control/README.md
+++ b/packages/components/src/angle-picker-control/README.md
@@ -19,7 +19,7 @@ function Example() {
     <AnglePickerControl
       value={ angle }
       onChange={ setAngle }
-    </>
+    />
   );
 }
 ```
@@ -55,3 +55,10 @@ A function that receives the new value of the input.
 
 The current value of the input. The value represents an angle in degrees
 and should be a value between 0 and 360.
+
+### `className`
+
+  - Type: `string`
+  - Required: No
+
+A string of classes to be added to the control component.

--- a/packages/components/src/angle-picker-control/types.ts
+++ b/packages/components/src/angle-picker-control/types.ts
@@ -23,6 +23,10 @@ export type AnglePickerControlProps = {
 	 * and should be a value between 0 and 360.
 	 */
 	value: number | string;
+	/**
+	 * Additional classes to apply to the angle picker.
+	 */
+	className?: string;
 };
 
 export type AngleCircleProps = Pick<


### PR DESCRIPTION
## What?

This PR adds the missing `className` prop for AnglePickerControl in the README and storybook 

## Why?

Fixes point 1 and 2 for https://github.com/WordPress/gutenberg/issues/68575

## How?

Added the `className` prop with description in the `README.md` and `types.ts`

## Testing Instructions

- Check the README and Types.ts for AnglePickerControl 

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

Before: 

<img width="1467" alt="image" src="https://github.com/user-attachments/assets/31f9a221-805a-4022-a79f-01de825b63d0" />

After: 

<img width="1470" alt="Screenshot 2025-01-10 at 10 31 06 AM" src="https://github.com/user-attachments/assets/8c019b40-804f-4c5f-9e72-f78495b06061" />




