### PR TITLE
Query Loop: It doesn't show sticky posts at the top when the query type is the default in the editor.

### DIFF
--- a/packages/block-library/src/post-template/edit.js
+++ b/packages/block-library/src/post-template/edit.js
@@ -202,6 +202,20 @@ export default function PostTemplateEdit( {
 			// block's postType, which is passed through block context.
 			const usedPostType = previewPostType || postType;
 
+			// Only handle sticky posts for 'post' post type.
+			const shouldHandleSticky = usedPostType === 'post';
+
+			// If sticky is not applicable for this post type, or sticky is not set
+			if ( ! shouldHandleSticky ) {
+				return {
+					posts: getEntityRecords( 'postType', usedPostType, {
+						...query,
+						...restQueryArgs,
+					} ),
+					blocks: getBlocks( clientId ),
+				};
+			}
+
 			// If sticky is not set, it will return all posts in the results.
 			// If sticky is set to `only`, it will limit the results to sticky posts only.
 			// If it is anything else, it will exclude sticky posts from results. For the record the value stored is `exclude`.


### PR DESCRIPTION
Fixes [#68570](https://github.com/WordPress/gutenberg/issues/68570)

## What?
Fixes the issue where sticky posts were not appearing at the top of Query Loop block results in the editor view, while they do appear at the top on the front end.

## Why?
There was an inconsistency between how sticky posts were displayed in the editor versus the front end. This caused confusion for users as the editor preview didn't accurately reflect what visitors would see on the site. The issue occurs because the editor view wasn't properly handling the sticky post ordering, while the PHP rendering on the front end did show sticky posts at the top by default.

## Testing Instructions
1. Create or edit a page that uses the Query Loop block
2. Make sure you have at least one sticky post on your site (you can make a post sticky in the post editor's Document Settings panel)
3. In the editor, observe that sticky posts now appear at the top of the Query Loop results
4. Preview the page on the front end to verify that the editor view matches the front-end display

## Screenshots or screencast <!-- if applicable -->

![Screenshot 2025-01-13 at 11 35 44 AM](https://github.com/user-attachments/assets/7edd92ca-31d2-4c8a-ab94-dcf76f75fe82)
![Screenshot 2025-01-13 at 11 35 50 AM](https://github.com/user-attachments/assets/9a37ebea-b3fc-48ce-8616-c41492520630)
![Screenshot 2025-01-13 at 11 36 00 AM](https://github.com/user-attachments/assets/0d42cf0d-ef3b-4d5c-af13-99666612ed0c)

