### PR TITLE
Simplify `sprintf` translation for percentage widths

### DIFF
--- a/packages/block-editor/src/components/image-size-control/index.js
+++ b/packages/block-editor/src/components/image-size-control/index.js
@@ -139,7 +139,7 @@ export default function ImageSizeControl( {
 									value={ scale }
 									label={ sprintf(
 										/* translators: Percentage value. */
-										__( '%1$d%%' ),
+										__( '%d%%' ),
 										scale
 									) }
 								/>

--- a/packages/block-library/src/button/edit.js
+++ b/packages/block-library/src/button/edit.js
@@ -150,7 +150,7 @@ function WidthPanel( { selectedWidth, setAttributes } ) {
 								value={ widthValue }
 								label={ sprintf(
 									/* translators: Percentage value. */
-									__( '%1$d%%' ),
+									__( '%d%%' ),
 									widthValue
 								) }
 							/>

--- a/packages/block-library/src/search/edit.js
+++ b/packages/block-library/src/search/edit.js
@@ -472,7 +472,7 @@ export default function SearchEdit( {
 										value={ widthValue }
 										label={ sprintf(
 											/* translators: Percentage value. */
-											__( '%1$d%%' ),
+											__( '%d%%' ),
 											widthValue
 										) }
 									/>


### PR DESCRIPTION
Related comment: https://github.com/WordPress/gutenberg/pull/68270#issuecomment-2579929201
Related issues: https://github.com/WordPress/gutenberg/issues/52787 , https://github.com/WordPress/gutenberg/pull/66323#pullrequestreview-2528862915
## What?
This PR refines the code quality by simplifying the translation of percentage widths.


## Why?
The previous implementation used `__( '%1$d%%' )` due to an ESLint error being flagged when using the simpler `__( '%d%%' )`. Now that the `sprintf` regex has been updated, this simplification is possible without causing issues. The change ensures consistency across the codebase and improves readability.


## How?
Replaced `__( '%1$d%%' ) `with `__( '%d%%' )` for percentage translations.


