### PR TITLE
Components: Fix icon condition for Badge

### DIFF
--- a/packages/components/src/badge/index.tsx
+++ b/packages/components/src/badge/index.tsx
@@ -15,45 +15,46 @@ import type { BadgeProps } from './types';
 import type { WordPressComponentProps } from '../context';
 import Icon from '../icon';
 
+/**
+ * Returns an icon based on the badge context.
+ *
+ * @return The corresponding icon for the provided context.
+ */
+function contextBasedIcon( intent: BadgeProps[ 'intent' ] = 'default' ) {
+	switch ( intent ) {
+		case 'info':
+			return info;
+		case 'success':
+			return published;
+		case 'warning':
+			return caution;
+		case 'error':
+			return error;
+		default:
+			return null;
+	}
+}
+
 function Badge( {
 	className,
 	intent = 'default',
 	children,
 	...props
 }: WordPressComponentProps< BadgeProps, 'span', false > ) {
-	/**
-	 * Returns an icon based on the badge context.
-	 *
-	 * @return The corresponding icon for the provided context.
-	 */
-	function contextBasedIcon() {
-		switch ( intent ) {
-			case 'info':
-				return info;
-			case 'success':
-				return published;
-			case 'warning':
-				return caution;
-			case 'error':
-				return error;
-			default:
-				return null;
-		}
-	}
+	const icon = contextBasedIcon( intent );
+	const hasIcon = !! icon;
 
 	return (
 		<span
-			className={ clsx(
-				'components-badge',
-				`is-${ intent }`,
-				intent !== 'default' && 'has-icon',
-				className
-			) }
+			className={ clsx( 'components-badge', className, {
+				[ `is-${ intent }` ]: intent,
+				'has-icon': hasIcon,
+			} ) }
 			{ ...props }
 		>
-			{ intent !== 'default' && (
+			{ hasIcon && (
 				<Icon
-					icon={ contextBasedIcon() }
+					icon={ icon }
 					size={ 16 }
 					fill="currentColor"
 					className="components-badge__icon"


### PR DESCRIPTION
## What?
PR fixes a condition when a Badge might render an icon; now, it depends on the value returned by the `contextBasedIcon` helper.

## Why?
While TypeScript will inform consumers that they're passing an invalid value as `intent`, components can also be accessed via `wp.component`, which allows users to pass unsupported intents like - `alert`.

## Testing Instructions
* All unit tests for the Badge component are passing.
* Smoke text the component in Storybook - `npm run storybook:dev`.

### Testing Instructions for Keyboard
Same

## Screenshots or screencast <!-- if applicable -->
![CleanShot 2025-01-10 at 11 09 53](https://github.com/user-attachments/assets/6822d16f-e5ef-49ab-a8bc-746a1dbe1e24)
