### PR TITLE
Storybook: Add BlockCanvas Component

### DIFF
--- a/packages/block-editor/src/components/block-canvas/stories/index.story.js
+++ b/packages/block-editor/src/components/block-canvas/stories/index.story.js
@@ -1,0 +1,59 @@
+/**
+ * Internal dependencies
+ */
+import { BlockCanvas, BlockList } from '../..';
+
+const meta = {
+	title: 'BlockEditor/BlockCanvas',
+	component: BlockCanvas,
+	parameters: {
+		docs: {
+			canvas: { sourceState: 'shown' },
+			description: {
+				component:
+					'The BlockCanvas component is used to render the canvas for the block editor.',
+			},
+		},
+	},
+	argTypes: {
+		children: {
+			control: false, // Disable direct control for `children` as it defaults to `BlockList`
+			description: 'The children to render in the canvas.',
+			table: {
+				type: { summary: 'node' },
+				defaultValue: { summary: 'BlockList' },
+			},
+		},
+		height: {
+			control: 'text',
+			description: 'The height of the canvas.',
+			table: {
+				type: { summary: 'string' },
+				defaultValue: { summary: '300px' },
+			},
+		},
+		styles: {
+			control: 'object',
+			description: 'The styles to apply to the canvas.',
+			table: {
+				type: { summary: 'object' },
+			},
+		},
+	},
+};
+
+export default meta;
+
+export const Default = {
+	args: {
+		height: '300px',
+		styles: {
+			border: '1px solid #ccc',
+			backgroundColor: '#f9f9f9',
+		},
+		children: <BlockList />, // Default `children` is `BlockList`
+	},
+	render: function Template( args ) {
+		return <BlockCanvas { ...args } />;
+	},
+};

--- a/packages/block-editor/src/components/block-canvas/stories/index.story.js
+++ b/packages/block-editor/src/components/block-canvas/stories/index.story.js
@@ -1,14 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { registerCoreBlocks } from '@wordpress/block-library';
-/**
- * Internal dependencies
- */
-import { BlockCanvas, BlockEditorProvider } from '../..';
-
-registerCoreBlocks();
+import {
+	BlockCanvas,
+	BlockEditorProvider,
+	BlockToolbar,
+} from '@wordpress/block-editor';
 
 const meta = {
 	title: 'BlockEditor/BlockCanvas',
@@ -22,6 +21,26 @@ const meta = {
 			},
 		},
 	},
+	decorators: [
+		( Story ) => {
+			const [ blocks, updateBlocks ] = useState( [] );
+
+			useEffect( () => {
+				registerCoreBlocks();
+			}, [] );
+
+			return (
+				<BlockEditorProvider
+					value={ blocks }
+					onInput={ ( newBlocks ) => updateBlocks( newBlocks ) }
+					onChange={ ( newBlocks ) => updateBlocks( newBlocks ) }
+				>
+					<BlockToolbar hideDragHandle />
+					<Story />
+				</BlockEditorProvider>
+			);
+		},
+	],
 	argTypes: {
 		children: {
 			control: false,
@@ -43,10 +62,7 @@ const meta = {
 			control: 'object',
 			description: 'The styles to apply to the canvas.',
 			table: {
-				type: {
-					summary:
-						'{ css?: string; assets?: string; isGlobalStyles?: boolean; __unstableType: string; }[]',
-				},
+				type: { summary: 'Array' },
 			},
 		},
 	},
@@ -55,17 +71,5 @@ const meta = {
 export default meta;
 
 export const Default = {
-	render: function Template( args ) {
-		const [ blocks, updateBlocks ] = useState( [] );
-
-		return (
-			<BlockEditorProvider
-				value={ blocks }
-				onInput={ ( newBlocks ) => updateBlocks( newBlocks ) }
-				onChange={ ( newBlocks ) => updateBlocks( newBlocks ) }
-			>
-				<BlockCanvas { ...args } />
-			</BlockEditorProvider>
-		);
-	},
+	render: ( args ) => <BlockCanvas { ...args } />,
 };

--- a/packages/block-editor/src/components/block-canvas/stories/index.story.js
+++ b/packages/block-editor/src/components/block-canvas/stories/index.story.js
@@ -36,7 +36,10 @@ const meta = {
 			control: 'object',
 			description: 'The styles to apply to the canvas.',
 			table: {
-				type: { summary: 'object' },
+				type: {
+					summary:
+						'{ css?: string; assets?: string; isGlobalStyles?: boolean; __unstableType: string; }[]',
+				},
 			},
 		},
 	},
@@ -46,12 +49,9 @@ export default meta;
 
 export const Default = {
 	args: {
-		height: '300px',
-		styles: {
-			border: '1px solid #ccc',
-			backgroundColor: '#f9f9f9',
-		},
-		children: <BlockList />, // Default `children` is `BlockList`
+		height: '100px',
+		styles: [ { css: `body{font-size: 16px;}` } ],
+		children: <BlockList />,
 	},
 	render: function Template( args ) {
 		return <BlockCanvas { ...args } />;

--- a/packages/block-editor/src/components/block-canvas/stories/index.story.js
+++ b/packages/block-editor/src/components/block-canvas/stories/index.story.js
@@ -1,7 +1,14 @@
 /**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+import { registerCoreBlocks } from '@wordpress/block-library';
+/**
  * Internal dependencies
  */
-import { BlockCanvas, BlockList } from '../..';
+import { BlockCanvas, BlockEditorProvider } from '../..';
+
+registerCoreBlocks();
 
 const meta = {
 	title: 'BlockEditor/BlockCanvas',
@@ -17,7 +24,7 @@ const meta = {
 	},
 	argTypes: {
 		children: {
-			control: false, // Disable direct control for `children` as it defaults to `BlockList`
+			control: false,
 			description: 'The children to render in the canvas.',
 			table: {
 				type: { summary: 'node' },
@@ -48,12 +55,17 @@ const meta = {
 export default meta;
 
 export const Default = {
-	args: {
-		height: '100px',
-		styles: [ { css: `body{font-size: 16px;}` } ],
-		children: <BlockList />,
-	},
 	render: function Template( args ) {
-		return <BlockCanvas { ...args } />;
+		const [ blocks, updateBlocks ] = useState( [] );
+
+		return (
+			<BlockEditorProvider
+				value={ blocks }
+				onInput={ ( newBlocks ) => updateBlocks( newBlocks ) }
+				onChange={ ( newBlocks ) => updateBlocks( newBlocks ) }
+			>
+				<BlockCanvas { ...args } />
+			</BlockEditorProvider>
+		);
 	},
 };


### PR DESCRIPTION
Part of https://github.com/WordPress/gutenberg/issues/67165

## What?
This PR adds Story for Block Canvas Component 

## Testing Instructions
- Run npm run storybook:dev
- Open the storybook on http://localhost:50240/
- Check the BlockCanvas Component 


## Screenshots or screencast

<img width="1470" alt="image" src="https://github.com/user-attachments/assets/0b15c8dd-7825-4d99-a957-9940b4751e9e" />

