### PR TITLE
Tools panel: Synced the visible label and accessible name 

### DIFF
--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 -   `Button`: Remove fixed width from small and compact buttons with icons ([#69378](https://github.com/WordPress/gutenberg/pull/69378)).
+-   `ToolsPanel`: Updated the ARIA labels to match the visible text to improve accessibilty ([#68592]((https://github.com/WordPress/gutenberg/pull/68592)))
 
 ## 29.5.0 (2025-02-28)
 

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -9,7 +9,7 @@
 ### Bug Fixes
 
 -   `Button`: Remove fixed width from small and compact buttons with icons ([#69378](https://github.com/WordPress/gutenberg/pull/69378)).
--   `ToolsPanel`: Updated the ARIA labels to match the visible text to improve accessibilty ([#68592]((https://github.com/WordPress/gutenberg/pull/68592)))
+-   `ToolsPanel`: Updated the ARIA labels to match the visible text to improve accessibilty ([#68592](https://github.com/WordPress/gutenberg/pull/68592)).
 
 ## 29.5.0 (2025-02-28)
 

--- a/packages/components/src/tools-panel/test/index.tsx
+++ b/packages/components/src/tools-panel/test/index.tsx
@@ -802,7 +802,7 @@ describe( 'ToolsPanel', () => {
 
 			const altItem = screen.getByText( 'Nested Control 2' );
 			const altMenuItem = screen.getByRole( 'menuitemcheckbox', {
-				name: 'Show Nested Control 2',
+				name: 'Nested Control 2',
 				checked: false,
 			} );
 
@@ -840,7 +840,7 @@ describe( 'ToolsPanel', () => {
 
 			const altItem = screen.getByText( 'Nested Control 2' );
 			const altMenuItem = screen.getByRole( 'menuitemcheckbox', {
-				name: 'Show Nested Control 2',
+				name: 'Nested Control 2',
 				checked: false,
 			} );
 
@@ -1090,12 +1090,12 @@ describe( 'ToolsPanel', () => {
 			// and appear in the panel menu.
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Show Alt',
+					name: 'Alt',
 				} )
 			).toBeInTheDocument();
 			expect(
 				screen.queryByRole( 'menuitemcheckbox', {
-					name: 'Hide and reset Example',
+					name: 'Example',
 				} )
 			).not.toBeInTheDocument();
 
@@ -1104,12 +1104,12 @@ describe( 'ToolsPanel', () => {
 			rerender( <TestSlotFillPanel panelId="9999" /> );
 			expect(
 				screen.queryByRole( 'menuitemcheckbox', {
-					name: 'Show Alt',
+					name: 'Alt',
 				} )
 			).not.toBeInTheDocument();
 			expect(
 				screen.getByRole( 'menuitemcheckbox', {
-					name: 'Hide and reset Example',
+					name: 'Example',
 				} )
 			).toBeInTheDocument();
 		} );

--- a/packages/components/src/tools-panel/tools-panel-header/component.tsx
+++ b/packages/components/src/tools-panel/tools-panel-header/component.tsx
@@ -98,24 +98,12 @@ const OptionalControlsGroup = ( {
 	return (
 		<>
 			{ items.map( ( [ label, isSelected ] ) => {
-				const itemLabel = isSelected
-					? sprintf(
-							// translators: %s: The name of the control being hidden and reset e.g. "Padding".
-							__( 'Hide and reset %s' ),
-							label
-					  )
-					: sprintf(
-							// translators: %s: The name of the control to display e.g. "Padding".
-							_x( 'Show %s', 'input control' ),
-							label
-					  );
-
 				return (
 					<MenuItem
 						key={ label }
 						icon={ isSelected ? check : null }
 						isSelected={ isSelected }
-						label={ itemLabel }
+						label={ label }
 						onClick={ () => {
 							if ( isSelected ) {
 								speak(

--- a/test/e2e/specs/editor/blocks/navigation-colors.spec.js
+++ b/test/e2e/specs/editor/blocks/navigation-colors.spec.js
@@ -144,9 +144,7 @@ test.describe( 'Navigation colors', () => {
 		await editor.openDocumentSettingsSidebar();
 		await page.getByRole( 'tab', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Color options' } ).click();
-		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Show Link' } )
-			.click();
+		await page.getByRole( 'menuitemcheckbox', { name: 'Link' } ).click();
 		await page.getByRole( 'tab', { name: 'Styles' } ).click();
 		await page.getByRole( 'button', { name: 'Link', exact: true } ).click();
 		// rga(207, 46 ,46) is the color of the "vivid red" color preset.

--- a/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/custom-sources.spec.js
@@ -774,7 +774,7 @@ test.describe( 'Registered sources', () => {
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', {
-					name: 'Show content',
+					name: 'content',
 				} )
 				.click();
 			await page.getByRole( 'button', { name: 'content' } ).click();
@@ -796,7 +796,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await page.getByLabel( 'Attributes options' ).click();
 			const contentAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show content',
+				name: 'content',
 			} );
 			await expect( contentAttribute ).toBeVisible();
 		} );
@@ -809,7 +809,7 @@ test.describe( 'Registered sources', () => {
 			} );
 			await page.getByLabel( 'Attributes options' ).click();
 			const contentAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show content',
+				name: 'content',
 			} );
 			await expect( contentAttribute ).toBeVisible();
 		} );
@@ -839,24 +839,24 @@ test.describe( 'Registered sources', () => {
 				.getByLabel( 'Attributes options' )
 				.click();
 			const urlAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show url',
+				name: 'url',
 			} );
 			await expect( urlAttribute ).toBeVisible();
 			const textAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show text',
+				name: 'text',
 			} );
 			await expect( textAttribute ).toBeVisible();
 			const linkTargetAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show linkTarget',
+				name: 'linkTarget',
 			} );
 			await expect( linkTargetAttribute ).toBeVisible();
 			const relAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show rel',
+				name: 'rel',
 			} );
 			await expect( relAttribute ).toBeVisible();
 			// Check not supported attributes are not included.
 			const tagNameAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show tagName',
+				name: 'tagName',
 			} );
 			await expect( tagNameAttribute ).toBeHidden();
 		} );
@@ -874,24 +874,24 @@ test.describe( 'Registered sources', () => {
 				.getByLabel( 'Attributes options' )
 				.click();
 			const urlAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show url',
+				name: 'url',
 			} );
 			await expect( urlAttribute ).toBeVisible();
 			const idAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show id',
+				name: 'id',
 			} );
 			await expect( idAttribute ).toBeVisible();
 			const titleAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show title',
+				name: 'title',
 			} );
 			await expect( titleAttribute ).toBeVisible();
 			const altAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show alt',
+				name: 'alt',
 			} );
 			await expect( altAttribute ).toBeVisible();
 			// Check not supported attributes are not included.
 			const linkClassAttribute = page.getByRole( 'menuitemcheckbox', {
-				name: 'Show linkClass',
+				name: 'linkClass',
 			} );
 			await expect( linkClassAttribute ).toBeHidden();
 		} );

--- a/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
+++ b/test/e2e/specs/editor/various/block-bindings/post-meta.spec.js
@@ -156,7 +156,7 @@ test.describe( 'Post Meta source', () => {
 				await page.getByLabel( 'Attributes options' ).click();
 				await page
 					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
+						name: 'content',
 					} )
 					.click();
 				const contentBinding = page.getByRole( 'button', {
@@ -187,7 +187,7 @@ test.describe( 'Post Meta source', () => {
 				await page.getByLabel( 'Attributes options' ).click();
 				await page
 					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
+						name: 'content',
 					} )
 					.click();
 				const contentBinding = page.getByRole( 'button', {
@@ -213,7 +213,7 @@ test.describe( 'Post Meta source', () => {
 				await page.getByLabel( 'Attributes options' ).click();
 				await page
 					.getByRole( 'menuitemcheckbox', {
-						name: 'Show content',
+						name: 'content',
 					} )
 					.click();
 				await page
@@ -575,7 +575,7 @@ test.describe( 'Post Meta source', () => {
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', {
-					name: 'Show content',
+					name: 'content',
 				} )
 				.click();
 			await page
@@ -598,7 +598,7 @@ test.describe( 'Post Meta source', () => {
 			await page.getByLabel( 'Attributes options' ).click();
 			await page
 				.getByRole( 'menuitemcheckbox', {
-					name: 'Show content',
+					name: 'content',
 				} )
 				.click();
 			await page

--- a/test/e2e/specs/editor/various/change-detection.spec.js
+++ b/test/e2e/specs/editor/various/change-detection.spec.js
@@ -455,7 +455,7 @@ test.describe( 'Change detection', () => {
 			.click();
 		await page
 			.getByRole( 'menu', { name: 'Typography options' } )
-			.getByRole( 'menuitemcheckbox', { name: 'Show drop cap' } )
+			.getByRole( 'menuitemcheckbox', { name: 'drop cap' } )
 			.click();
 
 		await page

--- a/test/e2e/specs/editor/various/editor-modes.spec.js
+++ b/test/e2e/specs/editor/various/editor-modes.spec.js
@@ -45,7 +45,7 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 			.getByRole( 'button', { name: 'Typography options' } )
 			.click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Show Drop cap' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Drop cap' } )
 			.click();
 
 		await expect(
@@ -74,7 +74,7 @@ test.describe( 'Editing modes (visual/HTML)', () => {
 			.getByRole( 'button', { name: 'Typography options' } )
 			.click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Show Drop cap' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Drop cap' } )
 			.click();
 		await page.getByRole( 'checkbox', { name: 'Drop cap' } ).check();
 

--- a/test/e2e/specs/editor/various/font-appearance-control.spec.js
+++ b/test/e2e/specs/editor/various/font-appearance-control.spec.js
@@ -81,7 +81,7 @@ test.describe( 'Font Appearance Control dropdown menu', () => {
 			.getByRole( 'button', { name: 'Typography options' } )
 			.click();
 		await page
-			.getByRole( 'menuitemcheckbox', { name: 'Show Appearance' } )
+			.getByRole( 'menuitemcheckbox', { name: 'Appearance' } )
 			.click();
 		await expect(
 			page.getByRole( 'combobox', { name: 'Appearance' } )

--- a/test/e2e/specs/widgets/customizing-widgets.spec.js
+++ b/test/e2e/specs/widgets/customizing-widgets.spec.js
@@ -553,7 +553,7 @@ test.describe( 'Widgets Customizer', () => {
 
 		// Change `drop cap` (Any change made in this section is sufficient; not required to be `drop cap`).
 		await page.click( 'role=button[name="Typography options"i]' );
-		await page.click( 'role=menuitemcheckbox[name="Show Drop cap"i]' );
+		await page.click( 'role=menuitemcheckbox[name="Drop cap"i]' );
 
 		await page.click( 'role=checkbox[name="Drop cap"i]' );
 


### PR DESCRIPTION
Fixes: https://github.com/WordPress/gutenberg/issues/65241

## What?
Updated aria-labels for Tools Panel items to match their visible text.


## Why?
Resolved mismatches between visual labels and accessible names, improving accessibility.


## How?
Refactored aria-label generation to reflect visible text directly without adding unnecessary text.

## Testing Instructions

1. Open the Site Editor > Styles > Colors > Elements options (the ellipsis icon button).
2. Open the Elements options popover.
3. Observe the toggle-able items in the menu have a visible text like H1, H2, etc.
4. Verify that the aria-label matches the visible text for toggle-able items.


## Screenshots or screencast 

|Before|After|
|-|-|
|<img width="559" alt="Screenshot 2025-01-10 at 3 36 40 PM" src="https://github.com/user-attachments/assets/4882816b-58cd-4330-8312-1828d39b7308" />|<img width="559" alt="Screenshot 2025-01-10 at 3 32 24 PM" src="https://github.com/user-attachments/assets/15390eda-ecb2-4dc9-ac47-5ab9da966213" />|
