### PR TITLE
Plugin: Remove ESLint rule for deprecated functions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,21 +5,6 @@ const glob = require( 'glob' ).sync;
 const { join } = require( 'path' );
 
 /**
- * Internal dependencies
- */
-const { version } = require( './package' );
-
-/**
- * Regular expression string matching a SemVer string with equal major/minor to
- * the current package version. Used in identifying deprecations.
- *
- * @type {string}
- */
-const majorMinorRegExp =
-	version.replace( /\.\d+$/, '' ).replace( /[\\^$.*+?()[\]{}|]/g, '\\$&' ) +
-	'(\\.\\d+)?';
-
-/**
  * The list of patterns matching files used only for development purposes.
  *
  * @type {string[]}
@@ -91,14 +76,6 @@ const restrictedSyntax = [
 		selector:
 			'ImportDeclaration[source.value=/^@wordpress\\u002F.+\\u002F/]',
 		message: 'Path access on WordPress dependencies is not allowed.',
-	},
-	{
-		selector:
-			'CallExpression[callee.name="deprecated"] Property[key.name="version"][value.value=/' +
-			majorMinorRegExp +
-			'/]',
-		message:
-			'Deprecated functions must be removed before releasing this version.',
 	},
 	{
 		selector:


### PR DESCRIPTION
## What?
PR removes the custom ESLint rule for the `deprecated` method, which suggests function removal based on version argument. It should fix failing CI checks.

## Why?
* This is an old rule, and the project no longer removes APIs for backward compatibility reasons.
* The version regex was incorrect. It used plugin versions, while most deprecation methods refer to the WP version.

## Testing Instructions
CI checks should be green.
