### PR TITLE
Update devdoc: 5-adding-a-delete-button.md

### DIFF
--- a/docs/how-to-guides/data-basics/5-adding-a-delete-button.md
+++ b/docs/how-to-guides/data-basics/5-adding-a-delete-button.md
@@ -142,7 +142,6 @@ wp.data.select( 'core' ).getLastEntityDeleteError( 'postType', 'page', 9 )
 Here's how we can apply it in `DeletePageButton`:
 
 ```js
-import { useEffect } from 'react';
 const DeletePageButton = ({ pageId }) => {
 	// ...
 	const { error, /* ... */ } = useSelect(
@@ -152,11 +151,10 @@ const DeletePageButton = ({ pageId }) => {
 		} ),
 		[pageId]
 	);
-	useEffect( () => {
-		if ( error ) {
-			// Display the error
-		}
-	}, [error] )
+	
+	if ( error ) {
+	    // Display the error
+	}	
 
 	// ...
 }
@@ -252,7 +250,6 @@ Now we're ready to tell the user about any errors that may have occurred.
 With the SnackbarNotices component in place, we're ready to dispatch some notifications! Here's how:
 
 ```js
-import { useEffect } from 'react';
 import { store as noticesStore } from '@wordpress/notices';
 function DeletePageButton( { pageId } ) {
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
@@ -307,7 +304,7 @@ And that's it!
 All the pieces are in place, great! Here’s all the changes we've made in this chapter:
 
 ```js
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, Modal, TextControl } from '@wordpress/components';
 

--- a/docs/how-to-guides/data-basics/5-adding-a-delete-button.md
+++ b/docs/how-to-guides/data-basics/5-adding-a-delete-button.md
@@ -307,6 +307,8 @@ All the pieces are in place, great! Here’s all the changes we've made in this 
 import { useState } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Button, Modal, TextControl } from '@wordpress/components';
+import { SnackbarList } from '@wordpress/components';
+import { store as noticesStore } from '@wordpress/notices';
 
 function MyFirstApp() {
 	const [searchTerm, setSearchTerm] = useState( '' );

--- a/docs/how-to-guides/data-basics/5-adding-a-delete-button.md
+++ b/docs/how-to-guides/data-basics/5-adding-a-delete-button.md
@@ -306,8 +306,7 @@ All the pieces are in place, great! Here’s all the changes we've made in this 
 ```js
 import { useState } from 'react';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { Button, Modal, TextControl } from '@wordpress/components';
-import { SnackbarList } from '@wordpress/components';
+import { Button, Modal, TextControl, SnackbarList } from '@wordpress/components';
 import { store as noticesStore } from '@wordpress/notices';
 
 function MyFirstApp() {


### PR DESCRIPTION
<!-- Thanks for contributing to Gutenberg! Please follow the Gutenberg Contributing Guidelines:
https://github.com/WordPress/gutenberg/blob/trunk/CONTRIBUTING.md -->

## What?
<!-- In a few words, what is the PR actually doing? -->
We don't use useEffect at last. We use SnackbarList of notices instead.

## Why?
<!-- Why is this PR necessary? What problem is it solving? Reference any existing previous issue(s) or PR(s), but please add a short summary here, too -->
The code show that.

## How?
<!-- How is your PR addressing the issue at hand? What are the implementation details? -->
So removing useEffect import and adding import SnackbarList, notices are needed.

## Testing Instructions
<!-- Please include step by step instructions on how to test this PR. -->
<!-- 1. Open a post or page. -->
<!-- 2. Insert a heading block. -->
<!-- 3. etc. -->
No need to test. It's just coding logic.

### Testing Instructions for Keyboard
<!-- How can you test the changes by using the keyboard only? Please note, this is required for PRs that change the user interface (UI). This ensures the PR can be tested for any possible accessibility regressions. -->

## Screenshots or screencast <!-- if applicable -->

<!-- If you would like to upload screenshots, feel free to use the table below when it is useful to show the difference between before and after the change. -->

|Before|After|
|-|-|
|<!-- Before screenshot here -->|<!-- After screenshot here -->|
