### PR TITLE
A11y: Remove `Tooltip` usage to prevent unexpected `tab stops`

### DIFF
--- a/packages/block-editor/src/components/border-radius-control/input-controls.js
+++ b/packages/block-editor/src/components/border-radius-control/input-controls.js
@@ -68,21 +68,22 @@ export default function BoxInputControls( {
 					: selectedUnits[ corner ] || selectedUnits.flat;
 
 				return (
-					<Tooltip text={ label } placement="top" key={ corner }>
-						<div className="components-border-radius-control__tooltip-wrapper">
-							<UnitControl
-								{ ...props }
-								aria-label={ label }
-								value={ [ parsedQuantity, computedUnit ].join(
-									''
-								) }
-								onChange={ createHandleOnChange( corner ) }
-								onUnitChange={ createHandleOnUnitChange(
-									corner
-								) }
-								size="__unstable-large"
-							/>
-						</div>
+					<Tooltip
+						text={ label }
+						placement="top"
+						key={ corner }
+						className="components-border-radius-control__tooltip-wrapper"
+					>
+						<UnitControl
+							{ ...props }
+							aria-label={ label }
+							value={ [ parsedQuantity, computedUnit ].join(
+								''
+							) }
+							onChange={ createHandleOnChange( corner ) }
+							onUnitChange={ createHandleOnUnitChange( corner ) }
+							size="__unstable-large"
+						/>
 					</Tooltip>
 				);
 			} ) }

--- a/packages/block-editor/src/components/border-radius-control/input-controls.js
+++ b/packages/block-editor/src/components/border-radius-control/input-controls.js
@@ -4,7 +4,6 @@
 import {
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue,
 	__experimentalUnitControl as UnitControl,
-	Tooltip,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -68,15 +67,13 @@ export default function BoxInputControls( {
 					: selectedUnits[ corner ] || selectedUnits.flat;
 
 				return (
-					<Tooltip
-						text={ label }
-						placement="top"
-						key={ corner }
+					<div
 						className="components-border-radius-control__tooltip-wrapper"
+						key={ corner }
 					>
 						<UnitControl
 							{ ...props }
-							aria-label={ label }
+							label={ label }
 							value={ [ parsedQuantity, computedUnit ].join(
 								''
 							) }
@@ -84,7 +81,7 @@ export default function BoxInputControls( {
 							onUnitChange={ createHandleOnUnitChange( corner ) }
 							size="__unstable-large"
 						/>
-					</Tooltip>
+					</div>
 				);
 			} ) }
 		</div>


### PR DESCRIPTION
## What, Why and How?
The tooltip wrapper was causing accessibility issues by adding `tabindex=0` to non-interactive elements, creating unexpected tab stops during keyboard navigation.

This was fixed by removing the `Tooltip` component as specified in [this comment](https://github.com/WordPress/gutenberg/issues/68591#issuecomment-2582382518), and by adding `Label` to `Unit Control` component.

## Testing Instructions
1. Select a Paragraph Block.
2. Navigate to `Dimension Settings` and check `Radius`.
3. Click on `Unlink radii`.
4. Try navigating through the input elements, and notice, it now just takes two tabs to traverse through each input.


## Screencast

![Demo](https://github.com/user-attachments/assets/c81b48ca-2f0a-4339-b785-75689dbe2d5c)



Closes: #68591 