### PR TITLE
Storybook: Add Story for Tool Selector Component

### DIFF
--- a/packages/block-editor/src/components/tool-selector/index.js
+++ b/packages/block-editor/src/components/tool-selector/index.js
@@ -30,6 +30,22 @@ const selectIcon = (
 	</SVG>
 );
 
+/**
+ * ToolSelector component is used to switch between the navigation and edit modes in the block editor.
+ *
+ * @example
+ * ```jsx
+ * import { ToolSelector } from '@wordpress/block-editor';
+ *
+ * function MyToolSelector() {
+ *    return <ToolSelector />;
+ * }
+ * ```
+ *
+ * @param {Object} props Props for the ToolSelector component
+ * @param {Object} ref   Ref for the ToolSelector component
+ * @return {Element} The ToolSelector component
+ */
 function ToolSelector( props, ref ) {
 	const mode = useSelect(
 		( select ) => select( blockEditorStore ).__unstableGetEditorMode(),

--- a/packages/block-editor/src/components/tool-selector/stories/index.story.js
+++ b/packages/block-editor/src/components/tool-selector/stories/index.story.js
@@ -1,0 +1,42 @@
+/**
+ * Internal dependencies
+ */
+import ToolSelector from '..';
+
+const meta = {
+	title: 'BlockEditor/ToolSelector',
+	component: ToolSelector,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The ToolSelector component is used to switch between the navigation and edit modes in the block editor.',
+			},
+		},
+	},
+	argTypes: {
+		props: {
+			control: 'object',
+			description: 'Props for the ToolSelector component',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+		ref: {
+			control: null,
+			description: 'Ref for the ToolSelector component',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	render: function Template( args ) {
+		return <ToolSelector { ...args } />;
+	},
+};


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds story for Tool Selector Component 

## Testing Instructions
- Run npm run storybook:dev
- Open the storybook on http://localhost:50240/
- Check the ToolSelector story.

## Screenshots or screencast 

<img width="1470" alt="Screenshot 2025-01-10 at 12 01 31 PM" src="https://github.com/user-attachments/assets/041c37c9-00cb-4801-b677-e94845a5befc" />
